### PR TITLE
Replace boilerplate COM interface code gen with `macro_rules`

### DIFF
--- a/crates/libs/bindgen/src/classes.rs
+++ b/crates/libs/bindgen/src/classes.rs
@@ -129,8 +129,10 @@ fn gen_class(gen: &Gen, def: TypeDef) -> TokenStream {
 }
 
 fn gen_conversions(gen: &Gen, def: TypeDef, name: &TokenStream, interfaces: &[Interface], cfg: &Cfg) -> TokenStream {
+    let features = gen.cfg_features(&cfg);
     let mut tokens = quote! {
-        crate::core::interface_hierarchy!(#name, ::windows::core::IUnknown, ::windows::core::IInspectable);
+        #features
+        ::windows::core::interface_hierarchy!(#name, ::windows::core::IUnknown, ::windows::core::IInspectable);
     };
 
     for interface in interfaces {

--- a/crates/libs/bindgen/src/classes.rs
+++ b/crates/libs/bindgen/src/classes.rs
@@ -129,32 +129,9 @@ fn gen_class(gen: &Gen, def: TypeDef) -> TokenStream {
 }
 
 fn gen_conversions(gen: &Gen, def: TypeDef, name: &TokenStream, interfaces: &[Interface], cfg: &Cfg) -> TokenStream {
-    let mut tokens = quote! {};
-
-    for def in &[Type::IUnknown, Type::IInspectable] {
-        let into = gen.type_name(def);
-        let features = gen.cfg_features(cfg);
-        tokens.combine(&quote! {
-            #features
-            impl ::core::convert::From<#name> for #into {
-                fn from(value: #name) -> Self {
-                    unsafe { ::core::mem::transmute(value) }
-                }
-            }
-            #features
-            impl ::core::convert::From<&#name> for #into {
-                fn from(value: &#name) -> Self {
-                    ::core::convert::From::from(::core::clone::Clone::clone(value))
-                }
-            }
-            #features
-            impl ::core::convert::From<&#name> for &#into {
-                fn from(value: &#name) -> Self {
-                    unsafe { ::core::mem::transmute(value) }
-                }
-            }
-        });
-    }
+    let mut tokens = quote! {
+        crate::core::interface_hierarchy!(#name, ::windows::core::IUnknown, ::windows::core::IInspectable);
+    };
 
     for interface in interfaces {
         if gen.reader.type_is_exclusive(&interface.ty) {

--- a/crates/libs/bindgen/src/classes.rs
+++ b/crates/libs/bindgen/src/classes.rs
@@ -129,7 +129,7 @@ fn gen_class(gen: &Gen, def: TypeDef) -> TokenStream {
 }
 
 fn gen_conversions(gen: &Gen, def: TypeDef, name: &TokenStream, interfaces: &[Interface], cfg: &Cfg) -> TokenStream {
-    let features = gen.cfg_features(&cfg);
+    let features = gen.cfg_features(cfg);
     let mut tokens = quote! {
         #features
         ::windows::core::interface_hierarchy!(#name, ::windows::core::IUnknown, ::windows::core::IInspectable);

--- a/crates/libs/bindgen/src/interfaces.rs
+++ b/crates/libs/bindgen/src/interfaces.rs
@@ -112,7 +112,7 @@ fn gen_win_interface(gen: &Gen, def: TypeDef) -> TokenStream {
         });
 
         if !vtables.is_empty() && generics.is_empty() {
-            let mut hierarchy = format!("crate::core::interface_hierarchy!({}", ident);
+            let mut hierarchy = format!("::windows::core::interface_hierarchy!({}", ident);
             let mut hierarchy_cfg = cfg.clone();
 
             for ty in &vtables {

--- a/crates/libs/windows/src/Windows/AI/MachineLearning/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/AI/MachineLearning/Preview/mod.rs
@@ -322,41 +322,7 @@ impl ILearningModelVariableDescriptorPreview {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<ILearningModelVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: ILearningModelVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a ILearningModelVariableDescriptorPreview> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILearningModelVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ILearningModelVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: &ILearningModelVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<ILearningModelVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: ILearningModelVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a ILearningModelVariableDescriptorPreview> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILearningModelVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ILearningModelVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: &ILearningModelVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILearningModelVariableDescriptorPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for ILearningModelVariableDescriptorPreview {
     fn clone(&self) -> Self {
@@ -608,41 +574,7 @@ impl ::windows::core::RuntimeName for ImageVariableDescriptorPreview {
     const NAME: &'static str = "Windows.AI.MachineLearning.Preview.ImageVariableDescriptorPreview";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<ImageVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: ImageVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ImageVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: &ImageVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ImageVariableDescriptorPreview> for &::windows::core::IUnknown {
-    fn from(value: &ImageVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<ImageVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: ImageVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ImageVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: &ImageVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ImageVariableDescriptorPreview> for &::windows::core::IInspectable {
-    fn from(value: &ImageVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageVariableDescriptorPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<ImageVariableDescriptorPreview> for ILearningModelVariableDescriptorPreview {
     type Error = ::windows::core::Error;
@@ -788,41 +720,7 @@ impl ::windows::core::RuntimeName for InferencingOptionsPreview {
     const NAME: &'static str = "Windows.AI.MachineLearning.Preview.InferencingOptionsPreview";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<InferencingOptionsPreview> for ::windows::core::IUnknown {
-    fn from(value: InferencingOptionsPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&InferencingOptionsPreview> for ::windows::core::IUnknown {
-    fn from(value: &InferencingOptionsPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&InferencingOptionsPreview> for &::windows::core::IUnknown {
-    fn from(value: &InferencingOptionsPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<InferencingOptionsPreview> for ::windows::core::IInspectable {
-    fn from(value: InferencingOptionsPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&InferencingOptionsPreview> for ::windows::core::IInspectable {
-    fn from(value: &InferencingOptionsPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&InferencingOptionsPreview> for &::windows::core::IInspectable {
-    fn from(value: &InferencingOptionsPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InferencingOptionsPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"AI_MachineLearning_Preview\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -969,41 +867,7 @@ impl ::core::iter::IntoIterator for &LearningModelBindingPreview {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<LearningModelBindingPreview> for ::windows::core::IUnknown {
-    fn from(value: LearningModelBindingPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelBindingPreview> for ::windows::core::IUnknown {
-    fn from(value: &LearningModelBindingPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelBindingPreview> for &::windows::core::IUnknown {
-    fn from(value: &LearningModelBindingPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<LearningModelBindingPreview> for ::windows::core::IInspectable {
-    fn from(value: LearningModelBindingPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelBindingPreview> for ::windows::core::IInspectable {
-    fn from(value: &LearningModelBindingPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelBindingPreview> for &::windows::core::IInspectable {
-    fn from(value: &LearningModelBindingPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LearningModelBindingPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
 impl ::core::convert::TryFrom<LearningModelBindingPreview> for super::super::super::Foundation::Collections::IIterable<super::super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
@@ -1168,41 +1032,7 @@ impl ::windows::core::RuntimeName for LearningModelDescriptionPreview {
     const NAME: &'static str = "Windows.AI.MachineLearning.Preview.LearningModelDescriptionPreview";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<LearningModelDescriptionPreview> for ::windows::core::IUnknown {
-    fn from(value: LearningModelDescriptionPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelDescriptionPreview> for ::windows::core::IUnknown {
-    fn from(value: &LearningModelDescriptionPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelDescriptionPreview> for &::windows::core::IUnknown {
-    fn from(value: &LearningModelDescriptionPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<LearningModelDescriptionPreview> for ::windows::core::IInspectable {
-    fn from(value: LearningModelDescriptionPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelDescriptionPreview> for ::windows::core::IInspectable {
-    fn from(value: &LearningModelDescriptionPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelDescriptionPreview> for &::windows::core::IInspectable {
-    fn from(value: &LearningModelDescriptionPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LearningModelDescriptionPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"AI_MachineLearning_Preview\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -1269,41 +1099,7 @@ impl ::windows::core::RuntimeName for LearningModelEvaluationResultPreview {
     const NAME: &'static str = "Windows.AI.MachineLearning.Preview.LearningModelEvaluationResultPreview";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<LearningModelEvaluationResultPreview> for ::windows::core::IUnknown {
-    fn from(value: LearningModelEvaluationResultPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelEvaluationResultPreview> for ::windows::core::IUnknown {
-    fn from(value: &LearningModelEvaluationResultPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelEvaluationResultPreview> for &::windows::core::IUnknown {
-    fn from(value: &LearningModelEvaluationResultPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<LearningModelEvaluationResultPreview> for ::windows::core::IInspectable {
-    fn from(value: LearningModelEvaluationResultPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelEvaluationResultPreview> for ::windows::core::IInspectable {
-    fn from(value: &LearningModelEvaluationResultPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelEvaluationResultPreview> for &::windows::core::IInspectable {
-    fn from(value: &LearningModelEvaluationResultPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LearningModelEvaluationResultPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"AI_MachineLearning_Preview\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -1428,41 +1224,7 @@ impl ::windows::core::RuntimeName for LearningModelPreview {
     const NAME: &'static str = "Windows.AI.MachineLearning.Preview.LearningModelPreview";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<LearningModelPreview> for ::windows::core::IUnknown {
-    fn from(value: LearningModelPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelPreview> for ::windows::core::IUnknown {
-    fn from(value: &LearningModelPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelPreview> for &::windows::core::IUnknown {
-    fn from(value: &LearningModelPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<LearningModelPreview> for ::windows::core::IInspectable {
-    fn from(value: LearningModelPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelPreview> for ::windows::core::IInspectable {
-    fn from(value: &LearningModelPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelPreview> for &::windows::core::IInspectable {
-    fn from(value: &LearningModelPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LearningModelPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"AI_MachineLearning_Preview\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -1547,41 +1309,7 @@ impl ::windows::core::RuntimeName for LearningModelVariableDescriptorPreview {
     const NAME: &'static str = "Windows.AI.MachineLearning.Preview.LearningModelVariableDescriptorPreview";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<LearningModelVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: LearningModelVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: &LearningModelVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelVariableDescriptorPreview> for &::windows::core::IUnknown {
-    fn from(value: &LearningModelVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<LearningModelVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: LearningModelVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: &LearningModelVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&LearningModelVariableDescriptorPreview> for &::windows::core::IInspectable {
-    fn from(value: &LearningModelVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LearningModelVariableDescriptorPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<LearningModelVariableDescriptorPreview> for ILearningModelVariableDescriptorPreview {
     type Error = ::windows::core::Error;
@@ -1724,41 +1452,7 @@ impl ::windows::core::RuntimeName for MapVariableDescriptorPreview {
     const NAME: &'static str = "Windows.AI.MachineLearning.Preview.MapVariableDescriptorPreview";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<MapVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: MapVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&MapVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: &MapVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&MapVariableDescriptorPreview> for &::windows::core::IUnknown {
-    fn from(value: &MapVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<MapVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: MapVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&MapVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: &MapVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&MapVariableDescriptorPreview> for &::windows::core::IInspectable {
-    fn from(value: &MapVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MapVariableDescriptorPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<MapVariableDescriptorPreview> for ILearningModelVariableDescriptorPreview {
     type Error = ::windows::core::Error;
@@ -1874,41 +1568,7 @@ impl ::windows::core::RuntimeName for SequenceVariableDescriptorPreview {
     const NAME: &'static str = "Windows.AI.MachineLearning.Preview.SequenceVariableDescriptorPreview";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SequenceVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: SequenceVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SequenceVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: &SequenceVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SequenceVariableDescriptorPreview> for &::windows::core::IUnknown {
-    fn from(value: &SequenceVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SequenceVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: SequenceVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SequenceVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: &SequenceVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SequenceVariableDescriptorPreview> for &::windows::core::IInspectable {
-    fn from(value: &SequenceVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SequenceVariableDescriptorPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<SequenceVariableDescriptorPreview> for ILearningModelVariableDescriptorPreview {
     type Error = ::windows::core::Error;
@@ -2033,41 +1693,7 @@ impl ::windows::core::RuntimeName for TensorVariableDescriptorPreview {
     const NAME: &'static str = "Windows.AI.MachineLearning.Preview.TensorVariableDescriptorPreview";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<TensorVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: TensorVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TensorVariableDescriptorPreview> for ::windows::core::IUnknown {
-    fn from(value: &TensorVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TensorVariableDescriptorPreview> for &::windows::core::IUnknown {
-    fn from(value: &TensorVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<TensorVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: TensorVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TensorVariableDescriptorPreview> for ::windows::core::IInspectable {
-    fn from(value: &TensorVariableDescriptorPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TensorVariableDescriptorPreview> for &::windows::core::IInspectable {
-    fn from(value: &TensorVariableDescriptorPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorVariableDescriptorPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<TensorVariableDescriptorPreview> for ILearningModelVariableDescriptorPreview {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/AI/MachineLearning/mod.rs
+++ b/crates/libs/windows/src/Windows/AI/MachineLearning/mod.rs
@@ -250,36 +250,7 @@ impl ILearningModelFeatureDescriptor {
         }
     }
 }
-impl ::core::convert::From<ILearningModelFeatureDescriptor> for ::windows::core::IUnknown {
-    fn from(value: ILearningModelFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILearningModelFeatureDescriptor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILearningModelFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILearningModelFeatureDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &ILearningModelFeatureDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILearningModelFeatureDescriptor> for ::windows::core::IInspectable {
-    fn from(value: ILearningModelFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILearningModelFeatureDescriptor> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILearningModelFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILearningModelFeatureDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &ILearningModelFeatureDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILearningModelFeatureDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ILearningModelFeatureDescriptor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -330,36 +301,7 @@ impl ILearningModelFeatureValue {
         }
     }
 }
-impl ::core::convert::From<ILearningModelFeatureValue> for ::windows::core::IUnknown {
-    fn from(value: ILearningModelFeatureValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILearningModelFeatureValue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILearningModelFeatureValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILearningModelFeatureValue> for ::windows::core::IUnknown {
-    fn from(value: &ILearningModelFeatureValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILearningModelFeatureValue> for ::windows::core::IInspectable {
-    fn from(value: ILearningModelFeatureValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILearningModelFeatureValue> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILearningModelFeatureValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILearningModelFeatureValue> for ::windows::core::IInspectable {
-    fn from(value: &ILearningModelFeatureValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILearningModelFeatureValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ILearningModelFeatureValue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -399,36 +341,7 @@ pub struct ILearningModelFeatureValue_Vtbl {
 #[repr(transparent)]
 pub struct ILearningModelOperatorProvider(::windows::core::IUnknown);
 impl ILearningModelOperatorProvider {}
-impl ::core::convert::From<ILearningModelOperatorProvider> for ::windows::core::IUnknown {
-    fn from(value: ILearningModelOperatorProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILearningModelOperatorProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILearningModelOperatorProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILearningModelOperatorProvider> for ::windows::core::IUnknown {
-    fn from(value: &ILearningModelOperatorProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILearningModelOperatorProvider> for ::windows::core::IInspectable {
-    fn from(value: ILearningModelOperatorProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILearningModelOperatorProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILearningModelOperatorProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILearningModelOperatorProvider> for ::windows::core::IInspectable {
-    fn from(value: &ILearningModelOperatorProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILearningModelOperatorProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ILearningModelOperatorProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -673,36 +586,7 @@ impl ITensor {
         }
     }
 }
-impl ::core::convert::From<ITensor> for ::windows::core::IUnknown {
-    fn from(value: ITensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITensor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITensor> for ::windows::core::IUnknown {
-    fn from(value: &ITensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITensor> for ::windows::core::IInspectable {
-    fn from(value: ITensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITensor> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ITensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITensor> for ::windows::core::IInspectable {
-    fn from(value: &ITensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITensor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ITensor> for ILearningModelFeatureValue {
     type Error = ::windows::core::Error;
     fn try_from(value: ITensor) -> ::windows::core::Result<Self> {
@@ -1712,36 +1596,7 @@ unsafe impl ::windows::core::Interface for ImageFeatureDescriptor {
 impl ::windows::core::RuntimeName for ImageFeatureDescriptor {
     const NAME: &'static str = "Windows.AI.MachineLearning.ImageFeatureDescriptor";
 }
-impl ::core::convert::From<ImageFeatureDescriptor> for ::windows::core::IUnknown {
-    fn from(value: ImageFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageFeatureDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &ImageFeatureDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageFeatureDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &ImageFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageFeatureDescriptor> for ::windows::core::IInspectable {
-    fn from(value: ImageFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageFeatureDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &ImageFeatureDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageFeatureDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &ImageFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageFeatureDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ImageFeatureDescriptor> for ILearningModelFeatureDescriptor {
     type Error = ::windows::core::Error;
     fn try_from(value: ImageFeatureDescriptor) -> ::windows::core::Result<Self> {
@@ -1829,36 +1684,7 @@ unsafe impl ::windows::core::Interface for ImageFeatureValue {
 impl ::windows::core::RuntimeName for ImageFeatureValue {
     const NAME: &'static str = "Windows.AI.MachineLearning.ImageFeatureValue";
 }
-impl ::core::convert::From<ImageFeatureValue> for ::windows::core::IUnknown {
-    fn from(value: ImageFeatureValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageFeatureValue> for ::windows::core::IUnknown {
-    fn from(value: &ImageFeatureValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageFeatureValue> for &::windows::core::IUnknown {
-    fn from(value: &ImageFeatureValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageFeatureValue> for ::windows::core::IInspectable {
-    fn from(value: ImageFeatureValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageFeatureValue> for ::windows::core::IInspectable {
-    fn from(value: &ImageFeatureValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageFeatureValue> for &::windows::core::IInspectable {
-    fn from(value: &ImageFeatureValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageFeatureValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ImageFeatureValue> for ILearningModelFeatureValue {
     type Error = ::windows::core::Error;
     fn try_from(value: ImageFeatureValue) -> ::windows::core::Result<Self> {
@@ -2084,36 +1910,7 @@ unsafe impl ::windows::core::Interface for LearningModel {
 impl ::windows::core::RuntimeName for LearningModel {
     const NAME: &'static str = "Windows.AI.MachineLearning.LearningModel";
 }
-impl ::core::convert::From<LearningModel> for ::windows::core::IUnknown {
-    fn from(value: LearningModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModel> for ::windows::core::IUnknown {
-    fn from(value: &LearningModel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModel> for &::windows::core::IUnknown {
-    fn from(value: &LearningModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LearningModel> for ::windows::core::IInspectable {
-    fn from(value: LearningModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModel> for ::windows::core::IInspectable {
-    fn from(value: &LearningModel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModel> for &::windows::core::IInspectable {
-    fn from(value: &LearningModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LearningModel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<LearningModel> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2266,36 +2063,7 @@ impl ::core::iter::IntoIterator for &LearningModelBinding {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<LearningModelBinding> for ::windows::core::IUnknown {
-    fn from(value: LearningModelBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModelBinding> for ::windows::core::IUnknown {
-    fn from(value: &LearningModelBinding) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModelBinding> for &::windows::core::IUnknown {
-    fn from(value: &LearningModelBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LearningModelBinding> for ::windows::core::IInspectable {
-    fn from(value: LearningModelBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModelBinding> for ::windows::core::IInspectable {
-    fn from(value: &LearningModelBinding) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModelBinding> for &::windows::core::IInspectable {
-    fn from(value: &LearningModelBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LearningModelBinding, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<LearningModelBinding> for super::super::Foundation::Collections::IIterable<super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
@@ -2425,36 +2193,7 @@ unsafe impl ::windows::core::Interface for LearningModelDevice {
 impl ::windows::core::RuntimeName for LearningModelDevice {
     const NAME: &'static str = "Windows.AI.MachineLearning.LearningModelDevice";
 }
-impl ::core::convert::From<LearningModelDevice> for ::windows::core::IUnknown {
-    fn from(value: LearningModelDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModelDevice> for ::windows::core::IUnknown {
-    fn from(value: &LearningModelDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModelDevice> for &::windows::core::IUnknown {
-    fn from(value: &LearningModelDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LearningModelDevice> for ::windows::core::IInspectable {
-    fn from(value: LearningModelDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModelDevice> for ::windows::core::IInspectable {
-    fn from(value: &LearningModelDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModelDevice> for &::windows::core::IInspectable {
-    fn from(value: &LearningModelDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LearningModelDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LearningModelDevice {}
 unsafe impl ::core::marker::Sync for LearningModelDevice {}
 #[doc = "*Required features: `\"AI_MachineLearning\"`*"]
@@ -2524,36 +2263,7 @@ unsafe impl ::windows::core::Interface for LearningModelEvaluationResult {
 impl ::windows::core::RuntimeName for LearningModelEvaluationResult {
     const NAME: &'static str = "Windows.AI.MachineLearning.LearningModelEvaluationResult";
 }
-impl ::core::convert::From<LearningModelEvaluationResult> for ::windows::core::IUnknown {
-    fn from(value: LearningModelEvaluationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModelEvaluationResult> for ::windows::core::IUnknown {
-    fn from(value: &LearningModelEvaluationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModelEvaluationResult> for &::windows::core::IUnknown {
-    fn from(value: &LearningModelEvaluationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LearningModelEvaluationResult> for ::windows::core::IInspectable {
-    fn from(value: LearningModelEvaluationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModelEvaluationResult> for ::windows::core::IInspectable {
-    fn from(value: &LearningModelEvaluationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModelEvaluationResult> for &::windows::core::IInspectable {
-    fn from(value: &LearningModelEvaluationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LearningModelEvaluationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LearningModelEvaluationResult {}
 unsafe impl ::core::marker::Sync for LearningModelEvaluationResult {}
 #[doc = "*Required features: `\"AI_MachineLearning\"`*"]
@@ -2692,36 +2402,7 @@ unsafe impl ::windows::core::Interface for LearningModelSession {
 impl ::windows::core::RuntimeName for LearningModelSession {
     const NAME: &'static str = "Windows.AI.MachineLearning.LearningModelSession";
 }
-impl ::core::convert::From<LearningModelSession> for ::windows::core::IUnknown {
-    fn from(value: LearningModelSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModelSession> for ::windows::core::IUnknown {
-    fn from(value: &LearningModelSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModelSession> for &::windows::core::IUnknown {
-    fn from(value: &LearningModelSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LearningModelSession> for ::windows::core::IInspectable {
-    fn from(value: LearningModelSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModelSession> for ::windows::core::IInspectable {
-    fn from(value: &LearningModelSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModelSession> for &::windows::core::IInspectable {
-    fn from(value: &LearningModelSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LearningModelSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<LearningModelSession> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2816,36 +2497,7 @@ unsafe impl ::windows::core::Interface for LearningModelSessionOptions {
 impl ::windows::core::RuntimeName for LearningModelSessionOptions {
     const NAME: &'static str = "Windows.AI.MachineLearning.LearningModelSessionOptions";
 }
-impl ::core::convert::From<LearningModelSessionOptions> for ::windows::core::IUnknown {
-    fn from(value: LearningModelSessionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModelSessionOptions> for ::windows::core::IUnknown {
-    fn from(value: &LearningModelSessionOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModelSessionOptions> for &::windows::core::IUnknown {
-    fn from(value: &LearningModelSessionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LearningModelSessionOptions> for ::windows::core::IInspectable {
-    fn from(value: LearningModelSessionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LearningModelSessionOptions> for ::windows::core::IInspectable {
-    fn from(value: &LearningModelSessionOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LearningModelSessionOptions> for &::windows::core::IInspectable {
-    fn from(value: &LearningModelSessionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LearningModelSessionOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LearningModelSessionOptions {}
 unsafe impl ::core::marker::Sync for LearningModelSessionOptions {}
 #[doc = "*Required features: `\"AI_MachineLearning\"`*"]
@@ -2927,36 +2579,7 @@ unsafe impl ::windows::core::Interface for MapFeatureDescriptor {
 impl ::windows::core::RuntimeName for MapFeatureDescriptor {
     const NAME: &'static str = "Windows.AI.MachineLearning.MapFeatureDescriptor";
 }
-impl ::core::convert::From<MapFeatureDescriptor> for ::windows::core::IUnknown {
-    fn from(value: MapFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapFeatureDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &MapFeatureDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapFeatureDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &MapFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MapFeatureDescriptor> for ::windows::core::IInspectable {
-    fn from(value: MapFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapFeatureDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &MapFeatureDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapFeatureDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &MapFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MapFeatureDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MapFeatureDescriptor> for ILearningModelFeatureDescriptor {
     type Error = ::windows::core::Error;
     fn try_from(value: MapFeatureDescriptor) -> ::windows::core::Result<Self> {
@@ -3050,36 +2673,7 @@ unsafe impl ::windows::core::Interface for SequenceFeatureDescriptor {
 impl ::windows::core::RuntimeName for SequenceFeatureDescriptor {
     const NAME: &'static str = "Windows.AI.MachineLearning.SequenceFeatureDescriptor";
 }
-impl ::core::convert::From<SequenceFeatureDescriptor> for ::windows::core::IUnknown {
-    fn from(value: SequenceFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SequenceFeatureDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &SequenceFeatureDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SequenceFeatureDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &SequenceFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SequenceFeatureDescriptor> for ::windows::core::IInspectable {
-    fn from(value: SequenceFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SequenceFeatureDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &SequenceFeatureDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SequenceFeatureDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &SequenceFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SequenceFeatureDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SequenceFeatureDescriptor> for ILearningModelFeatureDescriptor {
     type Error = ::windows::core::Error;
     fn try_from(value: SequenceFeatureDescriptor) -> ::windows::core::Result<Self> {
@@ -3257,36 +2851,7 @@ unsafe impl ::windows::core::Interface for TensorBoolean {
 impl ::windows::core::RuntimeName for TensorBoolean {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorBoolean";
 }
-impl ::core::convert::From<TensorBoolean> for ::windows::core::IUnknown {
-    fn from(value: TensorBoolean) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorBoolean> for ::windows::core::IUnknown {
-    fn from(value: &TensorBoolean) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorBoolean> for &::windows::core::IUnknown {
-    fn from(value: &TensorBoolean) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorBoolean> for ::windows::core::IInspectable {
-    fn from(value: TensorBoolean) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorBoolean> for ::windows::core::IInspectable {
-    fn from(value: &TensorBoolean) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorBoolean> for &::windows::core::IInspectable {
-    fn from(value: &TensorBoolean) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorBoolean, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorBoolean> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3527,36 +3092,7 @@ unsafe impl ::windows::core::Interface for TensorDouble {
 impl ::windows::core::RuntimeName for TensorDouble {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorDouble";
 }
-impl ::core::convert::From<TensorDouble> for ::windows::core::IUnknown {
-    fn from(value: TensorDouble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorDouble> for ::windows::core::IUnknown {
-    fn from(value: &TensorDouble) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorDouble> for &::windows::core::IUnknown {
-    fn from(value: &TensorDouble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorDouble> for ::windows::core::IInspectable {
-    fn from(value: TensorDouble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorDouble> for ::windows::core::IInspectable {
-    fn from(value: &TensorDouble) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorDouble> for &::windows::core::IInspectable {
-    fn from(value: &TensorDouble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorDouble, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorDouble> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3722,36 +3258,7 @@ unsafe impl ::windows::core::Interface for TensorFeatureDescriptor {
 impl ::windows::core::RuntimeName for TensorFeatureDescriptor {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorFeatureDescriptor";
 }
-impl ::core::convert::From<TensorFeatureDescriptor> for ::windows::core::IUnknown {
-    fn from(value: TensorFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorFeatureDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &TensorFeatureDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorFeatureDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &TensorFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorFeatureDescriptor> for ::windows::core::IInspectable {
-    fn from(value: TensorFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorFeatureDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &TensorFeatureDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorFeatureDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &TensorFeatureDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorFeatureDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<TensorFeatureDescriptor> for ILearningModelFeatureDescriptor {
     type Error = ::windows::core::Error;
     fn try_from(value: TensorFeatureDescriptor) -> ::windows::core::Result<Self> {
@@ -3929,36 +3436,7 @@ unsafe impl ::windows::core::Interface for TensorFloat {
 impl ::windows::core::RuntimeName for TensorFloat {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorFloat";
 }
-impl ::core::convert::From<TensorFloat> for ::windows::core::IUnknown {
-    fn from(value: TensorFloat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorFloat> for ::windows::core::IUnknown {
-    fn from(value: &TensorFloat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorFloat> for &::windows::core::IUnknown {
-    fn from(value: &TensorFloat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorFloat> for ::windows::core::IInspectable {
-    fn from(value: TensorFloat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorFloat> for ::windows::core::IInspectable {
-    fn from(value: &TensorFloat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorFloat> for &::windows::core::IInspectable {
-    fn from(value: &TensorFloat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorFloat, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorFloat> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4199,36 +3677,7 @@ unsafe impl ::windows::core::Interface for TensorFloat16Bit {
 impl ::windows::core::RuntimeName for TensorFloat16Bit {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorFloat16Bit";
 }
-impl ::core::convert::From<TensorFloat16Bit> for ::windows::core::IUnknown {
-    fn from(value: TensorFloat16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorFloat16Bit> for ::windows::core::IUnknown {
-    fn from(value: &TensorFloat16Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorFloat16Bit> for &::windows::core::IUnknown {
-    fn from(value: &TensorFloat16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorFloat16Bit> for ::windows::core::IInspectable {
-    fn from(value: TensorFloat16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorFloat16Bit> for ::windows::core::IInspectable {
-    fn from(value: &TensorFloat16Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorFloat16Bit> for &::windows::core::IInspectable {
-    fn from(value: &TensorFloat16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorFloat16Bit, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorFloat16Bit> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4469,36 +3918,7 @@ unsafe impl ::windows::core::Interface for TensorInt16Bit {
 impl ::windows::core::RuntimeName for TensorInt16Bit {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorInt16Bit";
 }
-impl ::core::convert::From<TensorInt16Bit> for ::windows::core::IUnknown {
-    fn from(value: TensorInt16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorInt16Bit> for ::windows::core::IUnknown {
-    fn from(value: &TensorInt16Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorInt16Bit> for &::windows::core::IUnknown {
-    fn from(value: &TensorInt16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorInt16Bit> for ::windows::core::IInspectable {
-    fn from(value: TensorInt16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorInt16Bit> for ::windows::core::IInspectable {
-    fn from(value: &TensorInt16Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorInt16Bit> for &::windows::core::IInspectable {
-    fn from(value: &TensorInt16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorInt16Bit, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorInt16Bit> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4739,36 +4159,7 @@ unsafe impl ::windows::core::Interface for TensorInt32Bit {
 impl ::windows::core::RuntimeName for TensorInt32Bit {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorInt32Bit";
 }
-impl ::core::convert::From<TensorInt32Bit> for ::windows::core::IUnknown {
-    fn from(value: TensorInt32Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorInt32Bit> for ::windows::core::IUnknown {
-    fn from(value: &TensorInt32Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorInt32Bit> for &::windows::core::IUnknown {
-    fn from(value: &TensorInt32Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorInt32Bit> for ::windows::core::IInspectable {
-    fn from(value: TensorInt32Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorInt32Bit> for ::windows::core::IInspectable {
-    fn from(value: &TensorInt32Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorInt32Bit> for &::windows::core::IInspectable {
-    fn from(value: &TensorInt32Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorInt32Bit, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorInt32Bit> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5009,36 +4400,7 @@ unsafe impl ::windows::core::Interface for TensorInt64Bit {
 impl ::windows::core::RuntimeName for TensorInt64Bit {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorInt64Bit";
 }
-impl ::core::convert::From<TensorInt64Bit> for ::windows::core::IUnknown {
-    fn from(value: TensorInt64Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorInt64Bit> for ::windows::core::IUnknown {
-    fn from(value: &TensorInt64Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorInt64Bit> for &::windows::core::IUnknown {
-    fn from(value: &TensorInt64Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorInt64Bit> for ::windows::core::IInspectable {
-    fn from(value: TensorInt64Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorInt64Bit> for ::windows::core::IInspectable {
-    fn from(value: &TensorInt64Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorInt64Bit> for &::windows::core::IInspectable {
-    fn from(value: &TensorInt64Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorInt64Bit, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorInt64Bit> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5279,36 +4641,7 @@ unsafe impl ::windows::core::Interface for TensorInt8Bit {
 impl ::windows::core::RuntimeName for TensorInt8Bit {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorInt8Bit";
 }
-impl ::core::convert::From<TensorInt8Bit> for ::windows::core::IUnknown {
-    fn from(value: TensorInt8Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorInt8Bit> for ::windows::core::IUnknown {
-    fn from(value: &TensorInt8Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorInt8Bit> for &::windows::core::IUnknown {
-    fn from(value: &TensorInt8Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorInt8Bit> for ::windows::core::IInspectable {
-    fn from(value: TensorInt8Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorInt8Bit> for ::windows::core::IInspectable {
-    fn from(value: &TensorInt8Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorInt8Bit> for &::windows::core::IInspectable {
-    fn from(value: &TensorInt8Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorInt8Bit, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorInt8Bit> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5537,36 +4870,7 @@ unsafe impl ::windows::core::Interface for TensorString {
 impl ::windows::core::RuntimeName for TensorString {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorString";
 }
-impl ::core::convert::From<TensorString> for ::windows::core::IUnknown {
-    fn from(value: TensorString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorString> for ::windows::core::IUnknown {
-    fn from(value: &TensorString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorString> for &::windows::core::IUnknown {
-    fn from(value: &TensorString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorString> for ::windows::core::IInspectable {
-    fn from(value: TensorString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorString> for ::windows::core::IInspectable {
-    fn from(value: &TensorString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorString> for &::windows::core::IInspectable {
-    fn from(value: &TensorString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorString, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorString> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5807,36 +5111,7 @@ unsafe impl ::windows::core::Interface for TensorUInt16Bit {
 impl ::windows::core::RuntimeName for TensorUInt16Bit {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorUInt16Bit";
 }
-impl ::core::convert::From<TensorUInt16Bit> for ::windows::core::IUnknown {
-    fn from(value: TensorUInt16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorUInt16Bit> for ::windows::core::IUnknown {
-    fn from(value: &TensorUInt16Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorUInt16Bit> for &::windows::core::IUnknown {
-    fn from(value: &TensorUInt16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorUInt16Bit> for ::windows::core::IInspectable {
-    fn from(value: TensorUInt16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorUInt16Bit> for ::windows::core::IInspectable {
-    fn from(value: &TensorUInt16Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorUInt16Bit> for &::windows::core::IInspectable {
-    fn from(value: &TensorUInt16Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorUInt16Bit, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorUInt16Bit> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -6077,36 +5352,7 @@ unsafe impl ::windows::core::Interface for TensorUInt32Bit {
 impl ::windows::core::RuntimeName for TensorUInt32Bit {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorUInt32Bit";
 }
-impl ::core::convert::From<TensorUInt32Bit> for ::windows::core::IUnknown {
-    fn from(value: TensorUInt32Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorUInt32Bit> for ::windows::core::IUnknown {
-    fn from(value: &TensorUInt32Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorUInt32Bit> for &::windows::core::IUnknown {
-    fn from(value: &TensorUInt32Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorUInt32Bit> for ::windows::core::IInspectable {
-    fn from(value: TensorUInt32Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorUInt32Bit> for ::windows::core::IInspectable {
-    fn from(value: &TensorUInt32Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorUInt32Bit> for &::windows::core::IInspectable {
-    fn from(value: &TensorUInt32Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorUInt32Bit, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorUInt32Bit> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -6347,36 +5593,7 @@ unsafe impl ::windows::core::Interface for TensorUInt64Bit {
 impl ::windows::core::RuntimeName for TensorUInt64Bit {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorUInt64Bit";
 }
-impl ::core::convert::From<TensorUInt64Bit> for ::windows::core::IUnknown {
-    fn from(value: TensorUInt64Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorUInt64Bit> for ::windows::core::IUnknown {
-    fn from(value: &TensorUInt64Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorUInt64Bit> for &::windows::core::IUnknown {
-    fn from(value: &TensorUInt64Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorUInt64Bit> for ::windows::core::IInspectable {
-    fn from(value: TensorUInt64Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorUInt64Bit> for ::windows::core::IInspectable {
-    fn from(value: &TensorUInt64Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorUInt64Bit> for &::windows::core::IInspectable {
-    fn from(value: &TensorUInt64Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorUInt64Bit, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorUInt64Bit> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -6617,36 +5834,7 @@ unsafe impl ::windows::core::Interface for TensorUInt8Bit {
 impl ::windows::core::RuntimeName for TensorUInt8Bit {
     const NAME: &'static str = "Windows.AI.MachineLearning.TensorUInt8Bit";
 }
-impl ::core::convert::From<TensorUInt8Bit> for ::windows::core::IUnknown {
-    fn from(value: TensorUInt8Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorUInt8Bit> for ::windows::core::IUnknown {
-    fn from(value: &TensorUInt8Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorUInt8Bit> for &::windows::core::IUnknown {
-    fn from(value: &TensorUInt8Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TensorUInt8Bit> for ::windows::core::IInspectable {
-    fn from(value: TensorUInt8Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TensorUInt8Bit> for ::windows::core::IInspectable {
-    fn from(value: &TensorUInt8Bit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TensorUInt8Bit> for &::windows::core::IInspectable {
-    fn from(value: &TensorUInt8Bit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TensorUInt8Bit, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<TensorUInt8Bit> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Activation/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Activation/mod.rs
@@ -24,36 +24,7 @@ impl IActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IActivatedEventArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -126,36 +97,7 @@ impl IActivatedEventArgsWithUser {
         }
     }
 }
-impl ::core::convert::From<IActivatedEventArgsWithUser> for ::windows::core::IUnknown {
-    fn from(value: IActivatedEventArgsWithUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActivatedEventArgsWithUser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActivatedEventArgsWithUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActivatedEventArgsWithUser> for ::windows::core::IUnknown {
-    fn from(value: &IActivatedEventArgsWithUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActivatedEventArgsWithUser> for ::windows::core::IInspectable {
-    fn from(value: IActivatedEventArgsWithUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActivatedEventArgsWithUser> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IActivatedEventArgsWithUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActivatedEventArgsWithUser> for ::windows::core::IInspectable {
-    fn from(value: &IActivatedEventArgsWithUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActivatedEventArgsWithUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IActivatedEventArgsWithUser> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IActivatedEventArgsWithUser) -> ::windows::core::Result<Self> {
@@ -246,36 +188,7 @@ impl IApplicationViewActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IApplicationViewActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IApplicationViewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationViewActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApplicationViewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationViewActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IApplicationViewActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IApplicationViewActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IApplicationViewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationViewActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IApplicationViewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationViewActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IApplicationViewActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApplicationViewActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IApplicationViewActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IApplicationViewActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -363,36 +276,7 @@ impl IAppointmentsProviderActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IAppointmentsProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IAppointmentsProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppointmentsProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IAppointmentsProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppointmentsProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IAppointmentsProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAppointmentsProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IAppointmentsProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppointmentsProviderActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IAppointmentsProviderActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IAppointmentsProviderActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -489,36 +373,7 @@ impl IAppointmentsProviderAddAppointmentActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IAppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderAddAppointmentActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderAddAppointmentActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppointmentsProviderAddAppointmentActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IAppointmentsProviderAddAppointmentActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IAppointmentsProviderAddAppointmentActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -637,36 +492,7 @@ impl IAppointmentsProviderRemoveAppointmentActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IAppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderRemoveAppointmentActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderRemoveAppointmentActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppointmentsProviderRemoveAppointmentActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IAppointmentsProviderRemoveAppointmentActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -785,36 +611,7 @@ impl IAppointmentsProviderReplaceAppointmentActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IAppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderReplaceAppointmentActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderReplaceAppointmentActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppointmentsProviderReplaceAppointmentActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IAppointmentsProviderReplaceAppointmentActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -947,36 +744,7 @@ impl IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -1106,36 +874,7 @@ impl IAppointmentsProviderShowTimeFrameActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IAppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderShowTimeFrameActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentsProviderShowTimeFrameActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppointmentsProviderShowTimeFrameActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IAppointmentsProviderShowTimeFrameActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IAppointmentsProviderShowTimeFrameActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -1230,36 +969,7 @@ impl IBackgroundActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IBackgroundActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBackgroundActivatedEventArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1331,36 +1041,7 @@ impl IBarcodeScannerPreviewActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IBarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBarcodeScannerPreviewActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBarcodeScannerPreviewActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBarcodeScannerPreviewActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IBarcodeScannerPreviewActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IBarcodeScannerPreviewActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -1450,36 +1131,7 @@ impl ICachedFileUpdaterActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<ICachedFileUpdaterActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ICachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICachedFileUpdaterActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICachedFileUpdaterActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ICachedFileUpdaterActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICachedFileUpdaterActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ICachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICachedFileUpdaterActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICachedFileUpdaterActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ICachedFileUpdaterActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICachedFileUpdaterActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ICachedFileUpdaterActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ICachedFileUpdaterActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -1577,36 +1229,7 @@ impl ICameraSettingsActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<ICameraSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ICameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICameraSettingsActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICameraSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ICameraSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICameraSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ICameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICameraSettingsActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICameraSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ICameraSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICameraSettingsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ICameraSettingsActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ICameraSettingsActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -1695,36 +1318,7 @@ impl ICommandLineActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<ICommandLineActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ICommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommandLineActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommandLineActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ICommandLineActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICommandLineActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ICommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommandLineActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommandLineActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ICommandLineActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommandLineActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ICommandLineActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ICommandLineActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -1834,36 +1428,7 @@ impl IContactActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IContactActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IContactActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IContactActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IContactActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IContactActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IContactActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IContactActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -1974,36 +1539,7 @@ impl IContactCallActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IContactCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactCallActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IContactCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactCallActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IContactCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IContactCallActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IContactCallActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -2133,36 +1669,7 @@ impl IContactMapActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IContactMapActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactMapActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactMapActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IContactMapActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactMapActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactMapActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactMapActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IContactMapActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactMapActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IContactMapActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IContactMapActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -2299,36 +1806,7 @@ impl IContactMessageActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IContactMessageActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactMessageActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactMessageActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IContactMessageActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactMessageActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactMessageActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactMessageActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IContactMessageActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactMessageActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IContactMessageActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IContactMessageActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -2430,36 +1908,7 @@ impl IContactPanelActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IContactPanelActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactPanelActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactPanelActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IContactPanelActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactPanelActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactPanelActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactPanelActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IContactPanelActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactPanelActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IContactPanelActivatedEventArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2537,36 +1986,7 @@ impl IContactPickerActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IContactPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactPickerActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IContactPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactPickerActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IContactPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactPickerActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IContactPickerActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IContactPickerActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -2680,36 +2100,7 @@ impl IContactPostActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IContactPostActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactPostActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactPostActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IContactPostActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactPostActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactPostActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactPostActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IContactPostActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactPostActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IContactPostActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IContactPostActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -2844,36 +2235,7 @@ impl IContactVideoCallActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IContactVideoCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactVideoCallActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactVideoCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IContactVideoCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactVideoCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactVideoCallActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactVideoCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IContactVideoCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactVideoCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IContactVideoCallActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IContactVideoCallActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -2985,36 +2347,7 @@ impl IContactsProviderActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IContactsProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IContactsProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactsProviderActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactsProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactsProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IContactsProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactsProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IContactsProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactsProviderActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactsProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactsProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IContactsProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactsProviderActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IContactsProviderActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IContactsProviderActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -3104,36 +2437,7 @@ impl IContinuationActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IContinuationActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IContinuationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContinuationActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContinuationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContinuationActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IContinuationActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContinuationActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IContinuationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContinuationActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContinuationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContinuationActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IContinuationActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContinuationActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IContinuationActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IContinuationActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -3231,36 +2535,7 @@ impl IDeviceActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IDeviceActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IDeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDeviceActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDeviceActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IDeviceActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDeviceActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IDeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDeviceActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IDeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDeviceActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IDeviceActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeviceActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IDeviceActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IDeviceActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -3351,36 +2626,7 @@ impl IDevicePairingActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IDevicePairingActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IDevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDevicePairingActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDevicePairingActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IDevicePairingActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDevicePairingActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IDevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDevicePairingActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IDevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDevicePairingActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IDevicePairingActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDevicePairingActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IDevicePairingActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IDevicePairingActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -3485,36 +2731,7 @@ impl IDialReceiverActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IDialReceiverActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IDialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDialReceiverActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDialReceiverActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IDialReceiverActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDialReceiverActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IDialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDialReceiverActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IDialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDialReceiverActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IDialReceiverActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDialReceiverActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IDialReceiverActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IDialReceiverActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -3630,36 +2847,7 @@ impl IFileActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IFileActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IFileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IFileActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IFileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IFileActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IFileActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IFileActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -3751,36 +2939,7 @@ impl IFileActivatedEventArgsWithCallerPackageFamilyName {
         }
     }
 }
-impl ::core::convert::From<IFileActivatedEventArgsWithCallerPackageFamilyName> for ::windows::core::IUnknown {
-    fn from(value: IFileActivatedEventArgsWithCallerPackageFamilyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileActivatedEventArgsWithCallerPackageFamilyName> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileActivatedEventArgsWithCallerPackageFamilyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileActivatedEventArgsWithCallerPackageFamilyName> for ::windows::core::IUnknown {
-    fn from(value: &IFileActivatedEventArgsWithCallerPackageFamilyName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileActivatedEventArgsWithCallerPackageFamilyName> for ::windows::core::IInspectable {
-    fn from(value: IFileActivatedEventArgsWithCallerPackageFamilyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileActivatedEventArgsWithCallerPackageFamilyName> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFileActivatedEventArgsWithCallerPackageFamilyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileActivatedEventArgsWithCallerPackageFamilyName> for ::windows::core::IInspectable {
-    fn from(value: &IFileActivatedEventArgsWithCallerPackageFamilyName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileActivatedEventArgsWithCallerPackageFamilyName, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IFileActivatedEventArgsWithCallerPackageFamilyName> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IFileActivatedEventArgsWithCallerPackageFamilyName) -> ::windows::core::Result<Self> {
@@ -3886,36 +3045,7 @@ impl IFileActivatedEventArgsWithNeighboringFiles {
         }
     }
 }
-impl ::core::convert::From<IFileActivatedEventArgsWithNeighboringFiles> for ::windows::core::IUnknown {
-    fn from(value: IFileActivatedEventArgsWithNeighboringFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileActivatedEventArgsWithNeighboringFiles> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileActivatedEventArgsWithNeighboringFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileActivatedEventArgsWithNeighboringFiles> for ::windows::core::IUnknown {
-    fn from(value: &IFileActivatedEventArgsWithNeighboringFiles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileActivatedEventArgsWithNeighboringFiles> for ::windows::core::IInspectable {
-    fn from(value: IFileActivatedEventArgsWithNeighboringFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileActivatedEventArgsWithNeighboringFiles> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFileActivatedEventArgsWithNeighboringFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileActivatedEventArgsWithNeighboringFiles> for ::windows::core::IInspectable {
-    fn from(value: &IFileActivatedEventArgsWithNeighboringFiles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileActivatedEventArgsWithNeighboringFiles, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IFileActivatedEventArgsWithNeighboringFiles> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IFileActivatedEventArgsWithNeighboringFiles) -> ::windows::core::Result<Self> {
@@ -4027,36 +3157,7 @@ impl IFileOpenPickerActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IFileOpenPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IFileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileOpenPickerActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileOpenPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IFileOpenPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileOpenPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IFileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileOpenPickerActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileOpenPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IFileOpenPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileOpenPickerActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IFileOpenPickerActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IFileOpenPickerActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -4126,36 +3227,7 @@ impl IFileOpenPickerActivatedEventArgs2 {
         }
     }
 }
-impl ::core::convert::From<IFileOpenPickerActivatedEventArgs2> for ::windows::core::IUnknown {
-    fn from(value: IFileOpenPickerActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileOpenPickerActivatedEventArgs2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileOpenPickerActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileOpenPickerActivatedEventArgs2> for ::windows::core::IUnknown {
-    fn from(value: &IFileOpenPickerActivatedEventArgs2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileOpenPickerActivatedEventArgs2> for ::windows::core::IInspectable {
-    fn from(value: IFileOpenPickerActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileOpenPickerActivatedEventArgs2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFileOpenPickerActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileOpenPickerActivatedEventArgs2> for ::windows::core::IInspectable {
-    fn from(value: &IFileOpenPickerActivatedEventArgs2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileOpenPickerActivatedEventArgs2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IFileOpenPickerActivatedEventArgs2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4238,41 +3310,7 @@ impl IFileOpenPickerContinuationEventArgs {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<IFileOpenPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IFileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IFileOpenPickerContinuationEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IFileOpenPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IFileOpenPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<IFileOpenPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IFileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IFileOpenPickerContinuationEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IFileOpenPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IFileOpenPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileOpenPickerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<IFileOpenPickerContinuationEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -4398,36 +3436,7 @@ impl IFileSavePickerActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IFileSavePickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IFileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileSavePickerActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileSavePickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IFileSavePickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileSavePickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IFileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileSavePickerActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileSavePickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IFileSavePickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSavePickerActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IFileSavePickerActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IFileSavePickerActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -4504,36 +3513,7 @@ impl IFileSavePickerActivatedEventArgs2 {
         }
     }
 }
-impl ::core::convert::From<IFileSavePickerActivatedEventArgs2> for ::windows::core::IUnknown {
-    fn from(value: IFileSavePickerActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileSavePickerActivatedEventArgs2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSavePickerActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileSavePickerActivatedEventArgs2> for ::windows::core::IUnknown {
-    fn from(value: &IFileSavePickerActivatedEventArgs2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileSavePickerActivatedEventArgs2> for ::windows::core::IInspectable {
-    fn from(value: IFileSavePickerActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileSavePickerActivatedEventArgs2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFileSavePickerActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileSavePickerActivatedEventArgs2> for ::windows::core::IInspectable {
-    fn from(value: &IFileSavePickerActivatedEventArgs2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSavePickerActivatedEventArgs2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IFileSavePickerActivatedEventArgs2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4617,41 +3597,7 @@ impl IFileSavePickerContinuationEventArgs {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<IFileSavePickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IFileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IFileSavePickerContinuationEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IFileSavePickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IFileSavePickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<IFileSavePickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IFileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IFileSavePickerContinuationEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IFileSavePickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IFileSavePickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSavePickerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<IFileSavePickerContinuationEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -4789,41 +3735,7 @@ impl IFolderPickerContinuationEventArgs {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<IFolderPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IFolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IFolderPickerContinuationEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IFolderPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IFolderPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<IFolderPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IFolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IFolderPickerContinuationEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IFolderPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IFolderPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderPickerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<IFolderPickerContinuationEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -4954,36 +3866,7 @@ impl ILaunchActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<ILaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ILaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILaunchActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ILaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ILaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILaunchActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ILaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILaunchActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ILaunchActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ILaunchActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -5086,36 +3969,7 @@ impl ILaunchActivatedEventArgs2 {
         }
     }
 }
-impl ::core::convert::From<ILaunchActivatedEventArgs2> for ::windows::core::IUnknown {
-    fn from(value: ILaunchActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILaunchActivatedEventArgs2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILaunchActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILaunchActivatedEventArgs2> for ::windows::core::IUnknown {
-    fn from(value: &ILaunchActivatedEventArgs2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILaunchActivatedEventArgs2> for ::windows::core::IInspectable {
-    fn from(value: ILaunchActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILaunchActivatedEventArgs2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILaunchActivatedEventArgs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILaunchActivatedEventArgs2> for ::windows::core::IInspectable {
-    fn from(value: &ILaunchActivatedEventArgs2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILaunchActivatedEventArgs2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ILaunchActivatedEventArgs2> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ILaunchActivatedEventArgs2) -> ::windows::core::Result<Self> {
@@ -5222,36 +4076,7 @@ impl ILockScreenActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<ILockScreenActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ILockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILockScreenActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILockScreenActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ILockScreenActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILockScreenActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ILockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILockScreenActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILockScreenActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ILockScreenActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILockScreenActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ILockScreenActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ILockScreenActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -5355,36 +4180,7 @@ impl ILockScreenCallActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<ILockScreenCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ILockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILockScreenCallActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILockScreenCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ILockScreenCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILockScreenCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ILockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILockScreenCallActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILockScreenCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ILockScreenCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILockScreenCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ILockScreenCallActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ILockScreenCallActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -5494,36 +4290,7 @@ impl IPhoneCallActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IPhoneCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IPhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhoneCallActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhoneCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IPhoneCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPhoneCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IPhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhoneCallActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhoneCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IPhoneCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhoneCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPhoneCallActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IPhoneCallActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -5611,36 +4378,7 @@ impl IPickerReturnedActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IPickerReturnedActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IPickerReturnedActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPickerReturnedActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPickerReturnedActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPickerReturnedActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IPickerReturnedActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPickerReturnedActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IPickerReturnedActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPickerReturnedActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPickerReturnedActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPickerReturnedActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IPickerReturnedActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPickerReturnedActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPickerReturnedActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IPickerReturnedActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -5728,36 +4466,7 @@ impl IPrelaunchActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IPrelaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IPrelaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrelaunchActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrelaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrelaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IPrelaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrelaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IPrelaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrelaunchActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrelaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrelaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IPrelaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrelaunchActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPrelaunchActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IPrelaunchActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -5847,36 +4556,7 @@ impl IPrint3DWorkflowActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IPrint3DWorkflowActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IPrint3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrint3DWorkflowActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrint3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrint3DWorkflowActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IPrint3DWorkflowActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrint3DWorkflowActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IPrint3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrint3DWorkflowActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrint3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrint3DWorkflowActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IPrint3DWorkflowActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrint3DWorkflowActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPrint3DWorkflowActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IPrint3DWorkflowActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -5969,36 +4649,7 @@ impl IPrintTaskSettingsActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IPrintTaskSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IPrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTaskSettingsActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTaskSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IPrintTaskSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintTaskSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IPrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTaskSettingsActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTaskSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IPrintTaskSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintTaskSettingsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPrintTaskSettingsActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IPrintTaskSettingsActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -6091,36 +4742,7 @@ impl IProtocolActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IProtocolActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtocolActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtocolActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IProtocolActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IProtocolActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtocolActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtocolActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IProtocolActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProtocolActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IProtocolActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IProtocolActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -6220,36 +4842,7 @@ impl IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData {
         }
     }
 }
-impl ::core::convert::From<IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData> for ::windows::core::IUnknown {
-    fn from(value: IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData> for ::windows::core::IUnknown {
-    fn from(value: &IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData> for ::windows::core::IInspectable {
-    fn from(value: IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData> for ::windows::core::IInspectable {
-    fn from(value: &IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData) -> ::windows::core::Result<Self> {
@@ -6343,36 +4936,7 @@ impl IProtocolForResultsActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IProtocolForResultsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtocolForResultsActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtocolForResultsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IProtocolForResultsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IProtocolForResultsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtocolForResultsActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtocolForResultsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IProtocolForResultsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProtocolForResultsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IProtocolForResultsActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IProtocolForResultsActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -6463,36 +5027,7 @@ impl IRestrictedLaunchActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IRestrictedLaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IRestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRestrictedLaunchActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRestrictedLaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IRestrictedLaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRestrictedLaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IRestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRestrictedLaunchActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IRestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRestrictedLaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IRestrictedLaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRestrictedLaunchActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IRestrictedLaunchActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IRestrictedLaunchActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -6587,36 +5122,7 @@ impl ISearchActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<ISearchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ISearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ISearchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISearchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ISearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ISearchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ISearchActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ISearchActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -6686,36 +5192,7 @@ impl ISearchActivatedEventArgsWithLinguisticDetails {
         }
     }
 }
-impl ::core::convert::From<ISearchActivatedEventArgsWithLinguisticDetails> for ::windows::core::IUnknown {
-    fn from(value: ISearchActivatedEventArgsWithLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchActivatedEventArgsWithLinguisticDetails> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchActivatedEventArgsWithLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchActivatedEventArgsWithLinguisticDetails> for ::windows::core::IUnknown {
-    fn from(value: &ISearchActivatedEventArgsWithLinguisticDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISearchActivatedEventArgsWithLinguisticDetails> for ::windows::core::IInspectable {
-    fn from(value: ISearchActivatedEventArgsWithLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchActivatedEventArgsWithLinguisticDetails> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISearchActivatedEventArgsWithLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchActivatedEventArgsWithLinguisticDetails> for ::windows::core::IInspectable {
-    fn from(value: &ISearchActivatedEventArgsWithLinguisticDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchActivatedEventArgsWithLinguisticDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISearchActivatedEventArgsWithLinguisticDetails {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6789,36 +5266,7 @@ impl IShareTargetActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IShareTargetActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShareTargetActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShareTargetActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IShareTargetActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IShareTargetActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShareTargetActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShareTargetActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IShareTargetActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShareTargetActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IShareTargetActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IShareTargetActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -6935,36 +5383,7 @@ impl IStartupTaskActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IStartupTaskActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IStartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStartupTaskActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStartupTaskActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IStartupTaskActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStartupTaskActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IStartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStartupTaskActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStartupTaskActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IStartupTaskActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStartupTaskActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IStartupTaskActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IStartupTaskActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -7079,36 +5498,7 @@ impl IToastNotificationActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IToastNotificationActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IToastNotificationActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IToastNotificationActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IToastNotificationActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IToastNotificationActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IToastNotificationActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IToastNotificationActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IToastNotificationActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IToastNotificationActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IToastNotificationActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IToastNotificationActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -7202,36 +5592,7 @@ impl IUserDataAccountProviderActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IUserDataAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IUserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserDataAccountProviderActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserDataAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IUserDataAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUserDataAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IUserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserDataAccountProviderActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IUserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserDataAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IUserDataAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserDataAccountProviderActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IUserDataAccountProviderActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IUserDataAccountProviderActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -7324,36 +5685,7 @@ impl IViewSwitcherProvider {
         }
     }
 }
-impl ::core::convert::From<IViewSwitcherProvider> for ::windows::core::IUnknown {
-    fn from(value: IViewSwitcherProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewSwitcherProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IViewSwitcherProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewSwitcherProvider> for ::windows::core::IUnknown {
-    fn from(value: &IViewSwitcherProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IViewSwitcherProvider> for ::windows::core::IInspectable {
-    fn from(value: IViewSwitcherProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewSwitcherProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IViewSwitcherProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewSwitcherProvider> for ::windows::core::IInspectable {
-    fn from(value: &IViewSwitcherProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IViewSwitcherProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IViewSwitcherProvider> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IViewSwitcherProvider) -> ::windows::core::Result<Self> {
@@ -7446,36 +5778,7 @@ impl IVoiceCommandActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IVoiceCommandActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IVoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVoiceCommandActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVoiceCommandActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IVoiceCommandActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVoiceCommandActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IVoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVoiceCommandActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVoiceCommandActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IVoiceCommandActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVoiceCommandActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IVoiceCommandActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IVoiceCommandActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -7582,36 +5885,7 @@ impl IWalletActionActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IWalletActionActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IWalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWalletActionActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWalletActionActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IWalletActionActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWalletActionActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IWalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWalletActionActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWalletActionActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IWalletActionActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWalletActionActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IWalletActionActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IWalletActionActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -7706,36 +5980,7 @@ impl IWebAccountProviderActivatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IWebAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IWebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderActivatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IWebAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IWebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderActivatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IWebAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAccountProviderActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IWebAccountProviderActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IWebAccountProviderActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -7837,36 +6082,7 @@ impl IWebAuthenticationBrokerContinuationEventArgs {
         }
     }
 }
-impl ::core::convert::From<IWebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAuthenticationBrokerContinuationEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAuthenticationBrokerContinuationEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAuthenticationBrokerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IWebAuthenticationBrokerContinuationEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: IWebAuthenticationBrokerContinuationEventArgs) -> ::windows::core::Result<Self> {
@@ -8026,36 +6242,7 @@ unsafe impl ::windows::core::Interface for AppointmentsProviderAddAppointmentAct
 impl ::windows::core::RuntimeName for AppointmentsProviderAddAppointmentActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.AppointmentsProviderAddAppointmentActivatedEventArgs";
 }
-impl ::core::convert::From<AppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderAddAppointmentActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderAddAppointmentActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentsProviderAddAppointmentActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AppointmentsProviderAddAppointmentActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: AppointmentsProviderAddAppointmentActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -8217,36 +6404,7 @@ unsafe impl ::windows::core::Interface for AppointmentsProviderRemoveAppointment
 impl ::windows::core::RuntimeName for AppointmentsProviderRemoveAppointmentActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.AppointmentsProviderRemoveAppointmentActivatedEventArgs";
 }
-impl ::core::convert::From<AppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderRemoveAppointmentActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderRemoveAppointmentActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentsProviderRemoveAppointmentActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AppointmentsProviderRemoveAppointmentActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: AppointmentsProviderRemoveAppointmentActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -8408,36 +6566,7 @@ unsafe impl ::windows::core::Interface for AppointmentsProviderReplaceAppointmen
 impl ::windows::core::RuntimeName for AppointmentsProviderReplaceAppointmentActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.AppointmentsProviderReplaceAppointmentActivatedEventArgs";
 }
-impl ::core::convert::From<AppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderReplaceAppointmentActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderReplaceAppointmentActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentsProviderReplaceAppointmentActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AppointmentsProviderReplaceAppointmentActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: AppointmentsProviderReplaceAppointmentActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -8613,36 +6742,7 @@ unsafe impl ::windows::core::Interface for AppointmentsProviderShowAppointmentDe
 impl ::windows::core::RuntimeName for AppointmentsProviderShowAppointmentDetailsActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.AppointmentsProviderShowAppointmentDetailsActivatedEventArgs";
 }
-impl ::core::convert::From<AppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentsProviderShowAppointmentDetailsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: AppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -8813,36 +6913,7 @@ unsafe impl ::windows::core::Interface for AppointmentsProviderShowTimeFrameActi
 impl ::windows::core::RuntimeName for AppointmentsProviderShowTimeFrameActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.AppointmentsProviderShowTimeFrameActivatedEventArgs";
 }
-impl ::core::convert::From<AppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderShowTimeFrameActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentsProviderShowTimeFrameActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentsProviderShowTimeFrameActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AppointmentsProviderShowTimeFrameActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: AppointmentsProviderShowTimeFrameActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -8967,36 +7038,7 @@ unsafe impl ::windows::core::Interface for BackgroundActivatedEventArgs {
 impl ::windows::core::RuntimeName for BackgroundActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.BackgroundActivatedEventArgs";
 }
-impl ::core::convert::From<BackgroundActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BackgroundActivatedEventArgs> for IBackgroundActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: BackgroundActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -9092,36 +7134,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerPreviewActivatedEventAr
 impl ::windows::core::RuntimeName for BarcodeScannerPreviewActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.BarcodeScannerPreviewActivatedEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerPreviewActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerPreviewActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerPreviewActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerPreviewActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerPreviewActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BarcodeScannerPreviewActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: BarcodeScannerPreviewActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -9257,36 +7270,7 @@ unsafe impl ::windows::core::Interface for CachedFileUpdaterActivatedEventArgs {
 impl ::windows::core::RuntimeName for CachedFileUpdaterActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.CachedFileUpdaterActivatedEventArgs";
 }
-impl ::core::convert::From<CachedFileUpdaterActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CachedFileUpdaterActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CachedFileUpdaterActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CachedFileUpdaterActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CachedFileUpdaterActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CachedFileUpdaterActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: CachedFileUpdaterActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -9418,36 +7402,7 @@ unsafe impl ::windows::core::Interface for CameraSettingsActivatedEventArgs {
 impl ::windows::core::RuntimeName for CameraSettingsActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.CameraSettingsActivatedEventArgs";
 }
-impl ::core::convert::From<CameraSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CameraSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraSettingsActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CameraSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CameraSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraSettingsActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CameraSettingsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CameraSettingsActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: CameraSettingsActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -9562,36 +7517,7 @@ unsafe impl ::windows::core::Interface for CommandLineActivatedEventArgs {
 impl ::windows::core::RuntimeName for CommandLineActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.CommandLineActivatedEventArgs";
 }
-impl ::core::convert::From<CommandLineActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CommandLineActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CommandLineActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CommandLineActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CommandLineActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CommandLineActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CommandLineActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CommandLineActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CommandLineActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CommandLineActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: CommandLineActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -9722,36 +7648,7 @@ unsafe impl ::windows::core::Interface for CommandLineActivationOperation {
 impl ::windows::core::RuntimeName for CommandLineActivationOperation {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.CommandLineActivationOperation";
 }
-impl ::core::convert::From<CommandLineActivationOperation> for ::windows::core::IUnknown {
-    fn from(value: CommandLineActivationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CommandLineActivationOperation> for ::windows::core::IUnknown {
-    fn from(value: &CommandLineActivationOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CommandLineActivationOperation> for &::windows::core::IUnknown {
-    fn from(value: &CommandLineActivationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CommandLineActivationOperation> for ::windows::core::IInspectable {
-    fn from(value: CommandLineActivationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CommandLineActivationOperation> for ::windows::core::IInspectable {
-    fn from(value: &CommandLineActivationOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CommandLineActivationOperation> for &::windows::core::IInspectable {
-    fn from(value: &CommandLineActivationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CommandLineActivationOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CommandLineActivationOperation {}
 unsafe impl ::core::marker::Sync for CommandLineActivationOperation {}
 #[doc = "*Required features: `\"ApplicationModel_Activation\"`*"]
@@ -9842,36 +7739,7 @@ unsafe impl ::windows::core::Interface for ContactCallActivatedEventArgs {
 impl ::windows::core::RuntimeName for ContactCallActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.ContactCallActivatedEventArgs";
 }
-impl ::core::convert::From<ContactCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactCallActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactCallActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactCallActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactCallActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -10014,36 +7882,7 @@ unsafe impl ::windows::core::Interface for ContactMapActivatedEventArgs {
 impl ::windows::core::RuntimeName for ContactMapActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.ContactMapActivatedEventArgs";
 }
-impl ::core::convert::From<ContactMapActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactMapActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactMapActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactMapActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactMapActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactMapActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactMapActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactMapActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactMapActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactMapActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactMapActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -10191,36 +8030,7 @@ unsafe impl ::windows::core::Interface for ContactMessageActivatedEventArgs {
 impl ::windows::core::RuntimeName for ContactMessageActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.ContactMessageActivatedEventArgs";
 }
-impl ::core::convert::From<ContactMessageActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactMessageActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactMessageActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactMessageActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactMessageActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactMessageActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactMessageActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactMessageActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactMessageActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactMessageActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactMessageActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -10365,36 +8175,7 @@ unsafe impl ::windows::core::Interface for ContactPanelActivatedEventArgs {
 impl ::windows::core::RuntimeName for ContactPanelActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.ContactPanelActivatedEventArgs";
 }
-impl ::core::convert::From<ContactPanelActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPanelActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactPanelActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPanelActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactPanelActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPanelActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactPanelActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPanelActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactPanelActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactPanelActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactPanelActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -10521,36 +8302,7 @@ unsafe impl ::windows::core::Interface for ContactPickerActivatedEventArgs {
 impl ::windows::core::RuntimeName for ContactPickerActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.ContactPickerActivatedEventArgs";
 }
-impl ::core::convert::From<ContactPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPickerActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPickerActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactPickerActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactPickerActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactPickerActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -10679,36 +8431,7 @@ unsafe impl ::windows::core::Interface for ContactPostActivatedEventArgs {
 impl ::windows::core::RuntimeName for ContactPostActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.ContactPostActivatedEventArgs";
 }
-impl ::core::convert::From<ContactPostActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPostActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactPostActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPostActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactPostActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPostActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactPostActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPostActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactPostActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactPostActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactPostActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -10856,36 +8579,7 @@ unsafe impl ::windows::core::Interface for ContactVideoCallActivatedEventArgs {
 impl ::windows::core::RuntimeName for ContactVideoCallActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.ContactVideoCallActivatedEventArgs";
 }
-impl ::core::convert::From<ContactVideoCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactVideoCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactVideoCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactVideoCallActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactVideoCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactVideoCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactVideoCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactVideoCallActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactVideoCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactVideoCallActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactVideoCallActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -11042,36 +8736,7 @@ unsafe impl ::windows::core::Interface for DeviceActivatedEventArgs {
 impl ::windows::core::RuntimeName for DeviceActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.DeviceActivatedEventArgs";
 }
-impl ::core::convert::From<DeviceActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DeviceActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DeviceActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DeviceActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: DeviceActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -11245,36 +8910,7 @@ unsafe impl ::windows::core::Interface for DevicePairingActivatedEventArgs {
 impl ::windows::core::RuntimeName for DevicePairingActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.DevicePairingActivatedEventArgs";
 }
-impl ::core::convert::From<DevicePairingActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePairingActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DevicePairingActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePairingActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DevicePairingActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePairingActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DevicePairingActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePairingActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DevicePairingActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DevicePairingActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: DevicePairingActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -11438,36 +9074,7 @@ unsafe impl ::windows::core::Interface for DialReceiverActivatedEventArgs {
 impl ::windows::core::RuntimeName for DialReceiverActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.DialReceiverActivatedEventArgs";
 }
-impl ::core::convert::From<DialReceiverActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialReceiverActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DialReceiverActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialReceiverActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DialReceiverActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialReceiverActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DialReceiverActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialReceiverActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DialReceiverActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DialReceiverActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: DialReceiverActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -11699,36 +9306,7 @@ unsafe impl ::windows::core::Interface for FileActivatedEventArgs {
 impl ::windows::core::RuntimeName for FileActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.FileActivatedEventArgs";
 }
-impl ::core::convert::From<FileActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: FileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &FileActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &FileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: FileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &FileActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &FileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<FileActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: FileActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -11947,36 +9525,7 @@ unsafe impl ::windows::core::Interface for FileOpenPickerActivatedEventArgs {
 impl ::windows::core::RuntimeName for FileOpenPickerActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.FileOpenPickerActivatedEventArgs";
 }
-impl ::core::convert::From<FileOpenPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: FileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileOpenPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &FileOpenPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileOpenPickerActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &FileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileOpenPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: FileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileOpenPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &FileOpenPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileOpenPickerActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &FileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileOpenPickerActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<FileOpenPickerActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: FileOpenPickerActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -12151,41 +9700,7 @@ impl ::windows::core::RuntimeName for FileOpenPickerContinuationEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.FileOpenPickerContinuationEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<FileOpenPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: FileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileOpenPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &FileOpenPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileOpenPickerContinuationEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &FileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<FileOpenPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: FileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileOpenPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &FileOpenPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileOpenPickerContinuationEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &FileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileOpenPickerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<FileOpenPickerContinuationEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -12368,36 +9883,7 @@ unsafe impl ::windows::core::Interface for FileSavePickerActivatedEventArgs {
 impl ::windows::core::RuntimeName for FileSavePickerActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.FileSavePickerActivatedEventArgs";
 }
-impl ::core::convert::From<FileSavePickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: FileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileSavePickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &FileSavePickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileSavePickerActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &FileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileSavePickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: FileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileSavePickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &FileSavePickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileSavePickerActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &FileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileSavePickerActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<FileSavePickerActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: FileSavePickerActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -12572,41 +10058,7 @@ impl ::windows::core::RuntimeName for FileSavePickerContinuationEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.FileSavePickerContinuationEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<FileSavePickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: FileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileSavePickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &FileSavePickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileSavePickerContinuationEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &FileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<FileSavePickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: FileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileSavePickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &FileSavePickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileSavePickerContinuationEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &FileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileSavePickerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<FileSavePickerContinuationEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -12795,41 +10247,7 @@ impl ::windows::core::RuntimeName for FolderPickerContinuationEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.FolderPickerContinuationEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<FolderPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: FolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FolderPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &FolderPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FolderPickerContinuationEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &FolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<FolderPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: FolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FolderPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &FolderPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FolderPickerContinuationEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &FolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FolderPickerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<FolderPickerContinuationEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -13033,36 +10451,7 @@ unsafe impl ::windows::core::Interface for LaunchActivatedEventArgs {
 impl ::windows::core::RuntimeName for LaunchActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.LaunchActivatedEventArgs";
 }
-impl ::core::convert::From<LaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LaunchActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LaunchActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LaunchActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LaunchActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: LaunchActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -13272,36 +10661,7 @@ unsafe impl ::windows::core::Interface for LockScreenActivatedEventArgs {
 impl ::windows::core::RuntimeName for LockScreenActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.LockScreenActivatedEventArgs";
 }
-impl ::core::convert::From<LockScreenActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LockScreenActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LockScreenActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LockScreenActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LockScreenActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LockScreenActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: LockScreenActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -13458,36 +10818,7 @@ unsafe impl ::windows::core::Interface for LockScreenCallActivatedEventArgs {
 impl ::windows::core::RuntimeName for LockScreenCallActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.LockScreenCallActivatedEventArgs";
 }
-impl ::core::convert::From<LockScreenCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LockScreenCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenCallActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LockScreenCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LockScreenCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenCallActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LockScreenCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LockScreenCallActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: LockScreenCallActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -13643,36 +10974,7 @@ unsafe impl ::windows::core::Interface for LockScreenComponentActivatedEventArgs
 impl ::windows::core::RuntimeName for LockScreenComponentActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.LockScreenComponentActivatedEventArgs";
 }
-impl ::core::convert::From<LockScreenComponentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LockScreenComponentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenComponentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LockScreenComponentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenComponentActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LockScreenComponentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LockScreenComponentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LockScreenComponentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenComponentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LockScreenComponentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenComponentActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LockScreenComponentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LockScreenComponentActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LockScreenComponentActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: LockScreenComponentActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -13768,36 +11070,7 @@ unsafe impl ::windows::core::Interface for PhoneCallActivatedEventArgs {
 impl ::windows::core::RuntimeName for PhoneCallActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.PhoneCallActivatedEventArgs";
 }
-impl ::core::convert::From<PhoneCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PhoneCallActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: PhoneCallActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -13922,36 +11195,7 @@ unsafe impl ::windows::core::Interface for PickerReturnedActivatedEventArgs {
 impl ::windows::core::RuntimeName for PickerReturnedActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.PickerReturnedActivatedEventArgs";
 }
-impl ::core::convert::From<PickerReturnedActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PickerReturnedActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PickerReturnedActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PickerReturnedActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PickerReturnedActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PickerReturnedActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PickerReturnedActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PickerReturnedActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PickerReturnedActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PickerReturnedActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PickerReturnedActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PickerReturnedActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PickerReturnedActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PickerReturnedActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: PickerReturnedActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -14059,36 +11303,7 @@ unsafe impl ::windows::core::Interface for Print3DWorkflowActivatedEventArgs {
 impl ::windows::core::RuntimeName for Print3DWorkflowActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.Print3DWorkflowActivatedEventArgs";
 }
-impl ::core::convert::From<Print3DWorkflowActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: Print3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &Print3DWorkflowActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &Print3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DWorkflowActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: Print3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &Print3DWorkflowActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &Print3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DWorkflowActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Print3DWorkflowActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: Print3DWorkflowActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -14196,36 +11411,7 @@ unsafe impl ::windows::core::Interface for PrintTaskSettingsActivatedEventArgs {
 impl ::windows::core::RuntimeName for PrintTaskSettingsActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.PrintTaskSettingsActivatedEventArgs";
 }
-impl ::core::convert::From<PrintTaskSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskSettingsActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskSettingsActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskSettingsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintTaskSettingsActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintTaskSettingsActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -14374,36 +11560,7 @@ unsafe impl ::windows::core::Interface for ProtocolActivatedEventArgs {
 impl ::windows::core::RuntimeName for ProtocolActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.ProtocolActivatedEventArgs";
 }
-impl ::core::convert::From<ProtocolActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtocolActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ProtocolActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtocolActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtocolActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtocolActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ProtocolActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtocolActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtocolActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ProtocolActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ProtocolActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -14637,36 +11794,7 @@ unsafe impl ::windows::core::Interface for ProtocolForResultsActivatedEventArgs 
 impl ::windows::core::RuntimeName for ProtocolForResultsActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.ProtocolForResultsActivatedEventArgs";
 }
-impl ::core::convert::From<ProtocolForResultsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtocolForResultsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ProtocolForResultsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtocolForResultsActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtocolForResultsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtocolForResultsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ProtocolForResultsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtocolForResultsActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtocolForResultsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ProtocolForResultsActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ProtocolForResultsActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -14876,36 +12004,7 @@ unsafe impl ::windows::core::Interface for RestrictedLaunchActivatedEventArgs {
 impl ::windows::core::RuntimeName for RestrictedLaunchActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.RestrictedLaunchActivatedEventArgs";
 }
-impl ::core::convert::From<RestrictedLaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RestrictedLaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RestrictedLaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RestrictedLaunchActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RestrictedLaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RestrictedLaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RestrictedLaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RestrictedLaunchActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RestrictedLaunchActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RestrictedLaunchActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: RestrictedLaunchActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -15071,36 +12170,7 @@ unsafe impl ::windows::core::Interface for SearchActivatedEventArgs {
 impl ::windows::core::RuntimeName for SearchActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.SearchActivatedEventArgs";
 }
-impl ::core::convert::From<SearchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SearchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SearchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SearchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SearchActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: SearchActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -15293,36 +12363,7 @@ unsafe impl ::windows::core::Interface for ShareTargetActivatedEventArgs {
 impl ::windows::core::RuntimeName for ShareTargetActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.ShareTargetActivatedEventArgs";
 }
-impl ::core::convert::From<ShareTargetActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareTargetActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ShareTargetActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareTargetActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShareTargetActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareTargetActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ShareTargetActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareTargetActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShareTargetActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ShareTargetActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ShareTargetActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -15443,36 +12484,7 @@ unsafe impl ::windows::core::Interface for SplashScreen {
 impl ::windows::core::RuntimeName for SplashScreen {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.SplashScreen";
 }
-impl ::core::convert::From<SplashScreen> for ::windows::core::IUnknown {
-    fn from(value: SplashScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SplashScreen> for ::windows::core::IUnknown {
-    fn from(value: &SplashScreen) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SplashScreen> for &::windows::core::IUnknown {
-    fn from(value: &SplashScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SplashScreen> for ::windows::core::IInspectable {
-    fn from(value: SplashScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SplashScreen> for ::windows::core::IInspectable {
-    fn from(value: &SplashScreen) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SplashScreen> for &::windows::core::IInspectable {
-    fn from(value: &SplashScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SplashScreen, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Activation\"`*"]
 #[repr(transparent)]
 pub struct StartupTaskActivatedEventArgs(::windows::core::IUnknown);
@@ -15547,36 +12559,7 @@ unsafe impl ::windows::core::Interface for StartupTaskActivatedEventArgs {
 impl ::windows::core::RuntimeName for StartupTaskActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.StartupTaskActivatedEventArgs";
 }
-impl ::core::convert::From<StartupTaskActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: StartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StartupTaskActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &StartupTaskActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StartupTaskActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &StartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StartupTaskActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: StartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StartupTaskActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &StartupTaskActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StartupTaskActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &StartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StartupTaskActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StartupTaskActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: StartupTaskActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -15682,36 +12665,7 @@ unsafe impl ::windows::core::Interface for TileActivatedInfo {
 impl ::windows::core::RuntimeName for TileActivatedInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.TileActivatedInfo";
 }
-impl ::core::convert::From<TileActivatedInfo> for ::windows::core::IUnknown {
-    fn from(value: TileActivatedInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileActivatedInfo> for ::windows::core::IUnknown {
-    fn from(value: &TileActivatedInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileActivatedInfo> for &::windows::core::IUnknown {
-    fn from(value: &TileActivatedInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TileActivatedInfo> for ::windows::core::IInspectable {
-    fn from(value: TileActivatedInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileActivatedInfo> for ::windows::core::IInspectable {
-    fn from(value: &TileActivatedInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileActivatedInfo> for &::windows::core::IInspectable {
-    fn from(value: &TileActivatedInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TileActivatedInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TileActivatedInfo {}
 unsafe impl ::core::marker::Sync for TileActivatedInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Activation\"`*"]
@@ -15804,36 +12758,7 @@ unsafe impl ::windows::core::Interface for ToastNotificationActivatedEventArgs {
 impl ::windows::core::RuntimeName for ToastNotificationActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.ToastNotificationActivatedEventArgs";
 }
-impl ::core::convert::From<ToastNotificationActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ToastNotificationActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastNotificationActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ToastNotificationActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastNotificationActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ToastNotificationActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: ToastNotificationActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -15979,36 +12904,7 @@ unsafe impl ::windows::core::Interface for UserDataAccountProviderActivatedEvent
 impl ::windows::core::RuntimeName for UserDataAccountProviderActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.UserDataAccountProviderActivatedEventArgs";
 }
-impl ::core::convert::From<UserDataAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserDataAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserDataAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataAccountProviderActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<UserDataAccountProviderActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: UserDataAccountProviderActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -16125,36 +13021,7 @@ unsafe impl ::windows::core::Interface for VoiceCommandActivatedEventArgs {
 impl ::windows::core::RuntimeName for VoiceCommandActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.VoiceCommandActivatedEventArgs";
 }
-impl ::core::convert::From<VoiceCommandActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: VoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &VoiceCommandActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &VoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceCommandActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: VoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &VoiceCommandActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &VoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceCommandActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VoiceCommandActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: VoiceCommandActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -16295,36 +13162,7 @@ unsafe impl ::windows::core::Interface for WalletActionActivatedEventArgs {
 impl ::windows::core::RuntimeName for WalletActionActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.WalletActionActivatedEventArgs";
 }
-impl ::core::convert::From<WalletActionActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletActionActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WalletActionActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletActionActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WalletActionActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletActionActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WalletActionActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletActionActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WalletActionActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WalletActionActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: WalletActionActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -16441,36 +13279,7 @@ unsafe impl ::windows::core::Interface for WebAccountProviderActivatedEventArgs 
 impl ::windows::core::RuntimeName for WebAccountProviderActivatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.WebAccountProviderActivatedEventArgs";
 }
-impl ::core::convert::From<WebAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountProviderActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebAccountProviderActivatedEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: WebAccountProviderActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -16606,36 +13415,7 @@ unsafe impl ::windows::core::Interface for WebAuthenticationBrokerContinuationEv
 impl ::windows::core::RuntimeName for WebAuthenticationBrokerContinuationEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.WebAuthenticationBrokerContinuationEventArgs";
 }
-impl ::core::convert::From<WebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebAuthenticationBrokerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAuthenticationBrokerContinuationEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebAuthenticationBrokerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAuthenticationBrokerContinuationEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAuthenticationBrokerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebAuthenticationBrokerContinuationEventArgs> for IActivatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: WebAuthenticationBrokerContinuationEventArgs) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/ApplicationModel/AppExtensions/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/AppExtensions/mod.rs
@@ -302,36 +302,7 @@ unsafe impl ::windows::core::Interface for AppExtension {
 impl ::windows::core::RuntimeName for AppExtension {
     const NAME: &'static str = "Windows.ApplicationModel.AppExtensions.AppExtension";
 }
-impl ::core::convert::From<AppExtension> for ::windows::core::IUnknown {
-    fn from(value: AppExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtension> for ::windows::core::IUnknown {
-    fn from(value: &AppExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtension> for &::windows::core::IUnknown {
-    fn from(value: &AppExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppExtension> for ::windows::core::IInspectable {
-    fn from(value: AppExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtension> for ::windows::core::IInspectable {
-    fn from(value: &AppExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtension> for &::windows::core::IInspectable {
-    fn from(value: &AppExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppExtension, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppExtension {}
 unsafe impl ::core::marker::Sync for AppExtension {}
 #[doc = "*Required features: `\"ApplicationModel_AppExtensions\"`*"]
@@ -475,36 +446,7 @@ unsafe impl ::windows::core::Interface for AppExtensionCatalog {
 impl ::windows::core::RuntimeName for AppExtensionCatalog {
     const NAME: &'static str = "Windows.ApplicationModel.AppExtensions.AppExtensionCatalog";
 }
-impl ::core::convert::From<AppExtensionCatalog> for ::windows::core::IUnknown {
-    fn from(value: AppExtensionCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionCatalog> for ::windows::core::IUnknown {
-    fn from(value: &AppExtensionCatalog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionCatalog> for &::windows::core::IUnknown {
-    fn from(value: &AppExtensionCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppExtensionCatalog> for ::windows::core::IInspectable {
-    fn from(value: AppExtensionCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionCatalog> for ::windows::core::IInspectable {
-    fn from(value: &AppExtensionCatalog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionCatalog> for &::windows::core::IInspectable {
-    fn from(value: &AppExtensionCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppExtensionCatalog, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_AppExtensions\"`*"]
 #[repr(transparent)]
 pub struct AppExtensionPackageInstalledEventArgs(::windows::core::IUnknown);
@@ -565,36 +507,7 @@ unsafe impl ::windows::core::Interface for AppExtensionPackageInstalledEventArgs
 impl ::windows::core::RuntimeName for AppExtensionPackageInstalledEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.AppExtensions.AppExtensionPackageInstalledEventArgs";
 }
-impl ::core::convert::From<AppExtensionPackageInstalledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppExtensionPackageInstalledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageInstalledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppExtensionPackageInstalledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageInstalledEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppExtensionPackageInstalledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppExtensionPackageInstalledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppExtensionPackageInstalledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageInstalledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppExtensionPackageInstalledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageInstalledEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppExtensionPackageInstalledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppExtensionPackageInstalledEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppExtensionPackageInstalledEventArgs {}
 unsafe impl ::core::marker::Sync for AppExtensionPackageInstalledEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_AppExtensions\"`*"]
@@ -648,36 +561,7 @@ unsafe impl ::windows::core::Interface for AppExtensionPackageStatusChangedEvent
 impl ::windows::core::RuntimeName for AppExtensionPackageStatusChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.AppExtensions.AppExtensionPackageStatusChangedEventArgs";
 }
-impl ::core::convert::From<AppExtensionPackageStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppExtensionPackageStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppExtensionPackageStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageStatusChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppExtensionPackageStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppExtensionPackageStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppExtensionPackageStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppExtensionPackageStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageStatusChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppExtensionPackageStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppExtensionPackageStatusChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppExtensionPackageStatusChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppExtensionPackageStatusChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_AppExtensions\"`*"]
@@ -731,36 +615,7 @@ unsafe impl ::windows::core::Interface for AppExtensionPackageUninstallingEventA
 impl ::windows::core::RuntimeName for AppExtensionPackageUninstallingEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.AppExtensions.AppExtensionPackageUninstallingEventArgs";
 }
-impl ::core::convert::From<AppExtensionPackageUninstallingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppExtensionPackageUninstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUninstallingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppExtensionPackageUninstallingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUninstallingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppExtensionPackageUninstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppExtensionPackageUninstallingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppExtensionPackageUninstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUninstallingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppExtensionPackageUninstallingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUninstallingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppExtensionPackageUninstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppExtensionPackageUninstallingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppExtensionPackageUninstallingEventArgs {}
 unsafe impl ::core::marker::Sync for AppExtensionPackageUninstallingEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_AppExtensions\"`*"]
@@ -823,36 +678,7 @@ unsafe impl ::windows::core::Interface for AppExtensionPackageUpdatedEventArgs {
 impl ::windows::core::RuntimeName for AppExtensionPackageUpdatedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.AppExtensions.AppExtensionPackageUpdatedEventArgs";
 }
-impl ::core::convert::From<AppExtensionPackageUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppExtensionPackageUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppExtensionPackageUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppExtensionPackageUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppExtensionPackageUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppExtensionPackageUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppExtensionPackageUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppExtensionPackageUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppExtensionPackageUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppExtensionPackageUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for AppExtensionPackageUpdatedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_AppExtensions\"`*"]
@@ -906,36 +732,7 @@ unsafe impl ::windows::core::Interface for AppExtensionPackageUpdatingEventArgs 
 impl ::windows::core::RuntimeName for AppExtensionPackageUpdatingEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.AppExtensions.AppExtensionPackageUpdatingEventArgs";
 }
-impl ::core::convert::From<AppExtensionPackageUpdatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppExtensionPackageUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUpdatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppExtensionPackageUpdatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUpdatingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppExtensionPackageUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppExtensionPackageUpdatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppExtensionPackageUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUpdatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppExtensionPackageUpdatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExtensionPackageUpdatingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppExtensionPackageUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppExtensionPackageUpdatingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppExtensionPackageUpdatingEventArgs {}
 unsafe impl ::core::marker::Sync for AppExtensionPackageUpdatingEventArgs {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/AppService/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/AppService/mod.rs
@@ -337,36 +337,7 @@ unsafe impl ::windows::core::Interface for AppServiceClosedEventArgs {
 impl ::windows::core::RuntimeName for AppServiceClosedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.AppService.AppServiceClosedEventArgs";
 }
-impl ::core::convert::From<AppServiceClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppServiceClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppServiceClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceClosedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppServiceClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppServiceClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppServiceClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppServiceClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceClosedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppServiceClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppServiceClosedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppServiceClosedEventArgs {}
 unsafe impl ::core::marker::Sync for AppServiceClosedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_AppService\"`*"]
@@ -526,36 +497,7 @@ unsafe impl ::windows::core::Interface for AppServiceConnection {
 impl ::windows::core::RuntimeName for AppServiceConnection {
     const NAME: &'static str = "Windows.ApplicationModel.AppService.AppServiceConnection";
 }
-impl ::core::convert::From<AppServiceConnection> for ::windows::core::IUnknown {
-    fn from(value: AppServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceConnection> for ::windows::core::IUnknown {
-    fn from(value: &AppServiceConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceConnection> for &::windows::core::IUnknown {
-    fn from(value: &AppServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppServiceConnection> for ::windows::core::IInspectable {
-    fn from(value: AppServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceConnection> for ::windows::core::IInspectable {
-    fn from(value: &AppServiceConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceConnection> for &::windows::core::IInspectable {
-    fn from(value: &AppServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppServiceConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<AppServiceConnection> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -621,36 +563,7 @@ unsafe impl ::windows::core::Interface for AppServiceDeferral {
 impl ::windows::core::RuntimeName for AppServiceDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.AppService.AppServiceDeferral";
 }
-impl ::core::convert::From<AppServiceDeferral> for ::windows::core::IUnknown {
-    fn from(value: AppServiceDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceDeferral> for ::windows::core::IUnknown {
-    fn from(value: &AppServiceDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceDeferral> for &::windows::core::IUnknown {
-    fn from(value: &AppServiceDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppServiceDeferral> for ::windows::core::IInspectable {
-    fn from(value: AppServiceDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceDeferral> for ::windows::core::IInspectable {
-    fn from(value: &AppServiceDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceDeferral> for &::windows::core::IInspectable {
-    fn from(value: &AppServiceDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppServiceDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppServiceDeferral {}
 unsafe impl ::core::marker::Sync for AppServiceDeferral {}
 #[doc = "*Required features: `\"ApplicationModel_AppService\"`*"]
@@ -708,36 +621,7 @@ unsafe impl ::windows::core::Interface for AppServiceRequest {
 impl ::windows::core::RuntimeName for AppServiceRequest {
     const NAME: &'static str = "Windows.ApplicationModel.AppService.AppServiceRequest";
 }
-impl ::core::convert::From<AppServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: AppServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &AppServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceRequest> for &::windows::core::IUnknown {
-    fn from(value: &AppServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: AppServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &AppServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceRequest> for &::windows::core::IInspectable {
-    fn from(value: &AppServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppServiceRequest {}
 unsafe impl ::core::marker::Sync for AppServiceRequest {}
 #[doc = "*Required features: `\"ApplicationModel_AppService\"`*"]
@@ -791,36 +675,7 @@ unsafe impl ::windows::core::Interface for AppServiceRequestReceivedEventArgs {
 impl ::windows::core::RuntimeName for AppServiceRequestReceivedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.AppService.AppServiceRequestReceivedEventArgs";
 }
-impl ::core::convert::From<AppServiceRequestReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppServiceRequestReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceRequestReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppServiceRequestReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceRequestReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppServiceRequestReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppServiceRequestReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppServiceRequestReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceRequestReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppServiceRequestReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceRequestReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppServiceRequestReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppServiceRequestReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppServiceRequestReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for AppServiceRequestReceivedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_AppService\"`*"]
@@ -876,36 +731,7 @@ unsafe impl ::windows::core::Interface for AppServiceResponse {
 impl ::windows::core::RuntimeName for AppServiceResponse {
     const NAME: &'static str = "Windows.ApplicationModel.AppService.AppServiceResponse";
 }
-impl ::core::convert::From<AppServiceResponse> for ::windows::core::IUnknown {
-    fn from(value: AppServiceResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceResponse> for ::windows::core::IUnknown {
-    fn from(value: &AppServiceResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceResponse> for &::windows::core::IUnknown {
-    fn from(value: &AppServiceResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppServiceResponse> for ::windows::core::IInspectable {
-    fn from(value: AppServiceResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceResponse> for ::windows::core::IInspectable {
-    fn from(value: &AppServiceResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceResponse> for &::windows::core::IInspectable {
-    fn from(value: &AppServiceResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppServiceResponse, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppServiceResponse {}
 unsafe impl ::core::marker::Sync for AppServiceResponse {}
 #[doc = "*Required features: `\"ApplicationModel_AppService\"`*"]
@@ -989,36 +815,7 @@ unsafe impl ::windows::core::Interface for AppServiceTriggerDetails {
 impl ::windows::core::RuntimeName for AppServiceTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.AppService.AppServiceTriggerDetails";
 }
-impl ::core::convert::From<AppServiceTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: AppServiceTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &AppServiceTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &AppServiceTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppServiceTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: AppServiceTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppServiceTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &AppServiceTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppServiceTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &AppServiceTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppServiceTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppServiceTriggerDetails {}
 unsafe impl ::core::marker::Sync for AppServiceTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_AppService\"`*"]
@@ -1074,36 +871,7 @@ unsafe impl ::windows::core::Interface for StatelessAppServiceResponse {
 impl ::windows::core::RuntimeName for StatelessAppServiceResponse {
     const NAME: &'static str = "Windows.ApplicationModel.AppService.StatelessAppServiceResponse";
 }
-impl ::core::convert::From<StatelessAppServiceResponse> for ::windows::core::IUnknown {
-    fn from(value: StatelessAppServiceResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StatelessAppServiceResponse> for ::windows::core::IUnknown {
-    fn from(value: &StatelessAppServiceResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StatelessAppServiceResponse> for &::windows::core::IUnknown {
-    fn from(value: &StatelessAppServiceResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StatelessAppServiceResponse> for ::windows::core::IInspectable {
-    fn from(value: StatelessAppServiceResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StatelessAppServiceResponse> for ::windows::core::IInspectable {
-    fn from(value: &StatelessAppServiceResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StatelessAppServiceResponse> for &::windows::core::IInspectable {
-    fn from(value: &StatelessAppServiceResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StatelessAppServiceResponse, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StatelessAppServiceResponse {}
 unsafe impl ::core::marker::Sync for StatelessAppServiceResponse {}
 #[doc = "*Required features: `\"ApplicationModel_AppService\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/AppointmentsProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/AppointmentsProvider/mod.rs
@@ -167,36 +167,7 @@ unsafe impl ::windows::core::Interface for AddAppointmentOperation {
 impl ::windows::core::RuntimeName for AddAppointmentOperation {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentsProvider.AddAppointmentOperation";
 }
-impl ::core::convert::From<AddAppointmentOperation> for ::windows::core::IUnknown {
-    fn from(value: AddAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AddAppointmentOperation> for ::windows::core::IUnknown {
-    fn from(value: &AddAppointmentOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AddAppointmentOperation> for &::windows::core::IUnknown {
-    fn from(value: &AddAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AddAppointmentOperation> for ::windows::core::IInspectable {
-    fn from(value: AddAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AddAppointmentOperation> for ::windows::core::IInspectable {
-    fn from(value: &AddAppointmentOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AddAppointmentOperation> for &::windows::core::IInspectable {
-    fn from(value: &AddAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AddAppointmentOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AddAppointmentOperation {}
 unsafe impl ::core::marker::Sync for AddAppointmentOperation {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_AppointmentsProvider\"`*"]
@@ -322,36 +293,7 @@ unsafe impl ::windows::core::Interface for RemoveAppointmentOperation {
 impl ::windows::core::RuntimeName for RemoveAppointmentOperation {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentsProvider.RemoveAppointmentOperation";
 }
-impl ::core::convert::From<RemoveAppointmentOperation> for ::windows::core::IUnknown {
-    fn from(value: RemoveAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoveAppointmentOperation> for ::windows::core::IUnknown {
-    fn from(value: &RemoveAppointmentOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoveAppointmentOperation> for &::windows::core::IUnknown {
-    fn from(value: &RemoveAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoveAppointmentOperation> for ::windows::core::IInspectable {
-    fn from(value: RemoveAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoveAppointmentOperation> for ::windows::core::IInspectable {
-    fn from(value: &RemoveAppointmentOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoveAppointmentOperation> for &::windows::core::IInspectable {
-    fn from(value: &RemoveAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoveAppointmentOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoveAppointmentOperation {}
 unsafe impl ::core::marker::Sync for RemoveAppointmentOperation {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_AppointmentsProvider\"`*"]
@@ -437,36 +379,7 @@ unsafe impl ::windows::core::Interface for ReplaceAppointmentOperation {
 impl ::windows::core::RuntimeName for ReplaceAppointmentOperation {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentsProvider.ReplaceAppointmentOperation";
 }
-impl ::core::convert::From<ReplaceAppointmentOperation> for ::windows::core::IUnknown {
-    fn from(value: ReplaceAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ReplaceAppointmentOperation> for ::windows::core::IUnknown {
-    fn from(value: &ReplaceAppointmentOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ReplaceAppointmentOperation> for &::windows::core::IUnknown {
-    fn from(value: &ReplaceAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ReplaceAppointmentOperation> for ::windows::core::IInspectable {
-    fn from(value: ReplaceAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ReplaceAppointmentOperation> for ::windows::core::IInspectable {
-    fn from(value: &ReplaceAppointmentOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ReplaceAppointmentOperation> for &::windows::core::IInspectable {
-    fn from(value: &ReplaceAppointmentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ReplaceAppointmentOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ReplaceAppointmentOperation {}
 unsafe impl ::core::marker::Sync for ReplaceAppointmentOperation {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/DataProvider/mod.rs
@@ -477,36 +477,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarCancelMeetingReque
 impl ::windows::core::RuntimeName for AppointmentCalendarCancelMeetingRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarCancelMeetingRequest";
 }
-impl ::core::convert::From<AppointmentCalendarCancelMeetingRequest> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarCancelMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCancelMeetingRequest> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarCancelMeetingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCancelMeetingRequest> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarCancelMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarCancelMeetingRequest> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarCancelMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCancelMeetingRequest> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarCancelMeetingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCancelMeetingRequest> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarCancelMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarCancelMeetingRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarCancelMeetingRequest {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarCancelMeetingRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -562,36 +533,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarCancelMeetingReque
 impl ::windows::core::RuntimeName for AppointmentCalendarCancelMeetingRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarCancelMeetingRequestEventArgs";
 }
-impl ::core::convert::From<AppointmentCalendarCancelMeetingRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarCancelMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCancelMeetingRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarCancelMeetingRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCancelMeetingRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarCancelMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarCancelMeetingRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarCancelMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCancelMeetingRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarCancelMeetingRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCancelMeetingRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarCancelMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarCancelMeetingRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarCancelMeetingRequestEventArgs {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarCancelMeetingRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -679,36 +621,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarCreateOrUpdateAppo
 impl ::windows::core::RuntimeName for AppointmentCalendarCreateOrUpdateAppointmentRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarCreateOrUpdateAppointmentRequest";
 }
-impl ::core::convert::From<AppointmentCalendarCreateOrUpdateAppointmentRequest> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarCreateOrUpdateAppointmentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCreateOrUpdateAppointmentRequest> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarCreateOrUpdateAppointmentRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCreateOrUpdateAppointmentRequest> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarCreateOrUpdateAppointmentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarCreateOrUpdateAppointmentRequest> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarCreateOrUpdateAppointmentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCreateOrUpdateAppointmentRequest> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarCreateOrUpdateAppointmentRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCreateOrUpdateAppointmentRequest> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarCreateOrUpdateAppointmentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarCreateOrUpdateAppointmentRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarCreateOrUpdateAppointmentRequest {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarCreateOrUpdateAppointmentRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -764,36 +677,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarCreateOrUpdateAppo
 impl ::windows::core::RuntimeName for AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs";
 }
-impl ::core::convert::From<AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -904,36 +788,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarForwardMeetingRequ
 impl ::windows::core::RuntimeName for AppointmentCalendarForwardMeetingRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarForwardMeetingRequest";
 }
-impl ::core::convert::From<AppointmentCalendarForwardMeetingRequest> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarForwardMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarForwardMeetingRequest> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarForwardMeetingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarForwardMeetingRequest> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarForwardMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarForwardMeetingRequest> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarForwardMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarForwardMeetingRequest> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarForwardMeetingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarForwardMeetingRequest> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarForwardMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarForwardMeetingRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarForwardMeetingRequest {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarForwardMeetingRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -989,36 +844,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarForwardMeetingRequ
 impl ::windows::core::RuntimeName for AppointmentCalendarForwardMeetingRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarForwardMeetingRequestEventArgs";
 }
-impl ::core::convert::From<AppointmentCalendarForwardMeetingRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarForwardMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarForwardMeetingRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarForwardMeetingRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarForwardMeetingRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarForwardMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarForwardMeetingRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarForwardMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarForwardMeetingRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarForwardMeetingRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarForwardMeetingRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarForwardMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarForwardMeetingRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarForwardMeetingRequestEventArgs {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarForwardMeetingRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -1131,36 +957,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarProposeNewTimeForM
 impl ::windows::core::RuntimeName for AppointmentCalendarProposeNewTimeForMeetingRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarProposeNewTimeForMeetingRequest";
 }
-impl ::core::convert::From<AppointmentCalendarProposeNewTimeForMeetingRequest> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarProposeNewTimeForMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarProposeNewTimeForMeetingRequest> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarProposeNewTimeForMeetingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarProposeNewTimeForMeetingRequest> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarProposeNewTimeForMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarProposeNewTimeForMeetingRequest> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarProposeNewTimeForMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarProposeNewTimeForMeetingRequest> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarProposeNewTimeForMeetingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarProposeNewTimeForMeetingRequest> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarProposeNewTimeForMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarProposeNewTimeForMeetingRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarProposeNewTimeForMeetingRequest {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarProposeNewTimeForMeetingRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -1216,36 +1013,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarProposeNewTimeForM
 impl ::windows::core::RuntimeName for AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs";
 }
-impl ::core::convert::From<AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -1310,36 +1078,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarSyncManagerSyncReq
 impl ::windows::core::RuntimeName for AppointmentCalendarSyncManagerSyncRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarSyncManagerSyncRequest";
 }
-impl ::core::convert::From<AppointmentCalendarSyncManagerSyncRequest> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManagerSyncRequest> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarSyncManagerSyncRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManagerSyncRequest> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarSyncManagerSyncRequest> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManagerSyncRequest> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarSyncManagerSyncRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManagerSyncRequest> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarSyncManagerSyncRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarSyncManagerSyncRequest {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarSyncManagerSyncRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -1395,36 +1134,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarSyncManagerSyncReq
 impl ::windows::core::RuntimeName for AppointmentCalendarSyncManagerSyncRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarSyncManagerSyncRequestEventArgs";
 }
-impl ::core::convert::From<AppointmentCalendarSyncManagerSyncRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManagerSyncRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarSyncManagerSyncRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManagerSyncRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarSyncManagerSyncRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManagerSyncRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarSyncManagerSyncRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManagerSyncRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarSyncManagerSyncRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarSyncManagerSyncRequestEventArgs {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarSyncManagerSyncRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -1533,36 +1243,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarUpdateMeetingRespo
 impl ::windows::core::RuntimeName for AppointmentCalendarUpdateMeetingResponseRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarUpdateMeetingResponseRequest";
 }
-impl ::core::convert::From<AppointmentCalendarUpdateMeetingResponseRequest> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarUpdateMeetingResponseRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarUpdateMeetingResponseRequest> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarUpdateMeetingResponseRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarUpdateMeetingResponseRequest> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarUpdateMeetingResponseRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarUpdateMeetingResponseRequest> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarUpdateMeetingResponseRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarUpdateMeetingResponseRequest> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarUpdateMeetingResponseRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarUpdateMeetingResponseRequest> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarUpdateMeetingResponseRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarUpdateMeetingResponseRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarUpdateMeetingResponseRequest {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarUpdateMeetingResponseRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -1618,36 +1299,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarUpdateMeetingRespo
 impl ::windows::core::RuntimeName for AppointmentCalendarUpdateMeetingResponseRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentCalendarUpdateMeetingResponseRequestEventArgs";
 }
-impl ::core::convert::From<AppointmentCalendarUpdateMeetingResponseRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarUpdateMeetingResponseRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarUpdateMeetingResponseRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarUpdateMeetingResponseRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarUpdateMeetingResponseRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarUpdateMeetingResponseRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarUpdateMeetingResponseRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarUpdateMeetingResponseRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarUpdateMeetingResponseRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarUpdateMeetingResponseRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarUpdateMeetingResponseRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarUpdateMeetingResponseRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarUpdateMeetingResponseRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarUpdateMeetingResponseRequestEventArgs {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarUpdateMeetingResponseRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -1781,36 +1433,7 @@ unsafe impl ::windows::core::Interface for AppointmentDataProviderConnection {
 impl ::windows::core::RuntimeName for AppointmentDataProviderConnection {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentDataProviderConnection";
 }
-impl ::core::convert::From<AppointmentDataProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: AppointmentDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentDataProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentDataProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentDataProviderConnection> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentDataProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: AppointmentDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentDataProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentDataProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentDataProviderConnection> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentDataProviderConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentDataProviderConnection {}
 unsafe impl ::core::marker::Sync for AppointmentDataProviderConnection {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments_DataProvider\"`*"]
@@ -1857,36 +1480,7 @@ unsafe impl ::windows::core::Interface for AppointmentDataProviderTriggerDetails
 impl ::windows::core::RuntimeName for AppointmentDataProviderTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.DataProvider.AppointmentDataProviderTriggerDetails";
 }
-impl ::core::convert::From<AppointmentDataProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: AppointmentDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentDataProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentDataProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentDataProviderTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentDataProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: AppointmentDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentDataProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentDataProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentDataProviderTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentDataProviderTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentDataProviderTriggerDetails {}
 unsafe impl ::core::marker::Sync for AppointmentDataProviderTriggerDetails {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
@@ -600,36 +600,7 @@ impl IAppointmentParticipant {
         unsafe { (::windows::core::Vtable::vtable(this).SetAddress)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(value)).ok() }
     }
 }
-impl ::core::convert::From<IAppointmentParticipant> for ::windows::core::IUnknown {
-    fn from(value: IAppointmentParticipant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentParticipant> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppointmentParticipant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentParticipant> for ::windows::core::IUnknown {
-    fn from(value: &IAppointmentParticipant) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppointmentParticipant> for ::windows::core::IInspectable {
-    fn from(value: IAppointmentParticipant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppointmentParticipant> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAppointmentParticipant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppointmentParticipant> for ::windows::core::IInspectable {
-    fn from(value: &IAppointmentParticipant) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppointmentParticipant, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAppointmentParticipant {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1448,36 +1419,7 @@ unsafe impl ::windows::core::Interface for Appointment {
 impl ::windows::core::RuntimeName for Appointment {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.Appointment";
 }
-impl ::core::convert::From<Appointment> for ::windows::core::IUnknown {
-    fn from(value: Appointment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Appointment> for ::windows::core::IUnknown {
-    fn from(value: &Appointment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Appointment> for &::windows::core::IUnknown {
-    fn from(value: &Appointment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Appointment> for ::windows::core::IInspectable {
-    fn from(value: Appointment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Appointment> for ::windows::core::IInspectable {
-    fn from(value: &Appointment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Appointment> for &::windows::core::IInspectable {
-    fn from(value: &Appointment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Appointment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Appointment {}
 unsafe impl ::core::marker::Sync for Appointment {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -1887,36 +1829,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendar {
 impl ::windows::core::RuntimeName for AppointmentCalendar {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentCalendar";
 }
-impl ::core::convert::From<AppointmentCalendar> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendar> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendar> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendar> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendar> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendar> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendar, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendar {}
 unsafe impl ::core::marker::Sync for AppointmentCalendar {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -2021,36 +1934,7 @@ unsafe impl ::windows::core::Interface for AppointmentCalendarSyncManager {
 impl ::windows::core::RuntimeName for AppointmentCalendarSyncManager {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentCalendarSyncManager";
 }
-impl ::core::convert::From<AppointmentCalendarSyncManager> for ::windows::core::IUnknown {
-    fn from(value: AppointmentCalendarSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManager> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarSyncManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManager> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentCalendarSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentCalendarSyncManager> for ::windows::core::IInspectable {
-    fn from(value: AppointmentCalendarSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManager> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarSyncManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentCalendarSyncManager> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentCalendarSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentCalendarSyncManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentCalendarSyncManager {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarSyncManager {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -2106,36 +1990,7 @@ unsafe impl ::windows::core::Interface for AppointmentConflictResult {
 impl ::windows::core::RuntimeName for AppointmentConflictResult {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentConflictResult";
 }
-impl ::core::convert::From<AppointmentConflictResult> for ::windows::core::IUnknown {
-    fn from(value: AppointmentConflictResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentConflictResult> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentConflictResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentConflictResult> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentConflictResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentConflictResult> for ::windows::core::IInspectable {
-    fn from(value: AppointmentConflictResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentConflictResult> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentConflictResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentConflictResult> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentConflictResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentConflictResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentConflictResult {}
 unsafe impl ::core::marker::Sync for AppointmentConflictResult {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -2198,36 +2053,7 @@ unsafe impl ::windows::core::Interface for AppointmentException {
 impl ::windows::core::RuntimeName for AppointmentException {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentException";
 }
-impl ::core::convert::From<AppointmentException> for ::windows::core::IUnknown {
-    fn from(value: AppointmentException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentException> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentException> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentException> for ::windows::core::IInspectable {
-    fn from(value: AppointmentException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentException> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentException> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentException, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentException {}
 unsafe impl ::core::marker::Sync for AppointmentException {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -2318,36 +2144,7 @@ unsafe impl ::windows::core::Interface for AppointmentInvitee {
 impl ::windows::core::RuntimeName for AppointmentInvitee {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentInvitee";
 }
-impl ::core::convert::From<AppointmentInvitee> for ::windows::core::IUnknown {
-    fn from(value: AppointmentInvitee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentInvitee> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentInvitee) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentInvitee> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentInvitee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentInvitee> for ::windows::core::IInspectable {
-    fn from(value: AppointmentInvitee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentInvitee> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentInvitee) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentInvitee> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentInvitee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentInvitee, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AppointmentInvitee> for IAppointmentParticipant {
     type Error = ::windows::core::Error;
     fn try_from(value: AppointmentInvitee) -> ::windows::core::Result<Self> {
@@ -2666,36 +2463,7 @@ unsafe impl ::windows::core::Interface for AppointmentManagerForUser {
 impl ::windows::core::RuntimeName for AppointmentManagerForUser {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentManagerForUser";
 }
-impl ::core::convert::From<AppointmentManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: AppointmentManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentManagerForUser> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: AppointmentManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentManagerForUser> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentManagerForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentManagerForUser {}
 unsafe impl ::core::marker::Sync for AppointmentManagerForUser {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -2764,36 +2532,7 @@ unsafe impl ::windows::core::Interface for AppointmentOrganizer {
 impl ::windows::core::RuntimeName for AppointmentOrganizer {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentOrganizer";
 }
-impl ::core::convert::From<AppointmentOrganizer> for ::windows::core::IUnknown {
-    fn from(value: AppointmentOrganizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentOrganizer> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentOrganizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentOrganizer> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentOrganizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentOrganizer> for ::windows::core::IInspectable {
-    fn from(value: AppointmentOrganizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentOrganizer> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentOrganizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentOrganizer> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentOrganizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentOrganizer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AppointmentOrganizer> for IAppointmentParticipant {
     type Error = ::windows::core::Error;
     fn try_from(value: AppointmentOrganizer) -> ::windows::core::Result<Self> {
@@ -3163,36 +2902,7 @@ unsafe impl ::windows::core::Interface for AppointmentRecurrence {
 impl ::windows::core::RuntimeName for AppointmentRecurrence {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentRecurrence";
 }
-impl ::core::convert::From<AppointmentRecurrence> for ::windows::core::IUnknown {
-    fn from(value: AppointmentRecurrence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentRecurrence> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentRecurrence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentRecurrence> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentRecurrence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentRecurrence> for ::windows::core::IInspectable {
-    fn from(value: AppointmentRecurrence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentRecurrence> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentRecurrence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentRecurrence> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentRecurrence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentRecurrence, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentRecurrence {}
 unsafe impl ::core::marker::Sync for AppointmentRecurrence {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -3450,36 +3160,7 @@ unsafe impl ::windows::core::Interface for AppointmentStore {
 impl ::windows::core::RuntimeName for AppointmentStore {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentStore";
 }
-impl ::core::convert::From<AppointmentStore> for ::windows::core::IUnknown {
-    fn from(value: AppointmentStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStore> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStore> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentStore> for ::windows::core::IInspectable {
-    fn from(value: AppointmentStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStore> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStore> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentStore {}
 unsafe impl ::core::marker::Sync for AppointmentStore {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -3540,36 +3221,7 @@ unsafe impl ::windows::core::Interface for AppointmentStoreChange {
 impl ::windows::core::RuntimeName for AppointmentStoreChange {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentStoreChange";
 }
-impl ::core::convert::From<AppointmentStoreChange> for ::windows::core::IUnknown {
-    fn from(value: AppointmentStoreChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChange> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChange> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentStoreChange> for ::windows::core::IInspectable {
-    fn from(value: AppointmentStoreChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChange> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChange> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentStoreChange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentStoreChange {}
 unsafe impl ::core::marker::Sync for AppointmentStoreChange {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -3626,36 +3278,7 @@ unsafe impl ::windows::core::Interface for AppointmentStoreChangeReader {
 impl ::windows::core::RuntimeName for AppointmentStoreChangeReader {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentStoreChangeReader";
 }
-impl ::core::convert::From<AppointmentStoreChangeReader> for ::windows::core::IUnknown {
-    fn from(value: AppointmentStoreChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangeReader> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangeReader> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentStoreChangeReader> for ::windows::core::IInspectable {
-    fn from(value: AppointmentStoreChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangeReader> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangeReader> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentStoreChangeReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentStoreChangeReader {}
 unsafe impl ::core::marker::Sync for AppointmentStoreChangeReader {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -3717,36 +3340,7 @@ unsafe impl ::windows::core::Interface for AppointmentStoreChangeTracker {
 impl ::windows::core::RuntimeName for AppointmentStoreChangeTracker {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentStoreChangeTracker";
 }
-impl ::core::convert::From<AppointmentStoreChangeTracker> for ::windows::core::IUnknown {
-    fn from(value: AppointmentStoreChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangeTracker> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreChangeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangeTracker> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentStoreChangeTracker> for ::windows::core::IInspectable {
-    fn from(value: AppointmentStoreChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangeTracker> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreChangeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangeTracker> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentStoreChangeTracker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentStoreChangeTracker {}
 unsafe impl ::core::marker::Sync for AppointmentStoreChangeTracker {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -3790,36 +3384,7 @@ unsafe impl ::windows::core::Interface for AppointmentStoreChangedDeferral {
 impl ::windows::core::RuntimeName for AppointmentStoreChangedDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentStoreChangedDeferral";
 }
-impl ::core::convert::From<AppointmentStoreChangedDeferral> for ::windows::core::IUnknown {
-    fn from(value: AppointmentStoreChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangedDeferral> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreChangedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangedDeferral> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentStoreChangedDeferral> for ::windows::core::IInspectable {
-    fn from(value: AppointmentStoreChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangedDeferral> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreChangedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangedDeferral> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentStoreChangedDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentStoreChangedDeferral {}
 unsafe impl ::core::marker::Sync for AppointmentStoreChangedDeferral {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -3866,36 +3431,7 @@ unsafe impl ::windows::core::Interface for AppointmentStoreChangedEventArgs {
 impl ::windows::core::RuntimeName for AppointmentStoreChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentStoreChangedEventArgs";
 }
-impl ::core::convert::From<AppointmentStoreChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppointmentStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentStoreChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppointmentStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentStoreChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentStoreChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppointmentStoreChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -3934,36 +3470,7 @@ unsafe impl ::windows::core::Interface for AppointmentStoreNotificationTriggerDe
 impl ::windows::core::RuntimeName for AppointmentStoreNotificationTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentStoreNotificationTriggerDetails";
 }
-impl ::core::convert::From<AppointmentStoreNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: AppointmentStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentStoreNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: AppointmentStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentStoreNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppointmentStoreNotificationTriggerDetails {}
 unsafe impl ::core::marker::Sync for AppointmentStoreNotificationTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]
@@ -4050,36 +3557,7 @@ unsafe impl ::windows::core::Interface for FindAppointmentsOptions {
 impl ::windows::core::RuntimeName for FindAppointmentsOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.FindAppointmentsOptions";
 }
-impl ::core::convert::From<FindAppointmentsOptions> for ::windows::core::IUnknown {
-    fn from(value: FindAppointmentsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FindAppointmentsOptions> for ::windows::core::IUnknown {
-    fn from(value: &FindAppointmentsOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FindAppointmentsOptions> for &::windows::core::IUnknown {
-    fn from(value: &FindAppointmentsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FindAppointmentsOptions> for ::windows::core::IInspectable {
-    fn from(value: FindAppointmentsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FindAppointmentsOptions> for ::windows::core::IInspectable {
-    fn from(value: &FindAppointmentsOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FindAppointmentsOptions> for &::windows::core::IInspectable {
-    fn from(value: &FindAppointmentsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FindAppointmentsOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FindAppointmentsOptions {}
 unsafe impl ::core::marker::Sync for FindAppointmentsOptions {}
 #[doc = "*Required features: `\"ApplicationModel_Appointments\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
@@ -177,36 +177,7 @@ pub struct IAppointmentStoreNotificationTrigger_Vtbl {
 #[repr(transparent)]
 pub struct IBackgroundCondition(::windows::core::IUnknown);
 impl IBackgroundCondition {}
-impl ::core::convert::From<IBackgroundCondition> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCondition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCondition> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCondition> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCondition> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCondition> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCondition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBackgroundCondition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -318,36 +289,7 @@ impl IBackgroundTask {
         unsafe { (::windows::core::Vtable::vtable(this).Run)(::windows::core::Vtable::as_raw(this), taskinstance.try_into().map_err(|e| e.into())?.abi()).ok() }
     }
 }
-impl ::core::convert::From<IBackgroundTask> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTask> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTask> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTask> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTask> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTask> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTask, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBackgroundTask {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -564,36 +506,7 @@ impl IBackgroundTaskInstance {
         }
     }
 }
-impl ::core::convert::From<IBackgroundTaskInstance> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTaskInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskInstance> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTaskInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskInstance> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTaskInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTaskInstance> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTaskInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskInstance> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTaskInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskInstance> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTaskInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTaskInstance, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBackgroundTaskInstance {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -716,36 +629,7 @@ impl IBackgroundTaskInstance2 {
         }
     }
 }
-impl ::core::convert::From<IBackgroundTaskInstance2> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTaskInstance2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskInstance2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTaskInstance2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskInstance2> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTaskInstance2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTaskInstance2> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTaskInstance2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskInstance2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTaskInstance2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskInstance2> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTaskInstance2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTaskInstance2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IBackgroundTaskInstance2> for IBackgroundTaskInstance {
     type Error = ::windows::core::Error;
     fn try_from(value: IBackgroundTaskInstance2) -> ::windows::core::Result<Self> {
@@ -875,36 +759,7 @@ impl IBackgroundTaskInstance4 {
         }
     }
 }
-impl ::core::convert::From<IBackgroundTaskInstance4> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTaskInstance4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskInstance4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTaskInstance4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskInstance4> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTaskInstance4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTaskInstance4> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTaskInstance4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskInstance4> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTaskInstance4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskInstance4> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTaskInstance4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTaskInstance4, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IBackgroundTaskInstance4> for IBackgroundTaskInstance {
     type Error = ::windows::core::Error;
     fn try_from(value: IBackgroundTaskInstance4) -> ::windows::core::Result<Self> {
@@ -1031,36 +886,7 @@ impl IBackgroundTaskRegistration {
         unsafe { (::windows::core::Vtable::vtable(this).Unregister)(::windows::core::Vtable::as_raw(this), canceltask).ok() }
     }
 }
-impl ::core::convert::From<IBackgroundTaskRegistration> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTaskRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTaskRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskRegistration> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTaskRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTaskRegistration> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTaskRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskRegistration> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTaskRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskRegistration> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTaskRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTaskRegistration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBackgroundTaskRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1174,36 +1000,7 @@ impl IBackgroundTaskRegistration2 {
         unsafe { (::windows::core::Vtable::vtable(this).Unregister)(::windows::core::Vtable::as_raw(this), canceltask).ok() }
     }
 }
-impl ::core::convert::From<IBackgroundTaskRegistration2> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTaskRegistration2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskRegistration2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTaskRegistration2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskRegistration2> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTaskRegistration2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTaskRegistration2> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTaskRegistration2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskRegistration2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTaskRegistration2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskRegistration2> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTaskRegistration2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTaskRegistration2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IBackgroundTaskRegistration2> for IBackgroundTaskRegistration {
     type Error = ::windows::core::Error;
     fn try_from(value: IBackgroundTaskRegistration2) -> ::windows::core::Result<Self> {
@@ -1318,36 +1115,7 @@ impl IBackgroundTaskRegistration3 {
         unsafe { (::windows::core::Vtable::vtable(this).Unregister)(::windows::core::Vtable::as_raw(this), canceltask).ok() }
     }
 }
-impl ::core::convert::From<IBackgroundTaskRegistration3> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTaskRegistration3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskRegistration3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTaskRegistration3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskRegistration3> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTaskRegistration3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTaskRegistration3> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTaskRegistration3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTaskRegistration3> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTaskRegistration3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTaskRegistration3> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTaskRegistration3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTaskRegistration3, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IBackgroundTaskRegistration3> for IBackgroundTaskRegistration {
     type Error = ::windows::core::Error;
     fn try_from(value: IBackgroundTaskRegistration3) -> ::windows::core::Result<Self> {
@@ -1487,36 +1255,7 @@ pub struct IBackgroundTaskRegistrationStatics2_Vtbl {
 #[repr(transparent)]
 pub struct IBackgroundTrigger(::windows::core::IUnknown);
 impl IBackgroundTrigger {}
-impl ::core::convert::From<IBackgroundTrigger> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTrigger> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTrigger> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTrigger> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTrigger> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBackgroundTrigger {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2774,36 +2513,7 @@ unsafe impl ::windows::core::Interface for ActivitySensorTrigger {
 impl ::windows::core::RuntimeName for ActivitySensorTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ActivitySensorTrigger";
 }
-impl ::core::convert::From<ActivitySensorTrigger> for ::windows::core::IUnknown {
-    fn from(value: ActivitySensorTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensorTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ActivitySensorTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensorTrigger> for &::windows::core::IUnknown {
-    fn from(value: &ActivitySensorTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivitySensorTrigger> for ::windows::core::IInspectable {
-    fn from(value: ActivitySensorTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensorTrigger> for ::windows::core::IInspectable {
-    fn from(value: &ActivitySensorTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensorTrigger> for &::windows::core::IInspectable {
-    fn from(value: &ActivitySensorTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivitySensorTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ActivitySensorTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: ActivitySensorTrigger) -> ::windows::core::Result<Self> {
@@ -2910,36 +2620,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastTrigger {
 impl ::windows::core::RuntimeName for AppBroadcastTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.AppBroadcastTrigger";
 }
-impl ::core::convert::From<AppBroadcastTrigger> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastTrigger> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastTrigger> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastTrigger> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastTrigger> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastTrigger> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AppBroadcastTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: AppBroadcastTrigger) -> ::windows::core::Result<Self> {
@@ -3068,36 +2749,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastTriggerProviderInfo {
 impl ::windows::core::RuntimeName for AppBroadcastTriggerProviderInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Background.AppBroadcastTriggerProviderInfo";
 }
-impl ::core::convert::From<AppBroadcastTriggerProviderInfo> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastTriggerProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastTriggerProviderInfo> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastTriggerProviderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastTriggerProviderInfo> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastTriggerProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastTriggerProviderInfo> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastTriggerProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastTriggerProviderInfo> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastTriggerProviderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastTriggerProviderInfo> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastTriggerProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastTriggerProviderInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastTriggerProviderInfo {}
 unsafe impl ::core::marker::Sync for AppBroadcastTriggerProviderInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Background\"`*"]
@@ -3162,36 +2814,7 @@ unsafe impl ::windows::core::Interface for ApplicationTrigger {
 impl ::windows::core::RuntimeName for ApplicationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ApplicationTrigger";
 }
-impl ::core::convert::From<ApplicationTrigger> for ::windows::core::IUnknown {
-    fn from(value: ApplicationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ApplicationTrigger> for ::windows::core::IInspectable {
-    fn from(value: ApplicationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ApplicationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: ApplicationTrigger) -> ::windows::core::Result<Self> {
@@ -3259,36 +2882,7 @@ unsafe impl ::windows::core::Interface for ApplicationTriggerDetails {
 impl ::windows::core::RuntimeName for ApplicationTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ApplicationTriggerDetails";
 }
-impl ::core::convert::From<ApplicationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: ApplicationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ApplicationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: ApplicationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ApplicationTriggerDetails {}
 unsafe impl ::core::marker::Sync for ApplicationTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Background\"`*"]
@@ -3335,36 +2929,7 @@ unsafe impl ::windows::core::Interface for AppointmentStoreNotificationTrigger {
 impl ::windows::core::RuntimeName for AppointmentStoreNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.AppointmentStoreNotificationTrigger";
 }
-impl ::core::convert::From<AppointmentStoreNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: AppointmentStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreNotificationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &AppointmentStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppointmentStoreNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: AppointmentStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppointmentStoreNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppointmentStoreNotificationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &AppointmentStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppointmentStoreNotificationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AppointmentStoreNotificationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: AppointmentStoreNotificationTrigger) -> ::windows::core::Result<Self> {
@@ -3596,36 +3161,7 @@ unsafe impl ::windows::core::Interface for BackgroundTaskBuilder {
 impl ::windows::core::RuntimeName for BackgroundTaskBuilder {
     const NAME: &'static str = "Windows.ApplicationModel.Background.BackgroundTaskBuilder";
 }
-impl ::core::convert::From<BackgroundTaskBuilder> for ::windows::core::IUnknown {
-    fn from(value: BackgroundTaskBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskBuilder> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskBuilder> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundTaskBuilder> for ::windows::core::IInspectable {
-    fn from(value: BackgroundTaskBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskBuilder> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskBuilder> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundTaskBuilder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Background\"`*"]
 #[repr(transparent)]
 pub struct BackgroundTaskCompletedEventArgs(::windows::core::IUnknown);
@@ -3674,36 +3210,7 @@ unsafe impl ::windows::core::Interface for BackgroundTaskCompletedEventArgs {
 impl ::windows::core::RuntimeName for BackgroundTaskCompletedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Background.BackgroundTaskCompletedEventArgs";
 }
-impl ::core::convert::From<BackgroundTaskCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BackgroundTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundTaskCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BackgroundTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundTaskCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackgroundTaskCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for BackgroundTaskCompletedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Background\"`*"]
@@ -3747,36 +3254,7 @@ unsafe impl ::windows::core::Interface for BackgroundTaskDeferral {
 impl ::windows::core::RuntimeName for BackgroundTaskDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.Background.BackgroundTaskDeferral";
 }
-impl ::core::convert::From<BackgroundTaskDeferral> for ::windows::core::IUnknown {
-    fn from(value: BackgroundTaskDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskDeferral> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskDeferral> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundTaskDeferral> for ::windows::core::IInspectable {
-    fn from(value: BackgroundTaskDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskDeferral> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskDeferral> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundTaskDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackgroundTaskDeferral {}
 unsafe impl ::core::marker::Sync for BackgroundTaskDeferral {}
 #[doc = "*Required features: `\"ApplicationModel_Background\"`*"]
@@ -3830,36 +3308,7 @@ unsafe impl ::windows::core::Interface for BackgroundTaskProgressEventArgs {
 impl ::windows::core::RuntimeName for BackgroundTaskProgressEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Background.BackgroundTaskProgressEventArgs";
 }
-impl ::core::convert::From<BackgroundTaskProgressEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BackgroundTaskProgressEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskProgressEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskProgressEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskProgressEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskProgressEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundTaskProgressEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BackgroundTaskProgressEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskProgressEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskProgressEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskProgressEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskProgressEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundTaskProgressEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackgroundTaskProgressEventArgs {}
 unsafe impl ::core::marker::Sync for BackgroundTaskProgressEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Background\"`*"]
@@ -3993,36 +3442,7 @@ unsafe impl ::windows::core::Interface for BackgroundTaskRegistration {
 impl ::windows::core::RuntimeName for BackgroundTaskRegistration {
     const NAME: &'static str = "Windows.ApplicationModel.Background.BackgroundTaskRegistration";
 }
-impl ::core::convert::From<BackgroundTaskRegistration> for ::windows::core::IUnknown {
-    fn from(value: BackgroundTaskRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskRegistration> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskRegistration> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundTaskRegistration> for ::windows::core::IInspectable {
-    fn from(value: BackgroundTaskRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskRegistration> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskRegistration> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundTaskRegistration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BackgroundTaskRegistration> for IBackgroundTaskRegistration {
     type Error = ::windows::core::Error;
     fn try_from(value: BackgroundTaskRegistration) -> ::windows::core::Result<Self> {
@@ -4174,36 +3594,7 @@ unsafe impl ::windows::core::Interface for BackgroundTaskRegistrationGroup {
 impl ::windows::core::RuntimeName for BackgroundTaskRegistrationGroup {
     const NAME: &'static str = "Windows.ApplicationModel.Background.BackgroundTaskRegistrationGroup";
 }
-impl ::core::convert::From<BackgroundTaskRegistrationGroup> for ::windows::core::IUnknown {
-    fn from(value: BackgroundTaskRegistrationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskRegistrationGroup> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskRegistrationGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskRegistrationGroup> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundTaskRegistrationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundTaskRegistrationGroup> for ::windows::core::IInspectable {
-    fn from(value: BackgroundTaskRegistrationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTaskRegistrationGroup> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskRegistrationGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTaskRegistrationGroup> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundTaskRegistrationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundTaskRegistrationGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackgroundTaskRegistrationGroup {}
 unsafe impl ::core::marker::Sync for BackgroundTaskRegistrationGroup {}
 #[doc = "*Required features: `\"ApplicationModel_Background\"`*"]
@@ -4329,36 +3720,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementPublisherTrig
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementPublisherTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.BluetoothLEAdvertisementPublisherTrigger";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementPublisherTrigger> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementPublisherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherTrigger> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementPublisherTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherTrigger> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementPublisherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementPublisherTrigger> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementPublisherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherTrigger> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementPublisherTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherTrigger> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementPublisherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementPublisherTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BluetoothLEAdvertisementPublisherTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: BluetoothLEAdvertisementPublisherTrigger) -> ::windows::core::Result<Self> {
@@ -4501,36 +3863,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementWatcherTrigge
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementWatcherTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.BluetoothLEAdvertisementWatcherTrigger";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementWatcherTrigger> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementWatcherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherTrigger> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementWatcherTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherTrigger> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementWatcherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementWatcherTrigger> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementWatcherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherTrigger> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementWatcherTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherTrigger> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementWatcherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementWatcherTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BluetoothLEAdvertisementWatcherTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: BluetoothLEAdvertisementWatcherTrigger) -> ::windows::core::Result<Self> {
@@ -4596,36 +3929,7 @@ unsafe impl ::windows::core::Interface for CachedFileUpdaterTrigger {
 impl ::windows::core::RuntimeName for CachedFileUpdaterTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.CachedFileUpdaterTrigger";
 }
-impl ::core::convert::From<CachedFileUpdaterTrigger> for ::windows::core::IUnknown {
-    fn from(value: CachedFileUpdaterTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterTrigger> for ::windows::core::IUnknown {
-    fn from(value: &CachedFileUpdaterTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterTrigger> for &::windows::core::IUnknown {
-    fn from(value: &CachedFileUpdaterTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CachedFileUpdaterTrigger> for ::windows::core::IInspectable {
-    fn from(value: CachedFileUpdaterTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterTrigger> for ::windows::core::IInspectable {
-    fn from(value: &CachedFileUpdaterTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterTrigger> for &::windows::core::IInspectable {
-    fn from(value: &CachedFileUpdaterTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CachedFileUpdaterTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CachedFileUpdaterTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: CachedFileUpdaterTrigger) -> ::windows::core::Result<Self> {
@@ -4709,36 +4013,7 @@ unsafe impl ::windows::core::Interface for CachedFileUpdaterTriggerDetails {
 impl ::windows::core::RuntimeName for CachedFileUpdaterTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Background.CachedFileUpdaterTriggerDetails";
 }
-impl ::core::convert::From<CachedFileUpdaterTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: CachedFileUpdaterTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &CachedFileUpdaterTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &CachedFileUpdaterTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CachedFileUpdaterTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: CachedFileUpdaterTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &CachedFileUpdaterTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &CachedFileUpdaterTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CachedFileUpdaterTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CachedFileUpdaterTriggerDetails {}
 unsafe impl ::core::marker::Sync for CachedFileUpdaterTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Background\"`*"]
@@ -4785,36 +4060,7 @@ unsafe impl ::windows::core::Interface for ChatMessageNotificationTrigger {
 impl ::windows::core::RuntimeName for ChatMessageNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ChatMessageNotificationTrigger";
 }
-impl ::core::convert::From<ChatMessageNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageNotificationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageNotificationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageNotificationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ChatMessageNotificationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: ChatMessageNotificationTrigger) -> ::windows::core::Result<Self> {
@@ -4880,36 +4126,7 @@ unsafe impl ::windows::core::Interface for ChatMessageReceivedNotificationTrigge
 impl ::windows::core::RuntimeName for ChatMessageReceivedNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ChatMessageReceivedNotificationTrigger";
 }
-impl ::core::convert::From<ChatMessageReceivedNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageReceivedNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageReceivedNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageReceivedNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageReceivedNotificationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageReceivedNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageReceivedNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageReceivedNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageReceivedNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageReceivedNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageReceivedNotificationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageReceivedNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageReceivedNotificationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ChatMessageReceivedNotificationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: ChatMessageReceivedNotificationTrigger) -> ::windows::core::Result<Self> {
@@ -4975,36 +4192,7 @@ unsafe impl ::windows::core::Interface for CommunicationBlockingAppSetAsActiveTr
 impl ::windows::core::RuntimeName for CommunicationBlockingAppSetAsActiveTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.CommunicationBlockingAppSetAsActiveTrigger";
 }
-impl ::core::convert::From<CommunicationBlockingAppSetAsActiveTrigger> for ::windows::core::IUnknown {
-    fn from(value: CommunicationBlockingAppSetAsActiveTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CommunicationBlockingAppSetAsActiveTrigger> for ::windows::core::IUnknown {
-    fn from(value: &CommunicationBlockingAppSetAsActiveTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CommunicationBlockingAppSetAsActiveTrigger> for &::windows::core::IUnknown {
-    fn from(value: &CommunicationBlockingAppSetAsActiveTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CommunicationBlockingAppSetAsActiveTrigger> for ::windows::core::IInspectable {
-    fn from(value: CommunicationBlockingAppSetAsActiveTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CommunicationBlockingAppSetAsActiveTrigger> for ::windows::core::IInspectable {
-    fn from(value: &CommunicationBlockingAppSetAsActiveTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CommunicationBlockingAppSetAsActiveTrigger> for &::windows::core::IInspectable {
-    fn from(value: &CommunicationBlockingAppSetAsActiveTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CommunicationBlockingAppSetAsActiveTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CommunicationBlockingAppSetAsActiveTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: CommunicationBlockingAppSetAsActiveTrigger) -> ::windows::core::Result<Self> {
@@ -5070,36 +4258,7 @@ unsafe impl ::windows::core::Interface for ContactStoreNotificationTrigger {
 impl ::windows::core::RuntimeName for ContactStoreNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ContactStoreNotificationTrigger";
 }
-impl ::core::convert::From<ContactStoreNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: ContactStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactStoreNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ContactStoreNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactStoreNotificationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &ContactStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactStoreNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: ContactStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactStoreNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &ContactStoreNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactStoreNotificationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &ContactStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactStoreNotificationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactStoreNotificationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactStoreNotificationTrigger) -> ::windows::core::Result<Self> {
@@ -5187,36 +4346,7 @@ unsafe impl ::windows::core::Interface for ContentPrefetchTrigger {
 impl ::windows::core::RuntimeName for ContentPrefetchTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ContentPrefetchTrigger";
 }
-impl ::core::convert::From<ContentPrefetchTrigger> for ::windows::core::IUnknown {
-    fn from(value: ContentPrefetchTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContentPrefetchTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ContentPrefetchTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContentPrefetchTrigger> for &::windows::core::IUnknown {
-    fn from(value: &ContentPrefetchTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContentPrefetchTrigger> for ::windows::core::IInspectable {
-    fn from(value: ContentPrefetchTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContentPrefetchTrigger> for ::windows::core::IInspectable {
-    fn from(value: &ContentPrefetchTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContentPrefetchTrigger> for &::windows::core::IInspectable {
-    fn from(value: &ContentPrefetchTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContentPrefetchTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContentPrefetchTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: ContentPrefetchTrigger) -> ::windows::core::Result<Self> {
@@ -5280,36 +4410,7 @@ unsafe impl ::windows::core::Interface for ConversationalAgentTrigger {
 impl ::windows::core::RuntimeName for ConversationalAgentTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ConversationalAgentTrigger";
 }
-impl ::core::convert::From<ConversationalAgentTrigger> for ::windows::core::IUnknown {
-    fn from(value: ConversationalAgentTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentTrigger> for &::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConversationalAgentTrigger> for ::windows::core::IInspectable {
-    fn from(value: ConversationalAgentTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentTrigger> for ::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentTrigger> for &::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConversationalAgentTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ConversationalAgentTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: ConversationalAgentTrigger) -> ::windows::core::Result<Self> {
@@ -5391,36 +4492,7 @@ unsafe impl ::windows::core::Interface for CustomSystemEventTrigger {
 impl ::windows::core::RuntimeName for CustomSystemEventTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.CustomSystemEventTrigger";
 }
-impl ::core::convert::From<CustomSystemEventTrigger> for ::windows::core::IUnknown {
-    fn from(value: CustomSystemEventTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CustomSystemEventTrigger> for ::windows::core::IUnknown {
-    fn from(value: &CustomSystemEventTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CustomSystemEventTrigger> for &::windows::core::IUnknown {
-    fn from(value: &CustomSystemEventTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CustomSystemEventTrigger> for ::windows::core::IInspectable {
-    fn from(value: CustomSystemEventTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CustomSystemEventTrigger> for ::windows::core::IInspectable {
-    fn from(value: &CustomSystemEventTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CustomSystemEventTrigger> for &::windows::core::IInspectable {
-    fn from(value: &CustomSystemEventTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CustomSystemEventTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CustomSystemEventTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: CustomSystemEventTrigger) -> ::windows::core::Result<Self> {
@@ -5515,36 +4587,7 @@ unsafe impl ::windows::core::Interface for DeviceConnectionChangeTrigger {
 impl ::windows::core::RuntimeName for DeviceConnectionChangeTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.DeviceConnectionChangeTrigger";
 }
-impl ::core::convert::From<DeviceConnectionChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: DeviceConnectionChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceConnectionChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: &DeviceConnectionChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceConnectionChangeTrigger> for &::windows::core::IUnknown {
-    fn from(value: &DeviceConnectionChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceConnectionChangeTrigger> for ::windows::core::IInspectable {
-    fn from(value: DeviceConnectionChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceConnectionChangeTrigger> for ::windows::core::IInspectable {
-    fn from(value: &DeviceConnectionChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceConnectionChangeTrigger> for &::windows::core::IInspectable {
-    fn from(value: &DeviceConnectionChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceConnectionChangeTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DeviceConnectionChangeTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: DeviceConnectionChangeTrigger) -> ::windows::core::Result<Self> {
@@ -5646,41 +4689,7 @@ impl ::windows::core::RuntimeName for DeviceManufacturerNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.DeviceManufacturerNotificationTrigger";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<DeviceManufacturerNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: DeviceManufacturerNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&DeviceManufacturerNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &DeviceManufacturerNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&DeviceManufacturerNotificationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &DeviceManufacturerNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<DeviceManufacturerNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: DeviceManufacturerNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&DeviceManufacturerNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &DeviceManufacturerNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&DeviceManufacturerNotificationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &DeviceManufacturerNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceManufacturerNotificationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<DeviceManufacturerNotificationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
@@ -5765,36 +4774,7 @@ unsafe impl ::windows::core::Interface for DeviceServicingTrigger {
 impl ::windows::core::RuntimeName for DeviceServicingTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.DeviceServicingTrigger";
 }
-impl ::core::convert::From<DeviceServicingTrigger> for ::windows::core::IUnknown {
-    fn from(value: DeviceServicingTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceServicingTrigger> for ::windows::core::IUnknown {
-    fn from(value: &DeviceServicingTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceServicingTrigger> for &::windows::core::IUnknown {
-    fn from(value: &DeviceServicingTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceServicingTrigger> for ::windows::core::IInspectable {
-    fn from(value: DeviceServicingTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceServicingTrigger> for ::windows::core::IInspectable {
-    fn from(value: &DeviceServicingTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceServicingTrigger> for &::windows::core::IInspectable {
-    fn from(value: &DeviceServicingTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceServicingTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DeviceServicingTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: DeviceServicingTrigger) -> ::windows::core::Result<Self> {
@@ -5878,36 +4858,7 @@ unsafe impl ::windows::core::Interface for DeviceUseTrigger {
 impl ::windows::core::RuntimeName for DeviceUseTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.DeviceUseTrigger";
 }
-impl ::core::convert::From<DeviceUseTrigger> for ::windows::core::IUnknown {
-    fn from(value: DeviceUseTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceUseTrigger> for ::windows::core::IUnknown {
-    fn from(value: &DeviceUseTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceUseTrigger> for &::windows::core::IUnknown {
-    fn from(value: &DeviceUseTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceUseTrigger> for ::windows::core::IInspectable {
-    fn from(value: DeviceUseTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceUseTrigger> for ::windows::core::IInspectable {
-    fn from(value: &DeviceUseTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceUseTrigger> for &::windows::core::IInspectable {
-    fn from(value: &DeviceUseTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceUseTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DeviceUseTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: DeviceUseTrigger) -> ::windows::core::Result<Self> {
@@ -5965,36 +4916,7 @@ unsafe impl ::windows::core::Interface for DeviceWatcherTrigger {
 impl ::windows::core::RuntimeName for DeviceWatcherTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.DeviceWatcherTrigger";
 }
-impl ::core::convert::From<DeviceWatcherTrigger> for ::windows::core::IUnknown {
-    fn from(value: DeviceWatcherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceWatcherTrigger> for ::windows::core::IUnknown {
-    fn from(value: &DeviceWatcherTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceWatcherTrigger> for &::windows::core::IUnknown {
-    fn from(value: &DeviceWatcherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceWatcherTrigger> for ::windows::core::IInspectable {
-    fn from(value: DeviceWatcherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceWatcherTrigger> for ::windows::core::IInspectable {
-    fn from(value: &DeviceWatcherTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceWatcherTrigger> for &::windows::core::IInspectable {
-    fn from(value: &DeviceWatcherTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceWatcherTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DeviceWatcherTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: DeviceWatcherTrigger) -> ::windows::core::Result<Self> {
@@ -6058,36 +4980,7 @@ unsafe impl ::windows::core::Interface for EmailStoreNotificationTrigger {
 impl ::windows::core::RuntimeName for EmailStoreNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.EmailStoreNotificationTrigger";
 }
-impl ::core::convert::From<EmailStoreNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: EmailStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailStoreNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &EmailStoreNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailStoreNotificationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &EmailStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailStoreNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: EmailStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailStoreNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &EmailStoreNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailStoreNotificationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &EmailStoreNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailStoreNotificationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<EmailStoreNotificationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: EmailStoreNotificationTrigger) -> ::windows::core::Result<Self> {
@@ -6190,36 +5083,7 @@ unsafe impl ::windows::core::Interface for GattCharacteristicNotificationTrigger
 impl ::windows::core::RuntimeName for GattCharacteristicNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.GattCharacteristicNotificationTrigger";
 }
-impl ::core::convert::From<GattCharacteristicNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: GattCharacteristicNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattCharacteristicNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &GattCharacteristicNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattCharacteristicNotificationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &GattCharacteristicNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattCharacteristicNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: GattCharacteristicNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattCharacteristicNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &GattCharacteristicNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattCharacteristicNotificationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &GattCharacteristicNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattCharacteristicNotificationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<GattCharacteristicNotificationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: GattCharacteristicNotificationTrigger) -> ::windows::core::Result<Self> {
@@ -6322,36 +5186,7 @@ unsafe impl ::windows::core::Interface for GattServiceProviderTrigger {
 impl ::windows::core::RuntimeName for GattServiceProviderTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.GattServiceProviderTrigger";
 }
-impl ::core::convert::From<GattServiceProviderTrigger> for ::windows::core::IUnknown {
-    fn from(value: GattServiceProviderTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTrigger> for ::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTrigger> for &::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattServiceProviderTrigger> for ::windows::core::IInspectable {
-    fn from(value: GattServiceProviderTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTrigger> for ::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTrigger> for &::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattServiceProviderTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<GattServiceProviderTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: GattServiceProviderTrigger) -> ::windows::core::Result<Self> {
@@ -6426,36 +5261,7 @@ unsafe impl ::windows::core::Interface for GattServiceProviderTriggerResult {
 impl ::windows::core::RuntimeName for GattServiceProviderTriggerResult {
     const NAME: &'static str = "Windows.ApplicationModel.Background.GattServiceProviderTriggerResult";
 }
-impl ::core::convert::From<GattServiceProviderTriggerResult> for ::windows::core::IUnknown {
-    fn from(value: GattServiceProviderTriggerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTriggerResult> for ::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderTriggerResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTriggerResult> for &::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderTriggerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattServiceProviderTriggerResult> for ::windows::core::IInspectable {
-    fn from(value: GattServiceProviderTriggerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTriggerResult> for ::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderTriggerResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTriggerResult> for &::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderTriggerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattServiceProviderTriggerResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattServiceProviderTriggerResult {}
 unsafe impl ::core::marker::Sync for GattServiceProviderTriggerResult {}
 #[doc = "*Required features: `\"ApplicationModel_Background\"`*"]
@@ -6517,36 +5323,7 @@ unsafe impl ::windows::core::Interface for GeovisitTrigger {
 impl ::windows::core::RuntimeName for GeovisitTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.GeovisitTrigger";
 }
-impl ::core::convert::From<GeovisitTrigger> for ::windows::core::IUnknown {
-    fn from(value: GeovisitTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeovisitTrigger> for ::windows::core::IUnknown {
-    fn from(value: &GeovisitTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeovisitTrigger> for &::windows::core::IUnknown {
-    fn from(value: &GeovisitTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GeovisitTrigger> for ::windows::core::IInspectable {
-    fn from(value: GeovisitTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeovisitTrigger> for ::windows::core::IInspectable {
-    fn from(value: &GeovisitTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeovisitTrigger> for &::windows::core::IInspectable {
-    fn from(value: &GeovisitTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GeovisitTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<GeovisitTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: GeovisitTrigger) -> ::windows::core::Result<Self> {
@@ -6623,36 +5400,7 @@ unsafe impl ::windows::core::Interface for LocationTrigger {
 impl ::windows::core::RuntimeName for LocationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.LocationTrigger";
 }
-impl ::core::convert::From<LocationTrigger> for ::windows::core::IUnknown {
-    fn from(value: LocationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &LocationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &LocationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LocationTrigger> for ::windows::core::IInspectable {
-    fn from(value: LocationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &LocationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &LocationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LocationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LocationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: LocationTrigger) -> ::windows::core::Result<Self> {
@@ -6736,36 +5484,7 @@ unsafe impl ::windows::core::Interface for MaintenanceTrigger {
 impl ::windows::core::RuntimeName for MaintenanceTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.MaintenanceTrigger";
 }
-impl ::core::convert::From<MaintenanceTrigger> for ::windows::core::IUnknown {
-    fn from(value: MaintenanceTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MaintenanceTrigger> for ::windows::core::IUnknown {
-    fn from(value: &MaintenanceTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MaintenanceTrigger> for &::windows::core::IUnknown {
-    fn from(value: &MaintenanceTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MaintenanceTrigger> for ::windows::core::IInspectable {
-    fn from(value: MaintenanceTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MaintenanceTrigger> for ::windows::core::IInspectable {
-    fn from(value: &MaintenanceTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MaintenanceTrigger> for &::windows::core::IInspectable {
-    fn from(value: &MaintenanceTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MaintenanceTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MaintenanceTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: MaintenanceTrigger) -> ::windows::core::Result<Self> {
@@ -6847,36 +5566,7 @@ unsafe impl ::windows::core::Interface for MediaProcessingTrigger {
 impl ::windows::core::RuntimeName for MediaProcessingTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.MediaProcessingTrigger";
 }
-impl ::core::convert::From<MediaProcessingTrigger> for ::windows::core::IUnknown {
-    fn from(value: MediaProcessingTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaProcessingTrigger> for ::windows::core::IUnknown {
-    fn from(value: &MediaProcessingTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaProcessingTrigger> for &::windows::core::IUnknown {
-    fn from(value: &MediaProcessingTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaProcessingTrigger> for ::windows::core::IInspectable {
-    fn from(value: MediaProcessingTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaProcessingTrigger> for ::windows::core::IInspectable {
-    fn from(value: &MediaProcessingTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaProcessingTrigger> for &::windows::core::IInspectable {
-    fn from(value: &MediaProcessingTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaProcessingTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MediaProcessingTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: MediaProcessingTrigger) -> ::windows::core::Result<Self> {
@@ -6940,36 +5630,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandDeviceServiceNotificat
 impl ::windows::core::RuntimeName for MobileBroadbandDeviceServiceNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.MobileBroadbandDeviceServiceNotificationTrigger";
 }
-impl ::core::convert::From<MobileBroadbandDeviceServiceNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandDeviceServiceNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceNotificationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandDeviceServiceNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandDeviceServiceNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceNotificationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandDeviceServiceNotificationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MobileBroadbandDeviceServiceNotificationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: MobileBroadbandDeviceServiceNotificationTrigger) -> ::windows::core::Result<Self> {
@@ -7035,36 +5696,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandPcoDataChangeTrigger {
 impl ::windows::core::RuntimeName for MobileBroadbandPcoDataChangeTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.MobileBroadbandPcoDataChangeTrigger";
 }
-impl ::core::convert::From<MobileBroadbandPcoDataChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandPcoDataChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPcoDataChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPcoDataChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPcoDataChangeTrigger> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPcoDataChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandPcoDataChangeTrigger> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandPcoDataChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPcoDataChangeTrigger> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPcoDataChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPcoDataChangeTrigger> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPcoDataChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandPcoDataChangeTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MobileBroadbandPcoDataChangeTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: MobileBroadbandPcoDataChangeTrigger) -> ::windows::core::Result<Self> {
@@ -7130,36 +5762,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandPinLockStateChangeTrig
 impl ::windows::core::RuntimeName for MobileBroadbandPinLockStateChangeTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.MobileBroadbandPinLockStateChangeTrigger";
 }
-impl ::core::convert::From<MobileBroadbandPinLockStateChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandPinLockStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPinLockStateChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChangeTrigger> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPinLockStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandPinLockStateChangeTrigger> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandPinLockStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChangeTrigger> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPinLockStateChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChangeTrigger> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPinLockStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandPinLockStateChangeTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MobileBroadbandPinLockStateChangeTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: MobileBroadbandPinLockStateChangeTrigger) -> ::windows::core::Result<Self> {
@@ -7225,36 +5828,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandRadioStateChangeTrigge
 impl ::windows::core::RuntimeName for MobileBroadbandRadioStateChangeTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.MobileBroadbandRadioStateChangeTrigger";
 }
-impl ::core::convert::From<MobileBroadbandRadioStateChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandRadioStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandRadioStateChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChangeTrigger> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandRadioStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandRadioStateChangeTrigger> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandRadioStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChangeTrigger> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandRadioStateChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChangeTrigger> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandRadioStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandRadioStateChangeTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MobileBroadbandRadioStateChangeTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: MobileBroadbandRadioStateChangeTrigger) -> ::windows::core::Result<Self> {
@@ -7320,36 +5894,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandRegistrationStateChang
 impl ::windows::core::RuntimeName for MobileBroadbandRegistrationStateChangeTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.MobileBroadbandRegistrationStateChangeTrigger";
 }
-impl ::core::convert::From<MobileBroadbandRegistrationStateChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandRegistrationStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRegistrationStateChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandRegistrationStateChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRegistrationStateChangeTrigger> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandRegistrationStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandRegistrationStateChangeTrigger> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandRegistrationStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRegistrationStateChangeTrigger> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandRegistrationStateChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRegistrationStateChangeTrigger> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandRegistrationStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandRegistrationStateChangeTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MobileBroadbandRegistrationStateChangeTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: MobileBroadbandRegistrationStateChangeTrigger) -> ::windows::core::Result<Self> {
@@ -7415,36 +5960,7 @@ unsafe impl ::windows::core::Interface for NetworkOperatorDataUsageTrigger {
 impl ::windows::core::RuntimeName for NetworkOperatorDataUsageTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.NetworkOperatorDataUsageTrigger";
 }
-impl ::core::convert::From<NetworkOperatorDataUsageTrigger> for ::windows::core::IUnknown {
-    fn from(value: NetworkOperatorDataUsageTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorDataUsageTrigger> for ::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorDataUsageTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorDataUsageTrigger> for &::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorDataUsageTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkOperatorDataUsageTrigger> for ::windows::core::IInspectable {
-    fn from(value: NetworkOperatorDataUsageTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorDataUsageTrigger> for ::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorDataUsageTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorDataUsageTrigger> for &::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorDataUsageTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkOperatorDataUsageTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<NetworkOperatorDataUsageTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: NetworkOperatorDataUsageTrigger) -> ::windows::core::Result<Self> {
@@ -7510,36 +6026,7 @@ unsafe impl ::windows::core::Interface for NetworkOperatorHotspotAuthenticationT
 impl ::windows::core::RuntimeName for NetworkOperatorHotspotAuthenticationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.NetworkOperatorHotspotAuthenticationTrigger";
 }
-impl ::core::convert::From<NetworkOperatorHotspotAuthenticationTrigger> for ::windows::core::IUnknown {
-    fn from(value: NetworkOperatorHotspotAuthenticationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorHotspotAuthenticationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorHotspotAuthenticationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorHotspotAuthenticationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorHotspotAuthenticationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkOperatorHotspotAuthenticationTrigger> for ::windows::core::IInspectable {
-    fn from(value: NetworkOperatorHotspotAuthenticationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorHotspotAuthenticationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorHotspotAuthenticationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorHotspotAuthenticationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorHotspotAuthenticationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkOperatorHotspotAuthenticationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<NetworkOperatorHotspotAuthenticationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: NetworkOperatorHotspotAuthenticationTrigger) -> ::windows::core::Result<Self> {
@@ -7614,36 +6101,7 @@ unsafe impl ::windows::core::Interface for NetworkOperatorNotificationTrigger {
 impl ::windows::core::RuntimeName for NetworkOperatorNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.NetworkOperatorNotificationTrigger";
 }
-impl ::core::convert::From<NetworkOperatorNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: NetworkOperatorNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorNotificationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkOperatorNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: NetworkOperatorNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorNotificationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkOperatorNotificationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<NetworkOperatorNotificationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: NetworkOperatorNotificationTrigger) -> ::windows::core::Result<Self> {
@@ -7707,36 +6165,7 @@ unsafe impl ::windows::core::Interface for PaymentAppCanMakePaymentTrigger {
 impl ::windows::core::RuntimeName for PaymentAppCanMakePaymentTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.PaymentAppCanMakePaymentTrigger";
 }
-impl ::core::convert::From<PaymentAppCanMakePaymentTrigger> for ::windows::core::IUnknown {
-    fn from(value: PaymentAppCanMakePaymentTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentAppCanMakePaymentTrigger> for ::windows::core::IUnknown {
-    fn from(value: &PaymentAppCanMakePaymentTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentAppCanMakePaymentTrigger> for &::windows::core::IUnknown {
-    fn from(value: &PaymentAppCanMakePaymentTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentAppCanMakePaymentTrigger> for ::windows::core::IInspectable {
-    fn from(value: PaymentAppCanMakePaymentTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentAppCanMakePaymentTrigger> for ::windows::core::IInspectable {
-    fn from(value: &PaymentAppCanMakePaymentTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentAppCanMakePaymentTrigger> for &::windows::core::IInspectable {
-    fn from(value: &PaymentAppCanMakePaymentTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentAppCanMakePaymentTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PaymentAppCanMakePaymentTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: PaymentAppCanMakePaymentTrigger) -> ::windows::core::Result<Self> {
@@ -7824,36 +6253,7 @@ unsafe impl ::windows::core::Interface for PhoneTrigger {
 impl ::windows::core::RuntimeName for PhoneTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.PhoneTrigger";
 }
-impl ::core::convert::From<PhoneTrigger> for ::windows::core::IUnknown {
-    fn from(value: PhoneTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneTrigger> for ::windows::core::IUnknown {
-    fn from(value: &PhoneTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneTrigger> for &::windows::core::IUnknown {
-    fn from(value: &PhoneTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneTrigger> for ::windows::core::IInspectable {
-    fn from(value: PhoneTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneTrigger> for ::windows::core::IInspectable {
-    fn from(value: &PhoneTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneTrigger> for &::windows::core::IInspectable {
-    fn from(value: &PhoneTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PhoneTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: PhoneTrigger) -> ::windows::core::Result<Self> {
@@ -7930,36 +6330,7 @@ unsafe impl ::windows::core::Interface for PushNotificationTrigger {
 impl ::windows::core::RuntimeName for PushNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.PushNotificationTrigger";
 }
-impl ::core::convert::From<PushNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: PushNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PushNotificationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &PushNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PushNotificationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &PushNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PushNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: PushNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PushNotificationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &PushNotificationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PushNotificationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &PushNotificationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PushNotificationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PushNotificationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: PushNotificationTrigger) -> ::windows::core::Result<Self> {
@@ -8025,36 +6396,7 @@ unsafe impl ::windows::core::Interface for RcsEndUserMessageAvailableTrigger {
 impl ::windows::core::RuntimeName for RcsEndUserMessageAvailableTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.RcsEndUserMessageAvailableTrigger";
 }
-impl ::core::convert::From<RcsEndUserMessageAvailableTrigger> for ::windows::core::IUnknown {
-    fn from(value: RcsEndUserMessageAvailableTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableTrigger> for ::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessageAvailableTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableTrigger> for &::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessageAvailableTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RcsEndUserMessageAvailableTrigger> for ::windows::core::IInspectable {
-    fn from(value: RcsEndUserMessageAvailableTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableTrigger> for ::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessageAvailableTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableTrigger> for &::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessageAvailableTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RcsEndUserMessageAvailableTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RcsEndUserMessageAvailableTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: RcsEndUserMessageAvailableTrigger) -> ::windows::core::Result<Self> {
@@ -8179,36 +6521,7 @@ unsafe impl ::windows::core::Interface for RfcommConnectionTrigger {
 impl ::windows::core::RuntimeName for RfcommConnectionTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.RfcommConnectionTrigger";
 }
-impl ::core::convert::From<RfcommConnectionTrigger> for ::windows::core::IUnknown {
-    fn from(value: RfcommConnectionTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommConnectionTrigger> for ::windows::core::IUnknown {
-    fn from(value: &RfcommConnectionTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommConnectionTrigger> for &::windows::core::IUnknown {
-    fn from(value: &RfcommConnectionTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RfcommConnectionTrigger> for ::windows::core::IInspectable {
-    fn from(value: RfcommConnectionTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommConnectionTrigger> for ::windows::core::IInspectable {
-    fn from(value: &RfcommConnectionTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommConnectionTrigger> for &::windows::core::IInspectable {
-    fn from(value: &RfcommConnectionTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RfcommConnectionTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RfcommConnectionTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: RfcommConnectionTrigger) -> ::windows::core::Result<Self> {
@@ -8285,41 +6598,7 @@ impl ::windows::core::RuntimeName for SecondaryAuthenticationFactorAuthenticatio
     const NAME: &'static str = "Windows.ApplicationModel.Background.SecondaryAuthenticationFactorAuthenticationTrigger";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorAuthenticationTrigger> for ::windows::core::IUnknown {
-    fn from(value: SecondaryAuthenticationFactorAuthenticationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationTrigger> for &::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorAuthenticationTrigger> for ::windows::core::IInspectable {
-    fn from(value: SecondaryAuthenticationFactorAuthenticationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationTrigger> for ::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationTrigger> for &::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SecondaryAuthenticationFactorAuthenticationTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<SecondaryAuthenticationFactorAuthenticationTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
@@ -8396,36 +6675,7 @@ unsafe impl ::windows::core::Interface for SensorDataThresholdTrigger {
 impl ::windows::core::RuntimeName for SensorDataThresholdTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.SensorDataThresholdTrigger";
 }
-impl ::core::convert::From<SensorDataThresholdTrigger> for ::windows::core::IUnknown {
-    fn from(value: SensorDataThresholdTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SensorDataThresholdTrigger> for ::windows::core::IUnknown {
-    fn from(value: &SensorDataThresholdTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SensorDataThresholdTrigger> for &::windows::core::IUnknown {
-    fn from(value: &SensorDataThresholdTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SensorDataThresholdTrigger> for ::windows::core::IInspectable {
-    fn from(value: SensorDataThresholdTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SensorDataThresholdTrigger> for ::windows::core::IInspectable {
-    fn from(value: &SensorDataThresholdTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SensorDataThresholdTrigger> for &::windows::core::IInspectable {
-    fn from(value: &SensorDataThresholdTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SensorDataThresholdTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SensorDataThresholdTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: SensorDataThresholdTrigger) -> ::windows::core::Result<Self> {
@@ -8506,36 +6756,7 @@ unsafe impl ::windows::core::Interface for SmartCardTrigger {
 impl ::windows::core::RuntimeName for SmartCardTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.SmartCardTrigger";
 }
-impl ::core::convert::From<SmartCardTrigger> for ::windows::core::IUnknown {
-    fn from(value: SmartCardTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardTrigger> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardTrigger> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardTrigger> for ::windows::core::IInspectable {
-    fn from(value: SmartCardTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardTrigger> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardTrigger> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SmartCardTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: SmartCardTrigger) -> ::windows::core::Result<Self> {
@@ -8605,36 +6826,7 @@ unsafe impl ::windows::core::Interface for SmsMessageReceivedTrigger {
 impl ::windows::core::RuntimeName for SmsMessageReceivedTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.SmsMessageReceivedTrigger";
 }
-impl ::core::convert::From<SmsMessageReceivedTrigger> for ::windows::core::IUnknown {
-    fn from(value: SmsMessageReceivedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsMessageReceivedTrigger> for ::windows::core::IUnknown {
-    fn from(value: &SmsMessageReceivedTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsMessageReceivedTrigger> for &::windows::core::IUnknown {
-    fn from(value: &SmsMessageReceivedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsMessageReceivedTrigger> for ::windows::core::IInspectable {
-    fn from(value: SmsMessageReceivedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsMessageReceivedTrigger> for ::windows::core::IInspectable {
-    fn from(value: &SmsMessageReceivedTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsMessageReceivedTrigger> for &::windows::core::IInspectable {
-    fn from(value: &SmsMessageReceivedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsMessageReceivedTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SmsMessageReceivedTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: SmsMessageReceivedTrigger) -> ::windows::core::Result<Self> {
@@ -8707,36 +6899,7 @@ unsafe impl ::windows::core::Interface for SocketActivityTrigger {
 impl ::windows::core::RuntimeName for SocketActivityTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.SocketActivityTrigger";
 }
-impl ::core::convert::From<SocketActivityTrigger> for ::windows::core::IUnknown {
-    fn from(value: SocketActivityTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SocketActivityTrigger> for ::windows::core::IUnknown {
-    fn from(value: &SocketActivityTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SocketActivityTrigger> for &::windows::core::IUnknown {
-    fn from(value: &SocketActivityTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SocketActivityTrigger> for ::windows::core::IInspectable {
-    fn from(value: SocketActivityTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SocketActivityTrigger> for ::windows::core::IInspectable {
-    fn from(value: &SocketActivityTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SocketActivityTrigger> for &::windows::core::IInspectable {
-    fn from(value: &SocketActivityTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocketActivityTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SocketActivityTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: SocketActivityTrigger) -> ::windows::core::Result<Self> {
@@ -8808,36 +6971,7 @@ unsafe impl ::windows::core::Interface for StorageLibraryChangeTrackerTrigger {
 impl ::windows::core::RuntimeName for StorageLibraryChangeTrackerTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.StorageLibraryChangeTrackerTrigger";
 }
-impl ::core::convert::From<StorageLibraryChangeTrackerTrigger> for ::windows::core::IUnknown {
-    fn from(value: StorageLibraryChangeTrackerTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerTrigger> for ::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChangeTrackerTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerTrigger> for &::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChangeTrackerTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageLibraryChangeTrackerTrigger> for ::windows::core::IInspectable {
-    fn from(value: StorageLibraryChangeTrackerTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerTrigger> for ::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChangeTrackerTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerTrigger> for &::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChangeTrackerTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageLibraryChangeTrackerTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StorageLibraryChangeTrackerTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: StorageLibraryChangeTrackerTrigger) -> ::windows::core::Result<Self> {
@@ -8921,36 +7055,7 @@ unsafe impl ::windows::core::Interface for StorageLibraryContentChangedTrigger {
 impl ::windows::core::RuntimeName for StorageLibraryContentChangedTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.StorageLibraryContentChangedTrigger";
 }
-impl ::core::convert::From<StorageLibraryContentChangedTrigger> for ::windows::core::IUnknown {
-    fn from(value: StorageLibraryContentChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryContentChangedTrigger> for ::windows::core::IUnknown {
-    fn from(value: &StorageLibraryContentChangedTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryContentChangedTrigger> for &::windows::core::IUnknown {
-    fn from(value: &StorageLibraryContentChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageLibraryContentChangedTrigger> for ::windows::core::IInspectable {
-    fn from(value: StorageLibraryContentChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryContentChangedTrigger> for ::windows::core::IInspectable {
-    fn from(value: &StorageLibraryContentChangedTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryContentChangedTrigger> for &::windows::core::IInspectable {
-    fn from(value: &StorageLibraryContentChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageLibraryContentChangedTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StorageLibraryContentChangedTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: StorageLibraryContentChangedTrigger) -> ::windows::core::Result<Self> {
@@ -9025,36 +7130,7 @@ unsafe impl ::windows::core::Interface for SystemCondition {
 impl ::windows::core::RuntimeName for SystemCondition {
     const NAME: &'static str = "Windows.ApplicationModel.Background.SystemCondition";
 }
-impl ::core::convert::From<SystemCondition> for ::windows::core::IUnknown {
-    fn from(value: SystemCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemCondition> for ::windows::core::IUnknown {
-    fn from(value: &SystemCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemCondition> for &::windows::core::IUnknown {
-    fn from(value: &SystemCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemCondition> for ::windows::core::IInspectable {
-    fn from(value: SystemCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemCondition> for ::windows::core::IInspectable {
-    fn from(value: &SystemCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemCondition> for &::windows::core::IInspectable {
-    fn from(value: &SystemCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemCondition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SystemCondition> for IBackgroundCondition {
     type Error = ::windows::core::Error;
     fn try_from(value: SystemCondition) -> ::windows::core::Result<Self> {
@@ -9136,36 +7212,7 @@ unsafe impl ::windows::core::Interface for SystemTrigger {
 impl ::windows::core::RuntimeName for SystemTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.SystemTrigger";
 }
-impl ::core::convert::From<SystemTrigger> for ::windows::core::IUnknown {
-    fn from(value: SystemTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemTrigger> for ::windows::core::IUnknown {
-    fn from(value: &SystemTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemTrigger> for &::windows::core::IUnknown {
-    fn from(value: &SystemTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemTrigger> for ::windows::core::IInspectable {
-    fn from(value: SystemTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemTrigger> for ::windows::core::IInspectable {
-    fn from(value: &SystemTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemTrigger> for &::windows::core::IInspectable {
-    fn from(value: &SystemTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SystemTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: SystemTrigger) -> ::windows::core::Result<Self> {
@@ -9229,36 +7276,7 @@ unsafe impl ::windows::core::Interface for TetheringEntitlementCheckTrigger {
 impl ::windows::core::RuntimeName for TetheringEntitlementCheckTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.TetheringEntitlementCheckTrigger";
 }
-impl ::core::convert::From<TetheringEntitlementCheckTrigger> for ::windows::core::IUnknown {
-    fn from(value: TetheringEntitlementCheckTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TetheringEntitlementCheckTrigger> for ::windows::core::IUnknown {
-    fn from(value: &TetheringEntitlementCheckTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TetheringEntitlementCheckTrigger> for &::windows::core::IUnknown {
-    fn from(value: &TetheringEntitlementCheckTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TetheringEntitlementCheckTrigger> for ::windows::core::IInspectable {
-    fn from(value: TetheringEntitlementCheckTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TetheringEntitlementCheckTrigger> for ::windows::core::IInspectable {
-    fn from(value: &TetheringEntitlementCheckTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TetheringEntitlementCheckTrigger> for &::windows::core::IInspectable {
-    fn from(value: &TetheringEntitlementCheckTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TetheringEntitlementCheckTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<TetheringEntitlementCheckTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: TetheringEntitlementCheckTrigger) -> ::windows::core::Result<Self> {
@@ -9342,36 +7360,7 @@ unsafe impl ::windows::core::Interface for TimeTrigger {
 impl ::windows::core::RuntimeName for TimeTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.TimeTrigger";
 }
-impl ::core::convert::From<TimeTrigger> for ::windows::core::IUnknown {
-    fn from(value: TimeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimeTrigger> for ::windows::core::IUnknown {
-    fn from(value: &TimeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimeTrigger> for &::windows::core::IUnknown {
-    fn from(value: &TimeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimeTrigger> for ::windows::core::IInspectable {
-    fn from(value: TimeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimeTrigger> for ::windows::core::IInspectable {
-    fn from(value: &TimeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimeTrigger> for &::windows::core::IInspectable {
-    fn from(value: &TimeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimeTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<TimeTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: TimeTrigger) -> ::windows::core::Result<Self> {
@@ -9446,36 +7435,7 @@ unsafe impl ::windows::core::Interface for ToastNotificationActionTrigger {
 impl ::windows::core::RuntimeName for ToastNotificationActionTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ToastNotificationActionTrigger";
 }
-impl ::core::convert::From<ToastNotificationActionTrigger> for ::windows::core::IUnknown {
-    fn from(value: ToastNotificationActionTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationActionTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ToastNotificationActionTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationActionTrigger> for &::windows::core::IUnknown {
-    fn from(value: &ToastNotificationActionTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastNotificationActionTrigger> for ::windows::core::IInspectable {
-    fn from(value: ToastNotificationActionTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationActionTrigger> for ::windows::core::IInspectable {
-    fn from(value: &ToastNotificationActionTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationActionTrigger> for &::windows::core::IInspectable {
-    fn from(value: &ToastNotificationActionTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastNotificationActionTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ToastNotificationActionTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: ToastNotificationActionTrigger) -> ::windows::core::Result<Self> {
@@ -9552,36 +7512,7 @@ unsafe impl ::windows::core::Interface for ToastNotificationHistoryChangedTrigge
 impl ::windows::core::RuntimeName for ToastNotificationHistoryChangedTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ToastNotificationHistoryChangedTrigger";
 }
-impl ::core::convert::From<ToastNotificationHistoryChangedTrigger> for ::windows::core::IUnknown {
-    fn from(value: ToastNotificationHistoryChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistoryChangedTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ToastNotificationHistoryChangedTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistoryChangedTrigger> for &::windows::core::IUnknown {
-    fn from(value: &ToastNotificationHistoryChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastNotificationHistoryChangedTrigger> for ::windows::core::IInspectable {
-    fn from(value: ToastNotificationHistoryChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistoryChangedTrigger> for ::windows::core::IInspectable {
-    fn from(value: &ToastNotificationHistoryChangedTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistoryChangedTrigger> for &::windows::core::IInspectable {
-    fn from(value: &ToastNotificationHistoryChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastNotificationHistoryChangedTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ToastNotificationHistoryChangedTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: ToastNotificationHistoryChangedTrigger) -> ::windows::core::Result<Self> {
@@ -9653,36 +7584,7 @@ unsafe impl ::windows::core::Interface for UserNotificationChangedTrigger {
 impl ::windows::core::RuntimeName for UserNotificationChangedTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.UserNotificationChangedTrigger";
 }
-impl ::core::convert::From<UserNotificationChangedTrigger> for ::windows::core::IUnknown {
-    fn from(value: UserNotificationChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserNotificationChangedTrigger> for ::windows::core::IUnknown {
-    fn from(value: &UserNotificationChangedTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserNotificationChangedTrigger> for &::windows::core::IUnknown {
-    fn from(value: &UserNotificationChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserNotificationChangedTrigger> for ::windows::core::IInspectable {
-    fn from(value: UserNotificationChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserNotificationChangedTrigger> for ::windows::core::IInspectable {
-    fn from(value: &UserNotificationChangedTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserNotificationChangedTrigger> for &::windows::core::IInspectable {
-    fn from(value: &UserNotificationChangedTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserNotificationChangedTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<UserNotificationChangedTrigger> for IBackgroundTrigger {
     type Error = ::windows::core::Error;
     fn try_from(value: UserNotificationChangedTrigger) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
@@ -162,36 +162,7 @@ unsafe impl ::windows::core::Interface for PhoneCallBlockedTriggerDetails {
 impl ::windows::core::RuntimeName for PhoneCallBlockedTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.Background.PhoneCallBlockedTriggerDetails";
 }
-impl ::core::convert::From<PhoneCallBlockedTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallBlockedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallBlockedTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallBlockedTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallBlockedTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallBlockedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallBlockedTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallBlockedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallBlockedTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallBlockedTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallBlockedTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallBlockedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallBlockedTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallBlockedTriggerDetails {}
 unsafe impl ::core::marker::Sync for PhoneCallBlockedTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Calls_Background\"`*"]
@@ -245,36 +216,7 @@ unsafe impl ::windows::core::Interface for PhoneCallOriginDataRequestTriggerDeta
 impl ::windows::core::RuntimeName for PhoneCallOriginDataRequestTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.Background.PhoneCallOriginDataRequestTriggerDetails";
 }
-impl ::core::convert::From<PhoneCallOriginDataRequestTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallOriginDataRequestTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallOriginDataRequestTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallOriginDataRequestTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallOriginDataRequestTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallOriginDataRequestTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallOriginDataRequestTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallOriginDataRequestTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallOriginDataRequestTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallOriginDataRequestTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallOriginDataRequestTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallOriginDataRequestTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallOriginDataRequestTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallOriginDataRequestTriggerDetails {}
 unsafe impl ::core::marker::Sync for PhoneCallOriginDataRequestTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Calls_Background\"`*"]
@@ -358,36 +300,7 @@ unsafe impl ::windows::core::Interface for PhoneIncomingCallDismissedTriggerDeta
 impl ::windows::core::RuntimeName for PhoneIncomingCallDismissedTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.Background.PhoneIncomingCallDismissedTriggerDetails";
 }
-impl ::core::convert::From<PhoneIncomingCallDismissedTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: PhoneIncomingCallDismissedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneIncomingCallDismissedTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &PhoneIncomingCallDismissedTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneIncomingCallDismissedTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &PhoneIncomingCallDismissedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneIncomingCallDismissedTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: PhoneIncomingCallDismissedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneIncomingCallDismissedTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &PhoneIncomingCallDismissedTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneIncomingCallDismissedTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &PhoneIncomingCallDismissedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneIncomingCallDismissedTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneIncomingCallDismissedTriggerDetails {}
 unsafe impl ::core::marker::Sync for PhoneIncomingCallDismissedTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Calls_Background\"`*"]
@@ -441,36 +354,7 @@ unsafe impl ::windows::core::Interface for PhoneIncomingCallNotificationTriggerD
 impl ::windows::core::RuntimeName for PhoneIncomingCallNotificationTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.Background.PhoneIncomingCallNotificationTriggerDetails";
 }
-impl ::core::convert::From<PhoneIncomingCallNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: PhoneIncomingCallNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneIncomingCallNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &PhoneIncomingCallNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneIncomingCallNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &PhoneIncomingCallNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneIncomingCallNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: PhoneIncomingCallNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneIncomingCallNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &PhoneIncomingCallNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneIncomingCallNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &PhoneIncomingCallNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneIncomingCallNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneIncomingCallNotificationTriggerDetails {}
 unsafe impl ::core::marker::Sync for PhoneIncomingCallNotificationTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Calls_Background\"`*"]
@@ -531,36 +415,7 @@ unsafe impl ::windows::core::Interface for PhoneLineChangedTriggerDetails {
 impl ::windows::core::RuntimeName for PhoneLineChangedTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.Background.PhoneLineChangedTriggerDetails";
 }
-impl ::core::convert::From<PhoneLineChangedTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: PhoneLineChangedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineChangedTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &PhoneLineChangedTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineChangedTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &PhoneLineChangedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneLineChangedTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: PhoneLineChangedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineChangedTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &PhoneLineChangedTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineChangedTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &PhoneLineChangedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneLineChangedTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneLineChangedTriggerDetails {}
 unsafe impl ::core::marker::Sync for PhoneLineChangedTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Calls_Background\"`*"]
@@ -621,36 +476,7 @@ unsafe impl ::windows::core::Interface for PhoneNewVoicemailMessageTriggerDetail
 impl ::windows::core::RuntimeName for PhoneNewVoicemailMessageTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.Background.PhoneNewVoicemailMessageTriggerDetails";
 }
-impl ::core::convert::From<PhoneNewVoicemailMessageTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: PhoneNewVoicemailMessageTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneNewVoicemailMessageTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &PhoneNewVoicemailMessageTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneNewVoicemailMessageTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &PhoneNewVoicemailMessageTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneNewVoicemailMessageTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: PhoneNewVoicemailMessageTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneNewVoicemailMessageTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &PhoneNewVoicemailMessageTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneNewVoicemailMessageTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &PhoneNewVoicemailMessageTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneNewVoicemailMessageTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneNewVoicemailMessageTriggerDetails {}
 unsafe impl ::core::marker::Sync for PhoneNewVoicemailMessageTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Calls_Background\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/Provider/mod.rs
@@ -209,36 +209,7 @@ unsafe impl ::windows::core::Interface for PhoneCallOrigin {
 impl ::windows::core::RuntimeName for PhoneCallOrigin {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin";
 }
-impl ::core::convert::From<PhoneCallOrigin> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallOrigin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallOrigin> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallOrigin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallOrigin> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallOrigin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallOrigin> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallOrigin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallOrigin> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallOrigin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallOrigin> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallOrigin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallOrigin, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallOrigin {}
 unsafe impl ::core::marker::Sync for PhoneCallOrigin {}
 #[doc = "*Required features: `\"ApplicationModel_Calls_Provider\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
@@ -1271,36 +1271,7 @@ unsafe impl ::windows::core::Interface for CallAnswerEventArgs {
 impl ::windows::core::RuntimeName for CallAnswerEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.CallAnswerEventArgs";
 }
-impl ::core::convert::From<CallAnswerEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CallAnswerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CallAnswerEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CallAnswerEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CallAnswerEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CallAnswerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CallAnswerEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CallAnswerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CallAnswerEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CallAnswerEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CallAnswerEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CallAnswerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CallAnswerEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CallAnswerEventArgs {}
 unsafe impl ::core::marker::Sync for CallAnswerEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -1347,36 +1318,7 @@ unsafe impl ::windows::core::Interface for CallRejectEventArgs {
 impl ::windows::core::RuntimeName for CallRejectEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.CallRejectEventArgs";
 }
-impl ::core::convert::From<CallRejectEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CallRejectEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CallRejectEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CallRejectEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CallRejectEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CallRejectEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CallRejectEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CallRejectEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CallRejectEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CallRejectEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CallRejectEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CallRejectEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CallRejectEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CallRejectEventArgs {}
 unsafe impl ::core::marker::Sync for CallRejectEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -1423,36 +1365,7 @@ unsafe impl ::windows::core::Interface for CallStateChangeEventArgs {
 impl ::windows::core::RuntimeName for CallStateChangeEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.CallStateChangeEventArgs";
 }
-impl ::core::convert::From<CallStateChangeEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CallStateChangeEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CallStateChangeEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CallStateChangeEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CallStateChangeEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CallStateChangeEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CallStateChangeEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CallStateChangeEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CallStateChangeEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CallStateChangeEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CallStateChangeEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CallStateChangeEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CallStateChangeEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CallStateChangeEventArgs {}
 unsafe impl ::core::marker::Sync for CallStateChangeEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -1496,36 +1409,7 @@ unsafe impl ::windows::core::Interface for LockScreenCallEndCallDeferral {
 impl ::windows::core::RuntimeName for LockScreenCallEndCallDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.LockScreenCallEndCallDeferral";
 }
-impl ::core::convert::From<LockScreenCallEndCallDeferral> for ::windows::core::IUnknown {
-    fn from(value: LockScreenCallEndCallDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenCallEndCallDeferral> for ::windows::core::IUnknown {
-    fn from(value: &LockScreenCallEndCallDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenCallEndCallDeferral> for &::windows::core::IUnknown {
-    fn from(value: &LockScreenCallEndCallDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LockScreenCallEndCallDeferral> for ::windows::core::IInspectable {
-    fn from(value: LockScreenCallEndCallDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenCallEndCallDeferral> for ::windows::core::IInspectable {
-    fn from(value: &LockScreenCallEndCallDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenCallEndCallDeferral> for &::windows::core::IInspectable {
-    fn from(value: &LockScreenCallEndCallDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LockScreenCallEndCallDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LockScreenCallEndCallDeferral {}
 unsafe impl ::core::marker::Sync for LockScreenCallEndCallDeferral {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -1581,36 +1465,7 @@ unsafe impl ::windows::core::Interface for LockScreenCallEndRequestedEventArgs {
 impl ::windows::core::RuntimeName for LockScreenCallEndRequestedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.LockScreenCallEndRequestedEventArgs";
 }
-impl ::core::convert::From<LockScreenCallEndRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LockScreenCallEndRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenCallEndRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LockScreenCallEndRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenCallEndRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LockScreenCallEndRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LockScreenCallEndRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LockScreenCallEndRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenCallEndRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LockScreenCallEndRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenCallEndRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LockScreenCallEndRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LockScreenCallEndRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LockScreenCallEndRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for LockScreenCallEndRequestedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -1695,36 +1550,7 @@ unsafe impl ::windows::core::Interface for LockScreenCallUI {
 impl ::windows::core::RuntimeName for LockScreenCallUI {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.LockScreenCallUI";
 }
-impl ::core::convert::From<LockScreenCallUI> for ::windows::core::IUnknown {
-    fn from(value: LockScreenCallUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenCallUI> for ::windows::core::IUnknown {
-    fn from(value: &LockScreenCallUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenCallUI> for &::windows::core::IUnknown {
-    fn from(value: &LockScreenCallUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LockScreenCallUI> for ::windows::core::IInspectable {
-    fn from(value: LockScreenCallUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenCallUI> for ::windows::core::IInspectable {
-    fn from(value: &LockScreenCallUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenCallUI> for &::windows::core::IInspectable {
-    fn from(value: &LockScreenCallUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LockScreenCallUI, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LockScreenCallUI {}
 unsafe impl ::core::marker::Sync for LockScreenCallUI {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -1771,36 +1597,7 @@ unsafe impl ::windows::core::Interface for MuteChangeEventArgs {
 impl ::windows::core::RuntimeName for MuteChangeEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.MuteChangeEventArgs";
 }
-impl ::core::convert::From<MuteChangeEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MuteChangeEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MuteChangeEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MuteChangeEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MuteChangeEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MuteChangeEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MuteChangeEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MuteChangeEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MuteChangeEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MuteChangeEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MuteChangeEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MuteChangeEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MuteChangeEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MuteChangeEventArgs {}
 unsafe impl ::core::marker::Sync for MuteChangeEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -2084,36 +1881,7 @@ unsafe impl ::windows::core::Interface for PhoneCall {
 impl ::windows::core::RuntimeName for PhoneCall {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCall";
 }
-impl ::core::convert::From<PhoneCall> for ::windows::core::IUnknown {
-    fn from(value: PhoneCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCall> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCall) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCall> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCall> for ::windows::core::IInspectable {
-    fn from(value: PhoneCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCall> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCall) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCall> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCall, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCall {}
 unsafe impl ::core::marker::Sync for PhoneCall {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -2404,36 +2172,7 @@ unsafe impl ::windows::core::Interface for PhoneCallHistoryEntry {
 impl ::windows::core::RuntimeName for PhoneCallHistoryEntry {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallHistoryEntry";
 }
-impl ::core::convert::From<PhoneCallHistoryEntry> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallHistoryEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntry> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntry> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallHistoryEntry> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallHistoryEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntry> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntry> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallHistoryEntry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallHistoryEntry {}
 unsafe impl ::core::marker::Sync for PhoneCallHistoryEntry {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -2535,36 +2274,7 @@ unsafe impl ::windows::core::Interface for PhoneCallHistoryEntryAddress {
 impl ::windows::core::RuntimeName for PhoneCallHistoryEntryAddress {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallHistoryEntryAddress";
 }
-impl ::core::convert::From<PhoneCallHistoryEntryAddress> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallHistoryEntryAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryAddress> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryEntryAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryAddress> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryEntryAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallHistoryEntryAddress> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallHistoryEntryAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryAddress> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryEntryAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryAddress> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryEntryAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallHistoryEntryAddress, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallHistoryEntryAddress {}
 unsafe impl ::core::marker::Sync for PhoneCallHistoryEntryAddress {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -2631,36 +2341,7 @@ unsafe impl ::windows::core::Interface for PhoneCallHistoryEntryQueryOptions {
 impl ::windows::core::RuntimeName for PhoneCallHistoryEntryQueryOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallHistoryEntryQueryOptions";
 }
-impl ::core::convert::From<PhoneCallHistoryEntryQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallHistoryEntryQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryEntryQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryQueryOptions> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryEntryQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallHistoryEntryQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallHistoryEntryQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryEntryQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryQueryOptions> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryEntryQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallHistoryEntryQueryOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallHistoryEntryQueryOptions {}
 unsafe impl ::core::marker::Sync for PhoneCallHistoryEntryQueryOptions {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -2709,36 +2390,7 @@ unsafe impl ::windows::core::Interface for PhoneCallHistoryEntryReader {
 impl ::windows::core::RuntimeName for PhoneCallHistoryEntryReader {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallHistoryEntryReader";
 }
-impl ::core::convert::From<PhoneCallHistoryEntryReader> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallHistoryEntryReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryReader> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryEntryReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryReader> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryEntryReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallHistoryEntryReader> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallHistoryEntryReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryReader> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryEntryReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryEntryReader> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryEntryReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallHistoryEntryReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallHistoryEntryReader {}
 unsafe impl ::core::marker::Sync for PhoneCallHistoryEntryReader {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -2829,36 +2481,7 @@ unsafe impl ::windows::core::Interface for PhoneCallHistoryManagerForUser {
 impl ::windows::core::RuntimeName for PhoneCallHistoryManagerForUser {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallHistoryManagerForUser";
 }
-impl ::core::convert::From<PhoneCallHistoryManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallHistoryManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryManagerForUser> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallHistoryManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallHistoryManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryManagerForUser> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallHistoryManagerForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallHistoryManagerForUser {}
 unsafe impl ::core::marker::Sync for PhoneCallHistoryManagerForUser {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -3018,36 +2641,7 @@ unsafe impl ::windows::core::Interface for PhoneCallHistoryStore {
 impl ::windows::core::RuntimeName for PhoneCallHistoryStore {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallHistoryStore";
 }
-impl ::core::convert::From<PhoneCallHistoryStore> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallHistoryStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryStore> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryStore> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallHistoryStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallHistoryStore> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallHistoryStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryStore> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallHistoryStore> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallHistoryStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallHistoryStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallHistoryStore {}
 unsafe impl ::core::marker::Sync for PhoneCallHistoryStore {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -3131,36 +2725,7 @@ unsafe impl ::windows::core::Interface for PhoneCallInfo {
 impl ::windows::core::RuntimeName for PhoneCallInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallInfo";
 }
-impl ::core::convert::From<PhoneCallInfo> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallInfo> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallInfo> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallInfo> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallInfo> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallInfo> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallInfo {}
 unsafe impl ::core::marker::Sync for PhoneCallInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -3281,36 +2846,7 @@ unsafe impl ::windows::core::Interface for PhoneCallStore {
 impl ::windows::core::RuntimeName for PhoneCallStore {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallStore";
 }
-impl ::core::convert::From<PhoneCallStore> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallStore> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallStore> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallStore> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallStore> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallStore> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallStore {}
 unsafe impl ::core::marker::Sync for PhoneCallStore {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -3357,36 +2893,7 @@ unsafe impl ::windows::core::Interface for PhoneCallVideoCapabilities {
 impl ::windows::core::RuntimeName for PhoneCallVideoCapabilities {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallVideoCapabilities";
 }
-impl ::core::convert::From<PhoneCallVideoCapabilities> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallVideoCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallVideoCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallVideoCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallVideoCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallVideoCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallVideoCapabilities> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallVideoCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallVideoCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallVideoCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallVideoCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallVideoCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallVideoCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallVideoCapabilities {}
 unsafe impl ::core::marker::Sync for PhoneCallVideoCapabilities {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -3462,36 +2969,7 @@ unsafe impl ::windows::core::Interface for PhoneCallsResult {
 impl ::windows::core::RuntimeName for PhoneCallsResult {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallsResult";
 }
-impl ::core::convert::From<PhoneCallsResult> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallsResult> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallsResult> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallsResult> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallsResult> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallsResult> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneCallsResult {}
 unsafe impl ::core::marker::Sync for PhoneCallsResult {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -3612,36 +3090,7 @@ unsafe impl ::windows::core::Interface for PhoneDialOptions {
 impl ::windows::core::RuntimeName for PhoneDialOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneDialOptions";
 }
-impl ::core::convert::From<PhoneDialOptions> for ::windows::core::IUnknown {
-    fn from(value: PhoneDialOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneDialOptions> for ::windows::core::IUnknown {
-    fn from(value: &PhoneDialOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneDialOptions> for &::windows::core::IUnknown {
-    fn from(value: &PhoneDialOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneDialOptions> for ::windows::core::IInspectable {
-    fn from(value: PhoneDialOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneDialOptions> for ::windows::core::IInspectable {
-    fn from(value: &PhoneDialOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneDialOptions> for &::windows::core::IInspectable {
-    fn from(value: &PhoneDialOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneDialOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneDialOptions {}
 unsafe impl ::core::marker::Sync for PhoneDialOptions {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -3855,36 +3304,7 @@ unsafe impl ::windows::core::Interface for PhoneLine {
 impl ::windows::core::RuntimeName for PhoneLine {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneLine";
 }
-impl ::core::convert::From<PhoneLine> for ::windows::core::IUnknown {
-    fn from(value: PhoneLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLine> for ::windows::core::IUnknown {
-    fn from(value: &PhoneLine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLine> for &::windows::core::IUnknown {
-    fn from(value: &PhoneLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneLine> for ::windows::core::IInspectable {
-    fn from(value: PhoneLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLine> for ::windows::core::IInspectable {
-    fn from(value: &PhoneLine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLine> for &::windows::core::IInspectable {
-    fn from(value: &PhoneLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneLine, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneLine {}
 unsafe impl ::core::marker::Sync for PhoneLine {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -3959,36 +3379,7 @@ unsafe impl ::windows::core::Interface for PhoneLineCellularDetails {
 impl ::windows::core::RuntimeName for PhoneLineCellularDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneLineCellularDetails";
 }
-impl ::core::convert::From<PhoneLineCellularDetails> for ::windows::core::IUnknown {
-    fn from(value: PhoneLineCellularDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineCellularDetails> for ::windows::core::IUnknown {
-    fn from(value: &PhoneLineCellularDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineCellularDetails> for &::windows::core::IUnknown {
-    fn from(value: &PhoneLineCellularDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneLineCellularDetails> for ::windows::core::IInspectable {
-    fn from(value: PhoneLineCellularDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineCellularDetails> for ::windows::core::IInspectable {
-    fn from(value: &PhoneLineCellularDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineCellularDetails> for &::windows::core::IInspectable {
-    fn from(value: &PhoneLineCellularDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneLineCellularDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneLineCellularDetails {}
 unsafe impl ::core::marker::Sync for PhoneLineCellularDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -4044,36 +3435,7 @@ unsafe impl ::windows::core::Interface for PhoneLineConfiguration {
 impl ::windows::core::RuntimeName for PhoneLineConfiguration {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneLineConfiguration";
 }
-impl ::core::convert::From<PhoneLineConfiguration> for ::windows::core::IUnknown {
-    fn from(value: PhoneLineConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &PhoneLineConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &PhoneLineConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneLineConfiguration> for ::windows::core::IInspectable {
-    fn from(value: PhoneLineConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &PhoneLineConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &PhoneLineConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneLineConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneLineConfiguration {}
 unsafe impl ::core::marker::Sync for PhoneLineConfiguration {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -4127,36 +3489,7 @@ unsafe impl ::windows::core::Interface for PhoneLineDialResult {
 impl ::windows::core::RuntimeName for PhoneLineDialResult {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneLineDialResult";
 }
-impl ::core::convert::From<PhoneLineDialResult> for ::windows::core::IUnknown {
-    fn from(value: PhoneLineDialResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineDialResult> for ::windows::core::IUnknown {
-    fn from(value: &PhoneLineDialResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineDialResult> for &::windows::core::IUnknown {
-    fn from(value: &PhoneLineDialResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneLineDialResult> for ::windows::core::IInspectable {
-    fn from(value: PhoneLineDialResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineDialResult> for ::windows::core::IInspectable {
-    fn from(value: &PhoneLineDialResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineDialResult> for &::windows::core::IInspectable {
-    fn from(value: &PhoneLineDialResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneLineDialResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneLineDialResult {}
 unsafe impl ::core::marker::Sync for PhoneLineDialResult {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -4329,36 +3662,7 @@ unsafe impl ::windows::core::Interface for PhoneLineTransportDevice {
 impl ::windows::core::RuntimeName for PhoneLineTransportDevice {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneLineTransportDevice";
 }
-impl ::core::convert::From<PhoneLineTransportDevice> for ::windows::core::IUnknown {
-    fn from(value: PhoneLineTransportDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineTransportDevice> for ::windows::core::IUnknown {
-    fn from(value: &PhoneLineTransportDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineTransportDevice> for &::windows::core::IUnknown {
-    fn from(value: &PhoneLineTransportDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneLineTransportDevice> for ::windows::core::IInspectable {
-    fn from(value: PhoneLineTransportDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineTransportDevice> for ::windows::core::IInspectable {
-    fn from(value: &PhoneLineTransportDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineTransportDevice> for &::windows::core::IInspectable {
-    fn from(value: &PhoneLineTransportDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneLineTransportDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneLineTransportDevice {}
 unsafe impl ::core::marker::Sync for PhoneLineTransportDevice {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -4488,36 +3792,7 @@ unsafe impl ::windows::core::Interface for PhoneLineWatcher {
 impl ::windows::core::RuntimeName for PhoneLineWatcher {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneLineWatcher";
 }
-impl ::core::convert::From<PhoneLineWatcher> for ::windows::core::IUnknown {
-    fn from(value: PhoneLineWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineWatcher> for ::windows::core::IUnknown {
-    fn from(value: &PhoneLineWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineWatcher> for &::windows::core::IUnknown {
-    fn from(value: &PhoneLineWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneLineWatcher> for ::windows::core::IInspectable {
-    fn from(value: PhoneLineWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineWatcher> for ::windows::core::IInspectable {
-    fn from(value: &PhoneLineWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineWatcher> for &::windows::core::IInspectable {
-    fn from(value: &PhoneLineWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneLineWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneLineWatcher {}
 unsafe impl ::core::marker::Sync for PhoneLineWatcher {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -4564,36 +3839,7 @@ unsafe impl ::windows::core::Interface for PhoneLineWatcherEventArgs {
 impl ::windows::core::RuntimeName for PhoneLineWatcherEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneLineWatcherEventArgs";
 }
-impl ::core::convert::From<PhoneLineWatcherEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PhoneLineWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineWatcherEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PhoneLineWatcherEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineWatcherEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PhoneLineWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneLineWatcherEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PhoneLineWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineWatcherEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PhoneLineWatcherEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineWatcherEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PhoneLineWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneLineWatcherEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneLineWatcherEventArgs {}
 unsafe impl ::core::marker::Sync for PhoneLineWatcherEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -4663,36 +3909,7 @@ unsafe impl ::windows::core::Interface for PhoneVoicemail {
 impl ::windows::core::RuntimeName for PhoneVoicemail {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneVoicemail";
 }
-impl ::core::convert::From<PhoneVoicemail> for ::windows::core::IUnknown {
-    fn from(value: PhoneVoicemail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneVoicemail> for ::windows::core::IUnknown {
-    fn from(value: &PhoneVoicemail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneVoicemail> for &::windows::core::IUnknown {
-    fn from(value: &PhoneVoicemail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneVoicemail> for ::windows::core::IInspectable {
-    fn from(value: PhoneVoicemail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneVoicemail> for ::windows::core::IInspectable {
-    fn from(value: &PhoneVoicemail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneVoicemail> for &::windows::core::IInspectable {
-    fn from(value: &PhoneVoicemail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneVoicemail, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneVoicemail {}
 unsafe impl ::core::marker::Sync for PhoneVoicemail {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -4847,36 +4064,7 @@ unsafe impl ::windows::core::Interface for VoipCallCoordinator {
 impl ::windows::core::RuntimeName for VoipCallCoordinator {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.VoipCallCoordinator";
 }
-impl ::core::convert::From<VoipCallCoordinator> for ::windows::core::IUnknown {
-    fn from(value: VoipCallCoordinator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoipCallCoordinator> for ::windows::core::IUnknown {
-    fn from(value: &VoipCallCoordinator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoipCallCoordinator> for &::windows::core::IUnknown {
-    fn from(value: &VoipCallCoordinator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoipCallCoordinator> for ::windows::core::IInspectable {
-    fn from(value: VoipCallCoordinator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoipCallCoordinator> for ::windows::core::IInspectable {
-    fn from(value: &VoipCallCoordinator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoipCallCoordinator> for &::windows::core::IInspectable {
-    fn from(value: &VoipCallCoordinator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoipCallCoordinator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoipCallCoordinator {}
 unsafe impl ::core::marker::Sync for VoipCallCoordinator {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]
@@ -5052,36 +4240,7 @@ unsafe impl ::windows::core::Interface for VoipPhoneCall {
 impl ::windows::core::RuntimeName for VoipPhoneCall {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.VoipPhoneCall";
 }
-impl ::core::convert::From<VoipPhoneCall> for ::windows::core::IUnknown {
-    fn from(value: VoipPhoneCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoipPhoneCall> for ::windows::core::IUnknown {
-    fn from(value: &VoipPhoneCall) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoipPhoneCall> for &::windows::core::IUnknown {
-    fn from(value: &VoipPhoneCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoipPhoneCall> for ::windows::core::IInspectable {
-    fn from(value: VoipPhoneCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoipPhoneCall> for ::windows::core::IInspectable {
-    fn from(value: &VoipPhoneCall) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoipPhoneCall> for &::windows::core::IInspectable {
-    fn from(value: &VoipPhoneCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoipPhoneCall, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoipPhoneCall {}
 unsafe impl ::core::marker::Sync for VoipPhoneCall {}
 #[doc = "*Required features: `\"ApplicationModel_Calls\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Chat/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Chat/mod.rs
@@ -190,36 +190,7 @@ impl IChatItem {
         }
     }
 }
-impl ::core::convert::From<IChatItem> for ::windows::core::IUnknown {
-    fn from(value: IChatItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IChatItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IChatItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IChatItem> for ::windows::core::IUnknown {
-    fn from(value: &IChatItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IChatItem> for ::windows::core::IInspectable {
-    fn from(value: IChatItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IChatItem> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IChatItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IChatItem> for ::windows::core::IInspectable {
-    fn from(value: &IChatItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IChatItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IChatItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1374,36 +1345,7 @@ unsafe impl ::windows::core::Interface for ChatCapabilities {
 impl ::windows::core::RuntimeName for ChatCapabilities {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatCapabilities";
 }
-impl ::core::convert::From<ChatCapabilities> for ::windows::core::IUnknown {
-    fn from(value: ChatCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &ChatCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &ChatCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatCapabilities> for ::windows::core::IInspectable {
-    fn from(value: ChatCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &ChatCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &ChatCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatCapabilities {}
 unsafe impl ::core::marker::Sync for ChatCapabilities {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -1635,36 +1577,7 @@ unsafe impl ::windows::core::Interface for ChatConversation {
 impl ::windows::core::RuntimeName for ChatConversation {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatConversation";
 }
-impl ::core::convert::From<ChatConversation> for ::windows::core::IUnknown {
-    fn from(value: ChatConversation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatConversation> for ::windows::core::IUnknown {
-    fn from(value: &ChatConversation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatConversation> for &::windows::core::IUnknown {
-    fn from(value: &ChatConversation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatConversation> for ::windows::core::IInspectable {
-    fn from(value: ChatConversation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatConversation> for ::windows::core::IInspectable {
-    fn from(value: &ChatConversation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatConversation> for &::windows::core::IInspectable {
-    fn from(value: &ChatConversation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatConversation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ChatConversation> for IChatItem {
     type Error = ::windows::core::Error;
     fn try_from(value: ChatConversation) -> ::windows::core::Result<Self> {
@@ -1741,36 +1654,7 @@ unsafe impl ::windows::core::Interface for ChatConversationReader {
 impl ::windows::core::RuntimeName for ChatConversationReader {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatConversationReader";
 }
-impl ::core::convert::From<ChatConversationReader> for ::windows::core::IUnknown {
-    fn from(value: ChatConversationReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatConversationReader> for ::windows::core::IUnknown {
-    fn from(value: &ChatConversationReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatConversationReader> for &::windows::core::IUnknown {
-    fn from(value: &ChatConversationReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatConversationReader> for ::windows::core::IInspectable {
-    fn from(value: ChatConversationReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatConversationReader> for ::windows::core::IInspectable {
-    fn from(value: &ChatConversationReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatConversationReader> for &::windows::core::IInspectable {
-    fn from(value: &ChatConversationReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatConversationReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatConversationReader {}
 unsafe impl ::core::marker::Sync for ChatConversationReader {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -1870,36 +1754,7 @@ unsafe impl ::windows::core::Interface for ChatConversationThreadingInfo {
 impl ::windows::core::RuntimeName for ChatConversationThreadingInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatConversationThreadingInfo";
 }
-impl ::core::convert::From<ChatConversationThreadingInfo> for ::windows::core::IUnknown {
-    fn from(value: ChatConversationThreadingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatConversationThreadingInfo> for ::windows::core::IUnknown {
-    fn from(value: &ChatConversationThreadingInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatConversationThreadingInfo> for &::windows::core::IUnknown {
-    fn from(value: &ChatConversationThreadingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatConversationThreadingInfo> for ::windows::core::IInspectable {
-    fn from(value: ChatConversationThreadingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatConversationThreadingInfo> for ::windows::core::IInspectable {
-    fn from(value: &ChatConversationThreadingInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatConversationThreadingInfo> for &::windows::core::IInspectable {
-    fn from(value: &ChatConversationThreadingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatConversationThreadingInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatConversationThreadingInfo {}
 unsafe impl ::core::marker::Sync for ChatConversationThreadingInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -2245,36 +2100,7 @@ unsafe impl ::windows::core::Interface for ChatMessage {
 impl ::windows::core::RuntimeName for ChatMessage {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessage";
 }
-impl ::core::convert::From<ChatMessage> for ::windows::core::IUnknown {
-    fn from(value: ChatMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessage> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessage> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessage> for ::windows::core::IInspectable {
-    fn from(value: ChatMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessage> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessage> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ChatMessage> for IChatItem {
     type Error = ::windows::core::Error;
     fn try_from(value: ChatMessage) -> ::windows::core::Result<Self> {
@@ -2443,36 +2269,7 @@ unsafe impl ::windows::core::Interface for ChatMessageAttachment {
 impl ::windows::core::RuntimeName for ChatMessageAttachment {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageAttachment";
 }
-impl ::core::convert::From<ChatMessageAttachment> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageAttachment> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageAttachment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageAttachment> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageAttachment> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageAttachment> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageAttachment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageAttachment> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageAttachment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageAttachment {}
 unsafe impl ::core::marker::Sync for ChatMessageAttachment {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -2546,36 +2343,7 @@ unsafe impl ::windows::core::Interface for ChatMessageChange {
 impl ::windows::core::RuntimeName for ChatMessageChange {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageChange";
 }
-impl ::core::convert::From<ChatMessageChange> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageChange> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageChange> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageChange> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageChange> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageChange> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageChange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageChange {}
 unsafe impl ::core::marker::Sync for ChatMessageChange {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -2632,36 +2400,7 @@ unsafe impl ::windows::core::Interface for ChatMessageChangeReader {
 impl ::windows::core::RuntimeName for ChatMessageChangeReader {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageChangeReader";
 }
-impl ::core::convert::From<ChatMessageChangeReader> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageChangeReader> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageChangeReader> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageChangeReader> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageChangeReader> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageChangeReader> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageChangeReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageChangeReader {}
 unsafe impl ::core::marker::Sync for ChatMessageChangeReader {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -2716,36 +2455,7 @@ unsafe impl ::windows::core::Interface for ChatMessageChangeTracker {
 impl ::windows::core::RuntimeName for ChatMessageChangeTracker {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageChangeTracker";
 }
-impl ::core::convert::From<ChatMessageChangeTracker> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageChangeTracker> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageChangeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageChangeTracker> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageChangeTracker> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageChangeTracker> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageChangeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageChangeTracker> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageChangeTracker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageChangeTracker {}
 unsafe impl ::core::marker::Sync for ChatMessageChangeTracker {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -2789,36 +2499,7 @@ unsafe impl ::windows::core::Interface for ChatMessageChangedDeferral {
 impl ::windows::core::RuntimeName for ChatMessageChangedDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageChangedDeferral";
 }
-impl ::core::convert::From<ChatMessageChangedDeferral> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageChangedDeferral> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageChangedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageChangedDeferral> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageChangedDeferral> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageChangedDeferral> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageChangedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageChangedDeferral> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageChangedDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageChangedDeferral {}
 unsafe impl ::core::marker::Sync for ChatMessageChangedDeferral {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -2865,36 +2546,7 @@ unsafe impl ::windows::core::Interface for ChatMessageChangedEventArgs {
 impl ::windows::core::RuntimeName for ChatMessageChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageChangedEventArgs";
 }
-impl ::core::convert::From<ChatMessageChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageChangedEventArgs {}
 unsafe impl ::core::marker::Sync for ChatMessageChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -3042,36 +2694,7 @@ unsafe impl ::windows::core::Interface for ChatMessageNotificationTriggerDetails
 impl ::windows::core::RuntimeName for ChatMessageNotificationTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageNotificationTriggerDetails";
 }
-impl ::core::convert::From<ChatMessageNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageNotificationTriggerDetails {}
 unsafe impl ::core::marker::Sync for ChatMessageNotificationTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -3129,36 +2752,7 @@ unsafe impl ::windows::core::Interface for ChatMessageReader {
 impl ::windows::core::RuntimeName for ChatMessageReader {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageReader";
 }
-impl ::core::convert::From<ChatMessageReader> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageReader> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageReader> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageReader> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageReader> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageReader> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageReader {}
 unsafe impl ::core::marker::Sync for ChatMessageReader {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -3472,36 +3066,7 @@ unsafe impl ::windows::core::Interface for ChatMessageStore {
 impl ::windows::core::RuntimeName for ChatMessageStore {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageStore";
 }
-impl ::core::convert::From<ChatMessageStore> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageStore> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageStore> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageStore> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageStore> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageStore> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageStore {}
 unsafe impl ::core::marker::Sync for ChatMessageStore {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -3555,36 +3120,7 @@ unsafe impl ::windows::core::Interface for ChatMessageStoreChangedEventArgs {
 impl ::windows::core::RuntimeName for ChatMessageStoreChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageStoreChangedEventArgs";
 }
-impl ::core::convert::From<ChatMessageStoreChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageStoreChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageStoreChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageStoreChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageStoreChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageStoreChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageStoreChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageStoreChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageStoreChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageStoreChangedEventArgs {}
 unsafe impl ::core::marker::Sync for ChatMessageStoreChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -3675,36 +3211,7 @@ unsafe impl ::windows::core::Interface for ChatMessageTransport {
 impl ::windows::core::RuntimeName for ChatMessageTransport {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageTransport";
 }
-impl ::core::convert::From<ChatMessageTransport> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageTransport> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageTransport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageTransport> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageTransport> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageTransport> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageTransport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageTransport> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageTransport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageTransport {}
 unsafe impl ::core::marker::Sync for ChatMessageTransport {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -3783,36 +3290,7 @@ unsafe impl ::windows::core::Interface for ChatMessageTransportConfiguration {
 impl ::windows::core::RuntimeName for ChatMessageTransportConfiguration {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageTransportConfiguration";
 }
-impl ::core::convert::From<ChatMessageTransportConfiguration> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageTransportConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageTransportConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageTransportConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageTransportConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageTransportConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageTransportConfiguration> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageTransportConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageTransportConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageTransportConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageTransportConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageTransportConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageTransportConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageTransportConfiguration {}
 unsafe impl ::core::marker::Sync for ChatMessageTransportConfiguration {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -3886,36 +3364,7 @@ unsafe impl ::windows::core::Interface for ChatMessageValidationResult {
 impl ::windows::core::RuntimeName for ChatMessageValidationResult {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageValidationResult";
 }
-impl ::core::convert::From<ChatMessageValidationResult> for ::windows::core::IUnknown {
-    fn from(value: ChatMessageValidationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageValidationResult> for ::windows::core::IUnknown {
-    fn from(value: &ChatMessageValidationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageValidationResult> for &::windows::core::IUnknown {
-    fn from(value: &ChatMessageValidationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatMessageValidationResult> for ::windows::core::IInspectable {
-    fn from(value: ChatMessageValidationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatMessageValidationResult> for ::windows::core::IInspectable {
-    fn from(value: &ChatMessageValidationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatMessageValidationResult> for &::windows::core::IInspectable {
-    fn from(value: &ChatMessageValidationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatMessageValidationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatMessageValidationResult {}
 unsafe impl ::core::marker::Sync for ChatMessageValidationResult {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -3973,36 +3422,7 @@ unsafe impl ::windows::core::Interface for ChatQueryOptions {
 impl ::windows::core::RuntimeName for ChatQueryOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatQueryOptions";
 }
-impl ::core::convert::From<ChatQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: ChatQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: &ChatQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatQueryOptions> for &::windows::core::IUnknown {
-    fn from(value: &ChatQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: ChatQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: &ChatQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatQueryOptions> for &::windows::core::IInspectable {
-    fn from(value: &ChatQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatQueryOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatQueryOptions {}
 unsafe impl ::core::marker::Sync for ChatQueryOptions {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -4133,36 +3553,7 @@ unsafe impl ::windows::core::Interface for ChatRecipientDeliveryInfo {
 impl ::windows::core::RuntimeName for ChatRecipientDeliveryInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatRecipientDeliveryInfo";
 }
-impl ::core::convert::From<ChatRecipientDeliveryInfo> for ::windows::core::IUnknown {
-    fn from(value: ChatRecipientDeliveryInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatRecipientDeliveryInfo> for ::windows::core::IUnknown {
-    fn from(value: &ChatRecipientDeliveryInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatRecipientDeliveryInfo> for &::windows::core::IUnknown {
-    fn from(value: &ChatRecipientDeliveryInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatRecipientDeliveryInfo> for ::windows::core::IInspectable {
-    fn from(value: ChatRecipientDeliveryInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatRecipientDeliveryInfo> for ::windows::core::IInspectable {
-    fn from(value: &ChatRecipientDeliveryInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatRecipientDeliveryInfo> for &::windows::core::IInspectable {
-    fn from(value: &ChatRecipientDeliveryInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatRecipientDeliveryInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatRecipientDeliveryInfo {}
 unsafe impl ::core::marker::Sync for ChatRecipientDeliveryInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -4220,36 +3611,7 @@ unsafe impl ::windows::core::Interface for ChatSearchReader {
 impl ::windows::core::RuntimeName for ChatSearchReader {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatSearchReader";
 }
-impl ::core::convert::From<ChatSearchReader> for ::windows::core::IUnknown {
-    fn from(value: ChatSearchReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatSearchReader> for ::windows::core::IUnknown {
-    fn from(value: &ChatSearchReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatSearchReader> for &::windows::core::IUnknown {
-    fn from(value: &ChatSearchReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatSearchReader> for ::windows::core::IInspectable {
-    fn from(value: ChatSearchReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatSearchReader> for ::windows::core::IInspectable {
-    fn from(value: &ChatSearchReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatSearchReader> for &::windows::core::IInspectable {
-    fn from(value: &ChatSearchReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatSearchReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatSearchReader {}
 unsafe impl ::core::marker::Sync for ChatSearchReader {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -4311,36 +3673,7 @@ unsafe impl ::windows::core::Interface for ChatSyncConfiguration {
 impl ::windows::core::RuntimeName for ChatSyncConfiguration {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatSyncConfiguration";
 }
-impl ::core::convert::From<ChatSyncConfiguration> for ::windows::core::IUnknown {
-    fn from(value: ChatSyncConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatSyncConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &ChatSyncConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatSyncConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &ChatSyncConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatSyncConfiguration> for ::windows::core::IInspectable {
-    fn from(value: ChatSyncConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatSyncConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &ChatSyncConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatSyncConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &ChatSyncConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatSyncConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatSyncConfiguration {}
 unsafe impl ::core::marker::Sync for ChatSyncConfiguration {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -4427,36 +3760,7 @@ unsafe impl ::windows::core::Interface for ChatSyncManager {
 impl ::windows::core::RuntimeName for ChatSyncManager {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatSyncManager";
 }
-impl ::core::convert::From<ChatSyncManager> for ::windows::core::IUnknown {
-    fn from(value: ChatSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatSyncManager> for ::windows::core::IUnknown {
-    fn from(value: &ChatSyncManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatSyncManager> for &::windows::core::IUnknown {
-    fn from(value: &ChatSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChatSyncManager> for ::windows::core::IInspectable {
-    fn from(value: ChatSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChatSyncManager> for ::windows::core::IInspectable {
-    fn from(value: &ChatSyncManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChatSyncManager> for &::windows::core::IInspectable {
-    fn from(value: &ChatSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChatSyncManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChatSyncManager {}
 unsafe impl ::core::marker::Sync for ChatSyncManager {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -4551,36 +3855,7 @@ unsafe impl ::windows::core::Interface for RcsEndUserMessage {
 impl ::windows::core::RuntimeName for RcsEndUserMessage {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.RcsEndUserMessage";
 }
-impl ::core::convert::From<RcsEndUserMessage> for ::windows::core::IUnknown {
-    fn from(value: RcsEndUserMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessage> for ::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessage> for &::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RcsEndUserMessage> for ::windows::core::IInspectable {
-    fn from(value: RcsEndUserMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessage> for ::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessage> for &::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RcsEndUserMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RcsEndUserMessage {}
 unsafe impl ::core::marker::Sync for RcsEndUserMessage {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -4627,36 +3902,7 @@ unsafe impl ::windows::core::Interface for RcsEndUserMessageAction {
 impl ::windows::core::RuntimeName for RcsEndUserMessageAction {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.RcsEndUserMessageAction";
 }
-impl ::core::convert::From<RcsEndUserMessageAction> for ::windows::core::IUnknown {
-    fn from(value: RcsEndUserMessageAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAction> for ::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessageAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAction> for &::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessageAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RcsEndUserMessageAction> for ::windows::core::IInspectable {
-    fn from(value: RcsEndUserMessageAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAction> for ::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessageAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAction> for &::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessageAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RcsEndUserMessageAction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RcsEndUserMessageAction {}
 unsafe impl ::core::marker::Sync for RcsEndUserMessageAction {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -4710,36 +3956,7 @@ unsafe impl ::windows::core::Interface for RcsEndUserMessageAvailableEventArgs {
 impl ::windows::core::RuntimeName for RcsEndUserMessageAvailableEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.RcsEndUserMessageAvailableEventArgs";
 }
-impl ::core::convert::From<RcsEndUserMessageAvailableEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RcsEndUserMessageAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessageAvailableEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessageAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RcsEndUserMessageAvailableEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RcsEndUserMessageAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessageAvailableEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessageAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RcsEndUserMessageAvailableEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RcsEndUserMessageAvailableEventArgs {}
 unsafe impl ::core::marker::Sync for RcsEndUserMessageAvailableEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -4793,36 +4010,7 @@ unsafe impl ::windows::core::Interface for RcsEndUserMessageAvailableTriggerDeta
 impl ::windows::core::RuntimeName for RcsEndUserMessageAvailableTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.RcsEndUserMessageAvailableTriggerDetails";
 }
-impl ::core::convert::From<RcsEndUserMessageAvailableTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: RcsEndUserMessageAvailableTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessageAvailableTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessageAvailableTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RcsEndUserMessageAvailableTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: RcsEndUserMessageAvailableTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessageAvailableTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageAvailableTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessageAvailableTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RcsEndUserMessageAvailableTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RcsEndUserMessageAvailableTriggerDetails {}
 unsafe impl ::core::marker::Sync for RcsEndUserMessageAvailableTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -4877,36 +4065,7 @@ unsafe impl ::windows::core::Interface for RcsEndUserMessageManager {
 impl ::windows::core::RuntimeName for RcsEndUserMessageManager {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.RcsEndUserMessageManager";
 }
-impl ::core::convert::From<RcsEndUserMessageManager> for ::windows::core::IUnknown {
-    fn from(value: RcsEndUserMessageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageManager> for ::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessageManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageManager> for &::windows::core::IUnknown {
-    fn from(value: &RcsEndUserMessageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RcsEndUserMessageManager> for ::windows::core::IInspectable {
-    fn from(value: RcsEndUserMessageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageManager> for ::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessageManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsEndUserMessageManager> for &::windows::core::IInspectable {
-    fn from(value: &RcsEndUserMessageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RcsEndUserMessageManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RcsEndUserMessageManager {}
 unsafe impl ::core::marker::Sync for RcsEndUserMessageManager {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -5013,36 +4172,7 @@ unsafe impl ::windows::core::Interface for RcsServiceKindSupportedChangedEventAr
 impl ::windows::core::RuntimeName for RcsServiceKindSupportedChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.RcsServiceKindSupportedChangedEventArgs";
 }
-impl ::core::convert::From<RcsServiceKindSupportedChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RcsServiceKindSupportedChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsServiceKindSupportedChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RcsServiceKindSupportedChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsServiceKindSupportedChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RcsServiceKindSupportedChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RcsServiceKindSupportedChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RcsServiceKindSupportedChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsServiceKindSupportedChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RcsServiceKindSupportedChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsServiceKindSupportedChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RcsServiceKindSupportedChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RcsServiceKindSupportedChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RcsServiceKindSupportedChangedEventArgs {}
 unsafe impl ::core::marker::Sync for RcsServiceKindSupportedChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -5148,36 +4278,7 @@ unsafe impl ::windows::core::Interface for RcsTransport {
 impl ::windows::core::RuntimeName for RcsTransport {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.RcsTransport";
 }
-impl ::core::convert::From<RcsTransport> for ::windows::core::IUnknown {
-    fn from(value: RcsTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsTransport> for ::windows::core::IUnknown {
-    fn from(value: &RcsTransport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsTransport> for &::windows::core::IUnknown {
-    fn from(value: &RcsTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RcsTransport> for ::windows::core::IInspectable {
-    fn from(value: RcsTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsTransport> for ::windows::core::IInspectable {
-    fn from(value: &RcsTransport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsTransport> for &::windows::core::IInspectable {
-    fn from(value: &RcsTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RcsTransport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RcsTransport {}
 unsafe impl ::core::marker::Sync for RcsTransport {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -5259,36 +4360,7 @@ unsafe impl ::windows::core::Interface for RcsTransportConfiguration {
 impl ::windows::core::RuntimeName for RcsTransportConfiguration {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.RcsTransportConfiguration";
 }
-impl ::core::convert::From<RcsTransportConfiguration> for ::windows::core::IUnknown {
-    fn from(value: RcsTransportConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsTransportConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &RcsTransportConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsTransportConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &RcsTransportConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RcsTransportConfiguration> for ::windows::core::IInspectable {
-    fn from(value: RcsTransportConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RcsTransportConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &RcsTransportConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RcsTransportConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &RcsTransportConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RcsTransportConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RcsTransportConfiguration {}
 unsafe impl ::core::marker::Sync for RcsTransportConfiguration {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]
@@ -5349,36 +4421,7 @@ unsafe impl ::windows::core::Interface for RemoteParticipantComposingChangedEven
 impl ::windows::core::RuntimeName for RemoteParticipantComposingChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.RemoteParticipantComposingChangedEventArgs";
 }
-impl ::core::convert::From<RemoteParticipantComposingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteParticipantComposingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteParticipantComposingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteParticipantComposingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteParticipantComposingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteParticipantComposingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteParticipantComposingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteParticipantComposingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteParticipantComposingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteParticipantComposingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteParticipantComposingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteParticipantComposingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteParticipantComposingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteParticipantComposingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteParticipantComposingChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Chat\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/DataProvider/mod.rs
@@ -352,36 +352,7 @@ unsafe impl ::windows::core::Interface for ContactDataProviderConnection {
 impl ::windows::core::RuntimeName for ContactDataProviderConnection {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.DataProvider.ContactDataProviderConnection";
 }
-impl ::core::convert::From<ContactDataProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: ContactDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactDataProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: &ContactDataProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactDataProviderConnection> for &::windows::core::IUnknown {
-    fn from(value: &ContactDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactDataProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: ContactDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactDataProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: &ContactDataProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactDataProviderConnection> for &::windows::core::IInspectable {
-    fn from(value: &ContactDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactDataProviderConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactDataProviderConnection {}
 unsafe impl ::core::marker::Sync for ContactDataProviderConnection {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts_DataProvider\"`*"]
@@ -428,36 +399,7 @@ unsafe impl ::windows::core::Interface for ContactDataProviderTriggerDetails {
 impl ::windows::core::RuntimeName for ContactDataProviderTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.DataProvider.ContactDataProviderTriggerDetails";
 }
-impl ::core::convert::From<ContactDataProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: ContactDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactDataProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &ContactDataProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactDataProviderTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &ContactDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactDataProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: ContactDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactDataProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &ContactDataProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactDataProviderTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &ContactDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactDataProviderTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactDataProviderTriggerDetails {}
 unsafe impl ::core::marker::Sync for ContactDataProviderTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts_DataProvider\"`*"]
@@ -529,36 +471,7 @@ unsafe impl ::windows::core::Interface for ContactListCreateOrUpdateContactReque
 impl ::windows::core::RuntimeName for ContactListCreateOrUpdateContactRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.DataProvider.ContactListCreateOrUpdateContactRequest";
 }
-impl ::core::convert::From<ContactListCreateOrUpdateContactRequest> for ::windows::core::IUnknown {
-    fn from(value: ContactListCreateOrUpdateContactRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListCreateOrUpdateContactRequest> for ::windows::core::IUnknown {
-    fn from(value: &ContactListCreateOrUpdateContactRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListCreateOrUpdateContactRequest> for &::windows::core::IUnknown {
-    fn from(value: &ContactListCreateOrUpdateContactRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactListCreateOrUpdateContactRequest> for ::windows::core::IInspectable {
-    fn from(value: ContactListCreateOrUpdateContactRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListCreateOrUpdateContactRequest> for ::windows::core::IInspectable {
-    fn from(value: &ContactListCreateOrUpdateContactRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListCreateOrUpdateContactRequest> for &::windows::core::IInspectable {
-    fn from(value: &ContactListCreateOrUpdateContactRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactListCreateOrUpdateContactRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactListCreateOrUpdateContactRequest {}
 unsafe impl ::core::marker::Sync for ContactListCreateOrUpdateContactRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts_DataProvider\"`*"]
@@ -614,36 +527,7 @@ unsafe impl ::windows::core::Interface for ContactListCreateOrUpdateContactReque
 impl ::windows::core::RuntimeName for ContactListCreateOrUpdateContactRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.DataProvider.ContactListCreateOrUpdateContactRequestEventArgs";
 }
-impl ::core::convert::From<ContactListCreateOrUpdateContactRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactListCreateOrUpdateContactRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListCreateOrUpdateContactRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactListCreateOrUpdateContactRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListCreateOrUpdateContactRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactListCreateOrUpdateContactRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactListCreateOrUpdateContactRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactListCreateOrUpdateContactRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListCreateOrUpdateContactRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactListCreateOrUpdateContactRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListCreateOrUpdateContactRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactListCreateOrUpdateContactRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactListCreateOrUpdateContactRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactListCreateOrUpdateContactRequestEventArgs {}
 unsafe impl ::core::marker::Sync for ContactListCreateOrUpdateContactRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts_DataProvider\"`*"]
@@ -715,36 +599,7 @@ unsafe impl ::windows::core::Interface for ContactListDeleteContactRequest {
 impl ::windows::core::RuntimeName for ContactListDeleteContactRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.DataProvider.ContactListDeleteContactRequest";
 }
-impl ::core::convert::From<ContactListDeleteContactRequest> for ::windows::core::IUnknown {
-    fn from(value: ContactListDeleteContactRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListDeleteContactRequest> for ::windows::core::IUnknown {
-    fn from(value: &ContactListDeleteContactRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListDeleteContactRequest> for &::windows::core::IUnknown {
-    fn from(value: &ContactListDeleteContactRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactListDeleteContactRequest> for ::windows::core::IInspectable {
-    fn from(value: ContactListDeleteContactRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListDeleteContactRequest> for ::windows::core::IInspectable {
-    fn from(value: &ContactListDeleteContactRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListDeleteContactRequest> for &::windows::core::IInspectable {
-    fn from(value: &ContactListDeleteContactRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactListDeleteContactRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactListDeleteContactRequest {}
 unsafe impl ::core::marker::Sync for ContactListDeleteContactRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts_DataProvider\"`*"]
@@ -800,36 +655,7 @@ unsafe impl ::windows::core::Interface for ContactListDeleteContactRequestEventA
 impl ::windows::core::RuntimeName for ContactListDeleteContactRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.DataProvider.ContactListDeleteContactRequestEventArgs";
 }
-impl ::core::convert::From<ContactListDeleteContactRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactListDeleteContactRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListDeleteContactRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactListDeleteContactRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListDeleteContactRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactListDeleteContactRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactListDeleteContactRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactListDeleteContactRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListDeleteContactRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactListDeleteContactRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListDeleteContactRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactListDeleteContactRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactListDeleteContactRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactListDeleteContactRequestEventArgs {}
 unsafe impl ::core::marker::Sync for ContactListDeleteContactRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts_DataProvider\"`*"]
@@ -924,36 +750,7 @@ unsafe impl ::windows::core::Interface for ContactListServerSearchReadBatchReque
 impl ::windows::core::RuntimeName for ContactListServerSearchReadBatchRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.DataProvider.ContactListServerSearchReadBatchRequest";
 }
-impl ::core::convert::From<ContactListServerSearchReadBatchRequest> for ::windows::core::IUnknown {
-    fn from(value: ContactListServerSearchReadBatchRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListServerSearchReadBatchRequest> for ::windows::core::IUnknown {
-    fn from(value: &ContactListServerSearchReadBatchRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListServerSearchReadBatchRequest> for &::windows::core::IUnknown {
-    fn from(value: &ContactListServerSearchReadBatchRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactListServerSearchReadBatchRequest> for ::windows::core::IInspectable {
-    fn from(value: ContactListServerSearchReadBatchRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListServerSearchReadBatchRequest> for ::windows::core::IInspectable {
-    fn from(value: &ContactListServerSearchReadBatchRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListServerSearchReadBatchRequest> for &::windows::core::IInspectable {
-    fn from(value: &ContactListServerSearchReadBatchRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactListServerSearchReadBatchRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactListServerSearchReadBatchRequest {}
 unsafe impl ::core::marker::Sync for ContactListServerSearchReadBatchRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts_DataProvider\"`*"]
@@ -1009,36 +806,7 @@ unsafe impl ::windows::core::Interface for ContactListServerSearchReadBatchReque
 impl ::windows::core::RuntimeName for ContactListServerSearchReadBatchRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.DataProvider.ContactListServerSearchReadBatchRequestEventArgs";
 }
-impl ::core::convert::From<ContactListServerSearchReadBatchRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactListServerSearchReadBatchRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListServerSearchReadBatchRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactListServerSearchReadBatchRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListServerSearchReadBatchRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactListServerSearchReadBatchRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactListServerSearchReadBatchRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactListServerSearchReadBatchRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListServerSearchReadBatchRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactListServerSearchReadBatchRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListServerSearchReadBatchRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactListServerSearchReadBatchRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactListServerSearchReadBatchRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactListServerSearchReadBatchRequestEventArgs {}
 unsafe impl ::core::marker::Sync for ContactListServerSearchReadBatchRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts_DataProvider\"`*"]
@@ -1103,36 +871,7 @@ unsafe impl ::windows::core::Interface for ContactListSyncManagerSyncRequest {
 impl ::windows::core::RuntimeName for ContactListSyncManagerSyncRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.DataProvider.ContactListSyncManagerSyncRequest";
 }
-impl ::core::convert::From<ContactListSyncManagerSyncRequest> for ::windows::core::IUnknown {
-    fn from(value: ContactListSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListSyncManagerSyncRequest> for ::windows::core::IUnknown {
-    fn from(value: &ContactListSyncManagerSyncRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListSyncManagerSyncRequest> for &::windows::core::IUnknown {
-    fn from(value: &ContactListSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactListSyncManagerSyncRequest> for ::windows::core::IInspectable {
-    fn from(value: ContactListSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListSyncManagerSyncRequest> for ::windows::core::IInspectable {
-    fn from(value: &ContactListSyncManagerSyncRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListSyncManagerSyncRequest> for &::windows::core::IInspectable {
-    fn from(value: &ContactListSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactListSyncManagerSyncRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactListSyncManagerSyncRequest {}
 unsafe impl ::core::marker::Sync for ContactListSyncManagerSyncRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts_DataProvider\"`*"]
@@ -1188,36 +927,7 @@ unsafe impl ::windows::core::Interface for ContactListSyncManagerSyncRequestEven
 impl ::windows::core::RuntimeName for ContactListSyncManagerSyncRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.DataProvider.ContactListSyncManagerSyncRequestEventArgs";
 }
-impl ::core::convert::From<ContactListSyncManagerSyncRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactListSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListSyncManagerSyncRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactListSyncManagerSyncRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListSyncManagerSyncRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactListSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactListSyncManagerSyncRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactListSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListSyncManagerSyncRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactListSyncManagerSyncRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListSyncManagerSyncRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactListSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactListSyncManagerSyncRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactListSyncManagerSyncRequestEventArgs {}
 unsafe impl ::core::marker::Sync for ContactListSyncManagerSyncRequestEventArgs {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/Provider/mod.rs
@@ -169,36 +169,7 @@ unsafe impl ::windows::core::Interface for ContactPickerUI {
 impl ::windows::core::RuntimeName for ContactPickerUI {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.Provider.ContactPickerUI";
 }
-impl ::core::convert::From<ContactPickerUI> for ::windows::core::IUnknown {
-    fn from(value: ContactPickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPickerUI> for ::windows::core::IUnknown {
-    fn from(value: &ContactPickerUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPickerUI> for &::windows::core::IUnknown {
-    fn from(value: &ContactPickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactPickerUI> for ::windows::core::IInspectable {
-    fn from(value: ContactPickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPickerUI> for ::windows::core::IInspectable {
-    fn from(value: &ContactPickerUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPickerUI> for &::windows::core::IInspectable {
-    fn from(value: &ContactPickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactPickerUI, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Contacts_Provider\"`*"]
 #[repr(transparent)]
 pub struct ContactRemovedEventArgs(::windows::core::IUnknown);
@@ -243,36 +214,7 @@ unsafe impl ::windows::core::Interface for ContactRemovedEventArgs {
 impl ::windows::core::RuntimeName for ContactRemovedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.Provider.ContactRemovedEventArgs";
 }
-impl ::core::convert::From<ContactRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Contacts_Provider\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
@@ -648,36 +648,7 @@ impl IContactField {
         }
     }
 }
-impl ::core::convert::From<IContactField> for ::windows::core::IUnknown {
-    fn from(value: IContactField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactField> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactField> for ::windows::core::IUnknown {
-    fn from(value: &IContactField) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactField> for ::windows::core::IInspectable {
-    fn from(value: IContactField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactField> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactField> for ::windows::core::IInspectable {
-    fn from(value: &IContactField) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactField, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IContactField {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -742,36 +713,7 @@ impl IContactFieldFactory {
         }
     }
 }
-impl ::core::convert::From<IContactFieldFactory> for ::windows::core::IUnknown {
-    fn from(value: IContactFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactFieldFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactFieldFactory> for ::windows::core::IUnknown {
-    fn from(value: &IContactFieldFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactFieldFactory> for ::windows::core::IInspectable {
-    fn from(value: IContactFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactFieldFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactFieldFactory> for ::windows::core::IInspectable {
-    fn from(value: &IContactFieldFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactFieldFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IContactFieldFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -915,36 +857,7 @@ impl IContactInstantMessageFieldFactory {
         }
     }
 }
-impl ::core::convert::From<IContactInstantMessageFieldFactory> for ::windows::core::IUnknown {
-    fn from(value: IContactInstantMessageFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactInstantMessageFieldFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactInstantMessageFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactInstantMessageFieldFactory> for ::windows::core::IUnknown {
-    fn from(value: &IContactInstantMessageFieldFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactInstantMessageFieldFactory> for ::windows::core::IInspectable {
-    fn from(value: IContactInstantMessageFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactInstantMessageFieldFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactInstantMessageFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactInstantMessageFieldFactory> for ::windows::core::IInspectable {
-    fn from(value: &IContactInstantMessageFieldFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactInstantMessageFieldFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IContactInstantMessageFieldFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1494,36 +1407,7 @@ impl IContactLocationFieldFactory {
         }
     }
 }
-impl ::core::convert::From<IContactLocationFieldFactory> for ::windows::core::IUnknown {
-    fn from(value: IContactLocationFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactLocationFieldFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactLocationFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactLocationFieldFactory> for ::windows::core::IUnknown {
-    fn from(value: &IContactLocationFieldFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactLocationFieldFactory> for ::windows::core::IInspectable {
-    fn from(value: IContactLocationFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactLocationFieldFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactLocationFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactLocationFieldFactory> for ::windows::core::IInspectable {
-    fn from(value: &IContactLocationFieldFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactLocationFieldFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IContactLocationFieldFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2471,36 +2355,7 @@ unsafe impl ::windows::core::Interface for AggregateContactManager {
 impl ::windows::core::RuntimeName for AggregateContactManager {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.AggregateContactManager";
 }
-impl ::core::convert::From<AggregateContactManager> for ::windows::core::IUnknown {
-    fn from(value: AggregateContactManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AggregateContactManager> for ::windows::core::IUnknown {
-    fn from(value: &AggregateContactManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AggregateContactManager> for &::windows::core::IUnknown {
-    fn from(value: &AggregateContactManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AggregateContactManager> for ::windows::core::IInspectable {
-    fn from(value: AggregateContactManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AggregateContactManager> for ::windows::core::IInspectable {
-    fn from(value: &AggregateContactManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AggregateContactManager> for &::windows::core::IInspectable {
-    fn from(value: &AggregateContactManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AggregateContactManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AggregateContactManager {}
 unsafe impl ::core::marker::Sync for AggregateContactManager {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -2945,36 +2800,7 @@ unsafe impl ::windows::core::Interface for Contact {
 impl ::windows::core::RuntimeName for Contact {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.Contact";
 }
-impl ::core::convert::From<Contact> for ::windows::core::IUnknown {
-    fn from(value: Contact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Contact> for ::windows::core::IUnknown {
-    fn from(value: &Contact) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Contact> for &::windows::core::IUnknown {
-    fn from(value: &Contact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Contact> for ::windows::core::IInspectable {
-    fn from(value: Contact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Contact> for ::windows::core::IInspectable {
-    fn from(value: &Contact) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Contact> for &::windows::core::IInspectable {
-    fn from(value: &Contact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Contact, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Contact {}
 unsafe impl ::core::marker::Sync for Contact {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -3098,36 +2924,7 @@ unsafe impl ::windows::core::Interface for ContactAddress {
 impl ::windows::core::RuntimeName for ContactAddress {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactAddress";
 }
-impl ::core::convert::From<ContactAddress> for ::windows::core::IUnknown {
-    fn from(value: ContactAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactAddress> for ::windows::core::IUnknown {
-    fn from(value: &ContactAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactAddress> for &::windows::core::IUnknown {
-    fn from(value: &ContactAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactAddress> for ::windows::core::IInspectable {
-    fn from(value: ContactAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactAddress> for ::windows::core::IInspectable {
-    fn from(value: &ContactAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactAddress> for &::windows::core::IInspectable {
-    fn from(value: &ContactAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactAddress, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactAddress {}
 unsafe impl ::core::marker::Sync for ContactAddress {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -3248,36 +3045,7 @@ unsafe impl ::windows::core::Interface for ContactAnnotation {
 impl ::windows::core::RuntimeName for ContactAnnotation {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactAnnotation";
 }
-impl ::core::convert::From<ContactAnnotation> for ::windows::core::IUnknown {
-    fn from(value: ContactAnnotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactAnnotation> for ::windows::core::IUnknown {
-    fn from(value: &ContactAnnotation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactAnnotation> for &::windows::core::IUnknown {
-    fn from(value: &ContactAnnotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactAnnotation> for ::windows::core::IInspectable {
-    fn from(value: ContactAnnotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactAnnotation> for ::windows::core::IInspectable {
-    fn from(value: &ContactAnnotation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactAnnotation> for &::windows::core::IInspectable {
-    fn from(value: &ContactAnnotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactAnnotation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactAnnotation {}
 unsafe impl ::core::marker::Sync for ContactAnnotation {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -3392,36 +3160,7 @@ unsafe impl ::windows::core::Interface for ContactAnnotationList {
 impl ::windows::core::RuntimeName for ContactAnnotationList {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactAnnotationList";
 }
-impl ::core::convert::From<ContactAnnotationList> for ::windows::core::IUnknown {
-    fn from(value: ContactAnnotationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactAnnotationList> for ::windows::core::IUnknown {
-    fn from(value: &ContactAnnotationList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactAnnotationList> for &::windows::core::IUnknown {
-    fn from(value: &ContactAnnotationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactAnnotationList> for ::windows::core::IInspectable {
-    fn from(value: ContactAnnotationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactAnnotationList> for ::windows::core::IInspectable {
-    fn from(value: &ContactAnnotationList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactAnnotationList> for &::windows::core::IInspectable {
-    fn from(value: &ContactAnnotationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactAnnotationList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactAnnotationList {}
 unsafe impl ::core::marker::Sync for ContactAnnotationList {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -3542,36 +3281,7 @@ unsafe impl ::windows::core::Interface for ContactAnnotationStore {
 impl ::windows::core::RuntimeName for ContactAnnotationStore {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactAnnotationStore";
 }
-impl ::core::convert::From<ContactAnnotationStore> for ::windows::core::IUnknown {
-    fn from(value: ContactAnnotationStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactAnnotationStore> for ::windows::core::IUnknown {
-    fn from(value: &ContactAnnotationStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactAnnotationStore> for &::windows::core::IUnknown {
-    fn from(value: &ContactAnnotationStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactAnnotationStore> for ::windows::core::IInspectable {
-    fn from(value: ContactAnnotationStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactAnnotationStore> for ::windows::core::IInspectable {
-    fn from(value: &ContactAnnotationStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactAnnotationStore> for &::windows::core::IInspectable {
-    fn from(value: &ContactAnnotationStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactAnnotationStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactAnnotationStore {}
 unsafe impl ::core::marker::Sync for ContactAnnotationStore {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -3627,36 +3337,7 @@ unsafe impl ::windows::core::Interface for ContactBatch {
 impl ::windows::core::RuntimeName for ContactBatch {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactBatch";
 }
-impl ::core::convert::From<ContactBatch> for ::windows::core::IUnknown {
-    fn from(value: ContactBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactBatch> for ::windows::core::IUnknown {
-    fn from(value: &ContactBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactBatch> for &::windows::core::IUnknown {
-    fn from(value: &ContactBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactBatch> for ::windows::core::IInspectable {
-    fn from(value: ContactBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactBatch> for ::windows::core::IInspectable {
-    fn from(value: &ContactBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactBatch> for &::windows::core::IInspectable {
-    fn from(value: &ContactBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactBatch, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactBatch {}
 unsafe impl ::core::marker::Sync for ContactBatch {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -3706,36 +3387,7 @@ unsafe impl ::windows::core::Interface for ContactCardDelayedDataLoader {
 impl ::windows::core::RuntimeName for ContactCardDelayedDataLoader {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactCardDelayedDataLoader";
 }
-impl ::core::convert::From<ContactCardDelayedDataLoader> for ::windows::core::IUnknown {
-    fn from(value: ContactCardDelayedDataLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactCardDelayedDataLoader> for ::windows::core::IUnknown {
-    fn from(value: &ContactCardDelayedDataLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactCardDelayedDataLoader> for &::windows::core::IUnknown {
-    fn from(value: &ContactCardDelayedDataLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactCardDelayedDataLoader> for ::windows::core::IInspectable {
-    fn from(value: ContactCardDelayedDataLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactCardDelayedDataLoader> for ::windows::core::IInspectable {
-    fn from(value: &ContactCardDelayedDataLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactCardDelayedDataLoader> for &::windows::core::IInspectable {
-    fn from(value: &ContactCardDelayedDataLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactCardDelayedDataLoader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ContactCardDelayedDataLoader> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3835,36 +3487,7 @@ unsafe impl ::windows::core::Interface for ContactCardOptions {
 impl ::windows::core::RuntimeName for ContactCardOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactCardOptions";
 }
-impl ::core::convert::From<ContactCardOptions> for ::windows::core::IUnknown {
-    fn from(value: ContactCardOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactCardOptions> for ::windows::core::IUnknown {
-    fn from(value: &ContactCardOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactCardOptions> for &::windows::core::IUnknown {
-    fn from(value: &ContactCardOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactCardOptions> for ::windows::core::IInspectable {
-    fn from(value: ContactCardOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactCardOptions> for ::windows::core::IInspectable {
-    fn from(value: &ContactCardOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactCardOptions> for &::windows::core::IInspectable {
-    fn from(value: &ContactCardOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactCardOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactCardOptions {}
 unsafe impl ::core::marker::Sync for ContactCardOptions {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -3918,36 +3541,7 @@ unsafe impl ::windows::core::Interface for ContactChange {
 impl ::windows::core::RuntimeName for ContactChange {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactChange";
 }
-impl ::core::convert::From<ContactChange> for ::windows::core::IUnknown {
-    fn from(value: ContactChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChange> for ::windows::core::IUnknown {
-    fn from(value: &ContactChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChange> for &::windows::core::IUnknown {
-    fn from(value: &ContactChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactChange> for ::windows::core::IInspectable {
-    fn from(value: ContactChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChange> for ::windows::core::IInspectable {
-    fn from(value: &ContactChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChange> for &::windows::core::IInspectable {
-    fn from(value: &ContactChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactChange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactChange {}
 unsafe impl ::core::marker::Sync for ContactChange {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -4004,36 +3598,7 @@ unsafe impl ::windows::core::Interface for ContactChangeReader {
 impl ::windows::core::RuntimeName for ContactChangeReader {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactChangeReader";
 }
-impl ::core::convert::From<ContactChangeReader> for ::windows::core::IUnknown {
-    fn from(value: ContactChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChangeReader> for ::windows::core::IUnknown {
-    fn from(value: &ContactChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChangeReader> for &::windows::core::IUnknown {
-    fn from(value: &ContactChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactChangeReader> for ::windows::core::IInspectable {
-    fn from(value: ContactChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChangeReader> for ::windows::core::IInspectable {
-    fn from(value: &ContactChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChangeReader> for &::windows::core::IInspectable {
-    fn from(value: &ContactChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactChangeReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactChangeReader {}
 unsafe impl ::core::marker::Sync for ContactChangeReader {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -4095,36 +3660,7 @@ unsafe impl ::windows::core::Interface for ContactChangeTracker {
 impl ::windows::core::RuntimeName for ContactChangeTracker {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactChangeTracker";
 }
-impl ::core::convert::From<ContactChangeTracker> for ::windows::core::IUnknown {
-    fn from(value: ContactChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChangeTracker> for ::windows::core::IUnknown {
-    fn from(value: &ContactChangeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChangeTracker> for &::windows::core::IUnknown {
-    fn from(value: &ContactChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactChangeTracker> for ::windows::core::IInspectable {
-    fn from(value: ContactChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChangeTracker> for ::windows::core::IInspectable {
-    fn from(value: &ContactChangeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChangeTracker> for &::windows::core::IInspectable {
-    fn from(value: &ContactChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactChangeTracker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactChangeTracker {}
 unsafe impl ::core::marker::Sync for ContactChangeTracker {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -4168,36 +3704,7 @@ unsafe impl ::windows::core::Interface for ContactChangedDeferral {
 impl ::windows::core::RuntimeName for ContactChangedDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactChangedDeferral";
 }
-impl ::core::convert::From<ContactChangedDeferral> for ::windows::core::IUnknown {
-    fn from(value: ContactChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChangedDeferral> for ::windows::core::IUnknown {
-    fn from(value: &ContactChangedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChangedDeferral> for &::windows::core::IUnknown {
-    fn from(value: &ContactChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactChangedDeferral> for ::windows::core::IInspectable {
-    fn from(value: ContactChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChangedDeferral> for ::windows::core::IInspectable {
-    fn from(value: &ContactChangedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChangedDeferral> for &::windows::core::IInspectable {
-    fn from(value: &ContactChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactChangedDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactChangedDeferral {}
 unsafe impl ::core::marker::Sync for ContactChangedDeferral {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -4244,36 +3751,7 @@ unsafe impl ::windows::core::Interface for ContactChangedEventArgs {
 impl ::windows::core::RuntimeName for ContactChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactChangedEventArgs";
 }
-impl ::core::convert::From<ContactChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactChangedEventArgs {}
 unsafe impl ::core::marker::Sync for ContactChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -4342,36 +3820,7 @@ unsafe impl ::windows::core::Interface for ContactConnectedServiceAccount {
 impl ::windows::core::RuntimeName for ContactConnectedServiceAccount {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactConnectedServiceAccount";
 }
-impl ::core::convert::From<ContactConnectedServiceAccount> for ::windows::core::IUnknown {
-    fn from(value: ContactConnectedServiceAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactConnectedServiceAccount> for ::windows::core::IUnknown {
-    fn from(value: &ContactConnectedServiceAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactConnectedServiceAccount> for &::windows::core::IUnknown {
-    fn from(value: &ContactConnectedServiceAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactConnectedServiceAccount> for ::windows::core::IInspectable {
-    fn from(value: ContactConnectedServiceAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactConnectedServiceAccount> for ::windows::core::IInspectable {
-    fn from(value: &ContactConnectedServiceAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactConnectedServiceAccount> for &::windows::core::IInspectable {
-    fn from(value: &ContactConnectedServiceAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactConnectedServiceAccount, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactConnectedServiceAccount {}
 unsafe impl ::core::marker::Sync for ContactConnectedServiceAccount {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -4497,36 +3946,7 @@ unsafe impl ::windows::core::Interface for ContactDate {
 impl ::windows::core::RuntimeName for ContactDate {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactDate";
 }
-impl ::core::convert::From<ContactDate> for ::windows::core::IUnknown {
-    fn from(value: ContactDate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactDate> for ::windows::core::IUnknown {
-    fn from(value: &ContactDate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactDate> for &::windows::core::IUnknown {
-    fn from(value: &ContactDate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactDate> for ::windows::core::IInspectable {
-    fn from(value: ContactDate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactDate> for ::windows::core::IInspectable {
-    fn from(value: &ContactDate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactDate> for &::windows::core::IInspectable {
-    fn from(value: &ContactDate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactDate, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactDate {}
 unsafe impl ::core::marker::Sync for ContactDate {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -4606,36 +4026,7 @@ unsafe impl ::windows::core::Interface for ContactEmail {
 impl ::windows::core::RuntimeName for ContactEmail {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactEmail";
 }
-impl ::core::convert::From<ContactEmail> for ::windows::core::IUnknown {
-    fn from(value: ContactEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactEmail> for ::windows::core::IUnknown {
-    fn from(value: &ContactEmail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactEmail> for &::windows::core::IUnknown {
-    fn from(value: &ContactEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactEmail> for ::windows::core::IInspectable {
-    fn from(value: ContactEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactEmail> for ::windows::core::IInspectable {
-    fn from(value: &ContactEmail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactEmail> for &::windows::core::IInspectable {
-    fn from(value: &ContactEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactEmail, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactEmail {}
 unsafe impl ::core::marker::Sync for ContactEmail {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -4726,36 +4117,7 @@ unsafe impl ::windows::core::Interface for ContactField {
 impl ::windows::core::RuntimeName for ContactField {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactField";
 }
-impl ::core::convert::From<ContactField> for ::windows::core::IUnknown {
-    fn from(value: ContactField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactField> for ::windows::core::IUnknown {
-    fn from(value: &ContactField) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactField> for &::windows::core::IUnknown {
-    fn from(value: &ContactField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactField> for ::windows::core::IInspectable {
-    fn from(value: ContactField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactField> for ::windows::core::IInspectable {
-    fn from(value: &ContactField) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactField> for &::windows::core::IInspectable {
-    fn from(value: &ContactField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactField, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactField> for IContactField {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactField) -> ::windows::core::Result<Self> {
@@ -4886,36 +4248,7 @@ unsafe impl ::windows::core::Interface for ContactFieldFactory {
 impl ::windows::core::RuntimeName for ContactFieldFactory {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactFieldFactory";
 }
-impl ::core::convert::From<ContactFieldFactory> for ::windows::core::IUnknown {
-    fn from(value: ContactFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactFieldFactory> for ::windows::core::IUnknown {
-    fn from(value: &ContactFieldFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactFieldFactory> for &::windows::core::IUnknown {
-    fn from(value: &ContactFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactFieldFactory> for ::windows::core::IInspectable {
-    fn from(value: ContactFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactFieldFactory> for ::windows::core::IInspectable {
-    fn from(value: &ContactFieldFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactFieldFactory> for &::windows::core::IInspectable {
-    fn from(value: &ContactFieldFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactFieldFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactFieldFactory> for IContactFieldFactory {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactFieldFactory) -> ::windows::core::Result<Self> {
@@ -5011,36 +4344,7 @@ unsafe impl ::windows::core::Interface for ContactGroup {
 impl ::windows::core::RuntimeName for ContactGroup {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactGroup";
 }
-impl ::core::convert::From<ContactGroup> for ::windows::core::IUnknown {
-    fn from(value: ContactGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactGroup> for ::windows::core::IUnknown {
-    fn from(value: &ContactGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactGroup> for &::windows::core::IUnknown {
-    fn from(value: &ContactGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactGroup> for ::windows::core::IInspectable {
-    fn from(value: ContactGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactGroup> for ::windows::core::IInspectable {
-    fn from(value: &ContactGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactGroup> for &::windows::core::IInspectable {
-    fn from(value: &ContactGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactGroup {}
 unsafe impl ::core::marker::Sync for ContactGroup {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -5150,36 +4454,7 @@ unsafe impl ::windows::core::Interface for ContactInformation {
 impl ::windows::core::RuntimeName for ContactInformation {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactInformation";
 }
-impl ::core::convert::From<ContactInformation> for ::windows::core::IUnknown {
-    fn from(value: ContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactInformation> for ::windows::core::IUnknown {
-    fn from(value: &ContactInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactInformation> for &::windows::core::IUnknown {
-    fn from(value: &ContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactInformation> for ::windows::core::IInspectable {
-    fn from(value: ContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactInformation> for ::windows::core::IInspectable {
-    fn from(value: &ContactInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactInformation> for &::windows::core::IInspectable {
-    fn from(value: &ContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
 #[repr(transparent)]
 pub struct ContactInstantMessageField(::windows::core::IUnknown);
@@ -5300,36 +4575,7 @@ unsafe impl ::windows::core::Interface for ContactInstantMessageField {
 impl ::windows::core::RuntimeName for ContactInstantMessageField {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactInstantMessageField";
 }
-impl ::core::convert::From<ContactInstantMessageField> for ::windows::core::IUnknown {
-    fn from(value: ContactInstantMessageField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactInstantMessageField> for ::windows::core::IUnknown {
-    fn from(value: &ContactInstantMessageField) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactInstantMessageField> for &::windows::core::IUnknown {
-    fn from(value: &ContactInstantMessageField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactInstantMessageField> for ::windows::core::IInspectable {
-    fn from(value: ContactInstantMessageField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactInstantMessageField> for ::windows::core::IInspectable {
-    fn from(value: &ContactInstantMessageField) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactInstantMessageField> for &::windows::core::IInspectable {
-    fn from(value: &ContactInstantMessageField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactInstantMessageField, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactInstantMessageField> for IContactField {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactInstantMessageField) -> ::windows::core::Result<Self> {
@@ -5483,36 +4729,7 @@ unsafe impl ::windows::core::Interface for ContactJobInfo {
 impl ::windows::core::RuntimeName for ContactJobInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactJobInfo";
 }
-impl ::core::convert::From<ContactJobInfo> for ::windows::core::IUnknown {
-    fn from(value: ContactJobInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactJobInfo> for ::windows::core::IUnknown {
-    fn from(value: &ContactJobInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactJobInfo> for &::windows::core::IUnknown {
-    fn from(value: &ContactJobInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactJobInfo> for ::windows::core::IInspectable {
-    fn from(value: ContactJobInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactJobInfo> for ::windows::core::IInspectable {
-    fn from(value: &ContactJobInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactJobInfo> for &::windows::core::IInspectable {
-    fn from(value: &ContactJobInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactJobInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactJobInfo {}
 unsafe impl ::core::marker::Sync for ContactJobInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -5806,36 +5023,7 @@ unsafe impl ::windows::core::Interface for ContactList {
 impl ::windows::core::RuntimeName for ContactList {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactList";
 }
-impl ::core::convert::From<ContactList> for ::windows::core::IUnknown {
-    fn from(value: ContactList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactList> for ::windows::core::IUnknown {
-    fn from(value: &ContactList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactList> for &::windows::core::IUnknown {
-    fn from(value: &ContactList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactList> for ::windows::core::IInspectable {
-    fn from(value: ContactList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactList> for ::windows::core::IInspectable {
-    fn from(value: &ContactList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactList> for &::windows::core::IInspectable {
-    fn from(value: &ContactList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactList {}
 unsafe impl ::core::marker::Sync for ContactList {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -5893,36 +5081,7 @@ unsafe impl ::windows::core::Interface for ContactListLimitedWriteOperations {
 impl ::windows::core::RuntimeName for ContactListLimitedWriteOperations {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactListLimitedWriteOperations";
 }
-impl ::core::convert::From<ContactListLimitedWriteOperations> for ::windows::core::IUnknown {
-    fn from(value: ContactListLimitedWriteOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListLimitedWriteOperations> for ::windows::core::IUnknown {
-    fn from(value: &ContactListLimitedWriteOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListLimitedWriteOperations> for &::windows::core::IUnknown {
-    fn from(value: &ContactListLimitedWriteOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactListLimitedWriteOperations> for ::windows::core::IInspectable {
-    fn from(value: ContactListLimitedWriteOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListLimitedWriteOperations> for ::windows::core::IInspectable {
-    fn from(value: &ContactListLimitedWriteOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListLimitedWriteOperations> for &::windows::core::IInspectable {
-    fn from(value: &ContactListLimitedWriteOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactListLimitedWriteOperations, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactListLimitedWriteOperations {}
 unsafe impl ::core::marker::Sync for ContactListLimitedWriteOperations {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -6486,36 +5645,7 @@ unsafe impl ::windows::core::Interface for ContactListSyncConstraints {
 impl ::windows::core::RuntimeName for ContactListSyncConstraints {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactListSyncConstraints";
 }
-impl ::core::convert::From<ContactListSyncConstraints> for ::windows::core::IUnknown {
-    fn from(value: ContactListSyncConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListSyncConstraints> for ::windows::core::IUnknown {
-    fn from(value: &ContactListSyncConstraints) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListSyncConstraints> for &::windows::core::IUnknown {
-    fn from(value: &ContactListSyncConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactListSyncConstraints> for ::windows::core::IInspectable {
-    fn from(value: ContactListSyncConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListSyncConstraints> for ::windows::core::IInspectable {
-    fn from(value: &ContactListSyncConstraints) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListSyncConstraints> for &::windows::core::IInspectable {
-    fn from(value: &ContactListSyncConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactListSyncConstraints, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactListSyncConstraints {}
 unsafe impl ::core::marker::Sync for ContactListSyncConstraints {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -6620,36 +5750,7 @@ unsafe impl ::windows::core::Interface for ContactListSyncManager {
 impl ::windows::core::RuntimeName for ContactListSyncManager {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactListSyncManager";
 }
-impl ::core::convert::From<ContactListSyncManager> for ::windows::core::IUnknown {
-    fn from(value: ContactListSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListSyncManager> for ::windows::core::IUnknown {
-    fn from(value: &ContactListSyncManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListSyncManager> for &::windows::core::IUnknown {
-    fn from(value: &ContactListSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactListSyncManager> for ::windows::core::IInspectable {
-    fn from(value: ContactListSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactListSyncManager> for ::windows::core::IInspectable {
-    fn from(value: &ContactListSyncManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactListSyncManager> for &::windows::core::IInspectable {
-    fn from(value: &ContactListSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactListSyncManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactListSyncManager {}
 unsafe impl ::core::marker::Sync for ContactListSyncManager {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -6782,36 +5883,7 @@ unsafe impl ::windows::core::Interface for ContactLocationField {
 impl ::windows::core::RuntimeName for ContactLocationField {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactLocationField";
 }
-impl ::core::convert::From<ContactLocationField> for ::windows::core::IUnknown {
-    fn from(value: ContactLocationField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactLocationField> for ::windows::core::IUnknown {
-    fn from(value: &ContactLocationField) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactLocationField> for &::windows::core::IUnknown {
-    fn from(value: &ContactLocationField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactLocationField> for ::windows::core::IInspectable {
-    fn from(value: ContactLocationField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactLocationField> for ::windows::core::IInspectable {
-    fn from(value: &ContactLocationField) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactLocationField> for &::windows::core::IInspectable {
-    fn from(value: &ContactLocationField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactLocationField, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactLocationField> for IContactField {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactLocationField) -> ::windows::core::Result<Self> {
@@ -7127,36 +6199,7 @@ unsafe impl ::windows::core::Interface for ContactManagerForUser {
 impl ::windows::core::RuntimeName for ContactManagerForUser {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactManagerForUser";
 }
-impl ::core::convert::From<ContactManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: ContactManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: &ContactManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactManagerForUser> for &::windows::core::IUnknown {
-    fn from(value: &ContactManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: ContactManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: &ContactManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactManagerForUser> for &::windows::core::IInspectable {
-    fn from(value: &ContactManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactManagerForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactManagerForUser {}
 unsafe impl ::core::marker::Sync for ContactManagerForUser {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -7219,36 +6262,7 @@ unsafe impl ::windows::core::Interface for ContactMatchReason {
 impl ::windows::core::RuntimeName for ContactMatchReason {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactMatchReason";
 }
-impl ::core::convert::From<ContactMatchReason> for ::windows::core::IUnknown {
-    fn from(value: ContactMatchReason) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactMatchReason> for ::windows::core::IUnknown {
-    fn from(value: &ContactMatchReason) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactMatchReason> for &::windows::core::IUnknown {
-    fn from(value: &ContactMatchReason) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactMatchReason> for ::windows::core::IInspectable {
-    fn from(value: ContactMatchReason) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactMatchReason> for ::windows::core::IInspectable {
-    fn from(value: &ContactMatchReason) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactMatchReason> for &::windows::core::IInspectable {
-    fn from(value: &ContactMatchReason) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactMatchReason, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactMatchReason {}
 unsafe impl ::core::marker::Sync for ContactMatchReason {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -7341,36 +6355,7 @@ unsafe impl ::windows::core::Interface for ContactPanel {
 impl ::windows::core::RuntimeName for ContactPanel {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactPanel";
 }
-impl ::core::convert::From<ContactPanel> for ::windows::core::IUnknown {
-    fn from(value: ContactPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPanel> for ::windows::core::IUnknown {
-    fn from(value: &ContactPanel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPanel> for &::windows::core::IUnknown {
-    fn from(value: &ContactPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactPanel> for ::windows::core::IInspectable {
-    fn from(value: ContactPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPanel> for ::windows::core::IInspectable {
-    fn from(value: &ContactPanel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPanel> for &::windows::core::IInspectable {
-    fn from(value: &ContactPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactPanel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactPanel {}
 unsafe impl ::core::marker::Sync for ContactPanel {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -7419,36 +6404,7 @@ unsafe impl ::windows::core::Interface for ContactPanelClosingEventArgs {
 impl ::windows::core::RuntimeName for ContactPanelClosingEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactPanelClosingEventArgs";
 }
-impl ::core::convert::From<ContactPanelClosingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactPanelClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPanelClosingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactPanelClosingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPanelClosingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactPanelClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactPanelClosingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactPanelClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPanelClosingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactPanelClosingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPanelClosingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactPanelClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactPanelClosingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactPanelClosingEventArgs {}
 unsafe impl ::core::marker::Sync for ContactPanelClosingEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -7499,36 +6455,7 @@ unsafe impl ::windows::core::Interface for ContactPanelLaunchFullAppRequestedEve
 impl ::windows::core::RuntimeName for ContactPanelLaunchFullAppRequestedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactPanelLaunchFullAppRequestedEventArgs";
 }
-impl ::core::convert::From<ContactPanelLaunchFullAppRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ContactPanelLaunchFullAppRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPanelLaunchFullAppRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ContactPanelLaunchFullAppRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPanelLaunchFullAppRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ContactPanelLaunchFullAppRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactPanelLaunchFullAppRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ContactPanelLaunchFullAppRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPanelLaunchFullAppRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ContactPanelLaunchFullAppRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPanelLaunchFullAppRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ContactPanelLaunchFullAppRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactPanelLaunchFullAppRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactPanelLaunchFullAppRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for ContactPanelLaunchFullAppRequestedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -7608,36 +6535,7 @@ unsafe impl ::windows::core::Interface for ContactPhone {
 impl ::windows::core::RuntimeName for ContactPhone {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactPhone";
 }
-impl ::core::convert::From<ContactPhone> for ::windows::core::IUnknown {
-    fn from(value: ContactPhone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPhone> for ::windows::core::IUnknown {
-    fn from(value: &ContactPhone) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPhone> for &::windows::core::IUnknown {
-    fn from(value: &ContactPhone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactPhone> for ::windows::core::IInspectable {
-    fn from(value: ContactPhone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPhone> for ::windows::core::IInspectable {
-    fn from(value: &ContactPhone) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPhone> for &::windows::core::IInspectable {
-    fn from(value: &ContactPhone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactPhone, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactPhone {}
 unsafe impl ::core::marker::Sync for ContactPhone {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -7790,36 +6688,7 @@ unsafe impl ::windows::core::Interface for ContactPicker {
 impl ::windows::core::RuntimeName for ContactPicker {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactPicker";
 }
-impl ::core::convert::From<ContactPicker> for ::windows::core::IUnknown {
-    fn from(value: ContactPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPicker> for ::windows::core::IUnknown {
-    fn from(value: &ContactPicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPicker> for &::windows::core::IUnknown {
-    fn from(value: &ContactPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactPicker> for ::windows::core::IInspectable {
-    fn from(value: ContactPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactPicker> for ::windows::core::IInspectable {
-    fn from(value: &ContactPicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactPicker> for &::windows::core::IInspectable {
-    fn from(value: &ContactPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactPicker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
 #[repr(transparent)]
 pub struct ContactQueryOptions(::windows::core::IUnknown);
@@ -7939,36 +6808,7 @@ unsafe impl ::windows::core::Interface for ContactQueryOptions {
 impl ::windows::core::RuntimeName for ContactQueryOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactQueryOptions";
 }
-impl ::core::convert::From<ContactQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: ContactQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: &ContactQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactQueryOptions> for &::windows::core::IUnknown {
-    fn from(value: &ContactQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: ContactQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: &ContactQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactQueryOptions> for &::windows::core::IInspectable {
-    fn from(value: &ContactQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactQueryOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactQueryOptions {}
 unsafe impl ::core::marker::Sync for ContactQueryOptions {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -8041,36 +6881,7 @@ unsafe impl ::windows::core::Interface for ContactQueryTextSearch {
 impl ::windows::core::RuntimeName for ContactQueryTextSearch {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactQueryTextSearch";
 }
-impl ::core::convert::From<ContactQueryTextSearch> for ::windows::core::IUnknown {
-    fn from(value: ContactQueryTextSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactQueryTextSearch> for ::windows::core::IUnknown {
-    fn from(value: &ContactQueryTextSearch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactQueryTextSearch> for &::windows::core::IUnknown {
-    fn from(value: &ContactQueryTextSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactQueryTextSearch> for ::windows::core::IInspectable {
-    fn from(value: ContactQueryTextSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactQueryTextSearch> for ::windows::core::IInspectable {
-    fn from(value: &ContactQueryTextSearch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactQueryTextSearch> for &::windows::core::IInspectable {
-    fn from(value: &ContactQueryTextSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactQueryTextSearch, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactQueryTextSearch {}
 unsafe impl ::core::marker::Sync for ContactQueryTextSearch {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -8128,36 +6939,7 @@ unsafe impl ::windows::core::Interface for ContactReader {
 impl ::windows::core::RuntimeName for ContactReader {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactReader";
 }
-impl ::core::convert::From<ContactReader> for ::windows::core::IUnknown {
-    fn from(value: ContactReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactReader> for ::windows::core::IUnknown {
-    fn from(value: &ContactReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactReader> for &::windows::core::IUnknown {
-    fn from(value: &ContactReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactReader> for ::windows::core::IInspectable {
-    fn from(value: ContactReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactReader> for ::windows::core::IInspectable {
-    fn from(value: &ContactReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactReader> for &::windows::core::IInspectable {
-    fn from(value: &ContactReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactReader {}
 unsafe impl ::core::marker::Sync for ContactReader {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -8237,36 +7019,7 @@ unsafe impl ::windows::core::Interface for ContactSignificantOther {
 impl ::windows::core::RuntimeName for ContactSignificantOther {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactSignificantOther";
 }
-impl ::core::convert::From<ContactSignificantOther> for ::windows::core::IUnknown {
-    fn from(value: ContactSignificantOther) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactSignificantOther> for ::windows::core::IUnknown {
-    fn from(value: &ContactSignificantOther) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactSignificantOther> for &::windows::core::IUnknown {
-    fn from(value: &ContactSignificantOther) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactSignificantOther> for ::windows::core::IInspectable {
-    fn from(value: ContactSignificantOther) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactSignificantOther> for ::windows::core::IInspectable {
-    fn from(value: &ContactSignificantOther) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactSignificantOther> for &::windows::core::IInspectable {
-    fn from(value: &ContactSignificantOther) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactSignificantOther, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactSignificantOther {}
 unsafe impl ::core::marker::Sync for ContactSignificantOther {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -8428,36 +7181,7 @@ unsafe impl ::windows::core::Interface for ContactStore {
 impl ::windows::core::RuntimeName for ContactStore {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactStore";
 }
-impl ::core::convert::From<ContactStore> for ::windows::core::IUnknown {
-    fn from(value: ContactStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactStore> for ::windows::core::IUnknown {
-    fn from(value: &ContactStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactStore> for &::windows::core::IUnknown {
-    fn from(value: &ContactStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactStore> for ::windows::core::IInspectable {
-    fn from(value: ContactStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactStore> for ::windows::core::IInspectable {
-    fn from(value: &ContactStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactStore> for &::windows::core::IInspectable {
-    fn from(value: &ContactStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactStore {}
 unsafe impl ::core::marker::Sync for ContactStore {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -8496,36 +7220,7 @@ unsafe impl ::windows::core::Interface for ContactStoreNotificationTriggerDetail
 impl ::windows::core::RuntimeName for ContactStoreNotificationTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactStoreNotificationTriggerDetails";
 }
-impl ::core::convert::From<ContactStoreNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: ContactStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactStoreNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &ContactStoreNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactStoreNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &ContactStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactStoreNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: ContactStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactStoreNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &ContactStoreNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactStoreNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &ContactStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactStoreNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactStoreNotificationTriggerDetails {}
 unsafe impl ::core::marker::Sync for ContactStoreNotificationTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -8609,36 +7304,7 @@ unsafe impl ::windows::core::Interface for ContactWebsite {
 impl ::windows::core::RuntimeName for ContactWebsite {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactWebsite";
 }
-impl ::core::convert::From<ContactWebsite> for ::windows::core::IUnknown {
-    fn from(value: ContactWebsite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactWebsite> for ::windows::core::IUnknown {
-    fn from(value: &ContactWebsite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactWebsite> for &::windows::core::IUnknown {
-    fn from(value: &ContactWebsite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactWebsite> for ::windows::core::IInspectable {
-    fn from(value: ContactWebsite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactWebsite> for ::windows::core::IInspectable {
-    fn from(value: &ContactWebsite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactWebsite> for &::windows::core::IInspectable {
-    fn from(value: &ContactWebsite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactWebsite, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactWebsite {}
 unsafe impl ::core::marker::Sync for ContactWebsite {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -8700,36 +7366,7 @@ unsafe impl ::windows::core::Interface for FullContactCardOptions {
 impl ::windows::core::RuntimeName for FullContactCardOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.FullContactCardOptions";
 }
-impl ::core::convert::From<FullContactCardOptions> for ::windows::core::IUnknown {
-    fn from(value: FullContactCardOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FullContactCardOptions> for ::windows::core::IUnknown {
-    fn from(value: &FullContactCardOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FullContactCardOptions> for &::windows::core::IUnknown {
-    fn from(value: &FullContactCardOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FullContactCardOptions> for ::windows::core::IInspectable {
-    fn from(value: FullContactCardOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FullContactCardOptions> for ::windows::core::IInspectable {
-    fn from(value: &FullContactCardOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FullContactCardOptions> for &::windows::core::IInspectable {
-    fn from(value: &FullContactCardOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FullContactCardOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FullContactCardOptions {}
 unsafe impl ::core::marker::Sync for FullContactCardOptions {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`, `\"deprecated\"`*"]
@@ -8842,36 +7479,7 @@ unsafe impl ::windows::core::Interface for PinnedContactIdsQueryResult {
 impl ::windows::core::RuntimeName for PinnedContactIdsQueryResult {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.PinnedContactIdsQueryResult";
 }
-impl ::core::convert::From<PinnedContactIdsQueryResult> for ::windows::core::IUnknown {
-    fn from(value: PinnedContactIdsQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PinnedContactIdsQueryResult> for ::windows::core::IUnknown {
-    fn from(value: &PinnedContactIdsQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PinnedContactIdsQueryResult> for &::windows::core::IUnknown {
-    fn from(value: &PinnedContactIdsQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PinnedContactIdsQueryResult> for ::windows::core::IInspectable {
-    fn from(value: PinnedContactIdsQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PinnedContactIdsQueryResult> for ::windows::core::IInspectable {
-    fn from(value: &PinnedContactIdsQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PinnedContactIdsQueryResult> for &::windows::core::IInspectable {
-    fn from(value: &PinnedContactIdsQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PinnedContactIdsQueryResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PinnedContactIdsQueryResult {}
 unsafe impl ::core::marker::Sync for PinnedContactIdsQueryResult {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]
@@ -9003,36 +7611,7 @@ unsafe impl ::windows::core::Interface for PinnedContactManager {
 impl ::windows::core::RuntimeName for PinnedContactManager {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.PinnedContactManager";
 }
-impl ::core::convert::From<PinnedContactManager> for ::windows::core::IUnknown {
-    fn from(value: PinnedContactManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PinnedContactManager> for ::windows::core::IUnknown {
-    fn from(value: &PinnedContactManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PinnedContactManager> for &::windows::core::IUnknown {
-    fn from(value: &PinnedContactManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PinnedContactManager> for ::windows::core::IInspectable {
-    fn from(value: PinnedContactManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PinnedContactManager> for ::windows::core::IInspectable {
-    fn from(value: &PinnedContactManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PinnedContactManager> for &::windows::core::IInspectable {
-    fn from(value: &PinnedContactManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PinnedContactManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PinnedContactManager {}
 unsafe impl ::core::marker::Sync for PinnedContactManager {}
 #[doc = "*Required features: `\"ApplicationModel_Contacts\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/ConversationalAgent/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ConversationalAgent/mod.rs
@@ -859,36 +859,7 @@ unsafe impl ::windows::core::Interface for ActivationSignalDetectionConfiguratio
 impl ::windows::core::RuntimeName for ActivationSignalDetectionConfiguration {
     const NAME: &'static str = "Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfiguration";
 }
-impl ::core::convert::From<ActivationSignalDetectionConfiguration> for ::windows::core::IUnknown {
-    fn from(value: ActivationSignalDetectionConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetectionConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &ActivationSignalDetectionConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetectionConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &ActivationSignalDetectionConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivationSignalDetectionConfiguration> for ::windows::core::IInspectable {
-    fn from(value: ActivationSignalDetectionConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetectionConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &ActivationSignalDetectionConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetectionConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &ActivationSignalDetectionConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivationSignalDetectionConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ActivationSignalDetectionConfiguration> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -964,36 +935,7 @@ unsafe impl ::windows::core::Interface for ActivationSignalDetectionConfiguratio
 impl ::windows::core::RuntimeName for ActivationSignalDetectionConfigurationCreationResult {
     const NAME: &'static str = "Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfigurationCreationResult";
 }
-impl ::core::convert::From<ActivationSignalDetectionConfigurationCreationResult> for ::windows::core::IUnknown {
-    fn from(value: ActivationSignalDetectionConfigurationCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetectionConfigurationCreationResult> for ::windows::core::IUnknown {
-    fn from(value: &ActivationSignalDetectionConfigurationCreationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetectionConfigurationCreationResult> for &::windows::core::IUnknown {
-    fn from(value: &ActivationSignalDetectionConfigurationCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivationSignalDetectionConfigurationCreationResult> for ::windows::core::IInspectable {
-    fn from(value: ActivationSignalDetectionConfigurationCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetectionConfigurationCreationResult> for ::windows::core::IInspectable {
-    fn from(value: &ActivationSignalDetectionConfigurationCreationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetectionConfigurationCreationResult> for &::windows::core::IInspectable {
-    fn from(value: &ActivationSignalDetectionConfigurationCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivationSignalDetectionConfigurationCreationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ActivationSignalDetectionConfigurationCreationResult {}
 unsafe impl ::core::marker::Sync for ActivationSignalDetectionConfigurationCreationResult {}
 #[doc = "*Required features: `\"ApplicationModel_ConversationalAgent\"`*"]
@@ -1216,36 +1158,7 @@ unsafe impl ::windows::core::Interface for ActivationSignalDetector {
 impl ::windows::core::RuntimeName for ActivationSignalDetector {
     const NAME: &'static str = "Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetector";
 }
-impl ::core::convert::From<ActivationSignalDetector> for ::windows::core::IUnknown {
-    fn from(value: ActivationSignalDetector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetector> for ::windows::core::IUnknown {
-    fn from(value: &ActivationSignalDetector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetector> for &::windows::core::IUnknown {
-    fn from(value: &ActivationSignalDetector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivationSignalDetector> for ::windows::core::IInspectable {
-    fn from(value: ActivationSignalDetector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetector> for ::windows::core::IInspectable {
-    fn from(value: &ActivationSignalDetector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivationSignalDetector> for &::windows::core::IInspectable {
-    fn from(value: &ActivationSignalDetector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivationSignalDetector, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ActivationSignalDetector {}
 unsafe impl ::core::marker::Sync for ActivationSignalDetector {}
 #[doc = "*Required features: `\"ApplicationModel_ConversationalAgent\"`*"]
@@ -1348,36 +1261,7 @@ unsafe impl ::windows::core::Interface for ConversationalAgentDetectorManager {
 impl ::windows::core::RuntimeName for ConversationalAgentDetectorManager {
     const NAME: &'static str = "Windows.ApplicationModel.ConversationalAgent.ConversationalAgentDetectorManager";
 }
-impl ::core::convert::From<ConversationalAgentDetectorManager> for ::windows::core::IUnknown {
-    fn from(value: ConversationalAgentDetectorManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentDetectorManager> for ::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentDetectorManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentDetectorManager> for &::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentDetectorManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConversationalAgentDetectorManager> for ::windows::core::IInspectable {
-    fn from(value: ConversationalAgentDetectorManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentDetectorManager> for ::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentDetectorManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentDetectorManager> for &::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentDetectorManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConversationalAgentDetectorManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ConversationalAgentDetectorManager {}
 unsafe impl ::core::marker::Sync for ConversationalAgentDetectorManager {}
 #[doc = "*Required features: `\"ApplicationModel_ConversationalAgent\"`*"]
@@ -1754,36 +1638,7 @@ unsafe impl ::windows::core::Interface for ConversationalAgentSession {
 impl ::windows::core::RuntimeName for ConversationalAgentSession {
     const NAME: &'static str = "Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSession";
 }
-impl ::core::convert::From<ConversationalAgentSession> for ::windows::core::IUnknown {
-    fn from(value: ConversationalAgentSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSession> for ::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSession> for &::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConversationalAgentSession> for ::windows::core::IInspectable {
-    fn from(value: ConversationalAgentSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSession> for ::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSession> for &::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConversationalAgentSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ConversationalAgentSession> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1844,36 +1699,7 @@ unsafe impl ::windows::core::Interface for ConversationalAgentSessionInterrupted
 impl ::windows::core::RuntimeName for ConversationalAgentSessionInterruptedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSessionInterruptedEventArgs";
 }
-impl ::core::convert::From<ConversationalAgentSessionInterruptedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ConversationalAgentSessionInterruptedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSessionInterruptedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentSessionInterruptedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSessionInterruptedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentSessionInterruptedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConversationalAgentSessionInterruptedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ConversationalAgentSessionInterruptedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSessionInterruptedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentSessionInterruptedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSessionInterruptedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentSessionInterruptedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConversationalAgentSessionInterruptedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ConversationalAgentSessionInterruptedEventArgs {}
 unsafe impl ::core::marker::Sync for ConversationalAgentSessionInterruptedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_ConversationalAgent\"`*"]
@@ -2004,36 +1830,7 @@ unsafe impl ::windows::core::Interface for ConversationalAgentSignal {
 impl ::windows::core::RuntimeName for ConversationalAgentSignal {
     const NAME: &'static str = "Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSignal";
 }
-impl ::core::convert::From<ConversationalAgentSignal> for ::windows::core::IUnknown {
-    fn from(value: ConversationalAgentSignal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSignal> for ::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentSignal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSignal> for &::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentSignal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConversationalAgentSignal> for ::windows::core::IInspectable {
-    fn from(value: ConversationalAgentSignal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSignal> for ::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentSignal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSignal> for &::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentSignal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConversationalAgentSignal, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ConversationalAgentSignal {}
 unsafe impl ::core::marker::Sync for ConversationalAgentSignal {}
 #[doc = "*Required features: `\"ApplicationModel_ConversationalAgent\"`*"]
@@ -2072,36 +1869,7 @@ unsafe impl ::windows::core::Interface for ConversationalAgentSignalDetectedEven
 impl ::windows::core::RuntimeName for ConversationalAgentSignalDetectedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSignalDetectedEventArgs";
 }
-impl ::core::convert::From<ConversationalAgentSignalDetectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ConversationalAgentSignalDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSignalDetectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentSignalDetectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSignalDetectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentSignalDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConversationalAgentSignalDetectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ConversationalAgentSignalDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSignalDetectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentSignalDetectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSignalDetectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentSignalDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConversationalAgentSignalDetectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ConversationalAgentSignalDetectedEventArgs {}
 unsafe impl ::core::marker::Sync for ConversationalAgentSignalDetectedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_ConversationalAgent\"`*"]
@@ -2148,36 +1916,7 @@ unsafe impl ::windows::core::Interface for ConversationalAgentSystemStateChanged
 impl ::windows::core::RuntimeName for ConversationalAgentSystemStateChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSystemStateChangedEventArgs";
 }
-impl ::core::convert::From<ConversationalAgentSystemStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ConversationalAgentSystemStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSystemStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentSystemStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSystemStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ConversationalAgentSystemStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConversationalAgentSystemStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ConversationalAgentSystemStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSystemStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentSystemStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConversationalAgentSystemStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ConversationalAgentSystemStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConversationalAgentSystemStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ConversationalAgentSystemStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for ConversationalAgentSystemStateChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_ConversationalAgent\"`*"]
@@ -2224,36 +1963,7 @@ unsafe impl ::windows::core::Interface for DetectionConfigurationAvailabilityCha
 impl ::windows::core::RuntimeName for DetectionConfigurationAvailabilityChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.ConversationalAgent.DetectionConfigurationAvailabilityChangedEventArgs";
 }
-impl ::core::convert::From<DetectionConfigurationAvailabilityChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DetectionConfigurationAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DetectionConfigurationAvailabilityChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DetectionConfigurationAvailabilityChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DetectionConfigurationAvailabilityChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DetectionConfigurationAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DetectionConfigurationAvailabilityChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DetectionConfigurationAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DetectionConfigurationAvailabilityChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DetectionConfigurationAvailabilityChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DetectionConfigurationAvailabilityChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DetectionConfigurationAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DetectionConfigurationAvailabilityChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DetectionConfigurationAvailabilityChangedEventArgs {}
 unsafe impl ::core::marker::Sync for DetectionConfigurationAvailabilityChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_ConversationalAgent\"`*"]
@@ -2330,36 +2040,7 @@ unsafe impl ::windows::core::Interface for DetectionConfigurationAvailabilityInf
 impl ::windows::core::RuntimeName for DetectionConfigurationAvailabilityInfo {
     const NAME: &'static str = "Windows.ApplicationModel.ConversationalAgent.DetectionConfigurationAvailabilityInfo";
 }
-impl ::core::convert::From<DetectionConfigurationAvailabilityInfo> for ::windows::core::IUnknown {
-    fn from(value: DetectionConfigurationAvailabilityInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DetectionConfigurationAvailabilityInfo> for ::windows::core::IUnknown {
-    fn from(value: &DetectionConfigurationAvailabilityInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DetectionConfigurationAvailabilityInfo> for &::windows::core::IUnknown {
-    fn from(value: &DetectionConfigurationAvailabilityInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DetectionConfigurationAvailabilityInfo> for ::windows::core::IInspectable {
-    fn from(value: DetectionConfigurationAvailabilityInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DetectionConfigurationAvailabilityInfo> for ::windows::core::IInspectable {
-    fn from(value: &DetectionConfigurationAvailabilityInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DetectionConfigurationAvailabilityInfo> for &::windows::core::IInspectable {
-    fn from(value: &DetectionConfigurationAvailabilityInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DetectionConfigurationAvailabilityInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DetectionConfigurationAvailabilityInfo {}
 unsafe impl ::core::marker::Sync for DetectionConfigurationAvailabilityInfo {}
 #[doc = "*Required features: `\"ApplicationModel_ConversationalAgent\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Core/mod.rs
@@ -210,36 +210,7 @@ impl ICoreApplicationUnhandledError {
         unsafe { (::windows::core::Vtable::vtable(this).RemoveUnhandledErrorDetected)(::windows::core::Vtable::as_raw(this), token).ok() }
     }
 }
-impl ::core::convert::From<ICoreApplicationUnhandledError> for ::windows::core::IUnknown {
-    fn from(value: ICoreApplicationUnhandledError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreApplicationUnhandledError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreApplicationUnhandledError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreApplicationUnhandledError> for ::windows::core::IUnknown {
-    fn from(value: &ICoreApplicationUnhandledError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICoreApplicationUnhandledError> for ::windows::core::IInspectable {
-    fn from(value: ICoreApplicationUnhandledError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreApplicationUnhandledError> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICoreApplicationUnhandledError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreApplicationUnhandledError> for ::windows::core::IInspectable {
-    fn from(value: &ICoreApplicationUnhandledError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreApplicationUnhandledError, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICoreApplicationUnhandledError {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -517,36 +488,7 @@ impl IFrameworkView {
         unsafe { (::windows::core::Vtable::vtable(this).Uninitialize)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IFrameworkView> for ::windows::core::IUnknown {
-    fn from(value: IFrameworkView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFrameworkView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFrameworkView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFrameworkView> for ::windows::core::IUnknown {
-    fn from(value: &IFrameworkView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFrameworkView> for ::windows::core::IInspectable {
-    fn from(value: IFrameworkView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFrameworkView> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFrameworkView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFrameworkView> for ::windows::core::IInspectable {
-    fn from(value: &IFrameworkView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFrameworkView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IFrameworkView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -601,36 +543,7 @@ impl IFrameworkViewSource {
         }
     }
 }
-impl ::core::convert::From<IFrameworkViewSource> for ::windows::core::IUnknown {
-    fn from(value: IFrameworkViewSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFrameworkViewSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFrameworkViewSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFrameworkViewSource> for ::windows::core::IUnknown {
-    fn from(value: &IFrameworkViewSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFrameworkViewSource> for ::windows::core::IInspectable {
-    fn from(value: IFrameworkViewSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFrameworkViewSource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFrameworkViewSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFrameworkViewSource> for ::windows::core::IInspectable {
-    fn from(value: &IFrameworkViewSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFrameworkViewSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IFrameworkViewSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -791,36 +704,7 @@ unsafe impl ::windows::core::Interface for AppListEntry {
 impl ::windows::core::RuntimeName for AppListEntry {
     const NAME: &'static str = "Windows.ApplicationModel.Core.AppListEntry";
 }
-impl ::core::convert::From<AppListEntry> for ::windows::core::IUnknown {
-    fn from(value: AppListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppListEntry> for ::windows::core::IUnknown {
-    fn from(value: &AppListEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppListEntry> for &::windows::core::IUnknown {
-    fn from(value: &AppListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppListEntry> for ::windows::core::IInspectable {
-    fn from(value: AppListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppListEntry> for ::windows::core::IInspectable {
-    fn from(value: &AppListEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppListEntry> for &::windows::core::IInspectable {
-    fn from(value: &AppListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppListEntry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppListEntry {}
 unsafe impl ::core::marker::Sync for AppListEntry {}
 #[doc = "*Required features: `\"ApplicationModel_Core\"`*"]
@@ -1197,36 +1081,7 @@ unsafe impl ::windows::core::Interface for CoreApplicationView {
 impl ::windows::core::RuntimeName for CoreApplicationView {
     const NAME: &'static str = "Windows.ApplicationModel.Core.CoreApplicationView";
 }
-impl ::core::convert::From<CoreApplicationView> for ::windows::core::IUnknown {
-    fn from(value: CoreApplicationView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreApplicationView> for ::windows::core::IUnknown {
-    fn from(value: &CoreApplicationView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreApplicationView> for &::windows::core::IUnknown {
-    fn from(value: &CoreApplicationView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreApplicationView> for ::windows::core::IInspectable {
-    fn from(value: CoreApplicationView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreApplicationView> for ::windows::core::IInspectable {
-    fn from(value: &CoreApplicationView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreApplicationView> for &::windows::core::IInspectable {
-    fn from(value: &CoreApplicationView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreApplicationView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Core\"`*"]
 #[repr(transparent)]
 pub struct CoreApplicationViewTitleBar(::windows::core::IUnknown);
@@ -1333,36 +1188,7 @@ unsafe impl ::windows::core::Interface for CoreApplicationViewTitleBar {
 impl ::windows::core::RuntimeName for CoreApplicationViewTitleBar {
     const NAME: &'static str = "Windows.ApplicationModel.Core.CoreApplicationViewTitleBar";
 }
-impl ::core::convert::From<CoreApplicationViewTitleBar> for ::windows::core::IUnknown {
-    fn from(value: CoreApplicationViewTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreApplicationViewTitleBar> for ::windows::core::IUnknown {
-    fn from(value: &CoreApplicationViewTitleBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreApplicationViewTitleBar> for &::windows::core::IUnknown {
-    fn from(value: &CoreApplicationViewTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreApplicationViewTitleBar> for ::windows::core::IInspectable {
-    fn from(value: CoreApplicationViewTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreApplicationViewTitleBar> for ::windows::core::IInspectable {
-    fn from(value: &CoreApplicationViewTitleBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreApplicationViewTitleBar> for &::windows::core::IInspectable {
-    fn from(value: &CoreApplicationViewTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreApplicationViewTitleBar, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Core\"`*"]
 #[repr(transparent)]
 pub struct HostedViewClosingEventArgs(::windows::core::IUnknown);
@@ -1409,36 +1235,7 @@ unsafe impl ::windows::core::Interface for HostedViewClosingEventArgs {
 impl ::windows::core::RuntimeName for HostedViewClosingEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Core.HostedViewClosingEventArgs";
 }
-impl ::core::convert::From<HostedViewClosingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: HostedViewClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HostedViewClosingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &HostedViewClosingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HostedViewClosingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &HostedViewClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HostedViewClosingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: HostedViewClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HostedViewClosingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &HostedViewClosingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HostedViewClosingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &HostedViewClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HostedViewClosingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HostedViewClosingEventArgs {}
 unsafe impl ::core::marker::Sync for HostedViewClosingEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Core\"`*"]
@@ -1489,36 +1286,7 @@ unsafe impl ::windows::core::Interface for UnhandledError {
 impl ::windows::core::RuntimeName for UnhandledError {
     const NAME: &'static str = "Windows.ApplicationModel.Core.UnhandledError";
 }
-impl ::core::convert::From<UnhandledError> for ::windows::core::IUnknown {
-    fn from(value: UnhandledError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UnhandledError> for ::windows::core::IUnknown {
-    fn from(value: &UnhandledError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UnhandledError> for &::windows::core::IUnknown {
-    fn from(value: &UnhandledError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UnhandledError> for ::windows::core::IInspectable {
-    fn from(value: UnhandledError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UnhandledError> for ::windows::core::IInspectable {
-    fn from(value: &UnhandledError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UnhandledError> for &::windows::core::IInspectable {
-    fn from(value: &UnhandledError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UnhandledError, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UnhandledError {}
 unsafe impl ::core::marker::Sync for UnhandledError {}
 #[doc = "*Required features: `\"ApplicationModel_Core\"`*"]
@@ -1565,36 +1333,7 @@ unsafe impl ::windows::core::Interface for UnhandledErrorDetectedEventArgs {
 impl ::windows::core::RuntimeName for UnhandledErrorDetectedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Core.UnhandledErrorDetectedEventArgs";
 }
-impl ::core::convert::From<UnhandledErrorDetectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UnhandledErrorDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UnhandledErrorDetectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UnhandledErrorDetectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UnhandledErrorDetectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UnhandledErrorDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UnhandledErrorDetectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UnhandledErrorDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UnhandledErrorDetectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UnhandledErrorDetectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UnhandledErrorDetectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UnhandledErrorDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UnhandledErrorDetectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UnhandledErrorDetectedEventArgs {}
 unsafe impl ::core::marker::Sync for UnhandledErrorDetectedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Core\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
@@ -190,36 +190,7 @@ impl ICoreDropOperationTarget {
         }
     }
 }
-impl ::core::convert::From<ICoreDropOperationTarget> for ::windows::core::IUnknown {
-    fn from(value: ICoreDropOperationTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreDropOperationTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreDropOperationTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreDropOperationTarget> for ::windows::core::IUnknown {
-    fn from(value: &ICoreDropOperationTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICoreDropOperationTarget> for ::windows::core::IInspectable {
-    fn from(value: ICoreDropOperationTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreDropOperationTarget> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICoreDropOperationTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreDropOperationTarget> for ::windows::core::IInspectable {
-    fn from(value: &ICoreDropOperationTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreDropOperationTarget, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICoreDropOperationTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -359,36 +330,7 @@ unsafe impl ::windows::core::Interface for CoreDragDropManager {
 impl ::windows::core::RuntimeName for CoreDragDropManager {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDragDropManager";
 }
-impl ::core::convert::From<CoreDragDropManager> for ::windows::core::IUnknown {
-    fn from(value: CoreDragDropManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDragDropManager> for ::windows::core::IUnknown {
-    fn from(value: &CoreDragDropManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDragDropManager> for &::windows::core::IUnknown {
-    fn from(value: &CoreDragDropManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreDragDropManager> for ::windows::core::IInspectable {
-    fn from(value: CoreDragDropManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDragDropManager> for ::windows::core::IInspectable {
-    fn from(value: &CoreDragDropManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDragDropManager> for &::windows::core::IInspectable {
-    fn from(value: &CoreDragDropManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreDragDropManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreDragDropManager {}
 unsafe impl ::core::marker::Sync for CoreDragDropManager {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer_DragDrop_Core\"`*"]
@@ -458,36 +400,7 @@ unsafe impl ::windows::core::Interface for CoreDragInfo {
 impl ::windows::core::RuntimeName for CoreDragInfo {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDragInfo";
 }
-impl ::core::convert::From<CoreDragInfo> for ::windows::core::IUnknown {
-    fn from(value: CoreDragInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDragInfo> for ::windows::core::IUnknown {
-    fn from(value: &CoreDragInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDragInfo> for &::windows::core::IUnknown {
-    fn from(value: &CoreDragInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreDragInfo> for ::windows::core::IInspectable {
-    fn from(value: CoreDragInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDragInfo> for ::windows::core::IInspectable {
-    fn from(value: &CoreDragInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDragInfo> for &::windows::core::IInspectable {
-    fn from(value: &CoreDragInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreDragInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreDragInfo {}
 unsafe impl ::core::marker::Sync for CoreDragInfo {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer_DragDrop_Core\"`*"]
@@ -588,36 +501,7 @@ unsafe impl ::windows::core::Interface for CoreDragOperation {
 impl ::windows::core::RuntimeName for CoreDragOperation {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDragOperation";
 }
-impl ::core::convert::From<CoreDragOperation> for ::windows::core::IUnknown {
-    fn from(value: CoreDragOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDragOperation> for ::windows::core::IUnknown {
-    fn from(value: &CoreDragOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDragOperation> for &::windows::core::IUnknown {
-    fn from(value: &CoreDragOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreDragOperation> for ::windows::core::IInspectable {
-    fn from(value: CoreDragOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDragOperation> for ::windows::core::IInspectable {
-    fn from(value: &CoreDragOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDragOperation> for &::windows::core::IInspectable {
-    fn from(value: &CoreDragOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreDragOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreDragOperation {}
 unsafe impl ::core::marker::Sync for CoreDragOperation {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer_DragDrop_Core\"`*"]
@@ -717,36 +601,7 @@ unsafe impl ::windows::core::Interface for CoreDragUIOverride {
 impl ::windows::core::RuntimeName for CoreDragUIOverride {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDragUIOverride";
 }
-impl ::core::convert::From<CoreDragUIOverride> for ::windows::core::IUnknown {
-    fn from(value: CoreDragUIOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDragUIOverride> for ::windows::core::IUnknown {
-    fn from(value: &CoreDragUIOverride) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDragUIOverride> for &::windows::core::IUnknown {
-    fn from(value: &CoreDragUIOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreDragUIOverride> for ::windows::core::IInspectable {
-    fn from(value: CoreDragUIOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDragUIOverride> for ::windows::core::IInspectable {
-    fn from(value: &CoreDragUIOverride) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDragUIOverride> for &::windows::core::IInspectable {
-    fn from(value: &CoreDragUIOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreDragUIOverride, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreDragUIOverride {}
 unsafe impl ::core::marker::Sync for CoreDragUIOverride {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer_DragDrop_Core\"`*"]
@@ -794,36 +649,7 @@ unsafe impl ::windows::core::Interface for CoreDropOperationTargetRequestedEvent
 impl ::windows::core::RuntimeName for CoreDropOperationTargetRequestedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DragDrop.Core.CoreDropOperationTargetRequestedEventArgs";
 }
-impl ::core::convert::From<CoreDropOperationTargetRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreDropOperationTargetRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDropOperationTargetRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreDropOperationTargetRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDropOperationTargetRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreDropOperationTargetRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreDropOperationTargetRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreDropOperationTargetRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDropOperationTargetRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreDropOperationTargetRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDropOperationTargetRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreDropOperationTargetRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreDropOperationTargetRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreDropOperationTargetRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for CoreDropOperationTargetRequestedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer_DragDrop_Core\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/ShareTarget/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/ShareTarget/mod.rs
@@ -187,36 +187,7 @@ unsafe impl ::windows::core::Interface for QuickLink {
 impl ::windows::core::RuntimeName for QuickLink {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ShareTarget.QuickLink";
 }
-impl ::core::convert::From<QuickLink> for ::windows::core::IUnknown {
-    fn from(value: QuickLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&QuickLink> for ::windows::core::IUnknown {
-    fn from(value: &QuickLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&QuickLink> for &::windows::core::IUnknown {
-    fn from(value: &QuickLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<QuickLink> for ::windows::core::IInspectable {
-    fn from(value: QuickLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&QuickLink> for ::windows::core::IInspectable {
-    fn from(value: &QuickLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&QuickLink> for &::windows::core::IInspectable {
-    fn from(value: &QuickLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(QuickLink, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer_ShareTarget\"`*"]
 #[repr(transparent)]
 pub struct ShareOperation(::windows::core::IUnknown);
@@ -309,35 +280,6 @@ unsafe impl ::windows::core::Interface for ShareOperation {
 impl ::windows::core::RuntimeName for ShareOperation {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ShareTarget.ShareOperation";
 }
-impl ::core::convert::From<ShareOperation> for ::windows::core::IUnknown {
-    fn from(value: ShareOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareOperation> for ::windows::core::IUnknown {
-    fn from(value: &ShareOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareOperation> for &::windows::core::IUnknown {
-    fn from(value: &ShareOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShareOperation> for ::windows::core::IInspectable {
-    fn from(value: ShareOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareOperation> for ::windows::core::IInspectable {
-    fn from(value: &ShareOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareOperation> for &::windows::core::IInspectable {
-    fn from(value: &ShareOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShareOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "implement")]
 ::core::include!("impl.rs");

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
@@ -1300,36 +1300,7 @@ unsafe impl ::windows::core::Interface for ClipboardContentOptions {
 impl ::windows::core::RuntimeName for ClipboardContentOptions {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ClipboardContentOptions";
 }
-impl ::core::convert::From<ClipboardContentOptions> for ::windows::core::IUnknown {
-    fn from(value: ClipboardContentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClipboardContentOptions> for ::windows::core::IUnknown {
-    fn from(value: &ClipboardContentOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClipboardContentOptions> for &::windows::core::IUnknown {
-    fn from(value: &ClipboardContentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClipboardContentOptions> for ::windows::core::IInspectable {
-    fn from(value: ClipboardContentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClipboardContentOptions> for ::windows::core::IInspectable {
-    fn from(value: &ClipboardContentOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClipboardContentOptions> for &::windows::core::IInspectable {
-    fn from(value: &ClipboardContentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClipboardContentOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ClipboardContentOptions {}
 unsafe impl ::core::marker::Sync for ClipboardContentOptions {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -1368,36 +1339,7 @@ unsafe impl ::windows::core::Interface for ClipboardHistoryChangedEventArgs {
 impl ::windows::core::RuntimeName for ClipboardHistoryChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ClipboardHistoryChangedEventArgs";
 }
-impl ::core::convert::From<ClipboardHistoryChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ClipboardHistoryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ClipboardHistoryChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ClipboardHistoryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClipboardHistoryChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ClipboardHistoryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ClipboardHistoryChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ClipboardHistoryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClipboardHistoryChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ClipboardHistoryChangedEventArgs {}
 unsafe impl ::core::marker::Sync for ClipboardHistoryChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -1460,36 +1402,7 @@ unsafe impl ::windows::core::Interface for ClipboardHistoryItem {
 impl ::windows::core::RuntimeName for ClipboardHistoryItem {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ClipboardHistoryItem";
 }
-impl ::core::convert::From<ClipboardHistoryItem> for ::windows::core::IUnknown {
-    fn from(value: ClipboardHistoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryItem> for ::windows::core::IUnknown {
-    fn from(value: &ClipboardHistoryItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryItem> for &::windows::core::IUnknown {
-    fn from(value: &ClipboardHistoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClipboardHistoryItem> for ::windows::core::IInspectable {
-    fn from(value: ClipboardHistoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryItem> for ::windows::core::IInspectable {
-    fn from(value: &ClipboardHistoryItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryItem> for &::windows::core::IInspectable {
-    fn from(value: &ClipboardHistoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClipboardHistoryItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ClipboardHistoryItem {}
 unsafe impl ::core::marker::Sync for ClipboardHistoryItem {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -1545,36 +1458,7 @@ unsafe impl ::windows::core::Interface for ClipboardHistoryItemsResult {
 impl ::windows::core::RuntimeName for ClipboardHistoryItemsResult {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ClipboardHistoryItemsResult";
 }
-impl ::core::convert::From<ClipboardHistoryItemsResult> for ::windows::core::IUnknown {
-    fn from(value: ClipboardHistoryItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryItemsResult> for ::windows::core::IUnknown {
-    fn from(value: &ClipboardHistoryItemsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryItemsResult> for &::windows::core::IUnknown {
-    fn from(value: &ClipboardHistoryItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClipboardHistoryItemsResult> for ::windows::core::IInspectable {
-    fn from(value: ClipboardHistoryItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryItemsResult> for ::windows::core::IInspectable {
-    fn from(value: &ClipboardHistoryItemsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClipboardHistoryItemsResult> for &::windows::core::IInspectable {
-    fn from(value: &ClipboardHistoryItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClipboardHistoryItemsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ClipboardHistoryItemsResult {}
 unsafe impl ::core::marker::Sync for ClipboardHistoryItemsResult {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -1782,36 +1666,7 @@ unsafe impl ::windows::core::Interface for DataPackage {
 impl ::windows::core::RuntimeName for DataPackage {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DataPackage";
 }
-impl ::core::convert::From<DataPackage> for ::windows::core::IUnknown {
-    fn from(value: DataPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPackage> for ::windows::core::IUnknown {
-    fn from(value: &DataPackage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPackage> for &::windows::core::IUnknown {
-    fn from(value: &DataPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataPackage> for ::windows::core::IInspectable {
-    fn from(value: DataPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPackage> for ::windows::core::IInspectable {
-    fn from(value: &DataPackage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPackage> for &::windows::core::IInspectable {
-    fn from(value: &DataPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataPackage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DataPackage {}
 unsafe impl ::core::marker::Sync for DataPackage {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -2109,36 +1964,7 @@ impl ::core::iter::IntoIterator for &DataPackagePropertySet {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<DataPackagePropertySet> for ::windows::core::IUnknown {
-    fn from(value: DataPackagePropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPackagePropertySet> for ::windows::core::IUnknown {
-    fn from(value: &DataPackagePropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPackagePropertySet> for &::windows::core::IUnknown {
-    fn from(value: &DataPackagePropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataPackagePropertySet> for ::windows::core::IInspectable {
-    fn from(value: DataPackagePropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPackagePropertySet> for ::windows::core::IInspectable {
-    fn from(value: &DataPackagePropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPackagePropertySet> for &::windows::core::IInspectable {
-    fn from(value: &DataPackagePropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataPackagePropertySet, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<DataPackagePropertySet> for super::super::Foundation::Collections::IIterable<super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
@@ -2392,36 +2218,7 @@ impl ::core::iter::IntoIterator for &DataPackagePropertySetView {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<DataPackagePropertySetView> for ::windows::core::IUnknown {
-    fn from(value: DataPackagePropertySetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPackagePropertySetView> for ::windows::core::IUnknown {
-    fn from(value: &DataPackagePropertySetView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPackagePropertySetView> for &::windows::core::IUnknown {
-    fn from(value: &DataPackagePropertySetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataPackagePropertySetView> for ::windows::core::IInspectable {
-    fn from(value: DataPackagePropertySetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPackagePropertySetView> for ::windows::core::IInspectable {
-    fn from(value: &DataPackagePropertySetView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPackagePropertySetView> for &::windows::core::IInspectable {
-    fn from(value: &DataPackagePropertySetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataPackagePropertySetView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<DataPackagePropertySetView> for super::super::Foundation::Collections::IIterable<super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
@@ -2669,36 +2466,7 @@ unsafe impl ::windows::core::Interface for DataPackageView {
 impl ::windows::core::RuntimeName for DataPackageView {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DataPackageView";
 }
-impl ::core::convert::From<DataPackageView> for ::windows::core::IUnknown {
-    fn from(value: DataPackageView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPackageView> for ::windows::core::IUnknown {
-    fn from(value: &DataPackageView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPackageView> for &::windows::core::IUnknown {
-    fn from(value: &DataPackageView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataPackageView> for ::windows::core::IInspectable {
-    fn from(value: DataPackageView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPackageView> for ::windows::core::IInspectable {
-    fn from(value: &DataPackageView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPackageView> for &::windows::core::IInspectable {
-    fn from(value: &DataPackageView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataPackageView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DataPackageView {}
 unsafe impl ::core::marker::Sync for DataPackageView {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -2742,36 +2510,7 @@ unsafe impl ::windows::core::Interface for DataProviderDeferral {
 impl ::windows::core::RuntimeName for DataProviderDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DataProviderDeferral";
 }
-impl ::core::convert::From<DataProviderDeferral> for ::windows::core::IUnknown {
-    fn from(value: DataProviderDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataProviderDeferral> for ::windows::core::IUnknown {
-    fn from(value: &DataProviderDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataProviderDeferral> for &::windows::core::IUnknown {
-    fn from(value: &DataProviderDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataProviderDeferral> for ::windows::core::IInspectable {
-    fn from(value: DataProviderDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataProviderDeferral> for ::windows::core::IInspectable {
-    fn from(value: &DataProviderDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataProviderDeferral> for &::windows::core::IInspectable {
-    fn from(value: &DataProviderDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataProviderDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DataProviderDeferral {}
 unsafe impl ::core::marker::Sync for DataProviderDeferral {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -2841,36 +2580,7 @@ unsafe impl ::windows::core::Interface for DataProviderRequest {
 impl ::windows::core::RuntimeName for DataProviderRequest {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DataProviderRequest";
 }
-impl ::core::convert::From<DataProviderRequest> for ::windows::core::IUnknown {
-    fn from(value: DataProviderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataProviderRequest> for ::windows::core::IUnknown {
-    fn from(value: &DataProviderRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataProviderRequest> for &::windows::core::IUnknown {
-    fn from(value: &DataProviderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataProviderRequest> for ::windows::core::IInspectable {
-    fn from(value: DataProviderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataProviderRequest> for ::windows::core::IInspectable {
-    fn from(value: &DataProviderRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataProviderRequest> for &::windows::core::IInspectable {
-    fn from(value: &DataProviderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataProviderRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DataProviderRequest {}
 unsafe impl ::core::marker::Sync for DataProviderRequest {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -2941,36 +2651,7 @@ unsafe impl ::windows::core::Interface for DataRequest {
 impl ::windows::core::RuntimeName for DataRequest {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DataRequest";
 }
-impl ::core::convert::From<DataRequest> for ::windows::core::IUnknown {
-    fn from(value: DataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataRequest> for ::windows::core::IUnknown {
-    fn from(value: &DataRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataRequest> for &::windows::core::IUnknown {
-    fn from(value: &DataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataRequest> for ::windows::core::IInspectable {
-    fn from(value: DataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataRequest> for ::windows::core::IInspectable {
-    fn from(value: &DataRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataRequest> for &::windows::core::IInspectable {
-    fn from(value: &DataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DataRequest {}
 unsafe impl ::core::marker::Sync for DataRequest {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -3014,36 +2695,7 @@ unsafe impl ::windows::core::Interface for DataRequestDeferral {
 impl ::windows::core::RuntimeName for DataRequestDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DataRequestDeferral";
 }
-impl ::core::convert::From<DataRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: DataRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: &DataRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataRequestDeferral> for &::windows::core::IUnknown {
-    fn from(value: &DataRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: DataRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: &DataRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataRequestDeferral> for &::windows::core::IInspectable {
-    fn from(value: &DataRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataRequestDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DataRequestDeferral {}
 unsafe impl ::core::marker::Sync for DataRequestDeferral {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -3090,36 +2742,7 @@ unsafe impl ::windows::core::Interface for DataRequestedEventArgs {
 impl ::windows::core::RuntimeName for DataRequestedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DataRequestedEventArgs";
 }
-impl ::core::convert::From<DataRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DataRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DataRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DataRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DataRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DataRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DataRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DataRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for DataRequestedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -3237,36 +2860,7 @@ unsafe impl ::windows::core::Interface for DataTransferManager {
 impl ::windows::core::RuntimeName for DataTransferManager {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.DataTransferManager";
 }
-impl ::core::convert::From<DataTransferManager> for ::windows::core::IUnknown {
-    fn from(value: DataTransferManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataTransferManager> for ::windows::core::IUnknown {
-    fn from(value: &DataTransferManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataTransferManager> for &::windows::core::IUnknown {
-    fn from(value: &DataTransferManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataTransferManager> for ::windows::core::IInspectable {
-    fn from(value: DataTransferManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataTransferManager> for ::windows::core::IInspectable {
-    fn from(value: &DataTransferManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataTransferManager> for &::windows::core::IInspectable {
-    fn from(value: &DataTransferManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataTransferManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
 pub struct HtmlFormatHelper;
 impl HtmlFormatHelper {
@@ -3342,36 +2936,7 @@ unsafe impl ::windows::core::Interface for OperationCompletedEventArgs {
 impl ::windows::core::RuntimeName for OperationCompletedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.OperationCompletedEventArgs";
 }
-impl ::core::convert::From<OperationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: OperationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OperationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &OperationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OperationCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &OperationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OperationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: OperationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OperationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &OperationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OperationCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &OperationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OperationCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OperationCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for OperationCompletedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -3418,36 +2983,7 @@ unsafe impl ::windows::core::Interface for ShareCompletedEventArgs {
 impl ::windows::core::RuntimeName for ShareCompletedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ShareCompletedEventArgs";
 }
-impl ::core::convert::From<ShareCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ShareCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ShareCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ShareCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShareCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ShareCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ShareCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ShareCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShareCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ShareCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for ShareCompletedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -3539,36 +3075,7 @@ unsafe impl ::windows::core::Interface for ShareProvider {
 impl ::windows::core::RuntimeName for ShareProvider {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ShareProvider";
 }
-impl ::core::convert::From<ShareProvider> for ::windows::core::IUnknown {
-    fn from(value: ShareProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareProvider> for ::windows::core::IUnknown {
-    fn from(value: &ShareProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareProvider> for &::windows::core::IUnknown {
-    fn from(value: &ShareProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShareProvider> for ::windows::core::IInspectable {
-    fn from(value: ShareProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareProvider> for ::windows::core::IInspectable {
-    fn from(value: &ShareProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareProvider> for &::windows::core::IInspectable {
-    fn from(value: &ShareProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShareProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ShareProvider {}
 unsafe impl ::core::marker::Sync for ShareProvider {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -3626,36 +3133,7 @@ unsafe impl ::windows::core::Interface for ShareProviderOperation {
 impl ::windows::core::RuntimeName for ShareProviderOperation {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ShareProviderOperation";
 }
-impl ::core::convert::From<ShareProviderOperation> for ::windows::core::IUnknown {
-    fn from(value: ShareProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareProviderOperation> for ::windows::core::IUnknown {
-    fn from(value: &ShareProviderOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareProviderOperation> for &::windows::core::IUnknown {
-    fn from(value: &ShareProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShareProviderOperation> for ::windows::core::IInspectable {
-    fn from(value: ShareProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareProviderOperation> for ::windows::core::IInspectable {
-    fn from(value: &ShareProviderOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareProviderOperation> for &::windows::core::IInspectable {
-    fn from(value: &ShareProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShareProviderOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ShareProviderOperation {}
 unsafe impl ::core::marker::Sync for ShareProviderOperation {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -3720,36 +3198,7 @@ unsafe impl ::windows::core::Interface for ShareProvidersRequestedEventArgs {
 impl ::windows::core::RuntimeName for ShareProvidersRequestedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ShareProvidersRequestedEventArgs";
 }
-impl ::core::convert::From<ShareProvidersRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ShareProvidersRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareProvidersRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ShareProvidersRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareProvidersRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ShareProvidersRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShareProvidersRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ShareProvidersRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareProvidersRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ShareProvidersRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareProvidersRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ShareProvidersRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShareProvidersRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ShareProvidersRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for ShareProvidersRequestedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -3803,36 +3252,7 @@ unsafe impl ::windows::core::Interface for ShareTargetInfo {
 impl ::windows::core::RuntimeName for ShareTargetInfo {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ShareTargetInfo";
 }
-impl ::core::convert::From<ShareTargetInfo> for ::windows::core::IUnknown {
-    fn from(value: ShareTargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareTargetInfo> for ::windows::core::IUnknown {
-    fn from(value: &ShareTargetInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareTargetInfo> for &::windows::core::IUnknown {
-    fn from(value: &ShareTargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShareTargetInfo> for ::windows::core::IInspectable {
-    fn from(value: ShareTargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareTargetInfo> for ::windows::core::IInspectable {
-    fn from(value: &ShareTargetInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareTargetInfo> for &::windows::core::IInspectable {
-    fn from(value: &ShareTargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShareTargetInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ShareTargetInfo {}
 unsafe impl ::core::marker::Sync for ShareTargetInfo {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -3909,36 +3329,7 @@ unsafe impl ::windows::core::Interface for ShareUIOptions {
 impl ::windows::core::RuntimeName for ShareUIOptions {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ShareUIOptions";
 }
-impl ::core::convert::From<ShareUIOptions> for ::windows::core::IUnknown {
-    fn from(value: ShareUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareUIOptions> for ::windows::core::IUnknown {
-    fn from(value: &ShareUIOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareUIOptions> for &::windows::core::IUnknown {
-    fn from(value: &ShareUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShareUIOptions> for ::windows::core::IInspectable {
-    fn from(value: ShareUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareUIOptions> for ::windows::core::IInspectable {
-    fn from(value: &ShareUIOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareUIOptions> for &::windows::core::IInspectable {
-    fn from(value: &ShareUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShareUIOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ShareUIOptions {}
 unsafe impl ::core::marker::Sync for ShareUIOptions {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -4098,36 +3489,7 @@ unsafe impl ::windows::core::Interface for TargetApplicationChosenEventArgs {
 impl ::windows::core::RuntimeName for TargetApplicationChosenEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.TargetApplicationChosenEventArgs";
 }
-impl ::core::convert::From<TargetApplicationChosenEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TargetApplicationChosenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetApplicationChosenEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TargetApplicationChosenEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetApplicationChosenEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TargetApplicationChosenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetApplicationChosenEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TargetApplicationChosenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetApplicationChosenEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TargetApplicationChosenEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetApplicationChosenEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TargetApplicationChosenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetApplicationChosenEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetApplicationChosenEventArgs {}
 unsafe impl ::core::marker::Sync for TargetApplicationChosenEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Email/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Email/DataProvider/mod.rs
@@ -1097,36 +1097,7 @@ unsafe impl ::windows::core::Interface for EmailDataProviderConnection {
 impl ::windows::core::RuntimeName for EmailDataProviderConnection {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailDataProviderConnection";
 }
-impl ::core::convert::From<EmailDataProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: EmailDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailDataProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: &EmailDataProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailDataProviderConnection> for &::windows::core::IUnknown {
-    fn from(value: &EmailDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailDataProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: EmailDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailDataProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: &EmailDataProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailDataProviderConnection> for &::windows::core::IInspectable {
-    fn from(value: &EmailDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailDataProviderConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailDataProviderConnection {}
 unsafe impl ::core::marker::Sync for EmailDataProviderConnection {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -1173,36 +1144,7 @@ unsafe impl ::windows::core::Interface for EmailDataProviderTriggerDetails {
 impl ::windows::core::RuntimeName for EmailDataProviderTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailDataProviderTriggerDetails";
 }
-impl ::core::convert::From<EmailDataProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: EmailDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailDataProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &EmailDataProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailDataProviderTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &EmailDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailDataProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: EmailDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailDataProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &EmailDataProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailDataProviderTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &EmailDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailDataProviderTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailDataProviderTriggerDetails {}
 unsafe impl ::core::marker::Sync for EmailDataProviderTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -1281,36 +1223,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxCreateFolderRequest {
 impl ::windows::core::RuntimeName for EmailMailboxCreateFolderRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxCreateFolderRequest";
 }
-impl ::core::convert::From<EmailMailboxCreateFolderRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxCreateFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxCreateFolderRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxCreateFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxCreateFolderRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxCreateFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxCreateFolderRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxCreateFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxCreateFolderRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxCreateFolderRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxCreateFolderRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -1366,36 +1279,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxCreateFolderRequestEventA
 impl ::windows::core::RuntimeName for EmailMailboxCreateFolderRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxCreateFolderRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxCreateFolderRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxCreateFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxCreateFolderRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxCreateFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxCreateFolderRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxCreateFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxCreateFolderRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxCreateFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxCreateFolderRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxCreateFolderRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxCreateFolderRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -1467,36 +1351,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxDeleteFolderRequest {
 impl ::windows::core::RuntimeName for EmailMailboxDeleteFolderRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxDeleteFolderRequest";
 }
-impl ::core::convert::From<EmailMailboxDeleteFolderRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxDeleteFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDeleteFolderRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDeleteFolderRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDeleteFolderRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDeleteFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxDeleteFolderRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxDeleteFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDeleteFolderRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDeleteFolderRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDeleteFolderRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDeleteFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxDeleteFolderRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxDeleteFolderRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxDeleteFolderRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -1552,36 +1407,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxDeleteFolderRequestEventA
 impl ::windows::core::RuntimeName for EmailMailboxDeleteFolderRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxDeleteFolderRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxDeleteFolderRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxDeleteFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDeleteFolderRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDeleteFolderRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDeleteFolderRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDeleteFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxDeleteFolderRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxDeleteFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDeleteFolderRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDeleteFolderRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDeleteFolderRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDeleteFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxDeleteFolderRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxDeleteFolderRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxDeleteFolderRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -1660,36 +1486,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxDownloadAttachmentRequest
 impl ::windows::core::RuntimeName for EmailMailboxDownloadAttachmentRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxDownloadAttachmentRequest";
 }
-impl ::core::convert::From<EmailMailboxDownloadAttachmentRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxDownloadAttachmentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadAttachmentRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDownloadAttachmentRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadAttachmentRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDownloadAttachmentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxDownloadAttachmentRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxDownloadAttachmentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadAttachmentRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDownloadAttachmentRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadAttachmentRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDownloadAttachmentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxDownloadAttachmentRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxDownloadAttachmentRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxDownloadAttachmentRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -1745,36 +1542,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxDownloadAttachmentRequest
 impl ::windows::core::RuntimeName for EmailMailboxDownloadAttachmentRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxDownloadAttachmentRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxDownloadAttachmentRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxDownloadAttachmentRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadAttachmentRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDownloadAttachmentRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadAttachmentRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDownloadAttachmentRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxDownloadAttachmentRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxDownloadAttachmentRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadAttachmentRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDownloadAttachmentRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadAttachmentRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDownloadAttachmentRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxDownloadAttachmentRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxDownloadAttachmentRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxDownloadAttachmentRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -1846,36 +1614,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxDownloadMessageRequest {
 impl ::windows::core::RuntimeName for EmailMailboxDownloadMessageRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxDownloadMessageRequest";
 }
-impl ::core::convert::From<EmailMailboxDownloadMessageRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxDownloadMessageRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadMessageRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDownloadMessageRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadMessageRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDownloadMessageRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxDownloadMessageRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxDownloadMessageRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadMessageRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDownloadMessageRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadMessageRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDownloadMessageRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxDownloadMessageRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxDownloadMessageRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxDownloadMessageRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -1931,36 +1670,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxDownloadMessageRequestEve
 impl ::windows::core::RuntimeName for EmailMailboxDownloadMessageRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxDownloadMessageRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxDownloadMessageRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxDownloadMessageRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadMessageRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDownloadMessageRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadMessageRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxDownloadMessageRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxDownloadMessageRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxDownloadMessageRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadMessageRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDownloadMessageRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxDownloadMessageRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxDownloadMessageRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxDownloadMessageRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxDownloadMessageRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxDownloadMessageRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -2032,36 +1742,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxEmptyFolderRequest {
 impl ::windows::core::RuntimeName for EmailMailboxEmptyFolderRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxEmptyFolderRequest";
 }
-impl ::core::convert::From<EmailMailboxEmptyFolderRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxEmptyFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxEmptyFolderRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxEmptyFolderRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxEmptyFolderRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxEmptyFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxEmptyFolderRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxEmptyFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxEmptyFolderRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxEmptyFolderRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxEmptyFolderRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxEmptyFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxEmptyFolderRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxEmptyFolderRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxEmptyFolderRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -2117,36 +1798,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxEmptyFolderRequestEventAr
 impl ::windows::core::RuntimeName for EmailMailboxEmptyFolderRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxEmptyFolderRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxEmptyFolderRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxEmptyFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxEmptyFolderRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxEmptyFolderRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxEmptyFolderRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxEmptyFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxEmptyFolderRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxEmptyFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxEmptyFolderRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxEmptyFolderRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxEmptyFolderRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxEmptyFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxEmptyFolderRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxEmptyFolderRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxEmptyFolderRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -2255,36 +1907,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxForwardMeetingRequest {
 impl ::windows::core::RuntimeName for EmailMailboxForwardMeetingRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxForwardMeetingRequest";
 }
-impl ::core::convert::From<EmailMailboxForwardMeetingRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxForwardMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxForwardMeetingRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxForwardMeetingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxForwardMeetingRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxForwardMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxForwardMeetingRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxForwardMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxForwardMeetingRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxForwardMeetingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxForwardMeetingRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxForwardMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxForwardMeetingRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxForwardMeetingRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxForwardMeetingRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -2340,36 +1963,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxForwardMeetingRequestEven
 impl ::windows::core::RuntimeName for EmailMailboxForwardMeetingRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxForwardMeetingRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxForwardMeetingRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxForwardMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxForwardMeetingRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxForwardMeetingRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxForwardMeetingRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxForwardMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxForwardMeetingRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxForwardMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxForwardMeetingRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxForwardMeetingRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxForwardMeetingRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxForwardMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxForwardMeetingRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxForwardMeetingRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxForwardMeetingRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -2441,36 +2035,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxGetAutoReplySettingsReque
 impl ::windows::core::RuntimeName for EmailMailboxGetAutoReplySettingsRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxGetAutoReplySettingsRequest";
 }
-impl ::core::convert::From<EmailMailboxGetAutoReplySettingsRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxGetAutoReplySettingsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxGetAutoReplySettingsRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxGetAutoReplySettingsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxGetAutoReplySettingsRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxGetAutoReplySettingsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxGetAutoReplySettingsRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxGetAutoReplySettingsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxGetAutoReplySettingsRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxGetAutoReplySettingsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxGetAutoReplySettingsRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxGetAutoReplySettingsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxGetAutoReplySettingsRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxGetAutoReplySettingsRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxGetAutoReplySettingsRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -2526,36 +2091,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxGetAutoReplySettingsReque
 impl ::windows::core::RuntimeName for EmailMailboxGetAutoReplySettingsRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxGetAutoReplySettingsRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxGetAutoReplySettingsRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxGetAutoReplySettingsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxGetAutoReplySettingsRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxGetAutoReplySettingsRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxGetAutoReplySettingsRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxGetAutoReplySettingsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxGetAutoReplySettingsRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxGetAutoReplySettingsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxGetAutoReplySettingsRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxGetAutoReplySettingsRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxGetAutoReplySettingsRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxGetAutoReplySettingsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxGetAutoReplySettingsRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxGetAutoReplySettingsRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxGetAutoReplySettingsRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -2641,36 +2177,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxMoveFolderRequest {
 impl ::windows::core::RuntimeName for EmailMailboxMoveFolderRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxMoveFolderRequest";
 }
-impl ::core::convert::From<EmailMailboxMoveFolderRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxMoveFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxMoveFolderRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxMoveFolderRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxMoveFolderRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxMoveFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxMoveFolderRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxMoveFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxMoveFolderRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxMoveFolderRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxMoveFolderRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxMoveFolderRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxMoveFolderRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxMoveFolderRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxMoveFolderRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -2726,36 +2233,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxMoveFolderRequestEventArg
 impl ::windows::core::RuntimeName for EmailMailboxMoveFolderRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxMoveFolderRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxMoveFolderRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxMoveFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxMoveFolderRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxMoveFolderRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxMoveFolderRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxMoveFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxMoveFolderRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxMoveFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxMoveFolderRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxMoveFolderRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxMoveFolderRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxMoveFolderRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxMoveFolderRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxMoveFolderRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxMoveFolderRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -2859,36 +2337,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxProposeNewTimeForMeetingR
 impl ::windows::core::RuntimeName for EmailMailboxProposeNewTimeForMeetingRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxProposeNewTimeForMeetingRequest";
 }
-impl ::core::convert::From<EmailMailboxProposeNewTimeForMeetingRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxProposeNewTimeForMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxProposeNewTimeForMeetingRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxProposeNewTimeForMeetingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxProposeNewTimeForMeetingRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxProposeNewTimeForMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxProposeNewTimeForMeetingRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxProposeNewTimeForMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxProposeNewTimeForMeetingRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxProposeNewTimeForMeetingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxProposeNewTimeForMeetingRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxProposeNewTimeForMeetingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxProposeNewTimeForMeetingRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxProposeNewTimeForMeetingRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxProposeNewTimeForMeetingRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -2944,36 +2393,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxProposeNewTimeForMeetingR
 impl ::windows::core::RuntimeName for EmailMailboxProposeNewTimeForMeetingRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxProposeNewTimeForMeetingRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxProposeNewTimeForMeetingRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxProposeNewTimeForMeetingRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxProposeNewTimeForMeetingRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxProposeNewTimeForMeetingRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxProposeNewTimeForMeetingRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxProposeNewTimeForMeetingRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxProposeNewTimeForMeetingRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxProposeNewTimeForMeetingRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxProposeNewTimeForMeetingRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxProposeNewTimeForMeetingRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -3051,36 +2471,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxResolveRecipientsRequest 
 impl ::windows::core::RuntimeName for EmailMailboxResolveRecipientsRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxResolveRecipientsRequest";
 }
-impl ::core::convert::From<EmailMailboxResolveRecipientsRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxResolveRecipientsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxResolveRecipientsRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxResolveRecipientsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxResolveRecipientsRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxResolveRecipientsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxResolveRecipientsRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxResolveRecipientsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxResolveRecipientsRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxResolveRecipientsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxResolveRecipientsRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxResolveRecipientsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxResolveRecipientsRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxResolveRecipientsRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxResolveRecipientsRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -3136,36 +2527,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxResolveRecipientsRequestE
 impl ::windows::core::RuntimeName for EmailMailboxResolveRecipientsRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxResolveRecipientsRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxResolveRecipientsRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxResolveRecipientsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxResolveRecipientsRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxResolveRecipientsRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxResolveRecipientsRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxResolveRecipientsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxResolveRecipientsRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxResolveRecipientsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxResolveRecipientsRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxResolveRecipientsRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxResolveRecipientsRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxResolveRecipientsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxResolveRecipientsRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxResolveRecipientsRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxResolveRecipientsRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -3267,36 +2629,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxServerSearchReadBatchRequ
 impl ::windows::core::RuntimeName for EmailMailboxServerSearchReadBatchRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxServerSearchReadBatchRequest";
 }
-impl ::core::convert::From<EmailMailboxServerSearchReadBatchRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxServerSearchReadBatchRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxServerSearchReadBatchRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxServerSearchReadBatchRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxServerSearchReadBatchRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxServerSearchReadBatchRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxServerSearchReadBatchRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxServerSearchReadBatchRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxServerSearchReadBatchRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxServerSearchReadBatchRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxServerSearchReadBatchRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxServerSearchReadBatchRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxServerSearchReadBatchRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxServerSearchReadBatchRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxServerSearchReadBatchRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -3352,36 +2685,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxServerSearchReadBatchRequ
 impl ::windows::core::RuntimeName for EmailMailboxServerSearchReadBatchRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxServerSearchReadBatchRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxServerSearchReadBatchRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxServerSearchReadBatchRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxServerSearchReadBatchRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxServerSearchReadBatchRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxServerSearchReadBatchRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxServerSearchReadBatchRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxServerSearchReadBatchRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxServerSearchReadBatchRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxServerSearchReadBatchRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxServerSearchReadBatchRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxServerSearchReadBatchRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxServerSearchReadBatchRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxServerSearchReadBatchRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxServerSearchReadBatchRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxServerSearchReadBatchRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -3453,36 +2757,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxSetAutoReplySettingsReque
 impl ::windows::core::RuntimeName for EmailMailboxSetAutoReplySettingsRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxSetAutoReplySettingsRequest";
 }
-impl ::core::convert::From<EmailMailboxSetAutoReplySettingsRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxSetAutoReplySettingsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxSetAutoReplySettingsRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxSetAutoReplySettingsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxSetAutoReplySettingsRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxSetAutoReplySettingsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxSetAutoReplySettingsRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxSetAutoReplySettingsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxSetAutoReplySettingsRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxSetAutoReplySettingsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxSetAutoReplySettingsRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxSetAutoReplySettingsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxSetAutoReplySettingsRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxSetAutoReplySettingsRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxSetAutoReplySettingsRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -3538,36 +2813,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxSetAutoReplySettingsReque
 impl ::windows::core::RuntimeName for EmailMailboxSetAutoReplySettingsRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxSetAutoReplySettingsRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxSetAutoReplySettingsRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxSetAutoReplySettingsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxSetAutoReplySettingsRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxSetAutoReplySettingsRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxSetAutoReplySettingsRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxSetAutoReplySettingsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxSetAutoReplySettingsRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxSetAutoReplySettingsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxSetAutoReplySettingsRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxSetAutoReplySettingsRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxSetAutoReplySettingsRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxSetAutoReplySettingsRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxSetAutoReplySettingsRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxSetAutoReplySettingsRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxSetAutoReplySettingsRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -3632,36 +2878,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxSyncManagerSyncRequest {
 impl ::windows::core::RuntimeName for EmailMailboxSyncManagerSyncRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxSyncManagerSyncRequest";
 }
-impl ::core::convert::From<EmailMailboxSyncManagerSyncRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManagerSyncRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxSyncManagerSyncRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManagerSyncRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxSyncManagerSyncRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManagerSyncRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxSyncManagerSyncRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManagerSyncRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxSyncManagerSyncRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxSyncManagerSyncRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxSyncManagerSyncRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -3717,36 +2934,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxSyncManagerSyncRequestEve
 impl ::windows::core::RuntimeName for EmailMailboxSyncManagerSyncRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxSyncManagerSyncRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxSyncManagerSyncRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManagerSyncRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxSyncManagerSyncRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManagerSyncRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxSyncManagerSyncRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManagerSyncRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxSyncManagerSyncRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManagerSyncRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxSyncManagerSyncRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxSyncManagerSyncRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxSyncManagerSyncRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -3846,36 +3034,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxUpdateMeetingResponseRequ
 impl ::windows::core::RuntimeName for EmailMailboxUpdateMeetingResponseRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxUpdateMeetingResponseRequest";
 }
-impl ::core::convert::From<EmailMailboxUpdateMeetingResponseRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxUpdateMeetingResponseRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxUpdateMeetingResponseRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxUpdateMeetingResponseRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxUpdateMeetingResponseRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxUpdateMeetingResponseRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxUpdateMeetingResponseRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxUpdateMeetingResponseRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxUpdateMeetingResponseRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxUpdateMeetingResponseRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxUpdateMeetingResponseRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxUpdateMeetingResponseRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxUpdateMeetingResponseRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxUpdateMeetingResponseRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxUpdateMeetingResponseRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -3931,36 +3090,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxUpdateMeetingResponseRequ
 impl ::windows::core::RuntimeName for EmailMailboxUpdateMeetingResponseRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxUpdateMeetingResponseRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxUpdateMeetingResponseRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxUpdateMeetingResponseRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxUpdateMeetingResponseRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxUpdateMeetingResponseRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxUpdateMeetingResponseRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxUpdateMeetingResponseRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxUpdateMeetingResponseRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxUpdateMeetingResponseRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxUpdateMeetingResponseRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxUpdateMeetingResponseRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxUpdateMeetingResponseRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxUpdateMeetingResponseRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxUpdateMeetingResponseRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxUpdateMeetingResponseRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxUpdateMeetingResponseRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -4038,36 +3168,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxValidateCertificatesReque
 impl ::windows::core::RuntimeName for EmailMailboxValidateCertificatesRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxValidateCertificatesRequest";
 }
-impl ::core::convert::From<EmailMailboxValidateCertificatesRequest> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxValidateCertificatesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxValidateCertificatesRequest> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxValidateCertificatesRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxValidateCertificatesRequest> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxValidateCertificatesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxValidateCertificatesRequest> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxValidateCertificatesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxValidateCertificatesRequest> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxValidateCertificatesRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxValidateCertificatesRequest> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxValidateCertificatesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxValidateCertificatesRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxValidateCertificatesRequest {}
 unsafe impl ::core::marker::Sync for EmailMailboxValidateCertificatesRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Email_DataProvider\"`*"]
@@ -4123,36 +3224,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxValidateCertificatesReque
 impl ::windows::core::RuntimeName for EmailMailboxValidateCertificatesRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.DataProvider.EmailMailboxValidateCertificatesRequestEventArgs";
 }
-impl ::core::convert::From<EmailMailboxValidateCertificatesRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxValidateCertificatesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxValidateCertificatesRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxValidateCertificatesRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxValidateCertificatesRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxValidateCertificatesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxValidateCertificatesRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxValidateCertificatesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxValidateCertificatesRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxValidateCertificatesRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxValidateCertificatesRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxValidateCertificatesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxValidateCertificatesRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxValidateCertificatesRequestEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxValidateCertificatesRequestEventArgs {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
@@ -1699,36 +1699,7 @@ unsafe impl ::windows::core::Interface for EmailAttachment {
 impl ::windows::core::RuntimeName for EmailAttachment {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailAttachment";
 }
-impl ::core::convert::From<EmailAttachment> for ::windows::core::IUnknown {
-    fn from(value: EmailAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailAttachment> for ::windows::core::IUnknown {
-    fn from(value: &EmailAttachment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailAttachment> for &::windows::core::IUnknown {
-    fn from(value: &EmailAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailAttachment> for ::windows::core::IInspectable {
-    fn from(value: EmailAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailAttachment> for ::windows::core::IInspectable {
-    fn from(value: &EmailAttachment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailAttachment> for &::windows::core::IInspectable {
-    fn from(value: &EmailAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailAttachment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailAttachment {}
 unsafe impl ::core::marker::Sync for EmailAttachment {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -1879,36 +1850,7 @@ unsafe impl ::windows::core::Interface for EmailConversation {
 impl ::windows::core::RuntimeName for EmailConversation {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailConversation";
 }
-impl ::core::convert::From<EmailConversation> for ::windows::core::IUnknown {
-    fn from(value: EmailConversation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailConversation> for ::windows::core::IUnknown {
-    fn from(value: &EmailConversation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailConversation> for &::windows::core::IUnknown {
-    fn from(value: &EmailConversation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailConversation> for ::windows::core::IInspectable {
-    fn from(value: EmailConversation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailConversation> for ::windows::core::IInspectable {
-    fn from(value: &EmailConversation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailConversation> for &::windows::core::IInspectable {
-    fn from(value: &EmailConversation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailConversation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailConversation {}
 unsafe impl ::core::marker::Sync for EmailConversation {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -1964,36 +1906,7 @@ unsafe impl ::windows::core::Interface for EmailConversationBatch {
 impl ::windows::core::RuntimeName for EmailConversationBatch {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailConversationBatch";
 }
-impl ::core::convert::From<EmailConversationBatch> for ::windows::core::IUnknown {
-    fn from(value: EmailConversationBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailConversationBatch> for ::windows::core::IUnknown {
-    fn from(value: &EmailConversationBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailConversationBatch> for &::windows::core::IUnknown {
-    fn from(value: &EmailConversationBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailConversationBatch> for ::windows::core::IInspectable {
-    fn from(value: EmailConversationBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailConversationBatch> for ::windows::core::IInspectable {
-    fn from(value: &EmailConversationBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailConversationBatch> for &::windows::core::IInspectable {
-    fn from(value: &EmailConversationBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailConversationBatch, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailConversationBatch {}
 unsafe impl ::core::marker::Sync for EmailConversationBatch {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -2042,36 +1955,7 @@ unsafe impl ::windows::core::Interface for EmailConversationReader {
 impl ::windows::core::RuntimeName for EmailConversationReader {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailConversationReader";
 }
-impl ::core::convert::From<EmailConversationReader> for ::windows::core::IUnknown {
-    fn from(value: EmailConversationReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailConversationReader> for ::windows::core::IUnknown {
-    fn from(value: &EmailConversationReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailConversationReader> for &::windows::core::IUnknown {
-    fn from(value: &EmailConversationReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailConversationReader> for ::windows::core::IInspectable {
-    fn from(value: EmailConversationReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailConversationReader> for ::windows::core::IInspectable {
-    fn from(value: &EmailConversationReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailConversationReader> for &::windows::core::IInspectable {
-    fn from(value: &EmailConversationReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailConversationReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailConversationReader {}
 unsafe impl ::core::marker::Sync for EmailConversationReader {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -2296,36 +2180,7 @@ unsafe impl ::windows::core::Interface for EmailFolder {
 impl ::windows::core::RuntimeName for EmailFolder {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailFolder";
 }
-impl ::core::convert::From<EmailFolder> for ::windows::core::IUnknown {
-    fn from(value: EmailFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailFolder> for ::windows::core::IUnknown {
-    fn from(value: &EmailFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailFolder> for &::windows::core::IUnknown {
-    fn from(value: &EmailFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailFolder> for ::windows::core::IInspectable {
-    fn from(value: EmailFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailFolder> for ::windows::core::IInspectable {
-    fn from(value: &EmailFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailFolder> for &::windows::core::IInspectable {
-    fn from(value: &EmailFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailFolder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailFolder {}
 unsafe impl ::core::marker::Sync for EmailFolder {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -2521,36 +2376,7 @@ unsafe impl ::windows::core::Interface for EmailIrmInfo {
 impl ::windows::core::RuntimeName for EmailIrmInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailIrmInfo";
 }
-impl ::core::convert::From<EmailIrmInfo> for ::windows::core::IUnknown {
-    fn from(value: EmailIrmInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailIrmInfo> for ::windows::core::IUnknown {
-    fn from(value: &EmailIrmInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailIrmInfo> for &::windows::core::IUnknown {
-    fn from(value: &EmailIrmInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailIrmInfo> for ::windows::core::IInspectable {
-    fn from(value: EmailIrmInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailIrmInfo> for ::windows::core::IInspectable {
-    fn from(value: &EmailIrmInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailIrmInfo> for &::windows::core::IInspectable {
-    fn from(value: &EmailIrmInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailIrmInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailIrmInfo {}
 unsafe impl ::core::marker::Sync for EmailIrmInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -2641,36 +2467,7 @@ unsafe impl ::windows::core::Interface for EmailIrmTemplate {
 impl ::windows::core::RuntimeName for EmailIrmTemplate {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailIrmTemplate";
 }
-impl ::core::convert::From<EmailIrmTemplate> for ::windows::core::IUnknown {
-    fn from(value: EmailIrmTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailIrmTemplate> for ::windows::core::IUnknown {
-    fn from(value: &EmailIrmTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailIrmTemplate> for &::windows::core::IUnknown {
-    fn from(value: &EmailIrmTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailIrmTemplate> for ::windows::core::IInspectable {
-    fn from(value: EmailIrmTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailIrmTemplate> for ::windows::core::IInspectable {
-    fn from(value: &EmailIrmTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailIrmTemplate> for &::windows::core::IInspectable {
-    fn from(value: &EmailIrmTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailIrmTemplate, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailIrmTemplate {}
 unsafe impl ::core::marker::Sync for EmailIrmTemplate {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -2738,36 +2535,7 @@ unsafe impl ::windows::core::Interface for EmailItemCounts {
 impl ::windows::core::RuntimeName for EmailItemCounts {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailItemCounts";
 }
-impl ::core::convert::From<EmailItemCounts> for ::windows::core::IUnknown {
-    fn from(value: EmailItemCounts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailItemCounts> for ::windows::core::IUnknown {
-    fn from(value: &EmailItemCounts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailItemCounts> for &::windows::core::IUnknown {
-    fn from(value: &EmailItemCounts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailItemCounts> for ::windows::core::IInspectable {
-    fn from(value: EmailItemCounts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailItemCounts> for ::windows::core::IInspectable {
-    fn from(value: &EmailItemCounts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailItemCounts> for &::windows::core::IInspectable {
-    fn from(value: &EmailItemCounts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailItemCounts, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailItemCounts {}
 unsafe impl ::core::marker::Sync for EmailItemCounts {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -3294,36 +3062,7 @@ unsafe impl ::windows::core::Interface for EmailMailbox {
 impl ::windows::core::RuntimeName for EmailMailbox {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailbox";
 }
-impl ::core::convert::From<EmailMailbox> for ::windows::core::IUnknown {
-    fn from(value: EmailMailbox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailbox> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailbox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailbox> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailbox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailbox> for ::windows::core::IInspectable {
-    fn from(value: EmailMailbox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailbox> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailbox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailbox> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailbox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailbox, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailbox {}
 unsafe impl ::core::marker::Sync for EmailMailbox {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -3377,36 +3116,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxAction {
 impl ::windows::core::RuntimeName for EmailMailboxAction {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxAction";
 }
-impl ::core::convert::From<EmailMailboxAction> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxAction> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxAction> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxAction> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxAction> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxAction> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxAction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxAction {}
 unsafe impl ::core::marker::Sync for EmailMailboxAction {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -3468,36 +3178,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxAutoReply {
 impl ::windows::core::RuntimeName for EmailMailboxAutoReply {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxAutoReply";
 }
-impl ::core::convert::From<EmailMailboxAutoReply> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxAutoReply) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxAutoReply> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxAutoReply) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxAutoReply> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxAutoReply) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxAutoReply> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxAutoReply) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxAutoReply> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxAutoReply) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxAutoReply> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxAutoReply) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxAutoReply, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxAutoReply {}
 unsafe impl ::core::marker::Sync for EmailMailboxAutoReply {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -3625,36 +3306,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxAutoReplySettings {
 impl ::windows::core::RuntimeName for EmailMailboxAutoReplySettings {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxAutoReplySettings";
 }
-impl ::core::convert::From<EmailMailboxAutoReplySettings> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxAutoReplySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxAutoReplySettings> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxAutoReplySettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxAutoReplySettings> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxAutoReplySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxAutoReplySettings> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxAutoReplySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxAutoReplySettings> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxAutoReplySettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxAutoReplySettings> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxAutoReplySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxAutoReplySettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxAutoReplySettings {}
 unsafe impl ::core::marker::Sync for EmailMailboxAutoReplySettings {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -3848,36 +3500,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxCapabilities {
 impl ::windows::core::RuntimeName for EmailMailboxCapabilities {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxCapabilities";
 }
-impl ::core::convert::From<EmailMailboxCapabilities> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxCapabilities> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxCapabilities {}
 unsafe impl ::core::marker::Sync for EmailMailboxCapabilities {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -3947,36 +3570,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxChange {
 impl ::windows::core::RuntimeName for EmailMailboxChange {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxChange";
 }
-impl ::core::convert::From<EmailMailboxChange> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxChange> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxChange> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxChange> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxChange> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxChange> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxChange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxChange {}
 unsafe impl ::core::marker::Sync for EmailMailboxChange {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -4033,36 +3627,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxChangeReader {
 impl ::windows::core::RuntimeName for EmailMailboxChangeReader {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxChangeReader";
 }
-impl ::core::convert::From<EmailMailboxChangeReader> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangeReader> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangeReader> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxChangeReader> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangeReader> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangeReader> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxChangeReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxChangeReader {}
 unsafe impl ::core::marker::Sync for EmailMailboxChangeReader {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -4124,36 +3689,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxChangeTracker {
 impl ::windows::core::RuntimeName for EmailMailboxChangeTracker {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxChangeTracker";
 }
-impl ::core::convert::From<EmailMailboxChangeTracker> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangeTracker> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxChangeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangeTracker> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxChangeTracker> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangeTracker> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxChangeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangeTracker> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxChangeTracker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxChangeTracker {}
 unsafe impl ::core::marker::Sync for EmailMailboxChangeTracker {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -4197,36 +3733,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxChangedDeferral {
 impl ::windows::core::RuntimeName for EmailMailboxChangedDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxChangedDeferral";
 }
-impl ::core::convert::From<EmailMailboxChangedDeferral> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangedDeferral> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxChangedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangedDeferral> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxChangedDeferral> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangedDeferral> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxChangedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangedDeferral> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxChangedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxChangedDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxChangedDeferral {}
 unsafe impl ::core::marker::Sync for EmailMailboxChangedDeferral {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -4273,36 +3780,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxChangedEventArgs {
 impl ::windows::core::RuntimeName for EmailMailboxChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxChangedEventArgs";
 }
-impl ::core::convert::From<EmailMailboxChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxChangedEventArgs {}
 unsafe impl ::core::marker::Sync for EmailMailboxChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -4356,36 +3834,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxCreateFolderResult {
 impl ::windows::core::RuntimeName for EmailMailboxCreateFolderResult {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxCreateFolderResult";
 }
-impl ::core::convert::From<EmailMailboxCreateFolderResult> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxCreateFolderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderResult> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxCreateFolderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderResult> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxCreateFolderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxCreateFolderResult> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxCreateFolderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderResult> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxCreateFolderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxCreateFolderResult> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxCreateFolderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxCreateFolderResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxCreateFolderResult {}
 unsafe impl ::core::marker::Sync for EmailMailboxCreateFolderResult {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -4507,36 +3956,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxPolicies {
 impl ::windows::core::RuntimeName for EmailMailboxPolicies {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxPolicies";
 }
-impl ::core::convert::From<EmailMailboxPolicies> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxPolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxPolicies> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxPolicies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxPolicies> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxPolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxPolicies> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxPolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxPolicies> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxPolicies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxPolicies> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxPolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxPolicies, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxPolicies {}
 unsafe impl ::core::marker::Sync for EmailMailboxPolicies {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -4641,36 +4061,7 @@ unsafe impl ::windows::core::Interface for EmailMailboxSyncManager {
 impl ::windows::core::RuntimeName for EmailMailboxSyncManager {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMailboxSyncManager";
 }
-impl ::core::convert::From<EmailMailboxSyncManager> for ::windows::core::IUnknown {
-    fn from(value: EmailMailboxSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManager> for ::windows::core::IUnknown {
-    fn from(value: &EmailMailboxSyncManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManager> for &::windows::core::IUnknown {
-    fn from(value: &EmailMailboxSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMailboxSyncManager> for ::windows::core::IInspectable {
-    fn from(value: EmailMailboxSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManager> for ::windows::core::IInspectable {
-    fn from(value: &EmailMailboxSyncManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMailboxSyncManager> for &::windows::core::IInspectable {
-    fn from(value: &EmailMailboxSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMailboxSyncManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMailboxSyncManager {}
 unsafe impl ::core::marker::Sync for EmailMailboxSyncManager {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -4783,36 +4174,7 @@ unsafe impl ::windows::core::Interface for EmailManagerForUser {
 impl ::windows::core::RuntimeName for EmailManagerForUser {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailManagerForUser";
 }
-impl ::core::convert::From<EmailManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: EmailManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: &EmailManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailManagerForUser> for &::windows::core::IUnknown {
-    fn from(value: &EmailManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: EmailManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: &EmailManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailManagerForUser> for &::windows::core::IInspectable {
-    fn from(value: &EmailManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailManagerForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailManagerForUser {}
 unsafe impl ::core::marker::Sync for EmailManagerForUser {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -5053,36 +4415,7 @@ unsafe impl ::windows::core::Interface for EmailMeetingInfo {
 impl ::windows::core::RuntimeName for EmailMeetingInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMeetingInfo";
 }
-impl ::core::convert::From<EmailMeetingInfo> for ::windows::core::IUnknown {
-    fn from(value: EmailMeetingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMeetingInfo> for ::windows::core::IUnknown {
-    fn from(value: &EmailMeetingInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMeetingInfo> for &::windows::core::IUnknown {
-    fn from(value: &EmailMeetingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMeetingInfo> for ::windows::core::IInspectable {
-    fn from(value: EmailMeetingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMeetingInfo> for ::windows::core::IInspectable {
-    fn from(value: &EmailMeetingInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMeetingInfo> for &::windows::core::IInspectable {
-    fn from(value: &EmailMeetingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMeetingInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMeetingInfo {}
 unsafe impl ::core::marker::Sync for EmailMeetingInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -5517,36 +4850,7 @@ unsafe impl ::windows::core::Interface for EmailMessage {
 impl ::windows::core::RuntimeName for EmailMessage {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMessage";
 }
-impl ::core::convert::From<EmailMessage> for ::windows::core::IUnknown {
-    fn from(value: EmailMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMessage> for ::windows::core::IUnknown {
-    fn from(value: &EmailMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMessage> for &::windows::core::IUnknown {
-    fn from(value: &EmailMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMessage> for ::windows::core::IInspectable {
-    fn from(value: EmailMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMessage> for ::windows::core::IInspectable {
-    fn from(value: &EmailMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMessage> for &::windows::core::IInspectable {
-    fn from(value: &EmailMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMessage {}
 unsafe impl ::core::marker::Sync for EmailMessage {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -5602,36 +4906,7 @@ unsafe impl ::windows::core::Interface for EmailMessageBatch {
 impl ::windows::core::RuntimeName for EmailMessageBatch {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMessageBatch";
 }
-impl ::core::convert::From<EmailMessageBatch> for ::windows::core::IUnknown {
-    fn from(value: EmailMessageBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMessageBatch> for ::windows::core::IUnknown {
-    fn from(value: &EmailMessageBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMessageBatch> for &::windows::core::IUnknown {
-    fn from(value: &EmailMessageBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMessageBatch> for ::windows::core::IInspectable {
-    fn from(value: EmailMessageBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMessageBatch> for ::windows::core::IInspectable {
-    fn from(value: &EmailMessageBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMessageBatch> for &::windows::core::IInspectable {
-    fn from(value: &EmailMessageBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMessageBatch, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMessageBatch {}
 unsafe impl ::core::marker::Sync for EmailMessageBatch {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -5680,36 +4955,7 @@ unsafe impl ::windows::core::Interface for EmailMessageReader {
 impl ::windows::core::RuntimeName for EmailMessageReader {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailMessageReader";
 }
-impl ::core::convert::From<EmailMessageReader> for ::windows::core::IUnknown {
-    fn from(value: EmailMessageReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMessageReader> for ::windows::core::IUnknown {
-    fn from(value: &EmailMessageReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMessageReader> for &::windows::core::IUnknown {
-    fn from(value: &EmailMessageReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailMessageReader> for ::windows::core::IInspectable {
-    fn from(value: EmailMessageReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailMessageReader> for ::windows::core::IInspectable {
-    fn from(value: &EmailMessageReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailMessageReader> for &::windows::core::IInspectable {
-    fn from(value: &EmailMessageReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailMessageReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailMessageReader {}
 unsafe impl ::core::marker::Sync for EmailMessageReader {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -5822,36 +5068,7 @@ unsafe impl ::windows::core::Interface for EmailQueryOptions {
 impl ::windows::core::RuntimeName for EmailQueryOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailQueryOptions";
 }
-impl ::core::convert::From<EmailQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: EmailQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: &EmailQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailQueryOptions> for &::windows::core::IUnknown {
-    fn from(value: &EmailQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: EmailQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: &EmailQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailQueryOptions> for &::windows::core::IInspectable {
-    fn from(value: &EmailQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailQueryOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailQueryOptions {}
 unsafe impl ::core::marker::Sync for EmailQueryOptions {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -5924,36 +5141,7 @@ unsafe impl ::windows::core::Interface for EmailQueryTextSearch {
 impl ::windows::core::RuntimeName for EmailQueryTextSearch {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailQueryTextSearch";
 }
-impl ::core::convert::From<EmailQueryTextSearch> for ::windows::core::IUnknown {
-    fn from(value: EmailQueryTextSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailQueryTextSearch> for ::windows::core::IUnknown {
-    fn from(value: &EmailQueryTextSearch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailQueryTextSearch> for &::windows::core::IUnknown {
-    fn from(value: &EmailQueryTextSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailQueryTextSearch> for ::windows::core::IInspectable {
-    fn from(value: EmailQueryTextSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailQueryTextSearch> for ::windows::core::IInspectable {
-    fn from(value: &EmailQueryTextSearch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailQueryTextSearch> for &::windows::core::IInspectable {
-    fn from(value: &EmailQueryTextSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailQueryTextSearch, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailQueryTextSearch {}
 unsafe impl ::core::marker::Sync for EmailQueryTextSearch {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -6039,36 +5227,7 @@ unsafe impl ::windows::core::Interface for EmailRecipient {
 impl ::windows::core::RuntimeName for EmailRecipient {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailRecipient";
 }
-impl ::core::convert::From<EmailRecipient> for ::windows::core::IUnknown {
-    fn from(value: EmailRecipient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailRecipient> for ::windows::core::IUnknown {
-    fn from(value: &EmailRecipient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailRecipient> for &::windows::core::IUnknown {
-    fn from(value: &EmailRecipient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailRecipient> for ::windows::core::IInspectable {
-    fn from(value: EmailRecipient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailRecipient> for ::windows::core::IInspectable {
-    fn from(value: &EmailRecipient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailRecipient> for &::windows::core::IInspectable {
-    fn from(value: &EmailRecipient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailRecipient, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailRecipient {}
 unsafe impl ::core::marker::Sync for EmailRecipient {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -6145,36 +5304,7 @@ unsafe impl ::windows::core::Interface for EmailRecipientResolutionResult {
 impl ::windows::core::RuntimeName for EmailRecipientResolutionResult {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailRecipientResolutionResult";
 }
-impl ::core::convert::From<EmailRecipientResolutionResult> for ::windows::core::IUnknown {
-    fn from(value: EmailRecipientResolutionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailRecipientResolutionResult> for ::windows::core::IUnknown {
-    fn from(value: &EmailRecipientResolutionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailRecipientResolutionResult> for &::windows::core::IUnknown {
-    fn from(value: &EmailRecipientResolutionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailRecipientResolutionResult> for ::windows::core::IInspectable {
-    fn from(value: EmailRecipientResolutionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailRecipientResolutionResult> for ::windows::core::IInspectable {
-    fn from(value: &EmailRecipientResolutionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailRecipientResolutionResult> for &::windows::core::IInspectable {
-    fn from(value: &EmailRecipientResolutionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailRecipientResolutionResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailRecipientResolutionResult {}
 unsafe impl ::core::marker::Sync for EmailRecipientResolutionResult {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -6305,36 +5435,7 @@ unsafe impl ::windows::core::Interface for EmailStore {
 impl ::windows::core::RuntimeName for EmailStore {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailStore";
 }
-impl ::core::convert::From<EmailStore> for ::windows::core::IUnknown {
-    fn from(value: EmailStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailStore> for ::windows::core::IUnknown {
-    fn from(value: &EmailStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailStore> for &::windows::core::IUnknown {
-    fn from(value: &EmailStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailStore> for ::windows::core::IInspectable {
-    fn from(value: EmailStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailStore> for ::windows::core::IInspectable {
-    fn from(value: &EmailStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailStore> for &::windows::core::IInspectable {
-    fn from(value: &EmailStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailStore {}
 unsafe impl ::core::marker::Sync for EmailStore {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]
@@ -6373,36 +5474,7 @@ unsafe impl ::windows::core::Interface for EmailStoreNotificationTriggerDetails 
 impl ::windows::core::RuntimeName for EmailStoreNotificationTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailStoreNotificationTriggerDetails";
 }
-impl ::core::convert::From<EmailStoreNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: EmailStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailStoreNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &EmailStoreNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailStoreNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &EmailStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailStoreNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: EmailStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailStoreNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &EmailStoreNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailStoreNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &EmailStoreNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailStoreNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmailStoreNotificationTriggerDetails {}
 unsafe impl ::core::marker::Sync for EmailStoreNotificationTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Email\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/Foreground/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/Foreground/mod.rs
@@ -87,36 +87,7 @@ unsafe impl ::windows::core::Interface for ExtendedExecutionForegroundRevokedEve
 impl ::windows::core::RuntimeName for ExtendedExecutionForegroundRevokedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.ExtendedExecution.Foreground.ExtendedExecutionForegroundRevokedEventArgs";
 }
-impl ::core::convert::From<ExtendedExecutionForegroundRevokedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ExtendedExecutionForegroundRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionForegroundRevokedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ExtendedExecutionForegroundRevokedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionForegroundRevokedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ExtendedExecutionForegroundRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ExtendedExecutionForegroundRevokedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ExtendedExecutionForegroundRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionForegroundRevokedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ExtendedExecutionForegroundRevokedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionForegroundRevokedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ExtendedExecutionForegroundRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ExtendedExecutionForegroundRevokedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ExtendedExecutionForegroundRevokedEventArgs {}
 unsafe impl ::core::marker::Sync for ExtendedExecutionForegroundRevokedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_ExtendedExecution_Foreground\"`*"]
@@ -215,36 +186,7 @@ unsafe impl ::windows::core::Interface for ExtendedExecutionForegroundSession {
 impl ::windows::core::RuntimeName for ExtendedExecutionForegroundSession {
     const NAME: &'static str = "Windows.ApplicationModel.ExtendedExecution.Foreground.ExtendedExecutionForegroundSession";
 }
-impl ::core::convert::From<ExtendedExecutionForegroundSession> for ::windows::core::IUnknown {
-    fn from(value: ExtendedExecutionForegroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionForegroundSession> for ::windows::core::IUnknown {
-    fn from(value: &ExtendedExecutionForegroundSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionForegroundSession> for &::windows::core::IUnknown {
-    fn from(value: &ExtendedExecutionForegroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ExtendedExecutionForegroundSession> for ::windows::core::IInspectable {
-    fn from(value: ExtendedExecutionForegroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionForegroundSession> for ::windows::core::IInspectable {
-    fn from(value: &ExtendedExecutionForegroundSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionForegroundSession> for &::windows::core::IInspectable {
-    fn from(value: &ExtendedExecutionForegroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ExtendedExecutionForegroundSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ExtendedExecutionForegroundSession> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/mod.rs
@@ -91,36 +91,7 @@ unsafe impl ::windows::core::Interface for ExtendedExecutionRevokedEventArgs {
 impl ::windows::core::RuntimeName for ExtendedExecutionRevokedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.ExtendedExecution.ExtendedExecutionRevokedEventArgs";
 }
-impl ::core::convert::From<ExtendedExecutionRevokedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ExtendedExecutionRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionRevokedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ExtendedExecutionRevokedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionRevokedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ExtendedExecutionRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ExtendedExecutionRevokedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ExtendedExecutionRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionRevokedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ExtendedExecutionRevokedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionRevokedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ExtendedExecutionRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ExtendedExecutionRevokedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ExtendedExecutionRevokedEventArgs {}
 unsafe impl ::core::marker::Sync for ExtendedExecutionRevokedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_ExtendedExecution\"`*"]
@@ -230,36 +201,7 @@ unsafe impl ::windows::core::Interface for ExtendedExecutionSession {
 impl ::windows::core::RuntimeName for ExtendedExecutionSession {
     const NAME: &'static str = "Windows.ApplicationModel.ExtendedExecution.ExtendedExecutionSession";
 }
-impl ::core::convert::From<ExtendedExecutionSession> for ::windows::core::IUnknown {
-    fn from(value: ExtendedExecutionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionSession> for ::windows::core::IUnknown {
-    fn from(value: &ExtendedExecutionSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionSession> for &::windows::core::IUnknown {
-    fn from(value: &ExtendedExecutionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ExtendedExecutionSession> for ::windows::core::IInspectable {
-    fn from(value: ExtendedExecutionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionSession> for ::windows::core::IInspectable {
-    fn from(value: &ExtendedExecutionSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExtendedExecutionSession> for &::windows::core::IInspectable {
-    fn from(value: &ExtendedExecutionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ExtendedExecutionSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ExtendedExecutionSession> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Holographic/mod.rs
@@ -100,36 +100,7 @@ unsafe impl ::windows::core::Interface for HolographicKeyboard {
 impl ::windows::core::RuntimeName for HolographicKeyboard {
     const NAME: &'static str = "Windows.ApplicationModel.Holographic.HolographicKeyboard";
 }
-impl ::core::convert::From<HolographicKeyboard> for ::windows::core::IUnknown {
-    fn from(value: HolographicKeyboard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicKeyboard> for ::windows::core::IUnknown {
-    fn from(value: &HolographicKeyboard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicKeyboard> for &::windows::core::IUnknown {
-    fn from(value: &HolographicKeyboard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicKeyboard> for ::windows::core::IInspectable {
-    fn from(value: HolographicKeyboard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicKeyboard> for ::windows::core::IInspectable {
-    fn from(value: &HolographicKeyboard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicKeyboard> for &::windows::core::IInspectable {
-    fn from(value: &HolographicKeyboard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicKeyboard, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicKeyboard {}
 unsafe impl ::core::marker::Sync for HolographicKeyboard {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/LockScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/LockScreen/mod.rs
@@ -227,36 +227,7 @@ unsafe impl ::windows::core::Interface for LockApplicationHost {
 impl ::windows::core::RuntimeName for LockApplicationHost {
     const NAME: &'static str = "Windows.ApplicationModel.LockScreen.LockApplicationHost";
 }
-impl ::core::convert::From<LockApplicationHost> for ::windows::core::IUnknown {
-    fn from(value: LockApplicationHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockApplicationHost> for ::windows::core::IUnknown {
-    fn from(value: &LockApplicationHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockApplicationHost> for &::windows::core::IUnknown {
-    fn from(value: &LockApplicationHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LockApplicationHost> for ::windows::core::IInspectable {
-    fn from(value: LockApplicationHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockApplicationHost> for ::windows::core::IInspectable {
-    fn from(value: &LockApplicationHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockApplicationHost> for &::windows::core::IInspectable {
-    fn from(value: &LockApplicationHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LockApplicationHost, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LockApplicationHost {}
 unsafe impl ::core::marker::Sync for LockApplicationHost {}
 #[doc = "*Required features: `\"ApplicationModel_LockScreen\"`*"]
@@ -334,36 +305,7 @@ unsafe impl ::windows::core::Interface for LockScreenBadge {
 impl ::windows::core::RuntimeName for LockScreenBadge {
     const NAME: &'static str = "Windows.ApplicationModel.LockScreen.LockScreenBadge";
 }
-impl ::core::convert::From<LockScreenBadge> for ::windows::core::IUnknown {
-    fn from(value: LockScreenBadge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenBadge> for ::windows::core::IUnknown {
-    fn from(value: &LockScreenBadge) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenBadge> for &::windows::core::IUnknown {
-    fn from(value: &LockScreenBadge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LockScreenBadge> for ::windows::core::IInspectable {
-    fn from(value: LockScreenBadge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenBadge> for ::windows::core::IInspectable {
-    fn from(value: &LockScreenBadge) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenBadge> for &::windows::core::IInspectable {
-    fn from(value: &LockScreenBadge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LockScreenBadge, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LockScreenBadge {}
 unsafe impl ::core::marker::Sync for LockScreenBadge {}
 #[doc = "*Required features: `\"ApplicationModel_LockScreen\"`*"]
@@ -499,36 +441,7 @@ unsafe impl ::windows::core::Interface for LockScreenInfo {
 impl ::windows::core::RuntimeName for LockScreenInfo {
     const NAME: &'static str = "Windows.ApplicationModel.LockScreen.LockScreenInfo";
 }
-impl ::core::convert::From<LockScreenInfo> for ::windows::core::IUnknown {
-    fn from(value: LockScreenInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenInfo> for ::windows::core::IUnknown {
-    fn from(value: &LockScreenInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenInfo> for &::windows::core::IUnknown {
-    fn from(value: &LockScreenInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LockScreenInfo> for ::windows::core::IInspectable {
-    fn from(value: LockScreenInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenInfo> for ::windows::core::IInspectable {
-    fn from(value: &LockScreenInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenInfo> for &::windows::core::IInspectable {
-    fn from(value: &LockScreenInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LockScreenInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LockScreenInfo {}
 unsafe impl ::core::marker::Sync for LockScreenInfo {}
 #[doc = "*Required features: `\"ApplicationModel_LockScreen\"`*"]
@@ -572,36 +485,7 @@ unsafe impl ::windows::core::Interface for LockScreenUnlockingDeferral {
 impl ::windows::core::RuntimeName for LockScreenUnlockingDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.LockScreen.LockScreenUnlockingDeferral";
 }
-impl ::core::convert::From<LockScreenUnlockingDeferral> for ::windows::core::IUnknown {
-    fn from(value: LockScreenUnlockingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenUnlockingDeferral> for ::windows::core::IUnknown {
-    fn from(value: &LockScreenUnlockingDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenUnlockingDeferral> for &::windows::core::IUnknown {
-    fn from(value: &LockScreenUnlockingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LockScreenUnlockingDeferral> for ::windows::core::IInspectable {
-    fn from(value: LockScreenUnlockingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenUnlockingDeferral> for ::windows::core::IInspectable {
-    fn from(value: &LockScreenUnlockingDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenUnlockingDeferral> for &::windows::core::IInspectable {
-    fn from(value: &LockScreenUnlockingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LockScreenUnlockingDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LockScreenUnlockingDeferral {}
 unsafe impl ::core::marker::Sync for LockScreenUnlockingDeferral {}
 #[doc = "*Required features: `\"ApplicationModel_LockScreen\"`*"]
@@ -657,36 +541,7 @@ unsafe impl ::windows::core::Interface for LockScreenUnlockingEventArgs {
 impl ::windows::core::RuntimeName for LockScreenUnlockingEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.LockScreen.LockScreenUnlockingEventArgs";
 }
-impl ::core::convert::From<LockScreenUnlockingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LockScreenUnlockingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenUnlockingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LockScreenUnlockingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenUnlockingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LockScreenUnlockingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LockScreenUnlockingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LockScreenUnlockingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LockScreenUnlockingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LockScreenUnlockingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LockScreenUnlockingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LockScreenUnlockingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LockScreenUnlockingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LockScreenUnlockingEventArgs {}
 unsafe impl ::core::marker::Sync for LockScreenUnlockingEventArgs {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Payments/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Payments/Provider/mod.rs
@@ -166,36 +166,7 @@ unsafe impl ::windows::core::Interface for PaymentAppCanMakePaymentTriggerDetail
 impl ::windows::core::RuntimeName for PaymentAppCanMakePaymentTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.Provider.PaymentAppCanMakePaymentTriggerDetails";
 }
-impl ::core::convert::From<PaymentAppCanMakePaymentTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: PaymentAppCanMakePaymentTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentAppCanMakePaymentTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &PaymentAppCanMakePaymentTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentAppCanMakePaymentTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &PaymentAppCanMakePaymentTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentAppCanMakePaymentTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: PaymentAppCanMakePaymentTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentAppCanMakePaymentTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &PaymentAppCanMakePaymentTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentAppCanMakePaymentTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &PaymentAppCanMakePaymentTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentAppCanMakePaymentTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentAppCanMakePaymentTriggerDetails {}
 unsafe impl ::core::marker::Sync for PaymentAppCanMakePaymentTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Payments_Provider\"`*"]
@@ -268,36 +239,7 @@ unsafe impl ::windows::core::Interface for PaymentAppManager {
 impl ::windows::core::RuntimeName for PaymentAppManager {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.Provider.PaymentAppManager";
 }
-impl ::core::convert::From<PaymentAppManager> for ::windows::core::IUnknown {
-    fn from(value: PaymentAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentAppManager> for ::windows::core::IUnknown {
-    fn from(value: &PaymentAppManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentAppManager> for &::windows::core::IUnknown {
-    fn from(value: &PaymentAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentAppManager> for ::windows::core::IInspectable {
-    fn from(value: PaymentAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentAppManager> for ::windows::core::IInspectable {
-    fn from(value: &PaymentAppManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentAppManager> for &::windows::core::IInspectable {
-    fn from(value: &PaymentAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentAppManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentAppManager {}
 unsafe impl ::core::marker::Sync for PaymentAppManager {}
 #[doc = "*Required features: `\"ApplicationModel_Payments_Provider\"`*"]
@@ -421,36 +363,7 @@ unsafe impl ::windows::core::Interface for PaymentTransaction {
 impl ::windows::core::RuntimeName for PaymentTransaction {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.Provider.PaymentTransaction";
 }
-impl ::core::convert::From<PaymentTransaction> for ::windows::core::IUnknown {
-    fn from(value: PaymentTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentTransaction> for ::windows::core::IUnknown {
-    fn from(value: &PaymentTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentTransaction> for &::windows::core::IUnknown {
-    fn from(value: &PaymentTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentTransaction> for ::windows::core::IInspectable {
-    fn from(value: PaymentTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentTransaction> for ::windows::core::IInspectable {
-    fn from(value: &PaymentTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentTransaction> for &::windows::core::IInspectable {
-    fn from(value: &PaymentTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentTransaction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentTransaction {}
 unsafe impl ::core::marker::Sync for PaymentTransaction {}
 #[doc = "*Required features: `\"ApplicationModel_Payments_Provider\"`*"]
@@ -497,36 +410,7 @@ unsafe impl ::windows::core::Interface for PaymentTransactionAcceptResult {
 impl ::windows::core::RuntimeName for PaymentTransactionAcceptResult {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.Provider.PaymentTransactionAcceptResult";
 }
-impl ::core::convert::From<PaymentTransactionAcceptResult> for ::windows::core::IUnknown {
-    fn from(value: PaymentTransactionAcceptResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentTransactionAcceptResult> for ::windows::core::IUnknown {
-    fn from(value: &PaymentTransactionAcceptResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentTransactionAcceptResult> for &::windows::core::IUnknown {
-    fn from(value: &PaymentTransactionAcceptResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentTransactionAcceptResult> for ::windows::core::IInspectable {
-    fn from(value: PaymentTransactionAcceptResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentTransactionAcceptResult> for ::windows::core::IInspectable {
-    fn from(value: &PaymentTransactionAcceptResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentTransactionAcceptResult> for &::windows::core::IInspectable {
-    fn from(value: &PaymentTransactionAcceptResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentTransactionAcceptResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentTransactionAcceptResult {}
 unsafe impl ::core::marker::Sync for PaymentTransactionAcceptResult {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
@@ -829,36 +829,7 @@ unsafe impl ::windows::core::Interface for PaymentAddress {
 impl ::windows::core::RuntimeName for PaymentAddress {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentAddress";
 }
-impl ::core::convert::From<PaymentAddress> for ::windows::core::IUnknown {
-    fn from(value: PaymentAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentAddress> for ::windows::core::IUnknown {
-    fn from(value: &PaymentAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentAddress> for &::windows::core::IUnknown {
-    fn from(value: &PaymentAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentAddress> for ::windows::core::IInspectable {
-    fn from(value: PaymentAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentAddress> for ::windows::core::IInspectable {
-    fn from(value: &PaymentAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentAddress> for &::windows::core::IInspectable {
-    fn from(value: &PaymentAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentAddress, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentAddress {}
 unsafe impl ::core::marker::Sync for PaymentAddress {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -916,36 +887,7 @@ unsafe impl ::windows::core::Interface for PaymentCanMakePaymentResult {
 impl ::windows::core::RuntimeName for PaymentCanMakePaymentResult {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentCanMakePaymentResult";
 }
-impl ::core::convert::From<PaymentCanMakePaymentResult> for ::windows::core::IUnknown {
-    fn from(value: PaymentCanMakePaymentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentCanMakePaymentResult> for ::windows::core::IUnknown {
-    fn from(value: &PaymentCanMakePaymentResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentCanMakePaymentResult> for &::windows::core::IUnknown {
-    fn from(value: &PaymentCanMakePaymentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentCanMakePaymentResult> for ::windows::core::IInspectable {
-    fn from(value: PaymentCanMakePaymentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentCanMakePaymentResult> for ::windows::core::IInspectable {
-    fn from(value: &PaymentCanMakePaymentResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentCanMakePaymentResult> for &::windows::core::IInspectable {
-    fn from(value: &PaymentCanMakePaymentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentCanMakePaymentResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentCanMakePaymentResult {}
 unsafe impl ::core::marker::Sync for PaymentCanMakePaymentResult {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -1035,36 +977,7 @@ unsafe impl ::windows::core::Interface for PaymentCurrencyAmount {
 impl ::windows::core::RuntimeName for PaymentCurrencyAmount {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentCurrencyAmount";
 }
-impl ::core::convert::From<PaymentCurrencyAmount> for ::windows::core::IUnknown {
-    fn from(value: PaymentCurrencyAmount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentCurrencyAmount> for ::windows::core::IUnknown {
-    fn from(value: &PaymentCurrencyAmount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentCurrencyAmount> for &::windows::core::IUnknown {
-    fn from(value: &PaymentCurrencyAmount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentCurrencyAmount> for ::windows::core::IInspectable {
-    fn from(value: PaymentCurrencyAmount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentCurrencyAmount> for ::windows::core::IInspectable {
-    fn from(value: &PaymentCurrencyAmount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentCurrencyAmount> for &::windows::core::IInspectable {
-    fn from(value: &PaymentCurrencyAmount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentCurrencyAmount, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentCurrencyAmount {}
 unsafe impl ::core::marker::Sync for PaymentCurrencyAmount {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -1202,36 +1115,7 @@ unsafe impl ::windows::core::Interface for PaymentDetails {
 impl ::windows::core::RuntimeName for PaymentDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentDetails";
 }
-impl ::core::convert::From<PaymentDetails> for ::windows::core::IUnknown {
-    fn from(value: PaymentDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentDetails> for ::windows::core::IUnknown {
-    fn from(value: &PaymentDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentDetails> for &::windows::core::IUnknown {
-    fn from(value: &PaymentDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentDetails> for ::windows::core::IInspectable {
-    fn from(value: PaymentDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentDetails> for ::windows::core::IInspectable {
-    fn from(value: &PaymentDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentDetails> for &::windows::core::IInspectable {
-    fn from(value: &PaymentDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentDetails {}
 unsafe impl ::core::marker::Sync for PaymentDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -1348,36 +1232,7 @@ unsafe impl ::windows::core::Interface for PaymentDetailsModifier {
 impl ::windows::core::RuntimeName for PaymentDetailsModifier {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentDetailsModifier";
 }
-impl ::core::convert::From<PaymentDetailsModifier> for ::windows::core::IUnknown {
-    fn from(value: PaymentDetailsModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentDetailsModifier> for ::windows::core::IUnknown {
-    fn from(value: &PaymentDetailsModifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentDetailsModifier> for &::windows::core::IUnknown {
-    fn from(value: &PaymentDetailsModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentDetailsModifier> for ::windows::core::IInspectable {
-    fn from(value: PaymentDetailsModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentDetailsModifier> for ::windows::core::IInspectable {
-    fn from(value: &PaymentDetailsModifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentDetailsModifier> for &::windows::core::IInspectable {
-    fn from(value: &PaymentDetailsModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentDetailsModifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentDetailsModifier {}
 unsafe impl ::core::marker::Sync for PaymentDetailsModifier {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -1461,36 +1316,7 @@ unsafe impl ::windows::core::Interface for PaymentItem {
 impl ::windows::core::RuntimeName for PaymentItem {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentItem";
 }
-impl ::core::convert::From<PaymentItem> for ::windows::core::IUnknown {
-    fn from(value: PaymentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentItem> for ::windows::core::IUnknown {
-    fn from(value: &PaymentItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentItem> for &::windows::core::IUnknown {
-    fn from(value: &PaymentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentItem> for ::windows::core::IInspectable {
-    fn from(value: PaymentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentItem> for ::windows::core::IInspectable {
-    fn from(value: &PaymentItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentItem> for &::windows::core::IInspectable {
-    fn from(value: &PaymentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentItem {}
 unsafe impl ::core::marker::Sync for PaymentItem {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -1573,36 +1399,7 @@ unsafe impl ::windows::core::Interface for PaymentMediator {
 impl ::windows::core::RuntimeName for PaymentMediator {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentMediator";
 }
-impl ::core::convert::From<PaymentMediator> for ::windows::core::IUnknown {
-    fn from(value: PaymentMediator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentMediator> for ::windows::core::IUnknown {
-    fn from(value: &PaymentMediator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentMediator> for &::windows::core::IUnknown {
-    fn from(value: &PaymentMediator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentMediator> for ::windows::core::IInspectable {
-    fn from(value: PaymentMediator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentMediator> for ::windows::core::IInspectable {
-    fn from(value: &PaymentMediator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentMediator> for &::windows::core::IInspectable {
-    fn from(value: &PaymentMediator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentMediator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentMediator {}
 unsafe impl ::core::marker::Sync for PaymentMediator {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -1678,36 +1475,7 @@ unsafe impl ::windows::core::Interface for PaymentMerchantInfo {
 impl ::windows::core::RuntimeName for PaymentMerchantInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentMerchantInfo";
 }
-impl ::core::convert::From<PaymentMerchantInfo> for ::windows::core::IUnknown {
-    fn from(value: PaymentMerchantInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentMerchantInfo> for ::windows::core::IUnknown {
-    fn from(value: &PaymentMerchantInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentMerchantInfo> for &::windows::core::IUnknown {
-    fn from(value: &PaymentMerchantInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentMerchantInfo> for ::windows::core::IInspectable {
-    fn from(value: PaymentMerchantInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentMerchantInfo> for ::windows::core::IInspectable {
-    fn from(value: &PaymentMerchantInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentMerchantInfo> for &::windows::core::IInspectable {
-    fn from(value: &PaymentMerchantInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentMerchantInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentMerchantInfo {}
 unsafe impl ::core::marker::Sync for PaymentMerchantInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -1792,36 +1560,7 @@ unsafe impl ::windows::core::Interface for PaymentMethodData {
 impl ::windows::core::RuntimeName for PaymentMethodData {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentMethodData";
 }
-impl ::core::convert::From<PaymentMethodData> for ::windows::core::IUnknown {
-    fn from(value: PaymentMethodData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentMethodData> for ::windows::core::IUnknown {
-    fn from(value: &PaymentMethodData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentMethodData> for &::windows::core::IUnknown {
-    fn from(value: &PaymentMethodData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentMethodData> for ::windows::core::IInspectable {
-    fn from(value: PaymentMethodData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentMethodData> for ::windows::core::IInspectable {
-    fn from(value: &PaymentMethodData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentMethodData> for &::windows::core::IInspectable {
-    fn from(value: &PaymentMethodData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentMethodData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentMethodData {}
 unsafe impl ::core::marker::Sync for PaymentMethodData {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -1923,36 +1662,7 @@ unsafe impl ::windows::core::Interface for PaymentOptions {
 impl ::windows::core::RuntimeName for PaymentOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentOptions";
 }
-impl ::core::convert::From<PaymentOptions> for ::windows::core::IUnknown {
-    fn from(value: PaymentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentOptions> for ::windows::core::IUnknown {
-    fn from(value: &PaymentOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentOptions> for &::windows::core::IUnknown {
-    fn from(value: &PaymentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentOptions> for ::windows::core::IInspectable {
-    fn from(value: PaymentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentOptions> for ::windows::core::IInspectable {
-    fn from(value: &PaymentOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentOptions> for &::windows::core::IInspectable {
-    fn from(value: &PaymentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentOptions {}
 unsafe impl ::core::marker::Sync for PaymentOptions {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -2087,36 +1797,7 @@ unsafe impl ::windows::core::Interface for PaymentRequest {
 impl ::windows::core::RuntimeName for PaymentRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentRequest";
 }
-impl ::core::convert::From<PaymentRequest> for ::windows::core::IUnknown {
-    fn from(value: PaymentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentRequest> for ::windows::core::IUnknown {
-    fn from(value: &PaymentRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentRequest> for &::windows::core::IUnknown {
-    fn from(value: &PaymentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentRequest> for ::windows::core::IInspectable {
-    fn from(value: PaymentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentRequest> for ::windows::core::IInspectable {
-    fn from(value: &PaymentRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentRequest> for &::windows::core::IInspectable {
-    fn from(value: &PaymentRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentRequest {}
 unsafe impl ::core::marker::Sync for PaymentRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -2181,36 +1862,7 @@ unsafe impl ::windows::core::Interface for PaymentRequestChangedArgs {
 impl ::windows::core::RuntimeName for PaymentRequestChangedArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentRequestChangedArgs";
 }
-impl ::core::convert::From<PaymentRequestChangedArgs> for ::windows::core::IUnknown {
-    fn from(value: PaymentRequestChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentRequestChangedArgs> for ::windows::core::IUnknown {
-    fn from(value: &PaymentRequestChangedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentRequestChangedArgs> for &::windows::core::IUnknown {
-    fn from(value: &PaymentRequestChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentRequestChangedArgs> for ::windows::core::IInspectable {
-    fn from(value: PaymentRequestChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentRequestChangedArgs> for ::windows::core::IInspectable {
-    fn from(value: &PaymentRequestChangedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentRequestChangedArgs> for &::windows::core::IInspectable {
-    fn from(value: &PaymentRequestChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentRequestChangedArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentRequestChangedArgs {}
 unsafe impl ::core::marker::Sync for PaymentRequestChangedArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -2300,36 +1952,7 @@ unsafe impl ::windows::core::Interface for PaymentRequestChangedResult {
 impl ::windows::core::RuntimeName for PaymentRequestChangedResult {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentRequestChangedResult";
 }
-impl ::core::convert::From<PaymentRequestChangedResult> for ::windows::core::IUnknown {
-    fn from(value: PaymentRequestChangedResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentRequestChangedResult> for ::windows::core::IUnknown {
-    fn from(value: &PaymentRequestChangedResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentRequestChangedResult> for &::windows::core::IUnknown {
-    fn from(value: &PaymentRequestChangedResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentRequestChangedResult> for ::windows::core::IInspectable {
-    fn from(value: PaymentRequestChangedResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentRequestChangedResult> for ::windows::core::IInspectable {
-    fn from(value: &PaymentRequestChangedResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentRequestChangedResult> for &::windows::core::IInspectable {
-    fn from(value: &PaymentRequestChangedResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentRequestChangedResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentRequestChangedResult {}
 unsafe impl ::core::marker::Sync for PaymentRequestChangedResult {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -2383,36 +2006,7 @@ unsafe impl ::windows::core::Interface for PaymentRequestSubmitResult {
 impl ::windows::core::RuntimeName for PaymentRequestSubmitResult {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentRequestSubmitResult";
 }
-impl ::core::convert::From<PaymentRequestSubmitResult> for ::windows::core::IUnknown {
-    fn from(value: PaymentRequestSubmitResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentRequestSubmitResult> for ::windows::core::IUnknown {
-    fn from(value: &PaymentRequestSubmitResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentRequestSubmitResult> for &::windows::core::IUnknown {
-    fn from(value: &PaymentRequestSubmitResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentRequestSubmitResult> for ::windows::core::IInspectable {
-    fn from(value: PaymentRequestSubmitResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentRequestSubmitResult> for ::windows::core::IInspectable {
-    fn from(value: &PaymentRequestSubmitResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentRequestSubmitResult> for &::windows::core::IInspectable {
-    fn from(value: &PaymentRequestSubmitResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentRequestSubmitResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentRequestSubmitResult {}
 unsafe impl ::core::marker::Sync for PaymentRequestSubmitResult {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -2503,36 +2097,7 @@ unsafe impl ::windows::core::Interface for PaymentResponse {
 impl ::windows::core::RuntimeName for PaymentResponse {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentResponse";
 }
-impl ::core::convert::From<PaymentResponse> for ::windows::core::IUnknown {
-    fn from(value: PaymentResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentResponse> for ::windows::core::IUnknown {
-    fn from(value: &PaymentResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentResponse> for &::windows::core::IUnknown {
-    fn from(value: &PaymentResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentResponse> for ::windows::core::IInspectable {
-    fn from(value: PaymentResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentResponse> for ::windows::core::IInspectable {
-    fn from(value: &PaymentResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentResponse> for &::windows::core::IInspectable {
-    fn from(value: &PaymentResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentResponse, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentResponse {}
 unsafe impl ::core::marker::Sync for PaymentResponse {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -2639,36 +2204,7 @@ unsafe impl ::windows::core::Interface for PaymentShippingOption {
 impl ::windows::core::RuntimeName for PaymentShippingOption {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentShippingOption";
 }
-impl ::core::convert::From<PaymentShippingOption> for ::windows::core::IUnknown {
-    fn from(value: PaymentShippingOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentShippingOption> for ::windows::core::IUnknown {
-    fn from(value: &PaymentShippingOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentShippingOption> for &::windows::core::IUnknown {
-    fn from(value: &PaymentShippingOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentShippingOption> for ::windows::core::IInspectable {
-    fn from(value: PaymentShippingOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentShippingOption> for ::windows::core::IInspectable {
-    fn from(value: &PaymentShippingOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentShippingOption> for &::windows::core::IInspectable {
-    fn from(value: &PaymentShippingOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentShippingOption, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentShippingOption {}
 unsafe impl ::core::marker::Sync for PaymentShippingOption {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]
@@ -2739,36 +2275,7 @@ unsafe impl ::windows::core::Interface for PaymentToken {
 impl ::windows::core::RuntimeName for PaymentToken {
     const NAME: &'static str = "Windows.ApplicationModel.Payments.PaymentToken";
 }
-impl ::core::convert::From<PaymentToken> for ::windows::core::IUnknown {
-    fn from(value: PaymentToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentToken> for ::windows::core::IUnknown {
-    fn from(value: &PaymentToken) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentToken> for &::windows::core::IUnknown {
-    fn from(value: &PaymentToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PaymentToken> for ::windows::core::IInspectable {
-    fn from(value: PaymentToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PaymentToken> for ::windows::core::IInspectable {
-    fn from(value: &PaymentToken) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PaymentToken> for &::windows::core::IInspectable {
-    fn from(value: &PaymentToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PaymentToken, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PaymentToken {}
 unsafe impl ::core::marker::Sync for PaymentToken {}
 #[doc = "*Required features: `\"ApplicationModel_Payments\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Preview/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Preview/Holographic/mod.rs
@@ -179,41 +179,7 @@ impl ::windows::core::RuntimeName for HolographicKeyboardPlacementOverridePrevie
     const NAME: &'static str = "Windows.ApplicationModel.Preview.Holographic.HolographicKeyboardPlacementOverridePreview";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<HolographicKeyboardPlacementOverridePreview> for ::windows::core::IUnknown {
-    fn from(value: HolographicKeyboardPlacementOverridePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicKeyboardPlacementOverridePreview> for ::windows::core::IUnknown {
-    fn from(value: &HolographicKeyboardPlacementOverridePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicKeyboardPlacementOverridePreview> for &::windows::core::IUnknown {
-    fn from(value: &HolographicKeyboardPlacementOverridePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<HolographicKeyboardPlacementOverridePreview> for ::windows::core::IInspectable {
-    fn from(value: HolographicKeyboardPlacementOverridePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicKeyboardPlacementOverridePreview> for ::windows::core::IInspectable {
-    fn from(value: &HolographicKeyboardPlacementOverridePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicKeyboardPlacementOverridePreview> for &::windows::core::IInspectable {
-    fn from(value: &HolographicKeyboardPlacementOverridePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicKeyboardPlacementOverridePreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for HolographicKeyboardPlacementOverridePreview {}
 #[cfg(feature = "deprecated")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Preview/InkWorkspace/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Preview/InkWorkspace/mod.rs
@@ -88,36 +88,7 @@ unsafe impl ::windows::core::Interface for InkWorkspaceHostedAppManager {
 impl ::windows::core::RuntimeName for InkWorkspaceHostedAppManager {
     const NAME: &'static str = "Windows.ApplicationModel.Preview.InkWorkspace.InkWorkspaceHostedAppManager";
 }
-impl ::core::convert::From<InkWorkspaceHostedAppManager> for ::windows::core::IUnknown {
-    fn from(value: InkWorkspaceHostedAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkWorkspaceHostedAppManager> for ::windows::core::IUnknown {
-    fn from(value: &InkWorkspaceHostedAppManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkWorkspaceHostedAppManager> for &::windows::core::IUnknown {
-    fn from(value: &InkWorkspaceHostedAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkWorkspaceHostedAppManager> for ::windows::core::IInspectable {
-    fn from(value: InkWorkspaceHostedAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkWorkspaceHostedAppManager> for ::windows::core::IInspectable {
-    fn from(value: &InkWorkspaceHostedAppManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkWorkspaceHostedAppManager> for &::windows::core::IInspectable {
-    fn from(value: &InkWorkspaceHostedAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkWorkspaceHostedAppManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkWorkspaceHostedAppManager {}
 unsafe impl ::core::marker::Sync for InkWorkspaceHostedAppManager {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Preview/Notes/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Preview/Notes/mod.rs
@@ -187,36 +187,7 @@ unsafe impl ::windows::core::Interface for NotePlacementChangedPreviewEventArgs 
 impl ::windows::core::RuntimeName for NotePlacementChangedPreviewEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Preview.Notes.NotePlacementChangedPreviewEventArgs";
 }
-impl ::core::convert::From<NotePlacementChangedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: NotePlacementChangedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotePlacementChangedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &NotePlacementChangedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotePlacementChangedPreviewEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &NotePlacementChangedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NotePlacementChangedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: NotePlacementChangedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotePlacementChangedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &NotePlacementChangedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotePlacementChangedPreviewEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &NotePlacementChangedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NotePlacementChangedPreviewEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NotePlacementChangedPreviewEventArgs {}
 unsafe impl ::core::marker::Sync for NotePlacementChangedPreviewEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Preview_Notes\"`*"]
@@ -270,36 +241,7 @@ unsafe impl ::windows::core::Interface for NoteVisibilityChangedPreviewEventArgs
 impl ::windows::core::RuntimeName for NoteVisibilityChangedPreviewEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Preview.Notes.NoteVisibilityChangedPreviewEventArgs";
 }
-impl ::core::convert::From<NoteVisibilityChangedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: NoteVisibilityChangedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NoteVisibilityChangedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &NoteVisibilityChangedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NoteVisibilityChangedPreviewEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &NoteVisibilityChangedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NoteVisibilityChangedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: NoteVisibilityChangedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NoteVisibilityChangedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &NoteVisibilityChangedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NoteVisibilityChangedPreviewEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &NoteVisibilityChangedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NoteVisibilityChangedPreviewEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NoteVisibilityChangedPreviewEventArgs {}
 unsafe impl ::core::marker::Sync for NoteVisibilityChangedPreviewEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Preview_Notes\"`*"]
@@ -486,36 +428,7 @@ unsafe impl ::windows::core::Interface for NotesWindowManagerPreview {
 impl ::windows::core::RuntimeName for NotesWindowManagerPreview {
     const NAME: &'static str = "Windows.ApplicationModel.Preview.Notes.NotesWindowManagerPreview";
 }
-impl ::core::convert::From<NotesWindowManagerPreview> for ::windows::core::IUnknown {
-    fn from(value: NotesWindowManagerPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotesWindowManagerPreview> for ::windows::core::IUnknown {
-    fn from(value: &NotesWindowManagerPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotesWindowManagerPreview> for &::windows::core::IUnknown {
-    fn from(value: &NotesWindowManagerPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NotesWindowManagerPreview> for ::windows::core::IInspectable {
-    fn from(value: NotesWindowManagerPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotesWindowManagerPreview> for ::windows::core::IInspectable {
-    fn from(value: &NotesWindowManagerPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotesWindowManagerPreview> for &::windows::core::IInspectable {
-    fn from(value: &NotesWindowManagerPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NotesWindowManagerPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NotesWindowManagerPreview {}
 unsafe impl ::core::marker::Sync for NotesWindowManagerPreview {}
 #[doc = "*Required features: `\"ApplicationModel_Preview_Notes\"`*"]
@@ -573,36 +486,7 @@ unsafe impl ::windows::core::Interface for NotesWindowManagerPreviewShowNoteOpti
 impl ::windows::core::RuntimeName for NotesWindowManagerPreviewShowNoteOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Preview.Notes.NotesWindowManagerPreviewShowNoteOptions";
 }
-impl ::core::convert::From<NotesWindowManagerPreviewShowNoteOptions> for ::windows::core::IUnknown {
-    fn from(value: NotesWindowManagerPreviewShowNoteOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotesWindowManagerPreviewShowNoteOptions> for ::windows::core::IUnknown {
-    fn from(value: &NotesWindowManagerPreviewShowNoteOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotesWindowManagerPreviewShowNoteOptions> for &::windows::core::IUnknown {
-    fn from(value: &NotesWindowManagerPreviewShowNoteOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NotesWindowManagerPreviewShowNoteOptions> for ::windows::core::IInspectable {
-    fn from(value: NotesWindowManagerPreviewShowNoteOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotesWindowManagerPreviewShowNoteOptions> for ::windows::core::IInspectable {
-    fn from(value: &NotesWindowManagerPreviewShowNoteOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotesWindowManagerPreviewShowNoteOptions> for &::windows::core::IInspectable {
-    fn from(value: &NotesWindowManagerPreviewShowNoteOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NotesWindowManagerPreviewShowNoteOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NotesWindowManagerPreviewShowNoteOptions {}
 unsafe impl ::core::marker::Sync for NotesWindowManagerPreviewShowNoteOptions {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/Core/mod.rs
@@ -392,36 +392,7 @@ unsafe impl ::windows::core::Interface for NamedResource {
 impl ::windows::core::RuntimeName for NamedResource {
     const NAME: &'static str = "Windows.ApplicationModel.Resources.Core.NamedResource";
 }
-impl ::core::convert::From<NamedResource> for ::windows::core::IUnknown {
-    fn from(value: NamedResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NamedResource> for ::windows::core::IUnknown {
-    fn from(value: &NamedResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NamedResource> for &::windows::core::IUnknown {
-    fn from(value: &NamedResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NamedResource> for ::windows::core::IInspectable {
-    fn from(value: NamedResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NamedResource> for ::windows::core::IInspectable {
-    fn from(value: &NamedResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NamedResource> for &::windows::core::IInspectable {
-    fn from(value: &NamedResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NamedResource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NamedResource {}
 unsafe impl ::core::marker::Sync for NamedResource {}
 #[doc = "*Required features: `\"ApplicationModel_Resources_Core\"`*"]
@@ -530,36 +501,7 @@ unsafe impl ::windows::core::Interface for ResourceCandidate {
 impl ::windows::core::RuntimeName for ResourceCandidate {
     const NAME: &'static str = "Windows.ApplicationModel.Resources.Core.ResourceCandidate";
 }
-impl ::core::convert::From<ResourceCandidate> for ::windows::core::IUnknown {
-    fn from(value: ResourceCandidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceCandidate> for ::windows::core::IUnknown {
-    fn from(value: &ResourceCandidate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceCandidate> for &::windows::core::IUnknown {
-    fn from(value: &ResourceCandidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ResourceCandidate> for ::windows::core::IInspectable {
-    fn from(value: ResourceCandidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceCandidate> for ::windows::core::IInspectable {
-    fn from(value: &ResourceCandidate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceCandidate> for &::windows::core::IInspectable {
-    fn from(value: &ResourceCandidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceCandidate, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ResourceCandidate {}
 unsafe impl ::core::marker::Sync for ResourceCandidate {}
 #[doc = "*Required features: `\"ApplicationModel_Resources_Core\"`, `\"Foundation_Collections\"`*"]
@@ -671,41 +613,7 @@ impl ::core::iter::IntoIterator for &ResourceCandidateVectorView {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceCandidateVectorView> for ::windows::core::IUnknown {
-    fn from(value: ResourceCandidateVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceCandidateVectorView> for ::windows::core::IUnknown {
-    fn from(value: &ResourceCandidateVectorView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceCandidateVectorView> for &::windows::core::IUnknown {
-    fn from(value: &ResourceCandidateVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceCandidateVectorView> for ::windows::core::IInspectable {
-    fn from(value: ResourceCandidateVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceCandidateVectorView> for ::windows::core::IInspectable {
-    fn from(value: &ResourceCandidateVectorView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceCandidateVectorView> for &::windows::core::IInspectable {
-    fn from(value: &ResourceCandidateVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceCandidateVectorView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<ResourceCandidateVectorView> for super::super::super::Foundation::Collections::IIterable<ResourceCandidate> {
     type Error = ::windows::core::Error;
@@ -927,36 +835,7 @@ unsafe impl ::windows::core::Interface for ResourceContext {
 impl ::windows::core::RuntimeName for ResourceContext {
     const NAME: &'static str = "Windows.ApplicationModel.Resources.Core.ResourceContext";
 }
-impl ::core::convert::From<ResourceContext> for ::windows::core::IUnknown {
-    fn from(value: ResourceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceContext> for ::windows::core::IUnknown {
-    fn from(value: &ResourceContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceContext> for &::windows::core::IUnknown {
-    fn from(value: &ResourceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ResourceContext> for ::windows::core::IInspectable {
-    fn from(value: ResourceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceContext> for ::windows::core::IInspectable {
-    fn from(value: &ResourceContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceContext> for &::windows::core::IInspectable {
-    fn from(value: &ResourceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ResourceContext {}
 unsafe impl ::core::marker::Sync for ResourceContext {}
 #[doc = "*Required features: `\"ApplicationModel_Resources_Core\"`, `\"Foundation_Collections\"`*"]
@@ -1068,41 +947,7 @@ impl ::core::iter::IntoIterator for &ResourceContextLanguagesVectorView {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceContextLanguagesVectorView> for ::windows::core::IUnknown {
-    fn from(value: ResourceContextLanguagesVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceContextLanguagesVectorView> for ::windows::core::IUnknown {
-    fn from(value: &ResourceContextLanguagesVectorView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceContextLanguagesVectorView> for &::windows::core::IUnknown {
-    fn from(value: &ResourceContextLanguagesVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceContextLanguagesVectorView> for ::windows::core::IInspectable {
-    fn from(value: ResourceContextLanguagesVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceContextLanguagesVectorView> for ::windows::core::IInspectable {
-    fn from(value: &ResourceContextLanguagesVectorView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceContextLanguagesVectorView> for &::windows::core::IInspectable {
-    fn from(value: &ResourceContextLanguagesVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceContextLanguagesVectorView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<ResourceContextLanguagesVectorView> for super::super::super::Foundation::Collections::IIterable<::windows::core::HSTRING> {
     type Error = ::windows::core::Error;
@@ -1266,36 +1111,7 @@ unsafe impl ::windows::core::Interface for ResourceManager {
 impl ::windows::core::RuntimeName for ResourceManager {
     const NAME: &'static str = "Windows.ApplicationModel.Resources.Core.ResourceManager";
 }
-impl ::core::convert::From<ResourceManager> for ::windows::core::IUnknown {
-    fn from(value: ResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceManager> for ::windows::core::IUnknown {
-    fn from(value: &ResourceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceManager> for &::windows::core::IUnknown {
-    fn from(value: &ResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ResourceManager> for ::windows::core::IInspectable {
-    fn from(value: ResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceManager> for ::windows::core::IInspectable {
-    fn from(value: &ResourceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceManager> for &::windows::core::IInspectable {
-    fn from(value: &ResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ResourceManager {}
 unsafe impl ::core::marker::Sync for ResourceManager {}
 #[doc = "*Required features: `\"ApplicationModel_Resources_Core\"`*"]
@@ -1423,36 +1239,7 @@ impl ::core::iter::IntoIterator for &ResourceMap {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<ResourceMap> for ::windows::core::IUnknown {
-    fn from(value: ResourceMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceMap> for ::windows::core::IUnknown {
-    fn from(value: &ResourceMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceMap> for &::windows::core::IUnknown {
-    fn from(value: &ResourceMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ResourceMap> for ::windows::core::IInspectable {
-    fn from(value: ResourceMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceMap> for ::windows::core::IInspectable {
-    fn from(value: &ResourceMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceMap> for &::windows::core::IInspectable {
-    fn from(value: &ResourceMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceMap, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<ResourceMap> for super::super::super::Foundation::Collections::IIterable<super::super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, NamedResource>> {
     type Error = ::windows::core::Error;
@@ -1583,41 +1370,7 @@ impl ::windows::core::RuntimeName for ResourceMapIterator {
     const NAME: &'static str = "Windows.ApplicationModel.Resources.Core.ResourceMapIterator";
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceMapIterator> for ::windows::core::IUnknown {
-    fn from(value: ResourceMapIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapIterator> for ::windows::core::IUnknown {
-    fn from(value: &ResourceMapIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapIterator> for &::windows::core::IUnknown {
-    fn from(value: &ResourceMapIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceMapIterator> for ::windows::core::IInspectable {
-    fn from(value: ResourceMapIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapIterator> for ::windows::core::IInspectable {
-    fn from(value: &ResourceMapIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapIterator> for &::windows::core::IInspectable {
-    fn from(value: &ResourceMapIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceMapIterator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<ResourceMapIterator> for super::super::super::Foundation::Collections::IIterator<super::super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, NamedResource>> {
     type Error = ::windows::core::Error;
@@ -1750,41 +1503,7 @@ impl ::core::iter::IntoIterator for &ResourceMapMapView {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceMapMapView> for ::windows::core::IUnknown {
-    fn from(value: ResourceMapMapView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapMapView> for ::windows::core::IUnknown {
-    fn from(value: &ResourceMapMapView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapMapView> for &::windows::core::IUnknown {
-    fn from(value: &ResourceMapMapView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceMapMapView> for ::windows::core::IInspectable {
-    fn from(value: ResourceMapMapView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapMapView> for ::windows::core::IInspectable {
-    fn from(value: &ResourceMapMapView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapMapView> for &::windows::core::IInspectable {
-    fn from(value: &ResourceMapMapView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceMapMapView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<ResourceMapMapView> for super::super::super::Foundation::Collections::IIterable<super::super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ResourceMap>> {
     type Error = ::windows::core::Error;
@@ -1917,41 +1636,7 @@ impl ::windows::core::RuntimeName for ResourceMapMapViewIterator {
     const NAME: &'static str = "Windows.ApplicationModel.Resources.Core.ResourceMapMapViewIterator";
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceMapMapViewIterator> for ::windows::core::IUnknown {
-    fn from(value: ResourceMapMapViewIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapMapViewIterator> for ::windows::core::IUnknown {
-    fn from(value: &ResourceMapMapViewIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapMapViewIterator> for &::windows::core::IUnknown {
-    fn from(value: &ResourceMapMapViewIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceMapMapViewIterator> for ::windows::core::IInspectable {
-    fn from(value: ResourceMapMapViewIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapMapViewIterator> for ::windows::core::IInspectable {
-    fn from(value: &ResourceMapMapViewIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceMapMapViewIterator> for &::windows::core::IInspectable {
-    fn from(value: &ResourceMapMapViewIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceMapMapViewIterator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<ResourceMapMapViewIterator> for super::super::super::Foundation::Collections::IIterator<super::super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ResourceMap>> {
     type Error = ::windows::core::Error;
@@ -2050,36 +1735,7 @@ unsafe impl ::windows::core::Interface for ResourceQualifier {
 impl ::windows::core::RuntimeName for ResourceQualifier {
     const NAME: &'static str = "Windows.ApplicationModel.Resources.Core.ResourceQualifier";
 }
-impl ::core::convert::From<ResourceQualifier> for ::windows::core::IUnknown {
-    fn from(value: ResourceQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceQualifier> for ::windows::core::IUnknown {
-    fn from(value: &ResourceQualifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceQualifier> for &::windows::core::IUnknown {
-    fn from(value: &ResourceQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ResourceQualifier> for ::windows::core::IInspectable {
-    fn from(value: ResourceQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceQualifier> for ::windows::core::IInspectable {
-    fn from(value: &ResourceQualifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceQualifier> for &::windows::core::IInspectable {
-    fn from(value: &ResourceQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceQualifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ResourceQualifier {}
 unsafe impl ::core::marker::Sync for ResourceQualifier {}
 #[doc = "*Required features: `\"ApplicationModel_Resources_Core\"`, `\"Foundation_Collections\"`*"]
@@ -2188,41 +1844,7 @@ impl ::core::iter::IntoIterator for &ResourceQualifierMapView {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceQualifierMapView> for ::windows::core::IUnknown {
-    fn from(value: ResourceQualifierMapView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierMapView> for ::windows::core::IUnknown {
-    fn from(value: &ResourceQualifierMapView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierMapView> for &::windows::core::IUnknown {
-    fn from(value: &ResourceQualifierMapView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceQualifierMapView> for ::windows::core::IInspectable {
-    fn from(value: ResourceQualifierMapView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierMapView> for ::windows::core::IInspectable {
-    fn from(value: &ResourceQualifierMapView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierMapView> for &::windows::core::IInspectable {
-    fn from(value: &ResourceQualifierMapView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceQualifierMapView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<ResourceQualifierMapView> for super::super::super::Foundation::Collections::IIterable<super::super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::HSTRING>> {
     type Error = ::windows::core::Error;
@@ -2416,41 +2038,7 @@ impl ::core::iter::IntoIterator for &ResourceQualifierObservableMap {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceQualifierObservableMap> for ::windows::core::IUnknown {
-    fn from(value: ResourceQualifierObservableMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierObservableMap> for ::windows::core::IUnknown {
-    fn from(value: &ResourceQualifierObservableMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierObservableMap> for &::windows::core::IUnknown {
-    fn from(value: &ResourceQualifierObservableMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceQualifierObservableMap> for ::windows::core::IInspectable {
-    fn from(value: ResourceQualifierObservableMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierObservableMap> for ::windows::core::IInspectable {
-    fn from(value: &ResourceQualifierObservableMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierObservableMap> for &::windows::core::IInspectable {
-    fn from(value: &ResourceQualifierObservableMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceQualifierObservableMap, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<ResourceQualifierObservableMap> for super::super::super::Foundation::Collections::IIterable<super::super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::HSTRING>> {
     type Error = ::windows::core::Error;
@@ -2630,41 +2218,7 @@ impl ::core::iter::IntoIterator for &ResourceQualifierVectorView {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceQualifierVectorView> for ::windows::core::IUnknown {
-    fn from(value: ResourceQualifierVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierVectorView> for ::windows::core::IUnknown {
-    fn from(value: &ResourceQualifierVectorView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierVectorView> for &::windows::core::IUnknown {
-    fn from(value: &ResourceQualifierVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ResourceQualifierVectorView> for ::windows::core::IInspectable {
-    fn from(value: ResourceQualifierVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierVectorView> for ::windows::core::IInspectable {
-    fn from(value: &ResourceQualifierVectorView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ResourceQualifierVectorView> for &::windows::core::IInspectable {
-    fn from(value: &ResourceQualifierVectorView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceQualifierVectorView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<ResourceQualifierVectorView> for super::super::super::Foundation::Collections::IIterable<ResourceQualifier> {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/Management/mod.rs
@@ -198,36 +198,7 @@ unsafe impl ::windows::core::Interface for IndexedResourceCandidate {
 impl ::windows::core::RuntimeName for IndexedResourceCandidate {
     const NAME: &'static str = "Windows.ApplicationModel.Resources.Management.IndexedResourceCandidate";
 }
-impl ::core::convert::From<IndexedResourceCandidate> for ::windows::core::IUnknown {
-    fn from(value: IndexedResourceCandidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IndexedResourceCandidate> for ::windows::core::IUnknown {
-    fn from(value: &IndexedResourceCandidate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IndexedResourceCandidate> for &::windows::core::IUnknown {
-    fn from(value: &IndexedResourceCandidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IndexedResourceCandidate> for ::windows::core::IInspectable {
-    fn from(value: IndexedResourceCandidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IndexedResourceCandidate> for ::windows::core::IInspectable {
-    fn from(value: &IndexedResourceCandidate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IndexedResourceCandidate> for &::windows::core::IInspectable {
-    fn from(value: &IndexedResourceCandidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IndexedResourceCandidate, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IndexedResourceCandidate {}
 unsafe impl ::core::marker::Sync for IndexedResourceCandidate {}
 #[doc = "*Required features: `\"ApplicationModel_Resources_Management\"`*"]
@@ -281,36 +252,7 @@ unsafe impl ::windows::core::Interface for IndexedResourceQualifier {
 impl ::windows::core::RuntimeName for IndexedResourceQualifier {
     const NAME: &'static str = "Windows.ApplicationModel.Resources.Management.IndexedResourceQualifier";
 }
-impl ::core::convert::From<IndexedResourceQualifier> for ::windows::core::IUnknown {
-    fn from(value: IndexedResourceQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IndexedResourceQualifier> for ::windows::core::IUnknown {
-    fn from(value: &IndexedResourceQualifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IndexedResourceQualifier> for &::windows::core::IUnknown {
-    fn from(value: &IndexedResourceQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IndexedResourceQualifier> for ::windows::core::IInspectable {
-    fn from(value: IndexedResourceQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IndexedResourceQualifier> for ::windows::core::IInspectable {
-    fn from(value: &IndexedResourceQualifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IndexedResourceQualifier> for &::windows::core::IInspectable {
-    fn from(value: &IndexedResourceQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IndexedResourceQualifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IndexedResourceQualifier {}
 unsafe impl ::core::marker::Sync for IndexedResourceQualifier {}
 #[doc = "*Required features: `\"ApplicationModel_Resources_Management\"`, `\"deprecated\"`*"]
@@ -407,41 +349,7 @@ impl ::windows::core::RuntimeName for ResourceIndexer {
     const NAME: &'static str = "Windows.ApplicationModel.Resources.Management.ResourceIndexer";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<ResourceIndexer> for ::windows::core::IUnknown {
-    fn from(value: ResourceIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ResourceIndexer> for ::windows::core::IUnknown {
-    fn from(value: &ResourceIndexer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ResourceIndexer> for &::windows::core::IUnknown {
-    fn from(value: &ResourceIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<ResourceIndexer> for ::windows::core::IInspectable {
-    fn from(value: ResourceIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ResourceIndexer> for ::windows::core::IInspectable {
-    fn from(value: &ResourceIndexer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ResourceIndexer> for &::windows::core::IInspectable {
-    fn from(value: &ResourceIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceIndexer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for ResourceIndexer {}
 #[cfg(feature = "deprecated")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/mod.rs
@@ -256,36 +256,7 @@ unsafe impl ::windows::core::Interface for ResourceLoader {
 impl ::windows::core::RuntimeName for ResourceLoader {
     const NAME: &'static str = "Windows.ApplicationModel.Resources.ResourceLoader";
 }
-impl ::core::convert::From<ResourceLoader> for ::windows::core::IUnknown {
-    fn from(value: ResourceLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceLoader> for ::windows::core::IUnknown {
-    fn from(value: &ResourceLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceLoader> for &::windows::core::IUnknown {
-    fn from(value: &ResourceLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ResourceLoader> for ::windows::core::IInspectable {
-    fn from(value: ResourceLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceLoader> for ::windows::core::IInspectable {
-    fn from(value: &ResourceLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceLoader> for &::windows::core::IInspectable {
-    fn from(value: &ResourceLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceLoader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ResourceLoader {}
 unsafe impl ::core::marker::Sync for ResourceLoader {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Search/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Search/Core/mod.rs
@@ -134,36 +134,7 @@ unsafe impl ::windows::core::Interface for RequestingFocusOnKeyboardInputEventAr
 impl ::windows::core::RuntimeName for RequestingFocusOnKeyboardInputEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Search.Core.RequestingFocusOnKeyboardInputEventArgs";
 }
-impl ::core::convert::From<RequestingFocusOnKeyboardInputEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RequestingFocusOnKeyboardInputEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RequestingFocusOnKeyboardInputEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RequestingFocusOnKeyboardInputEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RequestingFocusOnKeyboardInputEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RequestingFocusOnKeyboardInputEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RequestingFocusOnKeyboardInputEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RequestingFocusOnKeyboardInputEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RequestingFocusOnKeyboardInputEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RequestingFocusOnKeyboardInputEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RequestingFocusOnKeyboardInputEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RequestingFocusOnKeyboardInputEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RequestingFocusOnKeyboardInputEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RequestingFocusOnKeyboardInputEventArgs {}
 unsafe impl ::core::marker::Sync for RequestingFocusOnKeyboardInputEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Search_Core\"`*"]
@@ -247,36 +218,7 @@ unsafe impl ::windows::core::Interface for SearchSuggestion {
 impl ::windows::core::RuntimeName for SearchSuggestion {
     const NAME: &'static str = "Windows.ApplicationModel.Search.Core.SearchSuggestion";
 }
-impl ::core::convert::From<SearchSuggestion> for ::windows::core::IUnknown {
-    fn from(value: SearchSuggestion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestion> for ::windows::core::IUnknown {
-    fn from(value: &SearchSuggestion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestion> for &::windows::core::IUnknown {
-    fn from(value: &SearchSuggestion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SearchSuggestion> for ::windows::core::IInspectable {
-    fn from(value: SearchSuggestion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestion> for ::windows::core::IInspectable {
-    fn from(value: &SearchSuggestion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestion> for &::windows::core::IInspectable {
-    fn from(value: &SearchSuggestion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchSuggestion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Search_Core\"`*"]
 #[repr(transparent)]
 pub struct SearchSuggestionManager(::windows::core::IUnknown);
@@ -410,36 +352,7 @@ unsafe impl ::windows::core::Interface for SearchSuggestionManager {
 impl ::windows::core::RuntimeName for SearchSuggestionManager {
     const NAME: &'static str = "Windows.ApplicationModel.Search.Core.SearchSuggestionManager";
 }
-impl ::core::convert::From<SearchSuggestionManager> for ::windows::core::IUnknown {
-    fn from(value: SearchSuggestionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestionManager> for ::windows::core::IUnknown {
-    fn from(value: &SearchSuggestionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestionManager> for &::windows::core::IUnknown {
-    fn from(value: &SearchSuggestionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SearchSuggestionManager> for ::windows::core::IInspectable {
-    fn from(value: SearchSuggestionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestionManager> for ::windows::core::IInspectable {
-    fn from(value: &SearchSuggestionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestionManager> for &::windows::core::IInspectable {
-    fn from(value: &SearchSuggestionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchSuggestionManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Search_Core\"`*"]
 #[repr(transparent)]
 pub struct SearchSuggestionsRequestedEventArgs(::windows::core::IUnknown);
@@ -505,36 +418,7 @@ unsafe impl ::windows::core::Interface for SearchSuggestionsRequestedEventArgs {
 impl ::windows::core::RuntimeName for SearchSuggestionsRequestedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Search.Core.SearchSuggestionsRequestedEventArgs";
 }
-impl ::core::convert::From<SearchSuggestionsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SearchSuggestionsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SearchSuggestionsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SearchSuggestionsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SearchSuggestionsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SearchSuggestionsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SearchSuggestionsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SearchSuggestionsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchSuggestionsRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SearchSuggestionsRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for SearchSuggestionsRequestedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Search_Core\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Search/mod.rs
@@ -179,41 +179,7 @@ impl ISearchPaneQueryChangedEventArgs {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<ISearchPaneQueryChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ISearchPaneQueryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a ISearchPaneQueryChangedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchPaneQueryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ISearchPaneQueryChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ISearchPaneQueryChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<ISearchPaneQueryChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ISearchPaneQueryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a ISearchPaneQueryChangedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISearchPaneQueryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ISearchPaneQueryChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ISearchPaneQueryChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchPaneQueryChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for ISearchPaneQueryChangedEventArgs {
     fn clone(&self) -> Self {
@@ -677,36 +643,7 @@ unsafe impl ::windows::core::Interface for LocalContentSuggestionSettings {
 impl ::windows::core::RuntimeName for LocalContentSuggestionSettings {
     const NAME: &'static str = "Windows.ApplicationModel.Search.LocalContentSuggestionSettings";
 }
-impl ::core::convert::From<LocalContentSuggestionSettings> for ::windows::core::IUnknown {
-    fn from(value: LocalContentSuggestionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocalContentSuggestionSettings> for ::windows::core::IUnknown {
-    fn from(value: &LocalContentSuggestionSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocalContentSuggestionSettings> for &::windows::core::IUnknown {
-    fn from(value: &LocalContentSuggestionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LocalContentSuggestionSettings> for ::windows::core::IInspectable {
-    fn from(value: LocalContentSuggestionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocalContentSuggestionSettings> for ::windows::core::IInspectable {
-    fn from(value: &LocalContentSuggestionSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocalContentSuggestionSettings> for &::windows::core::IInspectable {
-    fn from(value: &LocalContentSuggestionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LocalContentSuggestionSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Search\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -969,41 +906,7 @@ impl ::windows::core::RuntimeName for SearchPane {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchPane";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPane> for ::windows::core::IUnknown {
-    fn from(value: SearchPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPane> for ::windows::core::IUnknown {
-    fn from(value: &SearchPane) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPane> for &::windows::core::IUnknown {
-    fn from(value: &SearchPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPane> for ::windows::core::IInspectable {
-    fn from(value: SearchPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPane> for ::windows::core::IInspectable {
-    fn from(value: &SearchPane) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPane> for &::windows::core::IInspectable {
-    fn from(value: &SearchPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchPane, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_Search\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -1079,41 +982,7 @@ impl ::windows::core::RuntimeName for SearchPaneQueryChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchPaneQueryChangedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneQueryChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SearchPaneQueryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneQueryChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SearchPaneQueryChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneQueryChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SearchPaneQueryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneQueryChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SearchPaneQueryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneQueryChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SearchPaneQueryChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneQueryChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SearchPaneQueryChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchPaneQueryChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<SearchPaneQueryChangedEventArgs> for ISearchPaneQueryChangedEventArgs {
     type Error = ::windows::core::Error;
@@ -1200,36 +1069,7 @@ unsafe impl ::windows::core::Interface for SearchPaneQueryLinguisticDetails {
 impl ::windows::core::RuntimeName for SearchPaneQueryLinguisticDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchPaneQueryLinguisticDetails";
 }
-impl ::core::convert::From<SearchPaneQueryLinguisticDetails> for ::windows::core::IUnknown {
-    fn from(value: SearchPaneQueryLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchPaneQueryLinguisticDetails> for ::windows::core::IUnknown {
-    fn from(value: &SearchPaneQueryLinguisticDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchPaneQueryLinguisticDetails> for &::windows::core::IUnknown {
-    fn from(value: &SearchPaneQueryLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SearchPaneQueryLinguisticDetails> for ::windows::core::IInspectable {
-    fn from(value: SearchPaneQueryLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchPaneQueryLinguisticDetails> for ::windows::core::IInspectable {
-    fn from(value: &SearchPaneQueryLinguisticDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchPaneQueryLinguisticDetails> for &::windows::core::IInspectable {
-    fn from(value: &SearchPaneQueryLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchPaneQueryLinguisticDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SearchPaneQueryLinguisticDetails {}
 unsafe impl ::core::marker::Sync for SearchPaneQueryLinguisticDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Search\"`, `\"deprecated\"`*"]
@@ -1307,41 +1147,7 @@ impl ::windows::core::RuntimeName for SearchPaneQuerySubmittedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchPaneQuerySubmittedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneQuerySubmittedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SearchPaneQuerySubmittedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneQuerySubmittedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SearchPaneQuerySubmittedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneQuerySubmittedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SearchPaneQuerySubmittedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneQuerySubmittedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SearchPaneQuerySubmittedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneQuerySubmittedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SearchPaneQuerySubmittedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneQuerySubmittedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SearchPaneQuerySubmittedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchPaneQuerySubmittedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SearchPaneQuerySubmittedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -1403,41 +1209,7 @@ impl ::windows::core::RuntimeName for SearchPaneResultSuggestionChosenEventArgs 
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchPaneResultSuggestionChosenEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneResultSuggestionChosenEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SearchPaneResultSuggestionChosenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneResultSuggestionChosenEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SearchPaneResultSuggestionChosenEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneResultSuggestionChosenEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SearchPaneResultSuggestionChosenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneResultSuggestionChosenEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SearchPaneResultSuggestionChosenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneResultSuggestionChosenEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SearchPaneResultSuggestionChosenEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneResultSuggestionChosenEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SearchPaneResultSuggestionChosenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchPaneResultSuggestionChosenEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SearchPaneResultSuggestionChosenEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -1517,41 +1289,7 @@ impl ::windows::core::RuntimeName for SearchPaneSuggestionsRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchPaneSuggestionsRequest";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneSuggestionsRequest> for ::windows::core::IUnknown {
-    fn from(value: SearchPaneSuggestionsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequest> for ::windows::core::IUnknown {
-    fn from(value: &SearchPaneSuggestionsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequest> for &::windows::core::IUnknown {
-    fn from(value: &SearchPaneSuggestionsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneSuggestionsRequest> for ::windows::core::IInspectable {
-    fn from(value: SearchPaneSuggestionsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequest> for ::windows::core::IInspectable {
-    fn from(value: &SearchPaneSuggestionsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequest> for &::windows::core::IInspectable {
-    fn from(value: &SearchPaneSuggestionsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchPaneSuggestionsRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SearchPaneSuggestionsRequest {}
 #[cfg(feature = "deprecated")]
@@ -1610,41 +1348,7 @@ impl ::windows::core::RuntimeName for SearchPaneSuggestionsRequestDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchPaneSuggestionsRequestDeferral";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneSuggestionsRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: SearchPaneSuggestionsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: &SearchPaneSuggestionsRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequestDeferral> for &::windows::core::IUnknown {
-    fn from(value: &SearchPaneSuggestionsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneSuggestionsRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: SearchPaneSuggestionsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: &SearchPaneSuggestionsRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequestDeferral> for &::windows::core::IInspectable {
-    fn from(value: &SearchPaneSuggestionsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchPaneSuggestionsRequestDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SearchPaneSuggestionsRequestDeferral {}
 #[cfg(feature = "deprecated")]
@@ -1733,41 +1437,7 @@ impl ::windows::core::RuntimeName for SearchPaneSuggestionsRequestedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchPaneSuggestionsRequestedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneSuggestionsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SearchPaneSuggestionsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SearchPaneSuggestionsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SearchPaneSuggestionsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneSuggestionsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SearchPaneSuggestionsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SearchPaneSuggestionsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneSuggestionsRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SearchPaneSuggestionsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchPaneSuggestionsRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<SearchPaneSuggestionsRequestedEventArgs> for ISearchPaneQueryChangedEventArgs {
     type Error = ::windows::core::Error;
@@ -1851,41 +1521,7 @@ impl ::windows::core::RuntimeName for SearchPaneVisibilityChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchPaneVisibilityChangedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneVisibilityChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SearchPaneVisibilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneVisibilityChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SearchPaneVisibilityChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneVisibilityChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SearchPaneVisibilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SearchPaneVisibilityChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SearchPaneVisibilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneVisibilityChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SearchPaneVisibilityChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SearchPaneVisibilityChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SearchPaneVisibilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchPaneVisibilityChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SearchPaneVisibilityChangedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -1967,36 +1603,7 @@ unsafe impl ::windows::core::Interface for SearchQueryLinguisticDetails {
 impl ::windows::core::RuntimeName for SearchQueryLinguisticDetails {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchQueryLinguisticDetails";
 }
-impl ::core::convert::From<SearchQueryLinguisticDetails> for ::windows::core::IUnknown {
-    fn from(value: SearchQueryLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchQueryLinguisticDetails> for ::windows::core::IUnknown {
-    fn from(value: &SearchQueryLinguisticDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchQueryLinguisticDetails> for &::windows::core::IUnknown {
-    fn from(value: &SearchQueryLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SearchQueryLinguisticDetails> for ::windows::core::IInspectable {
-    fn from(value: SearchQueryLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchQueryLinguisticDetails> for ::windows::core::IInspectable {
-    fn from(value: &SearchQueryLinguisticDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchQueryLinguisticDetails> for &::windows::core::IInspectable {
-    fn from(value: &SearchQueryLinguisticDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchQueryLinguisticDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SearchQueryLinguisticDetails {}
 unsafe impl ::core::marker::Sync for SearchQueryLinguisticDetails {}
 #[doc = "*Required features: `\"ApplicationModel_Search\"`*"]
@@ -2071,36 +1678,7 @@ unsafe impl ::windows::core::Interface for SearchSuggestionCollection {
 impl ::windows::core::RuntimeName for SearchSuggestionCollection {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchSuggestionCollection";
 }
-impl ::core::convert::From<SearchSuggestionCollection> for ::windows::core::IUnknown {
-    fn from(value: SearchSuggestionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestionCollection> for ::windows::core::IUnknown {
-    fn from(value: &SearchSuggestionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestionCollection> for &::windows::core::IUnknown {
-    fn from(value: &SearchSuggestionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SearchSuggestionCollection> for ::windows::core::IInspectable {
-    fn from(value: SearchSuggestionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestionCollection> for ::windows::core::IInspectable {
-    fn from(value: &SearchSuggestionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestionCollection> for &::windows::core::IInspectable {
-    fn from(value: &SearchSuggestionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchSuggestionCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SearchSuggestionCollection {}
 unsafe impl ::core::marker::Sync for SearchSuggestionCollection {}
 #[doc = "*Required features: `\"ApplicationModel_Search\"`*"]
@@ -2161,36 +1739,7 @@ unsafe impl ::windows::core::Interface for SearchSuggestionsRequest {
 impl ::windows::core::RuntimeName for SearchSuggestionsRequest {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchSuggestionsRequest";
 }
-impl ::core::convert::From<SearchSuggestionsRequest> for ::windows::core::IUnknown {
-    fn from(value: SearchSuggestionsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequest> for ::windows::core::IUnknown {
-    fn from(value: &SearchSuggestionsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequest> for &::windows::core::IUnknown {
-    fn from(value: &SearchSuggestionsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SearchSuggestionsRequest> for ::windows::core::IInspectable {
-    fn from(value: SearchSuggestionsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequest> for ::windows::core::IInspectable {
-    fn from(value: &SearchSuggestionsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequest> for &::windows::core::IInspectable {
-    fn from(value: &SearchSuggestionsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchSuggestionsRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SearchSuggestionsRequest {}
 unsafe impl ::core::marker::Sync for SearchSuggestionsRequest {}
 #[doc = "*Required features: `\"ApplicationModel_Search\"`*"]
@@ -2234,36 +1783,7 @@ unsafe impl ::windows::core::Interface for SearchSuggestionsRequestDeferral {
 impl ::windows::core::RuntimeName for SearchSuggestionsRequestDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.Search.SearchSuggestionsRequestDeferral";
 }
-impl ::core::convert::From<SearchSuggestionsRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: SearchSuggestionsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: &SearchSuggestionsRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequestDeferral> for &::windows::core::IUnknown {
-    fn from(value: &SearchSuggestionsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SearchSuggestionsRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: SearchSuggestionsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: &SearchSuggestionsRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SearchSuggestionsRequestDeferral> for &::windows::core::IInspectable {
-    fn from(value: &SearchSuggestionsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SearchSuggestionsRequestDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SearchSuggestionsRequestDeferral {}
 unsafe impl ::core::marker::Sync for SearchSuggestionsRequestDeferral {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/SocialInfo/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/SocialInfo/Provider/mod.rs
@@ -248,41 +248,7 @@ impl ::windows::core::RuntimeName for SocialDashboardItemUpdater {
     const NAME: &'static str = "Windows.ApplicationModel.SocialInfo.Provider.SocialDashboardItemUpdater";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialDashboardItemUpdater> for ::windows::core::IUnknown {
-    fn from(value: SocialDashboardItemUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialDashboardItemUpdater> for ::windows::core::IUnknown {
-    fn from(value: &SocialDashboardItemUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialDashboardItemUpdater> for &::windows::core::IUnknown {
-    fn from(value: &SocialDashboardItemUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialDashboardItemUpdater> for ::windows::core::IInspectable {
-    fn from(value: SocialDashboardItemUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialDashboardItemUpdater> for ::windows::core::IInspectable {
-    fn from(value: &SocialDashboardItemUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialDashboardItemUpdater> for &::windows::core::IInspectable {
-    fn from(value: &SocialDashboardItemUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocialDashboardItemUpdater, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SocialDashboardItemUpdater {}
 #[cfg(feature = "deprecated")]
@@ -371,41 +337,7 @@ impl ::windows::core::RuntimeName for SocialFeedUpdater {
     const NAME: &'static str = "Windows.ApplicationModel.SocialInfo.Provider.SocialFeedUpdater";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialFeedUpdater> for ::windows::core::IUnknown {
-    fn from(value: SocialFeedUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedUpdater> for ::windows::core::IUnknown {
-    fn from(value: &SocialFeedUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedUpdater> for &::windows::core::IUnknown {
-    fn from(value: &SocialFeedUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialFeedUpdater> for ::windows::core::IInspectable {
-    fn from(value: SocialFeedUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedUpdater> for ::windows::core::IInspectable {
-    fn from(value: &SocialFeedUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedUpdater> for &::windows::core::IInspectable {
-    fn from(value: &SocialFeedUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocialFeedUpdater, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SocialFeedUpdater {}
 #[cfg(feature = "deprecated")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/SocialInfo/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/SocialInfo/mod.rs
@@ -484,41 +484,7 @@ impl ::windows::core::RuntimeName for SocialFeedChildItem {
     const NAME: &'static str = "Windows.ApplicationModel.SocialInfo.SocialFeedChildItem";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialFeedChildItem> for ::windows::core::IUnknown {
-    fn from(value: SocialFeedChildItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedChildItem> for ::windows::core::IUnknown {
-    fn from(value: &SocialFeedChildItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedChildItem> for &::windows::core::IUnknown {
-    fn from(value: &SocialFeedChildItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialFeedChildItem> for ::windows::core::IInspectable {
-    fn from(value: SocialFeedChildItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedChildItem> for ::windows::core::IInspectable {
-    fn from(value: &SocialFeedChildItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedChildItem> for &::windows::core::IInspectable {
-    fn from(value: &SocialFeedChildItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocialFeedChildItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SocialFeedChildItem {}
 #[cfg(feature = "deprecated")]
@@ -616,41 +582,7 @@ impl ::windows::core::RuntimeName for SocialFeedContent {
     const NAME: &'static str = "Windows.ApplicationModel.SocialInfo.SocialFeedContent";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialFeedContent> for ::windows::core::IUnknown {
-    fn from(value: SocialFeedContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedContent> for ::windows::core::IUnknown {
-    fn from(value: &SocialFeedContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedContent> for &::windows::core::IUnknown {
-    fn from(value: &SocialFeedContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialFeedContent> for ::windows::core::IInspectable {
-    fn from(value: SocialFeedContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedContent> for ::windows::core::IInspectable {
-    fn from(value: &SocialFeedContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedContent> for &::windows::core::IInspectable {
-    fn from(value: &SocialFeedContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocialFeedContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SocialFeedContent {}
 #[cfg(feature = "deprecated")]
@@ -866,41 +798,7 @@ impl ::windows::core::RuntimeName for SocialFeedItem {
     const NAME: &'static str = "Windows.ApplicationModel.SocialInfo.SocialFeedItem";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialFeedItem> for ::windows::core::IUnknown {
-    fn from(value: SocialFeedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedItem> for ::windows::core::IUnknown {
-    fn from(value: &SocialFeedItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedItem> for &::windows::core::IUnknown {
-    fn from(value: &SocialFeedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialFeedItem> for ::windows::core::IInspectable {
-    fn from(value: SocialFeedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedItem> for ::windows::core::IInspectable {
-    fn from(value: &SocialFeedItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedItem> for &::windows::core::IInspectable {
-    fn from(value: &SocialFeedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocialFeedItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SocialFeedItem {}
 #[cfg(feature = "deprecated")]
@@ -1029,41 +927,7 @@ impl ::windows::core::RuntimeName for SocialFeedSharedItem {
     const NAME: &'static str = "Windows.ApplicationModel.SocialInfo.SocialFeedSharedItem";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialFeedSharedItem> for ::windows::core::IUnknown {
-    fn from(value: SocialFeedSharedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedSharedItem> for ::windows::core::IUnknown {
-    fn from(value: &SocialFeedSharedItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedSharedItem> for &::windows::core::IUnknown {
-    fn from(value: &SocialFeedSharedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialFeedSharedItem> for ::windows::core::IInspectable {
-    fn from(value: SocialFeedSharedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedSharedItem> for ::windows::core::IInspectable {
-    fn from(value: &SocialFeedSharedItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialFeedSharedItem> for &::windows::core::IInspectable {
-    fn from(value: &SocialFeedSharedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocialFeedSharedItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SocialFeedSharedItem {}
 #[cfg(feature = "deprecated")]
@@ -1181,41 +1045,7 @@ impl ::windows::core::RuntimeName for SocialItemThumbnail {
     const NAME: &'static str = "Windows.ApplicationModel.SocialInfo.SocialItemThumbnail";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialItemThumbnail> for ::windows::core::IUnknown {
-    fn from(value: SocialItemThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialItemThumbnail> for ::windows::core::IUnknown {
-    fn from(value: &SocialItemThumbnail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialItemThumbnail> for &::windows::core::IUnknown {
-    fn from(value: &SocialItemThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialItemThumbnail> for ::windows::core::IInspectable {
-    fn from(value: SocialItemThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialItemThumbnail> for ::windows::core::IInspectable {
-    fn from(value: &SocialItemThumbnail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialItemThumbnail> for &::windows::core::IInspectable {
-    fn from(value: &SocialItemThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocialItemThumbnail, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SocialItemThumbnail {}
 #[cfg(feature = "deprecated")]
@@ -1328,41 +1158,7 @@ impl ::windows::core::RuntimeName for SocialUserInfo {
     const NAME: &'static str = "Windows.ApplicationModel.SocialInfo.SocialUserInfo";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialUserInfo> for ::windows::core::IUnknown {
-    fn from(value: SocialUserInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialUserInfo> for ::windows::core::IUnknown {
-    fn from(value: &SocialUserInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialUserInfo> for &::windows::core::IUnknown {
-    fn from(value: &SocialUserInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SocialUserInfo> for ::windows::core::IInspectable {
-    fn from(value: SocialUserInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialUserInfo> for ::windows::core::IInspectable {
-    fn from(value: &SocialUserInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SocialUserInfo> for &::windows::core::IInspectable {
-    fn from(value: &SocialUserInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocialUserInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SocialUserInfo {}
 #[cfg(feature = "deprecated")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/LicenseManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/LicenseManagement/mod.rs
@@ -215,36 +215,7 @@ unsafe impl ::windows::core::Interface for LicenseSatisfactionInfo {
 impl ::windows::core::RuntimeName for LicenseSatisfactionInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Store.LicenseManagement.LicenseSatisfactionInfo";
 }
-impl ::core::convert::From<LicenseSatisfactionInfo> for ::windows::core::IUnknown {
-    fn from(value: LicenseSatisfactionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LicenseSatisfactionInfo> for ::windows::core::IUnknown {
-    fn from(value: &LicenseSatisfactionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LicenseSatisfactionInfo> for &::windows::core::IUnknown {
-    fn from(value: &LicenseSatisfactionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LicenseSatisfactionInfo> for ::windows::core::IInspectable {
-    fn from(value: LicenseSatisfactionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LicenseSatisfactionInfo> for ::windows::core::IInspectable {
-    fn from(value: &LicenseSatisfactionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LicenseSatisfactionInfo> for &::windows::core::IInspectable {
-    fn from(value: &LicenseSatisfactionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LicenseSatisfactionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LicenseSatisfactionInfo {}
 unsafe impl ::core::marker::Sync for LicenseSatisfactionInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Store_LicenseManagement\"`*"]
@@ -300,36 +271,7 @@ unsafe impl ::windows::core::Interface for LicenseSatisfactionResult {
 impl ::windows::core::RuntimeName for LicenseSatisfactionResult {
     const NAME: &'static str = "Windows.ApplicationModel.Store.LicenseManagement.LicenseSatisfactionResult";
 }
-impl ::core::convert::From<LicenseSatisfactionResult> for ::windows::core::IUnknown {
-    fn from(value: LicenseSatisfactionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LicenseSatisfactionResult> for ::windows::core::IUnknown {
-    fn from(value: &LicenseSatisfactionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LicenseSatisfactionResult> for &::windows::core::IUnknown {
-    fn from(value: &LicenseSatisfactionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LicenseSatisfactionResult> for ::windows::core::IInspectable {
-    fn from(value: LicenseSatisfactionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LicenseSatisfactionResult> for ::windows::core::IInspectable {
-    fn from(value: &LicenseSatisfactionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LicenseSatisfactionResult> for &::windows::core::IInspectable {
-    fn from(value: &LicenseSatisfactionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LicenseSatisfactionResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LicenseSatisfactionResult {}
 unsafe impl ::core::marker::Sync for LicenseSatisfactionResult {}
 #[doc = "*Required features: `\"ApplicationModel_Store_LicenseManagement\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/InstallControl/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/InstallControl/mod.rs
@@ -755,36 +755,7 @@ unsafe impl ::windows::core::Interface for AppInstallItem {
 impl ::windows::core::RuntimeName for AppInstallItem {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallItem";
 }
-impl ::core::convert::From<AppInstallItem> for ::windows::core::IUnknown {
-    fn from(value: AppInstallItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallItem> for ::windows::core::IUnknown {
-    fn from(value: &AppInstallItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallItem> for &::windows::core::IUnknown {
-    fn from(value: &AppInstallItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppInstallItem> for ::windows::core::IInspectable {
-    fn from(value: AppInstallItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallItem> for ::windows::core::IInspectable {
-    fn from(value: &AppInstallItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallItem> for &::windows::core::IInspectable {
-    fn from(value: &AppInstallItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppInstallItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppInstallItem {}
 unsafe impl ::core::marker::Sync for AppInstallItem {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview_InstallControl\"`*"]
@@ -1206,36 +1177,7 @@ unsafe impl ::windows::core::Interface for AppInstallManager {
 impl ::windows::core::RuntimeName for AppInstallManager {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallManager";
 }
-impl ::core::convert::From<AppInstallManager> for ::windows::core::IUnknown {
-    fn from(value: AppInstallManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallManager> for ::windows::core::IUnknown {
-    fn from(value: &AppInstallManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallManager> for &::windows::core::IUnknown {
-    fn from(value: &AppInstallManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppInstallManager> for ::windows::core::IInspectable {
-    fn from(value: AppInstallManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallManager> for ::windows::core::IInspectable {
-    fn from(value: &AppInstallManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallManager> for &::windows::core::IInspectable {
-    fn from(value: &AppInstallManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppInstallManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppInstallManager {}
 unsafe impl ::core::marker::Sync for AppInstallManager {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview_InstallControl\"`*"]
@@ -1282,36 +1224,7 @@ unsafe impl ::windows::core::Interface for AppInstallManagerItemEventArgs {
 impl ::windows::core::RuntimeName for AppInstallManagerItemEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallManagerItemEventArgs";
 }
-impl ::core::convert::From<AppInstallManagerItemEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppInstallManagerItemEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallManagerItemEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppInstallManagerItemEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallManagerItemEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppInstallManagerItemEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppInstallManagerItemEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppInstallManagerItemEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallManagerItemEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppInstallManagerItemEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallManagerItemEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppInstallManagerItemEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppInstallManagerItemEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppInstallManagerItemEventArgs {}
 unsafe impl ::core::marker::Sync for AppInstallManagerItemEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview_InstallControl\"`*"]
@@ -1527,36 +1440,7 @@ unsafe impl ::windows::core::Interface for AppInstallOptions {
 impl ::windows::core::RuntimeName for AppInstallOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallOptions";
 }
-impl ::core::convert::From<AppInstallOptions> for ::windows::core::IUnknown {
-    fn from(value: AppInstallOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallOptions> for ::windows::core::IUnknown {
-    fn from(value: &AppInstallOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallOptions> for &::windows::core::IUnknown {
-    fn from(value: &AppInstallOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppInstallOptions> for ::windows::core::IInspectable {
-    fn from(value: AppInstallOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallOptions> for ::windows::core::IInspectable {
-    fn from(value: &AppInstallOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallOptions> for &::windows::core::IInspectable {
-    fn from(value: &AppInstallOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppInstallOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppInstallOptions {}
 unsafe impl ::core::marker::Sync for AppInstallOptions {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview_InstallControl\"`*"]
@@ -1654,36 +1538,7 @@ unsafe impl ::windows::core::Interface for AppInstallStatus {
 impl ::windows::core::RuntimeName for AppInstallStatus {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.InstallControl.AppInstallStatus";
 }
-impl ::core::convert::From<AppInstallStatus> for ::windows::core::IUnknown {
-    fn from(value: AppInstallStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallStatus> for ::windows::core::IUnknown {
-    fn from(value: &AppInstallStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallStatus> for &::windows::core::IUnknown {
-    fn from(value: &AppInstallStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppInstallStatus> for ::windows::core::IInspectable {
-    fn from(value: AppInstallStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallStatus> for ::windows::core::IInspectable {
-    fn from(value: &AppInstallStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallStatus> for &::windows::core::IInspectable {
-    fn from(value: &AppInstallStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppInstallStatus, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppInstallStatus {}
 unsafe impl ::core::marker::Sync for AppInstallStatus {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview_InstallControl\"`*"]
@@ -1763,36 +1618,7 @@ unsafe impl ::windows::core::Interface for AppUpdateOptions {
 impl ::windows::core::RuntimeName for AppUpdateOptions {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.InstallControl.AppUpdateOptions";
 }
-impl ::core::convert::From<AppUpdateOptions> for ::windows::core::IUnknown {
-    fn from(value: AppUpdateOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppUpdateOptions> for ::windows::core::IUnknown {
-    fn from(value: &AppUpdateOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppUpdateOptions> for &::windows::core::IUnknown {
-    fn from(value: &AppUpdateOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppUpdateOptions> for ::windows::core::IInspectable {
-    fn from(value: AppUpdateOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppUpdateOptions> for ::windows::core::IInspectable {
-    fn from(value: &AppUpdateOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppUpdateOptions> for &::windows::core::IInspectable {
-    fn from(value: &AppUpdateOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppUpdateOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppUpdateOptions {}
 unsafe impl ::core::marker::Sync for AppUpdateOptions {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview_InstallControl\"`*"]
@@ -1839,36 +1665,7 @@ unsafe impl ::windows::core::Interface for GetEntitlementResult {
 impl ::windows::core::RuntimeName for GetEntitlementResult {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.InstallControl.GetEntitlementResult";
 }
-impl ::core::convert::From<GetEntitlementResult> for ::windows::core::IUnknown {
-    fn from(value: GetEntitlementResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GetEntitlementResult> for ::windows::core::IUnknown {
-    fn from(value: &GetEntitlementResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GetEntitlementResult> for &::windows::core::IUnknown {
-    fn from(value: &GetEntitlementResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GetEntitlementResult> for ::windows::core::IInspectable {
-    fn from(value: GetEntitlementResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GetEntitlementResult> for ::windows::core::IInspectable {
-    fn from(value: &GetEntitlementResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GetEntitlementResult> for &::windows::core::IInspectable {
-    fn from(value: &GetEntitlementResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GetEntitlementResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GetEntitlementResult {}
 unsafe impl ::core::marker::Sync for GetEntitlementResult {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview_InstallControl\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/mod.rs
@@ -358,36 +358,7 @@ unsafe impl ::windows::core::Interface for DeliveryOptimizationSettings {
 impl ::windows::core::RuntimeName for DeliveryOptimizationSettings {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.DeliveryOptimizationSettings";
 }
-impl ::core::convert::From<DeliveryOptimizationSettings> for ::windows::core::IUnknown {
-    fn from(value: DeliveryOptimizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeliveryOptimizationSettings> for ::windows::core::IUnknown {
-    fn from(value: &DeliveryOptimizationSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeliveryOptimizationSettings> for &::windows::core::IUnknown {
-    fn from(value: &DeliveryOptimizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeliveryOptimizationSettings> for ::windows::core::IInspectable {
-    fn from(value: DeliveryOptimizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeliveryOptimizationSettings> for ::windows::core::IInspectable {
-    fn from(value: &DeliveryOptimizationSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeliveryOptimizationSettings> for &::windows::core::IInspectable {
-    fn from(value: &DeliveryOptimizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeliveryOptimizationSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeliveryOptimizationSettings {}
 unsafe impl ::core::marker::Sync for DeliveryOptimizationSettings {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview\"`*"]
@@ -667,36 +638,7 @@ unsafe impl ::windows::core::Interface for StoreHardwareManufacturerInfo {
 impl ::windows::core::RuntimeName for StoreHardwareManufacturerInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.StoreHardwareManufacturerInfo";
 }
-impl ::core::convert::From<StoreHardwareManufacturerInfo> for ::windows::core::IUnknown {
-    fn from(value: StoreHardwareManufacturerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreHardwareManufacturerInfo> for ::windows::core::IUnknown {
-    fn from(value: &StoreHardwareManufacturerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreHardwareManufacturerInfo> for &::windows::core::IUnknown {
-    fn from(value: &StoreHardwareManufacturerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreHardwareManufacturerInfo> for ::windows::core::IInspectable {
-    fn from(value: StoreHardwareManufacturerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreHardwareManufacturerInfo> for ::windows::core::IInspectable {
-    fn from(value: &StoreHardwareManufacturerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreHardwareManufacturerInfo> for &::windows::core::IInspectable {
-    fn from(value: &StoreHardwareManufacturerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreHardwareManufacturerInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreHardwareManufacturerInfo {}
 unsafe impl ::core::marker::Sync for StoreHardwareManufacturerInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview\"`*"]
@@ -801,36 +743,7 @@ unsafe impl ::windows::core::Interface for StorePreviewProductInfo {
 impl ::windows::core::RuntimeName for StorePreviewProductInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.StorePreviewProductInfo";
 }
-impl ::core::convert::From<StorePreviewProductInfo> for ::windows::core::IUnknown {
-    fn from(value: StorePreviewProductInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePreviewProductInfo> for ::windows::core::IUnknown {
-    fn from(value: &StorePreviewProductInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePreviewProductInfo> for &::windows::core::IUnknown {
-    fn from(value: &StorePreviewProductInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorePreviewProductInfo> for ::windows::core::IInspectable {
-    fn from(value: StorePreviewProductInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePreviewProductInfo> for ::windows::core::IInspectable {
-    fn from(value: &StorePreviewProductInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePreviewProductInfo> for &::windows::core::IInspectable {
-    fn from(value: &StorePreviewProductInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorePreviewProductInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorePreviewProductInfo {}
 unsafe impl ::core::marker::Sync for StorePreviewProductInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview\"`*"]
@@ -877,36 +790,7 @@ unsafe impl ::windows::core::Interface for StorePreviewPurchaseResults {
 impl ::windows::core::RuntimeName for StorePreviewPurchaseResults {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.StorePreviewPurchaseResults";
 }
-impl ::core::convert::From<StorePreviewPurchaseResults> for ::windows::core::IUnknown {
-    fn from(value: StorePreviewPurchaseResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePreviewPurchaseResults> for ::windows::core::IUnknown {
-    fn from(value: &StorePreviewPurchaseResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePreviewPurchaseResults> for &::windows::core::IUnknown {
-    fn from(value: &StorePreviewPurchaseResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorePreviewPurchaseResults> for ::windows::core::IInspectable {
-    fn from(value: StorePreviewPurchaseResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePreviewPurchaseResults> for ::windows::core::IInspectable {
-    fn from(value: &StorePreviewPurchaseResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePreviewPurchaseResults> for &::windows::core::IInspectable {
-    fn from(value: &StorePreviewPurchaseResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorePreviewPurchaseResults, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorePreviewPurchaseResults {}
 unsafe impl ::core::marker::Sync for StorePreviewPurchaseResults {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview\"`*"]
@@ -1009,36 +893,7 @@ unsafe impl ::windows::core::Interface for StorePreviewSkuInfo {
 impl ::windows::core::RuntimeName for StorePreviewSkuInfo {
     const NAME: &'static str = "Windows.ApplicationModel.Store.Preview.StorePreviewSkuInfo";
 }
-impl ::core::convert::From<StorePreviewSkuInfo> for ::windows::core::IUnknown {
-    fn from(value: StorePreviewSkuInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePreviewSkuInfo> for ::windows::core::IUnknown {
-    fn from(value: &StorePreviewSkuInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePreviewSkuInfo> for &::windows::core::IUnknown {
-    fn from(value: &StorePreviewSkuInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorePreviewSkuInfo> for ::windows::core::IInspectable {
-    fn from(value: StorePreviewSkuInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePreviewSkuInfo> for ::windows::core::IInspectable {
-    fn from(value: &StorePreviewSkuInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePreviewSkuInfo> for &::windows::core::IInspectable {
-    fn from(value: &StorePreviewSkuInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorePreviewSkuInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorePreviewSkuInfo {}
 unsafe impl ::core::marker::Sync for StorePreviewSkuInfo {}
 #[doc = "*Required features: `\"ApplicationModel_Store_Preview\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/mod.rs
@@ -932,36 +932,7 @@ unsafe impl ::windows::core::Interface for LicenseInformation {
 impl ::windows::core::RuntimeName for LicenseInformation {
     const NAME: &'static str = "Windows.ApplicationModel.Store.LicenseInformation";
 }
-impl ::core::convert::From<LicenseInformation> for ::windows::core::IUnknown {
-    fn from(value: LicenseInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LicenseInformation> for ::windows::core::IUnknown {
-    fn from(value: &LicenseInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LicenseInformation> for &::windows::core::IUnknown {
-    fn from(value: &LicenseInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LicenseInformation> for ::windows::core::IInspectable {
-    fn from(value: LicenseInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LicenseInformation> for ::windows::core::IInspectable {
-    fn from(value: &LicenseInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LicenseInformation> for &::windows::core::IInspectable {
-    fn from(value: &LicenseInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LicenseInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LicenseInformation {}
 unsafe impl ::core::marker::Sync for LicenseInformation {}
 #[doc = "*Required features: `\"ApplicationModel_Store\"`*"]
@@ -1075,36 +1046,7 @@ unsafe impl ::windows::core::Interface for ListingInformation {
 impl ::windows::core::RuntimeName for ListingInformation {
     const NAME: &'static str = "Windows.ApplicationModel.Store.ListingInformation";
 }
-impl ::core::convert::From<ListingInformation> for ::windows::core::IUnknown {
-    fn from(value: ListingInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ListingInformation> for ::windows::core::IUnknown {
-    fn from(value: &ListingInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ListingInformation> for &::windows::core::IUnknown {
-    fn from(value: &ListingInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ListingInformation> for ::windows::core::IInspectable {
-    fn from(value: ListingInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ListingInformation> for ::windows::core::IInspectable {
-    fn from(value: &ListingInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ListingInformation> for &::windows::core::IInspectable {
-    fn from(value: &ListingInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ListingInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ListingInformation {}
 unsafe impl ::core::marker::Sync for ListingInformation {}
 #[doc = "*Required features: `\"ApplicationModel_Store\"`*"]
@@ -1174,36 +1116,7 @@ unsafe impl ::windows::core::Interface for ProductLicense {
 impl ::windows::core::RuntimeName for ProductLicense {
     const NAME: &'static str = "Windows.ApplicationModel.Store.ProductLicense";
 }
-impl ::core::convert::From<ProductLicense> for ::windows::core::IUnknown {
-    fn from(value: ProductLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProductLicense> for ::windows::core::IUnknown {
-    fn from(value: &ProductLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProductLicense> for &::windows::core::IUnknown {
-    fn from(value: &ProductLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProductLicense> for ::windows::core::IInspectable {
-    fn from(value: ProductLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProductLicense> for ::windows::core::IInspectable {
-    fn from(value: &ProductLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProductLicense> for &::windows::core::IInspectable {
-    fn from(value: &ProductLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProductLicense, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProductLicense {}
 unsafe impl ::core::marker::Sync for ProductLicense {}
 #[doc = "*Required features: `\"ApplicationModel_Store\"`*"]
@@ -1333,36 +1246,7 @@ unsafe impl ::windows::core::Interface for ProductListing {
 impl ::windows::core::RuntimeName for ProductListing {
     const NAME: &'static str = "Windows.ApplicationModel.Store.ProductListing";
 }
-impl ::core::convert::From<ProductListing> for ::windows::core::IUnknown {
-    fn from(value: ProductListing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProductListing> for ::windows::core::IUnknown {
-    fn from(value: &ProductListing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProductListing> for &::windows::core::IUnknown {
-    fn from(value: &ProductListing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProductListing> for ::windows::core::IInspectable {
-    fn from(value: ProductListing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProductListing> for ::windows::core::IInspectable {
-    fn from(value: &ProductListing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProductListing> for &::windows::core::IInspectable {
-    fn from(value: &ProductListing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProductListing, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProductListing {}
 unsafe impl ::core::marker::Sync for ProductListing {}
 #[doc = "*Required features: `\"ApplicationModel_Store\"`*"]
@@ -1457,36 +1341,7 @@ unsafe impl ::windows::core::Interface for ProductPurchaseDisplayProperties {
 impl ::windows::core::RuntimeName for ProductPurchaseDisplayProperties {
     const NAME: &'static str = "Windows.ApplicationModel.Store.ProductPurchaseDisplayProperties";
 }
-impl ::core::convert::From<ProductPurchaseDisplayProperties> for ::windows::core::IUnknown {
-    fn from(value: ProductPurchaseDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProductPurchaseDisplayProperties> for ::windows::core::IUnknown {
-    fn from(value: &ProductPurchaseDisplayProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProductPurchaseDisplayProperties> for &::windows::core::IUnknown {
-    fn from(value: &ProductPurchaseDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProductPurchaseDisplayProperties> for ::windows::core::IInspectable {
-    fn from(value: ProductPurchaseDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProductPurchaseDisplayProperties> for ::windows::core::IInspectable {
-    fn from(value: &ProductPurchaseDisplayProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProductPurchaseDisplayProperties> for &::windows::core::IInspectable {
-    fn from(value: &ProductPurchaseDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProductPurchaseDisplayProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProductPurchaseDisplayProperties {}
 unsafe impl ::core::marker::Sync for ProductPurchaseDisplayProperties {}
 #[doc = "*Required features: `\"ApplicationModel_Store\"`*"]
@@ -1554,36 +1409,7 @@ unsafe impl ::windows::core::Interface for PurchaseResults {
 impl ::windows::core::RuntimeName for PurchaseResults {
     const NAME: &'static str = "Windows.ApplicationModel.Store.PurchaseResults";
 }
-impl ::core::convert::From<PurchaseResults> for ::windows::core::IUnknown {
-    fn from(value: PurchaseResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PurchaseResults> for ::windows::core::IUnknown {
-    fn from(value: &PurchaseResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PurchaseResults> for &::windows::core::IUnknown {
-    fn from(value: &PurchaseResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PurchaseResults> for ::windows::core::IInspectable {
-    fn from(value: PurchaseResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PurchaseResults> for ::windows::core::IInspectable {
-    fn from(value: &PurchaseResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PurchaseResults> for &::windows::core::IInspectable {
-    fn from(value: &PurchaseResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PurchaseResults, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PurchaseResults {}
 unsafe impl ::core::marker::Sync for PurchaseResults {}
 #[doc = "*Required features: `\"ApplicationModel_Store\"`*"]
@@ -1644,36 +1470,7 @@ unsafe impl ::windows::core::Interface for UnfulfilledConsumable {
 impl ::windows::core::RuntimeName for UnfulfilledConsumable {
     const NAME: &'static str = "Windows.ApplicationModel.Store.UnfulfilledConsumable";
 }
-impl ::core::convert::From<UnfulfilledConsumable> for ::windows::core::IUnknown {
-    fn from(value: UnfulfilledConsumable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UnfulfilledConsumable> for ::windows::core::IUnknown {
-    fn from(value: &UnfulfilledConsumable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UnfulfilledConsumable> for &::windows::core::IUnknown {
-    fn from(value: &UnfulfilledConsumable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UnfulfilledConsumable> for ::windows::core::IInspectable {
-    fn from(value: UnfulfilledConsumable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UnfulfilledConsumable> for ::windows::core::IInspectable {
-    fn from(value: &UnfulfilledConsumable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UnfulfilledConsumable> for &::windows::core::IInspectable {
-    fn from(value: &UnfulfilledConsumable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UnfulfilledConsumable, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UnfulfilledConsumable {}
 unsafe impl ::core::marker::Sync for UnfulfilledConsumable {}
 #[doc = "*Required features: `\"ApplicationModel_Store\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/mod.rs
@@ -237,36 +237,7 @@ impl IUserActivityContentInfo {
         }
     }
 }
-impl ::core::convert::From<IUserActivityContentInfo> for ::windows::core::IUnknown {
-    fn from(value: IUserActivityContentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserActivityContentInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserActivityContentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserActivityContentInfo> for ::windows::core::IUnknown {
-    fn from(value: &IUserActivityContentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUserActivityContentInfo> for ::windows::core::IInspectable {
-    fn from(value: IUserActivityContentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserActivityContentInfo> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IUserActivityContentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserActivityContentInfo> for ::windows::core::IInspectable {
-    fn from(value: &IUserActivityContentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserActivityContentInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IUserActivityContentInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -721,36 +692,7 @@ unsafe impl ::windows::core::Interface for UserActivity {
 impl ::windows::core::RuntimeName for UserActivity {
     const NAME: &'static str = "Windows.ApplicationModel.UserActivities.UserActivity";
 }
-impl ::core::convert::From<UserActivity> for ::windows::core::IUnknown {
-    fn from(value: UserActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivity> for ::windows::core::IUnknown {
-    fn from(value: &UserActivity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivity> for &::windows::core::IUnknown {
-    fn from(value: &UserActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserActivity> for ::windows::core::IInspectable {
-    fn from(value: UserActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivity> for ::windows::core::IInspectable {
-    fn from(value: &UserActivity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivity> for &::windows::core::IInspectable {
-    fn from(value: &UserActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserActivity, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserActivity {}
 unsafe impl ::core::marker::Sync for UserActivity {}
 #[doc = "*Required features: `\"ApplicationModel_UserActivities\"`*"]
@@ -847,36 +789,7 @@ unsafe impl ::windows::core::Interface for UserActivityAttribution {
 impl ::windows::core::RuntimeName for UserActivityAttribution {
     const NAME: &'static str = "Windows.ApplicationModel.UserActivities.UserActivityAttribution";
 }
-impl ::core::convert::From<UserActivityAttribution> for ::windows::core::IUnknown {
-    fn from(value: UserActivityAttribution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityAttribution> for ::windows::core::IUnknown {
-    fn from(value: &UserActivityAttribution) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityAttribution> for &::windows::core::IUnknown {
-    fn from(value: &UserActivityAttribution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserActivityAttribution> for ::windows::core::IInspectable {
-    fn from(value: UserActivityAttribution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityAttribution> for ::windows::core::IInspectable {
-    fn from(value: &UserActivityAttribution) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityAttribution> for &::windows::core::IInspectable {
-    fn from(value: &UserActivityAttribution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserActivityAttribution, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserActivityAttribution {}
 unsafe impl ::core::marker::Sync for UserActivityAttribution {}
 #[doc = "*Required features: `\"ApplicationModel_UserActivities\"`*"]
@@ -1001,36 +914,7 @@ unsafe impl ::windows::core::Interface for UserActivityChannel {
 impl ::windows::core::RuntimeName for UserActivityChannel {
     const NAME: &'static str = "Windows.ApplicationModel.UserActivities.UserActivityChannel";
 }
-impl ::core::convert::From<UserActivityChannel> for ::windows::core::IUnknown {
-    fn from(value: UserActivityChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityChannel> for ::windows::core::IUnknown {
-    fn from(value: &UserActivityChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityChannel> for &::windows::core::IUnknown {
-    fn from(value: &UserActivityChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserActivityChannel> for ::windows::core::IInspectable {
-    fn from(value: UserActivityChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityChannel> for ::windows::core::IInspectable {
-    fn from(value: &UserActivityChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityChannel> for &::windows::core::IInspectable {
-    fn from(value: &UserActivityChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserActivityChannel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserActivityChannel {}
 unsafe impl ::core::marker::Sync for UserActivityChannel {}
 #[doc = "*Required features: `\"ApplicationModel_UserActivities\"`*"]
@@ -1088,36 +972,7 @@ unsafe impl ::windows::core::Interface for UserActivityContentInfo {
 impl ::windows::core::RuntimeName for UserActivityContentInfo {
     const NAME: &'static str = "Windows.ApplicationModel.UserActivities.UserActivityContentInfo";
 }
-impl ::core::convert::From<UserActivityContentInfo> for ::windows::core::IUnknown {
-    fn from(value: UserActivityContentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityContentInfo> for ::windows::core::IUnknown {
-    fn from(value: &UserActivityContentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityContentInfo> for &::windows::core::IUnknown {
-    fn from(value: &UserActivityContentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserActivityContentInfo> for ::windows::core::IInspectable {
-    fn from(value: UserActivityContentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityContentInfo> for ::windows::core::IInspectable {
-    fn from(value: &UserActivityContentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityContentInfo> for &::windows::core::IInspectable {
-    fn from(value: &UserActivityContentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserActivityContentInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<UserActivityContentInfo> for IUserActivityContentInfo {
     type Error = ::windows::core::Error;
     fn try_from(value: UserActivityContentInfo) -> ::windows::core::Result<Self> {
@@ -1180,36 +1035,7 @@ unsafe impl ::windows::core::Interface for UserActivityRequest {
 impl ::windows::core::RuntimeName for UserActivityRequest {
     const NAME: &'static str = "Windows.ApplicationModel.UserActivities.UserActivityRequest";
 }
-impl ::core::convert::From<UserActivityRequest> for ::windows::core::IUnknown {
-    fn from(value: UserActivityRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityRequest> for ::windows::core::IUnknown {
-    fn from(value: &UserActivityRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityRequest> for &::windows::core::IUnknown {
-    fn from(value: &UserActivityRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserActivityRequest> for ::windows::core::IInspectable {
-    fn from(value: UserActivityRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityRequest> for ::windows::core::IInspectable {
-    fn from(value: &UserActivityRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityRequest> for &::windows::core::IInspectable {
-    fn from(value: &UserActivityRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserActivityRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserActivityRequest {}
 unsafe impl ::core::marker::Sync for UserActivityRequest {}
 #[doc = "*Required features: `\"ApplicationModel_UserActivities\"`*"]
@@ -1275,36 +1101,7 @@ unsafe impl ::windows::core::Interface for UserActivityRequestManager {
 impl ::windows::core::RuntimeName for UserActivityRequestManager {
     const NAME: &'static str = "Windows.ApplicationModel.UserActivities.UserActivityRequestManager";
 }
-impl ::core::convert::From<UserActivityRequestManager> for ::windows::core::IUnknown {
-    fn from(value: UserActivityRequestManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityRequestManager> for ::windows::core::IUnknown {
-    fn from(value: &UserActivityRequestManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityRequestManager> for &::windows::core::IUnknown {
-    fn from(value: &UserActivityRequestManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserActivityRequestManager> for ::windows::core::IInspectable {
-    fn from(value: UserActivityRequestManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityRequestManager> for ::windows::core::IInspectable {
-    fn from(value: &UserActivityRequestManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityRequestManager> for &::windows::core::IInspectable {
-    fn from(value: &UserActivityRequestManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserActivityRequestManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel_UserActivities\"`*"]
 #[repr(transparent)]
 pub struct UserActivityRequestedEventArgs(::windows::core::IUnknown);
@@ -1358,36 +1155,7 @@ unsafe impl ::windows::core::Interface for UserActivityRequestedEventArgs {
 impl ::windows::core::RuntimeName for UserActivityRequestedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.UserActivities.UserActivityRequestedEventArgs";
 }
-impl ::core::convert::From<UserActivityRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserActivityRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserActivityRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserActivityRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserActivityRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserActivityRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserActivityRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserActivityRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserActivityRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserActivityRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for UserActivityRequestedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_UserActivities\"`*"]
@@ -1440,36 +1208,7 @@ unsafe impl ::windows::core::Interface for UserActivitySession {
 impl ::windows::core::RuntimeName for UserActivitySession {
     const NAME: &'static str = "Windows.ApplicationModel.UserActivities.UserActivitySession";
 }
-impl ::core::convert::From<UserActivitySession> for ::windows::core::IUnknown {
-    fn from(value: UserActivitySession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivitySession> for ::windows::core::IUnknown {
-    fn from(value: &UserActivitySession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivitySession> for &::windows::core::IUnknown {
-    fn from(value: &UserActivitySession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserActivitySession> for ::windows::core::IInspectable {
-    fn from(value: UserActivitySession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivitySession> for ::windows::core::IInspectable {
-    fn from(value: &UserActivitySession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivitySession> for &::windows::core::IInspectable {
-    fn from(value: &UserActivitySession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserActivitySession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<UserActivitySession> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1556,36 +1295,7 @@ unsafe impl ::windows::core::Interface for UserActivitySessionHistoryItem {
 impl ::windows::core::RuntimeName for UserActivitySessionHistoryItem {
     const NAME: &'static str = "Windows.ApplicationModel.UserActivities.UserActivitySessionHistoryItem";
 }
-impl ::core::convert::From<UserActivitySessionHistoryItem> for ::windows::core::IUnknown {
-    fn from(value: UserActivitySessionHistoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivitySessionHistoryItem> for ::windows::core::IUnknown {
-    fn from(value: &UserActivitySessionHistoryItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivitySessionHistoryItem> for &::windows::core::IUnknown {
-    fn from(value: &UserActivitySessionHistoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserActivitySessionHistoryItem> for ::windows::core::IInspectable {
-    fn from(value: UserActivitySessionHistoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivitySessionHistoryItem> for ::windows::core::IInspectable {
-    fn from(value: &UserActivitySessionHistoryItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivitySessionHistoryItem> for &::windows::core::IInspectable {
-    fn from(value: &UserActivitySessionHistoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserActivitySessionHistoryItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserActivitySessionHistoryItem {}
 unsafe impl ::core::marker::Sync for UserActivitySessionHistoryItem {}
 #[doc = "*Required features: `\"ApplicationModel_UserActivities\"`*"]
@@ -1703,36 +1413,7 @@ unsafe impl ::windows::core::Interface for UserActivityVisualElements {
 impl ::windows::core::RuntimeName for UserActivityVisualElements {
     const NAME: &'static str = "Windows.ApplicationModel.UserActivities.UserActivityVisualElements";
 }
-impl ::core::convert::From<UserActivityVisualElements> for ::windows::core::IUnknown {
-    fn from(value: UserActivityVisualElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityVisualElements> for ::windows::core::IUnknown {
-    fn from(value: &UserActivityVisualElements) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityVisualElements> for &::windows::core::IUnknown {
-    fn from(value: &UserActivityVisualElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserActivityVisualElements> for ::windows::core::IInspectable {
-    fn from(value: UserActivityVisualElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserActivityVisualElements> for ::windows::core::IInspectable {
-    fn from(value: &UserActivityVisualElements) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserActivityVisualElements> for &::windows::core::IInspectable {
-    fn from(value: &UserActivityVisualElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserActivityVisualElements, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserActivityVisualElements {}
 unsafe impl ::core::marker::Sync for UserActivityVisualElements {}
 #[doc = "*Required features: `\"ApplicationModel_UserActivities\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/mod.rs
@@ -47,36 +47,7 @@ impl IUserDataAccountProviderOperation {
         }
     }
 }
-impl ::core::convert::From<IUserDataAccountProviderOperation> for ::windows::core::IUnknown {
-    fn from(value: IUserDataAccountProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserDataAccountProviderOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserDataAccountProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserDataAccountProviderOperation> for ::windows::core::IUnknown {
-    fn from(value: &IUserDataAccountProviderOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUserDataAccountProviderOperation> for ::windows::core::IInspectable {
-    fn from(value: IUserDataAccountProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserDataAccountProviderOperation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IUserDataAccountProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserDataAccountProviderOperation> for ::windows::core::IInspectable {
-    fn from(value: &IUserDataAccountProviderOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserDataAccountProviderOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IUserDataAccountProviderOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -202,36 +173,7 @@ unsafe impl ::windows::core::Interface for UserDataAccountPartnerAccountInfo {
 impl ::windows::core::RuntimeName for UserDataAccountPartnerAccountInfo {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataAccounts.Provider.UserDataAccountPartnerAccountInfo";
 }
-impl ::core::convert::From<UserDataAccountPartnerAccountInfo> for ::windows::core::IUnknown {
-    fn from(value: UserDataAccountPartnerAccountInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountPartnerAccountInfo> for ::windows::core::IUnknown {
-    fn from(value: &UserDataAccountPartnerAccountInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountPartnerAccountInfo> for &::windows::core::IUnknown {
-    fn from(value: &UserDataAccountPartnerAccountInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataAccountPartnerAccountInfo> for ::windows::core::IInspectable {
-    fn from(value: UserDataAccountPartnerAccountInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountPartnerAccountInfo> for ::windows::core::IInspectable {
-    fn from(value: &UserDataAccountPartnerAccountInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountPartnerAccountInfo> for &::windows::core::IInspectable {
-    fn from(value: &UserDataAccountPartnerAccountInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataAccountPartnerAccountInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataAccountPartnerAccountInfo {}
 unsafe impl ::core::marker::Sync for UserDataAccountPartnerAccountInfo {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataAccounts_Provider\"`*"]
@@ -298,36 +240,7 @@ unsafe impl ::windows::core::Interface for UserDataAccountProviderAddAccountOper
 impl ::windows::core::RuntimeName for UserDataAccountProviderAddAccountOperation {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataAccounts.Provider.UserDataAccountProviderAddAccountOperation";
 }
-impl ::core::convert::From<UserDataAccountProviderAddAccountOperation> for ::windows::core::IUnknown {
-    fn from(value: UserDataAccountProviderAddAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderAddAccountOperation> for ::windows::core::IUnknown {
-    fn from(value: &UserDataAccountProviderAddAccountOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderAddAccountOperation> for &::windows::core::IUnknown {
-    fn from(value: &UserDataAccountProviderAddAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataAccountProviderAddAccountOperation> for ::windows::core::IInspectable {
-    fn from(value: UserDataAccountProviderAddAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderAddAccountOperation> for ::windows::core::IInspectable {
-    fn from(value: &UserDataAccountProviderAddAccountOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderAddAccountOperation> for &::windows::core::IInspectable {
-    fn from(value: &UserDataAccountProviderAddAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataAccountProviderAddAccountOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<UserDataAccountProviderAddAccountOperation> for IUserDataAccountProviderOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: UserDataAccountProviderAddAccountOperation) -> ::windows::core::Result<Self> {
@@ -404,36 +317,7 @@ unsafe impl ::windows::core::Interface for UserDataAccountProviderResolveErrorsO
 impl ::windows::core::RuntimeName for UserDataAccountProviderResolveErrorsOperation {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataAccounts.Provider.UserDataAccountProviderResolveErrorsOperation";
 }
-impl ::core::convert::From<UserDataAccountProviderResolveErrorsOperation> for ::windows::core::IUnknown {
-    fn from(value: UserDataAccountProviderResolveErrorsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderResolveErrorsOperation> for ::windows::core::IUnknown {
-    fn from(value: &UserDataAccountProviderResolveErrorsOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderResolveErrorsOperation> for &::windows::core::IUnknown {
-    fn from(value: &UserDataAccountProviderResolveErrorsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataAccountProviderResolveErrorsOperation> for ::windows::core::IInspectable {
-    fn from(value: UserDataAccountProviderResolveErrorsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderResolveErrorsOperation> for ::windows::core::IInspectable {
-    fn from(value: &UserDataAccountProviderResolveErrorsOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderResolveErrorsOperation> for &::windows::core::IInspectable {
-    fn from(value: &UserDataAccountProviderResolveErrorsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataAccountProviderResolveErrorsOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<UserDataAccountProviderResolveErrorsOperation> for IUserDataAccountProviderOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: UserDataAccountProviderResolveErrorsOperation) -> ::windows::core::Result<Self> {
@@ -510,36 +394,7 @@ unsafe impl ::windows::core::Interface for UserDataAccountProviderSettingsOperat
 impl ::windows::core::RuntimeName for UserDataAccountProviderSettingsOperation {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataAccounts.Provider.UserDataAccountProviderSettingsOperation";
 }
-impl ::core::convert::From<UserDataAccountProviderSettingsOperation> for ::windows::core::IUnknown {
-    fn from(value: UserDataAccountProviderSettingsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderSettingsOperation> for ::windows::core::IUnknown {
-    fn from(value: &UserDataAccountProviderSettingsOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderSettingsOperation> for &::windows::core::IUnknown {
-    fn from(value: &UserDataAccountProviderSettingsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataAccountProviderSettingsOperation> for ::windows::core::IInspectable {
-    fn from(value: UserDataAccountProviderSettingsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderSettingsOperation> for ::windows::core::IInspectable {
-    fn from(value: &UserDataAccountProviderSettingsOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountProviderSettingsOperation> for &::windows::core::IInspectable {
-    fn from(value: &UserDataAccountProviderSettingsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataAccountProviderSettingsOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<UserDataAccountProviderSettingsOperation> for IUserDataAccountProviderOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: UserDataAccountProviderSettingsOperation) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/SystemAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/SystemAccess/mod.rs
@@ -733,36 +733,7 @@ unsafe impl ::windows::core::Interface for DeviceAccountConfiguration {
 impl ::windows::core::RuntimeName for DeviceAccountConfiguration {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataAccounts.SystemAccess.DeviceAccountConfiguration";
 }
-impl ::core::convert::From<DeviceAccountConfiguration> for ::windows::core::IUnknown {
-    fn from(value: DeviceAccountConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceAccountConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &DeviceAccountConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceAccountConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &DeviceAccountConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceAccountConfiguration> for ::windows::core::IInspectable {
-    fn from(value: DeviceAccountConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceAccountConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &DeviceAccountConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceAccountConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &DeviceAccountConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceAccountConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceAccountConfiguration {}
 unsafe impl ::core::marker::Sync for DeviceAccountConfiguration {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataAccounts_SystemAccess\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
@@ -520,36 +520,7 @@ unsafe impl ::windows::core::Interface for UserDataAccount {
 impl ::windows::core::RuntimeName for UserDataAccount {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataAccounts.UserDataAccount";
 }
-impl ::core::convert::From<UserDataAccount> for ::windows::core::IUnknown {
-    fn from(value: UserDataAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccount> for ::windows::core::IUnknown {
-    fn from(value: &UserDataAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccount> for &::windows::core::IUnknown {
-    fn from(value: &UserDataAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataAccount> for ::windows::core::IInspectable {
-    fn from(value: UserDataAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccount> for ::windows::core::IInspectable {
-    fn from(value: &UserDataAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccount> for &::windows::core::IInspectable {
-    fn from(value: &UserDataAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataAccount, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataAccount {}
 unsafe impl ::core::marker::Sync for UserDataAccount {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataAccounts\"`*"]
@@ -664,36 +635,7 @@ unsafe impl ::windows::core::Interface for UserDataAccountManagerForUser {
 impl ::windows::core::RuntimeName for UserDataAccountManagerForUser {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataAccounts.UserDataAccountManagerForUser";
 }
-impl ::core::convert::From<UserDataAccountManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: UserDataAccountManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: &UserDataAccountManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountManagerForUser> for &::windows::core::IUnknown {
-    fn from(value: &UserDataAccountManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataAccountManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: UserDataAccountManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: &UserDataAccountManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountManagerForUser> for &::windows::core::IInspectable {
-    fn from(value: &UserDataAccountManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataAccountManagerForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataAccountManagerForUser {}
 unsafe impl ::core::marker::Sync for UserDataAccountManagerForUser {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataAccounts\"`*"]
@@ -793,36 +735,7 @@ unsafe impl ::windows::core::Interface for UserDataAccountStore {
 impl ::windows::core::RuntimeName for UserDataAccountStore {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataAccounts.UserDataAccountStore";
 }
-impl ::core::convert::From<UserDataAccountStore> for ::windows::core::IUnknown {
-    fn from(value: UserDataAccountStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountStore> for ::windows::core::IUnknown {
-    fn from(value: &UserDataAccountStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountStore> for &::windows::core::IUnknown {
-    fn from(value: &UserDataAccountStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataAccountStore> for ::windows::core::IInspectable {
-    fn from(value: UserDataAccountStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountStore> for ::windows::core::IInspectable {
-    fn from(value: &UserDataAccountStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountStore> for &::windows::core::IInspectable {
-    fn from(value: &UserDataAccountStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataAccountStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataAccountStore {}
 unsafe impl ::core::marker::Sync for UserDataAccountStore {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataAccounts\"`*"]
@@ -871,36 +784,7 @@ unsafe impl ::windows::core::Interface for UserDataAccountStoreChangedEventArgs 
 impl ::windows::core::RuntimeName for UserDataAccountStoreChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataAccounts.UserDataAccountStoreChangedEventArgs";
 }
-impl ::core::convert::From<UserDataAccountStoreChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserDataAccountStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountStoreChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserDataAccountStoreChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountStoreChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserDataAccountStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataAccountStoreChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserDataAccountStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAccountStoreChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserDataAccountStoreChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAccountStoreChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserDataAccountStoreChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataAccountStoreChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataAccountStoreChangedEventArgs {}
 unsafe impl ::core::marker::Sync for UserDataAccountStoreChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataAccounts\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/DataProvider/mod.rs
@@ -398,36 +398,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskDataProviderConnection {
 impl ::windows::core::RuntimeName for UserDataTaskDataProviderConnection {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskDataProviderConnection";
 }
-impl ::core::convert::From<UserDataTaskDataProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskDataProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskDataProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskDataProviderConnection> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskDataProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskDataProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskDataProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskDataProviderConnection> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskDataProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskDataProviderConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskDataProviderConnection {}
 unsafe impl ::core::marker::Sync for UserDataTaskDataProviderConnection {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks_DataProvider\"`*"]
@@ -474,36 +445,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskDataProviderTriggerDetail
 impl ::windows::core::RuntimeName for UserDataTaskDataProviderTriggerDetails {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskDataProviderTriggerDetails";
 }
-impl ::core::convert::From<UserDataTaskDataProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskDataProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskDataProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskDataProviderTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskDataProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskDataProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskDataProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskDataProviderTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskDataProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskDataProviderTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskDataProviderTriggerDetails {}
 unsafe impl ::core::marker::Sync for UserDataTaskDataProviderTriggerDetails {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks_DataProvider\"`*"]
@@ -575,36 +517,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListCompleteTaskRequest {
 impl ::windows::core::RuntimeName for UserDataTaskListCompleteTaskRequest {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListCompleteTaskRequest";
 }
-impl ::core::convert::From<UserDataTaskListCompleteTaskRequest> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListCompleteTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCompleteTaskRequest> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListCompleteTaskRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCompleteTaskRequest> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListCompleteTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListCompleteTaskRequest> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListCompleteTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCompleteTaskRequest> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListCompleteTaskRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCompleteTaskRequest> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListCompleteTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListCompleteTaskRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListCompleteTaskRequest {}
 unsafe impl ::core::marker::Sync for UserDataTaskListCompleteTaskRequest {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks_DataProvider\"`*"]
@@ -660,36 +573,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListCompleteTaskRequestEv
 impl ::windows::core::RuntimeName for UserDataTaskListCompleteTaskRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListCompleteTaskRequestEventArgs";
 }
-impl ::core::convert::From<UserDataTaskListCompleteTaskRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListCompleteTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCompleteTaskRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListCompleteTaskRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCompleteTaskRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListCompleteTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListCompleteTaskRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListCompleteTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCompleteTaskRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListCompleteTaskRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCompleteTaskRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListCompleteTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListCompleteTaskRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListCompleteTaskRequestEventArgs {}
 unsafe impl ::core::marker::Sync for UserDataTaskListCompleteTaskRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks_DataProvider\"`*"]
@@ -761,36 +645,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListCreateOrUpdateTaskReq
 impl ::windows::core::RuntimeName for UserDataTaskListCreateOrUpdateTaskRequest {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListCreateOrUpdateTaskRequest";
 }
-impl ::core::convert::From<UserDataTaskListCreateOrUpdateTaskRequest> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListCreateOrUpdateTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCreateOrUpdateTaskRequest> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListCreateOrUpdateTaskRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCreateOrUpdateTaskRequest> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListCreateOrUpdateTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListCreateOrUpdateTaskRequest> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListCreateOrUpdateTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCreateOrUpdateTaskRequest> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListCreateOrUpdateTaskRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCreateOrUpdateTaskRequest> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListCreateOrUpdateTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListCreateOrUpdateTaskRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListCreateOrUpdateTaskRequest {}
 unsafe impl ::core::marker::Sync for UserDataTaskListCreateOrUpdateTaskRequest {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks_DataProvider\"`*"]
@@ -846,36 +701,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListCreateOrUpdateTaskReq
 impl ::windows::core::RuntimeName for UserDataTaskListCreateOrUpdateTaskRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListCreateOrUpdateTaskRequestEventArgs";
 }
-impl ::core::convert::From<UserDataTaskListCreateOrUpdateTaskRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListCreateOrUpdateTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCreateOrUpdateTaskRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListCreateOrUpdateTaskRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCreateOrUpdateTaskRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListCreateOrUpdateTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListCreateOrUpdateTaskRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListCreateOrUpdateTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCreateOrUpdateTaskRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListCreateOrUpdateTaskRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListCreateOrUpdateTaskRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListCreateOrUpdateTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListCreateOrUpdateTaskRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListCreateOrUpdateTaskRequestEventArgs {}
 unsafe impl ::core::marker::Sync for UserDataTaskListCreateOrUpdateTaskRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks_DataProvider\"`*"]
@@ -947,36 +773,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListDeleteTaskRequest {
 impl ::windows::core::RuntimeName for UserDataTaskListDeleteTaskRequest {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListDeleteTaskRequest";
 }
-impl ::core::convert::From<UserDataTaskListDeleteTaskRequest> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListDeleteTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListDeleteTaskRequest> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListDeleteTaskRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListDeleteTaskRequest> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListDeleteTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListDeleteTaskRequest> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListDeleteTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListDeleteTaskRequest> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListDeleteTaskRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListDeleteTaskRequest> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListDeleteTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListDeleteTaskRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListDeleteTaskRequest {}
 unsafe impl ::core::marker::Sync for UserDataTaskListDeleteTaskRequest {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks_DataProvider\"`*"]
@@ -1032,36 +829,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListDeleteTaskRequestEven
 impl ::windows::core::RuntimeName for UserDataTaskListDeleteTaskRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListDeleteTaskRequestEventArgs";
 }
-impl ::core::convert::From<UserDataTaskListDeleteTaskRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListDeleteTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListDeleteTaskRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListDeleteTaskRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListDeleteTaskRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListDeleteTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListDeleteTaskRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListDeleteTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListDeleteTaskRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListDeleteTaskRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListDeleteTaskRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListDeleteTaskRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListDeleteTaskRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListDeleteTaskRequestEventArgs {}
 unsafe impl ::core::marker::Sync for UserDataTaskListDeleteTaskRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks_DataProvider\"`*"]
@@ -1133,36 +901,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListSkipOccurrenceRequest
 impl ::windows::core::RuntimeName for UserDataTaskListSkipOccurrenceRequest {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListSkipOccurrenceRequest";
 }
-impl ::core::convert::From<UserDataTaskListSkipOccurrenceRequest> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListSkipOccurrenceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSkipOccurrenceRequest> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListSkipOccurrenceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSkipOccurrenceRequest> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListSkipOccurrenceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListSkipOccurrenceRequest> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListSkipOccurrenceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSkipOccurrenceRequest> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListSkipOccurrenceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSkipOccurrenceRequest> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListSkipOccurrenceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListSkipOccurrenceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListSkipOccurrenceRequest {}
 unsafe impl ::core::marker::Sync for UserDataTaskListSkipOccurrenceRequest {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks_DataProvider\"`*"]
@@ -1218,36 +957,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListSkipOccurrenceRequest
 impl ::windows::core::RuntimeName for UserDataTaskListSkipOccurrenceRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListSkipOccurrenceRequestEventArgs";
 }
-impl ::core::convert::From<UserDataTaskListSkipOccurrenceRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListSkipOccurrenceRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSkipOccurrenceRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListSkipOccurrenceRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSkipOccurrenceRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListSkipOccurrenceRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListSkipOccurrenceRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListSkipOccurrenceRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSkipOccurrenceRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListSkipOccurrenceRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSkipOccurrenceRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListSkipOccurrenceRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListSkipOccurrenceRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListSkipOccurrenceRequestEventArgs {}
 unsafe impl ::core::marker::Sync for UserDataTaskListSkipOccurrenceRequestEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks_DataProvider\"`*"]
@@ -1312,36 +1022,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListSyncManagerSyncReques
 impl ::windows::core::RuntimeName for UserDataTaskListSyncManagerSyncRequest {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListSyncManagerSyncRequest";
 }
-impl ::core::convert::From<UserDataTaskListSyncManagerSyncRequest> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManagerSyncRequest> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListSyncManagerSyncRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManagerSyncRequest> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListSyncManagerSyncRequest> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManagerSyncRequest> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListSyncManagerSyncRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManagerSyncRequest> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListSyncManagerSyncRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListSyncManagerSyncRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListSyncManagerSyncRequest {}
 unsafe impl ::core::marker::Sync for UserDataTaskListSyncManagerSyncRequest {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks_DataProvider\"`*"]
@@ -1397,36 +1078,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListSyncManagerSyncReques
 impl ::windows::core::RuntimeName for UserDataTaskListSyncManagerSyncRequestEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.DataProvider.UserDataTaskListSyncManagerSyncRequestEventArgs";
 }
-impl ::core::convert::From<UserDataTaskListSyncManagerSyncRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManagerSyncRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListSyncManagerSyncRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManagerSyncRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListSyncManagerSyncRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManagerSyncRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListSyncManagerSyncRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManagerSyncRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListSyncManagerSyncRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListSyncManagerSyncRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListSyncManagerSyncRequestEventArgs {}
 unsafe impl ::core::marker::Sync for UserDataTaskListSyncManagerSyncRequestEventArgs {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
@@ -644,36 +644,7 @@ unsafe impl ::windows::core::Interface for UserDataTask {
 impl ::windows::core::RuntimeName for UserDataTask {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.UserDataTask";
 }
-impl ::core::convert::From<UserDataTask> for ::windows::core::IUnknown {
-    fn from(value: UserDataTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTask> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTask> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTask> for ::windows::core::IInspectable {
-    fn from(value: UserDataTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTask> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTask> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTask, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTask {}
 unsafe impl ::core::marker::Sync for UserDataTask {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks\"`*"]
@@ -722,36 +693,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskBatch {
 impl ::windows::core::RuntimeName for UserDataTaskBatch {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.UserDataTaskBatch";
 }
-impl ::core::convert::From<UserDataTaskBatch> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskBatch> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskBatch> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskBatch> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskBatch> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskBatch> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskBatch, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskBatch {}
 unsafe impl ::core::marker::Sync for UserDataTaskBatch {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks\"`*"]
@@ -927,36 +869,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskList {
 impl ::windows::core::RuntimeName for UserDataTaskList {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.UserDataTaskList";
 }
-impl ::core::convert::From<UserDataTaskList> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskList> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskList> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskList> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskList> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskList> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskList {}
 unsafe impl ::core::marker::Sync for UserDataTaskList {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks\"`*"]
@@ -1032,36 +945,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListLimitedWriteOperation
 impl ::windows::core::RuntimeName for UserDataTaskListLimitedWriteOperations {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.UserDataTaskListLimitedWriteOperations";
 }
-impl ::core::convert::From<UserDataTaskListLimitedWriteOperations> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListLimitedWriteOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListLimitedWriteOperations> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListLimitedWriteOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListLimitedWriteOperations> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListLimitedWriteOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListLimitedWriteOperations> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListLimitedWriteOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListLimitedWriteOperations> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListLimitedWriteOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListLimitedWriteOperations> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListLimitedWriteOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListLimitedWriteOperations, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListLimitedWriteOperations {}
 unsafe impl ::core::marker::Sync for UserDataTaskListLimitedWriteOperations {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks\"`*"]
@@ -1166,36 +1050,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskListSyncManager {
 impl ::windows::core::RuntimeName for UserDataTaskListSyncManager {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.UserDataTaskListSyncManager";
 }
-impl ::core::convert::From<UserDataTaskListSyncManager> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskListSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManager> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListSyncManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManager> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskListSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskListSyncManager> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskListSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManager> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListSyncManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskListSyncManager> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskListSyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskListSyncManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskListSyncManager {}
 unsafe impl ::core::marker::Sync for UserDataTaskListSyncManager {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks\"`*"]
@@ -1272,36 +1127,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskManager {
 impl ::windows::core::RuntimeName for UserDataTaskManager {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.UserDataTaskManager";
 }
-impl ::core::convert::From<UserDataTaskManager> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskManager> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskManager> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskManager> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskManager> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskManager> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskManager {}
 unsafe impl ::core::marker::Sync for UserDataTaskManager {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks\"`*"]
@@ -1370,36 +1196,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskQueryOptions {
 impl ::windows::core::RuntimeName for UserDataTaskQueryOptions {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.UserDataTaskQueryOptions";
 }
-impl ::core::convert::From<UserDataTaskQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskQueryOptions> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskQueryOptions> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskQueryOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskQueryOptions {}
 unsafe impl ::core::marker::Sync for UserDataTaskQueryOptions {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks\"`*"]
@@ -1448,36 +1245,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskReader {
 impl ::windows::core::RuntimeName for UserDataTaskReader {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.UserDataTaskReader";
 }
-impl ::core::convert::From<UserDataTaskReader> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskReader> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskReader> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskReader> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskReader> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskReader> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskReader {}
 unsafe impl ::core::marker::Sync for UserDataTaskReader {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks\"`*"]
@@ -1660,36 +1428,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskRecurrenceProperties {
 impl ::windows::core::RuntimeName for UserDataTaskRecurrenceProperties {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.UserDataTaskRecurrenceProperties";
 }
-impl ::core::convert::From<UserDataTaskRecurrenceProperties> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskRecurrenceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskRecurrenceProperties> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskRecurrenceProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskRecurrenceProperties> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskRecurrenceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskRecurrenceProperties> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskRecurrenceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskRecurrenceProperties> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskRecurrenceProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskRecurrenceProperties> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskRecurrenceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskRecurrenceProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskRecurrenceProperties {}
 unsafe impl ::core::marker::Sync for UserDataTaskRecurrenceProperties {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks\"`*"]
@@ -1796,36 +1535,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskRegenerationProperties {
 impl ::windows::core::RuntimeName for UserDataTaskRegenerationProperties {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.UserDataTaskRegenerationProperties";
 }
-impl ::core::convert::From<UserDataTaskRegenerationProperties> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskRegenerationProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskRegenerationProperties> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskRegenerationProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskRegenerationProperties> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskRegenerationProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskRegenerationProperties> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskRegenerationProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskRegenerationProperties> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskRegenerationProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskRegenerationProperties> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskRegenerationProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskRegenerationProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskRegenerationProperties {}
 unsafe impl ::core::marker::Sync for UserDataTaskRegenerationProperties {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks\"`*"]
@@ -1901,36 +1611,7 @@ unsafe impl ::windows::core::Interface for UserDataTaskStore {
 impl ::windows::core::RuntimeName for UserDataTaskStore {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataTasks.UserDataTaskStore";
 }
-impl ::core::convert::From<UserDataTaskStore> for ::windows::core::IUnknown {
-    fn from(value: UserDataTaskStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskStore> for ::windows::core::IUnknown {
-    fn from(value: &UserDataTaskStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskStore> for &::windows::core::IUnknown {
-    fn from(value: &UserDataTaskStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataTaskStore> for ::windows::core::IInspectable {
-    fn from(value: UserDataTaskStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataTaskStore> for ::windows::core::IInspectable {
-    fn from(value: &UserDataTaskStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataTaskStore> for &::windows::core::IInspectable {
-    fn from(value: &UserDataTaskStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataTaskStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataTaskStore {}
 unsafe impl ::core::marker::Sync for UserDataTaskStore {}
 #[doc = "*Required features: `\"ApplicationModel_UserDataTasks\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/VoiceCommands/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/VoiceCommands/mod.rs
@@ -345,36 +345,7 @@ unsafe impl ::windows::core::Interface for VoiceCommand {
 impl ::windows::core::RuntimeName for VoiceCommand {
     const NAME: &'static str = "Windows.ApplicationModel.VoiceCommands.VoiceCommand";
 }
-impl ::core::convert::From<VoiceCommand> for ::windows::core::IUnknown {
-    fn from(value: VoiceCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommand> for ::windows::core::IUnknown {
-    fn from(value: &VoiceCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommand> for &::windows::core::IUnknown {
-    fn from(value: &VoiceCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceCommand> for ::windows::core::IInspectable {
-    fn from(value: VoiceCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommand> for ::windows::core::IInspectable {
-    fn from(value: &VoiceCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommand> for &::windows::core::IInspectable {
-    fn from(value: &VoiceCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceCommand, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoiceCommand {}
 unsafe impl ::core::marker::Sync for VoiceCommand {}
 #[doc = "*Required features: `\"ApplicationModel_VoiceCommands\"`*"]
@@ -421,36 +392,7 @@ unsafe impl ::windows::core::Interface for VoiceCommandCompletedEventArgs {
 impl ::windows::core::RuntimeName for VoiceCommandCompletedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.VoiceCommands.VoiceCommandCompletedEventArgs";
 }
-impl ::core::convert::From<VoiceCommandCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: VoiceCommandCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &VoiceCommandCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &VoiceCommandCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceCommandCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: VoiceCommandCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &VoiceCommandCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &VoiceCommandCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceCommandCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoiceCommandCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for VoiceCommandCompletedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel_VoiceCommands\"`*"]
@@ -497,36 +439,7 @@ unsafe impl ::windows::core::Interface for VoiceCommandConfirmationResult {
 impl ::windows::core::RuntimeName for VoiceCommandConfirmationResult {
     const NAME: &'static str = "Windows.ApplicationModel.VoiceCommands.VoiceCommandConfirmationResult";
 }
-impl ::core::convert::From<VoiceCommandConfirmationResult> for ::windows::core::IUnknown {
-    fn from(value: VoiceCommandConfirmationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandConfirmationResult> for ::windows::core::IUnknown {
-    fn from(value: &VoiceCommandConfirmationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandConfirmationResult> for &::windows::core::IUnknown {
-    fn from(value: &VoiceCommandConfirmationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceCommandConfirmationResult> for ::windows::core::IInspectable {
-    fn from(value: VoiceCommandConfirmationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandConfirmationResult> for ::windows::core::IInspectable {
-    fn from(value: &VoiceCommandConfirmationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandConfirmationResult> for &::windows::core::IInspectable {
-    fn from(value: &VoiceCommandConfirmationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceCommandConfirmationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoiceCommandConfirmationResult {}
 unsafe impl ::core::marker::Sync for VoiceCommandConfirmationResult {}
 #[doc = "*Required features: `\"ApplicationModel_VoiceCommands\"`*"]
@@ -672,36 +585,7 @@ unsafe impl ::windows::core::Interface for VoiceCommandContentTile {
 impl ::windows::core::RuntimeName for VoiceCommandContentTile {
     const NAME: &'static str = "Windows.ApplicationModel.VoiceCommands.VoiceCommandContentTile";
 }
-impl ::core::convert::From<VoiceCommandContentTile> for ::windows::core::IUnknown {
-    fn from(value: VoiceCommandContentTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandContentTile> for ::windows::core::IUnknown {
-    fn from(value: &VoiceCommandContentTile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandContentTile> for &::windows::core::IUnknown {
-    fn from(value: &VoiceCommandContentTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceCommandContentTile> for ::windows::core::IInspectable {
-    fn from(value: VoiceCommandContentTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandContentTile> for ::windows::core::IInspectable {
-    fn from(value: &VoiceCommandContentTile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandContentTile> for &::windows::core::IInspectable {
-    fn from(value: &VoiceCommandContentTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceCommandContentTile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoiceCommandContentTile {}
 unsafe impl ::core::marker::Sync for VoiceCommandContentTile {}
 #[doc = "*Required features: `\"ApplicationModel_VoiceCommands\"`*"]
@@ -768,36 +652,7 @@ unsafe impl ::windows::core::Interface for VoiceCommandDefinition {
 impl ::windows::core::RuntimeName for VoiceCommandDefinition {
     const NAME: &'static str = "Windows.ApplicationModel.VoiceCommands.VoiceCommandDefinition";
 }
-impl ::core::convert::From<VoiceCommandDefinition> for ::windows::core::IUnknown {
-    fn from(value: VoiceCommandDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandDefinition> for ::windows::core::IUnknown {
-    fn from(value: &VoiceCommandDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandDefinition> for &::windows::core::IUnknown {
-    fn from(value: &VoiceCommandDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceCommandDefinition> for ::windows::core::IInspectable {
-    fn from(value: VoiceCommandDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandDefinition> for ::windows::core::IInspectable {
-    fn from(value: &VoiceCommandDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandDefinition> for &::windows::core::IInspectable {
-    fn from(value: &VoiceCommandDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceCommandDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoiceCommandDefinition {}
 unsafe impl ::core::marker::Sync for VoiceCommandDefinition {}
 #[doc = "*Required features: `\"ApplicationModel_VoiceCommands\"`*"]
@@ -872,36 +727,7 @@ unsafe impl ::windows::core::Interface for VoiceCommandDisambiguationResult {
 impl ::windows::core::RuntimeName for VoiceCommandDisambiguationResult {
     const NAME: &'static str = "Windows.ApplicationModel.VoiceCommands.VoiceCommandDisambiguationResult";
 }
-impl ::core::convert::From<VoiceCommandDisambiguationResult> for ::windows::core::IUnknown {
-    fn from(value: VoiceCommandDisambiguationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandDisambiguationResult> for ::windows::core::IUnknown {
-    fn from(value: &VoiceCommandDisambiguationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandDisambiguationResult> for &::windows::core::IUnknown {
-    fn from(value: &VoiceCommandDisambiguationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceCommandDisambiguationResult> for ::windows::core::IInspectable {
-    fn from(value: VoiceCommandDisambiguationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandDisambiguationResult> for ::windows::core::IInspectable {
-    fn from(value: &VoiceCommandDisambiguationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandDisambiguationResult> for &::windows::core::IInspectable {
-    fn from(value: &VoiceCommandDisambiguationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceCommandDisambiguationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoiceCommandDisambiguationResult {}
 unsafe impl ::core::marker::Sync for VoiceCommandDisambiguationResult {}
 #[doc = "*Required features: `\"ApplicationModel_VoiceCommands\"`*"]
@@ -1030,36 +856,7 @@ unsafe impl ::windows::core::Interface for VoiceCommandResponse {
 impl ::windows::core::RuntimeName for VoiceCommandResponse {
     const NAME: &'static str = "Windows.ApplicationModel.VoiceCommands.VoiceCommandResponse";
 }
-impl ::core::convert::From<VoiceCommandResponse> for ::windows::core::IUnknown {
-    fn from(value: VoiceCommandResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandResponse> for ::windows::core::IUnknown {
-    fn from(value: &VoiceCommandResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandResponse> for &::windows::core::IUnknown {
-    fn from(value: &VoiceCommandResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceCommandResponse> for ::windows::core::IInspectable {
-    fn from(value: VoiceCommandResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandResponse> for ::windows::core::IInspectable {
-    fn from(value: &VoiceCommandResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandResponse> for &::windows::core::IInspectable {
-    fn from(value: &VoiceCommandResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceCommandResponse, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoiceCommandResponse {}
 unsafe impl ::core::marker::Sync for VoiceCommandResponse {}
 #[doc = "*Required features: `\"ApplicationModel_VoiceCommands\"`*"]
@@ -1199,36 +996,7 @@ unsafe impl ::windows::core::Interface for VoiceCommandServiceConnection {
 impl ::windows::core::RuntimeName for VoiceCommandServiceConnection {
     const NAME: &'static str = "Windows.ApplicationModel.VoiceCommands.VoiceCommandServiceConnection";
 }
-impl ::core::convert::From<VoiceCommandServiceConnection> for ::windows::core::IUnknown {
-    fn from(value: VoiceCommandServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandServiceConnection> for ::windows::core::IUnknown {
-    fn from(value: &VoiceCommandServiceConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandServiceConnection> for &::windows::core::IUnknown {
-    fn from(value: &VoiceCommandServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceCommandServiceConnection> for ::windows::core::IInspectable {
-    fn from(value: VoiceCommandServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandServiceConnection> for ::windows::core::IInspectable {
-    fn from(value: &VoiceCommandServiceConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandServiceConnection> for &::windows::core::IInspectable {
-    fn from(value: &VoiceCommandServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceCommandServiceConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoiceCommandServiceConnection {}
 unsafe impl ::core::marker::Sync for VoiceCommandServiceConnection {}
 #[doc = "*Required features: `\"ApplicationModel_VoiceCommands\"`*"]
@@ -1297,36 +1065,7 @@ unsafe impl ::windows::core::Interface for VoiceCommandUserMessage {
 impl ::windows::core::RuntimeName for VoiceCommandUserMessage {
     const NAME: &'static str = "Windows.ApplicationModel.VoiceCommands.VoiceCommandUserMessage";
 }
-impl ::core::convert::From<VoiceCommandUserMessage> for ::windows::core::IUnknown {
-    fn from(value: VoiceCommandUserMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandUserMessage> for ::windows::core::IUnknown {
-    fn from(value: &VoiceCommandUserMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandUserMessage> for &::windows::core::IUnknown {
-    fn from(value: &VoiceCommandUserMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceCommandUserMessage> for ::windows::core::IInspectable {
-    fn from(value: VoiceCommandUserMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandUserMessage> for ::windows::core::IInspectable {
-    fn from(value: &VoiceCommandUserMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandUserMessage> for &::windows::core::IInspectable {
-    fn from(value: &VoiceCommandUserMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceCommandUserMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoiceCommandUserMessage {}
 unsafe impl ::core::marker::Sync for VoiceCommandUserMessage {}
 #[doc = "*Required features: `\"ApplicationModel_VoiceCommands\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Wallet/System/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Wallet/System/mod.rs
@@ -168,36 +168,7 @@ unsafe impl ::windows::core::Interface for WalletItemSystemStore {
 impl ::windows::core::RuntimeName for WalletItemSystemStore {
     const NAME: &'static str = "Windows.ApplicationModel.Wallet.System.WalletItemSystemStore";
 }
-impl ::core::convert::From<WalletItemSystemStore> for ::windows::core::IUnknown {
-    fn from(value: WalletItemSystemStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletItemSystemStore> for ::windows::core::IUnknown {
-    fn from(value: &WalletItemSystemStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletItemSystemStore> for &::windows::core::IUnknown {
-    fn from(value: &WalletItemSystemStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WalletItemSystemStore> for ::windows::core::IInspectable {
-    fn from(value: WalletItemSystemStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletItemSystemStore> for ::windows::core::IInspectable {
-    fn from(value: &WalletItemSystemStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletItemSystemStore> for &::windows::core::IInspectable {
-    fn from(value: &WalletItemSystemStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WalletItemSystemStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WalletItemSystemStore {}
 unsafe impl ::core::marker::Sync for WalletItemSystemStore {}
 #[doc = "*Required features: `\"ApplicationModel_Wallet_System\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Wallet/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Wallet/mod.rs
@@ -519,36 +519,7 @@ unsafe impl ::windows::core::Interface for WalletBarcode {
 impl ::windows::core::RuntimeName for WalletBarcode {
     const NAME: &'static str = "Windows.ApplicationModel.Wallet.WalletBarcode";
 }
-impl ::core::convert::From<WalletBarcode> for ::windows::core::IUnknown {
-    fn from(value: WalletBarcode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletBarcode> for ::windows::core::IUnknown {
-    fn from(value: &WalletBarcode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletBarcode> for &::windows::core::IUnknown {
-    fn from(value: &WalletBarcode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WalletBarcode> for ::windows::core::IInspectable {
-    fn from(value: WalletBarcode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletBarcode> for ::windows::core::IInspectable {
-    fn from(value: &WalletBarcode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletBarcode> for &::windows::core::IInspectable {
-    fn from(value: &WalletBarcode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WalletBarcode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WalletBarcode {}
 unsafe impl ::core::marker::Sync for WalletBarcode {}
 #[doc = "*Required features: `\"ApplicationModel_Wallet\"`*"]
@@ -998,36 +969,7 @@ unsafe impl ::windows::core::Interface for WalletItem {
 impl ::windows::core::RuntimeName for WalletItem {
     const NAME: &'static str = "Windows.ApplicationModel.Wallet.WalletItem";
 }
-impl ::core::convert::From<WalletItem> for ::windows::core::IUnknown {
-    fn from(value: WalletItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletItem> for ::windows::core::IUnknown {
-    fn from(value: &WalletItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletItem> for &::windows::core::IUnknown {
-    fn from(value: &WalletItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WalletItem> for ::windows::core::IInspectable {
-    fn from(value: WalletItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletItem> for ::windows::core::IInspectable {
-    fn from(value: &WalletItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletItem> for &::windows::core::IInspectable {
-    fn from(value: &WalletItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WalletItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WalletItem {}
 unsafe impl ::core::marker::Sync for WalletItem {}
 #[doc = "*Required features: `\"ApplicationModel_Wallet\"`*"]
@@ -1133,36 +1075,7 @@ unsafe impl ::windows::core::Interface for WalletItemCustomProperty {
 impl ::windows::core::RuntimeName for WalletItemCustomProperty {
     const NAME: &'static str = "Windows.ApplicationModel.Wallet.WalletItemCustomProperty";
 }
-impl ::core::convert::From<WalletItemCustomProperty> for ::windows::core::IUnknown {
-    fn from(value: WalletItemCustomProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletItemCustomProperty> for ::windows::core::IUnknown {
-    fn from(value: &WalletItemCustomProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletItemCustomProperty> for &::windows::core::IUnknown {
-    fn from(value: &WalletItemCustomProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WalletItemCustomProperty> for ::windows::core::IInspectable {
-    fn from(value: WalletItemCustomProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletItemCustomProperty> for ::windows::core::IInspectable {
-    fn from(value: &WalletItemCustomProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletItemCustomProperty> for &::windows::core::IInspectable {
-    fn from(value: &WalletItemCustomProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WalletItemCustomProperty, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WalletItemCustomProperty {}
 unsafe impl ::core::marker::Sync for WalletItemCustomProperty {}
 #[doc = "*Required features: `\"ApplicationModel_Wallet\"`*"]
@@ -1296,36 +1209,7 @@ unsafe impl ::windows::core::Interface for WalletItemStore {
 impl ::windows::core::RuntimeName for WalletItemStore {
     const NAME: &'static str = "Windows.ApplicationModel.Wallet.WalletItemStore";
 }
-impl ::core::convert::From<WalletItemStore> for ::windows::core::IUnknown {
-    fn from(value: WalletItemStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletItemStore> for ::windows::core::IUnknown {
-    fn from(value: &WalletItemStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletItemStore> for &::windows::core::IUnknown {
-    fn from(value: &WalletItemStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WalletItemStore> for ::windows::core::IInspectable {
-    fn from(value: WalletItemStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletItemStore> for ::windows::core::IInspectable {
-    fn from(value: &WalletItemStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletItemStore> for &::windows::core::IInspectable {
-    fn from(value: &WalletItemStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WalletItemStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WalletItemStore {}
 unsafe impl ::core::marker::Sync for WalletItemStore {}
 #[doc = "*Required features: `\"ApplicationModel_Wallet\"`*"]
@@ -1418,36 +1302,7 @@ unsafe impl ::windows::core::Interface for WalletRelevantLocation {
 impl ::windows::core::RuntimeName for WalletRelevantLocation {
     const NAME: &'static str = "Windows.ApplicationModel.Wallet.WalletRelevantLocation";
 }
-impl ::core::convert::From<WalletRelevantLocation> for ::windows::core::IUnknown {
-    fn from(value: WalletRelevantLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletRelevantLocation> for ::windows::core::IUnknown {
-    fn from(value: &WalletRelevantLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletRelevantLocation> for &::windows::core::IUnknown {
-    fn from(value: &WalletRelevantLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WalletRelevantLocation> for ::windows::core::IInspectable {
-    fn from(value: WalletRelevantLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletRelevantLocation> for ::windows::core::IInspectable {
-    fn from(value: &WalletRelevantLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletRelevantLocation> for &::windows::core::IInspectable {
-    fn from(value: &WalletRelevantLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WalletRelevantLocation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WalletRelevantLocation {}
 unsafe impl ::core::marker::Sync for WalletRelevantLocation {}
 #[doc = "*Required features: `\"ApplicationModel_Wallet\"`*"]
@@ -1568,36 +1423,7 @@ unsafe impl ::windows::core::Interface for WalletTransaction {
 impl ::windows::core::RuntimeName for WalletTransaction {
     const NAME: &'static str = "Windows.ApplicationModel.Wallet.WalletTransaction";
 }
-impl ::core::convert::From<WalletTransaction> for ::windows::core::IUnknown {
-    fn from(value: WalletTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletTransaction> for ::windows::core::IUnknown {
-    fn from(value: &WalletTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletTransaction> for &::windows::core::IUnknown {
-    fn from(value: &WalletTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WalletTransaction> for ::windows::core::IInspectable {
-    fn from(value: WalletTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletTransaction> for ::windows::core::IInspectable {
-    fn from(value: &WalletTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletTransaction> for &::windows::core::IInspectable {
-    fn from(value: &WalletTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WalletTransaction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WalletTransaction {}
 unsafe impl ::core::marker::Sync for WalletTransaction {}
 #[doc = "*Required features: `\"ApplicationModel_Wallet\"`*"]
@@ -1659,36 +1485,7 @@ unsafe impl ::windows::core::Interface for WalletVerb {
 impl ::windows::core::RuntimeName for WalletVerb {
     const NAME: &'static str = "Windows.ApplicationModel.Wallet.WalletVerb";
 }
-impl ::core::convert::From<WalletVerb> for ::windows::core::IUnknown {
-    fn from(value: WalletVerb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletVerb> for ::windows::core::IUnknown {
-    fn from(value: &WalletVerb) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletVerb> for &::windows::core::IUnknown {
-    fn from(value: &WalletVerb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WalletVerb> for ::windows::core::IInspectable {
-    fn from(value: WalletVerb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WalletVerb> for ::windows::core::IInspectable {
-    fn from(value: &WalletVerb) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WalletVerb> for &::windows::core::IInspectable {
-    fn from(value: &WalletVerb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WalletVerb, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WalletVerb {}
 unsafe impl ::core::marker::Sync for WalletVerb {}
 #[doc = "*Required features: `\"ApplicationModel_Wallet\"`*"]

--- a/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
@@ -321,36 +321,7 @@ impl IEnteredBackgroundEventArgs {
         }
     }
 }
-impl ::core::convert::From<IEnteredBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IEnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnteredBackgroundEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnteredBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IEnteredBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEnteredBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IEnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnteredBackgroundEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IEnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnteredBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IEnteredBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnteredBackgroundEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IEnteredBackgroundEventArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -471,36 +442,7 @@ impl ILeavingBackgroundEventArgs {
         }
     }
 }
-impl ::core::convert::From<ILeavingBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ILeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILeavingBackgroundEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILeavingBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ILeavingBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILeavingBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ILeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILeavingBackgroundEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILeavingBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ILeavingBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILeavingBackgroundEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ILeavingBackgroundEventArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1322,36 +1264,7 @@ impl ISuspendingDeferral {
         unsafe { (::windows::core::Vtable::vtable(this).Complete)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<ISuspendingDeferral> for ::windows::core::IUnknown {
-    fn from(value: ISuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISuspendingDeferral> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISuspendingDeferral> for ::windows::core::IUnknown {
-    fn from(value: &ISuspendingDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISuspendingDeferral> for ::windows::core::IInspectable {
-    fn from(value: ISuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISuspendingDeferral> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISuspendingDeferral> for ::windows::core::IInspectable {
-    fn from(value: &ISuspendingDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISuspendingDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISuspendingDeferral {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1399,36 +1312,7 @@ impl ISuspendingEventArgs {
         }
     }
 }
-impl ::core::convert::From<ISuspendingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ISuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISuspendingEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISuspendingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ISuspendingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISuspendingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ISuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISuspendingEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISuspendingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ISuspendingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISuspendingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISuspendingEventArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1485,36 +1369,7 @@ impl ISuspendingOperation {
         }
     }
 }
-impl ::core::convert::From<ISuspendingOperation> for ::windows::core::IUnknown {
-    fn from(value: ISuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISuspendingOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISuspendingOperation> for ::windows::core::IUnknown {
-    fn from(value: &ISuspendingOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISuspendingOperation> for ::windows::core::IInspectable {
-    fn from(value: ISuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISuspendingOperation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISuspendingOperation> for ::windows::core::IInspectable {
-    fn from(value: &ISuspendingOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISuspendingOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISuspendingOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1614,36 +1469,7 @@ unsafe impl ::windows::core::Interface for AppDisplayInfo {
 impl ::windows::core::RuntimeName for AppDisplayInfo {
     const NAME: &'static str = "Windows.ApplicationModel.AppDisplayInfo";
 }
-impl ::core::convert::From<AppDisplayInfo> for ::windows::core::IUnknown {
-    fn from(value: AppDisplayInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppDisplayInfo> for ::windows::core::IUnknown {
-    fn from(value: &AppDisplayInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppDisplayInfo> for &::windows::core::IUnknown {
-    fn from(value: &AppDisplayInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppDisplayInfo> for ::windows::core::IInspectable {
-    fn from(value: AppDisplayInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppDisplayInfo> for ::windows::core::IInspectable {
-    fn from(value: &AppDisplayInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppDisplayInfo> for &::windows::core::IInspectable {
-    fn from(value: &AppDisplayInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppDisplayInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppDisplayInfo {}
 unsafe impl ::core::marker::Sync for AppDisplayInfo {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -1757,36 +1583,7 @@ unsafe impl ::windows::core::Interface for AppInfo {
 impl ::windows::core::RuntimeName for AppInfo {
     const NAME: &'static str = "Windows.ApplicationModel.AppInfo";
 }
-impl ::core::convert::From<AppInfo> for ::windows::core::IUnknown {
-    fn from(value: AppInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInfo> for ::windows::core::IUnknown {
-    fn from(value: &AppInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInfo> for &::windows::core::IUnknown {
-    fn from(value: &AppInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppInfo> for ::windows::core::IInspectable {
-    fn from(value: AppInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInfo> for ::windows::core::IInspectable {
-    fn from(value: &AppInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInfo> for &::windows::core::IInspectable {
-    fn from(value: &AppInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppInfo {}
 unsafe impl ::core::marker::Sync for AppInfo {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -1952,36 +1749,7 @@ unsafe impl ::windows::core::Interface for AppInstallerInfo {
 impl ::windows::core::RuntimeName for AppInstallerInfo {
     const NAME: &'static str = "Windows.ApplicationModel.AppInstallerInfo";
 }
-impl ::core::convert::From<AppInstallerInfo> for ::windows::core::IUnknown {
-    fn from(value: AppInstallerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallerInfo> for ::windows::core::IUnknown {
-    fn from(value: &AppInstallerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallerInfo> for &::windows::core::IUnknown {
-    fn from(value: &AppInstallerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppInstallerInfo> for ::windows::core::IInspectable {
-    fn from(value: AppInstallerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallerInfo> for ::windows::core::IInspectable {
-    fn from(value: &AppInstallerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallerInfo> for &::windows::core::IInspectable {
-    fn from(value: &AppInstallerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppInstallerInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppInstallerInfo {}
 unsafe impl ::core::marker::Sync for AppInstallerInfo {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -2075,36 +1843,7 @@ unsafe impl ::windows::core::Interface for AppInstance {
 impl ::windows::core::RuntimeName for AppInstance {
     const NAME: &'static str = "Windows.ApplicationModel.AppInstance";
 }
-impl ::core::convert::From<AppInstance> for ::windows::core::IUnknown {
-    fn from(value: AppInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstance> for ::windows::core::IUnknown {
-    fn from(value: &AppInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstance> for &::windows::core::IUnknown {
-    fn from(value: &AppInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppInstance> for ::windows::core::IInspectable {
-    fn from(value: AppInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstance> for ::windows::core::IInspectable {
-    fn from(value: &AppInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstance> for &::windows::core::IInspectable {
-    fn from(value: &AppInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppInstance, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppInstance {}
 unsafe impl ::core::marker::Sync for AppInstance {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -2197,36 +1936,7 @@ unsafe impl ::windows::core::Interface for EnteredBackgroundEventArgs {
 impl ::windows::core::RuntimeName for EnteredBackgroundEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.EnteredBackgroundEventArgs";
 }
-impl ::core::convert::From<EnteredBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnteredBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EnteredBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnteredBackgroundEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EnteredBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnteredBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EnteredBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnteredBackgroundEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EnteredBackgroundEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<EnteredBackgroundEventArgs> for IEnteredBackgroundEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: EnteredBackgroundEventArgs) -> ::windows::core::Result<Self> {
@@ -2299,36 +2009,7 @@ unsafe impl ::windows::core::Interface for FullTrustProcessLaunchResult {
 impl ::windows::core::RuntimeName for FullTrustProcessLaunchResult {
     const NAME: &'static str = "Windows.ApplicationModel.FullTrustProcessLaunchResult";
 }
-impl ::core::convert::From<FullTrustProcessLaunchResult> for ::windows::core::IUnknown {
-    fn from(value: FullTrustProcessLaunchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FullTrustProcessLaunchResult> for ::windows::core::IUnknown {
-    fn from(value: &FullTrustProcessLaunchResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FullTrustProcessLaunchResult> for &::windows::core::IUnknown {
-    fn from(value: &FullTrustProcessLaunchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FullTrustProcessLaunchResult> for ::windows::core::IInspectable {
-    fn from(value: FullTrustProcessLaunchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FullTrustProcessLaunchResult> for ::windows::core::IInspectable {
-    fn from(value: &FullTrustProcessLaunchResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FullTrustProcessLaunchResult> for &::windows::core::IInspectable {
-    fn from(value: &FullTrustProcessLaunchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FullTrustProcessLaunchResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FullTrustProcessLaunchResult {}
 unsafe impl ::core::marker::Sync for FullTrustProcessLaunchResult {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -2442,36 +2123,7 @@ unsafe impl ::windows::core::Interface for LeavingBackgroundEventArgs {
 impl ::windows::core::RuntimeName for LeavingBackgroundEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.LeavingBackgroundEventArgs";
 }
-impl ::core::convert::From<LeavingBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LeavingBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LeavingBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LeavingBackgroundEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LeavingBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LeavingBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LeavingBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LeavingBackgroundEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LeavingBackgroundEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LeavingBackgroundEventArgs> for ILeavingBackgroundEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: LeavingBackgroundEventArgs) -> ::windows::core::Result<Self> {
@@ -2553,36 +2205,7 @@ unsafe impl ::windows::core::Interface for LimitedAccessFeatureRequestResult {
 impl ::windows::core::RuntimeName for LimitedAccessFeatureRequestResult {
     const NAME: &'static str = "Windows.ApplicationModel.LimitedAccessFeatureRequestResult";
 }
-impl ::core::convert::From<LimitedAccessFeatureRequestResult> for ::windows::core::IUnknown {
-    fn from(value: LimitedAccessFeatureRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LimitedAccessFeatureRequestResult> for ::windows::core::IUnknown {
-    fn from(value: &LimitedAccessFeatureRequestResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LimitedAccessFeatureRequestResult> for &::windows::core::IUnknown {
-    fn from(value: &LimitedAccessFeatureRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LimitedAccessFeatureRequestResult> for ::windows::core::IInspectable {
-    fn from(value: LimitedAccessFeatureRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LimitedAccessFeatureRequestResult> for ::windows::core::IInspectable {
-    fn from(value: &LimitedAccessFeatureRequestResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LimitedAccessFeatureRequestResult> for &::windows::core::IInspectable {
-    fn from(value: &LimitedAccessFeatureRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LimitedAccessFeatureRequestResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LimitedAccessFeatureRequestResult {}
 unsafe impl ::core::marker::Sync for LimitedAccessFeatureRequestResult {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -2985,36 +2608,7 @@ unsafe impl ::windows::core::Interface for Package {
 impl ::windows::core::RuntimeName for Package {
     const NAME: &'static str = "Windows.ApplicationModel.Package";
 }
-impl ::core::convert::From<Package> for ::windows::core::IUnknown {
-    fn from(value: Package) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Package> for ::windows::core::IUnknown {
-    fn from(value: &Package) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Package> for &::windows::core::IUnknown {
-    fn from(value: &Package) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Package> for ::windows::core::IInspectable {
-    fn from(value: Package) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Package> for ::windows::core::IInspectable {
-    fn from(value: &Package) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Package> for &::windows::core::IInspectable {
-    fn from(value: &Package) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Package, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Package {}
 unsafe impl ::core::marker::Sync for Package {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -3205,36 +2799,7 @@ unsafe impl ::windows::core::Interface for PackageCatalog {
 impl ::windows::core::RuntimeName for PackageCatalog {
     const NAME: &'static str = "Windows.ApplicationModel.PackageCatalog";
 }
-impl ::core::convert::From<PackageCatalog> for ::windows::core::IUnknown {
-    fn from(value: PackageCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageCatalog> for ::windows::core::IUnknown {
-    fn from(value: &PackageCatalog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageCatalog> for &::windows::core::IUnknown {
-    fn from(value: &PackageCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageCatalog> for ::windows::core::IInspectable {
-    fn from(value: PackageCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageCatalog> for ::windows::core::IInspectable {
-    fn from(value: &PackageCatalog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageCatalog> for &::windows::core::IInspectable {
-    fn from(value: &PackageCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageCatalog, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
 #[repr(transparent)]
 pub struct PackageCatalogAddOptionalPackageResult(::windows::core::IUnknown);
@@ -3286,36 +2851,7 @@ unsafe impl ::windows::core::Interface for PackageCatalogAddOptionalPackageResul
 impl ::windows::core::RuntimeName for PackageCatalogAddOptionalPackageResult {
     const NAME: &'static str = "Windows.ApplicationModel.PackageCatalogAddOptionalPackageResult";
 }
-impl ::core::convert::From<PackageCatalogAddOptionalPackageResult> for ::windows::core::IUnknown {
-    fn from(value: PackageCatalogAddOptionalPackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageCatalogAddOptionalPackageResult> for ::windows::core::IUnknown {
-    fn from(value: &PackageCatalogAddOptionalPackageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageCatalogAddOptionalPackageResult> for &::windows::core::IUnknown {
-    fn from(value: &PackageCatalogAddOptionalPackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageCatalogAddOptionalPackageResult> for ::windows::core::IInspectable {
-    fn from(value: PackageCatalogAddOptionalPackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageCatalogAddOptionalPackageResult> for ::windows::core::IInspectable {
-    fn from(value: &PackageCatalogAddOptionalPackageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageCatalogAddOptionalPackageResult> for &::windows::core::IInspectable {
-    fn from(value: &PackageCatalogAddOptionalPackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageCatalogAddOptionalPackageResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
 #[repr(transparent)]
 pub struct PackageCatalogAddResourcePackageResult(::windows::core::IUnknown);
@@ -3374,36 +2910,7 @@ unsafe impl ::windows::core::Interface for PackageCatalogAddResourcePackageResul
 impl ::windows::core::RuntimeName for PackageCatalogAddResourcePackageResult {
     const NAME: &'static str = "Windows.ApplicationModel.PackageCatalogAddResourcePackageResult";
 }
-impl ::core::convert::From<PackageCatalogAddResourcePackageResult> for ::windows::core::IUnknown {
-    fn from(value: PackageCatalogAddResourcePackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageCatalogAddResourcePackageResult> for ::windows::core::IUnknown {
-    fn from(value: &PackageCatalogAddResourcePackageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageCatalogAddResourcePackageResult> for &::windows::core::IUnknown {
-    fn from(value: &PackageCatalogAddResourcePackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageCatalogAddResourcePackageResult> for ::windows::core::IInspectable {
-    fn from(value: PackageCatalogAddResourcePackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageCatalogAddResourcePackageResult> for ::windows::core::IInspectable {
-    fn from(value: &PackageCatalogAddResourcePackageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageCatalogAddResourcePackageResult> for &::windows::core::IInspectable {
-    fn from(value: &PackageCatalogAddResourcePackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageCatalogAddResourcePackageResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageCatalogAddResourcePackageResult {}
 unsafe impl ::core::marker::Sync for PackageCatalogAddResourcePackageResult {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -3459,36 +2966,7 @@ unsafe impl ::windows::core::Interface for PackageCatalogRemoveOptionalPackagesR
 impl ::windows::core::RuntimeName for PackageCatalogRemoveOptionalPackagesResult {
     const NAME: &'static str = "Windows.ApplicationModel.PackageCatalogRemoveOptionalPackagesResult";
 }
-impl ::core::convert::From<PackageCatalogRemoveOptionalPackagesResult> for ::windows::core::IUnknown {
-    fn from(value: PackageCatalogRemoveOptionalPackagesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageCatalogRemoveOptionalPackagesResult> for ::windows::core::IUnknown {
-    fn from(value: &PackageCatalogRemoveOptionalPackagesResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageCatalogRemoveOptionalPackagesResult> for &::windows::core::IUnknown {
-    fn from(value: &PackageCatalogRemoveOptionalPackagesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageCatalogRemoveOptionalPackagesResult> for ::windows::core::IInspectable {
-    fn from(value: PackageCatalogRemoveOptionalPackagesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageCatalogRemoveOptionalPackagesResult> for ::windows::core::IInspectable {
-    fn from(value: &PackageCatalogRemoveOptionalPackagesResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageCatalogRemoveOptionalPackagesResult> for &::windows::core::IInspectable {
-    fn from(value: &PackageCatalogRemoveOptionalPackagesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageCatalogRemoveOptionalPackagesResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
 #[repr(transparent)]
 pub struct PackageCatalogRemoveResourcePackagesResult(::windows::core::IUnknown);
@@ -3542,36 +3020,7 @@ unsafe impl ::windows::core::Interface for PackageCatalogRemoveResourcePackagesR
 impl ::windows::core::RuntimeName for PackageCatalogRemoveResourcePackagesResult {
     const NAME: &'static str = "Windows.ApplicationModel.PackageCatalogRemoveResourcePackagesResult";
 }
-impl ::core::convert::From<PackageCatalogRemoveResourcePackagesResult> for ::windows::core::IUnknown {
-    fn from(value: PackageCatalogRemoveResourcePackagesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageCatalogRemoveResourcePackagesResult> for ::windows::core::IUnknown {
-    fn from(value: &PackageCatalogRemoveResourcePackagesResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageCatalogRemoveResourcePackagesResult> for &::windows::core::IUnknown {
-    fn from(value: &PackageCatalogRemoveResourcePackagesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageCatalogRemoveResourcePackagesResult> for ::windows::core::IInspectable {
-    fn from(value: PackageCatalogRemoveResourcePackagesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageCatalogRemoveResourcePackagesResult> for ::windows::core::IInspectable {
-    fn from(value: &PackageCatalogRemoveResourcePackagesResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageCatalogRemoveResourcePackagesResult> for &::windows::core::IInspectable {
-    fn from(value: &PackageCatalogRemoveResourcePackagesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageCatalogRemoveResourcePackagesResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageCatalogRemoveResourcePackagesResult {}
 unsafe impl ::core::marker::Sync for PackageCatalogRemoveResourcePackagesResult {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -3650,36 +3099,7 @@ unsafe impl ::windows::core::Interface for PackageContentGroup {
 impl ::windows::core::RuntimeName for PackageContentGroup {
     const NAME: &'static str = "Windows.ApplicationModel.PackageContentGroup";
 }
-impl ::core::convert::From<PackageContentGroup> for ::windows::core::IUnknown {
-    fn from(value: PackageContentGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageContentGroup> for ::windows::core::IUnknown {
-    fn from(value: &PackageContentGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageContentGroup> for &::windows::core::IUnknown {
-    fn from(value: &PackageContentGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageContentGroup> for ::windows::core::IInspectable {
-    fn from(value: PackageContentGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageContentGroup> for ::windows::core::IInspectable {
-    fn from(value: &PackageContentGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageContentGroup> for &::windows::core::IInspectable {
-    fn from(value: &PackageContentGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageContentGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageContentGroup {}
 unsafe impl ::core::marker::Sync for PackageContentGroup {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -3768,36 +3188,7 @@ unsafe impl ::windows::core::Interface for PackageContentGroupStagingEventArgs {
 impl ::windows::core::RuntimeName for PackageContentGroupStagingEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.PackageContentGroupStagingEventArgs";
 }
-impl ::core::convert::From<PackageContentGroupStagingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PackageContentGroupStagingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageContentGroupStagingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PackageContentGroupStagingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageContentGroupStagingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PackageContentGroupStagingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageContentGroupStagingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PackageContentGroupStagingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageContentGroupStagingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PackageContentGroupStagingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageContentGroupStagingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PackageContentGroupStagingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageContentGroupStagingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageContentGroupStagingEventArgs {}
 unsafe impl ::core::marker::Sync for PackageContentGroupStagingEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -3909,36 +3300,7 @@ unsafe impl ::windows::core::Interface for PackageId {
 impl ::windows::core::RuntimeName for PackageId {
     const NAME: &'static str = "Windows.ApplicationModel.PackageId";
 }
-impl ::core::convert::From<PackageId> for ::windows::core::IUnknown {
-    fn from(value: PackageId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageId> for ::windows::core::IUnknown {
-    fn from(value: &PackageId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageId> for &::windows::core::IUnknown {
-    fn from(value: &PackageId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageId> for ::windows::core::IInspectable {
-    fn from(value: PackageId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageId> for ::windows::core::IInspectable {
-    fn from(value: &PackageId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageId> for &::windows::core::IInspectable {
-    fn from(value: &PackageId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageId, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageId {}
 unsafe impl ::core::marker::Sync for PackageId {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -4013,36 +3375,7 @@ unsafe impl ::windows::core::Interface for PackageInstallingEventArgs {
 impl ::windows::core::RuntimeName for PackageInstallingEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.PackageInstallingEventArgs";
 }
-impl ::core::convert::From<PackageInstallingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PackageInstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageInstallingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PackageInstallingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageInstallingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PackageInstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageInstallingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PackageInstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageInstallingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PackageInstallingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageInstallingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PackageInstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageInstallingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageInstallingEventArgs {}
 unsafe impl ::core::marker::Sync for PackageInstallingEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -4117,36 +3450,7 @@ unsafe impl ::windows::core::Interface for PackageStagingEventArgs {
 impl ::windows::core::RuntimeName for PackageStagingEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.PackageStagingEventArgs";
 }
-impl ::core::convert::From<PackageStagingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PackageStagingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageStagingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PackageStagingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageStagingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PackageStagingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageStagingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PackageStagingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageStagingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PackageStagingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageStagingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PackageStagingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageStagingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageStagingEventArgs {}
 unsafe impl ::core::marker::Sync for PackageStagingEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -4277,36 +3581,7 @@ unsafe impl ::windows::core::Interface for PackageStatus {
 impl ::windows::core::RuntimeName for PackageStatus {
     const NAME: &'static str = "Windows.ApplicationModel.PackageStatus";
 }
-impl ::core::convert::From<PackageStatus> for ::windows::core::IUnknown {
-    fn from(value: PackageStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageStatus> for ::windows::core::IUnknown {
-    fn from(value: &PackageStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageStatus> for &::windows::core::IUnknown {
-    fn from(value: &PackageStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageStatus> for ::windows::core::IInspectable {
-    fn from(value: PackageStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageStatus> for ::windows::core::IInspectable {
-    fn from(value: &PackageStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageStatus> for &::windows::core::IInspectable {
-    fn from(value: &PackageStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageStatus, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageStatus {}
 unsafe impl ::core::marker::Sync for PackageStatus {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -4353,36 +3628,7 @@ unsafe impl ::windows::core::Interface for PackageStatusChangedEventArgs {
 impl ::windows::core::RuntimeName for PackageStatusChangedEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.PackageStatusChangedEventArgs";
 }
-impl ::core::convert::From<PackageStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PackageStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PackageStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageStatusChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PackageStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PackageStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PackageStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageStatusChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PackageStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageStatusChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageStatusChangedEventArgs {}
 unsafe impl ::core::marker::Sync for PackageStatusChangedEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -4457,36 +3703,7 @@ unsafe impl ::windows::core::Interface for PackageUninstallingEventArgs {
 impl ::windows::core::RuntimeName for PackageUninstallingEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.PackageUninstallingEventArgs";
 }
-impl ::core::convert::From<PackageUninstallingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PackageUninstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageUninstallingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PackageUninstallingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageUninstallingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PackageUninstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageUninstallingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PackageUninstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageUninstallingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PackageUninstallingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageUninstallingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PackageUninstallingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageUninstallingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageUninstallingEventArgs {}
 unsafe impl ::core::marker::Sync for PackageUninstallingEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -4540,36 +3757,7 @@ unsafe impl ::windows::core::Interface for PackageUpdateAvailabilityResult {
 impl ::windows::core::RuntimeName for PackageUpdateAvailabilityResult {
     const NAME: &'static str = "Windows.ApplicationModel.PackageUpdateAvailabilityResult";
 }
-impl ::core::convert::From<PackageUpdateAvailabilityResult> for ::windows::core::IUnknown {
-    fn from(value: PackageUpdateAvailabilityResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageUpdateAvailabilityResult> for ::windows::core::IUnknown {
-    fn from(value: &PackageUpdateAvailabilityResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageUpdateAvailabilityResult> for &::windows::core::IUnknown {
-    fn from(value: &PackageUpdateAvailabilityResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageUpdateAvailabilityResult> for ::windows::core::IInspectable {
-    fn from(value: PackageUpdateAvailabilityResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageUpdateAvailabilityResult> for ::windows::core::IInspectable {
-    fn from(value: &PackageUpdateAvailabilityResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageUpdateAvailabilityResult> for &::windows::core::IInspectable {
-    fn from(value: &PackageUpdateAvailabilityResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageUpdateAvailabilityResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageUpdateAvailabilityResult {}
 unsafe impl ::core::marker::Sync for PackageUpdateAvailabilityResult {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -4651,36 +3839,7 @@ unsafe impl ::windows::core::Interface for PackageUpdatingEventArgs {
 impl ::windows::core::RuntimeName for PackageUpdatingEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.PackageUpdatingEventArgs";
 }
-impl ::core::convert::From<PackageUpdatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PackageUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageUpdatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PackageUpdatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageUpdatingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PackageUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageUpdatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PackageUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageUpdatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PackageUpdatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageUpdatingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PackageUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageUpdatingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageUpdatingEventArgs {}
 unsafe impl ::core::marker::Sync for PackageUpdatingEventArgs {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -4768,36 +3927,7 @@ unsafe impl ::windows::core::Interface for StartupTask {
 impl ::windows::core::RuntimeName for StartupTask {
     const NAME: &'static str = "Windows.ApplicationModel.StartupTask";
 }
-impl ::core::convert::From<StartupTask> for ::windows::core::IUnknown {
-    fn from(value: StartupTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StartupTask> for ::windows::core::IUnknown {
-    fn from(value: &StartupTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StartupTask> for &::windows::core::IUnknown {
-    fn from(value: &StartupTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StartupTask> for ::windows::core::IInspectable {
-    fn from(value: StartupTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StartupTask> for ::windows::core::IInspectable {
-    fn from(value: &StartupTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StartupTask> for &::windows::core::IInspectable {
-    fn from(value: &StartupTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StartupTask, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StartupTask {}
 unsafe impl ::core::marker::Sync for StartupTask {}
 #[doc = "*Required features: `\"ApplicationModel\"`*"]
@@ -4841,36 +3971,7 @@ unsafe impl ::windows::core::Interface for SuspendingDeferral {
 impl ::windows::core::RuntimeName for SuspendingDeferral {
     const NAME: &'static str = "Windows.ApplicationModel.SuspendingDeferral";
 }
-impl ::core::convert::From<SuspendingDeferral> for ::windows::core::IUnknown {
-    fn from(value: SuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SuspendingDeferral> for ::windows::core::IUnknown {
-    fn from(value: &SuspendingDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SuspendingDeferral> for &::windows::core::IUnknown {
-    fn from(value: &SuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SuspendingDeferral> for ::windows::core::IInspectable {
-    fn from(value: SuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SuspendingDeferral> for ::windows::core::IInspectable {
-    fn from(value: &SuspendingDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SuspendingDeferral> for &::windows::core::IInspectable {
-    fn from(value: &SuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SuspendingDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SuspendingDeferral> for ISuspendingDeferral {
     type Error = ::windows::core::Error;
     fn try_from(value: SuspendingDeferral) -> ::windows::core::Result<Self> {
@@ -4936,36 +4037,7 @@ unsafe impl ::windows::core::Interface for SuspendingEventArgs {
 impl ::windows::core::RuntimeName for SuspendingEventArgs {
     const NAME: &'static str = "Windows.ApplicationModel.SuspendingEventArgs";
 }
-impl ::core::convert::From<SuspendingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SuspendingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SuspendingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SuspendingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SuspendingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SuspendingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SuspendingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SuspendingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SuspendingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SuspendingEventArgs> for ISuspendingEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: SuspendingEventArgs) -> ::windows::core::Result<Self> {
@@ -5040,36 +4112,7 @@ unsafe impl ::windows::core::Interface for SuspendingOperation {
 impl ::windows::core::RuntimeName for SuspendingOperation {
     const NAME: &'static str = "Windows.ApplicationModel.SuspendingOperation";
 }
-impl ::core::convert::From<SuspendingOperation> for ::windows::core::IUnknown {
-    fn from(value: SuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SuspendingOperation> for ::windows::core::IUnknown {
-    fn from(value: &SuspendingOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SuspendingOperation> for &::windows::core::IUnknown {
-    fn from(value: &SuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SuspendingOperation> for ::windows::core::IInspectable {
-    fn from(value: SuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SuspendingOperation> for ::windows::core::IInspectable {
-    fn from(value: &SuspendingOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SuspendingOperation> for &::windows::core::IInspectable {
-    fn from(value: &SuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SuspendingOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SuspendingOperation> for ISuspendingOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: SuspendingOperation) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Data/Json/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Json/mod.rs
@@ -159,36 +159,7 @@ impl IJsonValue {
         }
     }
 }
-impl ::core::convert::From<IJsonValue> for ::windows::core::IUnknown {
-    fn from(value: IJsonValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IJsonValue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IJsonValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IJsonValue> for ::windows::core::IUnknown {
-    fn from(value: &IJsonValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IJsonValue> for ::windows::core::IInspectable {
-    fn from(value: IJsonValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IJsonValue> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IJsonValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IJsonValue> for ::windows::core::IInspectable {
-    fn from(value: &IJsonValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IJsonValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IJsonValue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -546,36 +517,7 @@ impl ::core::iter::IntoIterator for &JsonArray {
         super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<JsonArray> for ::windows::core::IUnknown {
-    fn from(value: JsonArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JsonArray> for ::windows::core::IUnknown {
-    fn from(value: &JsonArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JsonArray> for &::windows::core::IUnknown {
-    fn from(value: &JsonArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<JsonArray> for ::windows::core::IInspectable {
-    fn from(value: JsonArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JsonArray> for ::windows::core::IInspectable {
-    fn from(value: &JsonArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JsonArray> for &::windows::core::IInspectable {
-    fn from(value: &JsonArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(JsonArray, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<JsonArray> for super::super::Foundation::Collections::IIterable<IJsonValue> {
     type Error = ::windows::core::Error;
@@ -978,36 +920,7 @@ impl ::core::iter::IntoIterator for &JsonObject {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<JsonObject> for ::windows::core::IUnknown {
-    fn from(value: JsonObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JsonObject> for ::windows::core::IUnknown {
-    fn from(value: &JsonObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JsonObject> for &::windows::core::IUnknown {
-    fn from(value: &JsonObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<JsonObject> for ::windows::core::IInspectable {
-    fn from(value: JsonObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JsonObject> for ::windows::core::IInspectable {
-    fn from(value: &JsonObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JsonObject> for &::windows::core::IInspectable {
-    fn from(value: &JsonObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(JsonObject, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<JsonObject> for super::super::Foundation::Collections::IIterable<super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, IJsonValue>> {
     type Error = ::windows::core::Error;
@@ -1236,36 +1149,7 @@ unsafe impl ::windows::core::Interface for JsonValue {
 impl ::windows::core::RuntimeName for JsonValue {
     const NAME: &'static str = "Windows.Data.Json.JsonValue";
 }
-impl ::core::convert::From<JsonValue> for ::windows::core::IUnknown {
-    fn from(value: JsonValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JsonValue> for ::windows::core::IUnknown {
-    fn from(value: &JsonValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JsonValue> for &::windows::core::IUnknown {
-    fn from(value: &JsonValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<JsonValue> for ::windows::core::IInspectable {
-    fn from(value: JsonValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JsonValue> for ::windows::core::IInspectable {
-    fn from(value: &JsonValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JsonValue> for &::windows::core::IInspectable {
-    fn from(value: &JsonValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(JsonValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<JsonValue> for IJsonValue {
     type Error = ::windows::core::Error;
     fn try_from(value: JsonValue) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Data/Pdf/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Pdf/mod.rs
@@ -262,36 +262,7 @@ unsafe impl ::windows::core::Interface for PdfDocument {
 impl ::windows::core::RuntimeName for PdfDocument {
     const NAME: &'static str = "Windows.Data.Pdf.PdfDocument";
 }
-impl ::core::convert::From<PdfDocument> for ::windows::core::IUnknown {
-    fn from(value: PdfDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PdfDocument> for ::windows::core::IUnknown {
-    fn from(value: &PdfDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PdfDocument> for &::windows::core::IUnknown {
-    fn from(value: &PdfDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PdfDocument> for ::windows::core::IInspectable {
-    fn from(value: PdfDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PdfDocument> for ::windows::core::IInspectable {
-    fn from(value: &PdfDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PdfDocument> for &::windows::core::IInspectable {
-    fn from(value: &PdfDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PdfDocument, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PdfDocument {}
 unsafe impl ::core::marker::Sync for PdfDocument {}
 #[doc = "*Required features: `\"Data_Pdf\"`*"]
@@ -409,36 +380,7 @@ unsafe impl ::windows::core::Interface for PdfPage {
 impl ::windows::core::RuntimeName for PdfPage {
     const NAME: &'static str = "Windows.Data.Pdf.PdfPage";
 }
-impl ::core::convert::From<PdfPage> for ::windows::core::IUnknown {
-    fn from(value: PdfPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PdfPage> for ::windows::core::IUnknown {
-    fn from(value: &PdfPage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PdfPage> for &::windows::core::IUnknown {
-    fn from(value: &PdfPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PdfPage> for ::windows::core::IInspectable {
-    fn from(value: PdfPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PdfPage> for ::windows::core::IInspectable {
-    fn from(value: &PdfPage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PdfPage> for &::windows::core::IInspectable {
-    fn from(value: &PdfPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PdfPage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<PdfPage> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -545,36 +487,7 @@ unsafe impl ::windows::core::Interface for PdfPageDimensions {
 impl ::windows::core::RuntimeName for PdfPageDimensions {
     const NAME: &'static str = "Windows.Data.Pdf.PdfPageDimensions";
 }
-impl ::core::convert::From<PdfPageDimensions> for ::windows::core::IUnknown {
-    fn from(value: PdfPageDimensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PdfPageDimensions> for ::windows::core::IUnknown {
-    fn from(value: &PdfPageDimensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PdfPageDimensions> for &::windows::core::IUnknown {
-    fn from(value: &PdfPageDimensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PdfPageDimensions> for ::windows::core::IInspectable {
-    fn from(value: PdfPageDimensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PdfPageDimensions> for ::windows::core::IInspectable {
-    fn from(value: &PdfPageDimensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PdfPageDimensions> for &::windows::core::IInspectable {
-    fn from(value: &PdfPageDimensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PdfPageDimensions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PdfPageDimensions {}
 unsafe impl ::core::marker::Sync for PdfPageDimensions {}
 #[doc = "*Required features: `\"Data_Pdf\"`*"]
@@ -695,36 +608,7 @@ unsafe impl ::windows::core::Interface for PdfPageRenderOptions {
 impl ::windows::core::RuntimeName for PdfPageRenderOptions {
     const NAME: &'static str = "Windows.Data.Pdf.PdfPageRenderOptions";
 }
-impl ::core::convert::From<PdfPageRenderOptions> for ::windows::core::IUnknown {
-    fn from(value: PdfPageRenderOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PdfPageRenderOptions> for ::windows::core::IUnknown {
-    fn from(value: &PdfPageRenderOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PdfPageRenderOptions> for &::windows::core::IUnknown {
-    fn from(value: &PdfPageRenderOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PdfPageRenderOptions> for ::windows::core::IInspectable {
-    fn from(value: PdfPageRenderOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PdfPageRenderOptions> for ::windows::core::IInspectable {
-    fn from(value: &PdfPageRenderOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PdfPageRenderOptions> for &::windows::core::IInspectable {
-    fn from(value: &PdfPageRenderOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PdfPageRenderOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PdfPageRenderOptions {}
 unsafe impl ::core::marker::Sync for PdfPageRenderOptions {}
 #[doc = "*Required features: `\"Data_Pdf\"`*"]

--- a/crates/libs/windows/src/Windows/Data/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Text/mod.rs
@@ -433,36 +433,7 @@ unsafe impl ::windows::core::Interface for AlternateWordForm {
 impl ::windows::core::RuntimeName for AlternateWordForm {
     const NAME: &'static str = "Windows.Data.Text.AlternateWordForm";
 }
-impl ::core::convert::From<AlternateWordForm> for ::windows::core::IUnknown {
-    fn from(value: AlternateWordForm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AlternateWordForm> for ::windows::core::IUnknown {
-    fn from(value: &AlternateWordForm) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AlternateWordForm> for &::windows::core::IUnknown {
-    fn from(value: &AlternateWordForm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AlternateWordForm> for ::windows::core::IInspectable {
-    fn from(value: AlternateWordForm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AlternateWordForm> for ::windows::core::IInspectable {
-    fn from(value: &AlternateWordForm) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AlternateWordForm> for &::windows::core::IInspectable {
-    fn from(value: &AlternateWordForm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AlternateWordForm, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AlternateWordForm {}
 unsafe impl ::core::marker::Sync for AlternateWordForm {}
 #[doc = "*Required features: `\"Data_Text\"`*"]
@@ -516,36 +487,7 @@ unsafe impl ::windows::core::Interface for SelectableWordSegment {
 impl ::windows::core::RuntimeName for SelectableWordSegment {
     const NAME: &'static str = "Windows.Data.Text.SelectableWordSegment";
 }
-impl ::core::convert::From<SelectableWordSegment> for ::windows::core::IUnknown {
-    fn from(value: SelectableWordSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SelectableWordSegment> for ::windows::core::IUnknown {
-    fn from(value: &SelectableWordSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SelectableWordSegment> for &::windows::core::IUnknown {
-    fn from(value: &SelectableWordSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SelectableWordSegment> for ::windows::core::IInspectable {
-    fn from(value: SelectableWordSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SelectableWordSegment> for ::windows::core::IInspectable {
-    fn from(value: &SelectableWordSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SelectableWordSegment> for &::windows::core::IInspectable {
-    fn from(value: &SelectableWordSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SelectableWordSegment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SelectableWordSegment {}
 unsafe impl ::core::marker::Sync for SelectableWordSegment {}
 #[doc = "*Required features: `\"Data_Text\"`*"]
@@ -625,36 +567,7 @@ unsafe impl ::windows::core::Interface for SelectableWordsSegmenter {
 impl ::windows::core::RuntimeName for SelectableWordsSegmenter {
     const NAME: &'static str = "Windows.Data.Text.SelectableWordsSegmenter";
 }
-impl ::core::convert::From<SelectableWordsSegmenter> for ::windows::core::IUnknown {
-    fn from(value: SelectableWordsSegmenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SelectableWordsSegmenter> for ::windows::core::IUnknown {
-    fn from(value: &SelectableWordsSegmenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SelectableWordsSegmenter> for &::windows::core::IUnknown {
-    fn from(value: &SelectableWordsSegmenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SelectableWordsSegmenter> for ::windows::core::IInspectable {
-    fn from(value: SelectableWordsSegmenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SelectableWordsSegmenter> for ::windows::core::IInspectable {
-    fn from(value: &SelectableWordsSegmenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SelectableWordsSegmenter> for &::windows::core::IInspectable {
-    fn from(value: &SelectableWordsSegmenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SelectableWordsSegmenter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SelectableWordsSegmenter {}
 unsafe impl ::core::marker::Sync for SelectableWordsSegmenter {}
 #[doc = "*Required features: `\"Data_Text\"`*"]
@@ -729,36 +642,7 @@ unsafe impl ::windows::core::Interface for SemanticTextQuery {
 impl ::windows::core::RuntimeName for SemanticTextQuery {
     const NAME: &'static str = "Windows.Data.Text.SemanticTextQuery";
 }
-impl ::core::convert::From<SemanticTextQuery> for ::windows::core::IUnknown {
-    fn from(value: SemanticTextQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SemanticTextQuery> for ::windows::core::IUnknown {
-    fn from(value: &SemanticTextQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SemanticTextQuery> for &::windows::core::IUnknown {
-    fn from(value: &SemanticTextQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SemanticTextQuery> for ::windows::core::IInspectable {
-    fn from(value: SemanticTextQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SemanticTextQuery> for ::windows::core::IInspectable {
-    fn from(value: &SemanticTextQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SemanticTextQuery> for &::windows::core::IInspectable {
-    fn from(value: &SemanticTextQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SemanticTextQuery, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SemanticTextQuery {}
 unsafe impl ::core::marker::Sync for SemanticTextQuery {}
 #[doc = "*Required features: `\"Data_Text\"`*"]
@@ -841,36 +725,7 @@ unsafe impl ::windows::core::Interface for TextConversionGenerator {
 impl ::windows::core::RuntimeName for TextConversionGenerator {
     const NAME: &'static str = "Windows.Data.Text.TextConversionGenerator";
 }
-impl ::core::convert::From<TextConversionGenerator> for ::windows::core::IUnknown {
-    fn from(value: TextConversionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TextConversionGenerator> for ::windows::core::IUnknown {
-    fn from(value: &TextConversionGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TextConversionGenerator> for &::windows::core::IUnknown {
-    fn from(value: &TextConversionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TextConversionGenerator> for ::windows::core::IInspectable {
-    fn from(value: TextConversionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TextConversionGenerator> for ::windows::core::IInspectable {
-    fn from(value: &TextConversionGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TextConversionGenerator> for &::windows::core::IInspectable {
-    fn from(value: &TextConversionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TextConversionGenerator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TextConversionGenerator {}
 unsafe impl ::core::marker::Sync for TextConversionGenerator {}
 #[doc = "*Required features: `\"Data_Text\"`*"]
@@ -924,36 +779,7 @@ unsafe impl ::windows::core::Interface for TextPhoneme {
 impl ::windows::core::RuntimeName for TextPhoneme {
     const NAME: &'static str = "Windows.Data.Text.TextPhoneme";
 }
-impl ::core::convert::From<TextPhoneme> for ::windows::core::IUnknown {
-    fn from(value: TextPhoneme) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TextPhoneme> for ::windows::core::IUnknown {
-    fn from(value: &TextPhoneme) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TextPhoneme> for &::windows::core::IUnknown {
-    fn from(value: &TextPhoneme) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TextPhoneme> for ::windows::core::IInspectable {
-    fn from(value: TextPhoneme) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TextPhoneme> for ::windows::core::IInspectable {
-    fn from(value: &TextPhoneme) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TextPhoneme> for &::windows::core::IInspectable {
-    fn from(value: &TextPhoneme) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TextPhoneme, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TextPhoneme {}
 unsafe impl ::core::marker::Sync for TextPhoneme {}
 #[doc = "*Required features: `\"Data_Text\"`*"]
@@ -1077,36 +903,7 @@ unsafe impl ::windows::core::Interface for TextPredictionGenerator {
 impl ::windows::core::RuntimeName for TextPredictionGenerator {
     const NAME: &'static str = "Windows.Data.Text.TextPredictionGenerator";
 }
-impl ::core::convert::From<TextPredictionGenerator> for ::windows::core::IUnknown {
-    fn from(value: TextPredictionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TextPredictionGenerator> for ::windows::core::IUnknown {
-    fn from(value: &TextPredictionGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TextPredictionGenerator> for &::windows::core::IUnknown {
-    fn from(value: &TextPredictionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TextPredictionGenerator> for ::windows::core::IInspectable {
-    fn from(value: TextPredictionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TextPredictionGenerator> for ::windows::core::IInspectable {
-    fn from(value: &TextPredictionGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TextPredictionGenerator> for &::windows::core::IInspectable {
-    fn from(value: &TextPredictionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TextPredictionGenerator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TextPredictionGenerator {}
 unsafe impl ::core::marker::Sync for TextPredictionGenerator {}
 #[doc = "*Required features: `\"Data_Text\"`*"]
@@ -1189,36 +986,7 @@ unsafe impl ::windows::core::Interface for TextReverseConversionGenerator {
 impl ::windows::core::RuntimeName for TextReverseConversionGenerator {
     const NAME: &'static str = "Windows.Data.Text.TextReverseConversionGenerator";
 }
-impl ::core::convert::From<TextReverseConversionGenerator> for ::windows::core::IUnknown {
-    fn from(value: TextReverseConversionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TextReverseConversionGenerator> for ::windows::core::IUnknown {
-    fn from(value: &TextReverseConversionGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TextReverseConversionGenerator> for &::windows::core::IUnknown {
-    fn from(value: &TextReverseConversionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TextReverseConversionGenerator> for ::windows::core::IInspectable {
-    fn from(value: TextReverseConversionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TextReverseConversionGenerator> for ::windows::core::IInspectable {
-    fn from(value: &TextReverseConversionGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TextReverseConversionGenerator> for &::windows::core::IInspectable {
-    fn from(value: &TextReverseConversionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TextReverseConversionGenerator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TextReverseConversionGenerator {}
 unsafe impl ::core::marker::Sync for TextReverseConversionGenerator {}
 #[doc = "*Required features: `\"Data_Text\"`*"]
@@ -1392,36 +1160,7 @@ unsafe impl ::windows::core::Interface for WordSegment {
 impl ::windows::core::RuntimeName for WordSegment {
     const NAME: &'static str = "Windows.Data.Text.WordSegment";
 }
-impl ::core::convert::From<WordSegment> for ::windows::core::IUnknown {
-    fn from(value: WordSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WordSegment> for ::windows::core::IUnknown {
-    fn from(value: &WordSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WordSegment> for &::windows::core::IUnknown {
-    fn from(value: &WordSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WordSegment> for ::windows::core::IInspectable {
-    fn from(value: WordSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WordSegment> for ::windows::core::IInspectable {
-    fn from(value: &WordSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WordSegment> for &::windows::core::IInspectable {
-    fn from(value: &WordSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WordSegment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WordSegment {}
 unsafe impl ::core::marker::Sync for WordSegment {}
 #[doc = "*Required features: `\"Data_Text\"`*"]
@@ -1501,36 +1240,7 @@ unsafe impl ::windows::core::Interface for WordsSegmenter {
 impl ::windows::core::RuntimeName for WordsSegmenter {
     const NAME: &'static str = "Windows.Data.Text.WordsSegmenter";
 }
-impl ::core::convert::From<WordsSegmenter> for ::windows::core::IUnknown {
-    fn from(value: WordsSegmenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WordsSegmenter> for ::windows::core::IUnknown {
-    fn from(value: &WordsSegmenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WordsSegmenter> for &::windows::core::IUnknown {
-    fn from(value: &WordsSegmenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WordsSegmenter> for ::windows::core::IInspectable {
-    fn from(value: WordsSegmenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WordsSegmenter> for ::windows::core::IInspectable {
-    fn from(value: &WordsSegmenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WordsSegmenter> for &::windows::core::IInspectable {
-    fn from(value: &WordsSegmenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WordsSegmenter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WordsSegmenter {}
 unsafe impl ::core::marker::Sync for WordsSegmenter {}
 #[doc = "*Required features: `\"Data_Text\"`*"]

--- a/crates/libs/windows/src/Windows/Data/Xml/Dom/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Xml/Dom/mod.rs
@@ -339,36 +339,7 @@ impl IXmlCharacterData {
         unsafe { (::windows::core::Vtable::vtable(this).SetInnerText)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(value)).ok() }
     }
 }
-impl ::core::convert::From<IXmlCharacterData> for ::windows::core::IUnknown {
-    fn from(value: IXmlCharacterData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlCharacterData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXmlCharacterData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlCharacterData> for ::windows::core::IUnknown {
-    fn from(value: &IXmlCharacterData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXmlCharacterData> for ::windows::core::IInspectable {
-    fn from(value: IXmlCharacterData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlCharacterData> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IXmlCharacterData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlCharacterData> for ::windows::core::IInspectable {
-    fn from(value: &IXmlCharacterData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXmlCharacterData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IXmlCharacterData> for IXmlNode {
     type Error = ::windows::core::Error;
     fn try_from(value: IXmlCharacterData) -> ::windows::core::Result<Self> {
@@ -953,36 +924,7 @@ impl IXmlNode {
         unsafe { (::windows::core::Vtable::vtable(this).SetInnerText)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(value)).ok() }
     }
 }
-impl ::core::convert::From<IXmlNode> for ::windows::core::IUnknown {
-    fn from(value: IXmlNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXmlNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlNode> for ::windows::core::IUnknown {
-    fn from(value: &IXmlNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXmlNode> for ::windows::core::IInspectable {
-    fn from(value: IXmlNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlNode> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IXmlNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlNode> for ::windows::core::IInspectable {
-    fn from(value: &IXmlNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXmlNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IXmlNode> for IXmlNodeSelector {
     type Error = ::windows::core::Error;
     fn try_from(value: IXmlNode) -> ::windows::core::Result<Self> {
@@ -1133,36 +1075,7 @@ impl IXmlNodeSelector {
         }
     }
 }
-impl ::core::convert::From<IXmlNodeSelector> for ::windows::core::IUnknown {
-    fn from(value: IXmlNodeSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlNodeSelector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXmlNodeSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlNodeSelector> for ::windows::core::IUnknown {
-    fn from(value: &IXmlNodeSelector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXmlNodeSelector> for ::windows::core::IInspectable {
-    fn from(value: IXmlNodeSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlNodeSelector> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IXmlNodeSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlNodeSelector> for ::windows::core::IInspectable {
-    fn from(value: &IXmlNodeSelector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXmlNodeSelector, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IXmlNodeSelector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1224,36 +1137,7 @@ impl IXmlNodeSerializer {
         unsafe { (::windows::core::Vtable::vtable(this).SetInnerText)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(value)).ok() }
     }
 }
-impl ::core::convert::From<IXmlNodeSerializer> for ::windows::core::IUnknown {
-    fn from(value: IXmlNodeSerializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlNodeSerializer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXmlNodeSerializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlNodeSerializer> for ::windows::core::IUnknown {
-    fn from(value: &IXmlNodeSerializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXmlNodeSerializer> for ::windows::core::IInspectable {
-    fn from(value: IXmlNodeSerializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlNodeSerializer> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IXmlNodeSerializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlNodeSerializer> for ::windows::core::IInspectable {
-    fn from(value: &IXmlNodeSerializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXmlNodeSerializer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IXmlNodeSerializer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1591,36 +1475,7 @@ impl IXmlText {
         unsafe { (::windows::core::Vtable::vtable(this).SetInnerText)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(value)).ok() }
     }
 }
-impl ::core::convert::From<IXmlText> for ::windows::core::IUnknown {
-    fn from(value: IXmlText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlText> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXmlText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlText> for ::windows::core::IUnknown {
-    fn from(value: &IXmlText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXmlText> for ::windows::core::IInspectable {
-    fn from(value: IXmlText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlText> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IXmlText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlText> for ::windows::core::IInspectable {
-    fn from(value: &IXmlText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXmlText, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IXmlText> for IXmlCharacterData {
     type Error = ::windows::core::Error;
     fn try_from(value: IXmlText) -> ::windows::core::Result<Self> {
@@ -2020,36 +1875,7 @@ unsafe impl ::windows::core::Interface for DtdEntity {
 impl ::windows::core::RuntimeName for DtdEntity {
     const NAME: &'static str = "Windows.Data.Xml.Dom.DtdEntity";
 }
-impl ::core::convert::From<DtdEntity> for ::windows::core::IUnknown {
-    fn from(value: DtdEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DtdEntity> for ::windows::core::IUnknown {
-    fn from(value: &DtdEntity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DtdEntity> for &::windows::core::IUnknown {
-    fn from(value: &DtdEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DtdEntity> for ::windows::core::IInspectable {
-    fn from(value: DtdEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DtdEntity> for ::windows::core::IInspectable {
-    fn from(value: &DtdEntity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DtdEntity> for &::windows::core::IInspectable {
-    fn from(value: &DtdEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DtdEntity, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DtdEntity> for IXmlNode {
     type Error = ::windows::core::Error;
     fn try_from(value: DtdEntity) -> ::windows::core::Result<Self> {
@@ -2390,36 +2216,7 @@ unsafe impl ::windows::core::Interface for DtdNotation {
 impl ::windows::core::RuntimeName for DtdNotation {
     const NAME: &'static str = "Windows.Data.Xml.Dom.DtdNotation";
 }
-impl ::core::convert::From<DtdNotation> for ::windows::core::IUnknown {
-    fn from(value: DtdNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DtdNotation> for ::windows::core::IUnknown {
-    fn from(value: &DtdNotation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DtdNotation> for &::windows::core::IUnknown {
-    fn from(value: &DtdNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DtdNotation> for ::windows::core::IInspectable {
-    fn from(value: DtdNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DtdNotation> for ::windows::core::IInspectable {
-    fn from(value: &DtdNotation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DtdNotation> for &::windows::core::IInspectable {
-    fn from(value: &DtdNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DtdNotation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DtdNotation> for IXmlNode {
     type Error = ::windows::core::Error;
     fn try_from(value: DtdNotation) -> ::windows::core::Result<Self> {
@@ -2771,36 +2568,7 @@ unsafe impl ::windows::core::Interface for XmlAttribute {
 impl ::windows::core::RuntimeName for XmlAttribute {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlAttribute";
 }
-impl ::core::convert::From<XmlAttribute> for ::windows::core::IUnknown {
-    fn from(value: XmlAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlAttribute> for ::windows::core::IUnknown {
-    fn from(value: &XmlAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlAttribute> for &::windows::core::IUnknown {
-    fn from(value: &XmlAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlAttribute> for ::windows::core::IInspectable {
-    fn from(value: XmlAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlAttribute> for ::windows::core::IInspectable {
-    fn from(value: &XmlAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlAttribute> for &::windows::core::IInspectable {
-    fn from(value: &XmlAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlAttribute, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<XmlAttribute> for IXmlNode {
     type Error = ::windows::core::Error;
     fn try_from(value: XmlAttribute) -> ::windows::core::Result<Self> {
@@ -3175,36 +2943,7 @@ unsafe impl ::windows::core::Interface for XmlCDataSection {
 impl ::windows::core::RuntimeName for XmlCDataSection {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlCDataSection";
 }
-impl ::core::convert::From<XmlCDataSection> for ::windows::core::IUnknown {
-    fn from(value: XmlCDataSection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlCDataSection> for ::windows::core::IUnknown {
-    fn from(value: &XmlCDataSection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlCDataSection> for &::windows::core::IUnknown {
-    fn from(value: &XmlCDataSection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlCDataSection> for ::windows::core::IInspectable {
-    fn from(value: XmlCDataSection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlCDataSection> for ::windows::core::IInspectable {
-    fn from(value: &XmlCDataSection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlCDataSection> for &::windows::core::IInspectable {
-    fn from(value: &XmlCDataSection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlCDataSection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<XmlCDataSection> for IXmlCharacterData {
     type Error = ::windows::core::Error;
     fn try_from(value: XmlCDataSection) -> ::windows::core::Result<Self> {
@@ -3610,36 +3349,7 @@ unsafe impl ::windows::core::Interface for XmlComment {
 impl ::windows::core::RuntimeName for XmlComment {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlComment";
 }
-impl ::core::convert::From<XmlComment> for ::windows::core::IUnknown {
-    fn from(value: XmlComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlComment> for ::windows::core::IUnknown {
-    fn from(value: &XmlComment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlComment> for &::windows::core::IUnknown {
-    fn from(value: &XmlComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlComment> for ::windows::core::IInspectable {
-    fn from(value: XmlComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlComment> for ::windows::core::IInspectable {
-    fn from(value: &XmlComment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlComment> for &::windows::core::IInspectable {
-    fn from(value: &XmlComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlComment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<XmlComment> for IXmlCharacterData {
     type Error = ::windows::core::Error;
     fn try_from(value: XmlComment) -> ::windows::core::Result<Self> {
@@ -4207,36 +3917,7 @@ unsafe impl ::windows::core::Interface for XmlDocument {
 impl ::windows::core::RuntimeName for XmlDocument {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlDocument";
 }
-impl ::core::convert::From<XmlDocument> for ::windows::core::IUnknown {
-    fn from(value: XmlDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlDocument> for ::windows::core::IUnknown {
-    fn from(value: &XmlDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlDocument> for &::windows::core::IUnknown {
-    fn from(value: &XmlDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlDocument> for ::windows::core::IInspectable {
-    fn from(value: XmlDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlDocument> for ::windows::core::IInspectable {
-    fn from(value: &XmlDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlDocument> for &::windows::core::IInspectable {
-    fn from(value: &XmlDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlDocument, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<XmlDocument> for IXmlNode {
     type Error = ::windows::core::Error;
     fn try_from(value: XmlDocument) -> ::windows::core::Result<Self> {
@@ -4563,36 +4244,7 @@ unsafe impl ::windows::core::Interface for XmlDocumentFragment {
 impl ::windows::core::RuntimeName for XmlDocumentFragment {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlDocumentFragment";
 }
-impl ::core::convert::From<XmlDocumentFragment> for ::windows::core::IUnknown {
-    fn from(value: XmlDocumentFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlDocumentFragment> for ::windows::core::IUnknown {
-    fn from(value: &XmlDocumentFragment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlDocumentFragment> for &::windows::core::IUnknown {
-    fn from(value: &XmlDocumentFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlDocumentFragment> for ::windows::core::IInspectable {
-    fn from(value: XmlDocumentFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlDocumentFragment> for ::windows::core::IInspectable {
-    fn from(value: &XmlDocumentFragment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlDocumentFragment> for &::windows::core::IInspectable {
-    fn from(value: &XmlDocumentFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlDocumentFragment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<XmlDocumentFragment> for IXmlNode {
     type Error = ::windows::core::Error;
     fn try_from(value: XmlDocumentFragment) -> ::windows::core::Result<Self> {
@@ -4940,36 +4592,7 @@ unsafe impl ::windows::core::Interface for XmlDocumentType {
 impl ::windows::core::RuntimeName for XmlDocumentType {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlDocumentType";
 }
-impl ::core::convert::From<XmlDocumentType> for ::windows::core::IUnknown {
-    fn from(value: XmlDocumentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlDocumentType> for ::windows::core::IUnknown {
-    fn from(value: &XmlDocumentType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlDocumentType> for &::windows::core::IUnknown {
-    fn from(value: &XmlDocumentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlDocumentType> for ::windows::core::IInspectable {
-    fn from(value: XmlDocumentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlDocumentType> for ::windows::core::IInspectable {
-    fn from(value: &XmlDocumentType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlDocumentType> for &::windows::core::IInspectable {
-    fn from(value: &XmlDocumentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlDocumentType, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<XmlDocumentType> for IXmlNode {
     type Error = ::windows::core::Error;
     fn try_from(value: XmlDocumentType) -> ::windows::core::Result<Self> {
@@ -5076,36 +4699,7 @@ unsafe impl ::windows::core::Interface for XmlDomImplementation {
 impl ::windows::core::RuntimeName for XmlDomImplementation {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlDomImplementation";
 }
-impl ::core::convert::From<XmlDomImplementation> for ::windows::core::IUnknown {
-    fn from(value: XmlDomImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlDomImplementation> for ::windows::core::IUnknown {
-    fn from(value: &XmlDomImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlDomImplementation> for &::windows::core::IUnknown {
-    fn from(value: &XmlDomImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlDomImplementation> for ::windows::core::IInspectable {
-    fn from(value: XmlDomImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlDomImplementation> for ::windows::core::IInspectable {
-    fn from(value: &XmlDomImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlDomImplementation> for &::windows::core::IInspectable {
-    fn from(value: &XmlDomImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlDomImplementation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XmlDomImplementation {}
 unsafe impl ::core::marker::Sync for XmlDomImplementation {}
 #[doc = "*Required features: `\"Data_Xml_Dom\"`*"]
@@ -5466,36 +5060,7 @@ unsafe impl ::windows::core::Interface for XmlElement {
 impl ::windows::core::RuntimeName for XmlElement {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlElement";
 }
-impl ::core::convert::From<XmlElement> for ::windows::core::IUnknown {
-    fn from(value: XmlElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlElement> for ::windows::core::IUnknown {
-    fn from(value: &XmlElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlElement> for &::windows::core::IUnknown {
-    fn from(value: &XmlElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlElement> for ::windows::core::IInspectable {
-    fn from(value: XmlElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlElement> for ::windows::core::IInspectable {
-    fn from(value: &XmlElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlElement> for &::windows::core::IInspectable {
-    fn from(value: &XmlElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlElement, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<XmlElement> for IXmlNode {
     type Error = ::windows::core::Error;
     fn try_from(value: XmlElement) -> ::windows::core::Result<Self> {
@@ -5822,36 +5387,7 @@ unsafe impl ::windows::core::Interface for XmlEntityReference {
 impl ::windows::core::RuntimeName for XmlEntityReference {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlEntityReference";
 }
-impl ::core::convert::From<XmlEntityReference> for ::windows::core::IUnknown {
-    fn from(value: XmlEntityReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlEntityReference> for ::windows::core::IUnknown {
-    fn from(value: &XmlEntityReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlEntityReference> for &::windows::core::IUnknown {
-    fn from(value: &XmlEntityReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlEntityReference> for ::windows::core::IInspectable {
-    fn from(value: XmlEntityReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlEntityReference> for ::windows::core::IInspectable {
-    fn from(value: &XmlEntityReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlEntityReference> for &::windows::core::IInspectable {
-    fn from(value: &XmlEntityReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlEntityReference, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<XmlEntityReference> for IXmlNode {
     type Error = ::windows::core::Error;
     fn try_from(value: XmlEntityReference) -> ::windows::core::Result<Self> {
@@ -6010,36 +5546,7 @@ unsafe impl ::windows::core::Interface for XmlLoadSettings {
 impl ::windows::core::RuntimeName for XmlLoadSettings {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlLoadSettings";
 }
-impl ::core::convert::From<XmlLoadSettings> for ::windows::core::IUnknown {
-    fn from(value: XmlLoadSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlLoadSettings> for ::windows::core::IUnknown {
-    fn from(value: &XmlLoadSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlLoadSettings> for &::windows::core::IUnknown {
-    fn from(value: &XmlLoadSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlLoadSettings> for ::windows::core::IInspectable {
-    fn from(value: XmlLoadSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlLoadSettings> for ::windows::core::IInspectable {
-    fn from(value: &XmlLoadSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlLoadSettings> for &::windows::core::IInspectable {
-    fn from(value: &XmlLoadSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlLoadSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XmlLoadSettings {}
 unsafe impl ::core::marker::Sync for XmlLoadSettings {}
 #[doc = "*Required features: `\"Data_Xml_Dom\"`*"]
@@ -6214,36 +5721,7 @@ impl ::core::iter::IntoIterator for &XmlNamedNodeMap {
         super::super::super::Foundation::Collections::VectorViewIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<XmlNamedNodeMap> for ::windows::core::IUnknown {
-    fn from(value: XmlNamedNodeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlNamedNodeMap> for ::windows::core::IUnknown {
-    fn from(value: &XmlNamedNodeMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlNamedNodeMap> for &::windows::core::IUnknown {
-    fn from(value: &XmlNamedNodeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlNamedNodeMap> for ::windows::core::IInspectable {
-    fn from(value: XmlNamedNodeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlNamedNodeMap> for ::windows::core::IInspectable {
-    fn from(value: &XmlNamedNodeMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlNamedNodeMap> for &::windows::core::IInspectable {
-    fn from(value: &XmlNamedNodeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlNamedNodeMap, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<XmlNamedNodeMap> for super::super::super::Foundation::Collections::IIterable<IXmlNode> {
     type Error = ::windows::core::Error;
@@ -6406,36 +5884,7 @@ impl ::core::iter::IntoIterator for &XmlNodeList {
         super::super::super::Foundation::Collections::VectorViewIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<XmlNodeList> for ::windows::core::IUnknown {
-    fn from(value: XmlNodeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlNodeList> for ::windows::core::IUnknown {
-    fn from(value: &XmlNodeList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlNodeList> for &::windows::core::IUnknown {
-    fn from(value: &XmlNodeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlNodeList> for ::windows::core::IInspectable {
-    fn from(value: XmlNodeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlNodeList> for ::windows::core::IInspectable {
-    fn from(value: &XmlNodeList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlNodeList> for &::windows::core::IInspectable {
-    fn from(value: &XmlNodeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlNodeList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<XmlNodeList> for super::super::super::Foundation::Collections::IIterable<IXmlNode> {
     type Error = ::windows::core::Error;
@@ -6767,36 +6216,7 @@ unsafe impl ::windows::core::Interface for XmlProcessingInstruction {
 impl ::windows::core::RuntimeName for XmlProcessingInstruction {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlProcessingInstruction";
 }
-impl ::core::convert::From<XmlProcessingInstruction> for ::windows::core::IUnknown {
-    fn from(value: XmlProcessingInstruction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlProcessingInstruction> for ::windows::core::IUnknown {
-    fn from(value: &XmlProcessingInstruction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlProcessingInstruction> for &::windows::core::IUnknown {
-    fn from(value: &XmlProcessingInstruction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlProcessingInstruction> for ::windows::core::IInspectable {
-    fn from(value: XmlProcessingInstruction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlProcessingInstruction> for ::windows::core::IInspectable {
-    fn from(value: &XmlProcessingInstruction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlProcessingInstruction> for &::windows::core::IInspectable {
-    fn from(value: &XmlProcessingInstruction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlProcessingInstruction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<XmlProcessingInstruction> for IXmlNode {
     type Error = ::windows::core::Error;
     fn try_from(value: XmlProcessingInstruction) -> ::windows::core::Result<Self> {
@@ -7171,36 +6591,7 @@ unsafe impl ::windows::core::Interface for XmlText {
 impl ::windows::core::RuntimeName for XmlText {
     const NAME: &'static str = "Windows.Data.Xml.Dom.XmlText";
 }
-impl ::core::convert::From<XmlText> for ::windows::core::IUnknown {
-    fn from(value: XmlText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlText> for ::windows::core::IUnknown {
-    fn from(value: &XmlText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlText> for &::windows::core::IUnknown {
-    fn from(value: &XmlText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XmlText> for ::windows::core::IInspectable {
-    fn from(value: XmlText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XmlText> for ::windows::core::IInspectable {
-    fn from(value: &XmlText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XmlText> for &::windows::core::IInspectable {
-    fn from(value: &XmlText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XmlText, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<XmlText> for IXmlCharacterData {
     type Error = ::windows::core::Error;
     fn try_from(value: XmlText) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Data/Xml/Xsl/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Xml/Xsl/mod.rs
@@ -128,36 +128,7 @@ unsafe impl ::windows::core::Interface for XsltProcessor {
 impl ::windows::core::RuntimeName for XsltProcessor {
     const NAME: &'static str = "Windows.Data.Xml.Xsl.XsltProcessor";
 }
-impl ::core::convert::From<XsltProcessor> for ::windows::core::IUnknown {
-    fn from(value: XsltProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XsltProcessor> for ::windows::core::IUnknown {
-    fn from(value: &XsltProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XsltProcessor> for &::windows::core::IUnknown {
-    fn from(value: &XsltProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XsltProcessor> for ::windows::core::IInspectable {
-    fn from(value: XsltProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XsltProcessor> for ::windows::core::IInspectable {
-    fn from(value: &XsltProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XsltProcessor> for &::windows::core::IInspectable {
-    fn from(value: &XsltProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XsltProcessor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XsltProcessor {}
 unsafe impl ::core::marker::Sync for XsltProcessor {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Devices/Adc/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Adc/Provider/mod.rs
@@ -64,36 +64,7 @@ impl IAdcControllerProvider {
         }
     }
 }
-impl ::core::convert::From<IAdcControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: IAdcControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdcControllerProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAdcControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdcControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: &IAdcControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAdcControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: IAdcControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdcControllerProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAdcControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdcControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: &IAdcControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAdcControllerProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAdcControllerProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -152,36 +123,7 @@ impl IAdcProvider {
         }
     }
 }
-impl ::core::convert::From<IAdcProvider> for ::windows::core::IUnknown {
-    fn from(value: IAdcProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdcProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAdcProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdcProvider> for ::windows::core::IUnknown {
-    fn from(value: &IAdcProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAdcProvider> for ::windows::core::IInspectable {
-    fn from(value: IAdcProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdcProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAdcProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdcProvider> for ::windows::core::IInspectable {
-    fn from(value: &IAdcProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAdcProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAdcProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Devices/Adc/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Adc/mod.rs
@@ -139,36 +139,7 @@ unsafe impl ::windows::core::Interface for AdcChannel {
 impl ::windows::core::RuntimeName for AdcChannel {
     const NAME: &'static str = "Windows.Devices.Adc.AdcChannel";
 }
-impl ::core::convert::From<AdcChannel> for ::windows::core::IUnknown {
-    fn from(value: AdcChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdcChannel> for ::windows::core::IUnknown {
-    fn from(value: &AdcChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdcChannel> for &::windows::core::IUnknown {
-    fn from(value: &AdcChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdcChannel> for ::windows::core::IInspectable {
-    fn from(value: AdcChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdcChannel> for ::windows::core::IInspectable {
-    fn from(value: &AdcChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdcChannel> for &::windows::core::IInspectable {
-    fn from(value: &AdcChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdcChannel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<AdcChannel> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -313,36 +284,7 @@ unsafe impl ::windows::core::Interface for AdcController {
 impl ::windows::core::RuntimeName for AdcController {
     const NAME: &'static str = "Windows.Devices.Adc.AdcController";
 }
-impl ::core::convert::From<AdcController> for ::windows::core::IUnknown {
-    fn from(value: AdcController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdcController> for ::windows::core::IUnknown {
-    fn from(value: &AdcController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdcController> for &::windows::core::IUnknown {
-    fn from(value: &AdcController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdcController> for ::windows::core::IInspectable {
-    fn from(value: AdcController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdcController> for ::windows::core::IInspectable {
-    fn from(value: &AdcController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdcController> for &::windows::core::IInspectable {
-    fn from(value: &AdcController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdcController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdcController {}
 unsafe impl ::core::marker::Sync for AdcController {}
 #[doc = "*Required features: `\"Devices_Adc\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/AllJoyn/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/AllJoyn/mod.rs
@@ -222,41 +222,7 @@ impl IAllJoynAcceptSessionJoiner {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<IAllJoynAcceptSessionJoiner> for ::windows::core::IUnknown {
-    fn from(value: IAllJoynAcceptSessionJoiner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IAllJoynAcceptSessionJoiner> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAllJoynAcceptSessionJoiner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IAllJoynAcceptSessionJoiner> for ::windows::core::IUnknown {
-    fn from(value: &IAllJoynAcceptSessionJoiner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<IAllJoynAcceptSessionJoiner> for ::windows::core::IInspectable {
-    fn from(value: IAllJoynAcceptSessionJoiner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IAllJoynAcceptSessionJoiner> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAllJoynAcceptSessionJoiner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IAllJoynAcceptSessionJoiner> for ::windows::core::IInspectable {
-    fn from(value: &IAllJoynAcceptSessionJoiner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAllJoynAcceptSessionJoiner, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for IAllJoynAcceptSessionJoiner {
     fn clone(&self) -> Self {
@@ -903,41 +869,7 @@ impl IAllJoynProducer {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<IAllJoynProducer> for ::windows::core::IUnknown {
-    fn from(value: IAllJoynProducer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IAllJoynProducer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAllJoynProducer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IAllJoynProducer> for ::windows::core::IUnknown {
-    fn from(value: &IAllJoynProducer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<IAllJoynProducer> for ::windows::core::IInspectable {
-    fn from(value: IAllJoynProducer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IAllJoynProducer> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAllJoynProducer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IAllJoynProducer> for ::windows::core::IInspectable {
-    fn from(value: &IAllJoynProducer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAllJoynProducer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for IAllJoynProducer {
     fn clone(&self) -> Self {
@@ -1750,41 +1682,7 @@ impl ::windows::core::RuntimeName for AllJoynAboutData {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynAboutData";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynAboutData> for ::windows::core::IUnknown {
-    fn from(value: AllJoynAboutData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAboutData> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynAboutData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAboutData> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynAboutData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynAboutData> for ::windows::core::IInspectable {
-    fn from(value: AllJoynAboutData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAboutData> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynAboutData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAboutData> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynAboutData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynAboutData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynAboutData {}
 #[cfg(feature = "deprecated")]
@@ -2003,41 +1901,7 @@ impl ::windows::core::RuntimeName for AllJoynAboutDataView {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynAboutDataView";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynAboutDataView> for ::windows::core::IUnknown {
-    fn from(value: AllJoynAboutDataView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAboutDataView> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynAboutDataView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAboutDataView> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynAboutDataView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynAboutDataView> for ::windows::core::IInspectable {
-    fn from(value: AllJoynAboutDataView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAboutDataView> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynAboutDataView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAboutDataView> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynAboutDataView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynAboutDataView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynAboutDataView {}
 #[cfg(feature = "deprecated")]
@@ -2159,41 +2023,7 @@ impl ::windows::core::RuntimeName for AllJoynAcceptSessionJoinerEventArgs {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynAcceptSessionJoinerEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynAcceptSessionJoinerEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynAcceptSessionJoinerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAcceptSessionJoinerEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynAcceptSessionJoinerEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAcceptSessionJoinerEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynAcceptSessionJoinerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynAcceptSessionJoinerEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynAcceptSessionJoinerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAcceptSessionJoinerEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynAcceptSessionJoinerEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAcceptSessionJoinerEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynAcceptSessionJoinerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynAcceptSessionJoinerEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynAcceptSessionJoinerEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -2273,41 +2103,7 @@ impl ::windows::core::RuntimeName for AllJoynAuthenticationCompleteEventArgs {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynAuthenticationCompleteEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynAuthenticationCompleteEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynAuthenticationCompleteEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAuthenticationCompleteEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynAuthenticationCompleteEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAuthenticationCompleteEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynAuthenticationCompleteEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynAuthenticationCompleteEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynAuthenticationCompleteEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAuthenticationCompleteEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynAuthenticationCompleteEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynAuthenticationCompleteEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynAuthenticationCompleteEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynAuthenticationCompleteEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynAuthenticationCompleteEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -2581,41 +2377,7 @@ impl ::windows::core::RuntimeName for AllJoynBusAttachment {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynBusAttachment";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynBusAttachment> for ::windows::core::IUnknown {
-    fn from(value: AllJoynBusAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusAttachment> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynBusAttachment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusAttachment> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynBusAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynBusAttachment> for ::windows::core::IInspectable {
-    fn from(value: AllJoynBusAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusAttachment> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynBusAttachment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusAttachment> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynBusAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynBusAttachment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynBusAttachment {}
 #[cfg(feature = "deprecated")]
@@ -2686,41 +2448,7 @@ impl ::windows::core::RuntimeName for AllJoynBusAttachmentStateChangedEventArgs 
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynBusAttachmentStateChangedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynBusAttachmentStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynBusAttachmentStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusAttachmentStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynBusAttachmentStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusAttachmentStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynBusAttachmentStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynBusAttachmentStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynBusAttachmentStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusAttachmentStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynBusAttachmentStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusAttachmentStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynBusAttachmentStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynBusAttachmentStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynBusAttachmentStateChangedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -2857,41 +2585,7 @@ impl ::windows::core::RuntimeName for AllJoynBusObject {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynBusObject";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynBusObject> for ::windows::core::IUnknown {
-    fn from(value: AllJoynBusObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusObject> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynBusObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusObject> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynBusObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynBusObject> for ::windows::core::IInspectable {
-    fn from(value: AllJoynBusObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusObject> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynBusObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusObject> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynBusObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynBusObject, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynBusObject {}
 #[cfg(feature = "deprecated")]
@@ -2967,41 +2661,7 @@ impl ::windows::core::RuntimeName for AllJoynBusObjectStoppedEventArgs {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynBusObjectStoppedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynBusObjectStoppedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynBusObjectStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusObjectStoppedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynBusObjectStoppedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusObjectStoppedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynBusObjectStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynBusObjectStoppedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynBusObjectStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusObjectStoppedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynBusObjectStoppedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynBusObjectStoppedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynBusObjectStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynBusObjectStoppedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynBusObjectStoppedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -3108,41 +2768,7 @@ impl ::windows::core::RuntimeName for AllJoynCredentials {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynCredentials";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynCredentials> for ::windows::core::IUnknown {
-    fn from(value: AllJoynCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentials> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynCredentials) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentials> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynCredentials> for ::windows::core::IInspectable {
-    fn from(value: AllJoynCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentials> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynCredentials) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentials> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynCredentials, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynCredentials {}
 #[cfg(feature = "deprecated")]
@@ -3240,41 +2866,7 @@ impl ::windows::core::RuntimeName for AllJoynCredentialsRequestedEventArgs {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynCredentialsRequestedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynCredentialsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynCredentialsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentialsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynCredentialsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentialsRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynCredentialsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynCredentialsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynCredentialsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentialsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynCredentialsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentialsRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynCredentialsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynCredentialsRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynCredentialsRequestedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -3396,41 +2988,7 @@ impl ::windows::core::RuntimeName for AllJoynCredentialsVerificationRequestedEve
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynCredentialsVerificationRequestedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynCredentialsVerificationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynCredentialsVerificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentialsVerificationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynCredentialsVerificationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentialsVerificationRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynCredentialsVerificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynCredentialsVerificationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynCredentialsVerificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentialsVerificationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynCredentialsVerificationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynCredentialsVerificationRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynCredentialsVerificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynCredentialsVerificationRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynCredentialsVerificationRequestedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -3506,41 +3064,7 @@ impl ::windows::core::RuntimeName for AllJoynMessageInfo {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynMessageInfo";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynMessageInfo> for ::windows::core::IUnknown {
-    fn from(value: AllJoynMessageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynMessageInfo> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynMessageInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynMessageInfo> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynMessageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynMessageInfo> for ::windows::core::IInspectable {
-    fn from(value: AllJoynMessageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynMessageInfo> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynMessageInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynMessageInfo> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynMessageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynMessageInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynMessageInfo {}
 #[cfg(feature = "deprecated")]
@@ -3616,41 +3140,7 @@ impl ::windows::core::RuntimeName for AllJoynProducerStoppedEventArgs {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynProducerStoppedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynProducerStoppedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynProducerStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynProducerStoppedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynProducerStoppedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynProducerStoppedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynProducerStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynProducerStoppedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynProducerStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynProducerStoppedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynProducerStoppedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynProducerStoppedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynProducerStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynProducerStoppedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynProducerStoppedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -3758,41 +3248,7 @@ impl ::windows::core::RuntimeName for AllJoynServiceInfo {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynServiceInfo";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynServiceInfo> for ::windows::core::IUnknown {
-    fn from(value: AllJoynServiceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynServiceInfo> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynServiceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynServiceInfo> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynServiceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynServiceInfo> for ::windows::core::IInspectable {
-    fn from(value: AllJoynServiceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynServiceInfo> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynServiceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynServiceInfo> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynServiceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynServiceInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynServiceInfo {}
 #[cfg(feature = "deprecated")]
@@ -3868,41 +3324,7 @@ impl ::windows::core::RuntimeName for AllJoynServiceInfoRemovedEventArgs {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynServiceInfoRemovedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynServiceInfoRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynServiceInfoRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynServiceInfoRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynServiceInfoRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynServiceInfoRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynServiceInfoRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynServiceInfoRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynServiceInfoRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynServiceInfoRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynServiceInfoRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynServiceInfoRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynServiceInfoRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynServiceInfoRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynServiceInfoRemovedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -4049,41 +3471,7 @@ impl ::windows::core::RuntimeName for AllJoynSession {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynSession";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynSession> for ::windows::core::IUnknown {
-    fn from(value: AllJoynSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSession> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSession> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynSession> for ::windows::core::IInspectable {
-    fn from(value: AllJoynSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSession> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSession> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynSession {}
 #[cfg(feature = "deprecated")]
@@ -4159,41 +3547,7 @@ impl ::windows::core::RuntimeName for AllJoynSessionJoinedEventArgs {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynSessionJoinedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynSessionJoinedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynSessionJoinedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionJoinedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynSessionJoinedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionJoinedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynSessionJoinedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynSessionJoinedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynSessionJoinedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionJoinedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynSessionJoinedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionJoinedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynSessionJoinedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynSessionJoinedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynSessionJoinedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -4269,41 +3623,7 @@ impl ::windows::core::RuntimeName for AllJoynSessionLostEventArgs {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynSessionLostEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynSessionLostEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynSessionLostEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionLostEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynSessionLostEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionLostEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynSessionLostEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynSessionLostEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynSessionLostEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionLostEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynSessionLostEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionLostEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynSessionLostEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynSessionLostEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynSessionLostEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -4379,41 +3699,7 @@ impl ::windows::core::RuntimeName for AllJoynSessionMemberAddedEventArgs {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynSessionMemberAddedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynSessionMemberAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynSessionMemberAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionMemberAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynSessionMemberAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionMemberAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynSessionMemberAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynSessionMemberAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynSessionMemberAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionMemberAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynSessionMemberAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionMemberAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynSessionMemberAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynSessionMemberAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynSessionMemberAddedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -4489,41 +3775,7 @@ impl ::windows::core::RuntimeName for AllJoynSessionMemberRemovedEventArgs {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynSessionMemberRemovedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynSessionMemberRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynSessionMemberRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionMemberRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynSessionMemberRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionMemberRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynSessionMemberRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynSessionMemberRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynSessionMemberRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionMemberRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynSessionMemberRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynSessionMemberRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynSessionMemberRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynSessionMemberRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynSessionMemberRemovedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -4759,41 +4011,7 @@ impl ::windows::core::RuntimeName for AllJoynWatcherStoppedEventArgs {
     const NAME: &'static str = "Windows.Devices.AllJoyn.AllJoynWatcherStoppedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynWatcherStoppedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AllJoynWatcherStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynWatcherStoppedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AllJoynWatcherStoppedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynWatcherStoppedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AllJoynWatcherStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<AllJoynWatcherStoppedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AllJoynWatcherStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynWatcherStoppedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AllJoynWatcherStoppedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&AllJoynWatcherStoppedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AllJoynWatcherStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AllJoynWatcherStoppedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for AllJoynWatcherStoppedEventArgs {}
 #[cfg(feature = "deprecated")]

--- a/crates/libs/windows/src/Windows/Devices/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Background/mod.rs
@@ -94,36 +94,7 @@ unsafe impl ::windows::core::Interface for DeviceServicingDetails {
 impl ::windows::core::RuntimeName for DeviceServicingDetails {
     const NAME: &'static str = "Windows.Devices.Background.DeviceServicingDetails";
 }
-impl ::core::convert::From<DeviceServicingDetails> for ::windows::core::IUnknown {
-    fn from(value: DeviceServicingDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceServicingDetails> for ::windows::core::IUnknown {
-    fn from(value: &DeviceServicingDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceServicingDetails> for &::windows::core::IUnknown {
-    fn from(value: &DeviceServicingDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceServicingDetails> for ::windows::core::IInspectable {
-    fn from(value: DeviceServicingDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceServicingDetails> for ::windows::core::IInspectable {
-    fn from(value: &DeviceServicingDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceServicingDetails> for &::windows::core::IInspectable {
-    fn from(value: &DeviceServicingDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceServicingDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceServicingDetails {}
 unsafe impl ::core::marker::Sync for DeviceServicingDetails {}
 #[doc = "*Required features: `\"Devices_Background\"`*"]
@@ -177,36 +148,7 @@ unsafe impl ::windows::core::Interface for DeviceUseDetails {
 impl ::windows::core::RuntimeName for DeviceUseDetails {
     const NAME: &'static str = "Windows.Devices.Background.DeviceUseDetails";
 }
-impl ::core::convert::From<DeviceUseDetails> for ::windows::core::IUnknown {
-    fn from(value: DeviceUseDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceUseDetails> for ::windows::core::IUnknown {
-    fn from(value: &DeviceUseDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceUseDetails> for &::windows::core::IUnknown {
-    fn from(value: &DeviceUseDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceUseDetails> for ::windows::core::IInspectable {
-    fn from(value: DeviceUseDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceUseDetails> for ::windows::core::IInspectable {
-    fn from(value: &DeviceUseDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceUseDetails> for &::windows::core::IInspectable {
-    fn from(value: &DeviceUseDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceUseDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceUseDetails {}
 unsafe impl ::core::marker::Sync for DeviceUseDetails {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
@@ -595,36 +595,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisement {
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisement {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisement";
 }
-impl ::core::convert::From<BluetoothLEAdvertisement> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisement> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisement> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisement> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisement> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisement> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisement, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAdvertisement {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisement {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Advertisement\"`*"]
@@ -729,36 +700,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementBytePattern {
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementBytePattern {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementBytePattern";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementBytePattern> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementBytePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementBytePattern> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementBytePattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementBytePattern> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementBytePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementBytePattern> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementBytePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementBytePattern> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementBytePattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementBytePattern> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementBytePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementBytePattern, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAdvertisementBytePattern {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementBytePattern {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Advertisement\"`*"]
@@ -852,36 +794,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementDataSection {
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementDataSection {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementDataSection";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementDataSection> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementDataSection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementDataSection> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementDataSection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementDataSection> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementDataSection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementDataSection> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementDataSection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementDataSection> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementDataSection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementDataSection> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementDataSection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementDataSection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAdvertisementDataSection {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementDataSection {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Advertisement\"`*"]
@@ -1092,36 +1005,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementFilter {
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementFilter {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementFilter";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementFilter> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementFilter> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementFilter> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementFilter> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementFilter> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementFilter> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAdvertisementFilter {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementFilter {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Advertisement\"`*"]
@@ -1268,36 +1152,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementPublisher {
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementPublisher {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementPublisher";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementPublisher> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisher> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementPublisher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisher> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementPublisher> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisher> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementPublisher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisher> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementPublisher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAdvertisementPublisher {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementPublisher {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Advertisement\"`*"]
@@ -1360,36 +1215,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementPublisherStat
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementPublisherStatusChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementPublisherStatusChangedEventArgs";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementPublisherStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherStatusChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementPublisherStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherStatusChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementPublisherStatusChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAdvertisementPublisherStatusChangedEventArgs {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementPublisherStatusChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Advertisement\"`*"]
@@ -1517,36 +1343,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementReceivedEvent
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementReceivedEventArgs";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAdvertisementReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementReceivedEventArgs {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Advertisement\"`*"]
@@ -1729,36 +1526,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementWatcher {
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementWatcher {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcher";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementWatcher> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcher> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcher> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementWatcher> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcher> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcher> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAdvertisementWatcher {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementWatcher {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Advertisement\"`*"]
@@ -1805,36 +1573,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementWatcherStoppe
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementWatcherStoppedEventArgs {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcherStoppedEventArgs";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementWatcherStoppedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementWatcherStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherStoppedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementWatcherStoppedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherStoppedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementWatcherStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementWatcherStoppedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementWatcherStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherStoppedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementWatcherStoppedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherStoppedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementWatcherStoppedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementWatcherStoppedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAdvertisementWatcherStoppedEventArgs {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementWatcherStoppedEventArgs {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Advertisement\"`*"]
@@ -1928,36 +1667,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEManufacturerData {
 impl ::windows::core::RuntimeName for BluetoothLEManufacturerData {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Advertisement.BluetoothLEManufacturerData";
 }
-impl ::core::convert::From<BluetoothLEManufacturerData> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEManufacturerData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEManufacturerData> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEManufacturerData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEManufacturerData> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEManufacturerData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEManufacturerData> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEManufacturerData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEManufacturerData> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEManufacturerData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEManufacturerData> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEManufacturerData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEManufacturerData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEManufacturerData {}
 unsafe impl ::core::marker::Sync for BluetoothLEManufacturerData {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Advertisement\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Background/mod.rs
@@ -286,36 +286,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementPublisherTrig
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementPublisherTriggerDetails {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Background.BluetoothLEAdvertisementPublisherTriggerDetails";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementPublisherTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementPublisherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementPublisherTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementPublisherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementPublisherTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementPublisherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementPublisherTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementPublisherTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementPublisherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementPublisherTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAdvertisementPublisherTriggerDetails {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementPublisherTriggerDetails {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Background\"`*"]
@@ -378,36 +349,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAdvertisementWatcherTrigge
 impl ::windows::core::RuntimeName for BluetoothLEAdvertisementWatcherTriggerDetails {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Background.BluetoothLEAdvertisementWatcherTriggerDetails";
 }
-impl ::core::convert::From<BluetoothLEAdvertisementWatcherTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAdvertisementWatcherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementWatcherTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAdvertisementWatcherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAdvertisementWatcherTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAdvertisementWatcherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementWatcherTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAdvertisementWatcherTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAdvertisementWatcherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAdvertisementWatcherTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAdvertisementWatcherTriggerDetails {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementWatcherTriggerDetails {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Background\"`*"]
@@ -488,36 +430,7 @@ unsafe impl ::windows::core::Interface for GattCharacteristicNotificationTrigger
 impl ::windows::core::RuntimeName for GattCharacteristicNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Background.GattCharacteristicNotificationTriggerDetails";
 }
-impl ::core::convert::From<GattCharacteristicNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: GattCharacteristicNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattCharacteristicNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &GattCharacteristicNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattCharacteristicNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &GattCharacteristicNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattCharacteristicNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: GattCharacteristicNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattCharacteristicNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &GattCharacteristicNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattCharacteristicNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &GattCharacteristicNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattCharacteristicNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattCharacteristicNotificationTriggerDetails {}
 unsafe impl ::core::marker::Sync for GattCharacteristicNotificationTriggerDetails {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Background\"`*"]
@@ -590,36 +503,7 @@ unsafe impl ::windows::core::Interface for GattServiceProviderConnection {
 impl ::windows::core::RuntimeName for GattServiceProviderConnection {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Background.GattServiceProviderConnection";
 }
-impl ::core::convert::From<GattServiceProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: GattServiceProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderConnection> for &::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattServiceProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: GattServiceProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderConnection> for &::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattServiceProviderConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattServiceProviderConnection {}
 unsafe impl ::core::marker::Sync for GattServiceProviderConnection {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Background\"`*"]
@@ -666,36 +550,7 @@ unsafe impl ::windows::core::Interface for GattServiceProviderTriggerDetails {
 impl ::windows::core::RuntimeName for GattServiceProviderTriggerDetails {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Background.GattServiceProviderTriggerDetails";
 }
-impl ::core::convert::From<GattServiceProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: GattServiceProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattServiceProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: GattServiceProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattServiceProviderTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattServiceProviderTriggerDetails {}
 unsafe impl ::core::marker::Sync for GattServiceProviderTriggerDetails {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Background\"`*"]
@@ -758,36 +613,7 @@ unsafe impl ::windows::core::Interface for RfcommConnectionTriggerDetails {
 impl ::windows::core::RuntimeName for RfcommConnectionTriggerDetails {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Background.RfcommConnectionTriggerDetails";
 }
-impl ::core::convert::From<RfcommConnectionTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: RfcommConnectionTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommConnectionTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &RfcommConnectionTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommConnectionTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &RfcommConnectionTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RfcommConnectionTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: RfcommConnectionTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommConnectionTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &RfcommConnectionTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommConnectionTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &RfcommConnectionTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RfcommConnectionTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RfcommConnectionTriggerDetails {}
 unsafe impl ::core::marker::Sync for RfcommConnectionTriggerDetails {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Background\"`*"]
@@ -872,36 +698,7 @@ unsafe impl ::windows::core::Interface for RfcommInboundConnectionInformation {
 impl ::windows::core::RuntimeName for RfcommInboundConnectionInformation {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Background.RfcommInboundConnectionInformation";
 }
-impl ::core::convert::From<RfcommInboundConnectionInformation> for ::windows::core::IUnknown {
-    fn from(value: RfcommInboundConnectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommInboundConnectionInformation> for ::windows::core::IUnknown {
-    fn from(value: &RfcommInboundConnectionInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommInboundConnectionInformation> for &::windows::core::IUnknown {
-    fn from(value: &RfcommInboundConnectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RfcommInboundConnectionInformation> for ::windows::core::IInspectable {
-    fn from(value: RfcommInboundConnectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommInboundConnectionInformation> for ::windows::core::IInspectable {
-    fn from(value: &RfcommInboundConnectionInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommInboundConnectionInformation> for &::windows::core::IInspectable {
-    fn from(value: &RfcommInboundConnectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RfcommInboundConnectionInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RfcommInboundConnectionInformation {}
 unsafe impl ::core::marker::Sync for RfcommInboundConnectionInformation {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Background\"`*"]
@@ -956,36 +753,7 @@ unsafe impl ::windows::core::Interface for RfcommOutboundConnectionInformation {
 impl ::windows::core::RuntimeName for RfcommOutboundConnectionInformation {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Background.RfcommOutboundConnectionInformation";
 }
-impl ::core::convert::From<RfcommOutboundConnectionInformation> for ::windows::core::IUnknown {
-    fn from(value: RfcommOutboundConnectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommOutboundConnectionInformation> for ::windows::core::IUnknown {
-    fn from(value: &RfcommOutboundConnectionInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommOutboundConnectionInformation> for &::windows::core::IUnknown {
-    fn from(value: &RfcommOutboundConnectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RfcommOutboundConnectionInformation> for ::windows::core::IInspectable {
-    fn from(value: RfcommOutboundConnectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommOutboundConnectionInformation> for ::windows::core::IInspectable {
-    fn from(value: &RfcommOutboundConnectionInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommOutboundConnectionInformation> for &::windows::core::IInspectable {
-    fn from(value: &RfcommOutboundConnectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RfcommOutboundConnectionInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RfcommOutboundConnectionInformation {}
 unsafe impl ::core::marker::Sync for RfcommOutboundConnectionInformation {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Background\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
@@ -1751,36 +1751,7 @@ unsafe impl ::windows::core::Interface for GattCharacteristic {
 impl ::windows::core::RuntimeName for GattCharacteristic {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattCharacteristic";
 }
-impl ::core::convert::From<GattCharacteristic> for ::windows::core::IUnknown {
-    fn from(value: GattCharacteristic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattCharacteristic> for ::windows::core::IUnknown {
-    fn from(value: &GattCharacteristic) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattCharacteristic> for &::windows::core::IUnknown {
-    fn from(value: &GattCharacteristic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattCharacteristic> for ::windows::core::IInspectable {
-    fn from(value: GattCharacteristic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattCharacteristic> for ::windows::core::IInspectable {
-    fn from(value: &GattCharacteristic) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattCharacteristic> for &::windows::core::IInspectable {
-    fn from(value: &GattCharacteristic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattCharacteristic, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattCharacteristic {}
 unsafe impl ::core::marker::Sync for GattCharacteristic {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -2348,36 +2319,7 @@ unsafe impl ::windows::core::Interface for GattCharacteristicsResult {
 impl ::windows::core::RuntimeName for GattCharacteristicsResult {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattCharacteristicsResult";
 }
-impl ::core::convert::From<GattCharacteristicsResult> for ::windows::core::IUnknown {
-    fn from(value: GattCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattCharacteristicsResult> for ::windows::core::IUnknown {
-    fn from(value: &GattCharacteristicsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattCharacteristicsResult> for &::windows::core::IUnknown {
-    fn from(value: &GattCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattCharacteristicsResult> for ::windows::core::IInspectable {
-    fn from(value: GattCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattCharacteristicsResult> for ::windows::core::IInspectable {
-    fn from(value: &GattCharacteristicsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattCharacteristicsResult> for &::windows::core::IInspectable {
-    fn from(value: &GattCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattCharacteristicsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattCharacteristicsResult {}
 unsafe impl ::core::marker::Sync for GattCharacteristicsResult {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -2447,36 +2389,7 @@ unsafe impl ::windows::core::Interface for GattClientNotificationResult {
 impl ::windows::core::RuntimeName for GattClientNotificationResult {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattClientNotificationResult";
 }
-impl ::core::convert::From<GattClientNotificationResult> for ::windows::core::IUnknown {
-    fn from(value: GattClientNotificationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattClientNotificationResult> for ::windows::core::IUnknown {
-    fn from(value: &GattClientNotificationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattClientNotificationResult> for &::windows::core::IUnknown {
-    fn from(value: &GattClientNotificationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattClientNotificationResult> for ::windows::core::IInspectable {
-    fn from(value: GattClientNotificationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattClientNotificationResult> for ::windows::core::IInspectable {
-    fn from(value: &GattClientNotificationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattClientNotificationResult> for &::windows::core::IInspectable {
-    fn from(value: &GattClientNotificationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattClientNotificationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattClientNotificationResult {}
 unsafe impl ::core::marker::Sync for GattClientNotificationResult {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -2598,36 +2511,7 @@ unsafe impl ::windows::core::Interface for GattDescriptor {
 impl ::windows::core::RuntimeName for GattDescriptor {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattDescriptor";
 }
-impl ::core::convert::From<GattDescriptor> for ::windows::core::IUnknown {
-    fn from(value: GattDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &GattDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &GattDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattDescriptor> for ::windows::core::IInspectable {
-    fn from(value: GattDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &GattDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &GattDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattDescriptor {}
 unsafe impl ::core::marker::Sync for GattDescriptor {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -2740,36 +2624,7 @@ unsafe impl ::windows::core::Interface for GattDescriptorsResult {
 impl ::windows::core::RuntimeName for GattDescriptorsResult {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattDescriptorsResult";
 }
-impl ::core::convert::From<GattDescriptorsResult> for ::windows::core::IUnknown {
-    fn from(value: GattDescriptorsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattDescriptorsResult> for ::windows::core::IUnknown {
-    fn from(value: &GattDescriptorsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattDescriptorsResult> for &::windows::core::IUnknown {
-    fn from(value: &GattDescriptorsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattDescriptorsResult> for ::windows::core::IInspectable {
-    fn from(value: GattDescriptorsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattDescriptorsResult> for ::windows::core::IInspectable {
-    fn from(value: &GattDescriptorsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattDescriptorsResult> for &::windows::core::IInspectable {
-    fn from(value: &GattDescriptorsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattDescriptorsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattDescriptorsResult {}
 unsafe impl ::core::marker::Sync for GattDescriptorsResult {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -3075,36 +2930,7 @@ unsafe impl ::windows::core::Interface for GattDeviceService {
 impl ::windows::core::RuntimeName for GattDeviceService {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattDeviceService";
 }
-impl ::core::convert::From<GattDeviceService> for ::windows::core::IUnknown {
-    fn from(value: GattDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattDeviceService> for ::windows::core::IUnknown {
-    fn from(value: &GattDeviceService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattDeviceService> for &::windows::core::IUnknown {
-    fn from(value: &GattDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattDeviceService> for ::windows::core::IInspectable {
-    fn from(value: GattDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattDeviceService> for ::windows::core::IInspectable {
-    fn from(value: &GattDeviceService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattDeviceService> for &::windows::core::IInspectable {
-    fn from(value: &GattDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattDeviceService, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<GattDeviceService> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3191,36 +3017,7 @@ unsafe impl ::windows::core::Interface for GattDeviceServicesResult {
 impl ::windows::core::RuntimeName for GattDeviceServicesResult {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattDeviceServicesResult";
 }
-impl ::core::convert::From<GattDeviceServicesResult> for ::windows::core::IUnknown {
-    fn from(value: GattDeviceServicesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattDeviceServicesResult> for ::windows::core::IUnknown {
-    fn from(value: &GattDeviceServicesResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattDeviceServicesResult> for &::windows::core::IUnknown {
-    fn from(value: &GattDeviceServicesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattDeviceServicesResult> for ::windows::core::IInspectable {
-    fn from(value: GattDeviceServicesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattDeviceServicesResult> for ::windows::core::IInspectable {
-    fn from(value: &GattDeviceServicesResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattDeviceServicesResult> for &::windows::core::IInspectable {
-    fn from(value: &GattDeviceServicesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattDeviceServicesResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattDeviceServicesResult {}
 unsafe impl ::core::marker::Sync for GattDeviceServicesResult {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -3411,36 +3208,7 @@ unsafe impl ::windows::core::Interface for GattLocalCharacteristic {
 impl ::windows::core::RuntimeName for GattLocalCharacteristic {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalCharacteristic";
 }
-impl ::core::convert::From<GattLocalCharacteristic> for ::windows::core::IUnknown {
-    fn from(value: GattLocalCharacteristic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristic> for ::windows::core::IUnknown {
-    fn from(value: &GattLocalCharacteristic) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristic> for &::windows::core::IUnknown {
-    fn from(value: &GattLocalCharacteristic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattLocalCharacteristic> for ::windows::core::IInspectable {
-    fn from(value: GattLocalCharacteristic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristic> for ::windows::core::IInspectable {
-    fn from(value: &GattLocalCharacteristic) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristic> for &::windows::core::IInspectable {
-    fn from(value: &GattLocalCharacteristic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattLocalCharacteristic, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattLocalCharacteristic {}
 unsafe impl ::core::marker::Sync for GattLocalCharacteristic {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -3559,36 +3327,7 @@ unsafe impl ::windows::core::Interface for GattLocalCharacteristicParameters {
 impl ::windows::core::RuntimeName for GattLocalCharacteristicParameters {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalCharacteristicParameters";
 }
-impl ::core::convert::From<GattLocalCharacteristicParameters> for ::windows::core::IUnknown {
-    fn from(value: GattLocalCharacteristicParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristicParameters> for ::windows::core::IUnknown {
-    fn from(value: &GattLocalCharacteristicParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristicParameters> for &::windows::core::IUnknown {
-    fn from(value: &GattLocalCharacteristicParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattLocalCharacteristicParameters> for ::windows::core::IInspectable {
-    fn from(value: GattLocalCharacteristicParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristicParameters> for ::windows::core::IInspectable {
-    fn from(value: &GattLocalCharacteristicParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristicParameters> for &::windows::core::IInspectable {
-    fn from(value: &GattLocalCharacteristicParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattLocalCharacteristicParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattLocalCharacteristicParameters {}
 unsafe impl ::core::marker::Sync for GattLocalCharacteristicParameters {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -3642,36 +3381,7 @@ unsafe impl ::windows::core::Interface for GattLocalCharacteristicResult {
 impl ::windows::core::RuntimeName for GattLocalCharacteristicResult {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalCharacteristicResult";
 }
-impl ::core::convert::From<GattLocalCharacteristicResult> for ::windows::core::IUnknown {
-    fn from(value: GattLocalCharacteristicResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristicResult> for ::windows::core::IUnknown {
-    fn from(value: &GattLocalCharacteristicResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristicResult> for &::windows::core::IUnknown {
-    fn from(value: &GattLocalCharacteristicResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattLocalCharacteristicResult> for ::windows::core::IInspectable {
-    fn from(value: GattLocalCharacteristicResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristicResult> for ::windows::core::IInspectable {
-    fn from(value: &GattLocalCharacteristicResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalCharacteristicResult> for &::windows::core::IInspectable {
-    fn from(value: &GattLocalCharacteristicResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattLocalCharacteristicResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattLocalCharacteristicResult {}
 unsafe impl ::core::marker::Sync for GattLocalCharacteristicResult {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -3771,36 +3481,7 @@ unsafe impl ::windows::core::Interface for GattLocalDescriptor {
 impl ::windows::core::RuntimeName for GattLocalDescriptor {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalDescriptor";
 }
-impl ::core::convert::From<GattLocalDescriptor> for ::windows::core::IUnknown {
-    fn from(value: GattLocalDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &GattLocalDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &GattLocalDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattLocalDescriptor> for ::windows::core::IInspectable {
-    fn from(value: GattLocalDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &GattLocalDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &GattLocalDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattLocalDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattLocalDescriptor {}
 unsafe impl ::core::marker::Sync for GattLocalDescriptor {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -3888,36 +3569,7 @@ unsafe impl ::windows::core::Interface for GattLocalDescriptorParameters {
 impl ::windows::core::RuntimeName for GattLocalDescriptorParameters {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalDescriptorParameters";
 }
-impl ::core::convert::From<GattLocalDescriptorParameters> for ::windows::core::IUnknown {
-    fn from(value: GattLocalDescriptorParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptorParameters> for ::windows::core::IUnknown {
-    fn from(value: &GattLocalDescriptorParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptorParameters> for &::windows::core::IUnknown {
-    fn from(value: &GattLocalDescriptorParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattLocalDescriptorParameters> for ::windows::core::IInspectable {
-    fn from(value: GattLocalDescriptorParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptorParameters> for ::windows::core::IInspectable {
-    fn from(value: &GattLocalDescriptorParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptorParameters> for &::windows::core::IInspectable {
-    fn from(value: &GattLocalDescriptorParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattLocalDescriptorParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattLocalDescriptorParameters {}
 unsafe impl ::core::marker::Sync for GattLocalDescriptorParameters {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -3971,36 +3623,7 @@ unsafe impl ::windows::core::Interface for GattLocalDescriptorResult {
 impl ::windows::core::RuntimeName for GattLocalDescriptorResult {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalDescriptorResult";
 }
-impl ::core::convert::From<GattLocalDescriptorResult> for ::windows::core::IUnknown {
-    fn from(value: GattLocalDescriptorResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptorResult> for ::windows::core::IUnknown {
-    fn from(value: &GattLocalDescriptorResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptorResult> for &::windows::core::IUnknown {
-    fn from(value: &GattLocalDescriptorResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattLocalDescriptorResult> for ::windows::core::IInspectable {
-    fn from(value: GattLocalDescriptorResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptorResult> for ::windows::core::IInspectable {
-    fn from(value: &GattLocalDescriptorResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalDescriptorResult> for &::windows::core::IInspectable {
-    fn from(value: &GattLocalDescriptorResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattLocalDescriptorResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattLocalDescriptorResult {}
 unsafe impl ::core::marker::Sync for GattLocalDescriptorResult {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -4065,36 +3688,7 @@ unsafe impl ::windows::core::Interface for GattLocalService {
 impl ::windows::core::RuntimeName for GattLocalService {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattLocalService";
 }
-impl ::core::convert::From<GattLocalService> for ::windows::core::IUnknown {
-    fn from(value: GattLocalService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalService> for ::windows::core::IUnknown {
-    fn from(value: &GattLocalService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalService> for &::windows::core::IUnknown {
-    fn from(value: &GattLocalService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattLocalService> for ::windows::core::IInspectable {
-    fn from(value: GattLocalService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattLocalService> for ::windows::core::IInspectable {
-    fn from(value: &GattLocalService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattLocalService> for &::windows::core::IInspectable {
-    fn from(value: &GattLocalService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattLocalService, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattLocalService {}
 unsafe impl ::core::marker::Sync for GattLocalService {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -4191,36 +3785,7 @@ unsafe impl ::windows::core::Interface for GattPresentationFormat {
 impl ::windows::core::RuntimeName for GattPresentationFormat {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattPresentationFormat";
 }
-impl ::core::convert::From<GattPresentationFormat> for ::windows::core::IUnknown {
-    fn from(value: GattPresentationFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattPresentationFormat> for ::windows::core::IUnknown {
-    fn from(value: &GattPresentationFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattPresentationFormat> for &::windows::core::IUnknown {
-    fn from(value: &GattPresentationFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattPresentationFormat> for ::windows::core::IInspectable {
-    fn from(value: GattPresentationFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattPresentationFormat> for ::windows::core::IInspectable {
-    fn from(value: &GattPresentationFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattPresentationFormat> for &::windows::core::IInspectable {
-    fn from(value: &GattPresentationFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattPresentationFormat, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattPresentationFormat {}
 unsafe impl ::core::marker::Sync for GattPresentationFormat {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -4571,36 +4136,7 @@ unsafe impl ::windows::core::Interface for GattReadClientCharacteristicConfigura
 impl ::windows::core::RuntimeName for GattReadClientCharacteristicConfigurationDescriptorResult {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattReadClientCharacteristicConfigurationDescriptorResult";
 }
-impl ::core::convert::From<GattReadClientCharacteristicConfigurationDescriptorResult> for ::windows::core::IUnknown {
-    fn from(value: GattReadClientCharacteristicConfigurationDescriptorResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattReadClientCharacteristicConfigurationDescriptorResult> for ::windows::core::IUnknown {
-    fn from(value: &GattReadClientCharacteristicConfigurationDescriptorResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattReadClientCharacteristicConfigurationDescriptorResult> for &::windows::core::IUnknown {
-    fn from(value: &GattReadClientCharacteristicConfigurationDescriptorResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattReadClientCharacteristicConfigurationDescriptorResult> for ::windows::core::IInspectable {
-    fn from(value: GattReadClientCharacteristicConfigurationDescriptorResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattReadClientCharacteristicConfigurationDescriptorResult> for ::windows::core::IInspectable {
-    fn from(value: &GattReadClientCharacteristicConfigurationDescriptorResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattReadClientCharacteristicConfigurationDescriptorResult> for &::windows::core::IInspectable {
-    fn from(value: &GattReadClientCharacteristicConfigurationDescriptorResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattReadClientCharacteristicConfigurationDescriptorResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattReadClientCharacteristicConfigurationDescriptorResult {}
 unsafe impl ::core::marker::Sync for GattReadClientCharacteristicConfigurationDescriptorResult {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -4690,36 +4226,7 @@ unsafe impl ::windows::core::Interface for GattReadRequest {
 impl ::windows::core::RuntimeName for GattReadRequest {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattReadRequest";
 }
-impl ::core::convert::From<GattReadRequest> for ::windows::core::IUnknown {
-    fn from(value: GattReadRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattReadRequest> for ::windows::core::IUnknown {
-    fn from(value: &GattReadRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattReadRequest> for &::windows::core::IUnknown {
-    fn from(value: &GattReadRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattReadRequest> for ::windows::core::IInspectable {
-    fn from(value: GattReadRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattReadRequest> for ::windows::core::IInspectable {
-    fn from(value: &GattReadRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattReadRequest> for &::windows::core::IInspectable {
-    fn from(value: &GattReadRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattReadRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattReadRequest {}
 unsafe impl ::core::marker::Sync for GattReadRequest {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -4784,36 +4291,7 @@ unsafe impl ::windows::core::Interface for GattReadRequestedEventArgs {
 impl ::windows::core::RuntimeName for GattReadRequestedEventArgs {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattReadRequestedEventArgs";
 }
-impl ::core::convert::From<GattReadRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GattReadRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattReadRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GattReadRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattReadRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GattReadRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattReadRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GattReadRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattReadRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GattReadRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattReadRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GattReadRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattReadRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattReadRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for GattReadRequestedEventArgs {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -4878,36 +4356,7 @@ unsafe impl ::windows::core::Interface for GattReadResult {
 impl ::windows::core::RuntimeName for GattReadResult {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattReadResult";
 }
-impl ::core::convert::From<GattReadResult> for ::windows::core::IUnknown {
-    fn from(value: GattReadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattReadResult> for ::windows::core::IUnknown {
-    fn from(value: &GattReadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattReadResult> for &::windows::core::IUnknown {
-    fn from(value: &GattReadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattReadResult> for ::windows::core::IInspectable {
-    fn from(value: GattReadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattReadResult> for ::windows::core::IInspectable {
-    fn from(value: &GattReadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattReadResult> for &::windows::core::IInspectable {
-    fn from(value: &GattReadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattReadResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattReadResult {}
 unsafe impl ::core::marker::Sync for GattReadResult {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -4982,36 +4431,7 @@ unsafe impl ::windows::core::Interface for GattReliableWriteTransaction {
 impl ::windows::core::RuntimeName for GattReliableWriteTransaction {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattReliableWriteTransaction";
 }
-impl ::core::convert::From<GattReliableWriteTransaction> for ::windows::core::IUnknown {
-    fn from(value: GattReliableWriteTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattReliableWriteTransaction> for ::windows::core::IUnknown {
-    fn from(value: &GattReliableWriteTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattReliableWriteTransaction> for &::windows::core::IUnknown {
-    fn from(value: &GattReliableWriteTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattReliableWriteTransaction> for ::windows::core::IInspectable {
-    fn from(value: GattReliableWriteTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattReliableWriteTransaction> for ::windows::core::IInspectable {
-    fn from(value: &GattReliableWriteTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattReliableWriteTransaction> for &::windows::core::IInspectable {
-    fn from(value: &GattReliableWriteTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattReliableWriteTransaction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattReliableWriteTransaction {}
 unsafe impl ::core::marker::Sync for GattReliableWriteTransaction {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -5065,36 +4485,7 @@ unsafe impl ::windows::core::Interface for GattRequestStateChangedEventArgs {
 impl ::windows::core::RuntimeName for GattRequestStateChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattRequestStateChangedEventArgs";
 }
-impl ::core::convert::From<GattRequestStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GattRequestStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattRequestStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GattRequestStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattRequestStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GattRequestStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattRequestStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GattRequestStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattRequestStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GattRequestStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattRequestStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GattRequestStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattRequestStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattRequestStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for GattRequestStateChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -5188,36 +4579,7 @@ unsafe impl ::windows::core::Interface for GattServiceProvider {
 impl ::windows::core::RuntimeName for GattServiceProvider {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceProvider";
 }
-impl ::core::convert::From<GattServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: GattServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: &GattServiceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProvider> for &::windows::core::IUnknown {
-    fn from(value: &GattServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattServiceProvider> for ::windows::core::IInspectable {
-    fn from(value: GattServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProvider> for ::windows::core::IInspectable {
-    fn from(value: &GattServiceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProvider> for &::windows::core::IInspectable {
-    fn from(value: &GattServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattServiceProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattServiceProvider {}
 unsafe impl ::core::marker::Sync for GattServiceProvider {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -5271,36 +4633,7 @@ unsafe impl ::windows::core::Interface for GattServiceProviderAdvertisementStatu
 impl ::windows::core::RuntimeName for GattServiceProviderAdvertisementStatusChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceProviderAdvertisementStatusChangedEventArgs";
 }
-impl ::core::convert::From<GattServiceProviderAdvertisementStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GattServiceProviderAdvertisementStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderAdvertisementStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderAdvertisementStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderAdvertisementStatusChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderAdvertisementStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattServiceProviderAdvertisementStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GattServiceProviderAdvertisementStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderAdvertisementStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderAdvertisementStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderAdvertisementStatusChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderAdvertisementStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattServiceProviderAdvertisementStatusChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattServiceProviderAdvertisementStatusChangedEventArgs {}
 unsafe impl ::core::marker::Sync for GattServiceProviderAdvertisementStatusChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -5388,36 +4721,7 @@ unsafe impl ::windows::core::Interface for GattServiceProviderAdvertisingParamet
 impl ::windows::core::RuntimeName for GattServiceProviderAdvertisingParameters {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceProviderAdvertisingParameters";
 }
-impl ::core::convert::From<GattServiceProviderAdvertisingParameters> for ::windows::core::IUnknown {
-    fn from(value: GattServiceProviderAdvertisingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderAdvertisingParameters> for ::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderAdvertisingParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderAdvertisingParameters> for &::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderAdvertisingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattServiceProviderAdvertisingParameters> for ::windows::core::IInspectable {
-    fn from(value: GattServiceProviderAdvertisingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderAdvertisingParameters> for ::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderAdvertisingParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderAdvertisingParameters> for &::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderAdvertisingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattServiceProviderAdvertisingParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattServiceProviderAdvertisingParameters {}
 unsafe impl ::core::marker::Sync for GattServiceProviderAdvertisingParameters {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -5471,36 +4775,7 @@ unsafe impl ::windows::core::Interface for GattServiceProviderResult {
 impl ::windows::core::RuntimeName for GattServiceProviderResult {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceProviderResult";
 }
-impl ::core::convert::From<GattServiceProviderResult> for ::windows::core::IUnknown {
-    fn from(value: GattServiceProviderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderResult> for ::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderResult> for &::windows::core::IUnknown {
-    fn from(value: &GattServiceProviderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattServiceProviderResult> for ::windows::core::IInspectable {
-    fn from(value: GattServiceProviderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattServiceProviderResult> for ::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattServiceProviderResult> for &::windows::core::IInspectable {
-    fn from(value: &GattServiceProviderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattServiceProviderResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattServiceProviderResult {}
 unsafe impl ::core::marker::Sync for GattServiceProviderResult {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -5777,36 +5052,7 @@ unsafe impl ::windows::core::Interface for GattSession {
 impl ::windows::core::RuntimeName for GattSession {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattSession";
 }
-impl ::core::convert::From<GattSession> for ::windows::core::IUnknown {
-    fn from(value: GattSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattSession> for ::windows::core::IUnknown {
-    fn from(value: &GattSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattSession> for &::windows::core::IUnknown {
-    fn from(value: &GattSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattSession> for ::windows::core::IInspectable {
-    fn from(value: GattSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattSession> for ::windows::core::IInspectable {
-    fn from(value: &GattSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattSession> for &::windows::core::IInspectable {
-    fn from(value: &GattSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<GattSession> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5882,36 +5128,7 @@ unsafe impl ::windows::core::Interface for GattSessionStatusChangedEventArgs {
 impl ::windows::core::RuntimeName for GattSessionStatusChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattSessionStatusChangedEventArgs";
 }
-impl ::core::convert::From<GattSessionStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GattSessionStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattSessionStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GattSessionStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattSessionStatusChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GattSessionStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattSessionStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GattSessionStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattSessionStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GattSessionStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattSessionStatusChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GattSessionStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattSessionStatusChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattSessionStatusChangedEventArgs {}
 unsafe impl ::core::marker::Sync for GattSessionStatusChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -5980,36 +5197,7 @@ unsafe impl ::windows::core::Interface for GattSubscribedClient {
 impl ::windows::core::RuntimeName for GattSubscribedClient {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattSubscribedClient";
 }
-impl ::core::convert::From<GattSubscribedClient> for ::windows::core::IUnknown {
-    fn from(value: GattSubscribedClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattSubscribedClient> for ::windows::core::IUnknown {
-    fn from(value: &GattSubscribedClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattSubscribedClient> for &::windows::core::IUnknown {
-    fn from(value: &GattSubscribedClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattSubscribedClient> for ::windows::core::IInspectable {
-    fn from(value: GattSubscribedClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattSubscribedClient> for ::windows::core::IInspectable {
-    fn from(value: &GattSubscribedClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattSubscribedClient> for &::windows::core::IInspectable {
-    fn from(value: &GattSubscribedClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattSubscribedClient, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattSubscribedClient {}
 unsafe impl ::core::marker::Sync for GattSubscribedClient {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -6067,36 +5255,7 @@ unsafe impl ::windows::core::Interface for GattValueChangedEventArgs {
 impl ::windows::core::RuntimeName for GattValueChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattValueChangedEventArgs";
 }
-impl ::core::convert::From<GattValueChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GattValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattValueChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GattValueChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattValueChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GattValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattValueChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GattValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattValueChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GattValueChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattValueChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GattValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattValueChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattValueChangedEventArgs {}
 unsafe impl ::core::marker::Sync for GattValueChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -6189,36 +5348,7 @@ unsafe impl ::windows::core::Interface for GattWriteRequest {
 impl ::windows::core::RuntimeName for GattWriteRequest {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattWriteRequest";
 }
-impl ::core::convert::From<GattWriteRequest> for ::windows::core::IUnknown {
-    fn from(value: GattWriteRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattWriteRequest> for ::windows::core::IUnknown {
-    fn from(value: &GattWriteRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattWriteRequest> for &::windows::core::IUnknown {
-    fn from(value: &GattWriteRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattWriteRequest> for ::windows::core::IInspectable {
-    fn from(value: GattWriteRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattWriteRequest> for ::windows::core::IInspectable {
-    fn from(value: &GattWriteRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattWriteRequest> for &::windows::core::IInspectable {
-    fn from(value: &GattWriteRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattWriteRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattWriteRequest {}
 unsafe impl ::core::marker::Sync for GattWriteRequest {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -6283,36 +5413,7 @@ unsafe impl ::windows::core::Interface for GattWriteRequestedEventArgs {
 impl ::windows::core::RuntimeName for GattWriteRequestedEventArgs {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattWriteRequestedEventArgs";
 }
-impl ::core::convert::From<GattWriteRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GattWriteRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattWriteRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GattWriteRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattWriteRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GattWriteRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattWriteRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GattWriteRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattWriteRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GattWriteRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattWriteRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GattWriteRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattWriteRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattWriteRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for GattWriteRequestedEventArgs {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]
@@ -6368,36 +5469,7 @@ unsafe impl ::windows::core::Interface for GattWriteResult {
 impl ::windows::core::RuntimeName for GattWriteResult {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattWriteResult";
 }
-impl ::core::convert::From<GattWriteResult> for ::windows::core::IUnknown {
-    fn from(value: GattWriteResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattWriteResult> for ::windows::core::IUnknown {
-    fn from(value: &GattWriteResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattWriteResult> for &::windows::core::IUnknown {
-    fn from(value: &GattWriteResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GattWriteResult> for ::windows::core::IInspectable {
-    fn from(value: GattWriteResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GattWriteResult> for ::windows::core::IInspectable {
-    fn from(value: &GattWriteResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GattWriteResult> for &::windows::core::IInspectable {
-    fn from(value: &GattWriteResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GattWriteResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GattWriteResult {}
 unsafe impl ::core::marker::Sync for GattWriteResult {}
 #[doc = "*Required features: `\"Devices_Bluetooth_GenericAttributeProfile\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Rfcomm/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Rfcomm/mod.rs
@@ -401,36 +401,7 @@ unsafe impl ::windows::core::Interface for RfcommDeviceService {
 impl ::windows::core::RuntimeName for RfcommDeviceService {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Rfcomm.RfcommDeviceService";
 }
-impl ::core::convert::From<RfcommDeviceService> for ::windows::core::IUnknown {
-    fn from(value: RfcommDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommDeviceService> for ::windows::core::IUnknown {
-    fn from(value: &RfcommDeviceService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommDeviceService> for &::windows::core::IUnknown {
-    fn from(value: &RfcommDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RfcommDeviceService> for ::windows::core::IInspectable {
-    fn from(value: RfcommDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommDeviceService> for ::windows::core::IInspectable {
-    fn from(value: &RfcommDeviceService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommDeviceService> for &::windows::core::IInspectable {
-    fn from(value: &RfcommDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RfcommDeviceService, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<RfcommDeviceService> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -508,36 +479,7 @@ unsafe impl ::windows::core::Interface for RfcommDeviceServicesResult {
 impl ::windows::core::RuntimeName for RfcommDeviceServicesResult {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Rfcomm.RfcommDeviceServicesResult";
 }
-impl ::core::convert::From<RfcommDeviceServicesResult> for ::windows::core::IUnknown {
-    fn from(value: RfcommDeviceServicesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommDeviceServicesResult> for ::windows::core::IUnknown {
-    fn from(value: &RfcommDeviceServicesResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommDeviceServicesResult> for &::windows::core::IUnknown {
-    fn from(value: &RfcommDeviceServicesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RfcommDeviceServicesResult> for ::windows::core::IInspectable {
-    fn from(value: RfcommDeviceServicesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommDeviceServicesResult> for ::windows::core::IInspectable {
-    fn from(value: &RfcommDeviceServicesResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommDeviceServicesResult> for &::windows::core::IInspectable {
-    fn from(value: &RfcommDeviceServicesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RfcommDeviceServicesResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RfcommDeviceServicesResult {}
 unsafe impl ::core::marker::Sync for RfcommDeviceServicesResult {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Rfcomm\"`*"]
@@ -651,36 +593,7 @@ unsafe impl ::windows::core::Interface for RfcommServiceId {
 impl ::windows::core::RuntimeName for RfcommServiceId {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Rfcomm.RfcommServiceId";
 }
-impl ::core::convert::From<RfcommServiceId> for ::windows::core::IUnknown {
-    fn from(value: RfcommServiceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommServiceId> for ::windows::core::IUnknown {
-    fn from(value: &RfcommServiceId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommServiceId> for &::windows::core::IUnknown {
-    fn from(value: &RfcommServiceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RfcommServiceId> for ::windows::core::IInspectable {
-    fn from(value: RfcommServiceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommServiceId> for ::windows::core::IInspectable {
-    fn from(value: &RfcommServiceId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommServiceId> for &::windows::core::IInspectable {
-    fn from(value: &RfcommServiceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RfcommServiceId, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RfcommServiceId {}
 unsafe impl ::core::marker::Sync for RfcommServiceId {}
 #[doc = "*Required features: `\"Devices_Bluetooth_Rfcomm\"`*"]
@@ -765,36 +678,7 @@ unsafe impl ::windows::core::Interface for RfcommServiceProvider {
 impl ::windows::core::RuntimeName for RfcommServiceProvider {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Rfcomm.RfcommServiceProvider";
 }
-impl ::core::convert::From<RfcommServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: RfcommServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: &RfcommServiceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommServiceProvider> for &::windows::core::IUnknown {
-    fn from(value: &RfcommServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RfcommServiceProvider> for ::windows::core::IInspectable {
-    fn from(value: RfcommServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RfcommServiceProvider> for ::windows::core::IInspectable {
-    fn from(value: &RfcommServiceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RfcommServiceProvider> for &::windows::core::IInspectable {
-    fn from(value: &RfcommServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RfcommServiceProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RfcommServiceProvider {}
 unsafe impl ::core::marker::Sync for RfcommServiceProvider {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
@@ -983,36 +983,7 @@ unsafe impl ::windows::core::Interface for BluetoothAdapter {
 impl ::windows::core::RuntimeName for BluetoothAdapter {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothAdapter";
 }
-impl ::core::convert::From<BluetoothAdapter> for ::windows::core::IUnknown {
-    fn from(value: BluetoothAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothAdapter> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothAdapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothAdapter> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothAdapter> for ::windows::core::IInspectable {
-    fn from(value: BluetoothAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothAdapter> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothAdapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothAdapter> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothAdapter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothAdapter {}
 unsafe impl ::core::marker::Sync for BluetoothAdapter {}
 #[doc = "*Required features: `\"Devices_Bluetooth\"`*"]
@@ -1097,36 +1068,7 @@ unsafe impl ::windows::core::Interface for BluetoothClassOfDevice {
 impl ::windows::core::RuntimeName for BluetoothClassOfDevice {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothClassOfDevice";
 }
-impl ::core::convert::From<BluetoothClassOfDevice> for ::windows::core::IUnknown {
-    fn from(value: BluetoothClassOfDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothClassOfDevice> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothClassOfDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothClassOfDevice> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothClassOfDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothClassOfDevice> for ::windows::core::IInspectable {
-    fn from(value: BluetoothClassOfDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothClassOfDevice> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothClassOfDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothClassOfDevice> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothClassOfDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothClassOfDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothClassOfDevice {}
 unsafe impl ::core::marker::Sync for BluetoothClassOfDevice {}
 #[doc = "*Required features: `\"Devices_Bluetooth\"`*"]
@@ -1426,36 +1368,7 @@ unsafe impl ::windows::core::Interface for BluetoothDevice {
 impl ::windows::core::RuntimeName for BluetoothDevice {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothDevice";
 }
-impl ::core::convert::From<BluetoothDevice> for ::windows::core::IUnknown {
-    fn from(value: BluetoothDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothDevice> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothDevice> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothDevice> for ::windows::core::IInspectable {
-    fn from(value: BluetoothDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothDevice> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothDevice> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<BluetoothDevice> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1549,36 +1462,7 @@ unsafe impl ::windows::core::Interface for BluetoothDeviceId {
 impl ::windows::core::RuntimeName for BluetoothDeviceId {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothDeviceId";
 }
-impl ::core::convert::From<BluetoothDeviceId> for ::windows::core::IUnknown {
-    fn from(value: BluetoothDeviceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothDeviceId> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothDeviceId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothDeviceId> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothDeviceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothDeviceId> for ::windows::core::IInspectable {
-    fn from(value: BluetoothDeviceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothDeviceId> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothDeviceId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothDeviceId> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothDeviceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothDeviceId, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothDeviceId {}
 unsafe impl ::core::marker::Sync for BluetoothDeviceId {}
 #[doc = "*Required features: `\"Devices_Bluetooth\"`*"]
@@ -1656,36 +1540,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEAppearance {
 impl ::windows::core::RuntimeName for BluetoothLEAppearance {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothLEAppearance";
 }
-impl ::core::convert::From<BluetoothLEAppearance> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEAppearance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAppearance> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAppearance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAppearance> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEAppearance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEAppearance> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEAppearance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEAppearance> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAppearance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEAppearance> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEAppearance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEAppearance, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEAppearance {}
 unsafe impl ::core::marker::Sync for BluetoothLEAppearance {}
 #[doc = "*Required features: `\"Devices_Bluetooth\"`*"]
@@ -2070,36 +1925,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEConnectionParameters {
 impl ::windows::core::RuntimeName for BluetoothLEConnectionParameters {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothLEConnectionParameters";
 }
-impl ::core::convert::From<BluetoothLEConnectionParameters> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionParameters> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEConnectionParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionParameters> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEConnectionParameters> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionParameters> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEConnectionParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionParameters> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEConnectionParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEConnectionParameters {}
 unsafe impl ::core::marker::Sync for BluetoothLEConnectionParameters {}
 #[doc = "*Required features: `\"Devices_Bluetooth\"`*"]
@@ -2153,36 +1979,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEConnectionPhy {
 impl ::windows::core::RuntimeName for BluetoothLEConnectionPhy {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothLEConnectionPhy";
 }
-impl ::core::convert::From<BluetoothLEConnectionPhy> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEConnectionPhy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionPhy> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEConnectionPhy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionPhy> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEConnectionPhy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEConnectionPhy> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEConnectionPhy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionPhy> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEConnectionPhy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionPhy> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEConnectionPhy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEConnectionPhy, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEConnectionPhy {}
 unsafe impl ::core::marker::Sync for BluetoothLEConnectionPhy {}
 #[doc = "*Required features: `\"Devices_Bluetooth\"`*"]
@@ -2243,36 +2040,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEConnectionPhyInfo {
 impl ::windows::core::RuntimeName for BluetoothLEConnectionPhyInfo {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothLEConnectionPhyInfo";
 }
-impl ::core::convert::From<BluetoothLEConnectionPhyInfo> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEConnectionPhyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionPhyInfo> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEConnectionPhyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionPhyInfo> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEConnectionPhyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEConnectionPhyInfo> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEConnectionPhyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionPhyInfo> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEConnectionPhyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEConnectionPhyInfo> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEConnectionPhyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEConnectionPhyInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEConnectionPhyInfo {}
 unsafe impl ::core::marker::Sync for BluetoothLEConnectionPhyInfo {}
 #[doc = "*Required features: `\"Devices_Bluetooth\"`*"]
@@ -2627,36 +2395,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEDevice {
 impl ::windows::core::RuntimeName for BluetoothLEDevice {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothLEDevice";
 }
-impl ::core::convert::From<BluetoothLEDevice> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEDevice> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEDevice> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEDevice> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEDevice> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEDevice> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<BluetoothLEDevice> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2769,36 +2508,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEPreferredConnectionParamet
 impl ::windows::core::RuntimeName for BluetoothLEPreferredConnectionParameters {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothLEPreferredConnectionParameters";
 }
-impl ::core::convert::From<BluetoothLEPreferredConnectionParameters> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEPreferredConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEPreferredConnectionParameters> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEPreferredConnectionParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEPreferredConnectionParameters> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEPreferredConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEPreferredConnectionParameters> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEPreferredConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEPreferredConnectionParameters> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEPreferredConnectionParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEPreferredConnectionParameters> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEPreferredConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEPreferredConnectionParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothLEPreferredConnectionParameters {}
 unsafe impl ::core::marker::Sync for BluetoothLEPreferredConnectionParameters {}
 #[doc = "*Required features: `\"Devices_Bluetooth\"`*"]
@@ -2851,36 +2561,7 @@ unsafe impl ::windows::core::Interface for BluetoothLEPreferredConnectionParamet
 impl ::windows::core::RuntimeName for BluetoothLEPreferredConnectionParametersRequest {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothLEPreferredConnectionParametersRequest";
 }
-impl ::core::convert::From<BluetoothLEPreferredConnectionParametersRequest> for ::windows::core::IUnknown {
-    fn from(value: BluetoothLEPreferredConnectionParametersRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEPreferredConnectionParametersRequest> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothLEPreferredConnectionParametersRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEPreferredConnectionParametersRequest> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothLEPreferredConnectionParametersRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothLEPreferredConnectionParametersRequest> for ::windows::core::IInspectable {
-    fn from(value: BluetoothLEPreferredConnectionParametersRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothLEPreferredConnectionParametersRequest> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothLEPreferredConnectionParametersRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothLEPreferredConnectionParametersRequest> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothLEPreferredConnectionParametersRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothLEPreferredConnectionParametersRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<BluetoothLEPreferredConnectionParametersRequest> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3025,36 +2706,7 @@ unsafe impl ::windows::core::Interface for BluetoothSignalStrengthFilter {
 impl ::windows::core::RuntimeName for BluetoothSignalStrengthFilter {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothSignalStrengthFilter";
 }
-impl ::core::convert::From<BluetoothSignalStrengthFilter> for ::windows::core::IUnknown {
-    fn from(value: BluetoothSignalStrengthFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothSignalStrengthFilter> for ::windows::core::IUnknown {
-    fn from(value: &BluetoothSignalStrengthFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothSignalStrengthFilter> for &::windows::core::IUnknown {
-    fn from(value: &BluetoothSignalStrengthFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BluetoothSignalStrengthFilter> for ::windows::core::IInspectable {
-    fn from(value: BluetoothSignalStrengthFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BluetoothSignalStrengthFilter> for ::windows::core::IInspectable {
-    fn from(value: &BluetoothSignalStrengthFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BluetoothSignalStrengthFilter> for &::windows::core::IInspectable {
-    fn from(value: &BluetoothSignalStrengthFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BluetoothSignalStrengthFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BluetoothSignalStrengthFilter {}
 unsafe impl ::core::marker::Sync for BluetoothSignalStrengthFilter {}
 #[doc = "*Required features: `\"Devices_Bluetooth\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Custom/mod.rs
@@ -87,36 +87,7 @@ impl IIOControlCode {
         }
     }
 }
-impl ::core::convert::From<IIOControlCode> for ::windows::core::IUnknown {
-    fn from(value: IIOControlCode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIOControlCode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIOControlCode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIOControlCode> for ::windows::core::IUnknown {
-    fn from(value: &IIOControlCode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IIOControlCode> for ::windows::core::IInspectable {
-    fn from(value: IIOControlCode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIOControlCode> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IIOControlCode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIOControlCode> for ::windows::core::IInspectable {
-    fn from(value: &IIOControlCode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIOControlCode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IIOControlCode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -294,36 +265,7 @@ unsafe impl ::windows::core::Interface for CustomDevice {
 impl ::windows::core::RuntimeName for CustomDevice {
     const NAME: &'static str = "Windows.Devices.Custom.CustomDevice";
 }
-impl ::core::convert::From<CustomDevice> for ::windows::core::IUnknown {
-    fn from(value: CustomDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CustomDevice> for ::windows::core::IUnknown {
-    fn from(value: &CustomDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CustomDevice> for &::windows::core::IUnknown {
-    fn from(value: &CustomDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CustomDevice> for ::windows::core::IInspectable {
-    fn from(value: CustomDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CustomDevice> for ::windows::core::IInspectable {
-    fn from(value: &CustomDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CustomDevice> for &::windows::core::IInspectable {
-    fn from(value: &CustomDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CustomDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CustomDevice {}
 unsafe impl ::core::marker::Sync for CustomDevice {}
 #[doc = "*Required features: `\"Devices_Custom\"`*"]
@@ -409,36 +351,7 @@ unsafe impl ::windows::core::Interface for IOControlCode {
 impl ::windows::core::RuntimeName for IOControlCode {
     const NAME: &'static str = "Windows.Devices.Custom.IOControlCode";
 }
-impl ::core::convert::From<IOControlCode> for ::windows::core::IUnknown {
-    fn from(value: IOControlCode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOControlCode> for ::windows::core::IUnknown {
-    fn from(value: &IOControlCode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IOControlCode> for &::windows::core::IUnknown {
-    fn from(value: &IOControlCode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IOControlCode> for ::windows::core::IInspectable {
-    fn from(value: IOControlCode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOControlCode> for ::windows::core::IInspectable {
-    fn from(value: &IOControlCode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IOControlCode> for &::windows::core::IInspectable {
-    fn from(value: &IOControlCode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IOControlCode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IOControlCode> for IIOControlCode {
     type Error = ::windows::core::Error;
     fn try_from(value: IOControlCode) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
@@ -942,36 +942,7 @@ unsafe impl ::windows::core::Interface for DisplayAdapter {
 impl ::windows::core::RuntimeName for DisplayAdapter {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayAdapter";
 }
-impl ::core::convert::From<DisplayAdapter> for ::windows::core::IUnknown {
-    fn from(value: DisplayAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayAdapter> for ::windows::core::IUnknown {
-    fn from(value: &DisplayAdapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayAdapter> for &::windows::core::IUnknown {
-    fn from(value: &DisplayAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayAdapter> for ::windows::core::IInspectable {
-    fn from(value: DisplayAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayAdapter> for ::windows::core::IInspectable {
-    fn from(value: &DisplayAdapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayAdapter> for &::windows::core::IInspectable {
-    fn from(value: &DisplayAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayAdapter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayAdapter {}
 unsafe impl ::core::marker::Sync for DisplayAdapter {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -1072,36 +1043,7 @@ unsafe impl ::windows::core::Interface for DisplayDevice {
 impl ::windows::core::RuntimeName for DisplayDevice {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayDevice";
 }
-impl ::core::convert::From<DisplayDevice> for ::windows::core::IUnknown {
-    fn from(value: DisplayDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayDevice> for ::windows::core::IUnknown {
-    fn from(value: &DisplayDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayDevice> for &::windows::core::IUnknown {
-    fn from(value: &DisplayDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayDevice> for ::windows::core::IInspectable {
-    fn from(value: DisplayDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayDevice> for ::windows::core::IInspectable {
-    fn from(value: &DisplayDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayDevice> for &::windows::core::IInspectable {
-    fn from(value: &DisplayDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayDevice {}
 unsafe impl ::core::marker::Sync for DisplayDevice {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -1140,36 +1082,7 @@ unsafe impl ::windows::core::Interface for DisplayFence {
 impl ::windows::core::RuntimeName for DisplayFence {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayFence";
 }
-impl ::core::convert::From<DisplayFence> for ::windows::core::IUnknown {
-    fn from(value: DisplayFence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayFence> for ::windows::core::IUnknown {
-    fn from(value: &DisplayFence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayFence> for &::windows::core::IUnknown {
-    fn from(value: &DisplayFence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayFence> for ::windows::core::IInspectable {
-    fn from(value: DisplayFence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayFence> for ::windows::core::IInspectable {
-    fn from(value: &DisplayFence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayFence> for &::windows::core::IInspectable {
-    fn from(value: &DisplayFence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayFence, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayFence {}
 unsafe impl ::core::marker::Sync for DisplayFence {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -1376,36 +1289,7 @@ unsafe impl ::windows::core::Interface for DisplayManager {
 impl ::windows::core::RuntimeName for DisplayManager {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayManager";
 }
-impl ::core::convert::From<DisplayManager> for ::windows::core::IUnknown {
-    fn from(value: DisplayManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManager> for ::windows::core::IUnknown {
-    fn from(value: &DisplayManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManager> for &::windows::core::IUnknown {
-    fn from(value: &DisplayManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayManager> for ::windows::core::IInspectable {
-    fn from(value: DisplayManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManager> for ::windows::core::IInspectable {
-    fn from(value: &DisplayManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManager> for &::windows::core::IInspectable {
-    fn from(value: &DisplayManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<DisplayManager> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1487,36 +1371,7 @@ unsafe impl ::windows::core::Interface for DisplayManagerChangedEventArgs {
 impl ::windows::core::RuntimeName for DisplayManagerChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayManagerChangedEventArgs";
 }
-impl ::core::convert::From<DisplayManagerChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DisplayManagerChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManagerChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DisplayManagerChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManagerChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DisplayManagerChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayManagerChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DisplayManagerChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManagerChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DisplayManagerChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManagerChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DisplayManagerChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayManagerChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayManagerChangedEventArgs {}
 unsafe impl ::core::marker::Sync for DisplayManagerChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -1576,36 +1431,7 @@ unsafe impl ::windows::core::Interface for DisplayManagerDisabledEventArgs {
 impl ::windows::core::RuntimeName for DisplayManagerDisabledEventArgs {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayManagerDisabledEventArgs";
 }
-impl ::core::convert::From<DisplayManagerDisabledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DisplayManagerDisabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManagerDisabledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DisplayManagerDisabledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManagerDisabledEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DisplayManagerDisabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayManagerDisabledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DisplayManagerDisabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManagerDisabledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DisplayManagerDisabledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManagerDisabledEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DisplayManagerDisabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayManagerDisabledEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayManagerDisabledEventArgs {}
 unsafe impl ::core::marker::Sync for DisplayManagerDisabledEventArgs {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -1665,36 +1491,7 @@ unsafe impl ::windows::core::Interface for DisplayManagerEnabledEventArgs {
 impl ::windows::core::RuntimeName for DisplayManagerEnabledEventArgs {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayManagerEnabledEventArgs";
 }
-impl ::core::convert::From<DisplayManagerEnabledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DisplayManagerEnabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManagerEnabledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DisplayManagerEnabledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManagerEnabledEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DisplayManagerEnabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayManagerEnabledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DisplayManagerEnabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManagerEnabledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DisplayManagerEnabledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManagerEnabledEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DisplayManagerEnabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayManagerEnabledEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayManagerEnabledEventArgs {}
 unsafe impl ::core::marker::Sync for DisplayManagerEnabledEventArgs {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -1754,36 +1551,7 @@ unsafe impl ::windows::core::Interface for DisplayManagerPathsFailedOrInvalidate
 impl ::windows::core::RuntimeName for DisplayManagerPathsFailedOrInvalidatedEventArgs {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayManagerPathsFailedOrInvalidatedEventArgs";
 }
-impl ::core::convert::From<DisplayManagerPathsFailedOrInvalidatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DisplayManagerPathsFailedOrInvalidatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManagerPathsFailedOrInvalidatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DisplayManagerPathsFailedOrInvalidatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManagerPathsFailedOrInvalidatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DisplayManagerPathsFailedOrInvalidatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayManagerPathsFailedOrInvalidatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DisplayManagerPathsFailedOrInvalidatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManagerPathsFailedOrInvalidatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DisplayManagerPathsFailedOrInvalidatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManagerPathsFailedOrInvalidatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DisplayManagerPathsFailedOrInvalidatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayManagerPathsFailedOrInvalidatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayManagerPathsFailedOrInvalidatedEventArgs {}
 unsafe impl ::core::marker::Sync for DisplayManagerPathsFailedOrInvalidatedEventArgs {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -1844,36 +1612,7 @@ unsafe impl ::windows::core::Interface for DisplayManagerResultWithState {
 impl ::windows::core::RuntimeName for DisplayManagerResultWithState {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayManagerResultWithState";
 }
-impl ::core::convert::From<DisplayManagerResultWithState> for ::windows::core::IUnknown {
-    fn from(value: DisplayManagerResultWithState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManagerResultWithState> for ::windows::core::IUnknown {
-    fn from(value: &DisplayManagerResultWithState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManagerResultWithState> for &::windows::core::IUnknown {
-    fn from(value: &DisplayManagerResultWithState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayManagerResultWithState> for ::windows::core::IInspectable {
-    fn from(value: DisplayManagerResultWithState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayManagerResultWithState> for ::windows::core::IInspectable {
-    fn from(value: &DisplayManagerResultWithState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayManagerResultWithState> for &::windows::core::IInspectable {
-    fn from(value: &DisplayManagerResultWithState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayManagerResultWithState, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayManagerResultWithState {}
 unsafe impl ::core::marker::Sync for DisplayManagerResultWithState {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -1995,36 +1734,7 @@ unsafe impl ::windows::core::Interface for DisplayModeInfo {
 impl ::windows::core::RuntimeName for DisplayModeInfo {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayModeInfo";
 }
-impl ::core::convert::From<DisplayModeInfo> for ::windows::core::IUnknown {
-    fn from(value: DisplayModeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayModeInfo> for ::windows::core::IUnknown {
-    fn from(value: &DisplayModeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayModeInfo> for &::windows::core::IUnknown {
-    fn from(value: &DisplayModeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayModeInfo> for ::windows::core::IInspectable {
-    fn from(value: DisplayModeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayModeInfo> for ::windows::core::IInspectable {
-    fn from(value: &DisplayModeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayModeInfo> for &::windows::core::IInspectable {
-    fn from(value: &DisplayModeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayModeInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayModeInfo {}
 unsafe impl ::core::marker::Sync for DisplayModeInfo {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -2261,36 +1971,7 @@ unsafe impl ::windows::core::Interface for DisplayPath {
 impl ::windows::core::RuntimeName for DisplayPath {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayPath";
 }
-impl ::core::convert::From<DisplayPath> for ::windows::core::IUnknown {
-    fn from(value: DisplayPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayPath> for ::windows::core::IUnknown {
-    fn from(value: &DisplayPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayPath> for &::windows::core::IUnknown {
-    fn from(value: &DisplayPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayPath> for ::windows::core::IInspectable {
-    fn from(value: DisplayPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayPath> for ::windows::core::IInspectable {
-    fn from(value: &DisplayPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayPath> for &::windows::core::IInspectable {
-    fn from(value: &DisplayPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayPath, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayPath {}
 unsafe impl ::core::marker::Sync for DisplayPath {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -2417,36 +2098,7 @@ unsafe impl ::windows::core::Interface for DisplayPrimaryDescription {
 impl ::windows::core::RuntimeName for DisplayPrimaryDescription {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayPrimaryDescription";
 }
-impl ::core::convert::From<DisplayPrimaryDescription> for ::windows::core::IUnknown {
-    fn from(value: DisplayPrimaryDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayPrimaryDescription> for ::windows::core::IUnknown {
-    fn from(value: &DisplayPrimaryDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayPrimaryDescription> for &::windows::core::IUnknown {
-    fn from(value: &DisplayPrimaryDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayPrimaryDescription> for ::windows::core::IInspectable {
-    fn from(value: DisplayPrimaryDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayPrimaryDescription> for ::windows::core::IInspectable {
-    fn from(value: &DisplayPrimaryDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayPrimaryDescription> for &::windows::core::IInspectable {
-    fn from(value: &DisplayPrimaryDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayPrimaryDescription, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayPrimaryDescription {}
 unsafe impl ::core::marker::Sync for DisplayPrimaryDescription {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -2485,36 +2137,7 @@ unsafe impl ::windows::core::Interface for DisplayScanout {
 impl ::windows::core::RuntimeName for DisplayScanout {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayScanout";
 }
-impl ::core::convert::From<DisplayScanout> for ::windows::core::IUnknown {
-    fn from(value: DisplayScanout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayScanout> for ::windows::core::IUnknown {
-    fn from(value: &DisplayScanout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayScanout> for &::windows::core::IUnknown {
-    fn from(value: &DisplayScanout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayScanout> for ::windows::core::IInspectable {
-    fn from(value: DisplayScanout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayScanout> for ::windows::core::IInspectable {
-    fn from(value: &DisplayScanout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayScanout> for &::windows::core::IInspectable {
-    fn from(value: &DisplayScanout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayScanout, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayScanout {}
 unsafe impl ::core::marker::Sync for DisplayScanout {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -2601,36 +2224,7 @@ unsafe impl ::windows::core::Interface for DisplaySource {
 impl ::windows::core::RuntimeName for DisplaySource {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplaySource";
 }
-impl ::core::convert::From<DisplaySource> for ::windows::core::IUnknown {
-    fn from(value: DisplaySource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplaySource> for ::windows::core::IUnknown {
-    fn from(value: &DisplaySource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplaySource> for &::windows::core::IUnknown {
-    fn from(value: &DisplaySource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplaySource> for ::windows::core::IInspectable {
-    fn from(value: DisplaySource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplaySource> for ::windows::core::IInspectable {
-    fn from(value: &DisplaySource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplaySource> for &::windows::core::IInspectable {
-    fn from(value: &DisplaySource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplaySource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplaySource {}
 unsafe impl ::core::marker::Sync for DisplaySource {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -2771,36 +2365,7 @@ unsafe impl ::windows::core::Interface for DisplayState {
 impl ::windows::core::RuntimeName for DisplayState {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayState";
 }
-impl ::core::convert::From<DisplayState> for ::windows::core::IUnknown {
-    fn from(value: DisplayState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayState> for ::windows::core::IUnknown {
-    fn from(value: &DisplayState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayState> for &::windows::core::IUnknown {
-    fn from(value: &DisplayState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayState> for ::windows::core::IInspectable {
-    fn from(value: DisplayState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayState> for ::windows::core::IInspectable {
-    fn from(value: &DisplayState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayState> for &::windows::core::IInspectable {
-    fn from(value: &DisplayState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayState, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayState {}
 unsafe impl ::core::marker::Sync for DisplayState {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -2854,36 +2419,7 @@ unsafe impl ::windows::core::Interface for DisplayStateOperationResult {
 impl ::windows::core::RuntimeName for DisplayStateOperationResult {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayStateOperationResult";
 }
-impl ::core::convert::From<DisplayStateOperationResult> for ::windows::core::IUnknown {
-    fn from(value: DisplayStateOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayStateOperationResult> for ::windows::core::IUnknown {
-    fn from(value: &DisplayStateOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayStateOperationResult> for &::windows::core::IUnknown {
-    fn from(value: &DisplayStateOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayStateOperationResult> for ::windows::core::IInspectable {
-    fn from(value: DisplayStateOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayStateOperationResult> for ::windows::core::IInspectable {
-    fn from(value: &DisplayStateOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayStateOperationResult> for &::windows::core::IInspectable {
-    fn from(value: &DisplayStateOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayStateOperationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayStateOperationResult {}
 unsafe impl ::core::marker::Sync for DisplayStateOperationResult {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -2922,36 +2458,7 @@ unsafe impl ::windows::core::Interface for DisplaySurface {
 impl ::windows::core::RuntimeName for DisplaySurface {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplaySurface";
 }
-impl ::core::convert::From<DisplaySurface> for ::windows::core::IUnknown {
-    fn from(value: DisplaySurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplaySurface> for ::windows::core::IUnknown {
-    fn from(value: &DisplaySurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplaySurface> for &::windows::core::IUnknown {
-    fn from(value: &DisplaySurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplaySurface> for ::windows::core::IInspectable {
-    fn from(value: DisplaySurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplaySurface> for ::windows::core::IInspectable {
-    fn from(value: &DisplaySurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplaySurface> for &::windows::core::IInspectable {
-    fn from(value: &DisplaySurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplaySurface, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplaySurface {}
 unsafe impl ::core::marker::Sync for DisplaySurface {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -3091,36 +2598,7 @@ unsafe impl ::windows::core::Interface for DisplayTarget {
 impl ::windows::core::RuntimeName for DisplayTarget {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayTarget";
 }
-impl ::core::convert::From<DisplayTarget> for ::windows::core::IUnknown {
-    fn from(value: DisplayTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayTarget> for ::windows::core::IUnknown {
-    fn from(value: &DisplayTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayTarget> for &::windows::core::IUnknown {
-    fn from(value: &DisplayTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayTarget> for ::windows::core::IInspectable {
-    fn from(value: DisplayTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayTarget> for ::windows::core::IInspectable {
-    fn from(value: &DisplayTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayTarget> for &::windows::core::IInspectable {
-    fn from(value: &DisplayTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayTarget, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayTarget {}
 unsafe impl ::core::marker::Sync for DisplayTarget {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -3172,36 +2650,7 @@ unsafe impl ::windows::core::Interface for DisplayTask {
 impl ::windows::core::RuntimeName for DisplayTask {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayTask";
 }
-impl ::core::convert::From<DisplayTask> for ::windows::core::IUnknown {
-    fn from(value: DisplayTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayTask> for ::windows::core::IUnknown {
-    fn from(value: &DisplayTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayTask> for &::windows::core::IUnknown {
-    fn from(value: &DisplayTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayTask> for ::windows::core::IInspectable {
-    fn from(value: DisplayTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayTask> for ::windows::core::IInspectable {
-    fn from(value: &DisplayTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayTask> for &::windows::core::IInspectable {
-    fn from(value: &DisplayTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayTask, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayTask {}
 unsafe impl ::core::marker::Sync for DisplayTask {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -3261,36 +2710,7 @@ unsafe impl ::windows::core::Interface for DisplayTaskPool {
 impl ::windows::core::RuntimeName for DisplayTaskPool {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayTaskPool";
 }
-impl ::core::convert::From<DisplayTaskPool> for ::windows::core::IUnknown {
-    fn from(value: DisplayTaskPool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayTaskPool> for ::windows::core::IUnknown {
-    fn from(value: &DisplayTaskPool) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayTaskPool> for &::windows::core::IUnknown {
-    fn from(value: &DisplayTaskPool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayTaskPool> for ::windows::core::IInspectable {
-    fn from(value: DisplayTaskPool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayTaskPool> for ::windows::core::IInspectable {
-    fn from(value: &DisplayTaskPool) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayTaskPool> for &::windows::core::IInspectable {
-    fn from(value: &DisplayTaskPool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayTaskPool, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayTaskPool {}
 unsafe impl ::core::marker::Sync for DisplayTaskPool {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -3351,36 +2771,7 @@ unsafe impl ::windows::core::Interface for DisplayTaskResult {
 impl ::windows::core::RuntimeName for DisplayTaskResult {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayTaskResult";
 }
-impl ::core::convert::From<DisplayTaskResult> for ::windows::core::IUnknown {
-    fn from(value: DisplayTaskResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayTaskResult> for ::windows::core::IUnknown {
-    fn from(value: &DisplayTaskResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayTaskResult> for &::windows::core::IUnknown {
-    fn from(value: &DisplayTaskResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayTaskResult> for ::windows::core::IInspectable {
-    fn from(value: DisplayTaskResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayTaskResult> for ::windows::core::IInspectable {
-    fn from(value: &DisplayTaskResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayTaskResult> for &::windows::core::IInspectable {
-    fn from(value: &DisplayTaskResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayTaskResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayTaskResult {}
 unsafe impl ::core::marker::Sync for DisplayTaskResult {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -3461,36 +2852,7 @@ unsafe impl ::windows::core::Interface for DisplayView {
 impl ::windows::core::RuntimeName for DisplayView {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayView";
 }
-impl ::core::convert::From<DisplayView> for ::windows::core::IUnknown {
-    fn from(value: DisplayView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayView> for ::windows::core::IUnknown {
-    fn from(value: &DisplayView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayView> for &::windows::core::IUnknown {
-    fn from(value: &DisplayView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayView> for ::windows::core::IInspectable {
-    fn from(value: DisplayView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayView> for ::windows::core::IInspectable {
-    fn from(value: &DisplayView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayView> for &::windows::core::IInspectable {
-    fn from(value: &DisplayView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayView {}
 unsafe impl ::core::marker::Sync for DisplayView {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]
@@ -3602,36 +2964,7 @@ unsafe impl ::windows::core::Interface for DisplayWireFormat {
 impl ::windows::core::RuntimeName for DisplayWireFormat {
     const NAME: &'static str = "Windows.Devices.Display.Core.DisplayWireFormat";
 }
-impl ::core::convert::From<DisplayWireFormat> for ::windows::core::IUnknown {
-    fn from(value: DisplayWireFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayWireFormat> for ::windows::core::IUnknown {
-    fn from(value: &DisplayWireFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayWireFormat> for &::windows::core::IUnknown {
-    fn from(value: &DisplayWireFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayWireFormat> for ::windows::core::IInspectable {
-    fn from(value: DisplayWireFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayWireFormat> for ::windows::core::IInspectable {
-    fn from(value: &DisplayWireFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayWireFormat> for &::windows::core::IInspectable {
-    fn from(value: &DisplayWireFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayWireFormat, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayWireFormat {}
 unsafe impl ::core::marker::Sync for DisplayWireFormat {}
 #[doc = "*Required features: `\"Devices_Display_Core\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Display/mod.rs
@@ -318,36 +318,7 @@ unsafe impl ::windows::core::Interface for DisplayMonitor {
 impl ::windows::core::RuntimeName for DisplayMonitor {
     const NAME: &'static str = "Windows.Devices.Display.DisplayMonitor";
 }
-impl ::core::convert::From<DisplayMonitor> for ::windows::core::IUnknown {
-    fn from(value: DisplayMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayMonitor> for ::windows::core::IUnknown {
-    fn from(value: &DisplayMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayMonitor> for &::windows::core::IUnknown {
-    fn from(value: &DisplayMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayMonitor> for ::windows::core::IInspectable {
-    fn from(value: DisplayMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayMonitor> for ::windows::core::IInspectable {
-    fn from(value: &DisplayMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayMonitor> for &::windows::core::IInspectable {
-    fn from(value: &DisplayMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayMonitor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayMonitor {}
 unsafe impl ::core::marker::Sync for DisplayMonitor {}
 #[doc = "*Required features: `\"Devices_Display\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Enumeration/Pnp/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Enumeration/Pnp/mod.rs
@@ -259,36 +259,7 @@ unsafe impl ::windows::core::Interface for PnpObject {
 impl ::windows::core::RuntimeName for PnpObject {
     const NAME: &'static str = "Windows.Devices.Enumeration.Pnp.PnpObject";
 }
-impl ::core::convert::From<PnpObject> for ::windows::core::IUnknown {
-    fn from(value: PnpObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PnpObject> for ::windows::core::IUnknown {
-    fn from(value: &PnpObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PnpObject> for &::windows::core::IUnknown {
-    fn from(value: &PnpObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PnpObject> for ::windows::core::IInspectable {
-    fn from(value: PnpObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PnpObject> for ::windows::core::IInspectable {
-    fn from(value: &PnpObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PnpObject> for &::windows::core::IInspectable {
-    fn from(value: &PnpObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PnpObject, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PnpObject {}
 unsafe impl ::core::marker::Sync for PnpObject {}
 #[doc = "*Required features: `\"Devices_Enumeration_Pnp\"`, `\"Foundation_Collections\"`*"]
@@ -400,41 +371,7 @@ impl ::core::iter::IntoIterator for &PnpObjectCollection {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PnpObjectCollection> for ::windows::core::IUnknown {
-    fn from(value: PnpObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PnpObjectCollection> for ::windows::core::IUnknown {
-    fn from(value: &PnpObjectCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PnpObjectCollection> for &::windows::core::IUnknown {
-    fn from(value: &PnpObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PnpObjectCollection> for ::windows::core::IInspectable {
-    fn from(value: PnpObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PnpObjectCollection> for ::windows::core::IInspectable {
-    fn from(value: &PnpObjectCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PnpObjectCollection> for &::windows::core::IInspectable {
-    fn from(value: &PnpObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PnpObjectCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<PnpObjectCollection> for super::super::super::Foundation::Collections::IIterable<PnpObject> {
     type Error = ::windows::core::Error;
@@ -543,36 +480,7 @@ unsafe impl ::windows::core::Interface for PnpObjectUpdate {
 impl ::windows::core::RuntimeName for PnpObjectUpdate {
     const NAME: &'static str = "Windows.Devices.Enumeration.Pnp.PnpObjectUpdate";
 }
-impl ::core::convert::From<PnpObjectUpdate> for ::windows::core::IUnknown {
-    fn from(value: PnpObjectUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PnpObjectUpdate> for ::windows::core::IUnknown {
-    fn from(value: &PnpObjectUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PnpObjectUpdate> for &::windows::core::IUnknown {
-    fn from(value: &PnpObjectUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PnpObjectUpdate> for ::windows::core::IInspectable {
-    fn from(value: PnpObjectUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PnpObjectUpdate> for ::windows::core::IInspectable {
-    fn from(value: &PnpObjectUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PnpObjectUpdate> for &::windows::core::IInspectable {
-    fn from(value: &PnpObjectUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PnpObjectUpdate, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PnpObjectUpdate {}
 unsafe impl ::core::marker::Sync for PnpObjectUpdate {}
 #[doc = "*Required features: `\"Devices_Enumeration_Pnp\"`*"]
@@ -702,36 +610,7 @@ unsafe impl ::windows::core::Interface for PnpObjectWatcher {
 impl ::windows::core::RuntimeName for PnpObjectWatcher {
     const NAME: &'static str = "Windows.Devices.Enumeration.Pnp.PnpObjectWatcher";
 }
-impl ::core::convert::From<PnpObjectWatcher> for ::windows::core::IUnknown {
-    fn from(value: PnpObjectWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PnpObjectWatcher> for ::windows::core::IUnknown {
-    fn from(value: &PnpObjectWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PnpObjectWatcher> for &::windows::core::IUnknown {
-    fn from(value: &PnpObjectWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PnpObjectWatcher> for ::windows::core::IInspectable {
-    fn from(value: PnpObjectWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PnpObjectWatcher> for ::windows::core::IInspectable {
-    fn from(value: &PnpObjectWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PnpObjectWatcher> for &::windows::core::IInspectable {
-    fn from(value: &PnpObjectWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PnpObjectWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PnpObjectWatcher {}
 unsafe impl ::core::marker::Sync for PnpObjectWatcher {}
 #[doc = "*Required features: `\"Devices_Enumeration_Pnp\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
@@ -427,36 +427,7 @@ pub struct IDevicePairingResult_Vtbl {
 #[repr(transparent)]
 pub struct IDevicePairingSettings(::windows::core::IUnknown);
 impl IDevicePairingSettings {}
-impl ::core::convert::From<IDevicePairingSettings> for ::windows::core::IUnknown {
-    fn from(value: IDevicePairingSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDevicePairingSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDevicePairingSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDevicePairingSettings> for ::windows::core::IUnknown {
-    fn from(value: &IDevicePairingSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDevicePairingSettings> for ::windows::core::IInspectable {
-    fn from(value: IDevicePairingSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDevicePairingSettings> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IDevicePairingSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDevicePairingSettings> for ::windows::core::IInspectable {
-    fn from(value: &IDevicePairingSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDevicePairingSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IDevicePairingSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -862,36 +833,7 @@ unsafe impl ::windows::core::Interface for DeviceAccessChangedEventArgs {
 impl ::windows::core::RuntimeName for DeviceAccessChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceAccessChangedEventArgs";
 }
-impl ::core::convert::From<DeviceAccessChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DeviceAccessChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceAccessChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DeviceAccessChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceAccessChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DeviceAccessChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceAccessChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DeviceAccessChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceAccessChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DeviceAccessChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceAccessChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DeviceAccessChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceAccessChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceAccessChangedEventArgs {}
 unsafe impl ::core::marker::Sync for DeviceAccessChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -976,36 +918,7 @@ unsafe impl ::windows::core::Interface for DeviceAccessInformation {
 impl ::windows::core::RuntimeName for DeviceAccessInformation {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceAccessInformation";
 }
-impl ::core::convert::From<DeviceAccessInformation> for ::windows::core::IUnknown {
-    fn from(value: DeviceAccessInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceAccessInformation> for ::windows::core::IUnknown {
-    fn from(value: &DeviceAccessInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceAccessInformation> for &::windows::core::IUnknown {
-    fn from(value: &DeviceAccessInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceAccessInformation> for ::windows::core::IInspectable {
-    fn from(value: DeviceAccessInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceAccessInformation> for ::windows::core::IInspectable {
-    fn from(value: &DeviceAccessInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceAccessInformation> for &::windows::core::IInspectable {
-    fn from(value: &DeviceAccessInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceAccessInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceAccessInformation {}
 unsafe impl ::core::marker::Sync for DeviceAccessInformation {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -1052,36 +965,7 @@ unsafe impl ::windows::core::Interface for DeviceConnectionChangeTriggerDetails 
 impl ::windows::core::RuntimeName for DeviceConnectionChangeTriggerDetails {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceConnectionChangeTriggerDetails";
 }
-impl ::core::convert::From<DeviceConnectionChangeTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: DeviceConnectionChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceConnectionChangeTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &DeviceConnectionChangeTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceConnectionChangeTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &DeviceConnectionChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceConnectionChangeTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: DeviceConnectionChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceConnectionChangeTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &DeviceConnectionChangeTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceConnectionChangeTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &DeviceConnectionChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceConnectionChangeTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceConnectionChangeTriggerDetails {}
 unsafe impl ::core::marker::Sync for DeviceConnectionChangeTriggerDetails {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -1128,36 +1012,7 @@ unsafe impl ::windows::core::Interface for DeviceDisconnectButtonClickedEventArg
 impl ::windows::core::RuntimeName for DeviceDisconnectButtonClickedEventArgs {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceDisconnectButtonClickedEventArgs";
 }
-impl ::core::convert::From<DeviceDisconnectButtonClickedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DeviceDisconnectButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceDisconnectButtonClickedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DeviceDisconnectButtonClickedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceDisconnectButtonClickedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DeviceDisconnectButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceDisconnectButtonClickedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DeviceDisconnectButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceDisconnectButtonClickedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DeviceDisconnectButtonClickedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceDisconnectButtonClickedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DeviceDisconnectButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceDisconnectButtonClickedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceDisconnectButtonClickedEventArgs {}
 unsafe impl ::core::marker::Sync for DeviceDisconnectButtonClickedEventArgs {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -1415,36 +1270,7 @@ unsafe impl ::windows::core::Interface for DeviceInformation {
 impl ::windows::core::RuntimeName for DeviceInformation {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceInformation";
 }
-impl ::core::convert::From<DeviceInformation> for ::windows::core::IUnknown {
-    fn from(value: DeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceInformation> for ::windows::core::IUnknown {
-    fn from(value: &DeviceInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceInformation> for &::windows::core::IUnknown {
-    fn from(value: &DeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceInformation> for ::windows::core::IInspectable {
-    fn from(value: DeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceInformation> for ::windows::core::IInspectable {
-    fn from(value: &DeviceInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceInformation> for &::windows::core::IInspectable {
-    fn from(value: &DeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceInformation {}
 unsafe impl ::core::marker::Sync for DeviceInformation {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`, `\"Foundation_Collections\"`*"]
@@ -1556,41 +1382,7 @@ impl ::core::iter::IntoIterator for &DeviceInformationCollection {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<DeviceInformationCollection> for ::windows::core::IUnknown {
-    fn from(value: DeviceInformationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&DeviceInformationCollection> for ::windows::core::IUnknown {
-    fn from(value: &DeviceInformationCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&DeviceInformationCollection> for &::windows::core::IUnknown {
-    fn from(value: &DeviceInformationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<DeviceInformationCollection> for ::windows::core::IInspectable {
-    fn from(value: DeviceInformationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&DeviceInformationCollection> for ::windows::core::IInspectable {
-    fn from(value: &DeviceInformationCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&DeviceInformationCollection> for &::windows::core::IInspectable {
-    fn from(value: &DeviceInformationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceInformationCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<DeviceInformationCollection> for super::super::Foundation::Collections::IIterable<DeviceInformation> {
     type Error = ::windows::core::Error;
@@ -1722,36 +1514,7 @@ unsafe impl ::windows::core::Interface for DeviceInformationCustomPairing {
 impl ::windows::core::RuntimeName for DeviceInformationCustomPairing {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceInformationCustomPairing";
 }
-impl ::core::convert::From<DeviceInformationCustomPairing> for ::windows::core::IUnknown {
-    fn from(value: DeviceInformationCustomPairing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceInformationCustomPairing> for ::windows::core::IUnknown {
-    fn from(value: &DeviceInformationCustomPairing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceInformationCustomPairing> for &::windows::core::IUnknown {
-    fn from(value: &DeviceInformationCustomPairing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceInformationCustomPairing> for ::windows::core::IInspectable {
-    fn from(value: DeviceInformationCustomPairing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceInformationCustomPairing> for ::windows::core::IInspectable {
-    fn from(value: &DeviceInformationCustomPairing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceInformationCustomPairing> for &::windows::core::IInspectable {
-    fn from(value: &DeviceInformationCustomPairing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceInformationCustomPairing, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceInformationCustomPairing {}
 unsafe impl ::core::marker::Sync for DeviceInformationCustomPairing {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -1881,36 +1644,7 @@ unsafe impl ::windows::core::Interface for DeviceInformationPairing {
 impl ::windows::core::RuntimeName for DeviceInformationPairing {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceInformationPairing";
 }
-impl ::core::convert::From<DeviceInformationPairing> for ::windows::core::IUnknown {
-    fn from(value: DeviceInformationPairing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceInformationPairing> for ::windows::core::IUnknown {
-    fn from(value: &DeviceInformationPairing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceInformationPairing> for &::windows::core::IUnknown {
-    fn from(value: &DeviceInformationPairing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceInformationPairing> for ::windows::core::IInspectable {
-    fn from(value: DeviceInformationPairing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceInformationPairing> for ::windows::core::IInspectable {
-    fn from(value: &DeviceInformationPairing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceInformationPairing> for &::windows::core::IInspectable {
-    fn from(value: &DeviceInformationPairing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceInformationPairing, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceInformationPairing {}
 unsafe impl ::core::marker::Sync for DeviceInformationPairing {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -1973,36 +1707,7 @@ unsafe impl ::windows::core::Interface for DeviceInformationUpdate {
 impl ::windows::core::RuntimeName for DeviceInformationUpdate {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceInformationUpdate";
 }
-impl ::core::convert::From<DeviceInformationUpdate> for ::windows::core::IUnknown {
-    fn from(value: DeviceInformationUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceInformationUpdate> for ::windows::core::IUnknown {
-    fn from(value: &DeviceInformationUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceInformationUpdate> for &::windows::core::IUnknown {
-    fn from(value: &DeviceInformationUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceInformationUpdate> for ::windows::core::IInspectable {
-    fn from(value: DeviceInformationUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceInformationUpdate> for ::windows::core::IInspectable {
-    fn from(value: &DeviceInformationUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceInformationUpdate> for &::windows::core::IInspectable {
-    fn from(value: &DeviceInformationUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceInformationUpdate, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceInformationUpdate {}
 unsafe impl ::core::marker::Sync for DeviceInformationUpdate {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -2086,36 +1791,7 @@ unsafe impl ::windows::core::Interface for DevicePairingRequestedEventArgs {
 impl ::windows::core::RuntimeName for DevicePairingRequestedEventArgs {
     const NAME: &'static str = "Windows.Devices.Enumeration.DevicePairingRequestedEventArgs";
 }
-impl ::core::convert::From<DevicePairingRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DevicePairingRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePairingRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DevicePairingRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePairingRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DevicePairingRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DevicePairingRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DevicePairingRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePairingRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DevicePairingRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePairingRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DevicePairingRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DevicePairingRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DevicePairingRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for DevicePairingRequestedEventArgs {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -2169,36 +1845,7 @@ unsafe impl ::windows::core::Interface for DevicePairingResult {
 impl ::windows::core::RuntimeName for DevicePairingResult {
     const NAME: &'static str = "Windows.Devices.Enumeration.DevicePairingResult";
 }
-impl ::core::convert::From<DevicePairingResult> for ::windows::core::IUnknown {
-    fn from(value: DevicePairingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePairingResult> for ::windows::core::IUnknown {
-    fn from(value: &DevicePairingResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePairingResult> for &::windows::core::IUnknown {
-    fn from(value: &DevicePairingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DevicePairingResult> for ::windows::core::IInspectable {
-    fn from(value: DevicePairingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePairingResult> for ::windows::core::IInspectable {
-    fn from(value: &DevicePairingResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePairingResult> for &::windows::core::IInspectable {
-    fn from(value: &DevicePairingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DevicePairingResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DevicePairingResult {}
 unsafe impl ::core::marker::Sync for DevicePairingResult {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -2351,36 +1998,7 @@ unsafe impl ::windows::core::Interface for DevicePicker {
 impl ::windows::core::RuntimeName for DevicePicker {
     const NAME: &'static str = "Windows.Devices.Enumeration.DevicePicker";
 }
-impl ::core::convert::From<DevicePicker> for ::windows::core::IUnknown {
-    fn from(value: DevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePicker> for ::windows::core::IUnknown {
-    fn from(value: &DevicePicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePicker> for &::windows::core::IUnknown {
-    fn from(value: &DevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DevicePicker> for ::windows::core::IInspectable {
-    fn from(value: DevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePicker> for ::windows::core::IInspectable {
-    fn from(value: &DevicePicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePicker> for &::windows::core::IInspectable {
-    fn from(value: &DevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DevicePicker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DevicePicker {}
 unsafe impl ::core::marker::Sync for DevicePicker {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -2521,36 +2139,7 @@ unsafe impl ::windows::core::Interface for DevicePickerAppearance {
 impl ::windows::core::RuntimeName for DevicePickerAppearance {
     const NAME: &'static str = "Windows.Devices.Enumeration.DevicePickerAppearance";
 }
-impl ::core::convert::From<DevicePickerAppearance> for ::windows::core::IUnknown {
-    fn from(value: DevicePickerAppearance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePickerAppearance> for ::windows::core::IUnknown {
-    fn from(value: &DevicePickerAppearance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePickerAppearance> for &::windows::core::IUnknown {
-    fn from(value: &DevicePickerAppearance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DevicePickerAppearance> for ::windows::core::IInspectable {
-    fn from(value: DevicePickerAppearance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePickerAppearance> for ::windows::core::IInspectable {
-    fn from(value: &DevicePickerAppearance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePickerAppearance> for &::windows::core::IInspectable {
-    fn from(value: &DevicePickerAppearance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DevicePickerAppearance, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DevicePickerAppearance {}
 unsafe impl ::core::marker::Sync for DevicePickerAppearance {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -2608,36 +2197,7 @@ unsafe impl ::windows::core::Interface for DevicePickerFilter {
 impl ::windows::core::RuntimeName for DevicePickerFilter {
     const NAME: &'static str = "Windows.Devices.Enumeration.DevicePickerFilter";
 }
-impl ::core::convert::From<DevicePickerFilter> for ::windows::core::IUnknown {
-    fn from(value: DevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePickerFilter> for ::windows::core::IUnknown {
-    fn from(value: &DevicePickerFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePickerFilter> for &::windows::core::IUnknown {
-    fn from(value: &DevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DevicePickerFilter> for ::windows::core::IInspectable {
-    fn from(value: DevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePickerFilter> for ::windows::core::IInspectable {
-    fn from(value: &DevicePickerFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePickerFilter> for &::windows::core::IInspectable {
-    fn from(value: &DevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DevicePickerFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DevicePickerFilter {}
 unsafe impl ::core::marker::Sync for DevicePickerFilter {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -2684,36 +2244,7 @@ unsafe impl ::windows::core::Interface for DeviceSelectedEventArgs {
 impl ::windows::core::RuntimeName for DeviceSelectedEventArgs {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceSelectedEventArgs";
 }
-impl ::core::convert::From<DeviceSelectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceSelectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DeviceSelectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceSelectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceSelectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceSelectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DeviceSelectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceSelectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceSelectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceSelectedEventArgs {}
 unsafe impl ::core::marker::Sync for DeviceSelectedEventArgs {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`, `\"Storage_Streams\"`*"]
@@ -2889,41 +2420,7 @@ impl ::windows::core::RuntimeName for DeviceThumbnail {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceThumbnail";
 }
 #[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<DeviceThumbnail> for ::windows::core::IUnknown {
-    fn from(value: DeviceThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&DeviceThumbnail> for ::windows::core::IUnknown {
-    fn from(value: &DeviceThumbnail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&DeviceThumbnail> for &::windows::core::IUnknown {
-    fn from(value: &DeviceThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<DeviceThumbnail> for ::windows::core::IInspectable {
-    fn from(value: DeviceThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&DeviceThumbnail> for ::windows::core::IInspectable {
-    fn from(value: &DeviceThumbnail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&DeviceThumbnail> for &::windows::core::IInspectable {
-    fn from(value: &DeviceThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceThumbnail, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 impl ::core::convert::TryFrom<DeviceThumbnail> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3104,36 +2601,7 @@ unsafe impl ::windows::core::Interface for DeviceUnpairingResult {
 impl ::windows::core::RuntimeName for DeviceUnpairingResult {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceUnpairingResult";
 }
-impl ::core::convert::From<DeviceUnpairingResult> for ::windows::core::IUnknown {
-    fn from(value: DeviceUnpairingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceUnpairingResult> for ::windows::core::IUnknown {
-    fn from(value: &DeviceUnpairingResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceUnpairingResult> for &::windows::core::IUnknown {
-    fn from(value: &DeviceUnpairingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceUnpairingResult> for ::windows::core::IInspectable {
-    fn from(value: DeviceUnpairingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceUnpairingResult> for ::windows::core::IInspectable {
-    fn from(value: &DeviceUnpairingResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceUnpairingResult> for &::windows::core::IInspectable {
-    fn from(value: &DeviceUnpairingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceUnpairingResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceUnpairingResult {}
 unsafe impl ::core::marker::Sync for DeviceUnpairingResult {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -3276,36 +2744,7 @@ unsafe impl ::windows::core::Interface for DeviceWatcher {
 impl ::windows::core::RuntimeName for DeviceWatcher {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceWatcher";
 }
-impl ::core::convert::From<DeviceWatcher> for ::windows::core::IUnknown {
-    fn from(value: DeviceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceWatcher> for ::windows::core::IUnknown {
-    fn from(value: &DeviceWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceWatcher> for &::windows::core::IUnknown {
-    fn from(value: &DeviceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceWatcher> for ::windows::core::IInspectable {
-    fn from(value: DeviceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceWatcher> for ::windows::core::IInspectable {
-    fn from(value: &DeviceWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceWatcher> for &::windows::core::IInspectable {
-    fn from(value: &DeviceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceWatcher {}
 unsafe impl ::core::marker::Sync for DeviceWatcher {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -3366,36 +2805,7 @@ unsafe impl ::windows::core::Interface for DeviceWatcherEvent {
 impl ::windows::core::RuntimeName for DeviceWatcherEvent {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceWatcherEvent";
 }
-impl ::core::convert::From<DeviceWatcherEvent> for ::windows::core::IUnknown {
-    fn from(value: DeviceWatcherEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceWatcherEvent> for ::windows::core::IUnknown {
-    fn from(value: &DeviceWatcherEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceWatcherEvent> for &::windows::core::IUnknown {
-    fn from(value: &DeviceWatcherEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceWatcherEvent> for ::windows::core::IInspectable {
-    fn from(value: DeviceWatcherEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceWatcherEvent> for ::windows::core::IInspectable {
-    fn from(value: &DeviceWatcherEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceWatcherEvent> for &::windows::core::IInspectable {
-    fn from(value: &DeviceWatcherEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceWatcherEvent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceWatcherEvent {}
 unsafe impl ::core::marker::Sync for DeviceWatcherEvent {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -3444,36 +2854,7 @@ unsafe impl ::windows::core::Interface for DeviceWatcherTriggerDetails {
 impl ::windows::core::RuntimeName for DeviceWatcherTriggerDetails {
     const NAME: &'static str = "Windows.Devices.Enumeration.DeviceWatcherTriggerDetails";
 }
-impl ::core::convert::From<DeviceWatcherTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: DeviceWatcherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceWatcherTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &DeviceWatcherTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceWatcherTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &DeviceWatcherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceWatcherTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: DeviceWatcherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceWatcherTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &DeviceWatcherTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceWatcherTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &DeviceWatcherTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceWatcherTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceWatcherTriggerDetails {}
 unsafe impl ::core::marker::Sync for DeviceWatcherTriggerDetails {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]
@@ -3541,36 +2922,7 @@ unsafe impl ::windows::core::Interface for EnclosureLocation {
 impl ::windows::core::RuntimeName for EnclosureLocation {
     const NAME: &'static str = "Windows.Devices.Enumeration.EnclosureLocation";
 }
-impl ::core::convert::From<EnclosureLocation> for ::windows::core::IUnknown {
-    fn from(value: EnclosureLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnclosureLocation> for ::windows::core::IUnknown {
-    fn from(value: &EnclosureLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnclosureLocation> for &::windows::core::IUnknown {
-    fn from(value: &EnclosureLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EnclosureLocation> for ::windows::core::IInspectable {
-    fn from(value: EnclosureLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnclosureLocation> for ::windows::core::IInspectable {
-    fn from(value: &EnclosureLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnclosureLocation> for &::windows::core::IInspectable {
-    fn from(value: &EnclosureLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EnclosureLocation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EnclosureLocation {}
 unsafe impl ::core::marker::Sync for EnclosureLocation {}
 #[doc = "*Required features: `\"Devices_Enumeration\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
@@ -266,36 +266,7 @@ unsafe impl ::windows::core::Interface for Geofence {
 impl ::windows::core::RuntimeName for Geofence {
     const NAME: &'static str = "Windows.Devices.Geolocation.Geofencing.Geofence";
 }
-impl ::core::convert::From<Geofence> for ::windows::core::IUnknown {
-    fn from(value: Geofence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geofence> for ::windows::core::IUnknown {
-    fn from(value: &Geofence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geofence> for &::windows::core::IUnknown {
-    fn from(value: &Geofence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Geofence> for ::windows::core::IInspectable {
-    fn from(value: Geofence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geofence> for ::windows::core::IInspectable {
-    fn from(value: &Geofence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geofence> for &::windows::core::IInspectable {
-    fn from(value: &Geofence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Geofence, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Geofence {}
 unsafe impl ::core::marker::Sync for Geofence {}
 #[doc = "*Required features: `\"Devices_Geolocation_Geofencing\"`*"]
@@ -408,36 +379,7 @@ unsafe impl ::windows::core::Interface for GeofenceMonitor {
 impl ::windows::core::RuntimeName for GeofenceMonitor {
     const NAME: &'static str = "Windows.Devices.Geolocation.Geofencing.GeofenceMonitor";
 }
-impl ::core::convert::From<GeofenceMonitor> for ::windows::core::IUnknown {
-    fn from(value: GeofenceMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeofenceMonitor> for ::windows::core::IUnknown {
-    fn from(value: &GeofenceMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeofenceMonitor> for &::windows::core::IUnknown {
-    fn from(value: &GeofenceMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GeofenceMonitor> for ::windows::core::IInspectable {
-    fn from(value: GeofenceMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeofenceMonitor> for ::windows::core::IInspectable {
-    fn from(value: &GeofenceMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeofenceMonitor> for &::windows::core::IInspectable {
-    fn from(value: &GeofenceMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GeofenceMonitor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GeofenceMonitor {}
 unsafe impl ::core::marker::Sync for GeofenceMonitor {}
 #[doc = "*Required features: `\"Devices_Geolocation_Geofencing\"`*"]
@@ -505,36 +447,7 @@ unsafe impl ::windows::core::Interface for GeofenceStateChangeReport {
 impl ::windows::core::RuntimeName for GeofenceStateChangeReport {
     const NAME: &'static str = "Windows.Devices.Geolocation.Geofencing.GeofenceStateChangeReport";
 }
-impl ::core::convert::From<GeofenceStateChangeReport> for ::windows::core::IUnknown {
-    fn from(value: GeofenceStateChangeReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeofenceStateChangeReport> for ::windows::core::IUnknown {
-    fn from(value: &GeofenceStateChangeReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeofenceStateChangeReport> for &::windows::core::IUnknown {
-    fn from(value: &GeofenceStateChangeReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GeofenceStateChangeReport> for ::windows::core::IInspectable {
-    fn from(value: GeofenceStateChangeReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeofenceStateChangeReport> for ::windows::core::IInspectable {
-    fn from(value: &GeofenceStateChangeReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeofenceStateChangeReport> for &::windows::core::IInspectable {
-    fn from(value: &GeofenceStateChangeReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GeofenceStateChangeReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GeofenceStateChangeReport {}
 unsafe impl ::core::marker::Sync for GeofenceStateChangeReport {}
 #[doc = "*Required features: `\"Devices_Geolocation_Geofencing\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/mod.rs
@@ -536,36 +536,7 @@ impl IGeoshape {
         }
     }
 }
-impl ::core::convert::From<IGeoshape> for ::windows::core::IUnknown {
-    fn from(value: IGeoshape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGeoshape> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGeoshape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGeoshape> for ::windows::core::IUnknown {
-    fn from(value: &IGeoshape) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGeoshape> for ::windows::core::IInspectable {
-    fn from(value: IGeoshape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGeoshape> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGeoshape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGeoshape> for ::windows::core::IInspectable {
-    fn from(value: &IGeoshape) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGeoshape, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGeoshape {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -819,36 +790,7 @@ unsafe impl ::windows::core::Interface for CivicAddress {
 impl ::windows::core::RuntimeName for CivicAddress {
     const NAME: &'static str = "Windows.Devices.Geolocation.CivicAddress";
 }
-impl ::core::convert::From<CivicAddress> for ::windows::core::IUnknown {
-    fn from(value: CivicAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CivicAddress> for ::windows::core::IUnknown {
-    fn from(value: &CivicAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CivicAddress> for &::windows::core::IUnknown {
-    fn from(value: &CivicAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CivicAddress> for ::windows::core::IInspectable {
-    fn from(value: CivicAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CivicAddress> for ::windows::core::IInspectable {
-    fn from(value: &CivicAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CivicAddress> for &::windows::core::IInspectable {
-    fn from(value: &CivicAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CivicAddress, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CivicAddress {}
 unsafe impl ::core::marker::Sync for CivicAddress {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]
@@ -1008,36 +950,7 @@ unsafe impl ::windows::core::Interface for GeoboundingBox {
 impl ::windows::core::RuntimeName for GeoboundingBox {
     const NAME: &'static str = "Windows.Devices.Geolocation.GeoboundingBox";
 }
-impl ::core::convert::From<GeoboundingBox> for ::windows::core::IUnknown {
-    fn from(value: GeoboundingBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeoboundingBox> for ::windows::core::IUnknown {
-    fn from(value: &GeoboundingBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeoboundingBox> for &::windows::core::IUnknown {
-    fn from(value: &GeoboundingBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GeoboundingBox> for ::windows::core::IInspectable {
-    fn from(value: GeoboundingBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeoboundingBox> for ::windows::core::IInspectable {
-    fn from(value: &GeoboundingBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeoboundingBox> for &::windows::core::IInspectable {
-    fn from(value: &GeoboundingBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GeoboundingBox, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<GeoboundingBox> for IGeoshape {
     type Error = ::windows::core::Error;
     fn try_from(value: GeoboundingBox) -> ::windows::core::Result<Self> {
@@ -1154,36 +1067,7 @@ unsafe impl ::windows::core::Interface for Geocircle {
 impl ::windows::core::RuntimeName for Geocircle {
     const NAME: &'static str = "Windows.Devices.Geolocation.Geocircle";
 }
-impl ::core::convert::From<Geocircle> for ::windows::core::IUnknown {
-    fn from(value: Geocircle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geocircle> for ::windows::core::IUnknown {
-    fn from(value: &Geocircle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geocircle> for &::windows::core::IUnknown {
-    fn from(value: &Geocircle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Geocircle> for ::windows::core::IInspectable {
-    fn from(value: Geocircle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geocircle> for ::windows::core::IInspectable {
-    fn from(value: &Geocircle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geocircle> for &::windows::core::IInspectable {
-    fn from(value: &Geocircle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Geocircle, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Geocircle> for IGeoshape {
     type Error = ::windows::core::Error;
     fn try_from(value: Geocircle) -> ::windows::core::Result<Self> {
@@ -1349,36 +1233,7 @@ unsafe impl ::windows::core::Interface for Geocoordinate {
 impl ::windows::core::RuntimeName for Geocoordinate {
     const NAME: &'static str = "Windows.Devices.Geolocation.Geocoordinate";
 }
-impl ::core::convert::From<Geocoordinate> for ::windows::core::IUnknown {
-    fn from(value: Geocoordinate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geocoordinate> for ::windows::core::IUnknown {
-    fn from(value: &Geocoordinate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geocoordinate> for &::windows::core::IUnknown {
-    fn from(value: &Geocoordinate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Geocoordinate> for ::windows::core::IInspectable {
-    fn from(value: Geocoordinate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geocoordinate> for ::windows::core::IInspectable {
-    fn from(value: &Geocoordinate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geocoordinate> for &::windows::core::IInspectable {
-    fn from(value: &Geocoordinate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Geocoordinate, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Geocoordinate {}
 unsafe impl ::core::marker::Sync for Geocoordinate {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]
@@ -1463,36 +1318,7 @@ unsafe impl ::windows::core::Interface for GeocoordinateSatelliteData {
 impl ::windows::core::RuntimeName for GeocoordinateSatelliteData {
     const NAME: &'static str = "Windows.Devices.Geolocation.GeocoordinateSatelliteData";
 }
-impl ::core::convert::From<GeocoordinateSatelliteData> for ::windows::core::IUnknown {
-    fn from(value: GeocoordinateSatelliteData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeocoordinateSatelliteData> for ::windows::core::IUnknown {
-    fn from(value: &GeocoordinateSatelliteData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeocoordinateSatelliteData> for &::windows::core::IUnknown {
-    fn from(value: &GeocoordinateSatelliteData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GeocoordinateSatelliteData> for ::windows::core::IInspectable {
-    fn from(value: GeocoordinateSatelliteData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeocoordinateSatelliteData> for ::windows::core::IInspectable {
-    fn from(value: &GeocoordinateSatelliteData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeocoordinateSatelliteData> for &::windows::core::IInspectable {
-    fn from(value: &GeocoordinateSatelliteData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GeocoordinateSatelliteData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GeocoordinateSatelliteData {}
 unsafe impl ::core::marker::Sync for GeocoordinateSatelliteData {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]
@@ -1707,36 +1533,7 @@ unsafe impl ::windows::core::Interface for Geolocator {
 impl ::windows::core::RuntimeName for Geolocator {
     const NAME: &'static str = "Windows.Devices.Geolocation.Geolocator";
 }
-impl ::core::convert::From<Geolocator> for ::windows::core::IUnknown {
-    fn from(value: Geolocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geolocator> for ::windows::core::IUnknown {
-    fn from(value: &Geolocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geolocator> for &::windows::core::IUnknown {
-    fn from(value: &Geolocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Geolocator> for ::windows::core::IInspectable {
-    fn from(value: Geolocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geolocator> for ::windows::core::IInspectable {
-    fn from(value: &Geolocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geolocator> for &::windows::core::IInspectable {
-    fn from(value: &Geolocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Geolocator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Geolocator {}
 unsafe impl ::core::marker::Sync for Geolocator {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]
@@ -1847,36 +1644,7 @@ unsafe impl ::windows::core::Interface for Geopath {
 impl ::windows::core::RuntimeName for Geopath {
     const NAME: &'static str = "Windows.Devices.Geolocation.Geopath";
 }
-impl ::core::convert::From<Geopath> for ::windows::core::IUnknown {
-    fn from(value: Geopath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geopath> for ::windows::core::IUnknown {
-    fn from(value: &Geopath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geopath> for &::windows::core::IUnknown {
-    fn from(value: &Geopath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Geopath> for ::windows::core::IInspectable {
-    fn from(value: Geopath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geopath> for ::windows::core::IInspectable {
-    fn from(value: &Geopath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geopath> for &::windows::core::IInspectable {
-    fn from(value: &Geopath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Geopath, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Geopath> for IGeoshape {
     type Error = ::windows::core::Error;
     fn try_from(value: Geopath) -> ::windows::core::Result<Self> {
@@ -1986,36 +1754,7 @@ unsafe impl ::windows::core::Interface for Geopoint {
 impl ::windows::core::RuntimeName for Geopoint {
     const NAME: &'static str = "Windows.Devices.Geolocation.Geopoint";
 }
-impl ::core::convert::From<Geopoint> for ::windows::core::IUnknown {
-    fn from(value: Geopoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geopoint> for ::windows::core::IUnknown {
-    fn from(value: &Geopoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geopoint> for &::windows::core::IUnknown {
-    fn from(value: &Geopoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Geopoint> for ::windows::core::IInspectable {
-    fn from(value: Geopoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geopoint> for ::windows::core::IInspectable {
-    fn from(value: &Geopoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geopoint> for &::windows::core::IInspectable {
-    fn from(value: &Geopoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Geopoint, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Geopoint> for IGeoshape {
     type Error = ::windows::core::Error;
     fn try_from(value: Geopoint) -> ::windows::core::Result<Self> {
@@ -2095,36 +1834,7 @@ unsafe impl ::windows::core::Interface for Geoposition {
 impl ::windows::core::RuntimeName for Geoposition {
     const NAME: &'static str = "Windows.Devices.Geolocation.Geoposition";
 }
-impl ::core::convert::From<Geoposition> for ::windows::core::IUnknown {
-    fn from(value: Geoposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geoposition> for ::windows::core::IUnknown {
-    fn from(value: &Geoposition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geoposition> for &::windows::core::IUnknown {
-    fn from(value: &Geoposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Geoposition> for ::windows::core::IInspectable {
-    fn from(value: Geoposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geoposition> for ::windows::core::IInspectable {
-    fn from(value: &Geoposition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geoposition> for &::windows::core::IInspectable {
-    fn from(value: &Geoposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Geoposition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Geoposition {}
 unsafe impl ::core::marker::Sync for Geoposition {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]
@@ -2187,36 +1897,7 @@ unsafe impl ::windows::core::Interface for Geovisit {
 impl ::windows::core::RuntimeName for Geovisit {
     const NAME: &'static str = "Windows.Devices.Geolocation.Geovisit";
 }
-impl ::core::convert::From<Geovisit> for ::windows::core::IUnknown {
-    fn from(value: Geovisit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geovisit> for ::windows::core::IUnknown {
-    fn from(value: &Geovisit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geovisit> for &::windows::core::IUnknown {
-    fn from(value: &Geovisit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Geovisit> for ::windows::core::IInspectable {
-    fn from(value: Geovisit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Geovisit> for ::windows::core::IInspectable {
-    fn from(value: &Geovisit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Geovisit> for &::windows::core::IInspectable {
-    fn from(value: &Geovisit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Geovisit, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Geovisit {}
 unsafe impl ::core::marker::Sync for Geovisit {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]
@@ -2306,36 +1987,7 @@ unsafe impl ::windows::core::Interface for GeovisitMonitor {
 impl ::windows::core::RuntimeName for GeovisitMonitor {
     const NAME: &'static str = "Windows.Devices.Geolocation.GeovisitMonitor";
 }
-impl ::core::convert::From<GeovisitMonitor> for ::windows::core::IUnknown {
-    fn from(value: GeovisitMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeovisitMonitor> for ::windows::core::IUnknown {
-    fn from(value: &GeovisitMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeovisitMonitor> for &::windows::core::IUnknown {
-    fn from(value: &GeovisitMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GeovisitMonitor> for ::windows::core::IInspectable {
-    fn from(value: GeovisitMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeovisitMonitor> for ::windows::core::IInspectable {
-    fn from(value: &GeovisitMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeovisitMonitor> for &::windows::core::IInspectable {
-    fn from(value: &GeovisitMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GeovisitMonitor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GeovisitMonitor {}
 unsafe impl ::core::marker::Sync for GeovisitMonitor {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]
@@ -2382,36 +2034,7 @@ unsafe impl ::windows::core::Interface for GeovisitStateChangedEventArgs {
 impl ::windows::core::RuntimeName for GeovisitStateChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Geolocation.GeovisitStateChangedEventArgs";
 }
-impl ::core::convert::From<GeovisitStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GeovisitStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeovisitStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GeovisitStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeovisitStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GeovisitStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GeovisitStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GeovisitStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeovisitStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GeovisitStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeovisitStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GeovisitStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GeovisitStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GeovisitStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for GeovisitStateChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]
@@ -2460,36 +2083,7 @@ unsafe impl ::windows::core::Interface for GeovisitTriggerDetails {
 impl ::windows::core::RuntimeName for GeovisitTriggerDetails {
     const NAME: &'static str = "Windows.Devices.Geolocation.GeovisitTriggerDetails";
 }
-impl ::core::convert::From<GeovisitTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: GeovisitTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeovisitTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &GeovisitTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeovisitTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &GeovisitTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GeovisitTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: GeovisitTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeovisitTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &GeovisitTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeovisitTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &GeovisitTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GeovisitTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GeovisitTriggerDetails {}
 unsafe impl ::core::marker::Sync for GeovisitTriggerDetails {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]
@@ -2536,36 +2130,7 @@ unsafe impl ::windows::core::Interface for PositionChangedEventArgs {
 impl ::windows::core::RuntimeName for PositionChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Geolocation.PositionChangedEventArgs";
 }
-impl ::core::convert::From<PositionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PositionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PositionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PositionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PositionChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PositionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PositionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PositionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PositionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PositionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PositionChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PositionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PositionChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PositionChangedEventArgs {}
 unsafe impl ::core::marker::Sync for PositionChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]
@@ -2612,36 +2177,7 @@ unsafe impl ::windows::core::Interface for StatusChangedEventArgs {
 impl ::windows::core::RuntimeName for StatusChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Geolocation.StatusChangedEventArgs";
 }
-impl ::core::convert::From<StatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: StatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &StatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StatusChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &StatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: StatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &StatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StatusChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &StatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StatusChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StatusChangedEventArgs {}
 unsafe impl ::core::marker::Sync for StatusChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]
@@ -2695,36 +2231,7 @@ unsafe impl ::windows::core::Interface for VenueData {
 impl ::windows::core::RuntimeName for VenueData {
     const NAME: &'static str = "Windows.Devices.Geolocation.VenueData";
 }
-impl ::core::convert::From<VenueData> for ::windows::core::IUnknown {
-    fn from(value: VenueData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VenueData> for ::windows::core::IUnknown {
-    fn from(value: &VenueData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VenueData> for &::windows::core::IUnknown {
-    fn from(value: &VenueData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VenueData> for ::windows::core::IInspectable {
-    fn from(value: VenueData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VenueData> for ::windows::core::IInspectable {
-    fn from(value: &VenueData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VenueData> for &::windows::core::IInspectable {
-    fn from(value: &VenueData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VenueData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VenueData {}
 unsafe impl ::core::marker::Sync for VenueData {}
 #[doc = "*Required features: `\"Devices_Geolocation\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Gpio/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Gpio/Provider/mod.rs
@@ -17,36 +17,7 @@ impl IGpioControllerProvider {
         }
     }
 }
-impl ::core::convert::From<IGpioControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: IGpioControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGpioControllerProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGpioControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGpioControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: &IGpioControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGpioControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: IGpioControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGpioControllerProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGpioControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGpioControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: &IGpioControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGpioControllerProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGpioControllerProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -161,36 +132,7 @@ impl IGpioPinProvider {
         }
     }
 }
-impl ::core::convert::From<IGpioPinProvider> for ::windows::core::IUnknown {
-    fn from(value: IGpioPinProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGpioPinProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGpioPinProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGpioPinProvider> for ::windows::core::IUnknown {
-    fn from(value: &IGpioPinProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGpioPinProvider> for ::windows::core::IInspectable {
-    fn from(value: IGpioPinProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGpioPinProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGpioPinProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGpioPinProvider> for ::windows::core::IInspectable {
-    fn from(value: &IGpioPinProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGpioPinProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGpioPinProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -292,36 +234,7 @@ impl IGpioProvider {
         }
     }
 }
-impl ::core::convert::From<IGpioProvider> for ::windows::core::IUnknown {
-    fn from(value: IGpioProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGpioProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGpioProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGpioProvider> for ::windows::core::IUnknown {
-    fn from(value: &IGpioProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGpioProvider> for ::windows::core::IInspectable {
-    fn from(value: IGpioProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGpioProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGpioProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGpioProvider> for ::windows::core::IInspectable {
-    fn from(value: &IGpioProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGpioProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGpioProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -415,36 +328,7 @@ unsafe impl ::windows::core::Interface for GpioPinProviderValueChangedEventArgs 
 impl ::windows::core::RuntimeName for GpioPinProviderValueChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Gpio.Provider.GpioPinProviderValueChangedEventArgs";
 }
-impl ::core::convert::From<GpioPinProviderValueChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GpioPinProviderValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioPinProviderValueChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GpioPinProviderValueChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioPinProviderValueChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GpioPinProviderValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GpioPinProviderValueChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GpioPinProviderValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioPinProviderValueChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GpioPinProviderValueChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioPinProviderValueChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GpioPinProviderValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GpioPinProviderValueChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GpioPinProviderValueChangedEventArgs {}
 unsafe impl ::core::marker::Sync for GpioPinProviderValueChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Gpio_Provider\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Gpio/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Gpio/mod.rs
@@ -303,36 +303,7 @@ unsafe impl ::windows::core::Interface for GpioChangeCounter {
 impl ::windows::core::RuntimeName for GpioChangeCounter {
     const NAME: &'static str = "Windows.Devices.Gpio.GpioChangeCounter";
 }
-impl ::core::convert::From<GpioChangeCounter> for ::windows::core::IUnknown {
-    fn from(value: GpioChangeCounter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioChangeCounter> for ::windows::core::IUnknown {
-    fn from(value: &GpioChangeCounter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioChangeCounter> for &::windows::core::IUnknown {
-    fn from(value: &GpioChangeCounter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GpioChangeCounter> for ::windows::core::IInspectable {
-    fn from(value: GpioChangeCounter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioChangeCounter> for ::windows::core::IInspectable {
-    fn from(value: &GpioChangeCounter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioChangeCounter> for &::windows::core::IInspectable {
-    fn from(value: &GpioChangeCounter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GpioChangeCounter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<GpioChangeCounter> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -511,36 +482,7 @@ unsafe impl ::windows::core::Interface for GpioChangeReader {
 impl ::windows::core::RuntimeName for GpioChangeReader {
     const NAME: &'static str = "Windows.Devices.Gpio.GpioChangeReader";
 }
-impl ::core::convert::From<GpioChangeReader> for ::windows::core::IUnknown {
-    fn from(value: GpioChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioChangeReader> for ::windows::core::IUnknown {
-    fn from(value: &GpioChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioChangeReader> for &::windows::core::IUnknown {
-    fn from(value: &GpioChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GpioChangeReader> for ::windows::core::IInspectable {
-    fn from(value: GpioChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioChangeReader> for ::windows::core::IInspectable {
-    fn from(value: &GpioChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioChangeReader> for &::windows::core::IInspectable {
-    fn from(value: &GpioChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GpioChangeReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<GpioChangeReader> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -666,36 +608,7 @@ unsafe impl ::windows::core::Interface for GpioController {
 impl ::windows::core::RuntimeName for GpioController {
     const NAME: &'static str = "Windows.Devices.Gpio.GpioController";
 }
-impl ::core::convert::From<GpioController> for ::windows::core::IUnknown {
-    fn from(value: GpioController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioController> for ::windows::core::IUnknown {
-    fn from(value: &GpioController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioController> for &::windows::core::IUnknown {
-    fn from(value: &GpioController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GpioController> for ::windows::core::IInspectable {
-    fn from(value: GpioController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioController> for ::windows::core::IInspectable {
-    fn from(value: &GpioController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioController> for &::windows::core::IInspectable {
-    fn from(value: &GpioController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GpioController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GpioController {}
 unsafe impl ::core::marker::Sync for GpioController {}
 #[doc = "*Required features: `\"Devices_Gpio\"`*"]
@@ -814,36 +727,7 @@ unsafe impl ::windows::core::Interface for GpioPin {
 impl ::windows::core::RuntimeName for GpioPin {
     const NAME: &'static str = "Windows.Devices.Gpio.GpioPin";
 }
-impl ::core::convert::From<GpioPin> for ::windows::core::IUnknown {
-    fn from(value: GpioPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioPin> for ::windows::core::IUnknown {
-    fn from(value: &GpioPin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioPin> for &::windows::core::IUnknown {
-    fn from(value: &GpioPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GpioPin> for ::windows::core::IInspectable {
-    fn from(value: GpioPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioPin> for ::windows::core::IInspectable {
-    fn from(value: &GpioPin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioPin> for &::windows::core::IInspectable {
-    fn from(value: &GpioPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GpioPin, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<GpioPin> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -912,36 +796,7 @@ unsafe impl ::windows::core::Interface for GpioPinValueChangedEventArgs {
 impl ::windows::core::RuntimeName for GpioPinValueChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Gpio.GpioPinValueChangedEventArgs";
 }
-impl ::core::convert::From<GpioPinValueChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GpioPinValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioPinValueChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GpioPinValueChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioPinValueChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GpioPinValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GpioPinValueChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GpioPinValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GpioPinValueChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GpioPinValueChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GpioPinValueChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GpioPinValueChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GpioPinValueChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GpioPinValueChangedEventArgs {}
 unsafe impl ::core::marker::Sync for GpioPinValueChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Gpio\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Haptics/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Haptics/mod.rs
@@ -353,36 +353,7 @@ unsafe impl ::windows::core::Interface for SimpleHapticsController {
 impl ::windows::core::RuntimeName for SimpleHapticsController {
     const NAME: &'static str = "Windows.Devices.Haptics.SimpleHapticsController";
 }
-impl ::core::convert::From<SimpleHapticsController> for ::windows::core::IUnknown {
-    fn from(value: SimpleHapticsController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SimpleHapticsController> for ::windows::core::IUnknown {
-    fn from(value: &SimpleHapticsController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SimpleHapticsController> for &::windows::core::IUnknown {
-    fn from(value: &SimpleHapticsController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SimpleHapticsController> for ::windows::core::IInspectable {
-    fn from(value: SimpleHapticsController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SimpleHapticsController> for ::windows::core::IInspectable {
-    fn from(value: &SimpleHapticsController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SimpleHapticsController> for &::windows::core::IInspectable {
-    fn from(value: &SimpleHapticsController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SimpleHapticsController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SimpleHapticsController {}
 unsafe impl ::core::marker::Sync for SimpleHapticsController {}
 #[doc = "*Required features: `\"Devices_Haptics\"`*"]
@@ -438,36 +409,7 @@ unsafe impl ::windows::core::Interface for SimpleHapticsControllerFeedback {
 impl ::windows::core::RuntimeName for SimpleHapticsControllerFeedback {
     const NAME: &'static str = "Windows.Devices.Haptics.SimpleHapticsControllerFeedback";
 }
-impl ::core::convert::From<SimpleHapticsControllerFeedback> for ::windows::core::IUnknown {
-    fn from(value: SimpleHapticsControllerFeedback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SimpleHapticsControllerFeedback> for ::windows::core::IUnknown {
-    fn from(value: &SimpleHapticsControllerFeedback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SimpleHapticsControllerFeedback> for &::windows::core::IUnknown {
-    fn from(value: &SimpleHapticsControllerFeedback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SimpleHapticsControllerFeedback> for ::windows::core::IInspectable {
-    fn from(value: SimpleHapticsControllerFeedback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SimpleHapticsControllerFeedback> for ::windows::core::IInspectable {
-    fn from(value: &SimpleHapticsControllerFeedback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SimpleHapticsControllerFeedback> for &::windows::core::IInspectable {
-    fn from(value: &SimpleHapticsControllerFeedback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SimpleHapticsControllerFeedback, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SimpleHapticsControllerFeedback {}
 unsafe impl ::core::marker::Sync for SimpleHapticsControllerFeedback {}
 #[doc = "*Required features: `\"Devices_Haptics\"`*"]
@@ -564,36 +506,7 @@ unsafe impl ::windows::core::Interface for VibrationDevice {
 impl ::windows::core::RuntimeName for VibrationDevice {
     const NAME: &'static str = "Windows.Devices.Haptics.VibrationDevice";
 }
-impl ::core::convert::From<VibrationDevice> for ::windows::core::IUnknown {
-    fn from(value: VibrationDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VibrationDevice> for ::windows::core::IUnknown {
-    fn from(value: &VibrationDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VibrationDevice> for &::windows::core::IUnknown {
-    fn from(value: &VibrationDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VibrationDevice> for ::windows::core::IInspectable {
-    fn from(value: VibrationDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VibrationDevice> for ::windows::core::IInspectable {
-    fn from(value: &VibrationDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VibrationDevice> for &::windows::core::IInspectable {
-    fn from(value: &VibrationDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VibrationDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VibrationDevice {}
 unsafe impl ::core::marker::Sync for VibrationDevice {}
 #[doc = "*Required features: `\"Devices_Haptics\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/HumanInterfaceDevice/mod.rs
@@ -389,36 +389,7 @@ unsafe impl ::windows::core::Interface for HidBooleanControl {
 impl ::windows::core::RuntimeName for HidBooleanControl {
     const NAME: &'static str = "Windows.Devices.HumanInterfaceDevice.HidBooleanControl";
 }
-impl ::core::convert::From<HidBooleanControl> for ::windows::core::IUnknown {
-    fn from(value: HidBooleanControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidBooleanControl> for ::windows::core::IUnknown {
-    fn from(value: &HidBooleanControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidBooleanControl> for &::windows::core::IUnknown {
-    fn from(value: &HidBooleanControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HidBooleanControl> for ::windows::core::IInspectable {
-    fn from(value: HidBooleanControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidBooleanControl> for ::windows::core::IInspectable {
-    fn from(value: &HidBooleanControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidBooleanControl> for &::windows::core::IInspectable {
-    fn from(value: &HidBooleanControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HidBooleanControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HidBooleanControl {}
 unsafe impl ::core::marker::Sync for HidBooleanControl {}
 #[doc = "*Required features: `\"Devices_HumanInterfaceDevice\"`*"]
@@ -509,36 +480,7 @@ unsafe impl ::windows::core::Interface for HidBooleanControlDescription {
 impl ::windows::core::RuntimeName for HidBooleanControlDescription {
     const NAME: &'static str = "Windows.Devices.HumanInterfaceDevice.HidBooleanControlDescription";
 }
-impl ::core::convert::From<HidBooleanControlDescription> for ::windows::core::IUnknown {
-    fn from(value: HidBooleanControlDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidBooleanControlDescription> for ::windows::core::IUnknown {
-    fn from(value: &HidBooleanControlDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidBooleanControlDescription> for &::windows::core::IUnknown {
-    fn from(value: &HidBooleanControlDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HidBooleanControlDescription> for ::windows::core::IInspectable {
-    fn from(value: HidBooleanControlDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidBooleanControlDescription> for ::windows::core::IInspectable {
-    fn from(value: &HidBooleanControlDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidBooleanControlDescription> for &::windows::core::IInspectable {
-    fn from(value: &HidBooleanControlDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HidBooleanControlDescription, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HidBooleanControlDescription {}
 unsafe impl ::core::marker::Sync for HidBooleanControlDescription {}
 #[doc = "*Required features: `\"Devices_HumanInterfaceDevice\"`*"]
@@ -606,36 +548,7 @@ unsafe impl ::windows::core::Interface for HidCollection {
 impl ::windows::core::RuntimeName for HidCollection {
     const NAME: &'static str = "Windows.Devices.HumanInterfaceDevice.HidCollection";
 }
-impl ::core::convert::From<HidCollection> for ::windows::core::IUnknown {
-    fn from(value: HidCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidCollection> for ::windows::core::IUnknown {
-    fn from(value: &HidCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidCollection> for &::windows::core::IUnknown {
-    fn from(value: &HidCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HidCollection> for ::windows::core::IInspectable {
-    fn from(value: HidCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidCollection> for ::windows::core::IInspectable {
-    fn from(value: &HidCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidCollection> for &::windows::core::IInspectable {
-    fn from(value: &HidCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HidCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HidCollection {}
 unsafe impl ::core::marker::Sync for HidCollection {}
 #[doc = "*Required features: `\"Devices_HumanInterfaceDevice\"`*"]
@@ -856,36 +769,7 @@ unsafe impl ::windows::core::Interface for HidDevice {
 impl ::windows::core::RuntimeName for HidDevice {
     const NAME: &'static str = "Windows.Devices.HumanInterfaceDevice.HidDevice";
 }
-impl ::core::convert::From<HidDevice> for ::windows::core::IUnknown {
-    fn from(value: HidDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidDevice> for ::windows::core::IUnknown {
-    fn from(value: &HidDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidDevice> for &::windows::core::IUnknown {
-    fn from(value: &HidDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HidDevice> for ::windows::core::IInspectable {
-    fn from(value: HidDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidDevice> for ::windows::core::IInspectable {
-    fn from(value: &HidDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidDevice> for &::windows::core::IInspectable {
-    fn from(value: &HidDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HidDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HidDevice> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1001,36 +885,7 @@ unsafe impl ::windows::core::Interface for HidFeatureReport {
 impl ::windows::core::RuntimeName for HidFeatureReport {
     const NAME: &'static str = "Windows.Devices.HumanInterfaceDevice.HidFeatureReport";
 }
-impl ::core::convert::From<HidFeatureReport> for ::windows::core::IUnknown {
-    fn from(value: HidFeatureReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidFeatureReport> for ::windows::core::IUnknown {
-    fn from(value: &HidFeatureReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidFeatureReport> for &::windows::core::IUnknown {
-    fn from(value: &HidFeatureReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HidFeatureReport> for ::windows::core::IInspectable {
-    fn from(value: HidFeatureReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidFeatureReport> for ::windows::core::IInspectable {
-    fn from(value: &HidFeatureReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidFeatureReport> for &::windows::core::IInspectable {
-    fn from(value: &HidFeatureReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HidFeatureReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HidFeatureReport {}
 unsafe impl ::core::marker::Sync for HidFeatureReport {}
 #[doc = "*Required features: `\"Devices_HumanInterfaceDevice\"`*"]
@@ -1132,36 +987,7 @@ unsafe impl ::windows::core::Interface for HidInputReport {
 impl ::windows::core::RuntimeName for HidInputReport {
     const NAME: &'static str = "Windows.Devices.HumanInterfaceDevice.HidInputReport";
 }
-impl ::core::convert::From<HidInputReport> for ::windows::core::IUnknown {
-    fn from(value: HidInputReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidInputReport> for ::windows::core::IUnknown {
-    fn from(value: &HidInputReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidInputReport> for &::windows::core::IUnknown {
-    fn from(value: &HidInputReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HidInputReport> for ::windows::core::IInspectable {
-    fn from(value: HidInputReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidInputReport> for ::windows::core::IInspectable {
-    fn from(value: &HidInputReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidInputReport> for &::windows::core::IInspectable {
-    fn from(value: &HidInputReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HidInputReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HidInputReport {}
 unsafe impl ::core::marker::Sync for HidInputReport {}
 #[doc = "*Required features: `\"Devices_HumanInterfaceDevice\"`*"]
@@ -1208,36 +1034,7 @@ unsafe impl ::windows::core::Interface for HidInputReportReceivedEventArgs {
 impl ::windows::core::RuntimeName for HidInputReportReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.HumanInterfaceDevice.HidInputReportReceivedEventArgs";
 }
-impl ::core::convert::From<HidInputReportReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: HidInputReportReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidInputReportReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &HidInputReportReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidInputReportReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &HidInputReportReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HidInputReportReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: HidInputReportReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidInputReportReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &HidInputReportReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidInputReportReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &HidInputReportReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HidInputReportReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HidInputReportReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for HidInputReportReceivedEventArgs {}
 #[doc = "*Required features: `\"Devices_HumanInterfaceDevice\"`*"]
@@ -1334,36 +1131,7 @@ unsafe impl ::windows::core::Interface for HidNumericControl {
 impl ::windows::core::RuntimeName for HidNumericControl {
     const NAME: &'static str = "Windows.Devices.HumanInterfaceDevice.HidNumericControl";
 }
-impl ::core::convert::From<HidNumericControl> for ::windows::core::IUnknown {
-    fn from(value: HidNumericControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidNumericControl> for ::windows::core::IUnknown {
-    fn from(value: &HidNumericControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidNumericControl> for &::windows::core::IUnknown {
-    fn from(value: &HidNumericControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HidNumericControl> for ::windows::core::IInspectable {
-    fn from(value: HidNumericControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidNumericControl> for ::windows::core::IInspectable {
-    fn from(value: &HidNumericControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidNumericControl> for &::windows::core::IInspectable {
-    fn from(value: &HidNumericControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HidNumericControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HidNumericControl {}
 unsafe impl ::core::marker::Sync for HidNumericControl {}
 #[doc = "*Required features: `\"Devices_HumanInterfaceDevice\"`*"]
@@ -1517,36 +1285,7 @@ unsafe impl ::windows::core::Interface for HidNumericControlDescription {
 impl ::windows::core::RuntimeName for HidNumericControlDescription {
     const NAME: &'static str = "Windows.Devices.HumanInterfaceDevice.HidNumericControlDescription";
 }
-impl ::core::convert::From<HidNumericControlDescription> for ::windows::core::IUnknown {
-    fn from(value: HidNumericControlDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidNumericControlDescription> for ::windows::core::IUnknown {
-    fn from(value: &HidNumericControlDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidNumericControlDescription> for &::windows::core::IUnknown {
-    fn from(value: &HidNumericControlDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HidNumericControlDescription> for ::windows::core::IInspectable {
-    fn from(value: HidNumericControlDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidNumericControlDescription> for ::windows::core::IInspectable {
-    fn from(value: &HidNumericControlDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidNumericControlDescription> for &::windows::core::IInspectable {
-    fn from(value: &HidNumericControlDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HidNumericControlDescription, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HidNumericControlDescription {}
 unsafe impl ::core::marker::Sync for HidNumericControlDescription {}
 #[doc = "*Required features: `\"Devices_HumanInterfaceDevice\"`*"]
@@ -1640,36 +1379,7 @@ unsafe impl ::windows::core::Interface for HidOutputReport {
 impl ::windows::core::RuntimeName for HidOutputReport {
     const NAME: &'static str = "Windows.Devices.HumanInterfaceDevice.HidOutputReport";
 }
-impl ::core::convert::From<HidOutputReport> for ::windows::core::IUnknown {
-    fn from(value: HidOutputReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidOutputReport> for ::windows::core::IUnknown {
-    fn from(value: &HidOutputReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidOutputReport> for &::windows::core::IUnknown {
-    fn from(value: &HidOutputReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HidOutputReport> for ::windows::core::IInspectable {
-    fn from(value: HidOutputReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidOutputReport> for ::windows::core::IInspectable {
-    fn from(value: &HidOutputReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidOutputReport> for &::windows::core::IInspectable {
-    fn from(value: &HidOutputReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HidOutputReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HidOutputReport {}
 unsafe impl ::core::marker::Sync for HidOutputReport {}
 #[doc = "*Required features: `\"Devices_HumanInterfaceDevice\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/I2c/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/Provider/mod.rs
@@ -10,36 +10,7 @@ impl II2cControllerProvider {
         }
     }
 }
-impl ::core::convert::From<II2cControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: II2cControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a II2cControllerProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a II2cControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&II2cControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: &II2cControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<II2cControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: II2cControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a II2cControllerProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a II2cControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&II2cControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: &II2cControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(II2cControllerProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for II2cControllerProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -126,36 +97,7 @@ impl II2cDeviceProvider {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<II2cDeviceProvider> for ::windows::core::IUnknown {
-    fn from(value: II2cDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a II2cDeviceProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a II2cDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&II2cDeviceProvider> for ::windows::core::IUnknown {
-    fn from(value: &II2cDeviceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<II2cDeviceProvider> for ::windows::core::IInspectable {
-    fn from(value: II2cDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a II2cDeviceProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a II2cDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&II2cDeviceProvider> for ::windows::core::IInspectable {
-    fn from(value: &II2cDeviceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(II2cDeviceProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<II2cDeviceProvider> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -233,36 +175,7 @@ impl II2cProvider {
         }
     }
 }
-impl ::core::convert::From<II2cProvider> for ::windows::core::IUnknown {
-    fn from(value: II2cProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a II2cProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a II2cProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&II2cProvider> for ::windows::core::IUnknown {
-    fn from(value: &II2cProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<II2cProvider> for ::windows::core::IInspectable {
-    fn from(value: II2cProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a II2cProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a II2cProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&II2cProvider> for ::windows::core::IInspectable {
-    fn from(value: &II2cProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(II2cProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for II2cProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -391,36 +304,7 @@ unsafe impl ::windows::core::Interface for ProviderI2cConnectionSettings {
 impl ::windows::core::RuntimeName for ProviderI2cConnectionSettings {
     const NAME: &'static str = "Windows.Devices.I2c.Provider.ProviderI2cConnectionSettings";
 }
-impl ::core::convert::From<ProviderI2cConnectionSettings> for ::windows::core::IUnknown {
-    fn from(value: ProviderI2cConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProviderI2cConnectionSettings> for ::windows::core::IUnknown {
-    fn from(value: &ProviderI2cConnectionSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProviderI2cConnectionSettings> for &::windows::core::IUnknown {
-    fn from(value: &ProviderI2cConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProviderI2cConnectionSettings> for ::windows::core::IInspectable {
-    fn from(value: ProviderI2cConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProviderI2cConnectionSettings> for ::windows::core::IInspectable {
-    fn from(value: &ProviderI2cConnectionSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProviderI2cConnectionSettings> for &::windows::core::IInspectable {
-    fn from(value: &ProviderI2cConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProviderI2cConnectionSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProviderI2cConnectionSettings {}
 unsafe impl ::core::marker::Sync for ProviderI2cConnectionSettings {}
 #[doc = "*Required features: `\"Devices_I2c_Provider\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/I2c/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/mod.rs
@@ -122,36 +122,7 @@ impl II2cDeviceStatics {
         }
     }
 }
-impl ::core::convert::From<II2cDeviceStatics> for ::windows::core::IUnknown {
-    fn from(value: II2cDeviceStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a II2cDeviceStatics> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a II2cDeviceStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&II2cDeviceStatics> for ::windows::core::IUnknown {
-    fn from(value: &II2cDeviceStatics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<II2cDeviceStatics> for ::windows::core::IInspectable {
-    fn from(value: II2cDeviceStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a II2cDeviceStatics> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a II2cDeviceStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&II2cDeviceStatics> for ::windows::core::IInspectable {
-    fn from(value: &II2cDeviceStatics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(II2cDeviceStatics, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for II2cDeviceStatics {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -273,36 +244,7 @@ unsafe impl ::windows::core::Interface for I2cConnectionSettings {
 impl ::windows::core::RuntimeName for I2cConnectionSettings {
     const NAME: &'static str = "Windows.Devices.I2c.I2cConnectionSettings";
 }
-impl ::core::convert::From<I2cConnectionSettings> for ::windows::core::IUnknown {
-    fn from(value: I2cConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&I2cConnectionSettings> for ::windows::core::IUnknown {
-    fn from(value: &I2cConnectionSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&I2cConnectionSettings> for &::windows::core::IUnknown {
-    fn from(value: &I2cConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<I2cConnectionSettings> for ::windows::core::IInspectable {
-    fn from(value: I2cConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&I2cConnectionSettings> for ::windows::core::IInspectable {
-    fn from(value: &I2cConnectionSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&I2cConnectionSettings> for &::windows::core::IInspectable {
-    fn from(value: &I2cConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(I2cConnectionSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for I2cConnectionSettings {}
 unsafe impl ::core::marker::Sync for I2cConnectionSettings {}
 #[doc = "*Required features: `\"Devices_I2c\"`*"]
@@ -374,36 +316,7 @@ unsafe impl ::windows::core::Interface for I2cController {
 impl ::windows::core::RuntimeName for I2cController {
     const NAME: &'static str = "Windows.Devices.I2c.I2cController";
 }
-impl ::core::convert::From<I2cController> for ::windows::core::IUnknown {
-    fn from(value: I2cController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&I2cController> for ::windows::core::IUnknown {
-    fn from(value: &I2cController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&I2cController> for &::windows::core::IUnknown {
-    fn from(value: &I2cController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<I2cController> for ::windows::core::IInspectable {
-    fn from(value: I2cController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&I2cController> for ::windows::core::IInspectable {
-    fn from(value: &I2cController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&I2cController> for &::windows::core::IInspectable {
-    fn from(value: &I2cController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(I2cController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for I2cController {}
 unsafe impl ::core::marker::Sync for I2cController {}
 #[doc = "*Required features: `\"Devices_I2c\"`*"]
@@ -521,36 +434,7 @@ unsafe impl ::windows::core::Interface for I2cDevice {
 impl ::windows::core::RuntimeName for I2cDevice {
     const NAME: &'static str = "Windows.Devices.I2c.I2cDevice";
 }
-impl ::core::convert::From<I2cDevice> for ::windows::core::IUnknown {
-    fn from(value: I2cDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&I2cDevice> for ::windows::core::IUnknown {
-    fn from(value: &I2cDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&I2cDevice> for &::windows::core::IUnknown {
-    fn from(value: &I2cDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<I2cDevice> for ::windows::core::IInspectable {
-    fn from(value: I2cDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&I2cDevice> for ::windows::core::IInspectable {
-    fn from(value: &I2cDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&I2cDevice> for &::windows::core::IInspectable {
-    fn from(value: &I2cDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(I2cDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<I2cDevice> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Devices/Input/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Input/Preview/mod.rs
@@ -350,36 +350,7 @@ unsafe impl ::windows::core::Interface for GazeDevicePreview {
 impl ::windows::core::RuntimeName for GazeDevicePreview {
     const NAME: &'static str = "Windows.Devices.Input.Preview.GazeDevicePreview";
 }
-impl ::core::convert::From<GazeDevicePreview> for ::windows::core::IUnknown {
-    fn from(value: GazeDevicePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeDevicePreview> for ::windows::core::IUnknown {
-    fn from(value: &GazeDevicePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeDevicePreview> for &::windows::core::IUnknown {
-    fn from(value: &GazeDevicePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GazeDevicePreview> for ::windows::core::IInspectable {
-    fn from(value: GazeDevicePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeDevicePreview> for ::windows::core::IInspectable {
-    fn from(value: &GazeDevicePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeDevicePreview> for &::windows::core::IInspectable {
-    fn from(value: &GazeDevicePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GazeDevicePreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GazeDevicePreview {}
 unsafe impl ::core::marker::Sync for GazeDevicePreview {}
 #[doc = "*Required features: `\"Devices_Input_Preview\"`*"]
@@ -426,36 +397,7 @@ unsafe impl ::windows::core::Interface for GazeDeviceWatcherAddedPreviewEventArg
 impl ::windows::core::RuntimeName for GazeDeviceWatcherAddedPreviewEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.Preview.GazeDeviceWatcherAddedPreviewEventArgs";
 }
-impl ::core::convert::From<GazeDeviceWatcherAddedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GazeDeviceWatcherAddedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherAddedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GazeDeviceWatcherAddedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherAddedPreviewEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GazeDeviceWatcherAddedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GazeDeviceWatcherAddedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GazeDeviceWatcherAddedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherAddedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GazeDeviceWatcherAddedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherAddedPreviewEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GazeDeviceWatcherAddedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GazeDeviceWatcherAddedPreviewEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GazeDeviceWatcherAddedPreviewEventArgs {}
 unsafe impl ::core::marker::Sync for GazeDeviceWatcherAddedPreviewEventArgs {}
 #[doc = "*Required features: `\"Devices_Input_Preview\"`*"]
@@ -563,36 +505,7 @@ unsafe impl ::windows::core::Interface for GazeDeviceWatcherPreview {
 impl ::windows::core::RuntimeName for GazeDeviceWatcherPreview {
     const NAME: &'static str = "Windows.Devices.Input.Preview.GazeDeviceWatcherPreview";
 }
-impl ::core::convert::From<GazeDeviceWatcherPreview> for ::windows::core::IUnknown {
-    fn from(value: GazeDeviceWatcherPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherPreview> for ::windows::core::IUnknown {
-    fn from(value: &GazeDeviceWatcherPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherPreview> for &::windows::core::IUnknown {
-    fn from(value: &GazeDeviceWatcherPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GazeDeviceWatcherPreview> for ::windows::core::IInspectable {
-    fn from(value: GazeDeviceWatcherPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherPreview> for ::windows::core::IInspectable {
-    fn from(value: &GazeDeviceWatcherPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherPreview> for &::windows::core::IInspectable {
-    fn from(value: &GazeDeviceWatcherPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GazeDeviceWatcherPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GazeDeviceWatcherPreview {}
 unsafe impl ::core::marker::Sync for GazeDeviceWatcherPreview {}
 #[doc = "*Required features: `\"Devices_Input_Preview\"`*"]
@@ -639,36 +552,7 @@ unsafe impl ::windows::core::Interface for GazeDeviceWatcherRemovedPreviewEventA
 impl ::windows::core::RuntimeName for GazeDeviceWatcherRemovedPreviewEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.Preview.GazeDeviceWatcherRemovedPreviewEventArgs";
 }
-impl ::core::convert::From<GazeDeviceWatcherRemovedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GazeDeviceWatcherRemovedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherRemovedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GazeDeviceWatcherRemovedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherRemovedPreviewEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GazeDeviceWatcherRemovedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GazeDeviceWatcherRemovedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GazeDeviceWatcherRemovedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherRemovedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GazeDeviceWatcherRemovedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherRemovedPreviewEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GazeDeviceWatcherRemovedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GazeDeviceWatcherRemovedPreviewEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GazeDeviceWatcherRemovedPreviewEventArgs {}
 unsafe impl ::core::marker::Sync for GazeDeviceWatcherRemovedPreviewEventArgs {}
 #[doc = "*Required features: `\"Devices_Input_Preview\"`*"]
@@ -715,36 +599,7 @@ unsafe impl ::windows::core::Interface for GazeDeviceWatcherUpdatedPreviewEventA
 impl ::windows::core::RuntimeName for GazeDeviceWatcherUpdatedPreviewEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.Preview.GazeDeviceWatcherUpdatedPreviewEventArgs";
 }
-impl ::core::convert::From<GazeDeviceWatcherUpdatedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GazeDeviceWatcherUpdatedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherUpdatedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GazeDeviceWatcherUpdatedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherUpdatedPreviewEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GazeDeviceWatcherUpdatedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GazeDeviceWatcherUpdatedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GazeDeviceWatcherUpdatedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherUpdatedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GazeDeviceWatcherUpdatedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeDeviceWatcherUpdatedPreviewEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GazeDeviceWatcherUpdatedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GazeDeviceWatcherUpdatedPreviewEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GazeDeviceWatcherUpdatedPreviewEventArgs {}
 unsafe impl ::core::marker::Sync for GazeDeviceWatcherUpdatedPreviewEventArgs {}
 #[doc = "*Required features: `\"Devices_Input_Preview\"`*"]
@@ -802,36 +657,7 @@ unsafe impl ::windows::core::Interface for GazeEnteredPreviewEventArgs {
 impl ::windows::core::RuntimeName for GazeEnteredPreviewEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.Preview.GazeEnteredPreviewEventArgs";
 }
-impl ::core::convert::From<GazeEnteredPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GazeEnteredPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeEnteredPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GazeEnteredPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeEnteredPreviewEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GazeEnteredPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GazeEnteredPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GazeEnteredPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeEnteredPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GazeEnteredPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeEnteredPreviewEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GazeEnteredPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GazeEnteredPreviewEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GazeEnteredPreviewEventArgs {}
 unsafe impl ::core::marker::Sync for GazeEnteredPreviewEventArgs {}
 #[doc = "*Required features: `\"Devices_Input_Preview\"`*"]
@@ -889,36 +715,7 @@ unsafe impl ::windows::core::Interface for GazeExitedPreviewEventArgs {
 impl ::windows::core::RuntimeName for GazeExitedPreviewEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.Preview.GazeExitedPreviewEventArgs";
 }
-impl ::core::convert::From<GazeExitedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GazeExitedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeExitedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GazeExitedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeExitedPreviewEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GazeExitedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GazeExitedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GazeExitedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeExitedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GazeExitedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeExitedPreviewEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GazeExitedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GazeExitedPreviewEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GazeExitedPreviewEventArgs {}
 unsafe impl ::core::marker::Sync for GazeExitedPreviewEventArgs {}
 #[doc = "*Required features: `\"Devices_Input_Preview\"`*"]
@@ -1020,36 +817,7 @@ unsafe impl ::windows::core::Interface for GazeInputSourcePreview {
 impl ::windows::core::RuntimeName for GazeInputSourcePreview {
     const NAME: &'static str = "Windows.Devices.Input.Preview.GazeInputSourcePreview";
 }
-impl ::core::convert::From<GazeInputSourcePreview> for ::windows::core::IUnknown {
-    fn from(value: GazeInputSourcePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeInputSourcePreview> for ::windows::core::IUnknown {
-    fn from(value: &GazeInputSourcePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeInputSourcePreview> for &::windows::core::IUnknown {
-    fn from(value: &GazeInputSourcePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GazeInputSourcePreview> for ::windows::core::IInspectable {
-    fn from(value: GazeInputSourcePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeInputSourcePreview> for ::windows::core::IInspectable {
-    fn from(value: &GazeInputSourcePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeInputSourcePreview> for &::windows::core::IInspectable {
-    fn from(value: &GazeInputSourcePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GazeInputSourcePreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GazeInputSourcePreview {}
 unsafe impl ::core::marker::Sync for GazeInputSourcePreview {}
 #[doc = "*Required features: `\"Devices_Input_Preview\"`*"]
@@ -1116,36 +884,7 @@ unsafe impl ::windows::core::Interface for GazeMovedPreviewEventArgs {
 impl ::windows::core::RuntimeName for GazeMovedPreviewEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.Preview.GazeMovedPreviewEventArgs";
 }
-impl ::core::convert::From<GazeMovedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GazeMovedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeMovedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GazeMovedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeMovedPreviewEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GazeMovedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GazeMovedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GazeMovedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazeMovedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GazeMovedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazeMovedPreviewEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GazeMovedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GazeMovedPreviewEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GazeMovedPreviewEventArgs {}
 unsafe impl ::core::marker::Sync for GazeMovedPreviewEventArgs {}
 #[doc = "*Required features: `\"Devices_Input_Preview\"`*"]
@@ -1226,36 +965,7 @@ unsafe impl ::windows::core::Interface for GazePointPreview {
 impl ::windows::core::RuntimeName for GazePointPreview {
     const NAME: &'static str = "Windows.Devices.Input.Preview.GazePointPreview";
 }
-impl ::core::convert::From<GazePointPreview> for ::windows::core::IUnknown {
-    fn from(value: GazePointPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazePointPreview> for ::windows::core::IUnknown {
-    fn from(value: &GazePointPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazePointPreview> for &::windows::core::IUnknown {
-    fn from(value: &GazePointPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GazePointPreview> for ::windows::core::IInspectable {
-    fn from(value: GazePointPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GazePointPreview> for ::windows::core::IInspectable {
-    fn from(value: &GazePointPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GazePointPreview> for &::windows::core::IInspectable {
-    fn from(value: &GazePointPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GazePointPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GazePointPreview {}
 unsafe impl ::core::marker::Sync for GazePointPreview {}
 #[doc = "*Required features: `\"Devices_Input_Preview\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Input/mod.rs
@@ -450,36 +450,7 @@ unsafe impl ::windows::core::Interface for KeyboardCapabilities {
 impl ::windows::core::RuntimeName for KeyboardCapabilities {
     const NAME: &'static str = "Windows.Devices.Input.KeyboardCapabilities";
 }
-impl ::core::convert::From<KeyboardCapabilities> for ::windows::core::IUnknown {
-    fn from(value: KeyboardCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyboardCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &KeyboardCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyboardCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &KeyboardCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<KeyboardCapabilities> for ::windows::core::IInspectable {
-    fn from(value: KeyboardCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyboardCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &KeyboardCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyboardCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &KeyboardCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(KeyboardCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for KeyboardCapabilities {}
 unsafe impl ::core::marker::Sync for KeyboardCapabilities {}
 #[doc = "*Required features: `\"Devices_Input\"`*"]
@@ -561,36 +532,7 @@ unsafe impl ::windows::core::Interface for MouseCapabilities {
 impl ::windows::core::RuntimeName for MouseCapabilities {
     const NAME: &'static str = "Windows.Devices.Input.MouseCapabilities";
 }
-impl ::core::convert::From<MouseCapabilities> for ::windows::core::IUnknown {
-    fn from(value: MouseCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MouseCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &MouseCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MouseCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &MouseCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MouseCapabilities> for ::windows::core::IInspectable {
-    fn from(value: MouseCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MouseCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &MouseCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MouseCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &MouseCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MouseCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MouseCapabilities {}
 unsafe impl ::core::marker::Sync for MouseCapabilities {}
 #[doc = "*Required features: `\"Devices_Input\"`*"]
@@ -656,36 +598,7 @@ unsafe impl ::windows::core::Interface for MouseDevice {
 impl ::windows::core::RuntimeName for MouseDevice {
     const NAME: &'static str = "Windows.Devices.Input.MouseDevice";
 }
-impl ::core::convert::From<MouseDevice> for ::windows::core::IUnknown {
-    fn from(value: MouseDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MouseDevice> for ::windows::core::IUnknown {
-    fn from(value: &MouseDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MouseDevice> for &::windows::core::IUnknown {
-    fn from(value: &MouseDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MouseDevice> for ::windows::core::IInspectable {
-    fn from(value: MouseDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MouseDevice> for ::windows::core::IInspectable {
-    fn from(value: &MouseDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MouseDevice> for &::windows::core::IInspectable {
-    fn from(value: &MouseDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MouseDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Devices_Input\"`*"]
 #[repr(transparent)]
 pub struct MouseEventArgs(::windows::core::IUnknown);
@@ -730,36 +643,7 @@ unsafe impl ::windows::core::Interface for MouseEventArgs {
 impl ::windows::core::RuntimeName for MouseEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.MouseEventArgs";
 }
-impl ::core::convert::From<MouseEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MouseEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MouseEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MouseEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MouseEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MouseEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MouseEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MouseEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MouseEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MouseEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MouseEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MouseEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MouseEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Devices_Input\"`*"]
 #[repr(transparent)]
 pub struct PenButtonListener(::windows::core::IUnknown);
@@ -875,36 +759,7 @@ unsafe impl ::windows::core::Interface for PenButtonListener {
 impl ::windows::core::RuntimeName for PenButtonListener {
     const NAME: &'static str = "Windows.Devices.Input.PenButtonListener";
 }
-impl ::core::convert::From<PenButtonListener> for ::windows::core::IUnknown {
-    fn from(value: PenButtonListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenButtonListener> for ::windows::core::IUnknown {
-    fn from(value: &PenButtonListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenButtonListener> for &::windows::core::IUnknown {
-    fn from(value: &PenButtonListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PenButtonListener> for ::windows::core::IInspectable {
-    fn from(value: PenButtonListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenButtonListener> for ::windows::core::IInspectable {
-    fn from(value: &PenButtonListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenButtonListener> for &::windows::core::IInspectable {
-    fn from(value: &PenButtonListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PenButtonListener, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PenButtonListener {}
 unsafe impl ::core::marker::Sync for PenButtonListener {}
 #[doc = "*Required features: `\"Devices_Input\"`*"]
@@ -971,36 +826,7 @@ unsafe impl ::windows::core::Interface for PenDevice {
 impl ::windows::core::RuntimeName for PenDevice {
     const NAME: &'static str = "Windows.Devices.Input.PenDevice";
 }
-impl ::core::convert::From<PenDevice> for ::windows::core::IUnknown {
-    fn from(value: PenDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenDevice> for ::windows::core::IUnknown {
-    fn from(value: &PenDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenDevice> for &::windows::core::IUnknown {
-    fn from(value: &PenDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PenDevice> for ::windows::core::IInspectable {
-    fn from(value: PenDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenDevice> for ::windows::core::IInspectable {
-    fn from(value: &PenDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenDevice> for &::windows::core::IInspectable {
-    fn from(value: &PenDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PenDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PenDevice {}
 unsafe impl ::core::marker::Sync for PenDevice {}
 #[doc = "*Required features: `\"Devices_Input\"`*"]
@@ -1103,36 +929,7 @@ unsafe impl ::windows::core::Interface for PenDockListener {
 impl ::windows::core::RuntimeName for PenDockListener {
     const NAME: &'static str = "Windows.Devices.Input.PenDockListener";
 }
-impl ::core::convert::From<PenDockListener> for ::windows::core::IUnknown {
-    fn from(value: PenDockListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenDockListener> for ::windows::core::IUnknown {
-    fn from(value: &PenDockListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenDockListener> for &::windows::core::IUnknown {
-    fn from(value: &PenDockListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PenDockListener> for ::windows::core::IInspectable {
-    fn from(value: PenDockListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenDockListener> for ::windows::core::IInspectable {
-    fn from(value: &PenDockListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenDockListener> for &::windows::core::IInspectable {
-    fn from(value: &PenDockListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PenDockListener, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PenDockListener {}
 unsafe impl ::core::marker::Sync for PenDockListener {}
 #[doc = "*Required features: `\"Devices_Input\"`*"]
@@ -1171,36 +968,7 @@ unsafe impl ::windows::core::Interface for PenDockedEventArgs {
 impl ::windows::core::RuntimeName for PenDockedEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.PenDockedEventArgs";
 }
-impl ::core::convert::From<PenDockedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PenDockedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenDockedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PenDockedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenDockedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PenDockedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PenDockedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PenDockedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenDockedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PenDockedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenDockedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PenDockedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PenDockedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PenDockedEventArgs {}
 unsafe impl ::core::marker::Sync for PenDockedEventArgs {}
 #[doc = "*Required features: `\"Devices_Input\"`*"]
@@ -1239,36 +1007,7 @@ unsafe impl ::windows::core::Interface for PenTailButtonClickedEventArgs {
 impl ::windows::core::RuntimeName for PenTailButtonClickedEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.PenTailButtonClickedEventArgs";
 }
-impl ::core::convert::From<PenTailButtonClickedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PenTailButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenTailButtonClickedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PenTailButtonClickedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenTailButtonClickedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PenTailButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PenTailButtonClickedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PenTailButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenTailButtonClickedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PenTailButtonClickedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenTailButtonClickedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PenTailButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PenTailButtonClickedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PenTailButtonClickedEventArgs {}
 unsafe impl ::core::marker::Sync for PenTailButtonClickedEventArgs {}
 #[doc = "*Required features: `\"Devices_Input\"`*"]
@@ -1307,36 +1046,7 @@ unsafe impl ::windows::core::Interface for PenTailButtonDoubleClickedEventArgs {
 impl ::windows::core::RuntimeName for PenTailButtonDoubleClickedEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.PenTailButtonDoubleClickedEventArgs";
 }
-impl ::core::convert::From<PenTailButtonDoubleClickedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PenTailButtonDoubleClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenTailButtonDoubleClickedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PenTailButtonDoubleClickedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenTailButtonDoubleClickedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PenTailButtonDoubleClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PenTailButtonDoubleClickedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PenTailButtonDoubleClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenTailButtonDoubleClickedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PenTailButtonDoubleClickedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenTailButtonDoubleClickedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PenTailButtonDoubleClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PenTailButtonDoubleClickedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PenTailButtonDoubleClickedEventArgs {}
 unsafe impl ::core::marker::Sync for PenTailButtonDoubleClickedEventArgs {}
 #[doc = "*Required features: `\"Devices_Input\"`*"]
@@ -1375,36 +1085,7 @@ unsafe impl ::windows::core::Interface for PenTailButtonLongPressedEventArgs {
 impl ::windows::core::RuntimeName for PenTailButtonLongPressedEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.PenTailButtonLongPressedEventArgs";
 }
-impl ::core::convert::From<PenTailButtonLongPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PenTailButtonLongPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenTailButtonLongPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PenTailButtonLongPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenTailButtonLongPressedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PenTailButtonLongPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PenTailButtonLongPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PenTailButtonLongPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenTailButtonLongPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PenTailButtonLongPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenTailButtonLongPressedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PenTailButtonLongPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PenTailButtonLongPressedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PenTailButtonLongPressedEventArgs {}
 unsafe impl ::core::marker::Sync for PenTailButtonLongPressedEventArgs {}
 #[doc = "*Required features: `\"Devices_Input\"`*"]
@@ -1443,36 +1124,7 @@ unsafe impl ::windows::core::Interface for PenUndockedEventArgs {
 impl ::windows::core::RuntimeName for PenUndockedEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.PenUndockedEventArgs";
 }
-impl ::core::convert::From<PenUndockedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PenUndockedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenUndockedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PenUndockedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenUndockedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PenUndockedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PenUndockedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PenUndockedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenUndockedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PenUndockedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenUndockedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PenUndockedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PenUndockedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PenUndockedEventArgs {}
 unsafe impl ::core::marker::Sync for PenUndockedEventArgs {}
 #[doc = "*Required features: `\"Devices_Input\"`*"]
@@ -1586,36 +1238,7 @@ unsafe impl ::windows::core::Interface for PointerDevice {
 impl ::windows::core::RuntimeName for PointerDevice {
     const NAME: &'static str = "Windows.Devices.Input.PointerDevice";
 }
-impl ::core::convert::From<PointerDevice> for ::windows::core::IUnknown {
-    fn from(value: PointerDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointerDevice> for ::windows::core::IUnknown {
-    fn from(value: &PointerDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointerDevice> for &::windows::core::IUnknown {
-    fn from(value: &PointerDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PointerDevice> for ::windows::core::IInspectable {
-    fn from(value: PointerDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointerDevice> for ::windows::core::IInspectable {
-    fn from(value: &PointerDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointerDevice> for &::windows::core::IInspectable {
-    fn from(value: &PointerDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PointerDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Devices_Input\"`*"]
 #[repr(transparent)]
 pub struct TouchCapabilities(::windows::core::IUnknown);
@@ -1674,36 +1297,7 @@ unsafe impl ::windows::core::Interface for TouchCapabilities {
 impl ::windows::core::RuntimeName for TouchCapabilities {
     const NAME: &'static str = "Windows.Devices.Input.TouchCapabilities";
 }
-impl ::core::convert::From<TouchCapabilities> for ::windows::core::IUnknown {
-    fn from(value: TouchCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TouchCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &TouchCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TouchCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &TouchCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TouchCapabilities> for ::windows::core::IInspectable {
-    fn from(value: TouchCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TouchCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &TouchCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TouchCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &TouchCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TouchCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TouchCapabilities {}
 unsafe impl ::core::marker::Sync for TouchCapabilities {}
 #[doc = "*Required features: `\"Devices_Input\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Lights/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/Effects/mod.rs
@@ -290,36 +290,7 @@ impl ILampArrayEffect {
         unsafe { (::windows::core::Vtable::vtable(this).SetZIndex)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<ILampArrayEffect> for ::windows::core::IUnknown {
-    fn from(value: ILampArrayEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILampArrayEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILampArrayEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILampArrayEffect> for ::windows::core::IUnknown {
-    fn from(value: &ILampArrayEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILampArrayEffect> for ::windows::core::IInspectable {
-    fn from(value: ILampArrayEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILampArrayEffect> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILampArrayEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILampArrayEffect> for ::windows::core::IInspectable {
-    fn from(value: &ILampArrayEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILampArrayEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ILampArrayEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -624,36 +595,7 @@ unsafe impl ::windows::core::Interface for LampArrayBitmapEffect {
 impl ::windows::core::RuntimeName for LampArrayBitmapEffect {
     const NAME: &'static str = "Windows.Devices.Lights.Effects.LampArrayBitmapEffect";
 }
-impl ::core::convert::From<LampArrayBitmapEffect> for ::windows::core::IUnknown {
-    fn from(value: LampArrayBitmapEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayBitmapEffect> for ::windows::core::IUnknown {
-    fn from(value: &LampArrayBitmapEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayBitmapEffect> for &::windows::core::IUnknown {
-    fn from(value: &LampArrayBitmapEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LampArrayBitmapEffect> for ::windows::core::IInspectable {
-    fn from(value: LampArrayBitmapEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayBitmapEffect> for ::windows::core::IInspectable {
-    fn from(value: &LampArrayBitmapEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayBitmapEffect> for &::windows::core::IInspectable {
-    fn from(value: &LampArrayBitmapEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LampArrayBitmapEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LampArrayBitmapEffect> for ILampArrayEffect {
     type Error = ::windows::core::Error;
     fn try_from(value: LampArrayBitmapEffect) -> ::windows::core::Result<Self> {
@@ -727,36 +669,7 @@ unsafe impl ::windows::core::Interface for LampArrayBitmapRequestedEventArgs {
 impl ::windows::core::RuntimeName for LampArrayBitmapRequestedEventArgs {
     const NAME: &'static str = "Windows.Devices.Lights.Effects.LampArrayBitmapRequestedEventArgs";
 }
-impl ::core::convert::From<LampArrayBitmapRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LampArrayBitmapRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayBitmapRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LampArrayBitmapRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayBitmapRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LampArrayBitmapRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LampArrayBitmapRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LampArrayBitmapRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayBitmapRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LampArrayBitmapRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayBitmapRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LampArrayBitmapRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LampArrayBitmapRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LampArrayBitmapRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for LampArrayBitmapRequestedEventArgs {}
 #[doc = "*Required features: `\"Devices_Lights_Effects\"`*"]
@@ -930,36 +843,7 @@ unsafe impl ::windows::core::Interface for LampArrayBlinkEffect {
 impl ::windows::core::RuntimeName for LampArrayBlinkEffect {
     const NAME: &'static str = "Windows.Devices.Lights.Effects.LampArrayBlinkEffect";
 }
-impl ::core::convert::From<LampArrayBlinkEffect> for ::windows::core::IUnknown {
-    fn from(value: LampArrayBlinkEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayBlinkEffect> for ::windows::core::IUnknown {
-    fn from(value: &LampArrayBlinkEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayBlinkEffect> for &::windows::core::IUnknown {
-    fn from(value: &LampArrayBlinkEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LampArrayBlinkEffect> for ::windows::core::IInspectable {
-    fn from(value: LampArrayBlinkEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayBlinkEffect> for ::windows::core::IInspectable {
-    fn from(value: &LampArrayBlinkEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayBlinkEffect> for &::windows::core::IInspectable {
-    fn from(value: &LampArrayBlinkEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LampArrayBlinkEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LampArrayBlinkEffect> for ILampArrayEffect {
     type Error = ::windows::core::Error;
     fn try_from(value: LampArrayBlinkEffect) -> ::windows::core::Result<Self> {
@@ -1096,36 +980,7 @@ unsafe impl ::windows::core::Interface for LampArrayColorRampEffect {
 impl ::windows::core::RuntimeName for LampArrayColorRampEffect {
     const NAME: &'static str = "Windows.Devices.Lights.Effects.LampArrayColorRampEffect";
 }
-impl ::core::convert::From<LampArrayColorRampEffect> for ::windows::core::IUnknown {
-    fn from(value: LampArrayColorRampEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayColorRampEffect> for ::windows::core::IUnknown {
-    fn from(value: &LampArrayColorRampEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayColorRampEffect> for &::windows::core::IUnknown {
-    fn from(value: &LampArrayColorRampEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LampArrayColorRampEffect> for ::windows::core::IInspectable {
-    fn from(value: LampArrayColorRampEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayColorRampEffect> for ::windows::core::IInspectable {
-    fn from(value: &LampArrayColorRampEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayColorRampEffect> for &::windows::core::IInspectable {
-    fn from(value: &LampArrayColorRampEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LampArrayColorRampEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LampArrayColorRampEffect> for ILampArrayEffect {
     type Error = ::windows::core::Error;
     fn try_from(value: LampArrayColorRampEffect) -> ::windows::core::Result<Self> {
@@ -1251,36 +1106,7 @@ unsafe impl ::windows::core::Interface for LampArrayCustomEffect {
 impl ::windows::core::RuntimeName for LampArrayCustomEffect {
     const NAME: &'static str = "Windows.Devices.Lights.Effects.LampArrayCustomEffect";
 }
-impl ::core::convert::From<LampArrayCustomEffect> for ::windows::core::IUnknown {
-    fn from(value: LampArrayCustomEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayCustomEffect> for ::windows::core::IUnknown {
-    fn from(value: &LampArrayCustomEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayCustomEffect> for &::windows::core::IUnknown {
-    fn from(value: &LampArrayCustomEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LampArrayCustomEffect> for ::windows::core::IInspectable {
-    fn from(value: LampArrayCustomEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayCustomEffect> for ::windows::core::IInspectable {
-    fn from(value: &LampArrayCustomEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayCustomEffect> for &::windows::core::IInspectable {
-    fn from(value: &LampArrayCustomEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LampArrayCustomEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LampArrayCustomEffect> for ILampArrayEffect {
     type Error = ::windows::core::Error;
     fn try_from(value: LampArrayCustomEffect) -> ::windows::core::Result<Self> {
@@ -1500,36 +1326,7 @@ impl ::core::iter::IntoIterator for &LampArrayEffectPlaylist {
         super::super::super::Foundation::Collections::VectorViewIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<LampArrayEffectPlaylist> for ::windows::core::IUnknown {
-    fn from(value: LampArrayEffectPlaylist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayEffectPlaylist> for ::windows::core::IUnknown {
-    fn from(value: &LampArrayEffectPlaylist) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayEffectPlaylist> for &::windows::core::IUnknown {
-    fn from(value: &LampArrayEffectPlaylist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LampArrayEffectPlaylist> for ::windows::core::IInspectable {
-    fn from(value: LampArrayEffectPlaylist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayEffectPlaylist> for ::windows::core::IInspectable {
-    fn from(value: &LampArrayEffectPlaylist) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayEffectPlaylist> for &::windows::core::IInspectable {
-    fn from(value: &LampArrayEffectPlaylist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LampArrayEffectPlaylist, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<LampArrayEffectPlaylist> for super::super::super::Foundation::Collections::IIterable<ILampArrayEffect> {
     type Error = ::windows::core::Error;
@@ -1691,36 +1488,7 @@ unsafe impl ::windows::core::Interface for LampArraySolidEffect {
 impl ::windows::core::RuntimeName for LampArraySolidEffect {
     const NAME: &'static str = "Windows.Devices.Lights.Effects.LampArraySolidEffect";
 }
-impl ::core::convert::From<LampArraySolidEffect> for ::windows::core::IUnknown {
-    fn from(value: LampArraySolidEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArraySolidEffect> for ::windows::core::IUnknown {
-    fn from(value: &LampArraySolidEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArraySolidEffect> for &::windows::core::IUnknown {
-    fn from(value: &LampArraySolidEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LampArraySolidEffect> for ::windows::core::IInspectable {
-    fn from(value: LampArraySolidEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArraySolidEffect> for ::windows::core::IInspectable {
-    fn from(value: &LampArraySolidEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArraySolidEffect> for &::windows::core::IInspectable {
-    fn from(value: &LampArraySolidEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LampArraySolidEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LampArraySolidEffect> for ILampArrayEffect {
     type Error = ::windows::core::Error;
     fn try_from(value: LampArraySolidEffect) -> ::windows::core::Result<Self> {
@@ -1812,36 +1580,7 @@ unsafe impl ::windows::core::Interface for LampArrayUpdateRequestedEventArgs {
 impl ::windows::core::RuntimeName for LampArrayUpdateRequestedEventArgs {
     const NAME: &'static str = "Windows.Devices.Lights.Effects.LampArrayUpdateRequestedEventArgs";
 }
-impl ::core::convert::From<LampArrayUpdateRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LampArrayUpdateRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayUpdateRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LampArrayUpdateRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayUpdateRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LampArrayUpdateRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LampArrayUpdateRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LampArrayUpdateRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArrayUpdateRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LampArrayUpdateRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArrayUpdateRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LampArrayUpdateRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LampArrayUpdateRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LampArrayUpdateRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for LampArrayUpdateRequestedEventArgs {}
 #[doc = "*Required features: `\"Devices_Lights_Effects\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
@@ -341,36 +341,7 @@ unsafe impl ::windows::core::Interface for Lamp {
 impl ::windows::core::RuntimeName for Lamp {
     const NAME: &'static str = "Windows.Devices.Lights.Lamp";
 }
-impl ::core::convert::From<Lamp> for ::windows::core::IUnknown {
-    fn from(value: Lamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Lamp> for ::windows::core::IUnknown {
-    fn from(value: &Lamp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Lamp> for &::windows::core::IUnknown {
-    fn from(value: &Lamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Lamp> for ::windows::core::IInspectable {
-    fn from(value: Lamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Lamp> for ::windows::core::IInspectable {
-    fn from(value: &Lamp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Lamp> for &::windows::core::IInspectable {
-    fn from(value: &Lamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Lamp, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<Lamp> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -634,36 +605,7 @@ unsafe impl ::windows::core::Interface for LampArray {
 impl ::windows::core::RuntimeName for LampArray {
     const NAME: &'static str = "Windows.Devices.Lights.LampArray";
 }
-impl ::core::convert::From<LampArray> for ::windows::core::IUnknown {
-    fn from(value: LampArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArray> for ::windows::core::IUnknown {
-    fn from(value: &LampArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArray> for &::windows::core::IUnknown {
-    fn from(value: &LampArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LampArray> for ::windows::core::IInspectable {
-    fn from(value: LampArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampArray> for ::windows::core::IInspectable {
-    fn from(value: &LampArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampArray> for &::windows::core::IInspectable {
-    fn from(value: &LampArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LampArray, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LampArray {}
 unsafe impl ::core::marker::Sync for LampArray {}
 #[doc = "*Required features: `\"Devices_Lights\"`*"]
@@ -710,36 +652,7 @@ unsafe impl ::windows::core::Interface for LampAvailabilityChangedEventArgs {
 impl ::windows::core::RuntimeName for LampAvailabilityChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Lights.LampAvailabilityChangedEventArgs";
 }
-impl ::core::convert::From<LampAvailabilityChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LampAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampAvailabilityChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LampAvailabilityChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampAvailabilityChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LampAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LampAvailabilityChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LampAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampAvailabilityChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LampAvailabilityChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampAvailabilityChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LampAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LampAvailabilityChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LampAvailabilityChangedEventArgs {}
 unsafe impl ::core::marker::Sync for LampAvailabilityChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Lights\"`*"]
@@ -857,36 +770,7 @@ unsafe impl ::windows::core::Interface for LampInfo {
 impl ::windows::core::RuntimeName for LampInfo {
     const NAME: &'static str = "Windows.Devices.Lights.LampInfo";
 }
-impl ::core::convert::From<LampInfo> for ::windows::core::IUnknown {
-    fn from(value: LampInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampInfo> for ::windows::core::IUnknown {
-    fn from(value: &LampInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampInfo> for &::windows::core::IUnknown {
-    fn from(value: &LampInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LampInfo> for ::windows::core::IInspectable {
-    fn from(value: LampInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LampInfo> for ::windows::core::IInspectable {
-    fn from(value: &LampInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LampInfo> for &::windows::core::IInspectable {
-    fn from(value: &LampInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LampInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LampInfo {}
 unsafe impl ::core::marker::Sync for LampInfo {}
 #[doc = "*Required features: `\"Devices_Lights\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Midi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Midi/mod.rs
@@ -133,36 +133,7 @@ impl IMidiMessage {
         }
     }
 }
-impl ::core::convert::From<IMidiMessage> for ::windows::core::IUnknown {
-    fn from(value: IMidiMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMidiMessage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMidiMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMidiMessage> for ::windows::core::IUnknown {
-    fn from(value: &IMidiMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMidiMessage> for ::windows::core::IInspectable {
-    fn from(value: IMidiMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMidiMessage> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMidiMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMidiMessage> for ::windows::core::IInspectable {
-    fn from(value: &IMidiMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMidiMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMidiMessage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -321,36 +292,7 @@ impl IMidiOutPort {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IMidiOutPort> for ::windows::core::IUnknown {
-    fn from(value: IMidiOutPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMidiOutPort> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMidiOutPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMidiOutPort> for ::windows::core::IUnknown {
-    fn from(value: &IMidiOutPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMidiOutPort> for ::windows::core::IInspectable {
-    fn from(value: IMidiOutPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMidiOutPort> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMidiOutPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMidiOutPort> for ::windows::core::IInspectable {
-    fn from(value: &IMidiOutPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMidiOutPort, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IMidiOutPort> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -750,36 +692,7 @@ unsafe impl ::windows::core::Interface for MidiActiveSensingMessage {
 impl ::windows::core::RuntimeName for MidiActiveSensingMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiActiveSensingMessage";
 }
-impl ::core::convert::From<MidiActiveSensingMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiActiveSensingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiActiveSensingMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiActiveSensingMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiActiveSensingMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiActiveSensingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiActiveSensingMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiActiveSensingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiActiveSensingMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiActiveSensingMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiActiveSensingMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiActiveSensingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiActiveSensingMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiActiveSensingMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiActiveSensingMessage) -> ::windows::core::Result<Self> {
@@ -888,36 +801,7 @@ unsafe impl ::windows::core::Interface for MidiChannelPressureMessage {
 impl ::windows::core::RuntimeName for MidiChannelPressureMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiChannelPressureMessage";
 }
-impl ::core::convert::From<MidiChannelPressureMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiChannelPressureMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiChannelPressureMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiChannelPressureMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiChannelPressureMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiChannelPressureMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiChannelPressureMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiChannelPressureMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiChannelPressureMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiChannelPressureMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiChannelPressureMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiChannelPressureMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiChannelPressureMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiChannelPressureMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiChannelPressureMessage) -> ::windows::core::Result<Self> {
@@ -1008,36 +892,7 @@ unsafe impl ::windows::core::Interface for MidiContinueMessage {
 impl ::windows::core::RuntimeName for MidiContinueMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiContinueMessage";
 }
-impl ::core::convert::From<MidiContinueMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiContinueMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiContinueMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiContinueMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiContinueMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiContinueMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiContinueMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiContinueMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiContinueMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiContinueMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiContinueMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiContinueMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiContinueMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiContinueMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiContinueMessage) -> ::windows::core::Result<Self> {
@@ -1153,36 +1008,7 @@ unsafe impl ::windows::core::Interface for MidiControlChangeMessage {
 impl ::windows::core::RuntimeName for MidiControlChangeMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiControlChangeMessage";
 }
-impl ::core::convert::From<MidiControlChangeMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiControlChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiControlChangeMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiControlChangeMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiControlChangeMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiControlChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiControlChangeMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiControlChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiControlChangeMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiControlChangeMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiControlChangeMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiControlChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiControlChangeMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiControlChangeMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiControlChangeMessage) -> ::windows::core::Result<Self> {
@@ -1288,36 +1114,7 @@ unsafe impl ::windows::core::Interface for MidiInPort {
 impl ::windows::core::RuntimeName for MidiInPort {
     const NAME: &'static str = "Windows.Devices.Midi.MidiInPort";
 }
-impl ::core::convert::From<MidiInPort> for ::windows::core::IUnknown {
-    fn from(value: MidiInPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiInPort> for ::windows::core::IUnknown {
-    fn from(value: &MidiInPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiInPort> for &::windows::core::IUnknown {
-    fn from(value: &MidiInPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiInPort> for ::windows::core::IInspectable {
-    fn from(value: MidiInPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiInPort> for ::windows::core::IInspectable {
-    fn from(value: &MidiInPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiInPort> for &::windows::core::IInspectable {
-    fn from(value: &MidiInPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiInPort, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MidiInPort> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1386,36 +1183,7 @@ unsafe impl ::windows::core::Interface for MidiMessageReceivedEventArgs {
 impl ::windows::core::RuntimeName for MidiMessageReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.Midi.MidiMessageReceivedEventArgs";
 }
-impl ::core::convert::From<MidiMessageReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MidiMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiMessageReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MidiMessageReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiMessageReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MidiMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiMessageReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MidiMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiMessageReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MidiMessageReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiMessageReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MidiMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiMessageReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MidiMessageReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MidiMessageReceivedEventArgs {}
 #[doc = "*Required features: `\"Devices_Midi\"`*"]
@@ -1512,36 +1280,7 @@ unsafe impl ::windows::core::Interface for MidiNoteOffMessage {
 impl ::windows::core::RuntimeName for MidiNoteOffMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiNoteOffMessage";
 }
-impl ::core::convert::From<MidiNoteOffMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiNoteOffMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiNoteOffMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiNoteOffMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiNoteOffMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiNoteOffMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiNoteOffMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiNoteOffMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiNoteOffMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiNoteOffMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiNoteOffMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiNoteOffMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiNoteOffMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiNoteOffMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiNoteOffMessage) -> ::windows::core::Result<Self> {
@@ -1657,36 +1396,7 @@ unsafe impl ::windows::core::Interface for MidiNoteOnMessage {
 impl ::windows::core::RuntimeName for MidiNoteOnMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiNoteOnMessage";
 }
-impl ::core::convert::From<MidiNoteOnMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiNoteOnMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiNoteOnMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiNoteOnMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiNoteOnMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiNoteOnMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiNoteOnMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiNoteOnMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiNoteOnMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiNoteOnMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiNoteOnMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiNoteOnMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiNoteOnMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiNoteOnMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiNoteOnMessage) -> ::windows::core::Result<Self> {
@@ -1795,36 +1505,7 @@ unsafe impl ::windows::core::Interface for MidiOutPort {
 impl ::windows::core::RuntimeName for MidiOutPort {
     const NAME: &'static str = "Windows.Devices.Midi.MidiOutPort";
 }
-impl ::core::convert::From<MidiOutPort> for ::windows::core::IUnknown {
-    fn from(value: MidiOutPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiOutPort> for ::windows::core::IUnknown {
-    fn from(value: &MidiOutPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiOutPort> for &::windows::core::IUnknown {
-    fn from(value: &MidiOutPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiOutPort> for ::windows::core::IInspectable {
-    fn from(value: MidiOutPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiOutPort> for ::windows::core::IInspectable {
-    fn from(value: &MidiOutPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiOutPort> for &::windows::core::IInspectable {
-    fn from(value: &MidiOutPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiOutPort, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MidiOutPort> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1955,36 +1636,7 @@ unsafe impl ::windows::core::Interface for MidiPitchBendChangeMessage {
 impl ::windows::core::RuntimeName for MidiPitchBendChangeMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiPitchBendChangeMessage";
 }
-impl ::core::convert::From<MidiPitchBendChangeMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiPitchBendChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiPitchBendChangeMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiPitchBendChangeMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiPitchBendChangeMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiPitchBendChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiPitchBendChangeMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiPitchBendChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiPitchBendChangeMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiPitchBendChangeMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiPitchBendChangeMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiPitchBendChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiPitchBendChangeMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiPitchBendChangeMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiPitchBendChangeMessage) -> ::windows::core::Result<Self> {
@@ -2100,36 +1752,7 @@ unsafe impl ::windows::core::Interface for MidiPolyphonicKeyPressureMessage {
 impl ::windows::core::RuntimeName for MidiPolyphonicKeyPressureMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiPolyphonicKeyPressureMessage";
 }
-impl ::core::convert::From<MidiPolyphonicKeyPressureMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiPolyphonicKeyPressureMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiPolyphonicKeyPressureMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiPolyphonicKeyPressureMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiPolyphonicKeyPressureMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiPolyphonicKeyPressureMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiPolyphonicKeyPressureMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiPolyphonicKeyPressureMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiPolyphonicKeyPressureMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiPolyphonicKeyPressureMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiPolyphonicKeyPressureMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiPolyphonicKeyPressureMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiPolyphonicKeyPressureMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiPolyphonicKeyPressureMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiPolyphonicKeyPressureMessage) -> ::windows::core::Result<Self> {
@@ -2238,36 +1861,7 @@ unsafe impl ::windows::core::Interface for MidiProgramChangeMessage {
 impl ::windows::core::RuntimeName for MidiProgramChangeMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiProgramChangeMessage";
 }
-impl ::core::convert::From<MidiProgramChangeMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiProgramChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiProgramChangeMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiProgramChangeMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiProgramChangeMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiProgramChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiProgramChangeMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiProgramChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiProgramChangeMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiProgramChangeMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiProgramChangeMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiProgramChangeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiProgramChangeMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiProgramChangeMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiProgramChangeMessage) -> ::windows::core::Result<Self> {
@@ -2369,36 +1963,7 @@ unsafe impl ::windows::core::Interface for MidiSongPositionPointerMessage {
 impl ::windows::core::RuntimeName for MidiSongPositionPointerMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiSongPositionPointerMessage";
 }
-impl ::core::convert::From<MidiSongPositionPointerMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiSongPositionPointerMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiSongPositionPointerMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiSongPositionPointerMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiSongPositionPointerMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiSongPositionPointerMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiSongPositionPointerMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiSongPositionPointerMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiSongPositionPointerMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiSongPositionPointerMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiSongPositionPointerMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiSongPositionPointerMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiSongPositionPointerMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiSongPositionPointerMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiSongPositionPointerMessage) -> ::windows::core::Result<Self> {
@@ -2500,36 +2065,7 @@ unsafe impl ::windows::core::Interface for MidiSongSelectMessage {
 impl ::windows::core::RuntimeName for MidiSongSelectMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiSongSelectMessage";
 }
-impl ::core::convert::From<MidiSongSelectMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiSongSelectMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiSongSelectMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiSongSelectMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiSongSelectMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiSongSelectMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiSongSelectMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiSongSelectMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiSongSelectMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiSongSelectMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiSongSelectMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiSongSelectMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiSongSelectMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiSongSelectMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiSongSelectMessage) -> ::windows::core::Result<Self> {
@@ -2620,36 +2156,7 @@ unsafe impl ::windows::core::Interface for MidiStartMessage {
 impl ::windows::core::RuntimeName for MidiStartMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiStartMessage";
 }
-impl ::core::convert::From<MidiStartMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiStartMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiStartMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiStartMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiStartMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiStartMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiStartMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiStartMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiStartMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiStartMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiStartMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiStartMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiStartMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiStartMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiStartMessage) -> ::windows::core::Result<Self> {
@@ -2740,36 +2247,7 @@ unsafe impl ::windows::core::Interface for MidiStopMessage {
 impl ::windows::core::RuntimeName for MidiStopMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiStopMessage";
 }
-impl ::core::convert::From<MidiStopMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiStopMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiStopMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiStopMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiStopMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiStopMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiStopMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiStopMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiStopMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiStopMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiStopMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiStopMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiStopMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiStopMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiStopMessage) -> ::windows::core::Result<Self> {
@@ -2908,36 +2386,7 @@ unsafe impl ::windows::core::Interface for MidiSynthesizer {
 impl ::windows::core::RuntimeName for MidiSynthesizer {
     const NAME: &'static str = "Windows.Devices.Midi.MidiSynthesizer";
 }
-impl ::core::convert::From<MidiSynthesizer> for ::windows::core::IUnknown {
-    fn from(value: MidiSynthesizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiSynthesizer> for ::windows::core::IUnknown {
-    fn from(value: &MidiSynthesizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiSynthesizer> for &::windows::core::IUnknown {
-    fn from(value: &MidiSynthesizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiSynthesizer> for ::windows::core::IInspectable {
-    fn from(value: MidiSynthesizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiSynthesizer> for ::windows::core::IInspectable {
-    fn from(value: &MidiSynthesizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiSynthesizer> for &::windows::core::IInspectable {
-    fn from(value: &MidiSynthesizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiSynthesizer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MidiSynthesizer> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3060,36 +2509,7 @@ unsafe impl ::windows::core::Interface for MidiSystemExclusiveMessage {
 impl ::windows::core::RuntimeName for MidiSystemExclusiveMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiSystemExclusiveMessage";
 }
-impl ::core::convert::From<MidiSystemExclusiveMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiSystemExclusiveMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiSystemExclusiveMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiSystemExclusiveMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiSystemExclusiveMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiSystemExclusiveMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiSystemExclusiveMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiSystemExclusiveMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiSystemExclusiveMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiSystemExclusiveMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiSystemExclusiveMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiSystemExclusiveMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiSystemExclusiveMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiSystemExclusiveMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiSystemExclusiveMessage) -> ::windows::core::Result<Self> {
@@ -3180,36 +2600,7 @@ unsafe impl ::windows::core::Interface for MidiSystemResetMessage {
 impl ::windows::core::RuntimeName for MidiSystemResetMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiSystemResetMessage";
 }
-impl ::core::convert::From<MidiSystemResetMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiSystemResetMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiSystemResetMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiSystemResetMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiSystemResetMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiSystemResetMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiSystemResetMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiSystemResetMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiSystemResetMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiSystemResetMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiSystemResetMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiSystemResetMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiSystemResetMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiSystemResetMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiSystemResetMessage) -> ::windows::core::Result<Self> {
@@ -3318,36 +2709,7 @@ unsafe impl ::windows::core::Interface for MidiTimeCodeMessage {
 impl ::windows::core::RuntimeName for MidiTimeCodeMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiTimeCodeMessage";
 }
-impl ::core::convert::From<MidiTimeCodeMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiTimeCodeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiTimeCodeMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiTimeCodeMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiTimeCodeMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiTimeCodeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiTimeCodeMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiTimeCodeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiTimeCodeMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiTimeCodeMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiTimeCodeMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiTimeCodeMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiTimeCodeMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiTimeCodeMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiTimeCodeMessage) -> ::windows::core::Result<Self> {
@@ -3438,36 +2800,7 @@ unsafe impl ::windows::core::Interface for MidiTimingClockMessage {
 impl ::windows::core::RuntimeName for MidiTimingClockMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiTimingClockMessage";
 }
-impl ::core::convert::From<MidiTimingClockMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiTimingClockMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiTimingClockMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiTimingClockMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiTimingClockMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiTimingClockMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiTimingClockMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiTimingClockMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiTimingClockMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiTimingClockMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiTimingClockMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiTimingClockMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiTimingClockMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiTimingClockMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiTimingClockMessage) -> ::windows::core::Result<Self> {
@@ -3558,36 +2891,7 @@ unsafe impl ::windows::core::Interface for MidiTuneRequestMessage {
 impl ::windows::core::RuntimeName for MidiTuneRequestMessage {
     const NAME: &'static str = "Windows.Devices.Midi.MidiTuneRequestMessage";
 }
-impl ::core::convert::From<MidiTuneRequestMessage> for ::windows::core::IUnknown {
-    fn from(value: MidiTuneRequestMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiTuneRequestMessage> for ::windows::core::IUnknown {
-    fn from(value: &MidiTuneRequestMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiTuneRequestMessage> for &::windows::core::IUnknown {
-    fn from(value: &MidiTuneRequestMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MidiTuneRequestMessage> for ::windows::core::IInspectable {
-    fn from(value: MidiTuneRequestMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MidiTuneRequestMessage> for ::windows::core::IInspectable {
-    fn from(value: &MidiTuneRequestMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MidiTuneRequestMessage> for &::windows::core::IInspectable {
-    fn from(value: &MidiTuneRequestMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MidiTuneRequestMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MidiTuneRequestMessage> for IMidiMessage {
     type Error = ::windows::core::Error;
     fn try_from(value: MidiTuneRequestMessage) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Devices/Perception/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Perception/Provider/mod.rs
@@ -305,41 +305,7 @@ impl IPerceptionFrameProvider {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<IPerceptionFrameProvider> for ::windows::core::IUnknown {
-    fn from(value: IPerceptionFrameProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IPerceptionFrameProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPerceptionFrameProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IPerceptionFrameProvider> for ::windows::core::IUnknown {
-    fn from(value: &IPerceptionFrameProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<IPerceptionFrameProvider> for ::windows::core::IInspectable {
-    fn from(value: IPerceptionFrameProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IPerceptionFrameProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPerceptionFrameProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IPerceptionFrameProvider> for ::windows::core::IInspectable {
-    fn from(value: &IPerceptionFrameProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPerceptionFrameProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<IPerceptionFrameProvider> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -509,41 +475,7 @@ impl IPerceptionFrameProviderManager {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<IPerceptionFrameProviderManager> for ::windows::core::IUnknown {
-    fn from(value: IPerceptionFrameProviderManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IPerceptionFrameProviderManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPerceptionFrameProviderManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IPerceptionFrameProviderManager> for ::windows::core::IUnknown {
-    fn from(value: &IPerceptionFrameProviderManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<IPerceptionFrameProviderManager> for ::windows::core::IInspectable {
-    fn from(value: IPerceptionFrameProviderManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IPerceptionFrameProviderManager> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPerceptionFrameProviderManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IPerceptionFrameProviderManager> for ::windows::core::IInspectable {
-    fn from(value: &IPerceptionFrameProviderManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPerceptionFrameProviderManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<IPerceptionFrameProviderManager> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -871,41 +803,7 @@ impl ::windows::core::RuntimeName for PerceptionControlGroup {
     const NAME: &'static str = "Windows.Devices.Perception.Provider.PerceptionControlGroup";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionControlGroup> for ::windows::core::IUnknown {
-    fn from(value: PerceptionControlGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionControlGroup> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionControlGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionControlGroup> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionControlGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionControlGroup> for ::windows::core::IInspectable {
-    fn from(value: PerceptionControlGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionControlGroup> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionControlGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionControlGroup> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionControlGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionControlGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionControlGroup {}
 #[cfg(feature = "deprecated")]
@@ -999,41 +897,7 @@ impl ::windows::core::RuntimeName for PerceptionCorrelation {
     const NAME: &'static str = "Windows.Devices.Perception.Provider.PerceptionCorrelation";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionCorrelation> for ::windows::core::IUnknown {
-    fn from(value: PerceptionCorrelation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionCorrelation> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionCorrelation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionCorrelation> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionCorrelation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionCorrelation> for ::windows::core::IInspectable {
-    fn from(value: PerceptionCorrelation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionCorrelation> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionCorrelation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionCorrelation> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionCorrelation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionCorrelation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionCorrelation {}
 #[cfg(feature = "deprecated")]
@@ -1113,41 +977,7 @@ impl ::windows::core::RuntimeName for PerceptionCorrelationGroup {
     const NAME: &'static str = "Windows.Devices.Perception.Provider.PerceptionCorrelationGroup";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionCorrelationGroup> for ::windows::core::IUnknown {
-    fn from(value: PerceptionCorrelationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionCorrelationGroup> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionCorrelationGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionCorrelationGroup> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionCorrelationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionCorrelationGroup> for ::windows::core::IInspectable {
-    fn from(value: PerceptionCorrelationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionCorrelationGroup> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionCorrelationGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionCorrelationGroup> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionCorrelationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionCorrelationGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionCorrelationGroup {}
 #[cfg(feature = "deprecated")]
@@ -1227,41 +1057,7 @@ impl ::windows::core::RuntimeName for PerceptionFaceAuthenticationGroup {
     const NAME: &'static str = "Windows.Devices.Perception.Provider.PerceptionFaceAuthenticationGroup";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionFaceAuthenticationGroup> for ::windows::core::IUnknown {
-    fn from(value: PerceptionFaceAuthenticationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFaceAuthenticationGroup> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionFaceAuthenticationGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFaceAuthenticationGroup> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionFaceAuthenticationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionFaceAuthenticationGroup> for ::windows::core::IInspectable {
-    fn from(value: PerceptionFaceAuthenticationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFaceAuthenticationGroup> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionFaceAuthenticationGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFaceAuthenticationGroup> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionFaceAuthenticationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionFaceAuthenticationGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionFaceAuthenticationGroup {}
 #[cfg(feature = "deprecated")]
@@ -1347,41 +1143,7 @@ impl ::windows::core::RuntimeName for PerceptionFrame {
     const NAME: &'static str = "Windows.Devices.Perception.Provider.PerceptionFrame";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionFrame> for ::windows::core::IUnknown {
-    fn from(value: PerceptionFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrame> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrame> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionFrame> for ::windows::core::IInspectable {
-    fn from(value: PerceptionFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrame> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrame> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionFrame {}
 #[cfg(feature = "deprecated")]
@@ -1516,41 +1278,7 @@ impl ::windows::core::RuntimeName for PerceptionFrameProviderInfo {
     const NAME: &'static str = "Windows.Devices.Perception.Provider.PerceptionFrameProviderInfo";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionFrameProviderInfo> for ::windows::core::IUnknown {
-    fn from(value: PerceptionFrameProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameProviderInfo> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionFrameProviderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameProviderInfo> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionFrameProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionFrameProviderInfo> for ::windows::core::IInspectable {
-    fn from(value: PerceptionFrameProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameProviderInfo> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionFrameProviderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameProviderInfo> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionFrameProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionFrameProviderInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionFrameProviderInfo {}
 #[cfg(feature = "deprecated")]
@@ -1751,41 +1479,7 @@ impl ::windows::core::RuntimeName for PerceptionPropertyChangeRequest {
     const NAME: &'static str = "Windows.Devices.Perception.Provider.PerceptionPropertyChangeRequest";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionPropertyChangeRequest> for ::windows::core::IUnknown {
-    fn from(value: PerceptionPropertyChangeRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionPropertyChangeRequest> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionPropertyChangeRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionPropertyChangeRequest> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionPropertyChangeRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionPropertyChangeRequest> for ::windows::core::IInspectable {
-    fn from(value: PerceptionPropertyChangeRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionPropertyChangeRequest> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionPropertyChangeRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionPropertyChangeRequest> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionPropertyChangeRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionPropertyChangeRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionPropertyChangeRequest {}
 #[cfg(feature = "deprecated")]
@@ -1876,41 +1570,7 @@ impl ::windows::core::RuntimeName for PerceptionVideoFrameAllocator {
     const NAME: &'static str = "Windows.Devices.Perception.Provider.PerceptionVideoFrameAllocator";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionVideoFrameAllocator> for ::windows::core::IUnknown {
-    fn from(value: PerceptionVideoFrameAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionVideoFrameAllocator> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionVideoFrameAllocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionVideoFrameAllocator> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionVideoFrameAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionVideoFrameAllocator> for ::windows::core::IInspectable {
-    fn from(value: PerceptionVideoFrameAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionVideoFrameAllocator> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionVideoFrameAllocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionVideoFrameAllocator> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionVideoFrameAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionVideoFrameAllocator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<PerceptionVideoFrameAllocator> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Devices/Perception/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Perception/mod.rs
@@ -2059,41 +2059,7 @@ impl ::windows::core::RuntimeName for PerceptionColorFrame {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionColorFrame";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrame> for ::windows::core::IUnknown {
-    fn from(value: PerceptionColorFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrame> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrame> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrame> for ::windows::core::IInspectable {
-    fn from(value: PerceptionColorFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrame> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrame> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionColorFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<PerceptionColorFrame> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2186,41 +2152,7 @@ impl ::windows::core::RuntimeName for PerceptionColorFrameArrivedEventArgs {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionColorFrameArrivedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PerceptionColorFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameArrivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PerceptionColorFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameArrivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionColorFrameArrivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionColorFrameArrivedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -2327,41 +2259,7 @@ impl ::windows::core::RuntimeName for PerceptionColorFrameReader {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionColorFrameReader";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameReader> for ::windows::core::IUnknown {
-    fn from(value: PerceptionColorFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameReader> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameReader> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameReader> for ::windows::core::IInspectable {
-    fn from(value: PerceptionColorFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameReader> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameReader> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionColorFrameReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<PerceptionColorFrameReader> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2729,41 +2627,7 @@ impl ::windows::core::RuntimeName for PerceptionColorFrameSource {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionColorFrameSource";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameSource> for ::windows::core::IUnknown {
-    fn from(value: PerceptionColorFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSource> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSource> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameSource> for ::windows::core::IInspectable {
-    fn from(value: PerceptionColorFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSource> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSource> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionColorFrameSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionColorFrameSource {}
 #[cfg(feature = "deprecated")]
@@ -2825,41 +2689,7 @@ impl ::windows::core::RuntimeName for PerceptionColorFrameSourceAddedEventArgs {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionColorFrameSourceAddedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameSourceAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PerceptionColorFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameSourceAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameSourceAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PerceptionColorFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameSourceAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionColorFrameSourceAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionColorFrameSourceAddedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -2921,41 +2751,7 @@ impl ::windows::core::RuntimeName for PerceptionColorFrameSourceRemovedEventArgs
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionColorFrameSourceRemovedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameSourceRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PerceptionColorFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameSourceRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameSourceRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PerceptionColorFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameSourceRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionColorFrameSourceRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionColorFrameSourceRemovedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -3089,41 +2885,7 @@ impl ::windows::core::RuntimeName for PerceptionColorFrameSourceWatcher {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionColorFrameSourceWatcher";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameSourceWatcher> for ::windows::core::IUnknown {
-    fn from(value: PerceptionColorFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceWatcher> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameSourceWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceWatcher> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionColorFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionColorFrameSourceWatcher> for ::windows::core::IInspectable {
-    fn from(value: PerceptionColorFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceWatcher> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameSourceWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionColorFrameSourceWatcher> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionColorFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionColorFrameSourceWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionColorFrameSourceWatcher {}
 #[cfg(feature = "deprecated")]
@@ -3209,41 +2971,7 @@ impl ::windows::core::RuntimeName for PerceptionControlSession {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionControlSession";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionControlSession> for ::windows::core::IUnknown {
-    fn from(value: PerceptionControlSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionControlSession> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionControlSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionControlSession> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionControlSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionControlSession> for ::windows::core::IInspectable {
-    fn from(value: PerceptionControlSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionControlSession> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionControlSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionControlSession> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionControlSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionControlSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<PerceptionControlSession> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3351,41 +3079,7 @@ impl ::windows::core::RuntimeName for PerceptionDepthCorrelatedCameraIntrinsics 
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionDepthCorrelatedCameraIntrinsics";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthCorrelatedCameraIntrinsics> for ::windows::core::IUnknown {
-    fn from(value: PerceptionDepthCorrelatedCameraIntrinsics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthCorrelatedCameraIntrinsics> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthCorrelatedCameraIntrinsics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthCorrelatedCameraIntrinsics> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthCorrelatedCameraIntrinsics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthCorrelatedCameraIntrinsics> for ::windows::core::IInspectable {
-    fn from(value: PerceptionDepthCorrelatedCameraIntrinsics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthCorrelatedCameraIntrinsics> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthCorrelatedCameraIntrinsics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthCorrelatedCameraIntrinsics> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthCorrelatedCameraIntrinsics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionDepthCorrelatedCameraIntrinsics, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionDepthCorrelatedCameraIntrinsics {}
 #[cfg(feature = "deprecated")]
@@ -3471,41 +3165,7 @@ impl ::windows::core::RuntimeName for PerceptionDepthCorrelatedCoordinateMapper 
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionDepthCorrelatedCoordinateMapper";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthCorrelatedCoordinateMapper> for ::windows::core::IUnknown {
-    fn from(value: PerceptionDepthCorrelatedCoordinateMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthCorrelatedCoordinateMapper> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthCorrelatedCoordinateMapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthCorrelatedCoordinateMapper> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthCorrelatedCoordinateMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthCorrelatedCoordinateMapper> for ::windows::core::IInspectable {
-    fn from(value: PerceptionDepthCorrelatedCoordinateMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthCorrelatedCoordinateMapper> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthCorrelatedCoordinateMapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthCorrelatedCoordinateMapper> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthCorrelatedCoordinateMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionDepthCorrelatedCoordinateMapper, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionDepthCorrelatedCoordinateMapper {}
 #[cfg(feature = "deprecated")]
@@ -3573,41 +3233,7 @@ impl ::windows::core::RuntimeName for PerceptionDepthFrame {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionDepthFrame";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrame> for ::windows::core::IUnknown {
-    fn from(value: PerceptionDepthFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrame> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrame> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrame> for ::windows::core::IInspectable {
-    fn from(value: PerceptionDepthFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrame> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrame> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionDepthFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<PerceptionDepthFrame> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3700,41 +3326,7 @@ impl ::windows::core::RuntimeName for PerceptionDepthFrameArrivedEventArgs {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionDepthFrameArrivedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PerceptionDepthFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameArrivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PerceptionDepthFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameArrivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionDepthFrameArrivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionDepthFrameArrivedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -3841,41 +3433,7 @@ impl ::windows::core::RuntimeName for PerceptionDepthFrameReader {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionDepthFrameReader";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameReader> for ::windows::core::IUnknown {
-    fn from(value: PerceptionDepthFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameReader> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameReader> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameReader> for ::windows::core::IInspectable {
-    fn from(value: PerceptionDepthFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameReader> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameReader> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionDepthFrameReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<PerceptionDepthFrameReader> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4243,41 +3801,7 @@ impl ::windows::core::RuntimeName for PerceptionDepthFrameSource {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionDepthFrameSource";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameSource> for ::windows::core::IUnknown {
-    fn from(value: PerceptionDepthFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSource> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSource> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameSource> for ::windows::core::IInspectable {
-    fn from(value: PerceptionDepthFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSource> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSource> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionDepthFrameSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionDepthFrameSource {}
 #[cfg(feature = "deprecated")]
@@ -4339,41 +3863,7 @@ impl ::windows::core::RuntimeName for PerceptionDepthFrameSourceAddedEventArgs {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionDepthFrameSourceAddedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameSourceAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PerceptionDepthFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameSourceAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameSourceAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PerceptionDepthFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameSourceAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionDepthFrameSourceAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionDepthFrameSourceAddedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -4435,41 +3925,7 @@ impl ::windows::core::RuntimeName for PerceptionDepthFrameSourceRemovedEventArgs
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionDepthFrameSourceRemovedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameSourceRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PerceptionDepthFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameSourceRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameSourceRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PerceptionDepthFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameSourceRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionDepthFrameSourceRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionDepthFrameSourceRemovedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -4603,41 +4059,7 @@ impl ::windows::core::RuntimeName for PerceptionDepthFrameSourceWatcher {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionDepthFrameSourceWatcher";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameSourceWatcher> for ::windows::core::IUnknown {
-    fn from(value: PerceptionDepthFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceWatcher> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameSourceWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceWatcher> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionDepthFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionDepthFrameSourceWatcher> for ::windows::core::IInspectable {
-    fn from(value: PerceptionDepthFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceWatcher> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameSourceWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionDepthFrameSourceWatcher> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionDepthFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionDepthFrameSourceWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionDepthFrameSourceWatcher {}
 #[cfg(feature = "deprecated")]
@@ -4708,41 +4130,7 @@ impl ::windows::core::RuntimeName for PerceptionFrameSourcePropertiesChangedEven
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionFrameSourcePropertiesChangedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionFrameSourcePropertiesChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PerceptionFrameSourcePropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameSourcePropertiesChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionFrameSourcePropertiesChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameSourcePropertiesChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionFrameSourcePropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionFrameSourcePropertiesChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PerceptionFrameSourcePropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameSourcePropertiesChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionFrameSourcePropertiesChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameSourcePropertiesChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionFrameSourcePropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionFrameSourcePropertiesChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionFrameSourcePropertiesChangedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -4813,41 +4201,7 @@ impl ::windows::core::RuntimeName for PerceptionFrameSourcePropertyChangeResult 
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionFrameSourcePropertyChangeResult";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionFrameSourcePropertyChangeResult> for ::windows::core::IUnknown {
-    fn from(value: PerceptionFrameSourcePropertyChangeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameSourcePropertyChangeResult> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionFrameSourcePropertyChangeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameSourcePropertyChangeResult> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionFrameSourcePropertyChangeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionFrameSourcePropertyChangeResult> for ::windows::core::IInspectable {
-    fn from(value: PerceptionFrameSourcePropertyChangeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameSourcePropertyChangeResult> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionFrameSourcePropertyChangeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionFrameSourcePropertyChangeResult> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionFrameSourcePropertyChangeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionFrameSourcePropertyChangeResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionFrameSourcePropertyChangeResult {}
 #[cfg(feature = "deprecated")]
@@ -4915,41 +4269,7 @@ impl ::windows::core::RuntimeName for PerceptionInfraredFrame {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionInfraredFrame";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrame> for ::windows::core::IUnknown {
-    fn from(value: PerceptionInfraredFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrame> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrame> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrame> for ::windows::core::IInspectable {
-    fn from(value: PerceptionInfraredFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrame> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrame> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionInfraredFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<PerceptionInfraredFrame> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5042,41 +4362,7 @@ impl ::windows::core::RuntimeName for PerceptionInfraredFrameArrivedEventArgs {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionInfraredFrameArrivedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PerceptionInfraredFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameArrivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PerceptionInfraredFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameArrivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionInfraredFrameArrivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionInfraredFrameArrivedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -5183,41 +4469,7 @@ impl ::windows::core::RuntimeName for PerceptionInfraredFrameReader {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionInfraredFrameReader";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameReader> for ::windows::core::IUnknown {
-    fn from(value: PerceptionInfraredFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameReader> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameReader> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameReader> for ::windows::core::IInspectable {
-    fn from(value: PerceptionInfraredFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameReader> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameReader> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionInfraredFrameReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<PerceptionInfraredFrameReader> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5585,41 +4837,7 @@ impl ::windows::core::RuntimeName for PerceptionInfraredFrameSource {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionInfraredFrameSource";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameSource> for ::windows::core::IUnknown {
-    fn from(value: PerceptionInfraredFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSource> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSource> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameSource> for ::windows::core::IInspectable {
-    fn from(value: PerceptionInfraredFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSource> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSource> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionInfraredFrameSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionInfraredFrameSource {}
 #[cfg(feature = "deprecated")]
@@ -5681,41 +4899,7 @@ impl ::windows::core::RuntimeName for PerceptionInfraredFrameSourceAddedEventArg
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionInfraredFrameSourceAddedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameSourceAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PerceptionInfraredFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameSourceAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameSourceAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PerceptionInfraredFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameSourceAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameSourceAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionInfraredFrameSourceAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionInfraredFrameSourceAddedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -5777,41 +4961,7 @@ impl ::windows::core::RuntimeName for PerceptionInfraredFrameSourceRemovedEventA
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionInfraredFrameSourceRemovedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameSourceRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PerceptionInfraredFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameSourceRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameSourceRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PerceptionInfraredFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameSourceRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameSourceRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionInfraredFrameSourceRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionInfraredFrameSourceRemovedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -5945,41 +5095,7 @@ impl ::windows::core::RuntimeName for PerceptionInfraredFrameSourceWatcher {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionInfraredFrameSourceWatcher";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameSourceWatcher> for ::windows::core::IUnknown {
-    fn from(value: PerceptionInfraredFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceWatcher> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameSourceWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceWatcher> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionInfraredFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionInfraredFrameSourceWatcher> for ::windows::core::IInspectable {
-    fn from(value: PerceptionInfraredFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceWatcher> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameSourceWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionInfraredFrameSourceWatcher> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionInfraredFrameSourceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionInfraredFrameSourceWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionInfraredFrameSourceWatcher {}
 #[cfg(feature = "deprecated")]
@@ -6086,41 +5202,7 @@ impl ::windows::core::RuntimeName for PerceptionVideoProfile {
     const NAME: &'static str = "Windows.Devices.Perception.PerceptionVideoProfile";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionVideoProfile> for ::windows::core::IUnknown {
-    fn from(value: PerceptionVideoProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionVideoProfile> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionVideoProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionVideoProfile> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionVideoProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PerceptionVideoProfile> for ::windows::core::IInspectable {
-    fn from(value: PerceptionVideoProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionVideoProfile> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionVideoProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PerceptionVideoProfile> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionVideoProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionVideoProfile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PerceptionVideoProfile {}
 #[cfg(feature = "deprecated")]

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/Provider/mod.rs
@@ -828,36 +828,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerDisableScannerRequest {
 impl ::windows::core::RuntimeName for BarcodeScannerDisableScannerRequest {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerDisableScannerRequest";
 }
-impl ::core::convert::From<BarcodeScannerDisableScannerRequest> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerDisableScannerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDisableScannerRequest> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerDisableScannerRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDisableScannerRequest> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerDisableScannerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerDisableScannerRequest> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerDisableScannerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDisableScannerRequest> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerDisableScannerRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDisableScannerRequest> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerDisableScannerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerDisableScannerRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerDisableScannerRequest {}
 unsafe impl ::core::marker::Sync for BarcodeScannerDisableScannerRequest {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -913,36 +884,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerDisableScannerRequestEv
 impl ::windows::core::RuntimeName for BarcodeScannerDisableScannerRequestEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerDisableScannerRequestEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerDisableScannerRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerDisableScannerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDisableScannerRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerDisableScannerRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDisableScannerRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerDisableScannerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerDisableScannerRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerDisableScannerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDisableScannerRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerDisableScannerRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDisableScannerRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerDisableScannerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerDisableScannerRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerDisableScannerRequestEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerDisableScannerRequestEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -1018,36 +960,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerEnableScannerRequest {
 impl ::windows::core::RuntimeName for BarcodeScannerEnableScannerRequest {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerEnableScannerRequest";
 }
-impl ::core::convert::From<BarcodeScannerEnableScannerRequest> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerEnableScannerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerEnableScannerRequest> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerEnableScannerRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerEnableScannerRequest> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerEnableScannerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerEnableScannerRequest> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerEnableScannerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerEnableScannerRequest> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerEnableScannerRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerEnableScannerRequest> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerEnableScannerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerEnableScannerRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerEnableScannerRequest {}
 unsafe impl ::core::marker::Sync for BarcodeScannerEnableScannerRequest {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -1103,36 +1016,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerEnableScannerRequestEve
 impl ::windows::core::RuntimeName for BarcodeScannerEnableScannerRequestEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerEnableScannerRequestEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerEnableScannerRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerEnableScannerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerEnableScannerRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerEnableScannerRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerEnableScannerRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerEnableScannerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerEnableScannerRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerEnableScannerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerEnableScannerRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerEnableScannerRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerEnableScannerRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerEnableScannerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerEnableScannerRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerEnableScannerRequestEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerEnableScannerRequestEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -1227,36 +1111,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerFrameReader {
 impl ::windows::core::RuntimeName for BarcodeScannerFrameReader {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerFrameReader";
 }
-impl ::core::convert::From<BarcodeScannerFrameReader> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerFrameReader> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerFrameReader> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerFrameReader> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerFrameReader> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerFrameReader> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerFrameReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<BarcodeScannerFrameReader> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1327,36 +1182,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerFrameReaderFrameArrived
 impl ::windows::core::RuntimeName for BarcodeScannerFrameReaderFrameArrivedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerFrameReaderFrameArrivedEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerFrameReaderFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerFrameReaderFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerFrameReaderFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerFrameReaderFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerFrameReaderFrameArrivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerFrameReaderFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerFrameReaderFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerFrameReaderFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerFrameReaderFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerFrameReaderFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerFrameReaderFrameArrivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerFrameReaderFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerFrameReaderFrameArrivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerFrameReaderFrameArrivedEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerFrameReaderFrameArrivedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -1439,36 +1265,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerGetSymbologyAttributesR
 impl ::windows::core::RuntimeName for BarcodeScannerGetSymbologyAttributesRequest {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerGetSymbologyAttributesRequest";
 }
-impl ::core::convert::From<BarcodeScannerGetSymbologyAttributesRequest> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerGetSymbologyAttributesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerGetSymbologyAttributesRequest> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerGetSymbologyAttributesRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerGetSymbologyAttributesRequest> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerGetSymbologyAttributesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerGetSymbologyAttributesRequest> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerGetSymbologyAttributesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerGetSymbologyAttributesRequest> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerGetSymbologyAttributesRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerGetSymbologyAttributesRequest> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerGetSymbologyAttributesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerGetSymbologyAttributesRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerGetSymbologyAttributesRequest {}
 unsafe impl ::core::marker::Sync for BarcodeScannerGetSymbologyAttributesRequest {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -1524,36 +1321,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerGetSymbologyAttributesR
 impl ::windows::core::RuntimeName for BarcodeScannerGetSymbologyAttributesRequestEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerGetSymbologyAttributesRequestEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerGetSymbologyAttributesRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerGetSymbologyAttributesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerGetSymbologyAttributesRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerGetSymbologyAttributesRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerGetSymbologyAttributesRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerGetSymbologyAttributesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerGetSymbologyAttributesRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerGetSymbologyAttributesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerGetSymbologyAttributesRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerGetSymbologyAttributesRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerGetSymbologyAttributesRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerGetSymbologyAttributesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerGetSymbologyAttributesRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerGetSymbologyAttributesRequestEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerGetSymbologyAttributesRequestEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -1629,36 +1397,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerHideVideoPreviewRequest
 impl ::windows::core::RuntimeName for BarcodeScannerHideVideoPreviewRequest {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerHideVideoPreviewRequest";
 }
-impl ::core::convert::From<BarcodeScannerHideVideoPreviewRequest> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerHideVideoPreviewRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerHideVideoPreviewRequest> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerHideVideoPreviewRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerHideVideoPreviewRequest> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerHideVideoPreviewRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerHideVideoPreviewRequest> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerHideVideoPreviewRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerHideVideoPreviewRequest> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerHideVideoPreviewRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerHideVideoPreviewRequest> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerHideVideoPreviewRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerHideVideoPreviewRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerHideVideoPreviewRequest {}
 unsafe impl ::core::marker::Sync for BarcodeScannerHideVideoPreviewRequest {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -1714,36 +1453,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerHideVideoPreviewRequest
 impl ::windows::core::RuntimeName for BarcodeScannerHideVideoPreviewRequestEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerHideVideoPreviewRequestEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerHideVideoPreviewRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerHideVideoPreviewRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerHideVideoPreviewRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerHideVideoPreviewRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerHideVideoPreviewRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerHideVideoPreviewRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerHideVideoPreviewRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerHideVideoPreviewRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerHideVideoPreviewRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerHideVideoPreviewRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerHideVideoPreviewRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerHideVideoPreviewRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerHideVideoPreviewRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerHideVideoPreviewRequestEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerHideVideoPreviewRequestEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -2032,36 +1742,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerProviderConnection {
 impl ::windows::core::RuntimeName for BarcodeScannerProviderConnection {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerProviderConnection";
 }
-impl ::core::convert::From<BarcodeScannerProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerProviderConnection> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerProviderConnection> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerProviderConnection> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerProviderConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerProviderConnection> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerProviderConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerProviderConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<BarcodeScannerProviderConnection> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2130,36 +1811,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerProviderTriggerDetails 
 impl ::windows::core::RuntimeName for BarcodeScannerProviderTriggerDetails {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerProviderTriggerDetails";
 }
-impl ::core::convert::From<BarcodeScannerProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerProviderTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerProviderTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerProviderTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerProviderTriggerDetails {}
 unsafe impl ::core::marker::Sync for BarcodeScannerProviderTriggerDetails {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -2244,36 +1896,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerSetActiveSymbologiesReq
 impl ::windows::core::RuntimeName for BarcodeScannerSetActiveSymbologiesRequest {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerSetActiveSymbologiesRequest";
 }
-impl ::core::convert::From<BarcodeScannerSetActiveSymbologiesRequest> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerSetActiveSymbologiesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetActiveSymbologiesRequest> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerSetActiveSymbologiesRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetActiveSymbologiesRequest> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerSetActiveSymbologiesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerSetActiveSymbologiesRequest> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerSetActiveSymbologiesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetActiveSymbologiesRequest> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerSetActiveSymbologiesRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetActiveSymbologiesRequest> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerSetActiveSymbologiesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerSetActiveSymbologiesRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerSetActiveSymbologiesRequest {}
 unsafe impl ::core::marker::Sync for BarcodeScannerSetActiveSymbologiesRequest {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -2329,36 +1952,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerSetActiveSymbologiesReq
 impl ::windows::core::RuntimeName for BarcodeScannerSetActiveSymbologiesRequestEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerSetActiveSymbologiesRequestEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerSetActiveSymbologiesRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerSetActiveSymbologiesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetActiveSymbologiesRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerSetActiveSymbologiesRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetActiveSymbologiesRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerSetActiveSymbologiesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerSetActiveSymbologiesRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerSetActiveSymbologiesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetActiveSymbologiesRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerSetActiveSymbologiesRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetActiveSymbologiesRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerSetActiveSymbologiesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerSetActiveSymbologiesRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerSetActiveSymbologiesRequestEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerSetActiveSymbologiesRequestEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -2448,36 +2042,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerSetSymbologyAttributesR
 impl ::windows::core::RuntimeName for BarcodeScannerSetSymbologyAttributesRequest {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerSetSymbologyAttributesRequest";
 }
-impl ::core::convert::From<BarcodeScannerSetSymbologyAttributesRequest> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerSetSymbologyAttributesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetSymbologyAttributesRequest> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerSetSymbologyAttributesRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetSymbologyAttributesRequest> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerSetSymbologyAttributesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerSetSymbologyAttributesRequest> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerSetSymbologyAttributesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetSymbologyAttributesRequest> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerSetSymbologyAttributesRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetSymbologyAttributesRequest> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerSetSymbologyAttributesRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerSetSymbologyAttributesRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerSetSymbologyAttributesRequest {}
 unsafe impl ::core::marker::Sync for BarcodeScannerSetSymbologyAttributesRequest {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -2533,36 +2098,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerSetSymbologyAttributesR
 impl ::windows::core::RuntimeName for BarcodeScannerSetSymbologyAttributesRequestEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerSetSymbologyAttributesRequestEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerSetSymbologyAttributesRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerSetSymbologyAttributesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetSymbologyAttributesRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerSetSymbologyAttributesRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetSymbologyAttributesRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerSetSymbologyAttributesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerSetSymbologyAttributesRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerSetSymbologyAttributesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetSymbologyAttributesRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerSetSymbologyAttributesRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerSetSymbologyAttributesRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerSetSymbologyAttributesRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerSetSymbologyAttributesRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerSetSymbologyAttributesRequestEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerSetSymbologyAttributesRequestEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -2638,36 +2174,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerStartSoftwareTriggerReq
 impl ::windows::core::RuntimeName for BarcodeScannerStartSoftwareTriggerRequest {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerStartSoftwareTriggerRequest";
 }
-impl ::core::convert::From<BarcodeScannerStartSoftwareTriggerRequest> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerStartSoftwareTriggerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStartSoftwareTriggerRequest> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerStartSoftwareTriggerRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStartSoftwareTriggerRequest> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerStartSoftwareTriggerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerStartSoftwareTriggerRequest> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerStartSoftwareTriggerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStartSoftwareTriggerRequest> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerStartSoftwareTriggerRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStartSoftwareTriggerRequest> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerStartSoftwareTriggerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerStartSoftwareTriggerRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerStartSoftwareTriggerRequest {}
 unsafe impl ::core::marker::Sync for BarcodeScannerStartSoftwareTriggerRequest {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -2723,36 +2230,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerStartSoftwareTriggerReq
 impl ::windows::core::RuntimeName for BarcodeScannerStartSoftwareTriggerRequestEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerStartSoftwareTriggerRequestEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerStartSoftwareTriggerRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerStartSoftwareTriggerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStartSoftwareTriggerRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerStartSoftwareTriggerRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStartSoftwareTriggerRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerStartSoftwareTriggerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerStartSoftwareTriggerRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerStartSoftwareTriggerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStartSoftwareTriggerRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerStartSoftwareTriggerRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStartSoftwareTriggerRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerStartSoftwareTriggerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerStartSoftwareTriggerRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerStartSoftwareTriggerRequestEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerStartSoftwareTriggerRequestEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -2828,36 +2306,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerStopSoftwareTriggerRequ
 impl ::windows::core::RuntimeName for BarcodeScannerStopSoftwareTriggerRequest {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerStopSoftwareTriggerRequest";
 }
-impl ::core::convert::From<BarcodeScannerStopSoftwareTriggerRequest> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerStopSoftwareTriggerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStopSoftwareTriggerRequest> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerStopSoftwareTriggerRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStopSoftwareTriggerRequest> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerStopSoftwareTriggerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerStopSoftwareTriggerRequest> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerStopSoftwareTriggerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStopSoftwareTriggerRequest> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerStopSoftwareTriggerRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStopSoftwareTriggerRequest> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerStopSoftwareTriggerRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerStopSoftwareTriggerRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerStopSoftwareTriggerRequest {}
 unsafe impl ::core::marker::Sync for BarcodeScannerStopSoftwareTriggerRequest {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -2913,36 +2362,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerStopSoftwareTriggerRequ
 impl ::windows::core::RuntimeName for BarcodeScannerStopSoftwareTriggerRequestEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerStopSoftwareTriggerRequestEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerStopSoftwareTriggerRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerStopSoftwareTriggerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStopSoftwareTriggerRequestEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerStopSoftwareTriggerRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStopSoftwareTriggerRequestEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerStopSoftwareTriggerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerStopSoftwareTriggerRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerStopSoftwareTriggerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStopSoftwareTriggerRequestEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerStopSoftwareTriggerRequestEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStopSoftwareTriggerRequestEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerStopSoftwareTriggerRequestEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerStopSoftwareTriggerRequestEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerStopSoftwareTriggerRequestEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerStopSoftwareTriggerRequestEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]
@@ -3020,36 +2440,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerVideoFrame {
 impl ::windows::core::RuntimeName for BarcodeScannerVideoFrame {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeScannerVideoFrame";
 }
-impl ::core::convert::From<BarcodeScannerVideoFrame> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerVideoFrame> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerVideoFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerVideoFrame> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerVideoFrame> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerVideoFrame> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerVideoFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerVideoFrame> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerVideoFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<BarcodeScannerVideoFrame> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3158,36 +2549,7 @@ unsafe impl ::windows::core::Interface for BarcodeSymbologyAttributesBuilder {
 impl ::windows::core::RuntimeName for BarcodeSymbologyAttributesBuilder {
     const NAME: &'static str = "Windows.Devices.PointOfService.Provider.BarcodeSymbologyAttributesBuilder";
 }
-impl ::core::convert::From<BarcodeSymbologyAttributesBuilder> for ::windows::core::IUnknown {
-    fn from(value: BarcodeSymbologyAttributesBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeSymbologyAttributesBuilder> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeSymbologyAttributesBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeSymbologyAttributesBuilder> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeSymbologyAttributesBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeSymbologyAttributesBuilder> for ::windows::core::IInspectable {
-    fn from(value: BarcodeSymbologyAttributesBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeSymbologyAttributesBuilder> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeSymbologyAttributesBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeSymbologyAttributesBuilder> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeSymbologyAttributesBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeSymbologyAttributesBuilder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeSymbologyAttributesBuilder {}
 unsafe impl ::core::marker::Sync for BarcodeSymbologyAttributesBuilder {}
 #[doc = "*Required features: `\"Devices_PointOfService_Provider\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
@@ -560,36 +560,7 @@ impl ICashDrawerEventSourceEventArgs {
         }
     }
 }
-impl ::core::convert::From<ICashDrawerEventSourceEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ICashDrawerEventSourceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICashDrawerEventSourceEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICashDrawerEventSourceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICashDrawerEventSourceEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ICashDrawerEventSourceEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICashDrawerEventSourceEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ICashDrawerEventSourceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICashDrawerEventSourceEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICashDrawerEventSourceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICashDrawerEventSourceEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ICashDrawerEventSourceEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICashDrawerEventSourceEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICashDrawerEventSourceEventArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1567,36 +1538,7 @@ impl ICommonClaimedPosPrinterStation {
         }
     }
 }
-impl ::core::convert::From<ICommonClaimedPosPrinterStation> for ::windows::core::IUnknown {
-    fn from(value: ICommonClaimedPosPrinterStation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommonClaimedPosPrinterStation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommonClaimedPosPrinterStation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommonClaimedPosPrinterStation> for ::windows::core::IUnknown {
-    fn from(value: &ICommonClaimedPosPrinterStation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICommonClaimedPosPrinterStation> for ::windows::core::IInspectable {
-    fn from(value: ICommonClaimedPosPrinterStation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommonClaimedPosPrinterStation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICommonClaimedPosPrinterStation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommonClaimedPosPrinterStation> for ::windows::core::IInspectable {
-    fn from(value: &ICommonClaimedPosPrinterStation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommonClaimedPosPrinterStation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICommonClaimedPosPrinterStation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1748,36 +1690,7 @@ impl ICommonPosPrintStationCapabilities {
         }
     }
 }
-impl ::core::convert::From<ICommonPosPrintStationCapabilities> for ::windows::core::IUnknown {
-    fn from(value: ICommonPosPrintStationCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommonPosPrintStationCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommonPosPrintStationCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommonPosPrintStationCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &ICommonPosPrintStationCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICommonPosPrintStationCapabilities> for ::windows::core::IInspectable {
-    fn from(value: ICommonPosPrintStationCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommonPosPrintStationCapabilities> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICommonPosPrintStationCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommonPosPrintStationCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &ICommonPosPrintStationCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommonPosPrintStationCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICommonPosPrintStationCapabilities {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1993,36 +1906,7 @@ impl ICommonReceiptSlipCapabilities {
         }
     }
 }
-impl ::core::convert::From<ICommonReceiptSlipCapabilities> for ::windows::core::IUnknown {
-    fn from(value: ICommonReceiptSlipCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommonReceiptSlipCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommonReceiptSlipCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommonReceiptSlipCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &ICommonReceiptSlipCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICommonReceiptSlipCapabilities> for ::windows::core::IInspectable {
-    fn from(value: ICommonReceiptSlipCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommonReceiptSlipCapabilities> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICommonReceiptSlipCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommonReceiptSlipCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &ICommonReceiptSlipCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommonReceiptSlipCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ICommonReceiptSlipCapabilities> for ICommonPosPrintStationCapabilities {
     type Error = ::windows::core::Error;
     fn try_from(value: ICommonReceiptSlipCapabilities) -> ::windows::core::Result<Self> {
@@ -3014,36 +2898,7 @@ impl IPosPrinterJob {
         }
     }
 }
-impl ::core::convert::From<IPosPrinterJob> for ::windows::core::IUnknown {
-    fn from(value: IPosPrinterJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPosPrinterJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPosPrinterJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPosPrinterJob> for ::windows::core::IUnknown {
-    fn from(value: &IPosPrinterJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPosPrinterJob> for ::windows::core::IInspectable {
-    fn from(value: IPosPrinterJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPosPrinterJob> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPosPrinterJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPosPrinterJob> for ::windows::core::IInspectable {
-    fn from(value: &IPosPrinterJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPosPrinterJob, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPosPrinterJob {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3312,36 +3167,7 @@ impl IReceiptOrSlipJob {
         }
     }
 }
-impl ::core::convert::From<IReceiptOrSlipJob> for ::windows::core::IUnknown {
-    fn from(value: IReceiptOrSlipJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IReceiptOrSlipJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IReceiptOrSlipJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IReceiptOrSlipJob> for ::windows::core::IUnknown {
-    fn from(value: &IReceiptOrSlipJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IReceiptOrSlipJob> for ::windows::core::IInspectable {
-    fn from(value: IReceiptOrSlipJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IReceiptOrSlipJob> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IReceiptOrSlipJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IReceiptOrSlipJob> for ::windows::core::IInspectable {
-    fn from(value: &IReceiptOrSlipJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IReceiptOrSlipJob, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IReceiptOrSlipJob> for IPosPrinterJob {
     type Error = ::windows::core::Error;
     fn try_from(value: IReceiptOrSlipJob) -> ::windows::core::Result<Self> {
@@ -3777,36 +3603,7 @@ unsafe impl ::windows::core::Interface for BarcodeScanner {
 impl ::windows::core::RuntimeName for BarcodeScanner {
     const NAME: &'static str = "Windows.Devices.PointOfService.BarcodeScanner";
 }
-impl ::core::convert::From<BarcodeScanner> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScanner> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScanner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScanner> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScanner> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScanner> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScanner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScanner> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScanner, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<BarcodeScanner> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3910,36 +3707,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerCapabilities {
 impl ::windows::core::RuntimeName for BarcodeScannerCapabilities {
     const NAME: &'static str = "Windows.Devices.PointOfService.BarcodeScannerCapabilities";
 }
-impl ::core::convert::From<BarcodeScannerCapabilities> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerCapabilities> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerCapabilities {}
 unsafe impl ::core::marker::Sync for BarcodeScannerCapabilities {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -3986,36 +3754,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerDataReceivedEventArgs {
 impl ::windows::core::RuntimeName for BarcodeScannerDataReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.BarcodeScannerDataReceivedEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDataReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerDataReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerDataReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerDataReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerDataReceivedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -4076,36 +3815,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerErrorOccurredEventArgs 
 impl ::windows::core::RuntimeName for BarcodeScannerErrorOccurredEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.BarcodeScannerErrorOccurredEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerErrorOccurredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerErrorOccurredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerErrorOccurredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerErrorOccurredEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerErrorOccurredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerErrorOccurredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerErrorOccurredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerErrorOccurredEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerErrorOccurredEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerErrorOccurredEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerErrorOccurredEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -4154,36 +3864,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerImagePreviewReceivedEve
 impl ::windows::core::RuntimeName for BarcodeScannerImagePreviewReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.BarcodeScannerImagePreviewReceivedEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerImagePreviewReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerImagePreviewReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerImagePreviewReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerImagePreviewReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerImagePreviewReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerImagePreviewReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerImagePreviewReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerImagePreviewReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerImagePreviewReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerImagePreviewReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerImagePreviewReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerImagePreviewReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerImagePreviewReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerImagePreviewReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerImagePreviewReceivedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -4267,36 +3948,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerReport {
 impl ::windows::core::RuntimeName for BarcodeScannerReport {
     const NAME: &'static str = "Windows.Devices.PointOfService.BarcodeScannerReport";
 }
-impl ::core::convert::From<BarcodeScannerReport> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerReport> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerReport> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerReport> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerReport> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerReport> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerReport {}
 unsafe impl ::core::marker::Sync for BarcodeScannerReport {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -4350,36 +4002,7 @@ unsafe impl ::windows::core::Interface for BarcodeScannerStatusUpdatedEventArgs 
 impl ::windows::core::RuntimeName for BarcodeScannerStatusUpdatedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.BarcodeScannerStatusUpdatedEventArgs";
 }
-impl ::core::convert::From<BarcodeScannerStatusUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarcodeScannerStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStatusUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerStatusUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStatusUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeScannerStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeScannerStatusUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarcodeScannerStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStatusUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerStatusUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeScannerStatusUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeScannerStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeScannerStatusUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeScannerStatusUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for BarcodeScannerStatusUpdatedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -5082,36 +4705,7 @@ unsafe impl ::windows::core::Interface for BarcodeSymbologyAttributes {
 impl ::windows::core::RuntimeName for BarcodeSymbologyAttributes {
     const NAME: &'static str = "Windows.Devices.PointOfService.BarcodeSymbologyAttributes";
 }
-impl ::core::convert::From<BarcodeSymbologyAttributes> for ::windows::core::IUnknown {
-    fn from(value: BarcodeSymbologyAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeSymbologyAttributes> for ::windows::core::IUnknown {
-    fn from(value: &BarcodeSymbologyAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeSymbologyAttributes> for &::windows::core::IUnknown {
-    fn from(value: &BarcodeSymbologyAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarcodeSymbologyAttributes> for ::windows::core::IInspectable {
-    fn from(value: BarcodeSymbologyAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarcodeSymbologyAttributes> for ::windows::core::IInspectable {
-    fn from(value: &BarcodeSymbologyAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarcodeSymbologyAttributes> for &::windows::core::IInspectable {
-    fn from(value: &BarcodeSymbologyAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarcodeSymbologyAttributes, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarcodeSymbologyAttributes {}
 unsafe impl ::core::marker::Sync for BarcodeSymbologyAttributes {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -5276,36 +4870,7 @@ unsafe impl ::windows::core::Interface for CashDrawer {
 impl ::windows::core::RuntimeName for CashDrawer {
     const NAME: &'static str = "Windows.Devices.PointOfService.CashDrawer";
 }
-impl ::core::convert::From<CashDrawer> for ::windows::core::IUnknown {
-    fn from(value: CashDrawer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawer> for ::windows::core::IUnknown {
-    fn from(value: &CashDrawer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawer> for &::windows::core::IUnknown {
-    fn from(value: &CashDrawer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CashDrawer> for ::windows::core::IInspectable {
-    fn from(value: CashDrawer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawer> for ::windows::core::IInspectable {
-    fn from(value: &CashDrawer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawer> for &::windows::core::IInspectable {
-    fn from(value: &CashDrawer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CashDrawer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<CashDrawer> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5409,36 +4974,7 @@ unsafe impl ::windows::core::Interface for CashDrawerCapabilities {
 impl ::windows::core::RuntimeName for CashDrawerCapabilities {
     const NAME: &'static str = "Windows.Devices.PointOfService.CashDrawerCapabilities";
 }
-impl ::core::convert::From<CashDrawerCapabilities> for ::windows::core::IUnknown {
-    fn from(value: CashDrawerCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &CashDrawerCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &CashDrawerCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CashDrawerCapabilities> for ::windows::core::IInspectable {
-    fn from(value: CashDrawerCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &CashDrawerCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &CashDrawerCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CashDrawerCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CashDrawerCapabilities {}
 unsafe impl ::core::marker::Sync for CashDrawerCapabilities {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -5558,36 +5094,7 @@ unsafe impl ::windows::core::Interface for CashDrawerCloseAlarm {
 impl ::windows::core::RuntimeName for CashDrawerCloseAlarm {
     const NAME: &'static str = "Windows.Devices.PointOfService.CashDrawerCloseAlarm";
 }
-impl ::core::convert::From<CashDrawerCloseAlarm> for ::windows::core::IUnknown {
-    fn from(value: CashDrawerCloseAlarm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerCloseAlarm> for ::windows::core::IUnknown {
-    fn from(value: &CashDrawerCloseAlarm) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerCloseAlarm> for &::windows::core::IUnknown {
-    fn from(value: &CashDrawerCloseAlarm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CashDrawerCloseAlarm> for ::windows::core::IInspectable {
-    fn from(value: CashDrawerCloseAlarm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerCloseAlarm> for ::windows::core::IInspectable {
-    fn from(value: &CashDrawerCloseAlarm) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerCloseAlarm> for &::windows::core::IInspectable {
-    fn from(value: &CashDrawerCloseAlarm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CashDrawerCloseAlarm, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CashDrawerCloseAlarm {}
 unsafe impl ::core::marker::Sync for CashDrawerCloseAlarm {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -5634,36 +5141,7 @@ unsafe impl ::windows::core::Interface for CashDrawerClosedEventArgs {
 impl ::windows::core::RuntimeName for CashDrawerClosedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.CashDrawerClosedEventArgs";
 }
-impl ::core::convert::From<CashDrawerClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CashDrawerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CashDrawerClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerClosedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CashDrawerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CashDrawerClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CashDrawerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CashDrawerClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerClosedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CashDrawerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CashDrawerClosedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CashDrawerClosedEventArgs> for ICashDrawerEventSourceEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: CashDrawerClosedEventArgs) -> ::windows::core::Result<Self> {
@@ -5752,36 +5230,7 @@ unsafe impl ::windows::core::Interface for CashDrawerEventSource {
 impl ::windows::core::RuntimeName for CashDrawerEventSource {
     const NAME: &'static str = "Windows.Devices.PointOfService.CashDrawerEventSource";
 }
-impl ::core::convert::From<CashDrawerEventSource> for ::windows::core::IUnknown {
-    fn from(value: CashDrawerEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerEventSource> for ::windows::core::IUnknown {
-    fn from(value: &CashDrawerEventSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerEventSource> for &::windows::core::IUnknown {
-    fn from(value: &CashDrawerEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CashDrawerEventSource> for ::windows::core::IInspectable {
-    fn from(value: CashDrawerEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerEventSource> for ::windows::core::IInspectable {
-    fn from(value: &CashDrawerEventSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerEventSource> for &::windows::core::IInspectable {
-    fn from(value: &CashDrawerEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CashDrawerEventSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CashDrawerEventSource {}
 unsafe impl ::core::marker::Sync for CashDrawerEventSource {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -5828,36 +5277,7 @@ unsafe impl ::windows::core::Interface for CashDrawerOpenedEventArgs {
 impl ::windows::core::RuntimeName for CashDrawerOpenedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.CashDrawerOpenedEventArgs";
 }
-impl ::core::convert::From<CashDrawerOpenedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CashDrawerOpenedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerOpenedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CashDrawerOpenedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerOpenedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CashDrawerOpenedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CashDrawerOpenedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CashDrawerOpenedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerOpenedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CashDrawerOpenedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerOpenedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CashDrawerOpenedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CashDrawerOpenedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CashDrawerOpenedEventArgs> for ICashDrawerEventSourceEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: CashDrawerOpenedEventArgs) -> ::windows::core::Result<Self> {
@@ -5930,36 +5350,7 @@ unsafe impl ::windows::core::Interface for CashDrawerStatus {
 impl ::windows::core::RuntimeName for CashDrawerStatus {
     const NAME: &'static str = "Windows.Devices.PointOfService.CashDrawerStatus";
 }
-impl ::core::convert::From<CashDrawerStatus> for ::windows::core::IUnknown {
-    fn from(value: CashDrawerStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerStatus> for ::windows::core::IUnknown {
-    fn from(value: &CashDrawerStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerStatus> for &::windows::core::IUnknown {
-    fn from(value: &CashDrawerStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CashDrawerStatus> for ::windows::core::IInspectable {
-    fn from(value: CashDrawerStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerStatus> for ::windows::core::IInspectable {
-    fn from(value: &CashDrawerStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerStatus> for &::windows::core::IInspectable {
-    fn from(value: &CashDrawerStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CashDrawerStatus, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CashDrawerStatus {}
 unsafe impl ::core::marker::Sync for CashDrawerStatus {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -6006,36 +5397,7 @@ unsafe impl ::windows::core::Interface for CashDrawerStatusUpdatedEventArgs {
 impl ::windows::core::RuntimeName for CashDrawerStatusUpdatedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.CashDrawerStatusUpdatedEventArgs";
 }
-impl ::core::convert::From<CashDrawerStatusUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CashDrawerStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerStatusUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CashDrawerStatusUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerStatusUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CashDrawerStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CashDrawerStatusUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CashDrawerStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CashDrawerStatusUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CashDrawerStatusUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CashDrawerStatusUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CashDrawerStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CashDrawerStatusUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CashDrawerStatusUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for CashDrawerStatusUpdatedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -6352,36 +5714,7 @@ unsafe impl ::windows::core::Interface for ClaimedBarcodeScanner {
 impl ::windows::core::RuntimeName for ClaimedBarcodeScanner {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedBarcodeScanner";
 }
-impl ::core::convert::From<ClaimedBarcodeScanner> for ::windows::core::IUnknown {
-    fn from(value: ClaimedBarcodeScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedBarcodeScanner> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedBarcodeScanner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedBarcodeScanner> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedBarcodeScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedBarcodeScanner> for ::windows::core::IInspectable {
-    fn from(value: ClaimedBarcodeScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedBarcodeScanner> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedBarcodeScanner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedBarcodeScanner> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedBarcodeScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedBarcodeScanner, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ClaimedBarcodeScanner> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -6442,36 +5775,7 @@ unsafe impl ::windows::core::Interface for ClaimedBarcodeScannerClosedEventArgs 
 impl ::windows::core::RuntimeName for ClaimedBarcodeScannerClosedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedBarcodeScannerClosedEventArgs";
 }
-impl ::core::convert::From<ClaimedBarcodeScannerClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ClaimedBarcodeScannerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedBarcodeScannerClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedBarcodeScannerClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedBarcodeScannerClosedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedBarcodeScannerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedBarcodeScannerClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ClaimedBarcodeScannerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedBarcodeScannerClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedBarcodeScannerClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedBarcodeScannerClosedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedBarcodeScannerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedBarcodeScannerClosedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ClaimedBarcodeScannerClosedEventArgs {}
 unsafe impl ::core::marker::Sync for ClaimedBarcodeScannerClosedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -6637,36 +5941,7 @@ unsafe impl ::windows::core::Interface for ClaimedCashDrawer {
 impl ::windows::core::RuntimeName for ClaimedCashDrawer {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedCashDrawer";
 }
-impl ::core::convert::From<ClaimedCashDrawer> for ::windows::core::IUnknown {
-    fn from(value: ClaimedCashDrawer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedCashDrawer> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedCashDrawer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedCashDrawer> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedCashDrawer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedCashDrawer> for ::windows::core::IInspectable {
-    fn from(value: ClaimedCashDrawer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedCashDrawer> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedCashDrawer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedCashDrawer> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedCashDrawer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedCashDrawer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ClaimedCashDrawer> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -6727,36 +6002,7 @@ unsafe impl ::windows::core::Interface for ClaimedCashDrawerClosedEventArgs {
 impl ::windows::core::RuntimeName for ClaimedCashDrawerClosedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedCashDrawerClosedEventArgs";
 }
-impl ::core::convert::From<ClaimedCashDrawerClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ClaimedCashDrawerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedCashDrawerClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedCashDrawerClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedCashDrawerClosedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedCashDrawerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedCashDrawerClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ClaimedCashDrawerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedCashDrawerClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedCashDrawerClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedCashDrawerClosedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedCashDrawerClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedCashDrawerClosedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ClaimedCashDrawerClosedEventArgs {}
 unsafe impl ::core::marker::Sync for ClaimedCashDrawerClosedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -6921,36 +6167,7 @@ unsafe impl ::windows::core::Interface for ClaimedJournalPrinter {
 impl ::windows::core::RuntimeName for ClaimedJournalPrinter {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedJournalPrinter";
 }
-impl ::core::convert::From<ClaimedJournalPrinter> for ::windows::core::IUnknown {
-    fn from(value: ClaimedJournalPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedJournalPrinter> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedJournalPrinter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedJournalPrinter> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedJournalPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedJournalPrinter> for ::windows::core::IInspectable {
-    fn from(value: ClaimedJournalPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedJournalPrinter> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedJournalPrinter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedJournalPrinter> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedJournalPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedJournalPrinter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ClaimedJournalPrinter> for ICommonClaimedPosPrinterStation {
     type Error = ::windows::core::Error;
     fn try_from(value: ClaimedJournalPrinter) -> ::windows::core::Result<Self> {
@@ -7280,36 +6497,7 @@ unsafe impl ::windows::core::Interface for ClaimedLineDisplay {
 impl ::windows::core::RuntimeName for ClaimedLineDisplay {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedLineDisplay";
 }
-impl ::core::convert::From<ClaimedLineDisplay> for ::windows::core::IUnknown {
-    fn from(value: ClaimedLineDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedLineDisplay> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedLineDisplay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedLineDisplay> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedLineDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedLineDisplay> for ::windows::core::IInspectable {
-    fn from(value: ClaimedLineDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedLineDisplay> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedLineDisplay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedLineDisplay> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedLineDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedLineDisplay, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ClaimedLineDisplay> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -7370,36 +6558,7 @@ unsafe impl ::windows::core::Interface for ClaimedLineDisplayClosedEventArgs {
 impl ::windows::core::RuntimeName for ClaimedLineDisplayClosedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedLineDisplayClosedEventArgs";
 }
-impl ::core::convert::From<ClaimedLineDisplayClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ClaimedLineDisplayClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedLineDisplayClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedLineDisplayClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedLineDisplayClosedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedLineDisplayClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedLineDisplayClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ClaimedLineDisplayClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedLineDisplayClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedLineDisplayClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedLineDisplayClosedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedLineDisplayClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedLineDisplayClosedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ClaimedLineDisplayClosedEventArgs {}
 unsafe impl ::core::marker::Sync for ClaimedLineDisplayClosedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -7699,36 +6858,7 @@ unsafe impl ::windows::core::Interface for ClaimedMagneticStripeReader {
 impl ::windows::core::RuntimeName for ClaimedMagneticStripeReader {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedMagneticStripeReader";
 }
-impl ::core::convert::From<ClaimedMagneticStripeReader> for ::windows::core::IUnknown {
-    fn from(value: ClaimedMagneticStripeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedMagneticStripeReader> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedMagneticStripeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedMagneticStripeReader> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedMagneticStripeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedMagneticStripeReader> for ::windows::core::IInspectable {
-    fn from(value: ClaimedMagneticStripeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedMagneticStripeReader> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedMagneticStripeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedMagneticStripeReader> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedMagneticStripeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedMagneticStripeReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ClaimedMagneticStripeReader> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -7789,36 +6919,7 @@ unsafe impl ::windows::core::Interface for ClaimedMagneticStripeReaderClosedEven
 impl ::windows::core::RuntimeName for ClaimedMagneticStripeReaderClosedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedMagneticStripeReaderClosedEventArgs";
 }
-impl ::core::convert::From<ClaimedMagneticStripeReaderClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ClaimedMagneticStripeReaderClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedMagneticStripeReaderClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedMagneticStripeReaderClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedMagneticStripeReaderClosedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedMagneticStripeReaderClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedMagneticStripeReaderClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ClaimedMagneticStripeReaderClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedMagneticStripeReaderClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedMagneticStripeReaderClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedMagneticStripeReaderClosedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedMagneticStripeReaderClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedMagneticStripeReaderClosedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ClaimedMagneticStripeReaderClosedEventArgs {}
 unsafe impl ::core::marker::Sync for ClaimedMagneticStripeReaderClosedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -8022,36 +7123,7 @@ unsafe impl ::windows::core::Interface for ClaimedPosPrinter {
 impl ::windows::core::RuntimeName for ClaimedPosPrinter {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedPosPrinter";
 }
-impl ::core::convert::From<ClaimedPosPrinter> for ::windows::core::IUnknown {
-    fn from(value: ClaimedPosPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedPosPrinter> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedPosPrinter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedPosPrinter> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedPosPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedPosPrinter> for ::windows::core::IInspectable {
-    fn from(value: ClaimedPosPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedPosPrinter> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedPosPrinter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedPosPrinter> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedPosPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedPosPrinter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ClaimedPosPrinter> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -8112,36 +7184,7 @@ unsafe impl ::windows::core::Interface for ClaimedPosPrinterClosedEventArgs {
 impl ::windows::core::RuntimeName for ClaimedPosPrinterClosedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedPosPrinterClosedEventArgs";
 }
-impl ::core::convert::From<ClaimedPosPrinterClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ClaimedPosPrinterClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedPosPrinterClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedPosPrinterClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedPosPrinterClosedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedPosPrinterClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedPosPrinterClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ClaimedPosPrinterClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedPosPrinterClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedPosPrinterClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedPosPrinterClosedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedPosPrinterClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedPosPrinterClosedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ClaimedPosPrinterClosedEventArgs {}
 unsafe impl ::core::marker::Sync for ClaimedPosPrinterClosedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -8345,36 +7388,7 @@ unsafe impl ::windows::core::Interface for ClaimedReceiptPrinter {
 impl ::windows::core::RuntimeName for ClaimedReceiptPrinter {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedReceiptPrinter";
 }
-impl ::core::convert::From<ClaimedReceiptPrinter> for ::windows::core::IUnknown {
-    fn from(value: ClaimedReceiptPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedReceiptPrinter> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedReceiptPrinter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedReceiptPrinter> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedReceiptPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedReceiptPrinter> for ::windows::core::IInspectable {
-    fn from(value: ClaimedReceiptPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedReceiptPrinter> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedReceiptPrinter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedReceiptPrinter> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedReceiptPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedReceiptPrinter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ClaimedReceiptPrinter> for ICommonClaimedPosPrinterStation {
     type Error = ::windows::core::Error;
     fn try_from(value: ClaimedReceiptPrinter) -> ::windows::core::Result<Self> {
@@ -8641,36 +7655,7 @@ unsafe impl ::windows::core::Interface for ClaimedSlipPrinter {
 impl ::windows::core::RuntimeName for ClaimedSlipPrinter {
     const NAME: &'static str = "Windows.Devices.PointOfService.ClaimedSlipPrinter";
 }
-impl ::core::convert::From<ClaimedSlipPrinter> for ::windows::core::IUnknown {
-    fn from(value: ClaimedSlipPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedSlipPrinter> for ::windows::core::IUnknown {
-    fn from(value: &ClaimedSlipPrinter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedSlipPrinter> for &::windows::core::IUnknown {
-    fn from(value: &ClaimedSlipPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClaimedSlipPrinter> for ::windows::core::IInspectable {
-    fn from(value: ClaimedSlipPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClaimedSlipPrinter> for ::windows::core::IInspectable {
-    fn from(value: &ClaimedSlipPrinter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClaimedSlipPrinter> for &::windows::core::IInspectable {
-    fn from(value: &ClaimedSlipPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClaimedSlipPrinter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ClaimedSlipPrinter> for ICommonClaimedPosPrinterStation {
     type Error = ::windows::core::Error;
     fn try_from(value: ClaimedSlipPrinter) -> ::windows::core::Result<Self> {
@@ -8762,36 +7747,7 @@ unsafe impl ::windows::core::Interface for JournalPrintJob {
 impl ::windows::core::RuntimeName for JournalPrintJob {
     const NAME: &'static str = "Windows.Devices.PointOfService.JournalPrintJob";
 }
-impl ::core::convert::From<JournalPrintJob> for ::windows::core::IUnknown {
-    fn from(value: JournalPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JournalPrintJob> for ::windows::core::IUnknown {
-    fn from(value: &JournalPrintJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JournalPrintJob> for &::windows::core::IUnknown {
-    fn from(value: &JournalPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<JournalPrintJob> for ::windows::core::IInspectable {
-    fn from(value: JournalPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JournalPrintJob> for ::windows::core::IInspectable {
-    fn from(value: &JournalPrintJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JournalPrintJob> for &::windows::core::IInspectable {
-    fn from(value: &JournalPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(JournalPrintJob, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<JournalPrintJob> for IPosPrinterJob {
     type Error = ::windows::core::Error;
     fn try_from(value: JournalPrintJob) -> ::windows::core::Result<Self> {
@@ -8985,36 +7941,7 @@ unsafe impl ::windows::core::Interface for JournalPrinterCapabilities {
 impl ::windows::core::RuntimeName for JournalPrinterCapabilities {
     const NAME: &'static str = "Windows.Devices.PointOfService.JournalPrinterCapabilities";
 }
-impl ::core::convert::From<JournalPrinterCapabilities> for ::windows::core::IUnknown {
-    fn from(value: JournalPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JournalPrinterCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &JournalPrinterCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JournalPrinterCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &JournalPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<JournalPrinterCapabilities> for ::windows::core::IInspectable {
-    fn from(value: JournalPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JournalPrinterCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &JournalPrinterCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JournalPrinterCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &JournalPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(JournalPrinterCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<JournalPrinterCapabilities> for ICommonPosPrintStationCapabilities {
     type Error = ::windows::core::Error;
     fn try_from(value: JournalPrinterCapabilities) -> ::windows::core::Result<Self> {
@@ -9190,36 +8117,7 @@ unsafe impl ::windows::core::Interface for LineDisplay {
 impl ::windows::core::RuntimeName for LineDisplay {
     const NAME: &'static str = "Windows.Devices.PointOfService.LineDisplay";
 }
-impl ::core::convert::From<LineDisplay> for ::windows::core::IUnknown {
-    fn from(value: LineDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplay> for ::windows::core::IUnknown {
-    fn from(value: &LineDisplay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplay> for &::windows::core::IUnknown {
-    fn from(value: &LineDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LineDisplay> for ::windows::core::IInspectable {
-    fn from(value: LineDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplay> for ::windows::core::IInspectable {
-    fn from(value: &LineDisplay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplay> for &::windows::core::IInspectable {
-    fn from(value: &LineDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LineDisplay, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<LineDisplay> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -9366,36 +8264,7 @@ unsafe impl ::windows::core::Interface for LineDisplayAttributes {
 impl ::windows::core::RuntimeName for LineDisplayAttributes {
     const NAME: &'static str = "Windows.Devices.PointOfService.LineDisplayAttributes";
 }
-impl ::core::convert::From<LineDisplayAttributes> for ::windows::core::IUnknown {
-    fn from(value: LineDisplayAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayAttributes> for ::windows::core::IUnknown {
-    fn from(value: &LineDisplayAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayAttributes> for &::windows::core::IUnknown {
-    fn from(value: &LineDisplayAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LineDisplayAttributes> for ::windows::core::IInspectable {
-    fn from(value: LineDisplayAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayAttributes> for ::windows::core::IInspectable {
-    fn from(value: &LineDisplayAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayAttributes> for &::windows::core::IInspectable {
-    fn from(value: &LineDisplayAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LineDisplayAttributes, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LineDisplayAttributes {}
 unsafe impl ::core::marker::Sync for LineDisplayAttributes {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -9561,36 +8430,7 @@ unsafe impl ::windows::core::Interface for LineDisplayCapabilities {
 impl ::windows::core::RuntimeName for LineDisplayCapabilities {
     const NAME: &'static str = "Windows.Devices.PointOfService.LineDisplayCapabilities";
 }
-impl ::core::convert::From<LineDisplayCapabilities> for ::windows::core::IUnknown {
-    fn from(value: LineDisplayCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &LineDisplayCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &LineDisplayCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LineDisplayCapabilities> for ::windows::core::IInspectable {
-    fn from(value: LineDisplayCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &LineDisplayCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &LineDisplayCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LineDisplayCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LineDisplayCapabilities {}
 unsafe impl ::core::marker::Sync for LineDisplayCapabilities {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -9695,36 +8535,7 @@ unsafe impl ::windows::core::Interface for LineDisplayCursor {
 impl ::windows::core::RuntimeName for LineDisplayCursor {
     const NAME: &'static str = "Windows.Devices.PointOfService.LineDisplayCursor";
 }
-impl ::core::convert::From<LineDisplayCursor> for ::windows::core::IUnknown {
-    fn from(value: LineDisplayCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayCursor> for ::windows::core::IUnknown {
-    fn from(value: &LineDisplayCursor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayCursor> for &::windows::core::IUnknown {
-    fn from(value: &LineDisplayCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LineDisplayCursor> for ::windows::core::IInspectable {
-    fn from(value: LineDisplayCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayCursor> for ::windows::core::IInspectable {
-    fn from(value: &LineDisplayCursor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayCursor> for &::windows::core::IInspectable {
-    fn from(value: &LineDisplayCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LineDisplayCursor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LineDisplayCursor {}
 unsafe impl ::core::marker::Sync for LineDisplayCursor {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -9812,36 +8623,7 @@ unsafe impl ::windows::core::Interface for LineDisplayCursorAttributes {
 impl ::windows::core::RuntimeName for LineDisplayCursorAttributes {
     const NAME: &'static str = "Windows.Devices.PointOfService.LineDisplayCursorAttributes";
 }
-impl ::core::convert::From<LineDisplayCursorAttributes> for ::windows::core::IUnknown {
-    fn from(value: LineDisplayCursorAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayCursorAttributes> for ::windows::core::IUnknown {
-    fn from(value: &LineDisplayCursorAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayCursorAttributes> for &::windows::core::IUnknown {
-    fn from(value: &LineDisplayCursorAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LineDisplayCursorAttributes> for ::windows::core::IInspectable {
-    fn from(value: LineDisplayCursorAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayCursorAttributes> for ::windows::core::IInspectable {
-    fn from(value: &LineDisplayCursorAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayCursorAttributes> for &::windows::core::IInspectable {
-    fn from(value: &LineDisplayCursorAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LineDisplayCursorAttributes, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LineDisplayCursorAttributes {}
 unsafe impl ::core::marker::Sync for LineDisplayCursorAttributes {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -9912,36 +8694,7 @@ unsafe impl ::windows::core::Interface for LineDisplayCustomGlyphs {
 impl ::windows::core::RuntimeName for LineDisplayCustomGlyphs {
     const NAME: &'static str = "Windows.Devices.PointOfService.LineDisplayCustomGlyphs";
 }
-impl ::core::convert::From<LineDisplayCustomGlyphs> for ::windows::core::IUnknown {
-    fn from(value: LineDisplayCustomGlyphs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayCustomGlyphs> for ::windows::core::IUnknown {
-    fn from(value: &LineDisplayCustomGlyphs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayCustomGlyphs> for &::windows::core::IUnknown {
-    fn from(value: &LineDisplayCustomGlyphs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LineDisplayCustomGlyphs> for ::windows::core::IInspectable {
-    fn from(value: LineDisplayCustomGlyphs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayCustomGlyphs> for ::windows::core::IInspectable {
-    fn from(value: &LineDisplayCustomGlyphs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayCustomGlyphs> for &::windows::core::IInspectable {
-    fn from(value: &LineDisplayCustomGlyphs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LineDisplayCustomGlyphs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LineDisplayCustomGlyphs {}
 unsafe impl ::core::marker::Sync for LineDisplayCustomGlyphs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -10040,36 +8793,7 @@ unsafe impl ::windows::core::Interface for LineDisplayMarquee {
 impl ::windows::core::RuntimeName for LineDisplayMarquee {
     const NAME: &'static str = "Windows.Devices.PointOfService.LineDisplayMarquee";
 }
-impl ::core::convert::From<LineDisplayMarquee> for ::windows::core::IUnknown {
-    fn from(value: LineDisplayMarquee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayMarquee> for ::windows::core::IUnknown {
-    fn from(value: &LineDisplayMarquee) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayMarquee> for &::windows::core::IUnknown {
-    fn from(value: &LineDisplayMarquee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LineDisplayMarquee> for ::windows::core::IInspectable {
-    fn from(value: LineDisplayMarquee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayMarquee> for ::windows::core::IInspectable {
-    fn from(value: &LineDisplayMarquee) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayMarquee> for &::windows::core::IInspectable {
-    fn from(value: &LineDisplayMarquee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LineDisplayMarquee, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LineDisplayMarquee {}
 unsafe impl ::core::marker::Sync for LineDisplayMarquee {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -10130,36 +8854,7 @@ unsafe impl ::windows::core::Interface for LineDisplayStatisticsCategorySelector
 impl ::windows::core::RuntimeName for LineDisplayStatisticsCategorySelector {
     const NAME: &'static str = "Windows.Devices.PointOfService.LineDisplayStatisticsCategorySelector";
 }
-impl ::core::convert::From<LineDisplayStatisticsCategorySelector> for ::windows::core::IUnknown {
-    fn from(value: LineDisplayStatisticsCategorySelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayStatisticsCategorySelector> for ::windows::core::IUnknown {
-    fn from(value: &LineDisplayStatisticsCategorySelector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayStatisticsCategorySelector> for &::windows::core::IUnknown {
-    fn from(value: &LineDisplayStatisticsCategorySelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LineDisplayStatisticsCategorySelector> for ::windows::core::IInspectable {
-    fn from(value: LineDisplayStatisticsCategorySelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayStatisticsCategorySelector> for ::windows::core::IInspectable {
-    fn from(value: &LineDisplayStatisticsCategorySelector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayStatisticsCategorySelector> for &::windows::core::IInspectable {
-    fn from(value: &LineDisplayStatisticsCategorySelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LineDisplayStatisticsCategorySelector, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LineDisplayStatisticsCategorySelector {}
 unsafe impl ::core::marker::Sync for LineDisplayStatisticsCategorySelector {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -10206,36 +8901,7 @@ unsafe impl ::windows::core::Interface for LineDisplayStatusUpdatedEventArgs {
 impl ::windows::core::RuntimeName for LineDisplayStatusUpdatedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.LineDisplayStatusUpdatedEventArgs";
 }
-impl ::core::convert::From<LineDisplayStatusUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LineDisplayStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayStatusUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LineDisplayStatusUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayStatusUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LineDisplayStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LineDisplayStatusUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LineDisplayStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayStatusUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LineDisplayStatusUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayStatusUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LineDisplayStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LineDisplayStatusUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LineDisplayStatusUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for LineDisplayStatusUpdatedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -10291,36 +8957,7 @@ unsafe impl ::windows::core::Interface for LineDisplayStoredBitmap {
 impl ::windows::core::RuntimeName for LineDisplayStoredBitmap {
     const NAME: &'static str = "Windows.Devices.PointOfService.LineDisplayStoredBitmap";
 }
-impl ::core::convert::From<LineDisplayStoredBitmap> for ::windows::core::IUnknown {
-    fn from(value: LineDisplayStoredBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayStoredBitmap> for ::windows::core::IUnknown {
-    fn from(value: &LineDisplayStoredBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayStoredBitmap> for &::windows::core::IUnknown {
-    fn from(value: &LineDisplayStoredBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LineDisplayStoredBitmap> for ::windows::core::IInspectable {
-    fn from(value: LineDisplayStoredBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayStoredBitmap> for ::windows::core::IInspectable {
-    fn from(value: &LineDisplayStoredBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayStoredBitmap> for &::windows::core::IInspectable {
-    fn from(value: &LineDisplayStoredBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LineDisplayStoredBitmap, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LineDisplayStoredBitmap {}
 unsafe impl ::core::marker::Sync for LineDisplayStoredBitmap {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -10521,36 +9158,7 @@ unsafe impl ::windows::core::Interface for LineDisplayWindow {
 impl ::windows::core::RuntimeName for LineDisplayWindow {
     const NAME: &'static str = "Windows.Devices.PointOfService.LineDisplayWindow";
 }
-impl ::core::convert::From<LineDisplayWindow> for ::windows::core::IUnknown {
-    fn from(value: LineDisplayWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayWindow> for ::windows::core::IUnknown {
-    fn from(value: &LineDisplayWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayWindow> for &::windows::core::IUnknown {
-    fn from(value: &LineDisplayWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LineDisplayWindow> for ::windows::core::IInspectable {
-    fn from(value: LineDisplayWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LineDisplayWindow> for ::windows::core::IInspectable {
-    fn from(value: &LineDisplayWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LineDisplayWindow> for &::windows::core::IInspectable {
-    fn from(value: &LineDisplayWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LineDisplayWindow, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<LineDisplayWindow> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -10737,36 +9345,7 @@ unsafe impl ::windows::core::Interface for MagneticStripeReader {
 impl ::windows::core::RuntimeName for MagneticStripeReader {
     const NAME: &'static str = "Windows.Devices.PointOfService.MagneticStripeReader";
 }
-impl ::core::convert::From<MagneticStripeReader> for ::windows::core::IUnknown {
-    fn from(value: MagneticStripeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReader> for ::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReader> for &::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagneticStripeReader> for ::windows::core::IInspectable {
-    fn from(value: MagneticStripeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReader> for ::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReader> for &::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagneticStripeReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MagneticStripeReader> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -10961,36 +9540,7 @@ unsafe impl ::windows::core::Interface for MagneticStripeReaderAamvaCardDataRece
 impl ::windows::core::RuntimeName for MagneticStripeReaderAamvaCardDataReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.MagneticStripeReaderAamvaCardDataReceivedEventArgs";
 }
-impl ::core::convert::From<MagneticStripeReaderAamvaCardDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MagneticStripeReaderAamvaCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderAamvaCardDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderAamvaCardDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderAamvaCardDataReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderAamvaCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagneticStripeReaderAamvaCardDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MagneticStripeReaderAamvaCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderAamvaCardDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderAamvaCardDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderAamvaCardDataReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderAamvaCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagneticStripeReaderAamvaCardDataReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MagneticStripeReaderAamvaCardDataReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MagneticStripeReaderAamvaCardDataReceivedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -11093,36 +9643,7 @@ unsafe impl ::windows::core::Interface for MagneticStripeReaderBankCardDataRecei
 impl ::windows::core::RuntimeName for MagneticStripeReaderBankCardDataReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.MagneticStripeReaderBankCardDataReceivedEventArgs";
 }
-impl ::core::convert::From<MagneticStripeReaderBankCardDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MagneticStripeReaderBankCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderBankCardDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderBankCardDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderBankCardDataReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderBankCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagneticStripeReaderBankCardDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MagneticStripeReaderBankCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderBankCardDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderBankCardDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderBankCardDataReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderBankCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagneticStripeReaderBankCardDataReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MagneticStripeReaderBankCardDataReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MagneticStripeReaderBankCardDataReceivedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -11239,36 +9760,7 @@ unsafe impl ::windows::core::Interface for MagneticStripeReaderCapabilities {
 impl ::windows::core::RuntimeName for MagneticStripeReaderCapabilities {
     const NAME: &'static str = "Windows.Devices.PointOfService.MagneticStripeReaderCapabilities";
 }
-impl ::core::convert::From<MagneticStripeReaderCapabilities> for ::windows::core::IUnknown {
-    fn from(value: MagneticStripeReaderCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagneticStripeReaderCapabilities> for ::windows::core::IInspectable {
-    fn from(value: MagneticStripeReaderCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagneticStripeReaderCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MagneticStripeReaderCapabilities {}
 unsafe impl ::core::marker::Sync for MagneticStripeReaderCapabilities {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -11416,36 +9908,7 @@ unsafe impl ::windows::core::Interface for MagneticStripeReaderErrorOccurredEven
 impl ::windows::core::RuntimeName for MagneticStripeReaderErrorOccurredEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.MagneticStripeReaderErrorOccurredEventArgs";
 }
-impl ::core::convert::From<MagneticStripeReaderErrorOccurredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MagneticStripeReaderErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderErrorOccurredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderErrorOccurredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderErrorOccurredEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagneticStripeReaderErrorOccurredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MagneticStripeReaderErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderErrorOccurredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderErrorOccurredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderErrorOccurredEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagneticStripeReaderErrorOccurredEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MagneticStripeReaderErrorOccurredEventArgs {}
 unsafe impl ::core::marker::Sync for MagneticStripeReaderErrorOccurredEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -11554,36 +10017,7 @@ unsafe impl ::windows::core::Interface for MagneticStripeReaderReport {
 impl ::windows::core::RuntimeName for MagneticStripeReaderReport {
     const NAME: &'static str = "Windows.Devices.PointOfService.MagneticStripeReaderReport";
 }
-impl ::core::convert::From<MagneticStripeReaderReport> for ::windows::core::IUnknown {
-    fn from(value: MagneticStripeReaderReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderReport> for ::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderReport> for &::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagneticStripeReaderReport> for ::windows::core::IInspectable {
-    fn from(value: MagneticStripeReaderReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderReport> for ::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderReport> for &::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagneticStripeReaderReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MagneticStripeReaderReport {}
 unsafe impl ::core::marker::Sync for MagneticStripeReaderReport {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -11637,36 +10071,7 @@ unsafe impl ::windows::core::Interface for MagneticStripeReaderStatusUpdatedEven
 impl ::windows::core::RuntimeName for MagneticStripeReaderStatusUpdatedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.MagneticStripeReaderStatusUpdatedEventArgs";
 }
-impl ::core::convert::From<MagneticStripeReaderStatusUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MagneticStripeReaderStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderStatusUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderStatusUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderStatusUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagneticStripeReaderStatusUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MagneticStripeReaderStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderStatusUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderStatusUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderStatusUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagneticStripeReaderStatusUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MagneticStripeReaderStatusUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for MagneticStripeReaderStatusUpdatedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -11733,36 +10138,7 @@ unsafe impl ::windows::core::Interface for MagneticStripeReaderTrackData {
 impl ::windows::core::RuntimeName for MagneticStripeReaderTrackData {
     const NAME: &'static str = "Windows.Devices.PointOfService.MagneticStripeReaderTrackData";
 }
-impl ::core::convert::From<MagneticStripeReaderTrackData> for ::windows::core::IUnknown {
-    fn from(value: MagneticStripeReaderTrackData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderTrackData> for ::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderTrackData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderTrackData> for &::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderTrackData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagneticStripeReaderTrackData> for ::windows::core::IInspectable {
-    fn from(value: MagneticStripeReaderTrackData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderTrackData> for ::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderTrackData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderTrackData> for &::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderTrackData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagneticStripeReaderTrackData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MagneticStripeReaderTrackData {}
 unsafe impl ::core::marker::Sync for MagneticStripeReaderTrackData {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -11809,36 +10185,7 @@ unsafe impl ::windows::core::Interface for MagneticStripeReaderVendorSpecificCar
 impl ::windows::core::RuntimeName for MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs";
 }
-impl ::core::convert::From<MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -12023,36 +10370,7 @@ unsafe impl ::windows::core::Interface for PosPrinter {
 impl ::windows::core::RuntimeName for PosPrinter {
     const NAME: &'static str = "Windows.Devices.PointOfService.PosPrinter";
 }
-impl ::core::convert::From<PosPrinter> for ::windows::core::IUnknown {
-    fn from(value: PosPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinter> for ::windows::core::IUnknown {
-    fn from(value: &PosPrinter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinter> for &::windows::core::IUnknown {
-    fn from(value: &PosPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PosPrinter> for ::windows::core::IInspectable {
-    fn from(value: PosPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinter> for ::windows::core::IInspectable {
-    fn from(value: &PosPrinter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinter> for &::windows::core::IInspectable {
-    fn from(value: &PosPrinter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PosPrinter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<PosPrinter> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -12184,36 +10502,7 @@ unsafe impl ::windows::core::Interface for PosPrinterCapabilities {
 impl ::windows::core::RuntimeName for PosPrinterCapabilities {
     const NAME: &'static str = "Windows.Devices.PointOfService.PosPrinterCapabilities";
 }
-impl ::core::convert::From<PosPrinterCapabilities> for ::windows::core::IUnknown {
-    fn from(value: PosPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &PosPrinterCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &PosPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PosPrinterCapabilities> for ::windows::core::IInspectable {
-    fn from(value: PosPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &PosPrinterCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &PosPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PosPrinterCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PosPrinterCapabilities {}
 unsafe impl ::core::marker::Sync for PosPrinterCapabilities {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -12306,36 +10595,7 @@ unsafe impl ::windows::core::Interface for PosPrinterFontProperty {
 impl ::windows::core::RuntimeName for PosPrinterFontProperty {
     const NAME: &'static str = "Windows.Devices.PointOfService.PosPrinterFontProperty";
 }
-impl ::core::convert::From<PosPrinterFontProperty> for ::windows::core::IUnknown {
-    fn from(value: PosPrinterFontProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterFontProperty> for ::windows::core::IUnknown {
-    fn from(value: &PosPrinterFontProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterFontProperty> for &::windows::core::IUnknown {
-    fn from(value: &PosPrinterFontProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PosPrinterFontProperty> for ::windows::core::IInspectable {
-    fn from(value: PosPrinterFontProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterFontProperty> for ::windows::core::IInspectable {
-    fn from(value: &PosPrinterFontProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterFontProperty> for &::windows::core::IInspectable {
-    fn from(value: &PosPrinterFontProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PosPrinterFontProperty, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PosPrinterFontProperty {}
 unsafe impl ::core::marker::Sync for PosPrinterFontProperty {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -12525,36 +10785,7 @@ unsafe impl ::windows::core::Interface for PosPrinterPrintOptions {
 impl ::windows::core::RuntimeName for PosPrinterPrintOptions {
     const NAME: &'static str = "Windows.Devices.PointOfService.PosPrinterPrintOptions";
 }
-impl ::core::convert::From<PosPrinterPrintOptions> for ::windows::core::IUnknown {
-    fn from(value: PosPrinterPrintOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterPrintOptions> for ::windows::core::IUnknown {
-    fn from(value: &PosPrinterPrintOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterPrintOptions> for &::windows::core::IUnknown {
-    fn from(value: &PosPrinterPrintOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PosPrinterPrintOptions> for ::windows::core::IInspectable {
-    fn from(value: PosPrinterPrintOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterPrintOptions> for ::windows::core::IInspectable {
-    fn from(value: &PosPrinterPrintOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterPrintOptions> for &::windows::core::IInspectable {
-    fn from(value: &PosPrinterPrintOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PosPrinterPrintOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PosPrinterPrintOptions {}
 unsafe impl ::core::marker::Sync for PosPrinterPrintOptions {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -12593,36 +10824,7 @@ unsafe impl ::windows::core::Interface for PosPrinterReleaseDeviceRequestedEvent
 impl ::windows::core::RuntimeName for PosPrinterReleaseDeviceRequestedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.PosPrinterReleaseDeviceRequestedEventArgs";
 }
-impl ::core::convert::From<PosPrinterReleaseDeviceRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PosPrinterReleaseDeviceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterReleaseDeviceRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PosPrinterReleaseDeviceRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterReleaseDeviceRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PosPrinterReleaseDeviceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PosPrinterReleaseDeviceRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PosPrinterReleaseDeviceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterReleaseDeviceRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PosPrinterReleaseDeviceRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterReleaseDeviceRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PosPrinterReleaseDeviceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PosPrinterReleaseDeviceRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PosPrinterReleaseDeviceRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for PosPrinterReleaseDeviceRequestedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -12676,36 +10878,7 @@ unsafe impl ::windows::core::Interface for PosPrinterStatus {
 impl ::windows::core::RuntimeName for PosPrinterStatus {
     const NAME: &'static str = "Windows.Devices.PointOfService.PosPrinterStatus";
 }
-impl ::core::convert::From<PosPrinterStatus> for ::windows::core::IUnknown {
-    fn from(value: PosPrinterStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterStatus> for ::windows::core::IUnknown {
-    fn from(value: &PosPrinterStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterStatus> for &::windows::core::IUnknown {
-    fn from(value: &PosPrinterStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PosPrinterStatus> for ::windows::core::IInspectable {
-    fn from(value: PosPrinterStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterStatus> for ::windows::core::IInspectable {
-    fn from(value: &PosPrinterStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterStatus> for &::windows::core::IInspectable {
-    fn from(value: &PosPrinterStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PosPrinterStatus, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PosPrinterStatus {}
 unsafe impl ::core::marker::Sync for PosPrinterStatus {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -12752,36 +10925,7 @@ unsafe impl ::windows::core::Interface for PosPrinterStatusUpdatedEventArgs {
 impl ::windows::core::RuntimeName for PosPrinterStatusUpdatedEventArgs {
     const NAME: &'static str = "Windows.Devices.PointOfService.PosPrinterStatusUpdatedEventArgs";
 }
-impl ::core::convert::From<PosPrinterStatusUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PosPrinterStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterStatusUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PosPrinterStatusUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterStatusUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PosPrinterStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PosPrinterStatusUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PosPrinterStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PosPrinterStatusUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PosPrinterStatusUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PosPrinterStatusUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PosPrinterStatusUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PosPrinterStatusUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PosPrinterStatusUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for PosPrinterStatusUpdatedEventArgs {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]
@@ -12948,36 +11092,7 @@ unsafe impl ::windows::core::Interface for ReceiptPrintJob {
 impl ::windows::core::RuntimeName for ReceiptPrintJob {
     const NAME: &'static str = "Windows.Devices.PointOfService.ReceiptPrintJob";
 }
-impl ::core::convert::From<ReceiptPrintJob> for ::windows::core::IUnknown {
-    fn from(value: ReceiptPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ReceiptPrintJob> for ::windows::core::IUnknown {
-    fn from(value: &ReceiptPrintJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ReceiptPrintJob> for &::windows::core::IUnknown {
-    fn from(value: &ReceiptPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ReceiptPrintJob> for ::windows::core::IInspectable {
-    fn from(value: ReceiptPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ReceiptPrintJob> for ::windows::core::IInspectable {
-    fn from(value: &ReceiptPrintJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ReceiptPrintJob> for &::windows::core::IInspectable {
-    fn from(value: &ReceiptPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ReceiptPrintJob, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ReceiptPrintJob> for IPosPrinterJob {
     type Error = ::windows::core::Error;
     fn try_from(value: ReceiptPrintJob) -> ::windows::core::Result<Self> {
@@ -13278,36 +11393,7 @@ unsafe impl ::windows::core::Interface for ReceiptPrinterCapabilities {
 impl ::windows::core::RuntimeName for ReceiptPrinterCapabilities {
     const NAME: &'static str = "Windows.Devices.PointOfService.ReceiptPrinterCapabilities";
 }
-impl ::core::convert::From<ReceiptPrinterCapabilities> for ::windows::core::IUnknown {
-    fn from(value: ReceiptPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ReceiptPrinterCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &ReceiptPrinterCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ReceiptPrinterCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &ReceiptPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ReceiptPrinterCapabilities> for ::windows::core::IInspectable {
-    fn from(value: ReceiptPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ReceiptPrinterCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &ReceiptPrinterCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ReceiptPrinterCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &ReceiptPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ReceiptPrinterCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ReceiptPrinterCapabilities> for ICommonPosPrintStationCapabilities {
     type Error = ::windows::core::Error;
     fn try_from(value: ReceiptPrinterCapabilities) -> ::windows::core::Result<Self> {
@@ -13496,36 +11582,7 @@ unsafe impl ::windows::core::Interface for SlipPrintJob {
 impl ::windows::core::RuntimeName for SlipPrintJob {
     const NAME: &'static str = "Windows.Devices.PointOfService.SlipPrintJob";
 }
-impl ::core::convert::From<SlipPrintJob> for ::windows::core::IUnknown {
-    fn from(value: SlipPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SlipPrintJob> for ::windows::core::IUnknown {
-    fn from(value: &SlipPrintJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SlipPrintJob> for &::windows::core::IUnknown {
-    fn from(value: &SlipPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SlipPrintJob> for ::windows::core::IInspectable {
-    fn from(value: SlipPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SlipPrintJob> for ::windows::core::IInspectable {
-    fn from(value: &SlipPrintJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SlipPrintJob> for &::windows::core::IInspectable {
-    fn from(value: &SlipPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SlipPrintJob, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SlipPrintJob> for IPosPrinterJob {
     type Error = ::windows::core::Error;
     fn try_from(value: SlipPrintJob) -> ::windows::core::Result<Self> {
@@ -13819,36 +11876,7 @@ unsafe impl ::windows::core::Interface for SlipPrinterCapabilities {
 impl ::windows::core::RuntimeName for SlipPrinterCapabilities {
     const NAME: &'static str = "Windows.Devices.PointOfService.SlipPrinterCapabilities";
 }
-impl ::core::convert::From<SlipPrinterCapabilities> for ::windows::core::IUnknown {
-    fn from(value: SlipPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SlipPrinterCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &SlipPrinterCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SlipPrinterCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &SlipPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SlipPrinterCapabilities> for ::windows::core::IInspectable {
-    fn from(value: SlipPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SlipPrinterCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &SlipPrinterCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SlipPrinterCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &SlipPrinterCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SlipPrinterCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SlipPrinterCapabilities> for ICommonPosPrintStationCapabilities {
     type Error = ::windows::core::Error;
     fn try_from(value: SlipPrinterCapabilities) -> ::windows::core::Result<Self> {
@@ -13965,36 +11993,7 @@ unsafe impl ::windows::core::Interface for UnifiedPosErrorData {
 impl ::windows::core::RuntimeName for UnifiedPosErrorData {
     const NAME: &'static str = "Windows.Devices.PointOfService.UnifiedPosErrorData";
 }
-impl ::core::convert::From<UnifiedPosErrorData> for ::windows::core::IUnknown {
-    fn from(value: UnifiedPosErrorData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UnifiedPosErrorData> for ::windows::core::IUnknown {
-    fn from(value: &UnifiedPosErrorData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UnifiedPosErrorData> for &::windows::core::IUnknown {
-    fn from(value: &UnifiedPosErrorData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UnifiedPosErrorData> for ::windows::core::IInspectable {
-    fn from(value: UnifiedPosErrorData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UnifiedPosErrorData> for ::windows::core::IInspectable {
-    fn from(value: &UnifiedPosErrorData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UnifiedPosErrorData> for &::windows::core::IInspectable {
-    fn from(value: &UnifiedPosErrorData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UnifiedPosErrorData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UnifiedPosErrorData {}
 unsafe impl ::core::marker::Sync for UnifiedPosErrorData {}
 #[doc = "*Required features: `\"Devices_PointOfService\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Power/mod.rs
@@ -167,36 +167,7 @@ unsafe impl ::windows::core::Interface for Battery {
 impl ::windows::core::RuntimeName for Battery {
     const NAME: &'static str = "Windows.Devices.Power.Battery";
 }
-impl ::core::convert::From<Battery> for ::windows::core::IUnknown {
-    fn from(value: Battery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Battery> for ::windows::core::IUnknown {
-    fn from(value: &Battery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Battery> for &::windows::core::IUnknown {
-    fn from(value: &Battery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Battery> for ::windows::core::IInspectable {
-    fn from(value: Battery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Battery> for ::windows::core::IInspectable {
-    fn from(value: &Battery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Battery> for &::windows::core::IInspectable {
-    fn from(value: &Battery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Battery, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Battery {}
 unsafe impl ::core::marker::Sync for Battery {}
 #[doc = "*Required features: `\"Devices_Power\"`*"]
@@ -281,36 +252,7 @@ unsafe impl ::windows::core::Interface for BatteryReport {
 impl ::windows::core::RuntimeName for BatteryReport {
     const NAME: &'static str = "Windows.Devices.Power.BatteryReport";
 }
-impl ::core::convert::From<BatteryReport> for ::windows::core::IUnknown {
-    fn from(value: BatteryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BatteryReport> for ::windows::core::IUnknown {
-    fn from(value: &BatteryReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BatteryReport> for &::windows::core::IUnknown {
-    fn from(value: &BatteryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BatteryReport> for ::windows::core::IInspectable {
-    fn from(value: BatteryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BatteryReport> for ::windows::core::IInspectable {
-    fn from(value: &BatteryReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BatteryReport> for &::windows::core::IInspectable {
-    fn from(value: &BatteryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BatteryReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BatteryReport {}
 unsafe impl ::core::marker::Sync for BatteryReport {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Devices/Printers/Extensions/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Printers/Extensions/mod.rs
@@ -277,36 +277,7 @@ unsafe impl ::windows::core::Interface for Print3DWorkflow {
 impl ::windows::core::RuntimeName for Print3DWorkflow {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.Print3DWorkflow";
 }
-impl ::core::convert::From<Print3DWorkflow> for ::windows::core::IUnknown {
-    fn from(value: Print3DWorkflow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DWorkflow> for ::windows::core::IUnknown {
-    fn from(value: &Print3DWorkflow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DWorkflow> for &::windows::core::IUnknown {
-    fn from(value: &Print3DWorkflow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DWorkflow> for ::windows::core::IInspectable {
-    fn from(value: Print3DWorkflow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DWorkflow> for ::windows::core::IInspectable {
-    fn from(value: &Print3DWorkflow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DWorkflow> for &::windows::core::IInspectable {
-    fn from(value: &Print3DWorkflow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DWorkflow, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Print3DWorkflow {}
 unsafe impl ::core::marker::Sync for Print3DWorkflow {}
 #[doc = "*Required features: `\"Devices_Printers_Extensions\"`*"]
@@ -368,36 +339,7 @@ unsafe impl ::windows::core::Interface for Print3DWorkflowPrintRequestedEventArg
 impl ::windows::core::RuntimeName for Print3DWorkflowPrintRequestedEventArgs {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.Print3DWorkflowPrintRequestedEventArgs";
 }
-impl ::core::convert::From<Print3DWorkflowPrintRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: Print3DWorkflowPrintRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowPrintRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &Print3DWorkflowPrintRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowPrintRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &Print3DWorkflowPrintRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DWorkflowPrintRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: Print3DWorkflowPrintRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowPrintRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &Print3DWorkflowPrintRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowPrintRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &Print3DWorkflowPrintRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DWorkflowPrintRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Print3DWorkflowPrintRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for Print3DWorkflowPrintRequestedEventArgs {}
 #[doc = "*Required features: `\"Devices_Printers_Extensions\"`*"]
@@ -444,36 +386,7 @@ unsafe impl ::windows::core::Interface for Print3DWorkflowPrinterChangedEventArg
 impl ::windows::core::RuntimeName for Print3DWorkflowPrinterChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.Print3DWorkflowPrinterChangedEventArgs";
 }
-impl ::core::convert::From<Print3DWorkflowPrinterChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: Print3DWorkflowPrinterChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowPrinterChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &Print3DWorkflowPrinterChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowPrinterChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &Print3DWorkflowPrinterChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DWorkflowPrinterChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: Print3DWorkflowPrinterChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowPrinterChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &Print3DWorkflowPrinterChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DWorkflowPrinterChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &Print3DWorkflowPrinterChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DWorkflowPrinterChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Print3DWorkflowPrinterChangedEventArgs {}
 unsafe impl ::core::marker::Sync for Print3DWorkflowPrinterChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Printers_Extensions\"`*"]
@@ -549,36 +462,7 @@ unsafe impl ::windows::core::Interface for PrintNotificationEventDetails {
 impl ::windows::core::RuntimeName for PrintNotificationEventDetails {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.PrintNotificationEventDetails";
 }
-impl ::core::convert::From<PrintNotificationEventDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintNotificationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintNotificationEventDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintNotificationEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintNotificationEventDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintNotificationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintNotificationEventDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintNotificationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintNotificationEventDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintNotificationEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintNotificationEventDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintNotificationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintNotificationEventDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintNotificationEventDetails {}
 unsafe impl ::core::marker::Sync for PrintNotificationEventDetails {}
 #[doc = "*Required features: `\"Devices_Printers_Extensions\"`*"]
@@ -640,36 +524,7 @@ unsafe impl ::windows::core::Interface for PrintTaskConfiguration {
 impl ::windows::core::RuntimeName for PrintTaskConfiguration {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.PrintTaskConfiguration";
 }
-impl ::core::convert::From<PrintTaskConfiguration> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskConfiguration> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Devices_Printers_Extensions\"`*"]
 #[repr(transparent)]
 pub struct PrintTaskConfigurationSaveRequest(::windows::core::IUnknown);
@@ -734,36 +589,7 @@ unsafe impl ::windows::core::Interface for PrintTaskConfigurationSaveRequest {
 impl ::windows::core::RuntimeName for PrintTaskConfigurationSaveRequest {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.PrintTaskConfigurationSaveRequest";
 }
-impl ::core::convert::From<PrintTaskConfigurationSaveRequest> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskConfigurationSaveRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequest> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskConfigurationSaveRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequest> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskConfigurationSaveRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskConfigurationSaveRequest> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskConfigurationSaveRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequest> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskConfigurationSaveRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequest> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskConfigurationSaveRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskConfigurationSaveRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Devices_Printers_Extensions\"`*"]
 #[repr(transparent)]
 pub struct PrintTaskConfigurationSaveRequestedDeferral(::windows::core::IUnknown);
@@ -805,36 +631,7 @@ unsafe impl ::windows::core::Interface for PrintTaskConfigurationSaveRequestedDe
 impl ::windows::core::RuntimeName for PrintTaskConfigurationSaveRequestedDeferral {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.PrintTaskConfigurationSaveRequestedDeferral";
 }
-impl ::core::convert::From<PrintTaskConfigurationSaveRequestedDeferral> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskConfigurationSaveRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequestedDeferral> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskConfigurationSaveRequestedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequestedDeferral> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskConfigurationSaveRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskConfigurationSaveRequestedDeferral> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskConfigurationSaveRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequestedDeferral> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskConfigurationSaveRequestedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequestedDeferral> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskConfigurationSaveRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskConfigurationSaveRequestedDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Devices_Printers_Extensions\"`*"]
 #[repr(transparent)]
 pub struct PrintTaskConfigurationSaveRequestedEventArgs(::windows::core::IUnknown);
@@ -879,36 +676,7 @@ unsafe impl ::windows::core::Interface for PrintTaskConfigurationSaveRequestedEv
 impl ::windows::core::RuntimeName for PrintTaskConfigurationSaveRequestedEventArgs {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.PrintTaskConfigurationSaveRequestedEventArgs";
 }
-impl ::core::convert::From<PrintTaskConfigurationSaveRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskConfigurationSaveRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskConfigurationSaveRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskConfigurationSaveRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskConfigurationSaveRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskConfigurationSaveRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskConfigurationSaveRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskConfigurationSaveRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskConfigurationSaveRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskConfigurationSaveRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Devices_Printers_Extensions\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/Devices/Printers/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Printers/mod.rs
@@ -494,36 +494,7 @@ unsafe impl ::windows::core::Interface for IppAttributeError {
 impl ::windows::core::RuntimeName for IppAttributeError {
     const NAME: &'static str = "Windows.Devices.Printers.IppAttributeError";
 }
-impl ::core::convert::From<IppAttributeError> for ::windows::core::IUnknown {
-    fn from(value: IppAttributeError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppAttributeError> for ::windows::core::IUnknown {
-    fn from(value: &IppAttributeError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppAttributeError> for &::windows::core::IUnknown {
-    fn from(value: &IppAttributeError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IppAttributeError> for ::windows::core::IInspectable {
-    fn from(value: IppAttributeError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppAttributeError> for ::windows::core::IInspectable {
-    fn from(value: &IppAttributeError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppAttributeError> for &::windows::core::IInspectable {
-    fn from(value: &IppAttributeError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IppAttributeError, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IppAttributeError {}
 unsafe impl ::core::marker::Sync for IppAttributeError {}
 #[doc = "*Required features: `\"Devices_Printers\"`*"]
@@ -1095,36 +1066,7 @@ unsafe impl ::windows::core::Interface for IppAttributeValue {
 impl ::windows::core::RuntimeName for IppAttributeValue {
     const NAME: &'static str = "Windows.Devices.Printers.IppAttributeValue";
 }
-impl ::core::convert::From<IppAttributeValue> for ::windows::core::IUnknown {
-    fn from(value: IppAttributeValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppAttributeValue> for ::windows::core::IUnknown {
-    fn from(value: &IppAttributeValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppAttributeValue> for &::windows::core::IUnknown {
-    fn from(value: &IppAttributeValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IppAttributeValue> for ::windows::core::IInspectable {
-    fn from(value: IppAttributeValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppAttributeValue> for ::windows::core::IInspectable {
-    fn from(value: &IppAttributeValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppAttributeValue> for &::windows::core::IInspectable {
-    fn from(value: &IppAttributeValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IppAttributeValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IppAttributeValue {}
 unsafe impl ::core::marker::Sync for IppAttributeValue {}
 #[doc = "*Required features: `\"Devices_Printers\"`*"]
@@ -1189,36 +1131,7 @@ unsafe impl ::windows::core::Interface for IppIntegerRange {
 impl ::windows::core::RuntimeName for IppIntegerRange {
     const NAME: &'static str = "Windows.Devices.Printers.IppIntegerRange";
 }
-impl ::core::convert::From<IppIntegerRange> for ::windows::core::IUnknown {
-    fn from(value: IppIntegerRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppIntegerRange> for ::windows::core::IUnknown {
-    fn from(value: &IppIntegerRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppIntegerRange> for &::windows::core::IUnknown {
-    fn from(value: &IppIntegerRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IppIntegerRange> for ::windows::core::IInspectable {
-    fn from(value: IppIntegerRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppIntegerRange> for ::windows::core::IInspectable {
-    fn from(value: &IppIntegerRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppIntegerRange> for &::windows::core::IInspectable {
-    fn from(value: &IppIntegerRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IppIntegerRange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IppIntegerRange {}
 unsafe impl ::core::marker::Sync for IppIntegerRange {}
 #[doc = "*Required features: `\"Devices_Printers\"`*"]
@@ -1326,36 +1239,7 @@ unsafe impl ::windows::core::Interface for IppPrintDevice {
 impl ::windows::core::RuntimeName for IppPrintDevice {
     const NAME: &'static str = "Windows.Devices.Printers.IppPrintDevice";
 }
-impl ::core::convert::From<IppPrintDevice> for ::windows::core::IUnknown {
-    fn from(value: IppPrintDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppPrintDevice> for ::windows::core::IUnknown {
-    fn from(value: &IppPrintDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppPrintDevice> for &::windows::core::IUnknown {
-    fn from(value: &IppPrintDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IppPrintDevice> for ::windows::core::IInspectable {
-    fn from(value: IppPrintDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppPrintDevice> for ::windows::core::IInspectable {
-    fn from(value: &IppPrintDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppPrintDevice> for &::windows::core::IInspectable {
-    fn from(value: &IppPrintDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IppPrintDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IppPrintDevice {}
 unsafe impl ::core::marker::Sync for IppPrintDevice {}
 #[doc = "*Required features: `\"Devices_Printers\"`*"]
@@ -1427,36 +1311,7 @@ unsafe impl ::windows::core::Interface for IppResolution {
 impl ::windows::core::RuntimeName for IppResolution {
     const NAME: &'static str = "Windows.Devices.Printers.IppResolution";
 }
-impl ::core::convert::From<IppResolution> for ::windows::core::IUnknown {
-    fn from(value: IppResolution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppResolution> for ::windows::core::IUnknown {
-    fn from(value: &IppResolution) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppResolution> for &::windows::core::IUnknown {
-    fn from(value: &IppResolution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IppResolution> for ::windows::core::IInspectable {
-    fn from(value: IppResolution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppResolution> for ::windows::core::IInspectable {
-    fn from(value: &IppResolution) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppResolution> for &::windows::core::IInspectable {
-    fn from(value: &IppResolution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IppResolution, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IppResolution {}
 unsafe impl ::core::marker::Sync for IppResolution {}
 #[doc = "*Required features: `\"Devices_Printers\"`*"]
@@ -1512,36 +1367,7 @@ unsafe impl ::windows::core::Interface for IppSetAttributesResult {
 impl ::windows::core::RuntimeName for IppSetAttributesResult {
     const NAME: &'static str = "Windows.Devices.Printers.IppSetAttributesResult";
 }
-impl ::core::convert::From<IppSetAttributesResult> for ::windows::core::IUnknown {
-    fn from(value: IppSetAttributesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppSetAttributesResult> for ::windows::core::IUnknown {
-    fn from(value: &IppSetAttributesResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppSetAttributesResult> for &::windows::core::IUnknown {
-    fn from(value: &IppSetAttributesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IppSetAttributesResult> for ::windows::core::IInspectable {
-    fn from(value: IppSetAttributesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppSetAttributesResult> for ::windows::core::IInspectable {
-    fn from(value: &IppSetAttributesResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppSetAttributesResult> for &::windows::core::IInspectable {
-    fn from(value: &IppSetAttributesResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IppSetAttributesResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IppSetAttributesResult {}
 unsafe impl ::core::marker::Sync for IppSetAttributesResult {}
 #[doc = "*Required features: `\"Devices_Printers\"`*"]
@@ -1606,36 +1432,7 @@ unsafe impl ::windows::core::Interface for IppTextWithLanguage {
 impl ::windows::core::RuntimeName for IppTextWithLanguage {
     const NAME: &'static str = "Windows.Devices.Printers.IppTextWithLanguage";
 }
-impl ::core::convert::From<IppTextWithLanguage> for ::windows::core::IUnknown {
-    fn from(value: IppTextWithLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppTextWithLanguage> for ::windows::core::IUnknown {
-    fn from(value: &IppTextWithLanguage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppTextWithLanguage> for &::windows::core::IUnknown {
-    fn from(value: &IppTextWithLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IppTextWithLanguage> for ::windows::core::IInspectable {
-    fn from(value: IppTextWithLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IppTextWithLanguage> for ::windows::core::IInspectable {
-    fn from(value: &IppTextWithLanguage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IppTextWithLanguage> for &::windows::core::IInspectable {
-    fn from(value: &IppTextWithLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IppTextWithLanguage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IppTextWithLanguage {}
 unsafe impl ::core::marker::Sync for IppTextWithLanguage {}
 #[doc = "*Required features: `\"Devices_Printers\"`*"]
@@ -1701,36 +1498,7 @@ unsafe impl ::windows::core::Interface for Print3DDevice {
 impl ::windows::core::RuntimeName for Print3DDevice {
     const NAME: &'static str = "Windows.Devices.Printers.Print3DDevice";
 }
-impl ::core::convert::From<Print3DDevice> for ::windows::core::IUnknown {
-    fn from(value: Print3DDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DDevice> for ::windows::core::IUnknown {
-    fn from(value: &Print3DDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DDevice> for &::windows::core::IUnknown {
-    fn from(value: &Print3DDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DDevice> for ::windows::core::IInspectable {
-    fn from(value: Print3DDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DDevice> for ::windows::core::IInspectable {
-    fn from(value: &Print3DDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DDevice> for &::windows::core::IInspectable {
-    fn from(value: &Print3DDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Print3DDevice {}
 unsafe impl ::core::marker::Sync for Print3DDevice {}
 #[doc = "*Required features: `\"Devices_Printers\"`*"]
@@ -1805,36 +1573,7 @@ unsafe impl ::windows::core::Interface for PrintSchema {
 impl ::windows::core::RuntimeName for PrintSchema {
     const NAME: &'static str = "Windows.Devices.Printers.PrintSchema";
 }
-impl ::core::convert::From<PrintSchema> for ::windows::core::IUnknown {
-    fn from(value: PrintSchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSchema> for ::windows::core::IUnknown {
-    fn from(value: &PrintSchema) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSchema> for &::windows::core::IUnknown {
-    fn from(value: &PrintSchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintSchema> for ::windows::core::IInspectable {
-    fn from(value: PrintSchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSchema> for ::windows::core::IInspectable {
-    fn from(value: &PrintSchema) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSchema> for &::windows::core::IInspectable {
-    fn from(value: &PrintSchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintSchema, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintSchema {}
 unsafe impl ::core::marker::Sync for PrintSchema {}
 #[doc = "*Required features: `\"Devices_Printers\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Pwm/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Pwm/Provider/mod.rs
@@ -58,36 +58,7 @@ impl IPwmControllerProvider {
         unsafe { (::windows::core::Vtable::vtable(this).SetPulseParameters)(::windows::core::Vtable::as_raw(this), pin, dutycycle, invertpolarity).ok() }
     }
 }
-impl ::core::convert::From<IPwmControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: IPwmControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPwmControllerProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPwmControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPwmControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: &IPwmControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPwmControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: IPwmControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPwmControllerProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPwmControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPwmControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: &IPwmControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPwmControllerProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPwmControllerProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -146,36 +117,7 @@ impl IPwmProvider {
         }
     }
 }
-impl ::core::convert::From<IPwmProvider> for ::windows::core::IUnknown {
-    fn from(value: IPwmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPwmProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPwmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPwmProvider> for ::windows::core::IUnknown {
-    fn from(value: &IPwmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPwmProvider> for ::windows::core::IInspectable {
-    fn from(value: IPwmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPwmProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPwmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPwmProvider> for ::windows::core::IInspectable {
-    fn from(value: &IPwmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPwmProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPwmProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Devices/Pwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Pwm/mod.rs
@@ -232,36 +232,7 @@ unsafe impl ::windows::core::Interface for PwmController {
 impl ::windows::core::RuntimeName for PwmController {
     const NAME: &'static str = "Windows.Devices.Pwm.PwmController";
 }
-impl ::core::convert::From<PwmController> for ::windows::core::IUnknown {
-    fn from(value: PwmController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PwmController> for ::windows::core::IUnknown {
-    fn from(value: &PwmController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PwmController> for &::windows::core::IUnknown {
-    fn from(value: &PwmController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PwmController> for ::windows::core::IInspectable {
-    fn from(value: PwmController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PwmController> for ::windows::core::IInspectable {
-    fn from(value: &PwmController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PwmController> for &::windows::core::IInspectable {
-    fn from(value: &PwmController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PwmController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PwmController {}
 unsafe impl ::core::marker::Sync for PwmController {}
 #[doc = "*Required features: `\"Devices_Pwm\"`*"]
@@ -351,36 +322,7 @@ unsafe impl ::windows::core::Interface for PwmPin {
 impl ::windows::core::RuntimeName for PwmPin {
     const NAME: &'static str = "Windows.Devices.Pwm.PwmPin";
 }
-impl ::core::convert::From<PwmPin> for ::windows::core::IUnknown {
-    fn from(value: PwmPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PwmPin> for ::windows::core::IUnknown {
-    fn from(value: &PwmPin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PwmPin> for &::windows::core::IUnknown {
-    fn from(value: &PwmPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PwmPin> for ::windows::core::IInspectable {
-    fn from(value: PwmPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PwmPin> for ::windows::core::IInspectable {
-    fn from(value: &PwmPin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PwmPin> for &::windows::core::IInspectable {
-    fn from(value: &PwmPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PwmPin, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<PwmPin> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Devices/Radios/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Radios/mod.rs
@@ -171,36 +171,7 @@ unsafe impl ::windows::core::Interface for Radio {
 impl ::windows::core::RuntimeName for Radio {
     const NAME: &'static str = "Windows.Devices.Radios.Radio";
 }
-impl ::core::convert::From<Radio> for ::windows::core::IUnknown {
-    fn from(value: Radio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Radio> for ::windows::core::IUnknown {
-    fn from(value: &Radio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Radio> for &::windows::core::IUnknown {
-    fn from(value: &Radio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Radio> for ::windows::core::IInspectable {
-    fn from(value: Radio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Radio> for ::windows::core::IInspectable {
-    fn from(value: &Radio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Radio> for &::windows::core::IInspectable {
-    fn from(value: &Radio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Radio, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Radio {}
 unsafe impl ::core::marker::Sync for Radio {}
 #[doc = "*Required features: `\"Devices_Radios\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Scanners/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Scanners/mod.rs
@@ -106,36 +106,7 @@ impl IImageScannerFormatConfiguration {
         }
     }
 }
-impl ::core::convert::From<IImageScannerFormatConfiguration> for ::windows::core::IUnknown {
-    fn from(value: IImageScannerFormatConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImageScannerFormatConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImageScannerFormatConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImageScannerFormatConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &IImageScannerFormatConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IImageScannerFormatConfiguration> for ::windows::core::IInspectable {
-    fn from(value: IImageScannerFormatConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImageScannerFormatConfiguration> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IImageScannerFormatConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImageScannerFormatConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &IImageScannerFormatConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImageScannerFormatConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IImageScannerFormatConfiguration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -431,36 +402,7 @@ impl IImageScannerSourceConfiguration {
         }
     }
 }
-impl ::core::convert::From<IImageScannerSourceConfiguration> for ::windows::core::IUnknown {
-    fn from(value: IImageScannerSourceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImageScannerSourceConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImageScannerSourceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImageScannerSourceConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &IImageScannerSourceConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IImageScannerSourceConfiguration> for ::windows::core::IInspectable {
-    fn from(value: IImageScannerSourceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImageScannerSourceConfiguration> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IImageScannerSourceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImageScannerSourceConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &IImageScannerSourceConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImageScannerSourceConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IImageScannerSourceConfiguration> for IImageScannerFormatConfiguration {
     type Error = ::windows::core::Error;
     fn try_from(value: IImageScannerSourceConfiguration) -> ::windows::core::Result<Self> {
@@ -701,36 +643,7 @@ unsafe impl ::windows::core::Interface for ImageScanner {
 impl ::windows::core::RuntimeName for ImageScanner {
     const NAME: &'static str = "Windows.Devices.Scanners.ImageScanner";
 }
-impl ::core::convert::From<ImageScanner> for ::windows::core::IUnknown {
-    fn from(value: ImageScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScanner> for ::windows::core::IUnknown {
-    fn from(value: &ImageScanner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScanner> for &::windows::core::IUnknown {
-    fn from(value: &ImageScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageScanner> for ::windows::core::IInspectable {
-    fn from(value: ImageScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScanner> for ::windows::core::IInspectable {
-    fn from(value: &ImageScanner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScanner> for &::windows::core::IInspectable {
-    fn from(value: &ImageScanner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageScanner, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ImageScanner {}
 unsafe impl ::core::marker::Sync for ImageScanner {}
 #[doc = "*Required features: `\"Devices_Scanners\"`*"]
@@ -795,36 +708,7 @@ unsafe impl ::windows::core::Interface for ImageScannerAutoConfiguration {
 impl ::windows::core::RuntimeName for ImageScannerAutoConfiguration {
     const NAME: &'static str = "Windows.Devices.Scanners.ImageScannerAutoConfiguration";
 }
-impl ::core::convert::From<ImageScannerAutoConfiguration> for ::windows::core::IUnknown {
-    fn from(value: ImageScannerAutoConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScannerAutoConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &ImageScannerAutoConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScannerAutoConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &ImageScannerAutoConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageScannerAutoConfiguration> for ::windows::core::IInspectable {
-    fn from(value: ImageScannerAutoConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScannerAutoConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &ImageScannerAutoConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScannerAutoConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &ImageScannerAutoConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageScannerAutoConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ImageScannerAutoConfiguration> for IImageScannerFormatConfiguration {
     type Error = ::windows::core::Error;
     fn try_from(value: ImageScannerAutoConfiguration) -> ::windows::core::Result<Self> {
@@ -1214,36 +1098,7 @@ unsafe impl ::windows::core::Interface for ImageScannerFeederConfiguration {
 impl ::windows::core::RuntimeName for ImageScannerFeederConfiguration {
     const NAME: &'static str = "Windows.Devices.Scanners.ImageScannerFeederConfiguration";
 }
-impl ::core::convert::From<ImageScannerFeederConfiguration> for ::windows::core::IUnknown {
-    fn from(value: ImageScannerFeederConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScannerFeederConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &ImageScannerFeederConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScannerFeederConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &ImageScannerFeederConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageScannerFeederConfiguration> for ::windows::core::IInspectable {
-    fn from(value: ImageScannerFeederConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScannerFeederConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &ImageScannerFeederConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScannerFeederConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &ImageScannerFeederConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageScannerFeederConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ImageScannerFeederConfiguration> for IImageScannerFormatConfiguration {
     type Error = ::windows::core::Error;
     fn try_from(value: ImageScannerFeederConfiguration) -> ::windows::core::Result<Self> {
@@ -1539,36 +1394,7 @@ unsafe impl ::windows::core::Interface for ImageScannerFlatbedConfiguration {
 impl ::windows::core::RuntimeName for ImageScannerFlatbedConfiguration {
     const NAME: &'static str = "Windows.Devices.Scanners.ImageScannerFlatbedConfiguration";
 }
-impl ::core::convert::From<ImageScannerFlatbedConfiguration> for ::windows::core::IUnknown {
-    fn from(value: ImageScannerFlatbedConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScannerFlatbedConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &ImageScannerFlatbedConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScannerFlatbedConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &ImageScannerFlatbedConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageScannerFlatbedConfiguration> for ::windows::core::IInspectable {
-    fn from(value: ImageScannerFlatbedConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScannerFlatbedConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &ImageScannerFlatbedConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScannerFlatbedConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &ImageScannerFlatbedConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageScannerFlatbedConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ImageScannerFlatbedConfiguration> for IImageScannerFormatConfiguration {
     type Error = ::windows::core::Error;
     fn try_from(value: ImageScannerFlatbedConfiguration) -> ::windows::core::Result<Self> {
@@ -1660,36 +1486,7 @@ unsafe impl ::windows::core::Interface for ImageScannerPreviewResult {
 impl ::windows::core::RuntimeName for ImageScannerPreviewResult {
     const NAME: &'static str = "Windows.Devices.Scanners.ImageScannerPreviewResult";
 }
-impl ::core::convert::From<ImageScannerPreviewResult> for ::windows::core::IUnknown {
-    fn from(value: ImageScannerPreviewResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScannerPreviewResult> for ::windows::core::IUnknown {
-    fn from(value: &ImageScannerPreviewResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScannerPreviewResult> for &::windows::core::IUnknown {
-    fn from(value: &ImageScannerPreviewResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageScannerPreviewResult> for ::windows::core::IInspectable {
-    fn from(value: ImageScannerPreviewResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScannerPreviewResult> for ::windows::core::IInspectable {
-    fn from(value: &ImageScannerPreviewResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScannerPreviewResult> for &::windows::core::IInspectable {
-    fn from(value: &ImageScannerPreviewResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageScannerPreviewResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ImageScannerPreviewResult {}
 unsafe impl ::core::marker::Sync for ImageScannerPreviewResult {}
 #[doc = "*Required features: `\"Devices_Scanners\"`*"]
@@ -1738,36 +1535,7 @@ unsafe impl ::windows::core::Interface for ImageScannerScanResult {
 impl ::windows::core::RuntimeName for ImageScannerScanResult {
     const NAME: &'static str = "Windows.Devices.Scanners.ImageScannerScanResult";
 }
-impl ::core::convert::From<ImageScannerScanResult> for ::windows::core::IUnknown {
-    fn from(value: ImageScannerScanResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScannerScanResult> for ::windows::core::IUnknown {
-    fn from(value: &ImageScannerScanResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScannerScanResult> for &::windows::core::IUnknown {
-    fn from(value: &ImageScannerScanResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageScannerScanResult> for ::windows::core::IInspectable {
-    fn from(value: ImageScannerScanResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageScannerScanResult> for ::windows::core::IInspectable {
-    fn from(value: &ImageScannerScanResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageScannerScanResult> for &::windows::core::IInspectable {
-    fn from(value: &ImageScannerScanResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageScannerScanResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ImageScannerScanResult {}
 unsafe impl ::core::marker::Sync for ImageScannerScanResult {}
 #[doc = "*Required features: `\"Devices_Scanners\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Sensors/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sensors/Custom/mod.rs
@@ -237,36 +237,7 @@ unsafe impl ::windows::core::Interface for CustomSensor {
 impl ::windows::core::RuntimeName for CustomSensor {
     const NAME: &'static str = "Windows.Devices.Sensors.Custom.CustomSensor";
 }
-impl ::core::convert::From<CustomSensor> for ::windows::core::IUnknown {
-    fn from(value: CustomSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CustomSensor> for ::windows::core::IUnknown {
-    fn from(value: &CustomSensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CustomSensor> for &::windows::core::IUnknown {
-    fn from(value: &CustomSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CustomSensor> for ::windows::core::IInspectable {
-    fn from(value: CustomSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CustomSensor> for ::windows::core::IInspectable {
-    fn from(value: &CustomSensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CustomSensor> for &::windows::core::IInspectable {
-    fn from(value: &CustomSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CustomSensor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CustomSensor {}
 unsafe impl ::core::marker::Sync for CustomSensor {}
 #[doc = "*Required features: `\"Devices_Sensors_Custom\"`*"]
@@ -333,36 +304,7 @@ unsafe impl ::windows::core::Interface for CustomSensorReading {
 impl ::windows::core::RuntimeName for CustomSensorReading {
     const NAME: &'static str = "Windows.Devices.Sensors.Custom.CustomSensorReading";
 }
-impl ::core::convert::From<CustomSensorReading> for ::windows::core::IUnknown {
-    fn from(value: CustomSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CustomSensorReading> for ::windows::core::IUnknown {
-    fn from(value: &CustomSensorReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CustomSensorReading> for &::windows::core::IUnknown {
-    fn from(value: &CustomSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CustomSensorReading> for ::windows::core::IInspectable {
-    fn from(value: CustomSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CustomSensorReading> for ::windows::core::IInspectable {
-    fn from(value: &CustomSensorReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CustomSensorReading> for &::windows::core::IInspectable {
-    fn from(value: &CustomSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CustomSensorReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CustomSensorReading {}
 unsafe impl ::core::marker::Sync for CustomSensorReading {}
 #[doc = "*Required features: `\"Devices_Sensors_Custom\"`*"]
@@ -409,36 +351,7 @@ unsafe impl ::windows::core::Interface for CustomSensorReadingChangedEventArgs {
 impl ::windows::core::RuntimeName for CustomSensorReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.Custom.CustomSensorReadingChangedEventArgs";
 }
-impl ::core::convert::From<CustomSensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CustomSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CustomSensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CustomSensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CustomSensorReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CustomSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CustomSensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CustomSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CustomSensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CustomSensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CustomSensorReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CustomSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CustomSensorReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CustomSensorReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for CustomSensorReadingChangedEventArgs {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Devices/Sensors/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sensors/mod.rs
@@ -2337,36 +2337,7 @@ pub struct IProximitySensorStatics2_Vtbl {
 #[repr(transparent)]
 pub struct ISensorDataThreshold(::windows::core::IUnknown);
 impl ISensorDataThreshold {}
-impl ::core::convert::From<ISensorDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: ISensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISensorDataThreshold> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISensorDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: &ISensorDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISensorDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: ISensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISensorDataThreshold> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISensorDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: &ISensorDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISensorDataThreshold, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISensorDataThreshold {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2758,36 +2729,7 @@ unsafe impl ::windows::core::Interface for Accelerometer {
 impl ::windows::core::RuntimeName for Accelerometer {
     const NAME: &'static str = "Windows.Devices.Sensors.Accelerometer";
 }
-impl ::core::convert::From<Accelerometer> for ::windows::core::IUnknown {
-    fn from(value: Accelerometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Accelerometer> for ::windows::core::IUnknown {
-    fn from(value: &Accelerometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Accelerometer> for &::windows::core::IUnknown {
-    fn from(value: &Accelerometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Accelerometer> for ::windows::core::IInspectable {
-    fn from(value: Accelerometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Accelerometer> for ::windows::core::IInspectable {
-    fn from(value: &Accelerometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Accelerometer> for &::windows::core::IInspectable {
-    fn from(value: &Accelerometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Accelerometer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Accelerometer {}
 unsafe impl ::core::marker::Sync for Accelerometer {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -2860,36 +2802,7 @@ unsafe impl ::windows::core::Interface for AccelerometerDataThreshold {
 impl ::windows::core::RuntimeName for AccelerometerDataThreshold {
     const NAME: &'static str = "Windows.Devices.Sensors.AccelerometerDataThreshold";
 }
-impl ::core::convert::From<AccelerometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: AccelerometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccelerometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: &AccelerometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccelerometerDataThreshold> for &::windows::core::IUnknown {
-    fn from(value: &AccelerometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AccelerometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: AccelerometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccelerometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: &AccelerometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccelerometerDataThreshold> for &::windows::core::IInspectable {
-    fn from(value: &AccelerometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AccelerometerDataThreshold, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AccelerometerDataThreshold {}
 unsafe impl ::core::marker::Sync for AccelerometerDataThreshold {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -2977,36 +2890,7 @@ unsafe impl ::windows::core::Interface for AccelerometerReading {
 impl ::windows::core::RuntimeName for AccelerometerReading {
     const NAME: &'static str = "Windows.Devices.Sensors.AccelerometerReading";
 }
-impl ::core::convert::From<AccelerometerReading> for ::windows::core::IUnknown {
-    fn from(value: AccelerometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccelerometerReading> for ::windows::core::IUnknown {
-    fn from(value: &AccelerometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccelerometerReading> for &::windows::core::IUnknown {
-    fn from(value: &AccelerometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AccelerometerReading> for ::windows::core::IInspectable {
-    fn from(value: AccelerometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccelerometerReading> for ::windows::core::IInspectable {
-    fn from(value: &AccelerometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccelerometerReading> for &::windows::core::IInspectable {
-    fn from(value: &AccelerometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AccelerometerReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AccelerometerReading {}
 unsafe impl ::core::marker::Sync for AccelerometerReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -3053,36 +2937,7 @@ unsafe impl ::windows::core::Interface for AccelerometerReadingChangedEventArgs 
 impl ::windows::core::RuntimeName for AccelerometerReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.AccelerometerReadingChangedEventArgs";
 }
-impl ::core::convert::From<AccelerometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AccelerometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccelerometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AccelerometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccelerometerReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AccelerometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AccelerometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AccelerometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccelerometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AccelerometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccelerometerReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AccelerometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AccelerometerReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AccelerometerReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AccelerometerReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -3131,36 +2986,7 @@ unsafe impl ::windows::core::Interface for AccelerometerShakenEventArgs {
 impl ::windows::core::RuntimeName for AccelerometerShakenEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.AccelerometerShakenEventArgs";
 }
-impl ::core::convert::From<AccelerometerShakenEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AccelerometerShakenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccelerometerShakenEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AccelerometerShakenEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccelerometerShakenEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AccelerometerShakenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AccelerometerShakenEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AccelerometerShakenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccelerometerShakenEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AccelerometerShakenEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccelerometerShakenEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AccelerometerShakenEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AccelerometerShakenEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AccelerometerShakenEventArgs {}
 unsafe impl ::core::marker::Sync for AccelerometerShakenEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -3306,36 +3132,7 @@ unsafe impl ::windows::core::Interface for ActivitySensor {
 impl ::windows::core::RuntimeName for ActivitySensor {
     const NAME: &'static str = "Windows.Devices.Sensors.ActivitySensor";
 }
-impl ::core::convert::From<ActivitySensor> for ::windows::core::IUnknown {
-    fn from(value: ActivitySensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensor> for ::windows::core::IUnknown {
-    fn from(value: &ActivitySensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensor> for &::windows::core::IUnknown {
-    fn from(value: &ActivitySensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivitySensor> for ::windows::core::IInspectable {
-    fn from(value: ActivitySensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensor> for ::windows::core::IInspectable {
-    fn from(value: &ActivitySensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensor> for &::windows::core::IInspectable {
-    fn from(value: &ActivitySensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivitySensor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ActivitySensor {}
 unsafe impl ::core::marker::Sync for ActivitySensor {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -3398,36 +3195,7 @@ unsafe impl ::windows::core::Interface for ActivitySensorReading {
 impl ::windows::core::RuntimeName for ActivitySensorReading {
     const NAME: &'static str = "Windows.Devices.Sensors.ActivitySensorReading";
 }
-impl ::core::convert::From<ActivitySensorReading> for ::windows::core::IUnknown {
-    fn from(value: ActivitySensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensorReading> for ::windows::core::IUnknown {
-    fn from(value: &ActivitySensorReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensorReading> for &::windows::core::IUnknown {
-    fn from(value: &ActivitySensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivitySensorReading> for ::windows::core::IInspectable {
-    fn from(value: ActivitySensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensorReading> for ::windows::core::IInspectable {
-    fn from(value: &ActivitySensorReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensorReading> for &::windows::core::IInspectable {
-    fn from(value: &ActivitySensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivitySensorReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ActivitySensorReading {}
 unsafe impl ::core::marker::Sync for ActivitySensorReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -3474,36 +3242,7 @@ unsafe impl ::windows::core::Interface for ActivitySensorReadingChangeReport {
 impl ::windows::core::RuntimeName for ActivitySensorReadingChangeReport {
     const NAME: &'static str = "Windows.Devices.Sensors.ActivitySensorReadingChangeReport";
 }
-impl ::core::convert::From<ActivitySensorReadingChangeReport> for ::windows::core::IUnknown {
-    fn from(value: ActivitySensorReadingChangeReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensorReadingChangeReport> for ::windows::core::IUnknown {
-    fn from(value: &ActivitySensorReadingChangeReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensorReadingChangeReport> for &::windows::core::IUnknown {
-    fn from(value: &ActivitySensorReadingChangeReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivitySensorReadingChangeReport> for ::windows::core::IInspectable {
-    fn from(value: ActivitySensorReadingChangeReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensorReadingChangeReport> for ::windows::core::IInspectable {
-    fn from(value: &ActivitySensorReadingChangeReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensorReadingChangeReport> for &::windows::core::IInspectable {
-    fn from(value: &ActivitySensorReadingChangeReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivitySensorReadingChangeReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ActivitySensorReadingChangeReport {}
 unsafe impl ::core::marker::Sync for ActivitySensorReadingChangeReport {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -3550,36 +3289,7 @@ unsafe impl ::windows::core::Interface for ActivitySensorReadingChangedEventArgs
 impl ::windows::core::RuntimeName for ActivitySensorReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.ActivitySensorReadingChangedEventArgs";
 }
-impl ::core::convert::From<ActivitySensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ActivitySensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ActivitySensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensorReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ActivitySensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivitySensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ActivitySensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ActivitySensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensorReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ActivitySensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivitySensorReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ActivitySensorReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for ActivitySensorReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -3628,36 +3338,7 @@ unsafe impl ::windows::core::Interface for ActivitySensorTriggerDetails {
 impl ::windows::core::RuntimeName for ActivitySensorTriggerDetails {
     const NAME: &'static str = "Windows.Devices.Sensors.ActivitySensorTriggerDetails";
 }
-impl ::core::convert::From<ActivitySensorTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: ActivitySensorTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensorTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &ActivitySensorTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensorTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &ActivitySensorTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivitySensorTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: ActivitySensorTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivitySensorTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &ActivitySensorTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivitySensorTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &ActivitySensorTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivitySensorTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ActivitySensorTriggerDetails {}
 unsafe impl ::core::marker::Sync for ActivitySensorTriggerDetails {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -3773,36 +3454,7 @@ unsafe impl ::windows::core::Interface for Altimeter {
 impl ::windows::core::RuntimeName for Altimeter {
     const NAME: &'static str = "Windows.Devices.Sensors.Altimeter";
 }
-impl ::core::convert::From<Altimeter> for ::windows::core::IUnknown {
-    fn from(value: Altimeter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Altimeter> for ::windows::core::IUnknown {
-    fn from(value: &Altimeter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Altimeter> for &::windows::core::IUnknown {
-    fn from(value: &Altimeter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Altimeter> for ::windows::core::IInspectable {
-    fn from(value: Altimeter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Altimeter> for ::windows::core::IInspectable {
-    fn from(value: &Altimeter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Altimeter> for &::windows::core::IInspectable {
-    fn from(value: &Altimeter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Altimeter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Altimeter {}
 unsafe impl ::core::marker::Sync for Altimeter {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -3876,36 +3528,7 @@ unsafe impl ::windows::core::Interface for AltimeterReading {
 impl ::windows::core::RuntimeName for AltimeterReading {
     const NAME: &'static str = "Windows.Devices.Sensors.AltimeterReading";
 }
-impl ::core::convert::From<AltimeterReading> for ::windows::core::IUnknown {
-    fn from(value: AltimeterReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AltimeterReading> for ::windows::core::IUnknown {
-    fn from(value: &AltimeterReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AltimeterReading> for &::windows::core::IUnknown {
-    fn from(value: &AltimeterReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AltimeterReading> for ::windows::core::IInspectable {
-    fn from(value: AltimeterReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AltimeterReading> for ::windows::core::IInspectable {
-    fn from(value: &AltimeterReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AltimeterReading> for &::windows::core::IInspectable {
-    fn from(value: &AltimeterReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AltimeterReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AltimeterReading {}
 unsafe impl ::core::marker::Sync for AltimeterReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -3952,36 +3575,7 @@ unsafe impl ::windows::core::Interface for AltimeterReadingChangedEventArgs {
 impl ::windows::core::RuntimeName for AltimeterReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.AltimeterReadingChangedEventArgs";
 }
-impl ::core::convert::From<AltimeterReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AltimeterReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AltimeterReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AltimeterReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AltimeterReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AltimeterReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AltimeterReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AltimeterReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AltimeterReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AltimeterReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AltimeterReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AltimeterReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AltimeterReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AltimeterReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AltimeterReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -4123,36 +3717,7 @@ unsafe impl ::windows::core::Interface for Barometer {
 impl ::windows::core::RuntimeName for Barometer {
     const NAME: &'static str = "Windows.Devices.Sensors.Barometer";
 }
-impl ::core::convert::From<Barometer> for ::windows::core::IUnknown {
-    fn from(value: Barometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Barometer> for ::windows::core::IUnknown {
-    fn from(value: &Barometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Barometer> for &::windows::core::IUnknown {
-    fn from(value: &Barometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Barometer> for ::windows::core::IInspectable {
-    fn from(value: Barometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Barometer> for ::windows::core::IInspectable {
-    fn from(value: &Barometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Barometer> for &::windows::core::IInspectable {
-    fn from(value: &Barometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Barometer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Barometer {}
 unsafe impl ::core::marker::Sync for Barometer {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -4203,36 +3768,7 @@ unsafe impl ::windows::core::Interface for BarometerDataThreshold {
 impl ::windows::core::RuntimeName for BarometerDataThreshold {
     const NAME: &'static str = "Windows.Devices.Sensors.BarometerDataThreshold";
 }
-impl ::core::convert::From<BarometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: BarometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: &BarometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarometerDataThreshold> for &::windows::core::IUnknown {
-    fn from(value: &BarometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: BarometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: &BarometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarometerDataThreshold> for &::windows::core::IInspectable {
-    fn from(value: &BarometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarometerDataThreshold, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarometerDataThreshold {}
 unsafe impl ::core::marker::Sync for BarometerDataThreshold {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -4306,36 +3842,7 @@ unsafe impl ::windows::core::Interface for BarometerReading {
 impl ::windows::core::RuntimeName for BarometerReading {
     const NAME: &'static str = "Windows.Devices.Sensors.BarometerReading";
 }
-impl ::core::convert::From<BarometerReading> for ::windows::core::IUnknown {
-    fn from(value: BarometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarometerReading> for ::windows::core::IUnknown {
-    fn from(value: &BarometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarometerReading> for &::windows::core::IUnknown {
-    fn from(value: &BarometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarometerReading> for ::windows::core::IInspectable {
-    fn from(value: BarometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarometerReading> for ::windows::core::IInspectable {
-    fn from(value: &BarometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarometerReading> for &::windows::core::IInspectable {
-    fn from(value: &BarometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarometerReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarometerReading {}
 unsafe impl ::core::marker::Sync for BarometerReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -4382,36 +3889,7 @@ unsafe impl ::windows::core::Interface for BarometerReadingChangedEventArgs {
 impl ::windows::core::RuntimeName for BarometerReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.BarometerReadingChangedEventArgs";
 }
-impl ::core::convert::From<BarometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BarometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BarometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarometerReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BarometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BarometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BarometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BarometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BarometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BarometerReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BarometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BarometerReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BarometerReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for BarometerReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -4568,36 +4046,7 @@ unsafe impl ::windows::core::Interface for Compass {
 impl ::windows::core::RuntimeName for Compass {
     const NAME: &'static str = "Windows.Devices.Sensors.Compass";
 }
-impl ::core::convert::From<Compass> for ::windows::core::IUnknown {
-    fn from(value: Compass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Compass> for ::windows::core::IUnknown {
-    fn from(value: &Compass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Compass> for &::windows::core::IUnknown {
-    fn from(value: &Compass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Compass> for ::windows::core::IInspectable {
-    fn from(value: Compass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Compass> for ::windows::core::IInspectable {
-    fn from(value: &Compass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Compass> for &::windows::core::IInspectable {
-    fn from(value: &Compass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Compass, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Compass {}
 unsafe impl ::core::marker::Sync for Compass {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -4648,36 +4097,7 @@ unsafe impl ::windows::core::Interface for CompassDataThreshold {
 impl ::windows::core::RuntimeName for CompassDataThreshold {
     const NAME: &'static str = "Windows.Devices.Sensors.CompassDataThreshold";
 }
-impl ::core::convert::From<CompassDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: CompassDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompassDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: &CompassDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompassDataThreshold> for &::windows::core::IUnknown {
-    fn from(value: &CompassDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompassDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: CompassDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompassDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: &CompassDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompassDataThreshold> for &::windows::core::IInspectable {
-    fn from(value: &CompassDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompassDataThreshold, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CompassDataThreshold {}
 unsafe impl ::core::marker::Sync for CompassDataThreshold {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -4767,36 +4187,7 @@ unsafe impl ::windows::core::Interface for CompassReading {
 impl ::windows::core::RuntimeName for CompassReading {
     const NAME: &'static str = "Windows.Devices.Sensors.CompassReading";
 }
-impl ::core::convert::From<CompassReading> for ::windows::core::IUnknown {
-    fn from(value: CompassReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompassReading> for ::windows::core::IUnknown {
-    fn from(value: &CompassReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompassReading> for &::windows::core::IUnknown {
-    fn from(value: &CompassReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompassReading> for ::windows::core::IInspectable {
-    fn from(value: CompassReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompassReading> for ::windows::core::IInspectable {
-    fn from(value: &CompassReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompassReading> for &::windows::core::IInspectable {
-    fn from(value: &CompassReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompassReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CompassReading {}
 unsafe impl ::core::marker::Sync for CompassReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -4843,36 +4234,7 @@ unsafe impl ::windows::core::Interface for CompassReadingChangedEventArgs {
 impl ::windows::core::RuntimeName for CompassReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.CompassReadingChangedEventArgs";
 }
-impl ::core::convert::From<CompassReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CompassReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompassReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CompassReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompassReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CompassReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompassReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CompassReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompassReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CompassReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompassReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CompassReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompassReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CompassReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for CompassReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -5029,36 +4391,7 @@ unsafe impl ::windows::core::Interface for Gyrometer {
 impl ::windows::core::RuntimeName for Gyrometer {
     const NAME: &'static str = "Windows.Devices.Sensors.Gyrometer";
 }
-impl ::core::convert::From<Gyrometer> for ::windows::core::IUnknown {
-    fn from(value: Gyrometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Gyrometer> for ::windows::core::IUnknown {
-    fn from(value: &Gyrometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Gyrometer> for &::windows::core::IUnknown {
-    fn from(value: &Gyrometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Gyrometer> for ::windows::core::IInspectable {
-    fn from(value: Gyrometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Gyrometer> for ::windows::core::IInspectable {
-    fn from(value: &Gyrometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Gyrometer> for &::windows::core::IInspectable {
-    fn from(value: &Gyrometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Gyrometer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Gyrometer {}
 unsafe impl ::core::marker::Sync for Gyrometer {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -5131,36 +4464,7 @@ unsafe impl ::windows::core::Interface for GyrometerDataThreshold {
 impl ::windows::core::RuntimeName for GyrometerDataThreshold {
     const NAME: &'static str = "Windows.Devices.Sensors.GyrometerDataThreshold";
 }
-impl ::core::convert::From<GyrometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: GyrometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GyrometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: &GyrometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GyrometerDataThreshold> for &::windows::core::IUnknown {
-    fn from(value: &GyrometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GyrometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: GyrometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GyrometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: &GyrometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GyrometerDataThreshold> for &::windows::core::IInspectable {
-    fn from(value: &GyrometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GyrometerDataThreshold, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GyrometerDataThreshold {}
 unsafe impl ::core::marker::Sync for GyrometerDataThreshold {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -5248,36 +4552,7 @@ unsafe impl ::windows::core::Interface for GyrometerReading {
 impl ::windows::core::RuntimeName for GyrometerReading {
     const NAME: &'static str = "Windows.Devices.Sensors.GyrometerReading";
 }
-impl ::core::convert::From<GyrometerReading> for ::windows::core::IUnknown {
-    fn from(value: GyrometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GyrometerReading> for ::windows::core::IUnknown {
-    fn from(value: &GyrometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GyrometerReading> for &::windows::core::IUnknown {
-    fn from(value: &GyrometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GyrometerReading> for ::windows::core::IInspectable {
-    fn from(value: GyrometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GyrometerReading> for ::windows::core::IInspectable {
-    fn from(value: &GyrometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GyrometerReading> for &::windows::core::IInspectable {
-    fn from(value: &GyrometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GyrometerReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GyrometerReading {}
 unsafe impl ::core::marker::Sync for GyrometerReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -5324,36 +4599,7 @@ unsafe impl ::windows::core::Interface for GyrometerReadingChangedEventArgs {
 impl ::windows::core::RuntimeName for GyrometerReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.GyrometerReadingChangedEventArgs";
 }
-impl ::core::convert::From<GyrometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GyrometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GyrometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GyrometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GyrometerReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GyrometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GyrometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GyrometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GyrometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GyrometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GyrometerReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GyrometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GyrometerReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GyrometerReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for GyrometerReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -5418,36 +4664,7 @@ unsafe impl ::windows::core::Interface for HingeAngleReading {
 impl ::windows::core::RuntimeName for HingeAngleReading {
     const NAME: &'static str = "Windows.Devices.Sensors.HingeAngleReading";
 }
-impl ::core::convert::From<HingeAngleReading> for ::windows::core::IUnknown {
-    fn from(value: HingeAngleReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HingeAngleReading> for ::windows::core::IUnknown {
-    fn from(value: &HingeAngleReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HingeAngleReading> for &::windows::core::IUnknown {
-    fn from(value: &HingeAngleReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HingeAngleReading> for ::windows::core::IInspectable {
-    fn from(value: HingeAngleReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HingeAngleReading> for ::windows::core::IInspectable {
-    fn from(value: &HingeAngleReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HingeAngleReading> for &::windows::core::IInspectable {
-    fn from(value: &HingeAngleReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HingeAngleReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HingeAngleReading {}
 unsafe impl ::core::marker::Sync for HingeAngleReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -5571,36 +4788,7 @@ unsafe impl ::windows::core::Interface for HingeAngleSensor {
 impl ::windows::core::RuntimeName for HingeAngleSensor {
     const NAME: &'static str = "Windows.Devices.Sensors.HingeAngleSensor";
 }
-impl ::core::convert::From<HingeAngleSensor> for ::windows::core::IUnknown {
-    fn from(value: HingeAngleSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HingeAngleSensor> for ::windows::core::IUnknown {
-    fn from(value: &HingeAngleSensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HingeAngleSensor> for &::windows::core::IUnknown {
-    fn from(value: &HingeAngleSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HingeAngleSensor> for ::windows::core::IInspectable {
-    fn from(value: HingeAngleSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HingeAngleSensor> for ::windows::core::IInspectable {
-    fn from(value: &HingeAngleSensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HingeAngleSensor> for &::windows::core::IInspectable {
-    fn from(value: &HingeAngleSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HingeAngleSensor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HingeAngleSensor {}
 unsafe impl ::core::marker::Sync for HingeAngleSensor {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -5647,36 +4835,7 @@ unsafe impl ::windows::core::Interface for HingeAngleSensorReadingChangedEventAr
 impl ::windows::core::RuntimeName for HingeAngleSensorReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.HingeAngleSensorReadingChangedEventArgs";
 }
-impl ::core::convert::From<HingeAngleSensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: HingeAngleSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HingeAngleSensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &HingeAngleSensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HingeAngleSensorReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &HingeAngleSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HingeAngleSensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: HingeAngleSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HingeAngleSensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &HingeAngleSensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HingeAngleSensorReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &HingeAngleSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HingeAngleSensorReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HingeAngleSensorReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for HingeAngleSensorReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -5862,36 +5021,7 @@ unsafe impl ::windows::core::Interface for Inclinometer {
 impl ::windows::core::RuntimeName for Inclinometer {
     const NAME: &'static str = "Windows.Devices.Sensors.Inclinometer";
 }
-impl ::core::convert::From<Inclinometer> for ::windows::core::IUnknown {
-    fn from(value: Inclinometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Inclinometer> for ::windows::core::IUnknown {
-    fn from(value: &Inclinometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Inclinometer> for &::windows::core::IUnknown {
-    fn from(value: &Inclinometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Inclinometer> for ::windows::core::IInspectable {
-    fn from(value: Inclinometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Inclinometer> for ::windows::core::IInspectable {
-    fn from(value: &Inclinometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Inclinometer> for &::windows::core::IInspectable {
-    fn from(value: &Inclinometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Inclinometer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Inclinometer {}
 unsafe impl ::core::marker::Sync for Inclinometer {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -5964,36 +5094,7 @@ unsafe impl ::windows::core::Interface for InclinometerDataThreshold {
 impl ::windows::core::RuntimeName for InclinometerDataThreshold {
     const NAME: &'static str = "Windows.Devices.Sensors.InclinometerDataThreshold";
 }
-impl ::core::convert::From<InclinometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: InclinometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InclinometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: &InclinometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InclinometerDataThreshold> for &::windows::core::IUnknown {
-    fn from(value: &InclinometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InclinometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: InclinometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InclinometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: &InclinometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InclinometerDataThreshold> for &::windows::core::IInspectable {
-    fn from(value: &InclinometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InclinometerDataThreshold, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InclinometerDataThreshold {}
 unsafe impl ::core::marker::Sync for InclinometerDataThreshold {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -6088,36 +5189,7 @@ unsafe impl ::windows::core::Interface for InclinometerReading {
 impl ::windows::core::RuntimeName for InclinometerReading {
     const NAME: &'static str = "Windows.Devices.Sensors.InclinometerReading";
 }
-impl ::core::convert::From<InclinometerReading> for ::windows::core::IUnknown {
-    fn from(value: InclinometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InclinometerReading> for ::windows::core::IUnknown {
-    fn from(value: &InclinometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InclinometerReading> for &::windows::core::IUnknown {
-    fn from(value: &InclinometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InclinometerReading> for ::windows::core::IInspectable {
-    fn from(value: InclinometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InclinometerReading> for ::windows::core::IInspectable {
-    fn from(value: &InclinometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InclinometerReading> for &::windows::core::IInspectable {
-    fn from(value: &InclinometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InclinometerReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InclinometerReading {}
 unsafe impl ::core::marker::Sync for InclinometerReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -6164,36 +5236,7 @@ unsafe impl ::windows::core::Interface for InclinometerReadingChangedEventArgs {
 impl ::windows::core::RuntimeName for InclinometerReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.InclinometerReadingChangedEventArgs";
 }
-impl ::core::convert::From<InclinometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: InclinometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InclinometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &InclinometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InclinometerReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &InclinometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InclinometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: InclinometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InclinometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &InclinometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InclinometerReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &InclinometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InclinometerReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InclinometerReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for InclinometerReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -6335,36 +5378,7 @@ unsafe impl ::windows::core::Interface for LightSensor {
 impl ::windows::core::RuntimeName for LightSensor {
     const NAME: &'static str = "Windows.Devices.Sensors.LightSensor";
 }
-impl ::core::convert::From<LightSensor> for ::windows::core::IUnknown {
-    fn from(value: LightSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LightSensor> for ::windows::core::IUnknown {
-    fn from(value: &LightSensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LightSensor> for &::windows::core::IUnknown {
-    fn from(value: &LightSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LightSensor> for ::windows::core::IInspectable {
-    fn from(value: LightSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LightSensor> for ::windows::core::IInspectable {
-    fn from(value: &LightSensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LightSensor> for &::windows::core::IInspectable {
-    fn from(value: &LightSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LightSensor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LightSensor {}
 unsafe impl ::core::marker::Sync for LightSensor {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -6426,36 +5440,7 @@ unsafe impl ::windows::core::Interface for LightSensorDataThreshold {
 impl ::windows::core::RuntimeName for LightSensorDataThreshold {
     const NAME: &'static str = "Windows.Devices.Sensors.LightSensorDataThreshold";
 }
-impl ::core::convert::From<LightSensorDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: LightSensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LightSensorDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: &LightSensorDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LightSensorDataThreshold> for &::windows::core::IUnknown {
-    fn from(value: &LightSensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LightSensorDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: LightSensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LightSensorDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: &LightSensorDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LightSensorDataThreshold> for &::windows::core::IInspectable {
-    fn from(value: &LightSensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LightSensorDataThreshold, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LightSensorDataThreshold {}
 unsafe impl ::core::marker::Sync for LightSensorDataThreshold {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -6529,36 +5514,7 @@ unsafe impl ::windows::core::Interface for LightSensorReading {
 impl ::windows::core::RuntimeName for LightSensorReading {
     const NAME: &'static str = "Windows.Devices.Sensors.LightSensorReading";
 }
-impl ::core::convert::From<LightSensorReading> for ::windows::core::IUnknown {
-    fn from(value: LightSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LightSensorReading> for ::windows::core::IUnknown {
-    fn from(value: &LightSensorReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LightSensorReading> for &::windows::core::IUnknown {
-    fn from(value: &LightSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LightSensorReading> for ::windows::core::IInspectable {
-    fn from(value: LightSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LightSensorReading> for ::windows::core::IInspectable {
-    fn from(value: &LightSensorReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LightSensorReading> for &::windows::core::IInspectable {
-    fn from(value: &LightSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LightSensorReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LightSensorReading {}
 unsafe impl ::core::marker::Sync for LightSensorReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -6605,36 +5561,7 @@ unsafe impl ::windows::core::Interface for LightSensorReadingChangedEventArgs {
 impl ::windows::core::RuntimeName for LightSensorReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.LightSensorReadingChangedEventArgs";
 }
-impl ::core::convert::From<LightSensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LightSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LightSensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LightSensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LightSensorReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LightSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LightSensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LightSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LightSensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LightSensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LightSensorReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LightSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LightSensorReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LightSensorReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for LightSensorReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -6791,36 +5718,7 @@ unsafe impl ::windows::core::Interface for Magnetometer {
 impl ::windows::core::RuntimeName for Magnetometer {
     const NAME: &'static str = "Windows.Devices.Sensors.Magnetometer";
 }
-impl ::core::convert::From<Magnetometer> for ::windows::core::IUnknown {
-    fn from(value: Magnetometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Magnetometer> for ::windows::core::IUnknown {
-    fn from(value: &Magnetometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Magnetometer> for &::windows::core::IUnknown {
-    fn from(value: &Magnetometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Magnetometer> for ::windows::core::IInspectable {
-    fn from(value: Magnetometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Magnetometer> for ::windows::core::IInspectable {
-    fn from(value: &Magnetometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Magnetometer> for &::windows::core::IInspectable {
-    fn from(value: &Magnetometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Magnetometer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Magnetometer {}
 unsafe impl ::core::marker::Sync for Magnetometer {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -6893,36 +5791,7 @@ unsafe impl ::windows::core::Interface for MagnetometerDataThreshold {
 impl ::windows::core::RuntimeName for MagnetometerDataThreshold {
     const NAME: &'static str = "Windows.Devices.Sensors.MagnetometerDataThreshold";
 }
-impl ::core::convert::From<MagnetometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: MagnetometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagnetometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: &MagnetometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagnetometerDataThreshold> for &::windows::core::IUnknown {
-    fn from(value: &MagnetometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagnetometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: MagnetometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagnetometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: &MagnetometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagnetometerDataThreshold> for &::windows::core::IInspectable {
-    fn from(value: &MagnetometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagnetometerDataThreshold, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MagnetometerDataThreshold {}
 unsafe impl ::core::marker::Sync for MagnetometerDataThreshold {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -7017,36 +5886,7 @@ unsafe impl ::windows::core::Interface for MagnetometerReading {
 impl ::windows::core::RuntimeName for MagnetometerReading {
     const NAME: &'static str = "Windows.Devices.Sensors.MagnetometerReading";
 }
-impl ::core::convert::From<MagnetometerReading> for ::windows::core::IUnknown {
-    fn from(value: MagnetometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagnetometerReading> for ::windows::core::IUnknown {
-    fn from(value: &MagnetometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagnetometerReading> for &::windows::core::IUnknown {
-    fn from(value: &MagnetometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagnetometerReading> for ::windows::core::IInspectable {
-    fn from(value: MagnetometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagnetometerReading> for ::windows::core::IInspectable {
-    fn from(value: &MagnetometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagnetometerReading> for &::windows::core::IInspectable {
-    fn from(value: &MagnetometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagnetometerReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MagnetometerReading {}
 unsafe impl ::core::marker::Sync for MagnetometerReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -7093,36 +5933,7 @@ unsafe impl ::windows::core::Interface for MagnetometerReadingChangedEventArgs {
 impl ::windows::core::RuntimeName for MagnetometerReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.MagnetometerReadingChangedEventArgs";
 }
-impl ::core::convert::From<MagnetometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MagnetometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagnetometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MagnetometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagnetometerReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MagnetometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MagnetometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MagnetometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MagnetometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MagnetometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MagnetometerReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MagnetometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MagnetometerReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MagnetometerReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for MagnetometerReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -7313,36 +6124,7 @@ unsafe impl ::windows::core::Interface for OrientationSensor {
 impl ::windows::core::RuntimeName for OrientationSensor {
     const NAME: &'static str = "Windows.Devices.Sensors.OrientationSensor";
 }
-impl ::core::convert::From<OrientationSensor> for ::windows::core::IUnknown {
-    fn from(value: OrientationSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OrientationSensor> for ::windows::core::IUnknown {
-    fn from(value: &OrientationSensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OrientationSensor> for &::windows::core::IUnknown {
-    fn from(value: &OrientationSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OrientationSensor> for ::windows::core::IInspectable {
-    fn from(value: OrientationSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OrientationSensor> for ::windows::core::IInspectable {
-    fn from(value: &OrientationSensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OrientationSensor> for &::windows::core::IInspectable {
-    fn from(value: &OrientationSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OrientationSensor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OrientationSensor {}
 unsafe impl ::core::marker::Sync for OrientationSensor {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -7430,36 +6212,7 @@ unsafe impl ::windows::core::Interface for OrientationSensorReading {
 impl ::windows::core::RuntimeName for OrientationSensorReading {
     const NAME: &'static str = "Windows.Devices.Sensors.OrientationSensorReading";
 }
-impl ::core::convert::From<OrientationSensorReading> for ::windows::core::IUnknown {
-    fn from(value: OrientationSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OrientationSensorReading> for ::windows::core::IUnknown {
-    fn from(value: &OrientationSensorReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OrientationSensorReading> for &::windows::core::IUnknown {
-    fn from(value: &OrientationSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OrientationSensorReading> for ::windows::core::IInspectable {
-    fn from(value: OrientationSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OrientationSensorReading> for ::windows::core::IInspectable {
-    fn from(value: &OrientationSensorReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OrientationSensorReading> for &::windows::core::IInspectable {
-    fn from(value: &OrientationSensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OrientationSensorReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OrientationSensorReading {}
 unsafe impl ::core::marker::Sync for OrientationSensorReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -7506,36 +6259,7 @@ unsafe impl ::windows::core::Interface for OrientationSensorReadingChangedEventA
 impl ::windows::core::RuntimeName for OrientationSensorReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.OrientationSensorReadingChangedEventArgs";
 }
-impl ::core::convert::From<OrientationSensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: OrientationSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OrientationSensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &OrientationSensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OrientationSensorReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &OrientationSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OrientationSensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: OrientationSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OrientationSensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &OrientationSensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OrientationSensorReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &OrientationSensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OrientationSensorReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OrientationSensorReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for OrientationSensorReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -7687,36 +6411,7 @@ unsafe impl ::windows::core::Interface for Pedometer {
 impl ::windows::core::RuntimeName for Pedometer {
     const NAME: &'static str = "Windows.Devices.Sensors.Pedometer";
 }
-impl ::core::convert::From<Pedometer> for ::windows::core::IUnknown {
-    fn from(value: Pedometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Pedometer> for ::windows::core::IUnknown {
-    fn from(value: &Pedometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Pedometer> for &::windows::core::IUnknown {
-    fn from(value: &Pedometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Pedometer> for ::windows::core::IInspectable {
-    fn from(value: Pedometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Pedometer> for ::windows::core::IInspectable {
-    fn from(value: &Pedometer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Pedometer> for &::windows::core::IInspectable {
-    fn from(value: &Pedometer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Pedometer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Pedometer {}
 unsafe impl ::core::marker::Sync for Pedometer {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -7767,36 +6462,7 @@ unsafe impl ::windows::core::Interface for PedometerDataThreshold {
 impl ::windows::core::RuntimeName for PedometerDataThreshold {
     const NAME: &'static str = "Windows.Devices.Sensors.PedometerDataThreshold";
 }
-impl ::core::convert::From<PedometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: PedometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PedometerDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: &PedometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PedometerDataThreshold> for &::windows::core::IUnknown {
-    fn from(value: &PedometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PedometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: PedometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PedometerDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: &PedometerDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PedometerDataThreshold> for &::windows::core::IInspectable {
-    fn from(value: &PedometerDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PedometerDataThreshold, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PedometerDataThreshold> for ISensorDataThreshold {
     type Error = ::windows::core::Error;
     fn try_from(value: PedometerDataThreshold) -> ::windows::core::Result<Self> {
@@ -7887,36 +6553,7 @@ unsafe impl ::windows::core::Interface for PedometerReading {
 impl ::windows::core::RuntimeName for PedometerReading {
     const NAME: &'static str = "Windows.Devices.Sensors.PedometerReading";
 }
-impl ::core::convert::From<PedometerReading> for ::windows::core::IUnknown {
-    fn from(value: PedometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PedometerReading> for ::windows::core::IUnknown {
-    fn from(value: &PedometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PedometerReading> for &::windows::core::IUnknown {
-    fn from(value: &PedometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PedometerReading> for ::windows::core::IInspectable {
-    fn from(value: PedometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PedometerReading> for ::windows::core::IInspectable {
-    fn from(value: &PedometerReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PedometerReading> for &::windows::core::IInspectable {
-    fn from(value: &PedometerReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PedometerReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PedometerReading {}
 unsafe impl ::core::marker::Sync for PedometerReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -7963,36 +6600,7 @@ unsafe impl ::windows::core::Interface for PedometerReadingChangedEventArgs {
 impl ::windows::core::RuntimeName for PedometerReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.PedometerReadingChangedEventArgs";
 }
-impl ::core::convert::From<PedometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PedometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PedometerReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PedometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PedometerReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PedometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PedometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PedometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PedometerReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PedometerReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PedometerReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PedometerReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PedometerReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PedometerReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for PedometerReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -8118,36 +6726,7 @@ unsafe impl ::windows::core::Interface for ProximitySensor {
 impl ::windows::core::RuntimeName for ProximitySensor {
     const NAME: &'static str = "Windows.Devices.Sensors.ProximitySensor";
 }
-impl ::core::convert::From<ProximitySensor> for ::windows::core::IUnknown {
-    fn from(value: ProximitySensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximitySensor> for ::windows::core::IUnknown {
-    fn from(value: &ProximitySensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximitySensor> for &::windows::core::IUnknown {
-    fn from(value: &ProximitySensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProximitySensor> for ::windows::core::IInspectable {
-    fn from(value: ProximitySensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximitySensor> for ::windows::core::IInspectable {
-    fn from(value: &ProximitySensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximitySensor> for &::windows::core::IInspectable {
-    fn from(value: &ProximitySensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProximitySensor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProximitySensor {}
 unsafe impl ::core::marker::Sync for ProximitySensor {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -8198,36 +6777,7 @@ unsafe impl ::windows::core::Interface for ProximitySensorDataThreshold {
 impl ::windows::core::RuntimeName for ProximitySensorDataThreshold {
     const NAME: &'static str = "Windows.Devices.Sensors.ProximitySensorDataThreshold";
 }
-impl ::core::convert::From<ProximitySensorDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: ProximitySensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximitySensorDataThreshold> for ::windows::core::IUnknown {
-    fn from(value: &ProximitySensorDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximitySensorDataThreshold> for &::windows::core::IUnknown {
-    fn from(value: &ProximitySensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProximitySensorDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: ProximitySensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximitySensorDataThreshold> for ::windows::core::IInspectable {
-    fn from(value: &ProximitySensorDataThreshold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximitySensorDataThreshold> for &::windows::core::IInspectable {
-    fn from(value: &ProximitySensorDataThreshold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProximitySensorDataThreshold, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ProximitySensorDataThreshold> for ISensorDataThreshold {
     type Error = ::windows::core::Error;
     fn try_from(value: ProximitySensorDataThreshold) -> ::windows::core::Result<Self> {
@@ -8303,41 +6853,7 @@ impl ::windows::core::RuntimeName for ProximitySensorDisplayOnOffController {
     const NAME: &'static str = "Windows.Devices.Sensors.ProximitySensorDisplayOnOffController";
 }
 #[cfg(feature = "Foundation")]
-impl ::core::convert::From<ProximitySensorDisplayOnOffController> for ::windows::core::IUnknown {
-    fn from(value: ProximitySensorDisplayOnOffController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&ProximitySensorDisplayOnOffController> for ::windows::core::IUnknown {
-    fn from(value: &ProximitySensorDisplayOnOffController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&ProximitySensorDisplayOnOffController> for &::windows::core::IUnknown {
-    fn from(value: &ProximitySensorDisplayOnOffController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<ProximitySensorDisplayOnOffController> for ::windows::core::IInspectable {
-    fn from(value: ProximitySensorDisplayOnOffController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&ProximitySensorDisplayOnOffController> for ::windows::core::IInspectable {
-    fn from(value: &ProximitySensorDisplayOnOffController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&ProximitySensorDisplayOnOffController> for &::windows::core::IInspectable {
-    fn from(value: &ProximitySensorDisplayOnOffController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProximitySensorDisplayOnOffController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ProximitySensorDisplayOnOffController> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -8426,36 +6942,7 @@ unsafe impl ::windows::core::Interface for ProximitySensorReading {
 impl ::windows::core::RuntimeName for ProximitySensorReading {
     const NAME: &'static str = "Windows.Devices.Sensors.ProximitySensorReading";
 }
-impl ::core::convert::From<ProximitySensorReading> for ::windows::core::IUnknown {
-    fn from(value: ProximitySensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximitySensorReading> for ::windows::core::IUnknown {
-    fn from(value: &ProximitySensorReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximitySensorReading> for &::windows::core::IUnknown {
-    fn from(value: &ProximitySensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProximitySensorReading> for ::windows::core::IInspectable {
-    fn from(value: ProximitySensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximitySensorReading> for ::windows::core::IInspectable {
-    fn from(value: &ProximitySensorReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximitySensorReading> for &::windows::core::IInspectable {
-    fn from(value: &ProximitySensorReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProximitySensorReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProximitySensorReading {}
 unsafe impl ::core::marker::Sync for ProximitySensorReading {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -8502,36 +6989,7 @@ unsafe impl ::windows::core::Interface for ProximitySensorReadingChangedEventArg
 impl ::windows::core::RuntimeName for ProximitySensorReadingChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.ProximitySensorReadingChangedEventArgs";
 }
-impl ::core::convert::From<ProximitySensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ProximitySensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximitySensorReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ProximitySensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximitySensorReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ProximitySensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProximitySensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ProximitySensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximitySensorReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ProximitySensorReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximitySensorReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ProximitySensorReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProximitySensorReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProximitySensorReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for ProximitySensorReadingChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -8585,36 +7043,7 @@ unsafe impl ::windows::core::Interface for SensorDataThresholdTriggerDetails {
 impl ::windows::core::RuntimeName for SensorDataThresholdTriggerDetails {
     const NAME: &'static str = "Windows.Devices.Sensors.SensorDataThresholdTriggerDetails";
 }
-impl ::core::convert::From<SensorDataThresholdTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: SensorDataThresholdTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SensorDataThresholdTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &SensorDataThresholdTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SensorDataThresholdTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &SensorDataThresholdTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SensorDataThresholdTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: SensorDataThresholdTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SensorDataThresholdTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &SensorDataThresholdTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SensorDataThresholdTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &SensorDataThresholdTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SensorDataThresholdTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SensorDataThresholdTriggerDetails {}
 unsafe impl ::core::marker::Sync for SensorDataThresholdTriggerDetails {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -8682,36 +7111,7 @@ unsafe impl ::windows::core::Interface for SensorQuaternion {
 impl ::windows::core::RuntimeName for SensorQuaternion {
     const NAME: &'static str = "Windows.Devices.Sensors.SensorQuaternion";
 }
-impl ::core::convert::From<SensorQuaternion> for ::windows::core::IUnknown {
-    fn from(value: SensorQuaternion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SensorQuaternion> for ::windows::core::IUnknown {
-    fn from(value: &SensorQuaternion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SensorQuaternion> for &::windows::core::IUnknown {
-    fn from(value: &SensorQuaternion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SensorQuaternion> for ::windows::core::IInspectable {
-    fn from(value: SensorQuaternion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SensorQuaternion> for ::windows::core::IInspectable {
-    fn from(value: &SensorQuaternion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SensorQuaternion> for &::windows::core::IInspectable {
-    fn from(value: &SensorQuaternion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SensorQuaternion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SensorQuaternion {}
 unsafe impl ::core::marker::Sync for SensorQuaternion {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -8814,36 +7214,7 @@ unsafe impl ::windows::core::Interface for SensorRotationMatrix {
 impl ::windows::core::RuntimeName for SensorRotationMatrix {
     const NAME: &'static str = "Windows.Devices.Sensors.SensorRotationMatrix";
 }
-impl ::core::convert::From<SensorRotationMatrix> for ::windows::core::IUnknown {
-    fn from(value: SensorRotationMatrix) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SensorRotationMatrix> for ::windows::core::IUnknown {
-    fn from(value: &SensorRotationMatrix) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SensorRotationMatrix> for &::windows::core::IUnknown {
-    fn from(value: &SensorRotationMatrix) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SensorRotationMatrix> for ::windows::core::IInspectable {
-    fn from(value: SensorRotationMatrix) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SensorRotationMatrix> for ::windows::core::IInspectable {
-    fn from(value: &SensorRotationMatrix) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SensorRotationMatrix> for &::windows::core::IInspectable {
-    fn from(value: &SensorRotationMatrix) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SensorRotationMatrix, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SensorRotationMatrix {}
 unsafe impl ::core::marker::Sync for SensorRotationMatrix {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -8957,36 +7328,7 @@ unsafe impl ::windows::core::Interface for SimpleOrientationSensor {
 impl ::windows::core::RuntimeName for SimpleOrientationSensor {
     const NAME: &'static str = "Windows.Devices.Sensors.SimpleOrientationSensor";
 }
-impl ::core::convert::From<SimpleOrientationSensor> for ::windows::core::IUnknown {
-    fn from(value: SimpleOrientationSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SimpleOrientationSensor> for ::windows::core::IUnknown {
-    fn from(value: &SimpleOrientationSensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SimpleOrientationSensor> for &::windows::core::IUnknown {
-    fn from(value: &SimpleOrientationSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SimpleOrientationSensor> for ::windows::core::IInspectable {
-    fn from(value: SimpleOrientationSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SimpleOrientationSensor> for ::windows::core::IInspectable {
-    fn from(value: &SimpleOrientationSensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SimpleOrientationSensor> for &::windows::core::IInspectable {
-    fn from(value: &SimpleOrientationSensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SimpleOrientationSensor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SimpleOrientationSensor {}
 unsafe impl ::core::marker::Sync for SimpleOrientationSensor {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]
@@ -9042,36 +7384,7 @@ unsafe impl ::windows::core::Interface for SimpleOrientationSensorOrientationCha
 impl ::windows::core::RuntimeName for SimpleOrientationSensorOrientationChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sensors.SimpleOrientationSensorOrientationChangedEventArgs";
 }
-impl ::core::convert::From<SimpleOrientationSensorOrientationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SimpleOrientationSensorOrientationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SimpleOrientationSensorOrientationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SimpleOrientationSensorOrientationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SimpleOrientationSensorOrientationChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SimpleOrientationSensorOrientationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SimpleOrientationSensorOrientationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SimpleOrientationSensorOrientationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SimpleOrientationSensorOrientationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SimpleOrientationSensorOrientationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SimpleOrientationSensorOrientationChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SimpleOrientationSensorOrientationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SimpleOrientationSensorOrientationChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SimpleOrientationSensorOrientationChangedEventArgs {}
 unsafe impl ::core::marker::Sync for SimpleOrientationSensorOrientationChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_Sensors\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/SerialCommunication/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SerialCommunication/mod.rs
@@ -170,36 +170,7 @@ unsafe impl ::windows::core::Interface for ErrorReceivedEventArgs {
 impl ::windows::core::RuntimeName for ErrorReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.SerialCommunication.ErrorReceivedEventArgs";
 }
-impl ::core::convert::From<ErrorReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ErrorReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ErrorReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ErrorReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ErrorReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ErrorReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ErrorReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ErrorReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ErrorReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ErrorReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ErrorReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ErrorReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ErrorReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ErrorReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for ErrorReceivedEventArgs {}
 #[doc = "*Required features: `\"Devices_SerialCommunication\"`*"]
@@ -246,36 +217,7 @@ unsafe impl ::windows::core::Interface for PinChangedEventArgs {
 impl ::windows::core::RuntimeName for PinChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.SerialCommunication.PinChangedEventArgs";
 }
-impl ::core::convert::From<PinChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PinChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PinChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PinChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PinChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PinChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PinChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PinChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PinChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PinChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PinChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PinChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PinChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PinChangedEventArgs {}
 unsafe impl ::core::marker::Sync for PinChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_SerialCommunication\"`*"]
@@ -567,36 +509,7 @@ unsafe impl ::windows::core::Interface for SerialDevice {
 impl ::windows::core::RuntimeName for SerialDevice {
     const NAME: &'static str = "Windows.Devices.SerialCommunication.SerialDevice";
 }
-impl ::core::convert::From<SerialDevice> for ::windows::core::IUnknown {
-    fn from(value: SerialDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SerialDevice> for ::windows::core::IUnknown {
-    fn from(value: &SerialDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SerialDevice> for &::windows::core::IUnknown {
-    fn from(value: &SerialDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SerialDevice> for ::windows::core::IInspectable {
-    fn from(value: SerialDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SerialDevice> for ::windows::core::IInspectable {
-    fn from(value: &SerialDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SerialDevice> for &::windows::core::IInspectable {
-    fn from(value: &SerialDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SerialDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<SerialDevice> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
@@ -1295,36 +1295,7 @@ unsafe impl ::windows::core::Interface for CardAddedEventArgs {
 impl ::windows::core::RuntimeName for CardAddedEventArgs {
     const NAME: &'static str = "Windows.Devices.SmartCards.CardAddedEventArgs";
 }
-impl ::core::convert::From<CardAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CardAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CardAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CardAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CardAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CardAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CardAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CardAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CardAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CardAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CardAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CardAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CardAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CardAddedEventArgs {}
 unsafe impl ::core::marker::Sync for CardAddedEventArgs {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -1371,36 +1342,7 @@ unsafe impl ::windows::core::Interface for CardRemovedEventArgs {
 impl ::windows::core::RuntimeName for CardRemovedEventArgs {
     const NAME: &'static str = "Windows.Devices.SmartCards.CardRemovedEventArgs";
 }
-impl ::core::convert::From<CardRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CardRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CardRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CardRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CardRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CardRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CardRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CardRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CardRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CardRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CardRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CardRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CardRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CardRemovedEventArgs {}
 unsafe impl ::core::marker::Sync for CardRemovedEventArgs {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -1502,36 +1444,7 @@ unsafe impl ::windows::core::Interface for SmartCard {
 impl ::windows::core::RuntimeName for SmartCard {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCard";
 }
-impl ::core::convert::From<SmartCard> for ::windows::core::IUnknown {
-    fn from(value: SmartCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCard> for ::windows::core::IUnknown {
-    fn from(value: &SmartCard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCard> for &::windows::core::IUnknown {
-    fn from(value: &SmartCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCard> for ::windows::core::IInspectable {
-    fn from(value: SmartCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCard> for ::windows::core::IInspectable {
-    fn from(value: &SmartCard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCard> for &::windows::core::IInspectable {
-    fn from(value: &SmartCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCard, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCard {}
 unsafe impl ::core::marker::Sync for SmartCard {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -1709,36 +1622,7 @@ unsafe impl ::windows::core::Interface for SmartCardAppletIdGroup {
 impl ::windows::core::RuntimeName for SmartCardAppletIdGroup {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardAppletIdGroup";
 }
-impl ::core::convert::From<SmartCardAppletIdGroup> for ::windows::core::IUnknown {
-    fn from(value: SmartCardAppletIdGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardAppletIdGroup> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardAppletIdGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardAppletIdGroup> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardAppletIdGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardAppletIdGroup> for ::windows::core::IInspectable {
-    fn from(value: SmartCardAppletIdGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardAppletIdGroup> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardAppletIdGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardAppletIdGroup> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardAppletIdGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardAppletIdGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardAppletIdGroup {}
 unsafe impl ::core::marker::Sync for SmartCardAppletIdGroup {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -1837,36 +1721,7 @@ unsafe impl ::windows::core::Interface for SmartCardAppletIdGroupRegistration {
 impl ::windows::core::RuntimeName for SmartCardAppletIdGroupRegistration {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardAppletIdGroupRegistration";
 }
-impl ::core::convert::From<SmartCardAppletIdGroupRegistration> for ::windows::core::IUnknown {
-    fn from(value: SmartCardAppletIdGroupRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardAppletIdGroupRegistration> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardAppletIdGroupRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardAppletIdGroupRegistration> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardAppletIdGroupRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardAppletIdGroupRegistration> for ::windows::core::IInspectable {
-    fn from(value: SmartCardAppletIdGroupRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardAppletIdGroupRegistration> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardAppletIdGroupRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardAppletIdGroupRegistration> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardAppletIdGroupRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardAppletIdGroupRegistration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardAppletIdGroupRegistration {}
 unsafe impl ::core::marker::Sync for SmartCardAppletIdGroupRegistration {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -2061,36 +1916,7 @@ unsafe impl ::windows::core::Interface for SmartCardAutomaticResponseApdu {
 impl ::windows::core::RuntimeName for SmartCardAutomaticResponseApdu {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardAutomaticResponseApdu";
 }
-impl ::core::convert::From<SmartCardAutomaticResponseApdu> for ::windows::core::IUnknown {
-    fn from(value: SmartCardAutomaticResponseApdu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardAutomaticResponseApdu> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardAutomaticResponseApdu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardAutomaticResponseApdu> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardAutomaticResponseApdu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardAutomaticResponseApdu> for ::windows::core::IInspectable {
-    fn from(value: SmartCardAutomaticResponseApdu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardAutomaticResponseApdu> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardAutomaticResponseApdu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardAutomaticResponseApdu> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardAutomaticResponseApdu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardAutomaticResponseApdu, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardAutomaticResponseApdu {}
 unsafe impl ::core::marker::Sync for SmartCardAutomaticResponseApdu {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -2199,36 +2025,7 @@ unsafe impl ::windows::core::Interface for SmartCardChallengeContext {
 impl ::windows::core::RuntimeName for SmartCardChallengeContext {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardChallengeContext";
 }
-impl ::core::convert::From<SmartCardChallengeContext> for ::windows::core::IUnknown {
-    fn from(value: SmartCardChallengeContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardChallengeContext> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardChallengeContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardChallengeContext> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardChallengeContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardChallengeContext> for ::windows::core::IInspectable {
-    fn from(value: SmartCardChallengeContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardChallengeContext> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardChallengeContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardChallengeContext> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardChallengeContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardChallengeContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<SmartCardChallengeContext> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2309,36 +2106,7 @@ unsafe impl ::windows::core::Interface for SmartCardConnection {
 impl ::windows::core::RuntimeName for SmartCardConnection {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardConnection";
 }
-impl ::core::convert::From<SmartCardConnection> for ::windows::core::IUnknown {
-    fn from(value: SmartCardConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardConnection> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardConnection> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardConnection> for ::windows::core::IInspectable {
-    fn from(value: SmartCardConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardConnection> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardConnection> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<SmartCardConnection> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2591,36 +2359,7 @@ unsafe impl ::windows::core::Interface for SmartCardCryptogramGenerator {
 impl ::windows::core::RuntimeName for SmartCardCryptogramGenerator {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardCryptogramGenerator";
 }
-impl ::core::convert::From<SmartCardCryptogramGenerator> for ::windows::core::IUnknown {
-    fn from(value: SmartCardCryptogramGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGenerator> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGenerator> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardCryptogramGenerator> for ::windows::core::IInspectable {
-    fn from(value: SmartCardCryptogramGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGenerator> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGenerator> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardCryptogramGenerator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardCryptogramGenerator {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramGenerator {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -2683,36 +2422,7 @@ unsafe impl ::windows::core::Interface for SmartCardCryptogramGetAllCryptogramMa
 impl ::windows::core::RuntimeName for SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult";
 }
-impl ::core::convert::From<SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult> for ::windows::core::IUnknown {
-    fn from(value: SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult> for ::windows::core::IInspectable {
-    fn from(value: SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -2775,36 +2485,7 @@ unsafe impl ::windows::core::Interface for SmartCardCryptogramGetAllCryptogramMa
 impl ::windows::core::RuntimeName for SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult";
 }
-impl ::core::convert::From<SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult> for ::windows::core::IUnknown {
-    fn from(value: SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult> for ::windows::core::IInspectable {
-    fn from(value: SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -2867,36 +2548,7 @@ unsafe impl ::windows::core::Interface for SmartCardCryptogramGetAllCryptogramSt
 impl ::windows::core::RuntimeName for SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult";
 }
-impl ::core::convert::From<SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult> for ::windows::core::IUnknown {
-    fn from(value: SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult> for ::windows::core::IInspectable {
-    fn from(value: SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -3005,36 +2657,7 @@ unsafe impl ::windows::core::Interface for SmartCardCryptogramMaterialCharacteri
 impl ::windows::core::RuntimeName for SmartCardCryptogramMaterialCharacteristics {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardCryptogramMaterialCharacteristics";
 }
-impl ::core::convert::From<SmartCardCryptogramMaterialCharacteristics> for ::windows::core::IUnknown {
-    fn from(value: SmartCardCryptogramMaterialCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialCharacteristics> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramMaterialCharacteristics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialCharacteristics> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramMaterialCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardCryptogramMaterialCharacteristics> for ::windows::core::IInspectable {
-    fn from(value: SmartCardCryptogramMaterialCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialCharacteristics> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramMaterialCharacteristics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialCharacteristics> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramMaterialCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardCryptogramMaterialCharacteristics, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardCryptogramMaterialCharacteristics {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramMaterialCharacteristics {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -3111,36 +2734,7 @@ unsafe impl ::windows::core::Interface for SmartCardCryptogramMaterialPackageCha
 impl ::windows::core::RuntimeName for SmartCardCryptogramMaterialPackageCharacteristics {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardCryptogramMaterialPackageCharacteristics";
 }
-impl ::core::convert::From<SmartCardCryptogramMaterialPackageCharacteristics> for ::windows::core::IUnknown {
-    fn from(value: SmartCardCryptogramMaterialPackageCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialPackageCharacteristics> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramMaterialPackageCharacteristics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialPackageCharacteristics> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramMaterialPackageCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardCryptogramMaterialPackageCharacteristics> for ::windows::core::IInspectable {
-    fn from(value: SmartCardCryptogramMaterialPackageCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialPackageCharacteristics> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramMaterialPackageCharacteristics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialPackageCharacteristics> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramMaterialPackageCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardCryptogramMaterialPackageCharacteristics, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardCryptogramMaterialPackageCharacteristics {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramMaterialPackageCharacteristics {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -3196,36 +2790,7 @@ unsafe impl ::windows::core::Interface for SmartCardCryptogramMaterialPossession
 impl ::windows::core::RuntimeName for SmartCardCryptogramMaterialPossessionProof {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardCryptogramMaterialPossessionProof";
 }
-impl ::core::convert::From<SmartCardCryptogramMaterialPossessionProof> for ::windows::core::IUnknown {
-    fn from(value: SmartCardCryptogramMaterialPossessionProof) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialPossessionProof> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramMaterialPossessionProof) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialPossessionProof> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramMaterialPossessionProof) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardCryptogramMaterialPossessionProof> for ::windows::core::IInspectable {
-    fn from(value: SmartCardCryptogramMaterialPossessionProof) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialPossessionProof> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramMaterialPossessionProof) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramMaterialPossessionProof> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramMaterialPossessionProof) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardCryptogramMaterialPossessionProof, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardCryptogramMaterialPossessionProof {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramMaterialPossessionProof {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -3379,36 +2944,7 @@ unsafe impl ::windows::core::Interface for SmartCardCryptogramPlacementStep {
 impl ::windows::core::RuntimeName for SmartCardCryptogramPlacementStep {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardCryptogramPlacementStep";
 }
-impl ::core::convert::From<SmartCardCryptogramPlacementStep> for ::windows::core::IUnknown {
-    fn from(value: SmartCardCryptogramPlacementStep) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramPlacementStep> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramPlacementStep) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramPlacementStep> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramPlacementStep) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardCryptogramPlacementStep> for ::windows::core::IInspectable {
-    fn from(value: SmartCardCryptogramPlacementStep) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramPlacementStep> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramPlacementStep) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramPlacementStep> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramPlacementStep) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardCryptogramPlacementStep, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardCryptogramPlacementStep {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramPlacementStep {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -3485,36 +3021,7 @@ unsafe impl ::windows::core::Interface for SmartCardCryptogramStorageKeyCharacte
 impl ::windows::core::RuntimeName for SmartCardCryptogramStorageKeyCharacteristics {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardCryptogramStorageKeyCharacteristics";
 }
-impl ::core::convert::From<SmartCardCryptogramStorageKeyCharacteristics> for ::windows::core::IUnknown {
-    fn from(value: SmartCardCryptogramStorageKeyCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramStorageKeyCharacteristics> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramStorageKeyCharacteristics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramStorageKeyCharacteristics> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramStorageKeyCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardCryptogramStorageKeyCharacteristics> for ::windows::core::IInspectable {
-    fn from(value: SmartCardCryptogramStorageKeyCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramStorageKeyCharacteristics> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramStorageKeyCharacteristics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramStorageKeyCharacteristics> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramStorageKeyCharacteristics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardCryptogramStorageKeyCharacteristics, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardCryptogramStorageKeyCharacteristics {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramStorageKeyCharacteristics {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -3618,36 +3125,7 @@ unsafe impl ::windows::core::Interface for SmartCardCryptogramStorageKeyInfo {
 impl ::windows::core::RuntimeName for SmartCardCryptogramStorageKeyInfo {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardCryptogramStorageKeyInfo";
 }
-impl ::core::convert::From<SmartCardCryptogramStorageKeyInfo> for ::windows::core::IUnknown {
-    fn from(value: SmartCardCryptogramStorageKeyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramStorageKeyInfo> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramStorageKeyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramStorageKeyInfo> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardCryptogramStorageKeyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardCryptogramStorageKeyInfo> for ::windows::core::IInspectable {
-    fn from(value: SmartCardCryptogramStorageKeyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramStorageKeyInfo> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramStorageKeyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardCryptogramStorageKeyInfo> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardCryptogramStorageKeyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardCryptogramStorageKeyInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardCryptogramStorageKeyInfo {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramStorageKeyInfo {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -3794,36 +3272,7 @@ unsafe impl ::windows::core::Interface for SmartCardEmulator {
 impl ::windows::core::RuntimeName for SmartCardEmulator {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardEmulator";
 }
-impl ::core::convert::From<SmartCardEmulator> for ::windows::core::IUnknown {
-    fn from(value: SmartCardEmulator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardEmulator> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardEmulator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardEmulator> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardEmulator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardEmulator> for ::windows::core::IInspectable {
-    fn from(value: SmartCardEmulator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardEmulator> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardEmulator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardEmulator> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardEmulator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardEmulator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardEmulator {}
 unsafe impl ::core::marker::Sync for SmartCardEmulator {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -3953,36 +3402,7 @@ unsafe impl ::windows::core::Interface for SmartCardEmulatorApduReceivedEventArg
 impl ::windows::core::RuntimeName for SmartCardEmulatorApduReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardEmulatorApduReceivedEventArgs";
 }
-impl ::core::convert::From<SmartCardEmulatorApduReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SmartCardEmulatorApduReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorApduReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardEmulatorApduReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorApduReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardEmulatorApduReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardEmulatorApduReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SmartCardEmulatorApduReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorApduReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardEmulatorApduReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorApduReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardEmulatorApduReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardEmulatorApduReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardEmulatorApduReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for SmartCardEmulatorApduReceivedEventArgs {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -4036,36 +3456,7 @@ unsafe impl ::windows::core::Interface for SmartCardEmulatorConnectionDeactivate
 impl ::windows::core::RuntimeName for SmartCardEmulatorConnectionDeactivatedEventArgs {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardEmulatorConnectionDeactivatedEventArgs";
 }
-impl ::core::convert::From<SmartCardEmulatorConnectionDeactivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SmartCardEmulatorConnectionDeactivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorConnectionDeactivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardEmulatorConnectionDeactivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorConnectionDeactivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardEmulatorConnectionDeactivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardEmulatorConnectionDeactivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SmartCardEmulatorConnectionDeactivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorConnectionDeactivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardEmulatorConnectionDeactivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorConnectionDeactivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardEmulatorConnectionDeactivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardEmulatorConnectionDeactivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardEmulatorConnectionDeactivatedEventArgs {}
 unsafe impl ::core::marker::Sync for SmartCardEmulatorConnectionDeactivatedEventArgs {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -4119,36 +3510,7 @@ unsafe impl ::windows::core::Interface for SmartCardEmulatorConnectionProperties
 impl ::windows::core::RuntimeName for SmartCardEmulatorConnectionProperties {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardEmulatorConnectionProperties";
 }
-impl ::core::convert::From<SmartCardEmulatorConnectionProperties> for ::windows::core::IUnknown {
-    fn from(value: SmartCardEmulatorConnectionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorConnectionProperties> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardEmulatorConnectionProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorConnectionProperties> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardEmulatorConnectionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardEmulatorConnectionProperties> for ::windows::core::IInspectable {
-    fn from(value: SmartCardEmulatorConnectionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorConnectionProperties> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardEmulatorConnectionProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardEmulatorConnectionProperties> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardEmulatorConnectionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardEmulatorConnectionProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardEmulatorConnectionProperties {}
 unsafe impl ::core::marker::Sync for SmartCardEmulatorConnectionProperties {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -4261,36 +3623,7 @@ unsafe impl ::windows::core::Interface for SmartCardPinPolicy {
 impl ::windows::core::RuntimeName for SmartCardPinPolicy {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardPinPolicy";
 }
-impl ::core::convert::From<SmartCardPinPolicy> for ::windows::core::IUnknown {
-    fn from(value: SmartCardPinPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardPinPolicy> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardPinPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardPinPolicy> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardPinPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardPinPolicy> for ::windows::core::IInspectable {
-    fn from(value: SmartCardPinPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardPinPolicy> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardPinPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardPinPolicy> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardPinPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardPinPolicy, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardPinPolicy {}
 unsafe impl ::core::marker::Sync for SmartCardPinPolicy {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -4334,36 +3667,7 @@ unsafe impl ::windows::core::Interface for SmartCardPinResetDeferral {
 impl ::windows::core::RuntimeName for SmartCardPinResetDeferral {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardPinResetDeferral";
 }
-impl ::core::convert::From<SmartCardPinResetDeferral> for ::windows::core::IUnknown {
-    fn from(value: SmartCardPinResetDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardPinResetDeferral> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardPinResetDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardPinResetDeferral> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardPinResetDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardPinResetDeferral> for ::windows::core::IInspectable {
-    fn from(value: SmartCardPinResetDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardPinResetDeferral> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardPinResetDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardPinResetDeferral> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardPinResetDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardPinResetDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardPinResetDeferral {}
 unsafe impl ::core::marker::Sync for SmartCardPinResetDeferral {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -4438,36 +3742,7 @@ unsafe impl ::windows::core::Interface for SmartCardPinResetRequest {
 impl ::windows::core::RuntimeName for SmartCardPinResetRequest {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardPinResetRequest";
 }
-impl ::core::convert::From<SmartCardPinResetRequest> for ::windows::core::IUnknown {
-    fn from(value: SmartCardPinResetRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardPinResetRequest> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardPinResetRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardPinResetRequest> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardPinResetRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardPinResetRequest> for ::windows::core::IInspectable {
-    fn from(value: SmartCardPinResetRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardPinResetRequest> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardPinResetRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardPinResetRequest> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardPinResetRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardPinResetRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardPinResetRequest {}
 unsafe impl ::core::marker::Sync for SmartCardPinResetRequest {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -4642,36 +3917,7 @@ unsafe impl ::windows::core::Interface for SmartCardProvisioning {
 impl ::windows::core::RuntimeName for SmartCardProvisioning {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardProvisioning";
 }
-impl ::core::convert::From<SmartCardProvisioning> for ::windows::core::IUnknown {
-    fn from(value: SmartCardProvisioning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardProvisioning> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardProvisioning) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardProvisioning> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardProvisioning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardProvisioning> for ::windows::core::IInspectable {
-    fn from(value: SmartCardProvisioning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardProvisioning> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardProvisioning) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardProvisioning> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardProvisioning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardProvisioning, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardProvisioning {}
 unsafe impl ::core::marker::Sync for SmartCardProvisioning {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -4805,36 +4051,7 @@ unsafe impl ::windows::core::Interface for SmartCardReader {
 impl ::windows::core::RuntimeName for SmartCardReader {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardReader";
 }
-impl ::core::convert::From<SmartCardReader> for ::windows::core::IUnknown {
-    fn from(value: SmartCardReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardReader> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardReader> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardReader> for ::windows::core::IInspectable {
-    fn from(value: SmartCardReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardReader> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardReader> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardReader {}
 unsafe impl ::core::marker::Sync for SmartCardReader {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]
@@ -4931,36 +4148,7 @@ unsafe impl ::windows::core::Interface for SmartCardTriggerDetails {
 impl ::windows::core::RuntimeName for SmartCardTriggerDetails {
     const NAME: &'static str = "Windows.Devices.SmartCards.SmartCardTriggerDetails";
 }
-impl ::core::convert::From<SmartCardTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: SmartCardTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &SmartCardTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &SmartCardTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmartCardTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: SmartCardTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmartCardTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &SmartCardTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmartCardTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &SmartCardTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmartCardTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmartCardTriggerDetails {}
 unsafe impl ::core::marker::Sync for SmartCardTriggerDetails {}
 #[doc = "*Required features: `\"Devices_SmartCards\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
@@ -95,41 +95,7 @@ impl ISmsBinaryMessage {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<ISmsBinaryMessage> for ::windows::core::IUnknown {
-    fn from(value: ISmsBinaryMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a ISmsBinaryMessage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISmsBinaryMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ISmsBinaryMessage> for ::windows::core::IUnknown {
-    fn from(value: &ISmsBinaryMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<ISmsBinaryMessage> for ::windows::core::IInspectable {
-    fn from(value: ISmsBinaryMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a ISmsBinaryMessage> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISmsBinaryMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ISmsBinaryMessage> for ::windows::core::IInspectable {
-    fn from(value: &ISmsBinaryMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISmsBinaryMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<ISmsBinaryMessage> for ISmsMessage {
     type Error = ::windows::core::Error;
@@ -333,41 +299,7 @@ impl ISmsDevice {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<ISmsDevice> for ::windows::core::IUnknown {
-    fn from(value: ISmsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a ISmsDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISmsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ISmsDevice> for ::windows::core::IUnknown {
-    fn from(value: &ISmsDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<ISmsDevice> for ::windows::core::IInspectable {
-    fn from(value: ISmsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a ISmsDevice> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISmsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ISmsDevice> for ::windows::core::IInspectable {
-    fn from(value: &ISmsDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISmsDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for ISmsDevice {
     fn clone(&self) -> Self {
@@ -721,36 +653,7 @@ impl ISmsMessage {
         }
     }
 }
-impl ::core::convert::From<ISmsMessage> for ::windows::core::IUnknown {
-    fn from(value: ISmsMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISmsMessage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISmsMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISmsMessage> for ::windows::core::IUnknown {
-    fn from(value: &ISmsMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISmsMessage> for ::windows::core::IInspectable {
-    fn from(value: ISmsMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISmsMessage> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISmsMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISmsMessage> for ::windows::core::IInspectable {
-    fn from(value: &ISmsMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISmsMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISmsMessage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -827,36 +730,7 @@ impl ISmsMessageBase {
         }
     }
 }
-impl ::core::convert::From<ISmsMessageBase> for ::windows::core::IUnknown {
-    fn from(value: ISmsMessageBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISmsMessageBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISmsMessageBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISmsMessageBase> for ::windows::core::IUnknown {
-    fn from(value: &ISmsMessageBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISmsMessageBase> for ::windows::core::IInspectable {
-    fn from(value: ISmsMessageBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISmsMessageBase> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISmsMessageBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISmsMessageBase> for ::windows::core::IInspectable {
-    fn from(value: &ISmsMessageBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISmsMessageBase, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISmsMessageBase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1218,41 +1092,7 @@ impl ISmsTextMessage {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<ISmsTextMessage> for ::windows::core::IUnknown {
-    fn from(value: ISmsTextMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a ISmsTextMessage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISmsTextMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ISmsTextMessage> for ::windows::core::IUnknown {
-    fn from(value: &ISmsTextMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<ISmsTextMessage> for ::windows::core::IInspectable {
-    fn from(value: ISmsTextMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a ISmsTextMessage> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISmsTextMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&ISmsTextMessage> for ::windows::core::IInspectable {
-    fn from(value: &ISmsTextMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISmsTextMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<ISmsTextMessage> for ISmsMessage {
     type Error = ::windows::core::Error;
@@ -1621,41 +1461,7 @@ impl ::std::future::Future for DeleteSmsMessageOperation {
     }
 }
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<DeleteSmsMessageOperation> for ::windows::core::IUnknown {
-    fn from(value: DeleteSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&DeleteSmsMessageOperation> for ::windows::core::IUnknown {
-    fn from(value: &DeleteSmsMessageOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&DeleteSmsMessageOperation> for &::windows::core::IUnknown {
-    fn from(value: &DeleteSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<DeleteSmsMessageOperation> for ::windows::core::IInspectable {
-    fn from(value: DeleteSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&DeleteSmsMessageOperation> for ::windows::core::IInspectable {
-    fn from(value: &DeleteSmsMessageOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&DeleteSmsMessageOperation> for &::windows::core::IInspectable {
-    fn from(value: &DeleteSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeleteSmsMessageOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<DeleteSmsMessageOperation> for super::super::Foundation::IAsyncAction {
     type Error = ::windows::core::Error;
@@ -1839,41 +1645,7 @@ impl ::std::future::Future for DeleteSmsMessagesOperation {
     }
 }
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<DeleteSmsMessagesOperation> for ::windows::core::IUnknown {
-    fn from(value: DeleteSmsMessagesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&DeleteSmsMessagesOperation> for ::windows::core::IUnknown {
-    fn from(value: &DeleteSmsMessagesOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&DeleteSmsMessagesOperation> for &::windows::core::IUnknown {
-    fn from(value: &DeleteSmsMessagesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<DeleteSmsMessagesOperation> for ::windows::core::IInspectable {
-    fn from(value: DeleteSmsMessagesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&DeleteSmsMessagesOperation> for ::windows::core::IInspectable {
-    fn from(value: &DeleteSmsMessagesOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&DeleteSmsMessagesOperation> for &::windows::core::IInspectable {
-    fn from(value: &DeleteSmsMessagesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeleteSmsMessagesOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<DeleteSmsMessagesOperation> for super::super::Foundation::IAsyncAction {
     type Error = ::windows::core::Error;
@@ -2060,41 +1832,7 @@ impl ::std::future::Future for GetSmsDeviceOperation {
     }
 }
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<GetSmsDeviceOperation> for ::windows::core::IUnknown {
-    fn from(value: GetSmsDeviceOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsDeviceOperation> for ::windows::core::IUnknown {
-    fn from(value: &GetSmsDeviceOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsDeviceOperation> for &::windows::core::IUnknown {
-    fn from(value: &GetSmsDeviceOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<GetSmsDeviceOperation> for ::windows::core::IInspectable {
-    fn from(value: GetSmsDeviceOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsDeviceOperation> for ::windows::core::IInspectable {
-    fn from(value: &GetSmsDeviceOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsDeviceOperation> for &::windows::core::IInspectable {
-    fn from(value: &GetSmsDeviceOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GetSmsDeviceOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<GetSmsDeviceOperation> for super::super::Foundation::IAsyncInfo {
     type Error = ::windows::core::Error;
@@ -2281,41 +2019,7 @@ impl ::std::future::Future for GetSmsMessageOperation {
     }
 }
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<GetSmsMessageOperation> for ::windows::core::IUnknown {
-    fn from(value: GetSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsMessageOperation> for ::windows::core::IUnknown {
-    fn from(value: &GetSmsMessageOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsMessageOperation> for &::windows::core::IUnknown {
-    fn from(value: &GetSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<GetSmsMessageOperation> for ::windows::core::IInspectable {
-    fn from(value: GetSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsMessageOperation> for ::windows::core::IInspectable {
-    fn from(value: &GetSmsMessageOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsMessageOperation> for &::windows::core::IInspectable {
-    fn from(value: &GetSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GetSmsMessageOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<GetSmsMessageOperation> for super::super::Foundation::IAsyncInfo {
     type Error = ::windows::core::Error;
@@ -2517,41 +2221,7 @@ impl ::std::future::Future for GetSmsMessagesOperation {
     }
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
-impl ::core::convert::From<GetSmsMessagesOperation> for ::windows::core::IUnknown {
-    fn from(value: GetSmsMessagesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsMessagesOperation> for ::windows::core::IUnknown {
-    fn from(value: &GetSmsMessagesOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsMessagesOperation> for &::windows::core::IUnknown {
-    fn from(value: &GetSmsMessagesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
-impl ::core::convert::From<GetSmsMessagesOperation> for ::windows::core::IInspectable {
-    fn from(value: GetSmsMessagesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsMessagesOperation> for ::windows::core::IInspectable {
-    fn from(value: &GetSmsMessagesOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
-impl ::core::convert::From<&GetSmsMessagesOperation> for &::windows::core::IInspectable {
-    fn from(value: &GetSmsMessagesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GetSmsMessagesOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
 impl ::core::convert::TryFrom<GetSmsMessagesOperation> for super::super::Foundation::IAsyncInfo {
     type Error = ::windows::core::Error;
@@ -2735,41 +2405,7 @@ impl ::std::future::Future for SendSmsMessageOperation {
     }
 }
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<SendSmsMessageOperation> for ::windows::core::IUnknown {
-    fn from(value: SendSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&SendSmsMessageOperation> for ::windows::core::IUnknown {
-    fn from(value: &SendSmsMessageOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&SendSmsMessageOperation> for &::windows::core::IUnknown {
-    fn from(value: &SendSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<SendSmsMessageOperation> for ::windows::core::IInspectable {
-    fn from(value: SendSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&SendSmsMessageOperation> for ::windows::core::IInspectable {
-    fn from(value: &SendSmsMessageOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation", feature = "deprecated"))]
-impl ::core::convert::From<&SendSmsMessageOperation> for &::windows::core::IInspectable {
-    fn from(value: &SendSmsMessageOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SendSmsMessageOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<SendSmsMessageOperation> for super::super::Foundation::IAsyncAction {
     type Error = ::windows::core::Error;
@@ -3027,36 +2663,7 @@ unsafe impl ::windows::core::Interface for SmsAppMessage {
 impl ::windows::core::RuntimeName for SmsAppMessage {
     const NAME: &'static str = "Windows.Devices.Sms.SmsAppMessage";
 }
-impl ::core::convert::From<SmsAppMessage> for ::windows::core::IUnknown {
-    fn from(value: SmsAppMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsAppMessage> for ::windows::core::IUnknown {
-    fn from(value: &SmsAppMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsAppMessage> for &::windows::core::IUnknown {
-    fn from(value: &SmsAppMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsAppMessage> for ::windows::core::IInspectable {
-    fn from(value: SmsAppMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsAppMessage> for ::windows::core::IInspectable {
-    fn from(value: &SmsAppMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsAppMessage> for &::windows::core::IInspectable {
-    fn from(value: &SmsAppMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsAppMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SmsAppMessage> for ISmsMessageBase {
     type Error = ::windows::core::Error;
     fn try_from(value: SmsAppMessage) -> ::windows::core::Result<Self> {
@@ -3177,41 +2784,7 @@ impl ::windows::core::RuntimeName for SmsBinaryMessage {
     const NAME: &'static str = "Windows.Devices.Sms.SmsBinaryMessage";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsBinaryMessage> for ::windows::core::IUnknown {
-    fn from(value: SmsBinaryMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsBinaryMessage> for ::windows::core::IUnknown {
-    fn from(value: &SmsBinaryMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsBinaryMessage> for &::windows::core::IUnknown {
-    fn from(value: &SmsBinaryMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsBinaryMessage> for ::windows::core::IInspectable {
-    fn from(value: SmsBinaryMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsBinaryMessage> for ::windows::core::IInspectable {
-    fn from(value: &SmsBinaryMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsBinaryMessage> for &::windows::core::IInspectable {
-    fn from(value: &SmsBinaryMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsBinaryMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<SmsBinaryMessage> for ISmsBinaryMessage {
     type Error = ::windows::core::Error;
@@ -3404,36 +2977,7 @@ unsafe impl ::windows::core::Interface for SmsBroadcastMessage {
 impl ::windows::core::RuntimeName for SmsBroadcastMessage {
     const NAME: &'static str = "Windows.Devices.Sms.SmsBroadcastMessage";
 }
-impl ::core::convert::From<SmsBroadcastMessage> for ::windows::core::IUnknown {
-    fn from(value: SmsBroadcastMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsBroadcastMessage> for ::windows::core::IUnknown {
-    fn from(value: &SmsBroadcastMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsBroadcastMessage> for &::windows::core::IUnknown {
-    fn from(value: &SmsBroadcastMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsBroadcastMessage> for ::windows::core::IInspectable {
-    fn from(value: SmsBroadcastMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsBroadcastMessage> for ::windows::core::IInspectable {
-    fn from(value: &SmsBroadcastMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsBroadcastMessage> for &::windows::core::IInspectable {
-    fn from(value: &SmsBroadcastMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsBroadcastMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SmsBroadcastMessage> for ISmsMessageBase {
     type Error = ::windows::core::Error;
     fn try_from(value: SmsBroadcastMessage) -> ::windows::core::Result<Self> {
@@ -3635,41 +3179,7 @@ impl ::windows::core::RuntimeName for SmsDevice {
     const NAME: &'static str = "Windows.Devices.Sms.SmsDevice";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsDevice> for ::windows::core::IUnknown {
-    fn from(value: SmsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsDevice> for ::windows::core::IUnknown {
-    fn from(value: &SmsDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsDevice> for &::windows::core::IUnknown {
-    fn from(value: &SmsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsDevice> for ::windows::core::IInspectable {
-    fn from(value: SmsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsDevice> for ::windows::core::IInspectable {
-    fn from(value: &SmsDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsDevice> for &::windows::core::IInspectable {
-    fn from(value: &SmsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<SmsDevice> for ISmsDevice {
     type Error = ::windows::core::Error;
@@ -3843,36 +3353,7 @@ unsafe impl ::windows::core::Interface for SmsDevice2 {
 impl ::windows::core::RuntimeName for SmsDevice2 {
     const NAME: &'static str = "Windows.Devices.Sms.SmsDevice2";
 }
-impl ::core::convert::From<SmsDevice2> for ::windows::core::IUnknown {
-    fn from(value: SmsDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsDevice2> for ::windows::core::IUnknown {
-    fn from(value: &SmsDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsDevice2> for &::windows::core::IUnknown {
-    fn from(value: &SmsDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsDevice2> for ::windows::core::IInspectable {
-    fn from(value: SmsDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsDevice2> for ::windows::core::IInspectable {
-    fn from(value: &SmsDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsDevice2> for &::windows::core::IInspectable {
-    fn from(value: &SmsDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsDevice2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Devices_Sms\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -3966,41 +3447,7 @@ impl ::windows::core::RuntimeName for SmsDeviceMessageStore {
     const NAME: &'static str = "Windows.Devices.Sms.SmsDeviceMessageStore";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsDeviceMessageStore> for ::windows::core::IUnknown {
-    fn from(value: SmsDeviceMessageStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsDeviceMessageStore> for ::windows::core::IUnknown {
-    fn from(value: &SmsDeviceMessageStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsDeviceMessageStore> for &::windows::core::IUnknown {
-    fn from(value: &SmsDeviceMessageStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsDeviceMessageStore> for ::windows::core::IInspectable {
-    fn from(value: SmsDeviceMessageStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsDeviceMessageStore> for ::windows::core::IInspectable {
-    fn from(value: &SmsDeviceMessageStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsDeviceMessageStore> for &::windows::core::IInspectable {
-    fn from(value: &SmsDeviceMessageStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsDeviceMessageStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Devices_Sms\"`*"]
 #[repr(transparent)]
 pub struct SmsFilterRule(::windows::core::IUnknown);
@@ -4166,36 +3613,7 @@ unsafe impl ::windows::core::Interface for SmsFilterRule {
 impl ::windows::core::RuntimeName for SmsFilterRule {
     const NAME: &'static str = "Windows.Devices.Sms.SmsFilterRule";
 }
-impl ::core::convert::From<SmsFilterRule> for ::windows::core::IUnknown {
-    fn from(value: SmsFilterRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsFilterRule> for ::windows::core::IUnknown {
-    fn from(value: &SmsFilterRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsFilterRule> for &::windows::core::IUnknown {
-    fn from(value: &SmsFilterRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsFilterRule> for ::windows::core::IInspectable {
-    fn from(value: SmsFilterRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsFilterRule> for ::windows::core::IInspectable {
-    fn from(value: &SmsFilterRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsFilterRule> for &::windows::core::IInspectable {
-    fn from(value: &SmsFilterRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsFilterRule, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmsFilterRule {}
 unsafe impl ::core::marker::Sync for SmsFilterRule {}
 #[doc = "*Required features: `\"Devices_Sms\"`*"]
@@ -4262,36 +3680,7 @@ unsafe impl ::windows::core::Interface for SmsFilterRules {
 impl ::windows::core::RuntimeName for SmsFilterRules {
     const NAME: &'static str = "Windows.Devices.Sms.SmsFilterRules";
 }
-impl ::core::convert::From<SmsFilterRules> for ::windows::core::IUnknown {
-    fn from(value: SmsFilterRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsFilterRules> for ::windows::core::IUnknown {
-    fn from(value: &SmsFilterRules) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsFilterRules> for &::windows::core::IUnknown {
-    fn from(value: &SmsFilterRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsFilterRules> for ::windows::core::IInspectable {
-    fn from(value: SmsFilterRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsFilterRules> for ::windows::core::IInspectable {
-    fn from(value: &SmsFilterRules) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsFilterRules> for &::windows::core::IInspectable {
-    fn from(value: &SmsFilterRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsFilterRules, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmsFilterRules {}
 unsafe impl ::core::marker::Sync for SmsFilterRules {}
 #[doc = "*Required features: `\"Devices_Sms\"`, `\"deprecated\"`*"]
@@ -4360,41 +3749,7 @@ impl ::windows::core::RuntimeName for SmsMessageReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sms.SmsMessageReceivedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsMessageReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SmsMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsMessageReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SmsMessageReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsMessageReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SmsMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsMessageReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SmsMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsMessageReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SmsMessageReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsMessageReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SmsMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsMessageReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Devices_Sms\"`*"]
 #[repr(transparent)]
 pub struct SmsMessageReceivedTriggerDetails(::windows::core::IUnknown);
@@ -4489,36 +3844,7 @@ unsafe impl ::windows::core::Interface for SmsMessageReceivedTriggerDetails {
 impl ::windows::core::RuntimeName for SmsMessageReceivedTriggerDetails {
     const NAME: &'static str = "Windows.Devices.Sms.SmsMessageReceivedTriggerDetails";
 }
-impl ::core::convert::From<SmsMessageReceivedTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: SmsMessageReceivedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsMessageReceivedTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &SmsMessageReceivedTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsMessageReceivedTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &SmsMessageReceivedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsMessageReceivedTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: SmsMessageReceivedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsMessageReceivedTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &SmsMessageReceivedTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsMessageReceivedTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &SmsMessageReceivedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsMessageReceivedTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmsMessageReceivedTriggerDetails {}
 unsafe impl ::core::marker::Sync for SmsMessageReceivedTriggerDetails {}
 #[doc = "*Required features: `\"Devices_Sms\"`*"]
@@ -4603,36 +3929,7 @@ unsafe impl ::windows::core::Interface for SmsMessageRegistration {
 impl ::windows::core::RuntimeName for SmsMessageRegistration {
     const NAME: &'static str = "Windows.Devices.Sms.SmsMessageRegistration";
 }
-impl ::core::convert::From<SmsMessageRegistration> for ::windows::core::IUnknown {
-    fn from(value: SmsMessageRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsMessageRegistration> for ::windows::core::IUnknown {
-    fn from(value: &SmsMessageRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsMessageRegistration> for &::windows::core::IUnknown {
-    fn from(value: &SmsMessageRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsMessageRegistration> for ::windows::core::IInspectable {
-    fn from(value: SmsMessageRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsMessageRegistration> for ::windows::core::IInspectable {
-    fn from(value: &SmsMessageRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsMessageRegistration> for &::windows::core::IInspectable {
-    fn from(value: &SmsMessageRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsMessageRegistration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Devices_Sms\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -4717,41 +4014,7 @@ impl ::windows::core::RuntimeName for SmsReceivedEventDetails {
     const NAME: &'static str = "Windows.Devices.Sms.SmsReceivedEventDetails";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsReceivedEventDetails> for ::windows::core::IUnknown {
-    fn from(value: SmsReceivedEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsReceivedEventDetails> for ::windows::core::IUnknown {
-    fn from(value: &SmsReceivedEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsReceivedEventDetails> for &::windows::core::IUnknown {
-    fn from(value: &SmsReceivedEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsReceivedEventDetails> for ::windows::core::IInspectable {
-    fn from(value: SmsReceivedEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsReceivedEventDetails> for ::windows::core::IInspectable {
-    fn from(value: &SmsReceivedEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsReceivedEventDetails> for &::windows::core::IInspectable {
-    fn from(value: &SmsReceivedEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsReceivedEventDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SmsReceivedEventDetails {}
 #[cfg(feature = "deprecated")]
@@ -4844,36 +4107,7 @@ unsafe impl ::windows::core::Interface for SmsSendMessageResult {
 impl ::windows::core::RuntimeName for SmsSendMessageResult {
     const NAME: &'static str = "Windows.Devices.Sms.SmsSendMessageResult";
 }
-impl ::core::convert::From<SmsSendMessageResult> for ::windows::core::IUnknown {
-    fn from(value: SmsSendMessageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsSendMessageResult> for ::windows::core::IUnknown {
-    fn from(value: &SmsSendMessageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsSendMessageResult> for &::windows::core::IUnknown {
-    fn from(value: &SmsSendMessageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsSendMessageResult> for ::windows::core::IInspectable {
-    fn from(value: SmsSendMessageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsSendMessageResult> for ::windows::core::IInspectable {
-    fn from(value: &SmsSendMessageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsSendMessageResult> for &::windows::core::IInspectable {
-    fn from(value: &SmsSendMessageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsSendMessageResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SmsSendMessageResult {}
 unsafe impl ::core::marker::Sync for SmsSendMessageResult {}
 #[doc = "*Required features: `\"Devices_Sms\"`*"]
@@ -5001,36 +4235,7 @@ unsafe impl ::windows::core::Interface for SmsStatusMessage {
 impl ::windows::core::RuntimeName for SmsStatusMessage {
     const NAME: &'static str = "Windows.Devices.Sms.SmsStatusMessage";
 }
-impl ::core::convert::From<SmsStatusMessage> for ::windows::core::IUnknown {
-    fn from(value: SmsStatusMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsStatusMessage> for ::windows::core::IUnknown {
-    fn from(value: &SmsStatusMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsStatusMessage> for &::windows::core::IUnknown {
-    fn from(value: &SmsStatusMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsStatusMessage> for ::windows::core::IInspectable {
-    fn from(value: SmsStatusMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsStatusMessage> for ::windows::core::IInspectable {
-    fn from(value: &SmsStatusMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsStatusMessage> for &::windows::core::IInspectable {
-    fn from(value: &SmsStatusMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsStatusMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SmsStatusMessage> for ISmsMessageBase {
     type Error = ::windows::core::Error;
     fn try_from(value: SmsStatusMessage) -> ::windows::core::Result<Self> {
@@ -5248,41 +4453,7 @@ impl ::windows::core::RuntimeName for SmsTextMessage {
     const NAME: &'static str = "Windows.Devices.Sms.SmsTextMessage";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsTextMessage> for ::windows::core::IUnknown {
-    fn from(value: SmsTextMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsTextMessage> for ::windows::core::IUnknown {
-    fn from(value: &SmsTextMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsTextMessage> for &::windows::core::IUnknown {
-    fn from(value: &SmsTextMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SmsTextMessage> for ::windows::core::IInspectable {
-    fn from(value: SmsTextMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsTextMessage> for ::windows::core::IInspectable {
-    fn from(value: &SmsTextMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SmsTextMessage> for &::windows::core::IInspectable {
-    fn from(value: &SmsTextMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsTextMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<SmsTextMessage> for ISmsMessage {
     type Error = ::windows::core::Error;
@@ -5506,36 +4677,7 @@ unsafe impl ::windows::core::Interface for SmsTextMessage2 {
 impl ::windows::core::RuntimeName for SmsTextMessage2 {
     const NAME: &'static str = "Windows.Devices.Sms.SmsTextMessage2";
 }
-impl ::core::convert::From<SmsTextMessage2> for ::windows::core::IUnknown {
-    fn from(value: SmsTextMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsTextMessage2> for ::windows::core::IUnknown {
-    fn from(value: &SmsTextMessage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsTextMessage2> for &::windows::core::IUnknown {
-    fn from(value: &SmsTextMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsTextMessage2> for ::windows::core::IInspectable {
-    fn from(value: SmsTextMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsTextMessage2> for ::windows::core::IInspectable {
-    fn from(value: &SmsTextMessage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsTextMessage2> for &::windows::core::IInspectable {
-    fn from(value: &SmsTextMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsTextMessage2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SmsTextMessage2> for ISmsMessageBase {
     type Error = ::windows::core::Error;
     fn try_from(value: SmsTextMessage2) -> ::windows::core::Result<Self> {
@@ -5661,36 +4803,7 @@ unsafe impl ::windows::core::Interface for SmsVoicemailMessage {
 impl ::windows::core::RuntimeName for SmsVoicemailMessage {
     const NAME: &'static str = "Windows.Devices.Sms.SmsVoicemailMessage";
 }
-impl ::core::convert::From<SmsVoicemailMessage> for ::windows::core::IUnknown {
-    fn from(value: SmsVoicemailMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsVoicemailMessage> for ::windows::core::IUnknown {
-    fn from(value: &SmsVoicemailMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsVoicemailMessage> for &::windows::core::IUnknown {
-    fn from(value: &SmsVoicemailMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsVoicemailMessage> for ::windows::core::IInspectable {
-    fn from(value: SmsVoicemailMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsVoicemailMessage> for ::windows::core::IInspectable {
-    fn from(value: &SmsVoicemailMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsVoicemailMessage> for &::windows::core::IInspectable {
-    fn from(value: &SmsVoicemailMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsVoicemailMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SmsVoicemailMessage> for ISmsMessageBase {
     type Error = ::windows::core::Error;
     fn try_from(value: SmsVoicemailMessage) -> ::windows::core::Result<Self> {
@@ -5839,36 +4952,7 @@ unsafe impl ::windows::core::Interface for SmsWapMessage {
 impl ::windows::core::RuntimeName for SmsWapMessage {
     const NAME: &'static str = "Windows.Devices.Sms.SmsWapMessage";
 }
-impl ::core::convert::From<SmsWapMessage> for ::windows::core::IUnknown {
-    fn from(value: SmsWapMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsWapMessage> for ::windows::core::IUnknown {
-    fn from(value: &SmsWapMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsWapMessage> for &::windows::core::IUnknown {
-    fn from(value: &SmsWapMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SmsWapMessage> for ::windows::core::IInspectable {
-    fn from(value: SmsWapMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SmsWapMessage> for ::windows::core::IInspectable {
-    fn from(value: &SmsWapMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SmsWapMessage> for &::windows::core::IInspectable {
-    fn from(value: &SmsWapMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SmsWapMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SmsWapMessage> for ISmsMessageBase {
     type Error = ::windows::core::Error;
     fn try_from(value: SmsWapMessage) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Devices/Spi/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/Provider/mod.rs
@@ -49,36 +49,7 @@ impl ISpiControllerProvider {
         }
     }
 }
-impl ::core::convert::From<ISpiControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: ISpiControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpiControllerProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpiControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpiControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISpiControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpiControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: ISpiControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpiControllerProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISpiControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpiControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: &ISpiControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpiControllerProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISpiControllerProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -155,36 +126,7 @@ impl ISpiDeviceProvider {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<ISpiDeviceProvider> for ::windows::core::IUnknown {
-    fn from(value: ISpiDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpiDeviceProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpiDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpiDeviceProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISpiDeviceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpiDeviceProvider> for ::windows::core::IInspectable {
-    fn from(value: ISpiDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpiDeviceProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISpiDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpiDeviceProvider> for ::windows::core::IInspectable {
-    fn from(value: &ISpiDeviceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpiDeviceProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ISpiDeviceProvider> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -261,36 +203,7 @@ impl ISpiProvider {
         }
     }
 }
-impl ::core::convert::From<ISpiProvider> for ::windows::core::IUnknown {
-    fn from(value: ISpiProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpiProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpiProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpiProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISpiProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpiProvider> for ::windows::core::IInspectable {
-    fn from(value: ISpiProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpiProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISpiProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpiProvider> for ::windows::core::IInspectable {
-    fn from(value: &ISpiProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpiProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISpiProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -432,36 +345,7 @@ unsafe impl ::windows::core::Interface for ProviderSpiConnectionSettings {
 impl ::windows::core::RuntimeName for ProviderSpiConnectionSettings {
     const NAME: &'static str = "Windows.Devices.Spi.Provider.ProviderSpiConnectionSettings";
 }
-impl ::core::convert::From<ProviderSpiConnectionSettings> for ::windows::core::IUnknown {
-    fn from(value: ProviderSpiConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProviderSpiConnectionSettings> for ::windows::core::IUnknown {
-    fn from(value: &ProviderSpiConnectionSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProviderSpiConnectionSettings> for &::windows::core::IUnknown {
-    fn from(value: &ProviderSpiConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProviderSpiConnectionSettings> for ::windows::core::IInspectable {
-    fn from(value: ProviderSpiConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProviderSpiConnectionSettings> for ::windows::core::IInspectable {
-    fn from(value: &ProviderSpiConnectionSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProviderSpiConnectionSettings> for &::windows::core::IInspectable {
-    fn from(value: &ProviderSpiConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProviderSpiConnectionSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProviderSpiConnectionSettings {}
 unsafe impl ::core::marker::Sync for ProviderSpiConnectionSettings {}
 #[doc = "*Required features: `\"Devices_Spi_Provider\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/Spi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/mod.rs
@@ -152,36 +152,7 @@ impl ISpiDeviceStatics {
         }
     }
 }
-impl ::core::convert::From<ISpiDeviceStatics> for ::windows::core::IUnknown {
-    fn from(value: ISpiDeviceStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpiDeviceStatics> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpiDeviceStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpiDeviceStatics> for ::windows::core::IUnknown {
-    fn from(value: &ISpiDeviceStatics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpiDeviceStatics> for ::windows::core::IInspectable {
-    fn from(value: ISpiDeviceStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpiDeviceStatics> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISpiDeviceStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpiDeviceStatics> for ::windows::core::IInspectable {
-    fn from(value: &ISpiDeviceStatics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpiDeviceStatics, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISpiDeviceStatics {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -290,36 +261,7 @@ unsafe impl ::windows::core::Interface for SpiBusInfo {
 impl ::windows::core::RuntimeName for SpiBusInfo {
     const NAME: &'static str = "Windows.Devices.Spi.SpiBusInfo";
 }
-impl ::core::convert::From<SpiBusInfo> for ::windows::core::IUnknown {
-    fn from(value: SpiBusInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpiBusInfo> for ::windows::core::IUnknown {
-    fn from(value: &SpiBusInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpiBusInfo> for &::windows::core::IUnknown {
-    fn from(value: &SpiBusInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpiBusInfo> for ::windows::core::IInspectable {
-    fn from(value: SpiBusInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpiBusInfo> for ::windows::core::IInspectable {
-    fn from(value: &SpiBusInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpiBusInfo> for &::windows::core::IInspectable {
-    fn from(value: &SpiBusInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpiBusInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpiBusInfo {}
 unsafe impl ::core::marker::Sync for SpiBusInfo {}
 #[doc = "*Required features: `\"Devices_Spi\"`*"]
@@ -425,36 +367,7 @@ unsafe impl ::windows::core::Interface for SpiConnectionSettings {
 impl ::windows::core::RuntimeName for SpiConnectionSettings {
     const NAME: &'static str = "Windows.Devices.Spi.SpiConnectionSettings";
 }
-impl ::core::convert::From<SpiConnectionSettings> for ::windows::core::IUnknown {
-    fn from(value: SpiConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpiConnectionSettings> for ::windows::core::IUnknown {
-    fn from(value: &SpiConnectionSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpiConnectionSettings> for &::windows::core::IUnknown {
-    fn from(value: &SpiConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpiConnectionSettings> for ::windows::core::IInspectable {
-    fn from(value: SpiConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpiConnectionSettings> for ::windows::core::IInspectable {
-    fn from(value: &SpiConnectionSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpiConnectionSettings> for &::windows::core::IInspectable {
-    fn from(value: &SpiConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpiConnectionSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpiConnectionSettings {}
 unsafe impl ::core::marker::Sync for SpiConnectionSettings {}
 #[doc = "*Required features: `\"Devices_Spi\"`*"]
@@ -526,36 +439,7 @@ unsafe impl ::windows::core::Interface for SpiController {
 impl ::windows::core::RuntimeName for SpiController {
     const NAME: &'static str = "Windows.Devices.Spi.SpiController";
 }
-impl ::core::convert::From<SpiController> for ::windows::core::IUnknown {
-    fn from(value: SpiController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpiController> for ::windows::core::IUnknown {
-    fn from(value: &SpiController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpiController> for &::windows::core::IUnknown {
-    fn from(value: &SpiController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpiController> for ::windows::core::IInspectable {
-    fn from(value: SpiController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpiController> for ::windows::core::IInspectable {
-    fn from(value: &SpiController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpiController> for &::windows::core::IInspectable {
-    fn from(value: &SpiController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpiController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpiController {}
 unsafe impl ::core::marker::Sync for SpiController {}
 #[doc = "*Required features: `\"Devices_Spi\"`*"]
@@ -662,36 +546,7 @@ unsafe impl ::windows::core::Interface for SpiDevice {
 impl ::windows::core::RuntimeName for SpiDevice {
     const NAME: &'static str = "Windows.Devices.Spi.SpiDevice";
 }
-impl ::core::convert::From<SpiDevice> for ::windows::core::IUnknown {
-    fn from(value: SpiDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpiDevice> for ::windows::core::IUnknown {
-    fn from(value: &SpiDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpiDevice> for &::windows::core::IUnknown {
-    fn from(value: &SpiDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpiDevice> for ::windows::core::IInspectable {
-    fn from(value: SpiDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpiDevice> for ::windows::core::IInspectable {
-    fn from(value: &SpiDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpiDevice> for &::windows::core::IInspectable {
-    fn from(value: &SpiDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpiDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<SpiDevice> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
@@ -690,36 +690,7 @@ unsafe impl ::windows::core::Interface for UsbBulkInEndpointDescriptor {
 impl ::windows::core::RuntimeName for UsbBulkInEndpointDescriptor {
     const NAME: &'static str = "Windows.Devices.Usb.UsbBulkInEndpointDescriptor";
 }
-impl ::core::convert::From<UsbBulkInEndpointDescriptor> for ::windows::core::IUnknown {
-    fn from(value: UsbBulkInEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbBulkInEndpointDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &UsbBulkInEndpointDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbBulkInEndpointDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &UsbBulkInEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbBulkInEndpointDescriptor> for ::windows::core::IInspectable {
-    fn from(value: UsbBulkInEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbBulkInEndpointDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &UsbBulkInEndpointDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbBulkInEndpointDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &UsbBulkInEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbBulkInEndpointDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbBulkInEndpointDescriptor {}
 unsafe impl ::core::marker::Sync for UsbBulkInEndpointDescriptor {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -806,36 +777,7 @@ unsafe impl ::windows::core::Interface for UsbBulkInPipe {
 impl ::windows::core::RuntimeName for UsbBulkInPipe {
     const NAME: &'static str = "Windows.Devices.Usb.UsbBulkInPipe";
 }
-impl ::core::convert::From<UsbBulkInPipe> for ::windows::core::IUnknown {
-    fn from(value: UsbBulkInPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbBulkInPipe> for ::windows::core::IUnknown {
-    fn from(value: &UsbBulkInPipe) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbBulkInPipe> for &::windows::core::IUnknown {
-    fn from(value: &UsbBulkInPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbBulkInPipe> for ::windows::core::IInspectable {
-    fn from(value: UsbBulkInPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbBulkInPipe> for ::windows::core::IInspectable {
-    fn from(value: &UsbBulkInPipe) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbBulkInPipe> for &::windows::core::IInspectable {
-    fn from(value: &UsbBulkInPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbBulkInPipe, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbBulkInPipe {}
 unsafe impl ::core::marker::Sync for UsbBulkInPipe {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -896,36 +838,7 @@ unsafe impl ::windows::core::Interface for UsbBulkOutEndpointDescriptor {
 impl ::windows::core::RuntimeName for UsbBulkOutEndpointDescriptor {
     const NAME: &'static str = "Windows.Devices.Usb.UsbBulkOutEndpointDescriptor";
 }
-impl ::core::convert::From<UsbBulkOutEndpointDescriptor> for ::windows::core::IUnknown {
-    fn from(value: UsbBulkOutEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbBulkOutEndpointDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &UsbBulkOutEndpointDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbBulkOutEndpointDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &UsbBulkOutEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbBulkOutEndpointDescriptor> for ::windows::core::IInspectable {
-    fn from(value: UsbBulkOutEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbBulkOutEndpointDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &UsbBulkOutEndpointDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbBulkOutEndpointDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &UsbBulkOutEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbBulkOutEndpointDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbBulkOutEndpointDescriptor {}
 unsafe impl ::core::marker::Sync for UsbBulkOutEndpointDescriptor {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -1001,36 +914,7 @@ unsafe impl ::windows::core::Interface for UsbBulkOutPipe {
 impl ::windows::core::RuntimeName for UsbBulkOutPipe {
     const NAME: &'static str = "Windows.Devices.Usb.UsbBulkOutPipe";
 }
-impl ::core::convert::From<UsbBulkOutPipe> for ::windows::core::IUnknown {
-    fn from(value: UsbBulkOutPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbBulkOutPipe> for ::windows::core::IUnknown {
-    fn from(value: &UsbBulkOutPipe) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbBulkOutPipe> for &::windows::core::IUnknown {
-    fn from(value: &UsbBulkOutPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbBulkOutPipe> for ::windows::core::IInspectable {
-    fn from(value: UsbBulkOutPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbBulkOutPipe> for ::windows::core::IInspectable {
-    fn from(value: &UsbBulkOutPipe) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbBulkOutPipe> for &::windows::core::IInspectable {
-    fn from(value: &UsbBulkOutPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbBulkOutPipe, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbBulkOutPipe {}
 unsafe impl ::core::marker::Sync for UsbBulkOutPipe {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -1095,36 +979,7 @@ unsafe impl ::windows::core::Interface for UsbConfiguration {
 impl ::windows::core::RuntimeName for UsbConfiguration {
     const NAME: &'static str = "Windows.Devices.Usb.UsbConfiguration";
 }
-impl ::core::convert::From<UsbConfiguration> for ::windows::core::IUnknown {
-    fn from(value: UsbConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &UsbConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &UsbConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbConfiguration> for ::windows::core::IInspectable {
-    fn from(value: UsbConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &UsbConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &UsbConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbConfiguration {}
 unsafe impl ::core::marker::Sync for UsbConfiguration {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -1209,36 +1064,7 @@ unsafe impl ::windows::core::Interface for UsbConfigurationDescriptor {
 impl ::windows::core::RuntimeName for UsbConfigurationDescriptor {
     const NAME: &'static str = "Windows.Devices.Usb.UsbConfigurationDescriptor";
 }
-impl ::core::convert::From<UsbConfigurationDescriptor> for ::windows::core::IUnknown {
-    fn from(value: UsbConfigurationDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbConfigurationDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &UsbConfigurationDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbConfigurationDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &UsbConfigurationDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbConfigurationDescriptor> for ::windows::core::IInspectable {
-    fn from(value: UsbConfigurationDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbConfigurationDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &UsbConfigurationDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbConfigurationDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &UsbConfigurationDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbConfigurationDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbConfigurationDescriptor {}
 unsafe impl ::core::marker::Sync for UsbConfigurationDescriptor {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -1329,36 +1155,7 @@ unsafe impl ::windows::core::Interface for UsbControlRequestType {
 impl ::windows::core::RuntimeName for UsbControlRequestType {
     const NAME: &'static str = "Windows.Devices.Usb.UsbControlRequestType";
 }
-impl ::core::convert::From<UsbControlRequestType> for ::windows::core::IUnknown {
-    fn from(value: UsbControlRequestType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbControlRequestType> for ::windows::core::IUnknown {
-    fn from(value: &UsbControlRequestType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbControlRequestType> for &::windows::core::IUnknown {
-    fn from(value: &UsbControlRequestType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbControlRequestType> for ::windows::core::IInspectable {
-    fn from(value: UsbControlRequestType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbControlRequestType> for ::windows::core::IInspectable {
-    fn from(value: &UsbControlRequestType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbControlRequestType> for &::windows::core::IInspectable {
-    fn from(value: &UsbControlRequestType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbControlRequestType, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbControlRequestType {}
 unsafe impl ::core::marker::Sync for UsbControlRequestType {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -1422,36 +1219,7 @@ unsafe impl ::windows::core::Interface for UsbDescriptor {
 impl ::windows::core::RuntimeName for UsbDescriptor {
     const NAME: &'static str = "Windows.Devices.Usb.UsbDescriptor";
 }
-impl ::core::convert::From<UsbDescriptor> for ::windows::core::IUnknown {
-    fn from(value: UsbDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &UsbDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &UsbDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbDescriptor> for ::windows::core::IInspectable {
-    fn from(value: UsbDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &UsbDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &UsbDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbDescriptor {}
 unsafe impl ::core::marker::Sync for UsbDescriptor {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -1599,36 +1367,7 @@ unsafe impl ::windows::core::Interface for UsbDevice {
 impl ::windows::core::RuntimeName for UsbDevice {
     const NAME: &'static str = "Windows.Devices.Usb.UsbDevice";
 }
-impl ::core::convert::From<UsbDevice> for ::windows::core::IUnknown {
-    fn from(value: UsbDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbDevice> for ::windows::core::IUnknown {
-    fn from(value: &UsbDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbDevice> for &::windows::core::IUnknown {
-    fn from(value: &UsbDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbDevice> for ::windows::core::IInspectable {
-    fn from(value: UsbDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbDevice> for ::windows::core::IInspectable {
-    fn from(value: &UsbDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbDevice> for &::windows::core::IInspectable {
-    fn from(value: &UsbDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<UsbDevice> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1746,36 +1485,7 @@ unsafe impl ::windows::core::Interface for UsbDeviceClass {
 impl ::windows::core::RuntimeName for UsbDeviceClass {
     const NAME: &'static str = "Windows.Devices.Usb.UsbDeviceClass";
 }
-impl ::core::convert::From<UsbDeviceClass> for ::windows::core::IUnknown {
-    fn from(value: UsbDeviceClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbDeviceClass> for ::windows::core::IUnknown {
-    fn from(value: &UsbDeviceClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbDeviceClass> for &::windows::core::IUnknown {
-    fn from(value: &UsbDeviceClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbDeviceClass> for ::windows::core::IInspectable {
-    fn from(value: UsbDeviceClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbDeviceClass> for ::windows::core::IInspectable {
-    fn from(value: &UsbDeviceClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbDeviceClass> for &::windows::core::IInspectable {
-    fn from(value: &UsbDeviceClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbDeviceClass, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbDeviceClass {}
 unsafe impl ::core::marker::Sync for UsbDeviceClass {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -1874,36 +1584,7 @@ unsafe impl ::windows::core::Interface for UsbDeviceClasses {
 impl ::windows::core::RuntimeName for UsbDeviceClasses {
     const NAME: &'static str = "Windows.Devices.Usb.UsbDeviceClasses";
 }
-impl ::core::convert::From<UsbDeviceClasses> for ::windows::core::IUnknown {
-    fn from(value: UsbDeviceClasses) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbDeviceClasses> for ::windows::core::IUnknown {
-    fn from(value: &UsbDeviceClasses) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbDeviceClasses> for &::windows::core::IUnknown {
-    fn from(value: &UsbDeviceClasses) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbDeviceClasses> for ::windows::core::IInspectable {
-    fn from(value: UsbDeviceClasses) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbDeviceClasses> for ::windows::core::IInspectable {
-    fn from(value: &UsbDeviceClasses) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbDeviceClasses> for &::windows::core::IInspectable {
-    fn from(value: &UsbDeviceClasses) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbDeviceClasses, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbDeviceClasses {}
 unsafe impl ::core::marker::Sync for UsbDeviceClasses {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -1985,36 +1666,7 @@ unsafe impl ::windows::core::Interface for UsbDeviceDescriptor {
 impl ::windows::core::RuntimeName for UsbDeviceDescriptor {
     const NAME: &'static str = "Windows.Devices.Usb.UsbDeviceDescriptor";
 }
-impl ::core::convert::From<UsbDeviceDescriptor> for ::windows::core::IUnknown {
-    fn from(value: UsbDeviceDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbDeviceDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &UsbDeviceDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbDeviceDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &UsbDeviceDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbDeviceDescriptor> for ::windows::core::IInspectable {
-    fn from(value: UsbDeviceDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbDeviceDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &UsbDeviceDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbDeviceDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &UsbDeviceDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbDeviceDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbDeviceDescriptor {}
 unsafe impl ::core::marker::Sync for UsbDeviceDescriptor {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -2120,36 +1772,7 @@ unsafe impl ::windows::core::Interface for UsbEndpointDescriptor {
 impl ::windows::core::RuntimeName for UsbEndpointDescriptor {
     const NAME: &'static str = "Windows.Devices.Usb.UsbEndpointDescriptor";
 }
-impl ::core::convert::From<UsbEndpointDescriptor> for ::windows::core::IUnknown {
-    fn from(value: UsbEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbEndpointDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &UsbEndpointDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbEndpointDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &UsbEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbEndpointDescriptor> for ::windows::core::IInspectable {
-    fn from(value: UsbEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbEndpointDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &UsbEndpointDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbEndpointDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &UsbEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbEndpointDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbEndpointDescriptor {}
 unsafe impl ::core::marker::Sync for UsbEndpointDescriptor {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -2250,36 +1873,7 @@ unsafe impl ::windows::core::Interface for UsbInterface {
 impl ::windows::core::RuntimeName for UsbInterface {
     const NAME: &'static str = "Windows.Devices.Usb.UsbInterface";
 }
-impl ::core::convert::From<UsbInterface> for ::windows::core::IUnknown {
-    fn from(value: UsbInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterface> for ::windows::core::IUnknown {
-    fn from(value: &UsbInterface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterface> for &::windows::core::IUnknown {
-    fn from(value: &UsbInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbInterface> for ::windows::core::IInspectable {
-    fn from(value: UsbInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterface> for ::windows::core::IInspectable {
-    fn from(value: &UsbInterface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterface> for &::windows::core::IInspectable {
-    fn from(value: &UsbInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbInterface, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbInterface {}
 unsafe impl ::core::marker::Sync for UsbInterface {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -2371,36 +1965,7 @@ unsafe impl ::windows::core::Interface for UsbInterfaceDescriptor {
 impl ::windows::core::RuntimeName for UsbInterfaceDescriptor {
     const NAME: &'static str = "Windows.Devices.Usb.UsbInterfaceDescriptor";
 }
-impl ::core::convert::From<UsbInterfaceDescriptor> for ::windows::core::IUnknown {
-    fn from(value: UsbInterfaceDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterfaceDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &UsbInterfaceDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterfaceDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &UsbInterfaceDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbInterfaceDescriptor> for ::windows::core::IInspectable {
-    fn from(value: UsbInterfaceDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterfaceDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &UsbInterfaceDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterfaceDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &UsbInterfaceDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbInterfaceDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbInterfaceDescriptor {}
 unsafe impl ::core::marker::Sync for UsbInterfaceDescriptor {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -2508,36 +2073,7 @@ unsafe impl ::windows::core::Interface for UsbInterfaceSetting {
 impl ::windows::core::RuntimeName for UsbInterfaceSetting {
     const NAME: &'static str = "Windows.Devices.Usb.UsbInterfaceSetting";
 }
-impl ::core::convert::From<UsbInterfaceSetting> for ::windows::core::IUnknown {
-    fn from(value: UsbInterfaceSetting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterfaceSetting> for ::windows::core::IUnknown {
-    fn from(value: &UsbInterfaceSetting) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterfaceSetting> for &::windows::core::IUnknown {
-    fn from(value: &UsbInterfaceSetting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbInterfaceSetting> for ::windows::core::IInspectable {
-    fn from(value: UsbInterfaceSetting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterfaceSetting> for ::windows::core::IInspectable {
-    fn from(value: &UsbInterfaceSetting) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterfaceSetting> for &::windows::core::IInspectable {
-    fn from(value: &UsbInterfaceSetting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbInterfaceSetting, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbInterfaceSetting {}
 unsafe impl ::core::marker::Sync for UsbInterfaceSetting {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -2607,36 +2143,7 @@ unsafe impl ::windows::core::Interface for UsbInterruptInEndpointDescriptor {
 impl ::windows::core::RuntimeName for UsbInterruptInEndpointDescriptor {
     const NAME: &'static str = "Windows.Devices.Usb.UsbInterruptInEndpointDescriptor";
 }
-impl ::core::convert::From<UsbInterruptInEndpointDescriptor> for ::windows::core::IUnknown {
-    fn from(value: UsbInterruptInEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterruptInEndpointDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &UsbInterruptInEndpointDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterruptInEndpointDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &UsbInterruptInEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbInterruptInEndpointDescriptor> for ::windows::core::IInspectable {
-    fn from(value: UsbInterruptInEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterruptInEndpointDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &UsbInterruptInEndpointDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterruptInEndpointDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &UsbInterruptInEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbInterruptInEndpointDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbInterruptInEndpointDescriptor {}
 unsafe impl ::core::marker::Sync for UsbInterruptInEndpointDescriptor {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -2685,36 +2192,7 @@ unsafe impl ::windows::core::Interface for UsbInterruptInEventArgs {
 impl ::windows::core::RuntimeName for UsbInterruptInEventArgs {
     const NAME: &'static str = "Windows.Devices.Usb.UsbInterruptInEventArgs";
 }
-impl ::core::convert::From<UsbInterruptInEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UsbInterruptInEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterruptInEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UsbInterruptInEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterruptInEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UsbInterruptInEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbInterruptInEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UsbInterruptInEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterruptInEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UsbInterruptInEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterruptInEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UsbInterruptInEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbInterruptInEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbInterruptInEventArgs {}
 unsafe impl ::core::marker::Sync for UsbInterruptInEventArgs {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -2785,36 +2263,7 @@ unsafe impl ::windows::core::Interface for UsbInterruptInPipe {
 impl ::windows::core::RuntimeName for UsbInterruptInPipe {
     const NAME: &'static str = "Windows.Devices.Usb.UsbInterruptInPipe";
 }
-impl ::core::convert::From<UsbInterruptInPipe> for ::windows::core::IUnknown {
-    fn from(value: UsbInterruptInPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterruptInPipe> for ::windows::core::IUnknown {
-    fn from(value: &UsbInterruptInPipe) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterruptInPipe> for &::windows::core::IUnknown {
-    fn from(value: &UsbInterruptInPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbInterruptInPipe> for ::windows::core::IInspectable {
-    fn from(value: UsbInterruptInPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterruptInPipe> for ::windows::core::IInspectable {
-    fn from(value: &UsbInterruptInPipe) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterruptInPipe> for &::windows::core::IInspectable {
-    fn from(value: &UsbInterruptInPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbInterruptInPipe, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbInterruptInPipe {}
 unsafe impl ::core::marker::Sync for UsbInterruptInPipe {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -2884,36 +2333,7 @@ unsafe impl ::windows::core::Interface for UsbInterruptOutEndpointDescriptor {
 impl ::windows::core::RuntimeName for UsbInterruptOutEndpointDescriptor {
     const NAME: &'static str = "Windows.Devices.Usb.UsbInterruptOutEndpointDescriptor";
 }
-impl ::core::convert::From<UsbInterruptOutEndpointDescriptor> for ::windows::core::IUnknown {
-    fn from(value: UsbInterruptOutEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterruptOutEndpointDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &UsbInterruptOutEndpointDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterruptOutEndpointDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &UsbInterruptOutEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbInterruptOutEndpointDescriptor> for ::windows::core::IInspectable {
-    fn from(value: UsbInterruptOutEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterruptOutEndpointDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &UsbInterruptOutEndpointDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterruptOutEndpointDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &UsbInterruptOutEndpointDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbInterruptOutEndpointDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbInterruptOutEndpointDescriptor {}
 unsafe impl ::core::marker::Sync for UsbInterruptOutEndpointDescriptor {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -2989,36 +2409,7 @@ unsafe impl ::windows::core::Interface for UsbInterruptOutPipe {
 impl ::windows::core::RuntimeName for UsbInterruptOutPipe {
     const NAME: &'static str = "Windows.Devices.Usb.UsbInterruptOutPipe";
 }
-impl ::core::convert::From<UsbInterruptOutPipe> for ::windows::core::IUnknown {
-    fn from(value: UsbInterruptOutPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterruptOutPipe> for ::windows::core::IUnknown {
-    fn from(value: &UsbInterruptOutPipe) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterruptOutPipe> for &::windows::core::IUnknown {
-    fn from(value: &UsbInterruptOutPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbInterruptOutPipe> for ::windows::core::IInspectable {
-    fn from(value: UsbInterruptOutPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbInterruptOutPipe> for ::windows::core::IInspectable {
-    fn from(value: &UsbInterruptOutPipe) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbInterruptOutPipe> for &::windows::core::IInspectable {
-    fn from(value: &UsbInterruptOutPipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbInterruptOutPipe, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbInterruptOutPipe {}
 unsafe impl ::core::marker::Sync for UsbInterruptOutPipe {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]
@@ -3137,36 +2528,7 @@ unsafe impl ::windows::core::Interface for UsbSetupPacket {
 impl ::windows::core::RuntimeName for UsbSetupPacket {
     const NAME: &'static str = "Windows.Devices.Usb.UsbSetupPacket";
 }
-impl ::core::convert::From<UsbSetupPacket> for ::windows::core::IUnknown {
-    fn from(value: UsbSetupPacket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbSetupPacket> for ::windows::core::IUnknown {
-    fn from(value: &UsbSetupPacket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbSetupPacket> for &::windows::core::IUnknown {
-    fn from(value: &UsbSetupPacket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UsbSetupPacket> for ::windows::core::IInspectable {
-    fn from(value: UsbSetupPacket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UsbSetupPacket> for ::windows::core::IInspectable {
-    fn from(value: &UsbSetupPacket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UsbSetupPacket> for &::windows::core::IInspectable {
-    fn from(value: &UsbSetupPacket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UsbSetupPacket, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UsbSetupPacket {}
 unsafe impl ::core::marker::Sync for UsbSetupPacket {}
 #[doc = "*Required features: `\"Devices_Usb\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/WiFi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFi/mod.rs
@@ -342,36 +342,7 @@ unsafe impl ::windows::core::Interface for WiFiAdapter {
 impl ::windows::core::RuntimeName for WiFiAdapter {
     const NAME: &'static str = "Windows.Devices.WiFi.WiFiAdapter";
 }
-impl ::core::convert::From<WiFiAdapter> for ::windows::core::IUnknown {
-    fn from(value: WiFiAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiAdapter> for ::windows::core::IUnknown {
-    fn from(value: &WiFiAdapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiAdapter> for &::windows::core::IUnknown {
-    fn from(value: &WiFiAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiAdapter> for ::windows::core::IInspectable {
-    fn from(value: WiFiAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiAdapter> for ::windows::core::IInspectable {
-    fn from(value: &WiFiAdapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiAdapter> for &::windows::core::IInspectable {
-    fn from(value: &WiFiAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiAdapter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiAdapter {}
 unsafe impl ::core::marker::Sync for WiFiAdapter {}
 #[doc = "*Required features: `\"Devices_WiFi\"`*"]
@@ -494,36 +465,7 @@ unsafe impl ::windows::core::Interface for WiFiAvailableNetwork {
 impl ::windows::core::RuntimeName for WiFiAvailableNetwork {
     const NAME: &'static str = "Windows.Devices.WiFi.WiFiAvailableNetwork";
 }
-impl ::core::convert::From<WiFiAvailableNetwork> for ::windows::core::IUnknown {
-    fn from(value: WiFiAvailableNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiAvailableNetwork> for ::windows::core::IUnknown {
-    fn from(value: &WiFiAvailableNetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiAvailableNetwork> for &::windows::core::IUnknown {
-    fn from(value: &WiFiAvailableNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiAvailableNetwork> for ::windows::core::IInspectable {
-    fn from(value: WiFiAvailableNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiAvailableNetwork> for ::windows::core::IInspectable {
-    fn from(value: &WiFiAvailableNetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiAvailableNetwork> for &::windows::core::IInspectable {
-    fn from(value: &WiFiAvailableNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiAvailableNetwork, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiAvailableNetwork {}
 unsafe impl ::core::marker::Sync for WiFiAvailableNetwork {}
 #[doc = "*Required features: `\"Devices_WiFi\"`*"]
@@ -570,36 +512,7 @@ unsafe impl ::windows::core::Interface for WiFiConnectionResult {
 impl ::windows::core::RuntimeName for WiFiConnectionResult {
     const NAME: &'static str = "Windows.Devices.WiFi.WiFiConnectionResult";
 }
-impl ::core::convert::From<WiFiConnectionResult> for ::windows::core::IUnknown {
-    fn from(value: WiFiConnectionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiConnectionResult> for ::windows::core::IUnknown {
-    fn from(value: &WiFiConnectionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiConnectionResult> for &::windows::core::IUnknown {
-    fn from(value: &WiFiConnectionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiConnectionResult> for ::windows::core::IInspectable {
-    fn from(value: WiFiConnectionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiConnectionResult> for ::windows::core::IInspectable {
-    fn from(value: &WiFiConnectionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiConnectionResult> for &::windows::core::IInspectable {
-    fn from(value: &WiFiConnectionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiConnectionResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiConnectionResult {}
 unsafe impl ::core::marker::Sync for WiFiConnectionResult {}
 #[doc = "*Required features: `\"Devices_WiFi\"`*"]
@@ -657,36 +570,7 @@ unsafe impl ::windows::core::Interface for WiFiNetworkReport {
 impl ::windows::core::RuntimeName for WiFiNetworkReport {
     const NAME: &'static str = "Windows.Devices.WiFi.WiFiNetworkReport";
 }
-impl ::core::convert::From<WiFiNetworkReport> for ::windows::core::IUnknown {
-    fn from(value: WiFiNetworkReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiNetworkReport> for ::windows::core::IUnknown {
-    fn from(value: &WiFiNetworkReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiNetworkReport> for &::windows::core::IUnknown {
-    fn from(value: &WiFiNetworkReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiNetworkReport> for ::windows::core::IInspectable {
-    fn from(value: WiFiNetworkReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiNetworkReport> for ::windows::core::IInspectable {
-    fn from(value: &WiFiNetworkReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiNetworkReport> for &::windows::core::IInspectable {
-    fn from(value: &WiFiNetworkReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiNetworkReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiNetworkReport {}
 unsafe impl ::core::marker::Sync for WiFiNetworkReport {}
 #[doc = "*Required features: `\"Devices_WiFi\"`*"]
@@ -742,36 +626,7 @@ unsafe impl ::windows::core::Interface for WiFiWpsConfigurationResult {
 impl ::windows::core::RuntimeName for WiFiWpsConfigurationResult {
     const NAME: &'static str = "Windows.Devices.WiFi.WiFiWpsConfigurationResult";
 }
-impl ::core::convert::From<WiFiWpsConfigurationResult> for ::windows::core::IUnknown {
-    fn from(value: WiFiWpsConfigurationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiWpsConfigurationResult> for ::windows::core::IUnknown {
-    fn from(value: &WiFiWpsConfigurationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiWpsConfigurationResult> for &::windows::core::IUnknown {
-    fn from(value: &WiFiWpsConfigurationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiWpsConfigurationResult> for ::windows::core::IInspectable {
-    fn from(value: WiFiWpsConfigurationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiWpsConfigurationResult> for ::windows::core::IInspectable {
-    fn from(value: &WiFiWpsConfigurationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiWpsConfigurationResult> for &::windows::core::IInspectable {
-    fn from(value: &WiFiWpsConfigurationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiWpsConfigurationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiWpsConfigurationResult {}
 unsafe impl ::core::marker::Sync for WiFiWpsConfigurationResult {}
 #[doc = "*Required features: `\"Devices_WiFi\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/WiFiDirect/Services/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFiDirect/Services/mod.rs
@@ -496,36 +496,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectService {
 impl ::windows::core::RuntimeName for WiFiDirectService {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.Services.WiFiDirectService";
 }
-impl ::core::convert::From<WiFiDirectService> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectService> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectService> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectService> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectService> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectService> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectService, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectService {}
 unsafe impl ::core::marker::Sync for WiFiDirectService {}
 #[doc = "*Required features: `\"Devices_WiFiDirect_Services\"`*"]
@@ -768,36 +739,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectServiceAdvertiser {
 impl ::windows::core::RuntimeName for WiFiDirectServiceAdvertiser {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAdvertiser";
 }
-impl ::core::convert::From<WiFiDirectServiceAdvertiser> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectServiceAdvertiser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceAdvertiser> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceAdvertiser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceAdvertiser> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceAdvertiser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectServiceAdvertiser> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectServiceAdvertiser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceAdvertiser> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceAdvertiser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceAdvertiser> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceAdvertiser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectServiceAdvertiser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectServiceAdvertiser {}
 unsafe impl ::core::marker::Sync for WiFiDirectServiceAdvertiser {}
 #[doc = "*Required features: `\"Devices_WiFiDirect_Services\"`*"]
@@ -853,36 +795,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectServiceAutoAcceptSessionCon
 impl ::windows::core::RuntimeName for WiFiDirectServiceAutoAcceptSessionConnectedEventArgs {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.Services.WiFiDirectServiceAutoAcceptSessionConnectedEventArgs";
 }
-impl ::core::convert::From<WiFiDirectServiceAutoAcceptSessionConnectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectServiceAutoAcceptSessionConnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceAutoAcceptSessionConnectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceAutoAcceptSessionConnectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceAutoAcceptSessionConnectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceAutoAcceptSessionConnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectServiceAutoAcceptSessionConnectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectServiceAutoAcceptSessionConnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceAutoAcceptSessionConnectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceAutoAcceptSessionConnectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceAutoAcceptSessionConnectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceAutoAcceptSessionConnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectServiceAutoAcceptSessionConnectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectServiceAutoAcceptSessionConnectedEventArgs {}
 unsafe impl ::core::marker::Sync for WiFiDirectServiceAutoAcceptSessionConnectedEventArgs {}
 #[doc = "*Required features: `\"Devices_WiFiDirect_Services\"`*"]
@@ -936,36 +849,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectServiceProvisioningInfo {
 impl ::windows::core::RuntimeName for WiFiDirectServiceProvisioningInfo {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.Services.WiFiDirectServiceProvisioningInfo";
 }
-impl ::core::convert::From<WiFiDirectServiceProvisioningInfo> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectServiceProvisioningInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceProvisioningInfo> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceProvisioningInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceProvisioningInfo> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceProvisioningInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectServiceProvisioningInfo> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectServiceProvisioningInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceProvisioningInfo> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceProvisioningInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceProvisioningInfo> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceProvisioningInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectServiceProvisioningInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectServiceProvisioningInfo {}
 unsafe impl ::core::marker::Sync for WiFiDirectServiceProvisioningInfo {}
 #[doc = "*Required features: `\"Devices_WiFiDirect_Services\"`*"]
@@ -1021,36 +905,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectServiceRemotePortAddedEvent
 impl ::windows::core::RuntimeName for WiFiDirectServiceRemotePortAddedEventArgs {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.Services.WiFiDirectServiceRemotePortAddedEventArgs";
 }
-impl ::core::convert::From<WiFiDirectServiceRemotePortAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectServiceRemotePortAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceRemotePortAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceRemotePortAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceRemotePortAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceRemotePortAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectServiceRemotePortAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectServiceRemotePortAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceRemotePortAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceRemotePortAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceRemotePortAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceRemotePortAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectServiceRemotePortAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectServiceRemotePortAddedEventArgs {}
 unsafe impl ::core::marker::Sync for WiFiDirectServiceRemotePortAddedEventArgs {}
 #[doc = "*Required features: `\"Devices_WiFiDirect_Services\"`*"]
@@ -1202,36 +1057,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectServiceSession {
 impl ::windows::core::RuntimeName for WiFiDirectServiceSession {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSession";
 }
-impl ::core::convert::From<WiFiDirectServiceSession> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectServiceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSession> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSession> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectServiceSession> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectServiceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSession> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSession> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectServiceSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<WiFiDirectServiceSession> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1302,36 +1128,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectServiceSessionDeferredEvent
 impl ::windows::core::RuntimeName for WiFiDirectServiceSessionDeferredEventArgs {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionDeferredEventArgs";
 }
-impl ::core::convert::From<WiFiDirectServiceSessionDeferredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectServiceSessionDeferredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionDeferredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceSessionDeferredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionDeferredEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceSessionDeferredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectServiceSessionDeferredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectServiceSessionDeferredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionDeferredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceSessionDeferredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionDeferredEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceSessionDeferredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectServiceSessionDeferredEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectServiceSessionDeferredEventArgs {}
 unsafe impl ::core::marker::Sync for WiFiDirectServiceSessionDeferredEventArgs {}
 #[doc = "*Required features: `\"Devices_WiFiDirect_Services\"`*"]
@@ -1402,36 +1199,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectServiceSessionRequest {
 impl ::windows::core::RuntimeName for WiFiDirectServiceSessionRequest {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequest";
 }
-impl ::core::convert::From<WiFiDirectServiceSessionRequest> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectServiceSessionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionRequest> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceSessionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionRequest> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceSessionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectServiceSessionRequest> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectServiceSessionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionRequest> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceSessionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionRequest> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceSessionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectServiceSessionRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<WiFiDirectServiceSessionRequest> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1500,36 +1268,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectServiceSessionRequestedEven
 impl ::windows::core::RuntimeName for WiFiDirectServiceSessionRequestedEventArgs {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.Services.WiFiDirectServiceSessionRequestedEventArgs";
 }
-impl ::core::convert::From<WiFiDirectServiceSessionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectServiceSessionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceSessionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectServiceSessionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectServiceSessionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectServiceSessionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceSessionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectServiceSessionRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectServiceSessionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectServiceSessionRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectServiceSessionRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for WiFiDirectServiceSessionRequestedEventArgs {}
 #[doc = "*Required features: `\"Devices_WiFiDirect_Services\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/WiFiDirect/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFiDirect/mod.rs
@@ -436,36 +436,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectAdvertisement {
 impl ::windows::core::RuntimeName for WiFiDirectAdvertisement {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.WiFiDirectAdvertisement";
 }
-impl ::core::convert::From<WiFiDirectAdvertisement> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectAdvertisement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisement> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectAdvertisement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisement> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectAdvertisement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectAdvertisement> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectAdvertisement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisement> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectAdvertisement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisement> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectAdvertisement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectAdvertisement, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectAdvertisement {}
 unsafe impl ::core::marker::Sync for WiFiDirectAdvertisement {}
 #[doc = "*Required features: `\"Devices_WiFiDirect\"`*"]
@@ -549,36 +520,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectAdvertisementPublisher {
 impl ::windows::core::RuntimeName for WiFiDirectAdvertisementPublisher {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.WiFiDirectAdvertisementPublisher";
 }
-impl ::core::convert::From<WiFiDirectAdvertisementPublisher> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectAdvertisementPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisementPublisher> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectAdvertisementPublisher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisementPublisher> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectAdvertisementPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectAdvertisementPublisher> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectAdvertisementPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisementPublisher> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectAdvertisementPublisher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisementPublisher> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectAdvertisementPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectAdvertisementPublisher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectAdvertisementPublisher {}
 unsafe impl ::core::marker::Sync for WiFiDirectAdvertisementPublisher {}
 #[doc = "*Required features: `\"Devices_WiFiDirect\"`*"]
@@ -632,36 +574,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectAdvertisementPublisherStatu
 impl ::windows::core::RuntimeName for WiFiDirectAdvertisementPublisherStatusChangedEventArgs {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.WiFiDirectAdvertisementPublisherStatusChangedEventArgs";
 }
-impl ::core::convert::From<WiFiDirectAdvertisementPublisherStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisementPublisherStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisementPublisherStatusChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectAdvertisementPublisherStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisementPublisherStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectAdvertisementPublisherStatusChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectAdvertisementPublisherStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectAdvertisementPublisherStatusChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectAdvertisementPublisherStatusChangedEventArgs {}
 unsafe impl ::core::marker::Sync for WiFiDirectAdvertisementPublisherStatusChangedEventArgs {}
 #[doc = "*Required features: `\"Devices_WiFiDirect\"`*"]
@@ -723,36 +636,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectConnectionListener {
 impl ::windows::core::RuntimeName for WiFiDirectConnectionListener {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.WiFiDirectConnectionListener";
 }
-impl ::core::convert::From<WiFiDirectConnectionListener> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectConnectionListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionListener> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectConnectionListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionListener> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectConnectionListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectConnectionListener> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectConnectionListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionListener> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectConnectionListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionListener> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectConnectionListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectConnectionListener, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectConnectionListener {}
 unsafe impl ::core::marker::Sync for WiFiDirectConnectionListener {}
 #[doc = "*Required features: `\"Devices_WiFiDirect\"`*"]
@@ -843,36 +727,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectConnectionParameters {
 impl ::windows::core::RuntimeName for WiFiDirectConnectionParameters {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.WiFiDirectConnectionParameters";
 }
-impl ::core::convert::From<WiFiDirectConnectionParameters> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionParameters> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectConnectionParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionParameters> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectConnectionParameters> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionParameters> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectConnectionParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionParameters> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectConnectionParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectConnectionParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Devices_Enumeration")]
 impl ::core::convert::TryFrom<WiFiDirectConnectionParameters> for super::Enumeration::IDevicePairingSettings {
     type Error = ::windows::core::Error;
@@ -949,36 +804,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectConnectionRequest {
 impl ::windows::core::RuntimeName for WiFiDirectConnectionRequest {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.WiFiDirectConnectionRequest";
 }
-impl ::core::convert::From<WiFiDirectConnectionRequest> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectConnectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionRequest> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectConnectionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionRequest> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectConnectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectConnectionRequest> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectConnectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionRequest> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectConnectionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionRequest> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectConnectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectConnectionRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<WiFiDirectConnectionRequest> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1047,36 +873,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectConnectionRequestedEventArg
 impl ::windows::core::RuntimeName for WiFiDirectConnectionRequestedEventArgs {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.WiFiDirectConnectionRequestedEventArgs";
 }
-impl ::core::convert::From<WiFiDirectConnectionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectConnectionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectConnectionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectConnectionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectConnectionRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectConnectionRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectConnectionRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for WiFiDirectConnectionRequestedEventArgs {}
 #[doc = "*Required features: `\"Devices_WiFiDirect\"`*"]
@@ -1198,36 +995,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectDevice {
 impl ::windows::core::RuntimeName for WiFiDirectDevice {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.WiFiDirectDevice";
 }
-impl ::core::convert::From<WiFiDirectDevice> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectDevice> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectDevice> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectDevice> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectDevice> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectDevice> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<WiFiDirectDevice> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1370,36 +1138,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectInformationElement {
 impl ::windows::core::RuntimeName for WiFiDirectInformationElement {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.WiFiDirectInformationElement";
 }
-impl ::core::convert::From<WiFiDirectInformationElement> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectInformationElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectInformationElement> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectInformationElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectInformationElement> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectInformationElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectInformationElement> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectInformationElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectInformationElement> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectInformationElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectInformationElement> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectInformationElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectInformationElement, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectInformationElement {}
 unsafe impl ::core::marker::Sync for WiFiDirectInformationElement {}
 #[doc = "*Required features: `\"Devices_WiFiDirect\"`*"]
@@ -1476,36 +1215,7 @@ unsafe impl ::windows::core::Interface for WiFiDirectLegacySettings {
 impl ::windows::core::RuntimeName for WiFiDirectLegacySettings {
     const NAME: &'static str = "Windows.Devices.WiFiDirect.WiFiDirectLegacySettings";
 }
-impl ::core::convert::From<WiFiDirectLegacySettings> for ::windows::core::IUnknown {
-    fn from(value: WiFiDirectLegacySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectLegacySettings> for ::windows::core::IUnknown {
-    fn from(value: &WiFiDirectLegacySettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectLegacySettings> for &::windows::core::IUnknown {
-    fn from(value: &WiFiDirectLegacySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WiFiDirectLegacySettings> for ::windows::core::IInspectable {
-    fn from(value: WiFiDirectLegacySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WiFiDirectLegacySettings> for ::windows::core::IInspectable {
-    fn from(value: &WiFiDirectLegacySettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WiFiDirectLegacySettings> for &::windows::core::IInspectable {
-    fn from(value: &WiFiDirectLegacySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WiFiDirectLegacySettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WiFiDirectLegacySettings {}
 unsafe impl ::core::marker::Sync for WiFiDirectLegacySettings {}
 #[doc = "*Required features: `\"Devices_WiFiDirect\"`*"]

--- a/crates/libs/windows/src/Windows/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/mod.rs
@@ -110,36 +110,7 @@ impl ILowLevelDevicesAggregateProvider {
         }
     }
 }
-impl ::core::convert::From<ILowLevelDevicesAggregateProvider> for ::windows::core::IUnknown {
-    fn from(value: ILowLevelDevicesAggregateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILowLevelDevicesAggregateProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILowLevelDevicesAggregateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILowLevelDevicesAggregateProvider> for ::windows::core::IUnknown {
-    fn from(value: &ILowLevelDevicesAggregateProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILowLevelDevicesAggregateProvider> for ::windows::core::IInspectable {
-    fn from(value: ILowLevelDevicesAggregateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILowLevelDevicesAggregateProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILowLevelDevicesAggregateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILowLevelDevicesAggregateProvider> for ::windows::core::IInspectable {
-    fn from(value: &ILowLevelDevicesAggregateProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILowLevelDevicesAggregateProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ILowLevelDevicesAggregateProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -349,36 +320,7 @@ unsafe impl ::windows::core::Interface for LowLevelDevicesAggregateProvider {
 impl ::windows::core::RuntimeName for LowLevelDevicesAggregateProvider {
     const NAME: &'static str = "Windows.Devices.LowLevelDevicesAggregateProvider";
 }
-impl ::core::convert::From<LowLevelDevicesAggregateProvider> for ::windows::core::IUnknown {
-    fn from(value: LowLevelDevicesAggregateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLevelDevicesAggregateProvider> for ::windows::core::IUnknown {
-    fn from(value: &LowLevelDevicesAggregateProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLevelDevicesAggregateProvider> for &::windows::core::IUnknown {
-    fn from(value: &LowLevelDevicesAggregateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LowLevelDevicesAggregateProvider> for ::windows::core::IInspectable {
-    fn from(value: LowLevelDevicesAggregateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLevelDevicesAggregateProvider> for ::windows::core::IInspectable {
-    fn from(value: &LowLevelDevicesAggregateProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLevelDevicesAggregateProvider> for &::windows::core::IInspectable {
-    fn from(value: &LowLevelDevicesAggregateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LowLevelDevicesAggregateProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LowLevelDevicesAggregateProvider> for ILowLevelDevicesAggregateProvider {
     type Error = ::windows::core::Error;
     fn try_from(value: LowLevelDevicesAggregateProvider) -> ::windows::core::Result<Self> {
@@ -455,36 +397,7 @@ unsafe impl ::windows::core::Interface for LowLevelDevicesController {
 impl ::windows::core::RuntimeName for LowLevelDevicesController {
     const NAME: &'static str = "Windows.Devices.LowLevelDevicesController";
 }
-impl ::core::convert::From<LowLevelDevicesController> for ::windows::core::IUnknown {
-    fn from(value: LowLevelDevicesController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLevelDevicesController> for ::windows::core::IUnknown {
-    fn from(value: &LowLevelDevicesController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLevelDevicesController> for &::windows::core::IUnknown {
-    fn from(value: &LowLevelDevicesController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LowLevelDevicesController> for ::windows::core::IInspectable {
-    fn from(value: LowLevelDevicesController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLevelDevicesController> for ::windows::core::IInspectable {
-    fn from(value: &LowLevelDevicesController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLevelDevicesController> for &::windows::core::IInspectable {
-    fn from(value: &LowLevelDevicesController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LowLevelDevicesController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LowLevelDevicesController {}
 unsafe impl ::core::marker::Sync for LowLevelDevicesController {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Embedded/DeviceLockdown/mod.rs
+++ b/crates/libs/windows/src/Windows/Embedded/DeviceLockdown/mod.rs
@@ -121,36 +121,7 @@ unsafe impl ::windows::core::Interface for DeviceLockdownProfileInformation {
 impl ::windows::core::RuntimeName for DeviceLockdownProfileInformation {
     const NAME: &'static str = "Windows.Embedded.DeviceLockdown.DeviceLockdownProfileInformation";
 }
-impl ::core::convert::From<DeviceLockdownProfileInformation> for ::windows::core::IUnknown {
-    fn from(value: DeviceLockdownProfileInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceLockdownProfileInformation> for ::windows::core::IUnknown {
-    fn from(value: &DeviceLockdownProfileInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceLockdownProfileInformation> for &::windows::core::IUnknown {
-    fn from(value: &DeviceLockdownProfileInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeviceLockdownProfileInformation> for ::windows::core::IInspectable {
-    fn from(value: DeviceLockdownProfileInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeviceLockdownProfileInformation> for ::windows::core::IInspectable {
-    fn from(value: &DeviceLockdownProfileInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeviceLockdownProfileInformation> for &::windows::core::IInspectable {
-    fn from(value: &DeviceLockdownProfileInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeviceLockdownProfileInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeviceLockdownProfileInformation {}
 unsafe impl ::core::marker::Sync for DeviceLockdownProfileInformation {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
@@ -1228,36 +1228,7 @@ impl IPropertySet {
         unsafe { (::windows::core::Vtable::vtable(this).RemoveMapChanged)(::windows::core::Vtable::as_raw(this), token).ok() }
     }
 }
-impl ::core::convert::From<IPropertySet> for ::windows::core::IUnknown {
-    fn from(value: IPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertySet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertySet> for ::windows::core::IUnknown {
-    fn from(value: &IPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertySet> for ::windows::core::IInspectable {
-    fn from(value: IPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertySet> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertySet> for ::windows::core::IInspectable {
-    fn from(value: &IPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertySet, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPropertySet> for IIterable<IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
     fn try_from(value: IPropertySet) -> ::windows::core::Result<Self> {
@@ -1602,36 +1573,7 @@ impl IVectorChangedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IVectorChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IVectorChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVectorChangedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVectorChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVectorChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IVectorChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVectorChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IVectorChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVectorChangedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVectorChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVectorChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IVectorChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVectorChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVectorChangedEventArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1958,36 +1900,7 @@ impl ::core::iter::IntoIterator for &PropertySet {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<PropertySet> for ::windows::core::IUnknown {
-    fn from(value: PropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PropertySet> for ::windows::core::IUnknown {
-    fn from(value: &PropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PropertySet> for &::windows::core::IUnknown {
-    fn from(value: &PropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PropertySet> for ::windows::core::IInspectable {
-    fn from(value: PropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PropertySet> for ::windows::core::IInspectable {
-    fn from(value: &PropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PropertySet> for &::windows::core::IInspectable {
-    fn from(value: &PropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PropertySet, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PropertySet> for IIterable<IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
     fn try_from(value: PropertySet) -> ::windows::core::Result<Self> {
@@ -2185,36 +2098,7 @@ impl ::core::iter::IntoIterator for &StringMap {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<StringMap> for ::windows::core::IUnknown {
-    fn from(value: StringMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StringMap> for ::windows::core::IUnknown {
-    fn from(value: &StringMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StringMap> for &::windows::core::IUnknown {
-    fn from(value: &StringMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StringMap> for ::windows::core::IInspectable {
-    fn from(value: StringMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StringMap> for ::windows::core::IInspectable {
-    fn from(value: &StringMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StringMap> for &::windows::core::IInspectable {
-    fn from(value: &StringMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StringMap, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StringMap> for IIterable<IKeyValuePair<::windows::core::HSTRING, ::windows::core::HSTRING>> {
     type Error = ::windows::core::Error;
     fn try_from(value: StringMap) -> ::windows::core::Result<Self> {
@@ -2396,36 +2280,7 @@ impl ::core::iter::IntoIterator for &ValueSet {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<ValueSet> for ::windows::core::IUnknown {
-    fn from(value: ValueSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ValueSet> for ::windows::core::IUnknown {
-    fn from(value: &ValueSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ValueSet> for &::windows::core::IUnknown {
-    fn from(value: &ValueSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ValueSet> for ::windows::core::IInspectable {
-    fn from(value: ValueSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ValueSet> for ::windows::core::IInspectable {
-    fn from(value: &ValueSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ValueSet> for &::windows::core::IInspectable {
-    fn from(value: &ValueSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ValueSet, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ValueSet> for IIterable<IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
     fn try_from(value: ValueSet) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
@@ -67,36 +67,7 @@ impl IErrorReportingSettings {
         }
     }
 }
-impl ::core::convert::From<IErrorReportingSettings> for ::windows::core::IUnknown {
-    fn from(value: IErrorReportingSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IErrorReportingSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IErrorReportingSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IErrorReportingSettings> for ::windows::core::IUnknown {
-    fn from(value: &IErrorReportingSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IErrorReportingSettings> for ::windows::core::IInspectable {
-    fn from(value: IErrorReportingSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IErrorReportingSettings> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IErrorReportingSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IErrorReportingSettings> for ::windows::core::IInspectable {
-    fn from(value: &IErrorReportingSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IErrorReportingSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IErrorReportingSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -193,36 +164,7 @@ impl IFileLoggingSession {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IFileLoggingSession> for ::windows::core::IUnknown {
-    fn from(value: IFileLoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileLoggingSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileLoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileLoggingSession> for ::windows::core::IUnknown {
-    fn from(value: &IFileLoggingSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileLoggingSession> for ::windows::core::IInspectable {
-    fn from(value: IFileLoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileLoggingSession> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IFileLoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileLoggingSession> for ::windows::core::IInspectable {
-    fn from(value: &IFileLoggingSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileLoggingSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IFileLoggingSession> for super::IClosable {
     type Error = ::windows::core::Error;
     fn try_from(value: IFileLoggingSession) -> ::windows::core::Result<Self> {
@@ -426,36 +368,7 @@ impl ILoggingChannel {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<ILoggingChannel> for ::windows::core::IUnknown {
-    fn from(value: ILoggingChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILoggingChannel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILoggingChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILoggingChannel> for ::windows::core::IUnknown {
-    fn from(value: &ILoggingChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILoggingChannel> for ::windows::core::IInspectable {
-    fn from(value: ILoggingChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILoggingChannel> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILoggingChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILoggingChannel> for ::windows::core::IInspectable {
-    fn from(value: &ILoggingChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILoggingChannel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ILoggingChannel> for super::IClosable {
     type Error = ::windows::core::Error;
     fn try_from(value: ILoggingChannel) -> ::windows::core::Result<Self> {
@@ -821,36 +734,7 @@ impl ILoggingSession {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<ILoggingSession> for ::windows::core::IUnknown {
-    fn from(value: ILoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILoggingSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILoggingSession> for ::windows::core::IUnknown {
-    fn from(value: &ILoggingSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILoggingSession> for ::windows::core::IInspectable {
-    fn from(value: ILoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILoggingSession> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILoggingSession> for ::windows::core::IInspectable {
-    fn from(value: &ILoggingSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILoggingSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ILoggingSession> for super::IClosable {
     type Error = ::windows::core::Error;
     fn try_from(value: ILoggingSession) -> ::windows::core::Result<Self> {
@@ -997,36 +881,7 @@ impl ILoggingTarget {
         }
     }
 }
-impl ::core::convert::From<ILoggingTarget> for ::windows::core::IUnknown {
-    fn from(value: ILoggingTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILoggingTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILoggingTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILoggingTarget> for ::windows::core::IUnknown {
-    fn from(value: &ILoggingTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILoggingTarget> for ::windows::core::IInspectable {
-    fn from(value: ILoggingTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILoggingTarget> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILoggingTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILoggingTarget> for ::windows::core::IInspectable {
-    fn from(value: &ILoggingTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILoggingTarget, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ILoggingTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1193,36 +1048,7 @@ unsafe impl ::windows::core::Interface for ErrorDetails {
 impl ::windows::core::RuntimeName for ErrorDetails {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.ErrorDetails";
 }
-impl ::core::convert::From<ErrorDetails> for ::windows::core::IUnknown {
-    fn from(value: ErrorDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ErrorDetails> for ::windows::core::IUnknown {
-    fn from(value: &ErrorDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ErrorDetails> for &::windows::core::IUnknown {
-    fn from(value: &ErrorDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ErrorDetails> for ::windows::core::IInspectable {
-    fn from(value: ErrorDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ErrorDetails> for ::windows::core::IInspectable {
-    fn from(value: &ErrorDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ErrorDetails> for &::windows::core::IInspectable {
-    fn from(value: &ErrorDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ErrorDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ErrorDetails {}
 unsafe impl ::core::marker::Sync for ErrorDetails {}
 #[doc = "*Required features: `\"Foundation_Diagnostics\"`*"]
@@ -1328,36 +1154,7 @@ unsafe impl ::windows::core::Interface for FileLoggingSession {
 impl ::windows::core::RuntimeName for FileLoggingSession {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.FileLoggingSession";
 }
-impl ::core::convert::From<FileLoggingSession> for ::windows::core::IUnknown {
-    fn from(value: FileLoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileLoggingSession> for ::windows::core::IUnknown {
-    fn from(value: &FileLoggingSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileLoggingSession> for &::windows::core::IUnknown {
-    fn from(value: &FileLoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileLoggingSession> for ::windows::core::IInspectable {
-    fn from(value: FileLoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileLoggingSession> for ::windows::core::IInspectable {
-    fn from(value: &FileLoggingSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileLoggingSession> for &::windows::core::IInspectable {
-    fn from(value: &FileLoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileLoggingSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<FileLoggingSession> for super::IClosable {
     type Error = ::windows::core::Error;
     fn try_from(value: FileLoggingSession) -> ::windows::core::Result<Self> {
@@ -1444,36 +1241,7 @@ unsafe impl ::windows::core::Interface for LogFileGeneratedEventArgs {
 impl ::windows::core::RuntimeName for LogFileGeneratedEventArgs {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.LogFileGeneratedEventArgs";
 }
-impl ::core::convert::From<LogFileGeneratedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LogFileGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LogFileGeneratedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LogFileGeneratedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LogFileGeneratedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LogFileGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LogFileGeneratedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LogFileGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LogFileGeneratedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LogFileGeneratedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LogFileGeneratedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LogFileGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LogFileGeneratedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LogFileGeneratedEventArgs {}
 unsafe impl ::core::marker::Sync for LogFileGeneratedEventArgs {}
 #[doc = "*Required features: `\"Foundation_Diagnostics\"`*"]
@@ -1640,36 +1408,7 @@ unsafe impl ::windows::core::Interface for LoggingActivity {
 impl ::windows::core::RuntimeName for LoggingActivity {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.LoggingActivity";
 }
-impl ::core::convert::From<LoggingActivity> for ::windows::core::IUnknown {
-    fn from(value: LoggingActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingActivity> for ::windows::core::IUnknown {
-    fn from(value: &LoggingActivity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingActivity> for &::windows::core::IUnknown {
-    fn from(value: &LoggingActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LoggingActivity> for ::windows::core::IInspectable {
-    fn from(value: LoggingActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingActivity> for ::windows::core::IInspectable {
-    fn from(value: &LoggingActivity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingActivity> for &::windows::core::IInspectable {
-    fn from(value: &LoggingActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LoggingActivity, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LoggingActivity> for super::IClosable {
     type Error = ::windows::core::Error;
     fn try_from(value: LoggingActivity) -> ::windows::core::Result<Self> {
@@ -1901,36 +1640,7 @@ unsafe impl ::windows::core::Interface for LoggingChannel {
 impl ::windows::core::RuntimeName for LoggingChannel {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.LoggingChannel";
 }
-impl ::core::convert::From<LoggingChannel> for ::windows::core::IUnknown {
-    fn from(value: LoggingChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingChannel> for ::windows::core::IUnknown {
-    fn from(value: &LoggingChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingChannel> for &::windows::core::IUnknown {
-    fn from(value: &LoggingChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LoggingChannel> for ::windows::core::IInspectable {
-    fn from(value: LoggingChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingChannel> for ::windows::core::IInspectable {
-    fn from(value: &LoggingChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingChannel> for &::windows::core::IInspectable {
-    fn from(value: &LoggingChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LoggingChannel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LoggingChannel> for super::IClosable {
     type Error = ::windows::core::Error;
     fn try_from(value: LoggingChannel) -> ::windows::core::Result<Self> {
@@ -2056,36 +1766,7 @@ unsafe impl ::windows::core::Interface for LoggingChannelOptions {
 impl ::windows::core::RuntimeName for LoggingChannelOptions {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.LoggingChannelOptions";
 }
-impl ::core::convert::From<LoggingChannelOptions> for ::windows::core::IUnknown {
-    fn from(value: LoggingChannelOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingChannelOptions> for ::windows::core::IUnknown {
-    fn from(value: &LoggingChannelOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingChannelOptions> for &::windows::core::IUnknown {
-    fn from(value: &LoggingChannelOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LoggingChannelOptions> for ::windows::core::IInspectable {
-    fn from(value: LoggingChannelOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingChannelOptions> for ::windows::core::IInspectable {
-    fn from(value: &LoggingChannelOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingChannelOptions> for &::windows::core::IInspectable {
-    fn from(value: &LoggingChannelOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LoggingChannelOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LoggingChannelOptions {}
 unsafe impl ::core::marker::Sync for LoggingChannelOptions {}
 #[doc = "*Required features: `\"Foundation_Diagnostics\"`*"]
@@ -2592,36 +2273,7 @@ unsafe impl ::windows::core::Interface for LoggingFields {
 impl ::windows::core::RuntimeName for LoggingFields {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.LoggingFields";
 }
-impl ::core::convert::From<LoggingFields> for ::windows::core::IUnknown {
-    fn from(value: LoggingFields) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingFields> for ::windows::core::IUnknown {
-    fn from(value: &LoggingFields) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingFields> for &::windows::core::IUnknown {
-    fn from(value: &LoggingFields) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LoggingFields> for ::windows::core::IInspectable {
-    fn from(value: LoggingFields) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingFields> for ::windows::core::IInspectable {
-    fn from(value: &LoggingFields) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingFields> for &::windows::core::IInspectable {
-    fn from(value: &LoggingFields) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LoggingFields, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LoggingFields {}
 unsafe impl ::core::marker::Sync for LoggingFields {}
 #[doc = "*Required features: `\"Foundation_Diagnostics\"`*"]
@@ -2745,36 +2397,7 @@ unsafe impl ::windows::core::Interface for LoggingOptions {
 impl ::windows::core::RuntimeName for LoggingOptions {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.LoggingOptions";
 }
-impl ::core::convert::From<LoggingOptions> for ::windows::core::IUnknown {
-    fn from(value: LoggingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingOptions> for ::windows::core::IUnknown {
-    fn from(value: &LoggingOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingOptions> for &::windows::core::IUnknown {
-    fn from(value: &LoggingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LoggingOptions> for ::windows::core::IInspectable {
-    fn from(value: LoggingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingOptions> for ::windows::core::IInspectable {
-    fn from(value: &LoggingOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingOptions> for &::windows::core::IInspectable {
-    fn from(value: &LoggingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LoggingOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LoggingOptions {}
 unsafe impl ::core::marker::Sync for LoggingOptions {}
 #[doc = "*Required features: `\"Foundation_Diagnostics\"`*"]
@@ -2873,36 +2496,7 @@ unsafe impl ::windows::core::Interface for LoggingSession {
 impl ::windows::core::RuntimeName for LoggingSession {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.LoggingSession";
 }
-impl ::core::convert::From<LoggingSession> for ::windows::core::IUnknown {
-    fn from(value: LoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingSession> for ::windows::core::IUnknown {
-    fn from(value: &LoggingSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingSession> for &::windows::core::IUnknown {
-    fn from(value: &LoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LoggingSession> for ::windows::core::IInspectable {
-    fn from(value: LoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LoggingSession> for ::windows::core::IInspectable {
-    fn from(value: &LoggingSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LoggingSession> for &::windows::core::IInspectable {
-    fn from(value: &LoggingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LoggingSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LoggingSession> for super::IClosable {
     type Error = ::windows::core::Error;
     fn try_from(value: LoggingSession) -> ::windows::core::Result<Self> {
@@ -2998,36 +2592,7 @@ unsafe impl ::windows::core::Interface for RuntimeBrokerErrorSettings {
 impl ::windows::core::RuntimeName for RuntimeBrokerErrorSettings {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.RuntimeBrokerErrorSettings";
 }
-impl ::core::convert::From<RuntimeBrokerErrorSettings> for ::windows::core::IUnknown {
-    fn from(value: RuntimeBrokerErrorSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RuntimeBrokerErrorSettings> for ::windows::core::IUnknown {
-    fn from(value: &RuntimeBrokerErrorSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RuntimeBrokerErrorSettings> for &::windows::core::IUnknown {
-    fn from(value: &RuntimeBrokerErrorSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RuntimeBrokerErrorSettings> for ::windows::core::IInspectable {
-    fn from(value: RuntimeBrokerErrorSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RuntimeBrokerErrorSettings> for ::windows::core::IInspectable {
-    fn from(value: &RuntimeBrokerErrorSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RuntimeBrokerErrorSettings> for &::windows::core::IInspectable {
-    fn from(value: &RuntimeBrokerErrorSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RuntimeBrokerErrorSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RuntimeBrokerErrorSettings> for IErrorReportingSettings {
     type Error = ::windows::core::Error;
     fn try_from(value: RuntimeBrokerErrorSettings) -> ::windows::core::Result<Self> {
@@ -3100,36 +2665,7 @@ unsafe impl ::windows::core::Interface for TracingStatusChangedEventArgs {
 impl ::windows::core::RuntimeName for TracingStatusChangedEventArgs {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.TracingStatusChangedEventArgs";
 }
-impl ::core::convert::From<TracingStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TracingStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TracingStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TracingStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TracingStatusChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TracingStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TracingStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TracingStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TracingStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TracingStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TracingStatusChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TracingStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TracingStatusChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TracingStatusChangedEventArgs {}
 unsafe impl ::core::marker::Sync for TracingStatusChangedEventArgs {}
 #[doc = "*Required features: `\"Foundation_Diagnostics\"`*"]

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -55,36 +55,7 @@ impl IAsyncAction {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IAsyncAction> for ::windows::core::IUnknown {
-    fn from(value: IAsyncAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncAction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAsyncAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncAction> for ::windows::core::IUnknown {
-    fn from(value: &IAsyncAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAsyncAction> for ::windows::core::IInspectable {
-    fn from(value: IAsyncAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncAction> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAsyncAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncAction> for ::windows::core::IInspectable {
-    fn from(value: &IAsyncAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAsyncAction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IAsyncAction> for IAsyncInfo {
     type Error = ::windows::core::Error;
     fn try_from(value: IAsyncAction) -> ::windows::core::Result<Self> {
@@ -391,36 +362,7 @@ impl IAsyncInfo {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IAsyncInfo> for ::windows::core::IUnknown {
-    fn from(value: IAsyncInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAsyncInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncInfo> for ::windows::core::IUnknown {
-    fn from(value: &IAsyncInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAsyncInfo> for ::windows::core::IInspectable {
-    fn from(value: IAsyncInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncInfo> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAsyncInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncInfo> for ::windows::core::IInspectable {
-    fn from(value: &IAsyncInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAsyncInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAsyncInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -835,36 +777,7 @@ impl IClosable {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IClosable> for ::windows::core::IUnknown {
-    fn from(value: IClosable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IClosable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IClosable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IClosable> for ::windows::core::IUnknown {
-    fn from(value: &IClosable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IClosable> for ::windows::core::IInspectable {
-    fn from(value: IClosable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IClosable> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IClosable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IClosable> for ::windows::core::IInspectable {
-    fn from(value: &IClosable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IClosable, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IClosable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -942,36 +855,7 @@ impl IGetActivationFactory {
         }
     }
 }
-impl ::core::convert::From<IGetActivationFactory> for ::windows::core::IUnknown {
-    fn from(value: IGetActivationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetActivationFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetActivationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetActivationFactory> for ::windows::core::IUnknown {
-    fn from(value: &IGetActivationFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGetActivationFactory> for ::windows::core::IInspectable {
-    fn from(value: IGetActivationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetActivationFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGetActivationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetActivationFactory> for ::windows::core::IInspectable {
-    fn from(value: &IGetActivationFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetActivationFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGetActivationFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1040,36 +924,7 @@ impl IMemoryBuffer {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IMemoryBuffer> for ::windows::core::IUnknown {
-    fn from(value: IMemoryBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMemoryBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMemoryBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMemoryBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IMemoryBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMemoryBuffer> for ::windows::core::IInspectable {
-    fn from(value: IMemoryBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMemoryBuffer> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMemoryBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMemoryBuffer> for ::windows::core::IInspectable {
-    fn from(value: &IMemoryBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMemoryBuffer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IMemoryBuffer> for IClosable {
     type Error = ::windows::core::Error;
     fn try_from(value: IMemoryBuffer) -> ::windows::core::Result<Self> {
@@ -1166,36 +1021,7 @@ impl IMemoryBufferReference {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IMemoryBufferReference> for ::windows::core::IUnknown {
-    fn from(value: IMemoryBufferReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMemoryBufferReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMemoryBufferReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMemoryBufferReference> for ::windows::core::IUnknown {
-    fn from(value: &IMemoryBufferReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMemoryBufferReference> for ::windows::core::IInspectable {
-    fn from(value: IMemoryBufferReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMemoryBufferReference> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMemoryBufferReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMemoryBufferReference> for ::windows::core::IInspectable {
-    fn from(value: &IMemoryBufferReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMemoryBufferReference, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IMemoryBufferReference> for IClosable {
     type Error = ::windows::core::Error;
     fn try_from(value: IMemoryBufferReference) -> ::windows::core::Result<Self> {
@@ -1473,36 +1299,7 @@ impl IPropertyValue {
         unsafe { (::windows::core::Vtable::vtable(this).GetRectArray)(::windows::core::Vtable::as_raw(this), value.set_abi_len(), value as *mut _ as _).ok() }
     }
 }
-impl ::core::convert::From<IPropertyValue> for ::windows::core::IUnknown {
-    fn from(value: IPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyValue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyValue> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertyValue> for ::windows::core::IInspectable {
-    fn from(value: IPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyValue> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyValue> for ::windows::core::IInspectable {
-    fn from(value: &IPropertyValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPropertyValue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2277,36 +2074,7 @@ impl IStringable {
         }
     }
 }
-impl ::core::convert::From<IStringable> for ::windows::core::IUnknown {
-    fn from(value: IStringable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStringable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStringable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStringable> for ::windows::core::IUnknown {
-    fn from(value: &IStringable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStringable> for ::windows::core::IInspectable {
-    fn from(value: IStringable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStringable> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStringable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStringable> for ::windows::core::IInspectable {
-    fn from(value: &IStringable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStringable, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStringable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2440,36 +2208,7 @@ impl IWwwFormUrlDecoderEntry {
         }
     }
 }
-impl ::core::convert::From<IWwwFormUrlDecoderEntry> for ::windows::core::IUnknown {
-    fn from(value: IWwwFormUrlDecoderEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWwwFormUrlDecoderEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWwwFormUrlDecoderEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWwwFormUrlDecoderEntry> for ::windows::core::IUnknown {
-    fn from(value: &IWwwFormUrlDecoderEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWwwFormUrlDecoderEntry> for ::windows::core::IInspectable {
-    fn from(value: IWwwFormUrlDecoderEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWwwFormUrlDecoderEntry> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWwwFormUrlDecoderEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWwwFormUrlDecoderEntry> for ::windows::core::IInspectable {
-    fn from(value: &IWwwFormUrlDecoderEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWwwFormUrlDecoderEntry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWwwFormUrlDecoderEntry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2592,36 +2331,7 @@ unsafe impl ::windows::core::Interface for Deferral {
 impl ::windows::core::RuntimeName for Deferral {
     const NAME: &'static str = "Windows.Foundation.Deferral";
 }
-impl ::core::convert::From<Deferral> for ::windows::core::IUnknown {
-    fn from(value: Deferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Deferral> for ::windows::core::IUnknown {
-    fn from(value: &Deferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Deferral> for &::windows::core::IUnknown {
-    fn from(value: &Deferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Deferral> for ::windows::core::IInspectable {
-    fn from(value: Deferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Deferral> for ::windows::core::IInspectable {
-    fn from(value: &Deferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Deferral> for &::windows::core::IInspectable {
-    fn from(value: &Deferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Deferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Deferral> for IClosable {
     type Error = ::windows::core::Error;
     fn try_from(value: Deferral) -> ::windows::core::Result<Self> {
@@ -2732,36 +2442,7 @@ unsafe impl ::windows::core::Interface for MemoryBuffer {
 impl ::windows::core::RuntimeName for MemoryBuffer {
     const NAME: &'static str = "Windows.Foundation.MemoryBuffer";
 }
-impl ::core::convert::From<MemoryBuffer> for ::windows::core::IUnknown {
-    fn from(value: MemoryBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MemoryBuffer> for ::windows::core::IUnknown {
-    fn from(value: &MemoryBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MemoryBuffer> for &::windows::core::IUnknown {
-    fn from(value: &MemoryBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MemoryBuffer> for ::windows::core::IInspectable {
-    fn from(value: MemoryBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MemoryBuffer> for ::windows::core::IInspectable {
-    fn from(value: &MemoryBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MemoryBuffer> for &::windows::core::IInspectable {
-    fn from(value: &MemoryBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MemoryBuffer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MemoryBuffer> for IClosable {
     type Error = ::windows::core::Error;
     fn try_from(value: MemoryBuffer) -> ::windows::core::Result<Self> {
@@ -3262,36 +2943,7 @@ unsafe impl ::windows::core::Interface for Uri {
 impl ::windows::core::RuntimeName for Uri {
     const NAME: &'static str = "Windows.Foundation.Uri";
 }
-impl ::core::convert::From<Uri> for ::windows::core::IUnknown {
-    fn from(value: Uri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Uri> for ::windows::core::IUnknown {
-    fn from(value: &Uri) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Uri> for &::windows::core::IUnknown {
-    fn from(value: &Uri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Uri> for ::windows::core::IInspectable {
-    fn from(value: Uri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Uri> for ::windows::core::IInspectable {
-    fn from(value: &Uri) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Uri> for &::windows::core::IInspectable {
-    fn from(value: &Uri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Uri, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Uri> for IStringable {
     type Error = ::windows::core::Error;
     fn try_from(value: Uri) -> ::windows::core::Result<Self> {
@@ -3433,36 +3085,7 @@ impl ::core::iter::IntoIterator for &WwwFormUrlDecoder {
         Collections::VectorViewIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<WwwFormUrlDecoder> for ::windows::core::IUnknown {
-    fn from(value: WwwFormUrlDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WwwFormUrlDecoder> for ::windows::core::IUnknown {
-    fn from(value: &WwwFormUrlDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WwwFormUrlDecoder> for &::windows::core::IUnknown {
-    fn from(value: &WwwFormUrlDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WwwFormUrlDecoder> for ::windows::core::IInspectable {
-    fn from(value: WwwFormUrlDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WwwFormUrlDecoder> for ::windows::core::IInspectable {
-    fn from(value: &WwwFormUrlDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WwwFormUrlDecoder> for &::windows::core::IInspectable {
-    fn from(value: &WwwFormUrlDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WwwFormUrlDecoder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<WwwFormUrlDecoder> for Collections::IIterable<IWwwFormUrlDecoderEntry> {
     type Error = ::windows::core::Error;
@@ -3560,36 +3183,7 @@ unsafe impl ::windows::core::Interface for WwwFormUrlDecoderEntry {
 impl ::windows::core::RuntimeName for WwwFormUrlDecoderEntry {
     const NAME: &'static str = "Windows.Foundation.WwwFormUrlDecoderEntry";
 }
-impl ::core::convert::From<WwwFormUrlDecoderEntry> for ::windows::core::IUnknown {
-    fn from(value: WwwFormUrlDecoderEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WwwFormUrlDecoderEntry> for ::windows::core::IUnknown {
-    fn from(value: &WwwFormUrlDecoderEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WwwFormUrlDecoderEntry> for &::windows::core::IUnknown {
-    fn from(value: &WwwFormUrlDecoderEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WwwFormUrlDecoderEntry> for ::windows::core::IInspectable {
-    fn from(value: WwwFormUrlDecoderEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WwwFormUrlDecoderEntry> for ::windows::core::IInspectable {
-    fn from(value: &WwwFormUrlDecoderEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WwwFormUrlDecoderEntry> for &::windows::core::IInspectable {
-    fn from(value: &WwwFormUrlDecoderEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WwwFormUrlDecoderEntry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WwwFormUrlDecoderEntry> for IWwwFormUrlDecoderEntry {
     type Error = ::windows::core::Error;
     fn try_from(value: WwwFormUrlDecoderEntry) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Gaming/Input/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/Custom/mod.rs
@@ -30,36 +30,7 @@ impl ICustomGameControllerFactory {
         unsafe { (::windows::core::Vtable::vtable(this).OnGameControllerRemoved)(::windows::core::Vtable::as_raw(this), value.try_into().map_err(|e| e.into())?.abi()).ok() }
     }
 }
-impl ::core::convert::From<ICustomGameControllerFactory> for ::windows::core::IUnknown {
-    fn from(value: ICustomGameControllerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICustomGameControllerFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICustomGameControllerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICustomGameControllerFactory> for ::windows::core::IUnknown {
-    fn from(value: &ICustomGameControllerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICustomGameControllerFactory> for ::windows::core::IInspectable {
-    fn from(value: ICustomGameControllerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICustomGameControllerFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICustomGameControllerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICustomGameControllerFactory> for ::windows::core::IInspectable {
-    fn from(value: &ICustomGameControllerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICustomGameControllerFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICustomGameControllerFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -142,36 +113,7 @@ impl IGameControllerInputSink {
         unsafe { (::windows::core::Vtable::vtable(this).OnInputSuspended)(::windows::core::Vtable::as_raw(this), timestamp).ok() }
     }
 }
-impl ::core::convert::From<IGameControllerInputSink> for ::windows::core::IUnknown {
-    fn from(value: IGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameControllerInputSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameControllerInputSink> for ::windows::core::IUnknown {
-    fn from(value: &IGameControllerInputSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGameControllerInputSink> for ::windows::core::IInspectable {
-    fn from(value: IGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameControllerInputSink> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameControllerInputSink> for ::windows::core::IInspectable {
-    fn from(value: &IGameControllerInputSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGameControllerInputSink, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGameControllerInputSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -248,36 +190,7 @@ impl IGameControllerProvider {
         }
     }
 }
-impl ::core::convert::From<IGameControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: IGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameControllerProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: &IGameControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGameControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: IGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameControllerProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: &IGameControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGameControllerProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGameControllerProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -355,36 +268,7 @@ impl IGipGameControllerInputSink {
         unsafe { (::windows::core::Vtable::vtable(this).OnInputSuspended)(::windows::core::Vtable::as_raw(this), timestamp).ok() }
     }
 }
-impl ::core::convert::From<IGipGameControllerInputSink> for ::windows::core::IUnknown {
-    fn from(value: IGipGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGipGameControllerInputSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGipGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGipGameControllerInputSink> for ::windows::core::IUnknown {
-    fn from(value: &IGipGameControllerInputSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGipGameControllerInputSink> for ::windows::core::IInspectable {
-    fn from(value: IGipGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGipGameControllerInputSink> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGipGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGipGameControllerInputSink> for ::windows::core::IInspectable {
-    fn from(value: &IGipGameControllerInputSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGipGameControllerInputSink, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IGipGameControllerInputSink> for IGameControllerInputSink {
     type Error = ::windows::core::Error;
     fn try_from(value: IGipGameControllerInputSink) -> ::windows::core::Result<Self> {
@@ -477,36 +361,7 @@ impl IHidGameControllerInputSink {
         unsafe { (::windows::core::Vtable::vtable(this).OnInputSuspended)(::windows::core::Vtable::as_raw(this), timestamp).ok() }
     }
 }
-impl ::core::convert::From<IHidGameControllerInputSink> for ::windows::core::IUnknown {
-    fn from(value: IHidGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHidGameControllerInputSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHidGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHidGameControllerInputSink> for ::windows::core::IUnknown {
-    fn from(value: &IHidGameControllerInputSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHidGameControllerInputSink> for ::windows::core::IInspectable {
-    fn from(value: IHidGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHidGameControllerInputSink> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IHidGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHidGameControllerInputSink> for ::windows::core::IInspectable {
-    fn from(value: &IHidGameControllerInputSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHidGameControllerInputSink, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IHidGameControllerInputSink> for IGameControllerInputSink {
     type Error = ::windows::core::Error;
     fn try_from(value: IHidGameControllerInputSink) -> ::windows::core::Result<Self> {
@@ -597,36 +452,7 @@ impl IXusbGameControllerInputSink {
         unsafe { (::windows::core::Vtable::vtable(this).OnInputSuspended)(::windows::core::Vtable::as_raw(this), timestamp).ok() }
     }
 }
-impl ::core::convert::From<IXusbGameControllerInputSink> for ::windows::core::IUnknown {
-    fn from(value: IXusbGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXusbGameControllerInputSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXusbGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXusbGameControllerInputSink> for ::windows::core::IUnknown {
-    fn from(value: &IXusbGameControllerInputSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXusbGameControllerInputSink> for ::windows::core::IInspectable {
-    fn from(value: IXusbGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXusbGameControllerInputSink> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IXusbGameControllerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXusbGameControllerInputSink> for ::windows::core::IInspectable {
-    fn from(value: &IXusbGameControllerInputSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXusbGameControllerInputSink, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IXusbGameControllerInputSink> for IGameControllerInputSink {
     type Error = ::windows::core::Error;
     fn try_from(value: IXusbGameControllerInputSink) -> ::windows::core::Result<Self> {
@@ -804,36 +630,7 @@ unsafe impl ::windows::core::Interface for GipFirmwareUpdateResult {
 impl ::windows::core::RuntimeName for GipFirmwareUpdateResult {
     const NAME: &'static str = "Windows.Gaming.Input.Custom.GipFirmwareUpdateResult";
 }
-impl ::core::convert::From<GipFirmwareUpdateResult> for ::windows::core::IUnknown {
-    fn from(value: GipFirmwareUpdateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GipFirmwareUpdateResult> for ::windows::core::IUnknown {
-    fn from(value: &GipFirmwareUpdateResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GipFirmwareUpdateResult> for &::windows::core::IUnknown {
-    fn from(value: &GipFirmwareUpdateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GipFirmwareUpdateResult> for ::windows::core::IInspectable {
-    fn from(value: GipFirmwareUpdateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GipFirmwareUpdateResult> for ::windows::core::IInspectable {
-    fn from(value: &GipFirmwareUpdateResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GipFirmwareUpdateResult> for &::windows::core::IInspectable {
-    fn from(value: &GipFirmwareUpdateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GipFirmwareUpdateResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GipFirmwareUpdateResult {}
 unsafe impl ::core::marker::Sync for GipFirmwareUpdateResult {}
 #[doc = "*Required features: `\"Gaming_Input_Custom\"`*"]
@@ -929,36 +726,7 @@ unsafe impl ::windows::core::Interface for GipGameControllerProvider {
 impl ::windows::core::RuntimeName for GipGameControllerProvider {
     const NAME: &'static str = "Windows.Gaming.Input.Custom.GipGameControllerProvider";
 }
-impl ::core::convert::From<GipGameControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: GipGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GipGameControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: &GipGameControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GipGameControllerProvider> for &::windows::core::IUnknown {
-    fn from(value: &GipGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GipGameControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: GipGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GipGameControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: &GipGameControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GipGameControllerProvider> for &::windows::core::IInspectable {
-    fn from(value: &GipGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GipGameControllerProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<GipGameControllerProvider> for IGameControllerProvider {
     type Error = ::windows::core::Error;
     fn try_from(value: GipGameControllerProvider) -> ::windows::core::Result<Self> {
@@ -1078,36 +846,7 @@ unsafe impl ::windows::core::Interface for HidGameControllerProvider {
 impl ::windows::core::RuntimeName for HidGameControllerProvider {
     const NAME: &'static str = "Windows.Gaming.Input.Custom.HidGameControllerProvider";
 }
-impl ::core::convert::From<HidGameControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: HidGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidGameControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: &HidGameControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidGameControllerProvider> for &::windows::core::IUnknown {
-    fn from(value: &HidGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HidGameControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: HidGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HidGameControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: &HidGameControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HidGameControllerProvider> for &::windows::core::IInspectable {
-    fn from(value: &HidGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HidGameControllerProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<HidGameControllerProvider> for IGameControllerProvider {
     type Error = ::windows::core::Error;
     fn try_from(value: HidGameControllerProvider) -> ::windows::core::Result<Self> {
@@ -1205,36 +944,7 @@ unsafe impl ::windows::core::Interface for XusbGameControllerProvider {
 impl ::windows::core::RuntimeName for XusbGameControllerProvider {
     const NAME: &'static str = "Windows.Gaming.Input.Custom.XusbGameControllerProvider";
 }
-impl ::core::convert::From<XusbGameControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: XusbGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XusbGameControllerProvider> for ::windows::core::IUnknown {
-    fn from(value: &XusbGameControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XusbGameControllerProvider> for &::windows::core::IUnknown {
-    fn from(value: &XusbGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XusbGameControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: XusbGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XusbGameControllerProvider> for ::windows::core::IInspectable {
-    fn from(value: &XusbGameControllerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XusbGameControllerProvider> for &::windows::core::IInspectable {
-    fn from(value: &XusbGameControllerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XusbGameControllerProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<XusbGameControllerProvider> for IGameControllerProvider {
     type Error = ::windows::core::Error;
     fn try_from(value: XusbGameControllerProvider) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
@@ -85,36 +85,7 @@ impl IForceFeedbackEffect {
         unsafe { (::windows::core::Vtable::vtable(this).Stop)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IForceFeedbackEffect> for ::windows::core::IUnknown {
-    fn from(value: IForceFeedbackEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IForceFeedbackEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IForceFeedbackEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IForceFeedbackEffect> for ::windows::core::IUnknown {
-    fn from(value: &IForceFeedbackEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IForceFeedbackEffect> for ::windows::core::IInspectable {
-    fn from(value: IForceFeedbackEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IForceFeedbackEffect> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IForceFeedbackEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IForceFeedbackEffect> for ::windows::core::IInspectable {
-    fn from(value: &IForceFeedbackEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IForceFeedbackEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IForceFeedbackEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -343,36 +314,7 @@ unsafe impl ::windows::core::Interface for ConditionForceEffect {
 impl ::windows::core::RuntimeName for ConditionForceEffect {
     const NAME: &'static str = "Windows.Gaming.Input.ForceFeedback.ConditionForceEffect";
 }
-impl ::core::convert::From<ConditionForceEffect> for ::windows::core::IUnknown {
-    fn from(value: ConditionForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConditionForceEffect> for ::windows::core::IUnknown {
-    fn from(value: &ConditionForceEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConditionForceEffect> for &::windows::core::IUnknown {
-    fn from(value: &ConditionForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConditionForceEffect> for ::windows::core::IInspectable {
-    fn from(value: ConditionForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConditionForceEffect> for ::windows::core::IInspectable {
-    fn from(value: &ConditionForceEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConditionForceEffect> for &::windows::core::IInspectable {
-    fn from(value: &ConditionForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConditionForceEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ConditionForceEffect> for IForceFeedbackEffect {
     type Error = ::windows::core::Error;
     fn try_from(value: ConditionForceEffect) -> ::windows::core::Result<Self> {
@@ -476,36 +418,7 @@ unsafe impl ::windows::core::Interface for ConstantForceEffect {
 impl ::windows::core::RuntimeName for ConstantForceEffect {
     const NAME: &'static str = "Windows.Gaming.Input.ForceFeedback.ConstantForceEffect";
 }
-impl ::core::convert::From<ConstantForceEffect> for ::windows::core::IUnknown {
-    fn from(value: ConstantForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConstantForceEffect> for ::windows::core::IUnknown {
-    fn from(value: &ConstantForceEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConstantForceEffect> for &::windows::core::IUnknown {
-    fn from(value: &ConstantForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConstantForceEffect> for ::windows::core::IInspectable {
-    fn from(value: ConstantForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConstantForceEffect> for ::windows::core::IInspectable {
-    fn from(value: &ConstantForceEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConstantForceEffect> for &::windows::core::IInspectable {
-    fn from(value: &ConstantForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConstantForceEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ConstantForceEffect> for IForceFeedbackEffect {
     type Error = ::windows::core::Error;
     fn try_from(value: ConstantForceEffect) -> ::windows::core::Result<Self> {
@@ -661,36 +574,7 @@ unsafe impl ::windows::core::Interface for ForceFeedbackMotor {
 impl ::windows::core::RuntimeName for ForceFeedbackMotor {
     const NAME: &'static str = "Windows.Gaming.Input.ForceFeedback.ForceFeedbackMotor";
 }
-impl ::core::convert::From<ForceFeedbackMotor> for ::windows::core::IUnknown {
-    fn from(value: ForceFeedbackMotor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ForceFeedbackMotor> for ::windows::core::IUnknown {
-    fn from(value: &ForceFeedbackMotor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ForceFeedbackMotor> for &::windows::core::IUnknown {
-    fn from(value: &ForceFeedbackMotor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ForceFeedbackMotor> for ::windows::core::IInspectable {
-    fn from(value: ForceFeedbackMotor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ForceFeedbackMotor> for ::windows::core::IInspectable {
-    fn from(value: &ForceFeedbackMotor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ForceFeedbackMotor> for &::windows::core::IInspectable {
-    fn from(value: &ForceFeedbackMotor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ForceFeedbackMotor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ForceFeedbackMotor {}
 unsafe impl ::core::marker::Sync for ForceFeedbackMotor {}
 #[doc = "*Required features: `\"Gaming_Input_ForceFeedback\"`*"]
@@ -786,36 +670,7 @@ unsafe impl ::windows::core::Interface for PeriodicForceEffect {
 impl ::windows::core::RuntimeName for PeriodicForceEffect {
     const NAME: &'static str = "Windows.Gaming.Input.ForceFeedback.PeriodicForceEffect";
 }
-impl ::core::convert::From<PeriodicForceEffect> for ::windows::core::IUnknown {
-    fn from(value: PeriodicForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PeriodicForceEffect> for ::windows::core::IUnknown {
-    fn from(value: &PeriodicForceEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PeriodicForceEffect> for &::windows::core::IUnknown {
-    fn from(value: &PeriodicForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PeriodicForceEffect> for ::windows::core::IInspectable {
-    fn from(value: PeriodicForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PeriodicForceEffect> for ::windows::core::IInspectable {
-    fn from(value: &PeriodicForceEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PeriodicForceEffect> for &::windows::core::IInspectable {
-    fn from(value: &PeriodicForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PeriodicForceEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PeriodicForceEffect> for IForceFeedbackEffect {
     type Error = ::windows::core::Error;
     fn try_from(value: PeriodicForceEffect) -> ::windows::core::Result<Self> {
@@ -919,36 +774,7 @@ unsafe impl ::windows::core::Interface for RampForceEffect {
 impl ::windows::core::RuntimeName for RampForceEffect {
     const NAME: &'static str = "Windows.Gaming.Input.ForceFeedback.RampForceEffect";
 }
-impl ::core::convert::From<RampForceEffect> for ::windows::core::IUnknown {
-    fn from(value: RampForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RampForceEffect> for ::windows::core::IUnknown {
-    fn from(value: &RampForceEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RampForceEffect> for &::windows::core::IUnknown {
-    fn from(value: &RampForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RampForceEffect> for ::windows::core::IInspectable {
-    fn from(value: RampForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RampForceEffect> for ::windows::core::IInspectable {
-    fn from(value: &RampForceEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RampForceEffect> for &::windows::core::IInspectable {
-    fn from(value: &RampForceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RampForceEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RampForceEffect> for IForceFeedbackEffect {
     type Error = ::windows::core::Error;
     fn try_from(value: RampForceEffect) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
@@ -194,36 +194,7 @@ impl IGameController {
         }
     }
 }
-impl ::core::convert::From<IGameController> for ::windows::core::IUnknown {
-    fn from(value: IGameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameController> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameController> for ::windows::core::IUnknown {
-    fn from(value: &IGameController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGameController> for ::windows::core::IInspectable {
-    fn from(value: IGameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameController> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameController> for ::windows::core::IInspectable {
-    fn from(value: &IGameController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGameController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGameController {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -302,36 +273,7 @@ impl IGameControllerBatteryInfo {
         }
     }
 }
-impl ::core::convert::From<IGameControllerBatteryInfo> for ::windows::core::IUnknown {
-    fn from(value: IGameControllerBatteryInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameControllerBatteryInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGameControllerBatteryInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameControllerBatteryInfo> for ::windows::core::IUnknown {
-    fn from(value: &IGameControllerBatteryInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGameControllerBatteryInfo> for ::windows::core::IInspectable {
-    fn from(value: IGameControllerBatteryInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameControllerBatteryInfo> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGameControllerBatteryInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameControllerBatteryInfo> for ::windows::core::IInspectable {
-    fn from(value: &IGameControllerBatteryInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGameControllerBatteryInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGameControllerBatteryInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -870,36 +812,7 @@ unsafe impl ::windows::core::Interface for ArcadeStick {
 impl ::windows::core::RuntimeName for ArcadeStick {
     const NAME: &'static str = "Windows.Gaming.Input.ArcadeStick";
 }
-impl ::core::convert::From<ArcadeStick> for ::windows::core::IUnknown {
-    fn from(value: ArcadeStick) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ArcadeStick> for ::windows::core::IUnknown {
-    fn from(value: &ArcadeStick) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ArcadeStick> for &::windows::core::IUnknown {
-    fn from(value: &ArcadeStick) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ArcadeStick> for ::windows::core::IInspectable {
-    fn from(value: ArcadeStick) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ArcadeStick> for ::windows::core::IInspectable {
-    fn from(value: &ArcadeStick) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ArcadeStick> for &::windows::core::IInspectable {
-    fn from(value: &ArcadeStick) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ArcadeStick, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ArcadeStick> for IGameController {
     type Error = ::windows::core::Error;
     fn try_from(value: ArcadeStick) -> ::windows::core::Result<Self> {
@@ -1124,36 +1037,7 @@ unsafe impl ::windows::core::Interface for FlightStick {
 impl ::windows::core::RuntimeName for FlightStick {
     const NAME: &'static str = "Windows.Gaming.Input.FlightStick";
 }
-impl ::core::convert::From<FlightStick> for ::windows::core::IUnknown {
-    fn from(value: FlightStick) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FlightStick> for ::windows::core::IUnknown {
-    fn from(value: &FlightStick) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FlightStick> for &::windows::core::IUnknown {
-    fn from(value: &FlightStick) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FlightStick> for ::windows::core::IInspectable {
-    fn from(value: FlightStick) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FlightStick> for ::windows::core::IInspectable {
-    fn from(value: &FlightStick) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FlightStick> for &::windows::core::IInspectable {
-    fn from(value: &FlightStick) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FlightStick, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<FlightStick> for IGameController {
     type Error = ::windows::core::Error;
     fn try_from(value: FlightStick) -> ::windows::core::Result<Self> {
@@ -1387,36 +1271,7 @@ unsafe impl ::windows::core::Interface for Gamepad {
 impl ::windows::core::RuntimeName for Gamepad {
     const NAME: &'static str = "Windows.Gaming.Input.Gamepad";
 }
-impl ::core::convert::From<Gamepad> for ::windows::core::IUnknown {
-    fn from(value: Gamepad) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Gamepad> for ::windows::core::IUnknown {
-    fn from(value: &Gamepad) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Gamepad> for &::windows::core::IUnknown {
-    fn from(value: &Gamepad) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Gamepad> for ::windows::core::IInspectable {
-    fn from(value: Gamepad) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Gamepad> for ::windows::core::IInspectable {
-    fn from(value: &Gamepad) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Gamepad> for &::windows::core::IInspectable {
-    fn from(value: &Gamepad) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Gamepad, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Gamepad> for IGameController {
     type Error = ::windows::core::Error;
     fn try_from(value: Gamepad) -> ::windows::core::Result<Self> {
@@ -1517,36 +1372,7 @@ unsafe impl ::windows::core::Interface for Headset {
 impl ::windows::core::RuntimeName for Headset {
     const NAME: &'static str = "Windows.Gaming.Input.Headset";
 }
-impl ::core::convert::From<Headset> for ::windows::core::IUnknown {
-    fn from(value: Headset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Headset> for ::windows::core::IUnknown {
-    fn from(value: &Headset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Headset> for &::windows::core::IUnknown {
-    fn from(value: &Headset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Headset> for ::windows::core::IInspectable {
-    fn from(value: Headset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Headset> for ::windows::core::IInspectable {
-    fn from(value: &Headset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Headset> for &::windows::core::IInspectable {
-    fn from(value: &Headset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Headset, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Headset> for IGameControllerBatteryInfo {
     type Error = ::windows::core::Error;
     fn try_from(value: Headset) -> ::windows::core::Result<Self> {
@@ -1794,36 +1620,7 @@ unsafe impl ::windows::core::Interface for RacingWheel {
 impl ::windows::core::RuntimeName for RacingWheel {
     const NAME: &'static str = "Windows.Gaming.Input.RacingWheel";
 }
-impl ::core::convert::From<RacingWheel> for ::windows::core::IUnknown {
-    fn from(value: RacingWheel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RacingWheel> for ::windows::core::IUnknown {
-    fn from(value: &RacingWheel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RacingWheel> for &::windows::core::IUnknown {
-    fn from(value: &RacingWheel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RacingWheel> for ::windows::core::IInspectable {
-    fn from(value: RacingWheel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RacingWheel> for ::windows::core::IInspectable {
-    fn from(value: &RacingWheel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RacingWheel> for &::windows::core::IInspectable {
-    fn from(value: &RacingWheel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RacingWheel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RacingWheel> for IGameController {
     type Error = ::windows::core::Error;
     fn try_from(value: RacingWheel) -> ::windows::core::Result<Self> {
@@ -2115,36 +1912,7 @@ unsafe impl ::windows::core::Interface for RawGameController {
 impl ::windows::core::RuntimeName for RawGameController {
     const NAME: &'static str = "Windows.Gaming.Input.RawGameController";
 }
-impl ::core::convert::From<RawGameController> for ::windows::core::IUnknown {
-    fn from(value: RawGameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RawGameController> for ::windows::core::IUnknown {
-    fn from(value: &RawGameController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RawGameController> for &::windows::core::IUnknown {
-    fn from(value: &RawGameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RawGameController> for ::windows::core::IInspectable {
-    fn from(value: RawGameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RawGameController> for ::windows::core::IInspectable {
-    fn from(value: &RawGameController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RawGameController> for &::windows::core::IInspectable {
-    fn from(value: &RawGameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RawGameController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RawGameController> for IGameController {
     type Error = ::windows::core::Error;
     fn try_from(value: RawGameController) -> ::windows::core::Result<Self> {
@@ -2374,36 +2142,7 @@ unsafe impl ::windows::core::Interface for UINavigationController {
 impl ::windows::core::RuntimeName for UINavigationController {
     const NAME: &'static str = "Windows.Gaming.Input.UINavigationController";
 }
-impl ::core::convert::From<UINavigationController> for ::windows::core::IUnknown {
-    fn from(value: UINavigationController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UINavigationController> for ::windows::core::IUnknown {
-    fn from(value: &UINavigationController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UINavigationController> for &::windows::core::IUnknown {
-    fn from(value: &UINavigationController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UINavigationController> for ::windows::core::IInspectable {
-    fn from(value: UINavigationController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UINavigationController> for ::windows::core::IInspectable {
-    fn from(value: &UINavigationController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UINavigationController> for &::windows::core::IInspectable {
-    fn from(value: &UINavigationController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UINavigationController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<UINavigationController> for IGameController {
     type Error = ::windows::core::Error;
     fn try_from(value: UINavigationController) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
@@ -46,36 +46,7 @@ impl IGameListEntry {
         }
     }
 }
-impl ::core::convert::From<IGameListEntry> for ::windows::core::IUnknown {
-    fn from(value: IGameListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameListEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGameListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameListEntry> for ::windows::core::IUnknown {
-    fn from(value: &IGameListEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGameListEntry> for ::windows::core::IInspectable {
-    fn from(value: IGameListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameListEntry> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGameListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameListEntry> for ::windows::core::IInspectable {
-    fn from(value: &IGameListEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGameListEntry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGameListEntry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -580,36 +551,7 @@ unsafe impl ::windows::core::Interface for GameListEntry {
 impl ::windows::core::RuntimeName for GameListEntry {
     const NAME: &'static str = "Windows.Gaming.Preview.GamesEnumeration.GameListEntry";
 }
-impl ::core::convert::From<GameListEntry> for ::windows::core::IUnknown {
-    fn from(value: GameListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameListEntry> for ::windows::core::IUnknown {
-    fn from(value: &GameListEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameListEntry> for &::windows::core::IUnknown {
-    fn from(value: &GameListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameListEntry> for ::windows::core::IInspectable {
-    fn from(value: GameListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameListEntry> for ::windows::core::IInspectable {
-    fn from(value: &GameListEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameListEntry> for &::windows::core::IInspectable {
-    fn from(value: &GameListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameListEntry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<GameListEntry> for IGameListEntry {
     type Error = ::windows::core::Error;
     fn try_from(value: GameListEntry) -> ::windows::core::Result<Self> {
@@ -822,36 +764,7 @@ unsafe impl ::windows::core::Interface for GameModeConfiguration {
 impl ::windows::core::RuntimeName for GameModeConfiguration {
     const NAME: &'static str = "Windows.Gaming.Preview.GamesEnumeration.GameModeConfiguration";
 }
-impl ::core::convert::From<GameModeConfiguration> for ::windows::core::IUnknown {
-    fn from(value: GameModeConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameModeConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &GameModeConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameModeConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &GameModeConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameModeConfiguration> for ::windows::core::IInspectable {
-    fn from(value: GameModeConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameModeConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &GameModeConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameModeConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &GameModeConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameModeConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameModeConfiguration {}
 unsafe impl ::core::marker::Sync for GameModeConfiguration {}
 #[doc = "*Required features: `\"Gaming_Preview_GamesEnumeration\"`*"]
@@ -920,36 +833,7 @@ unsafe impl ::windows::core::Interface for GameModeUserConfiguration {
 impl ::windows::core::RuntimeName for GameModeUserConfiguration {
     const NAME: &'static str = "Windows.Gaming.Preview.GamesEnumeration.GameModeUserConfiguration";
 }
-impl ::core::convert::From<GameModeUserConfiguration> for ::windows::core::IUnknown {
-    fn from(value: GameModeUserConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameModeUserConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &GameModeUserConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameModeUserConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &GameModeUserConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameModeUserConfiguration> for ::windows::core::IInspectable {
-    fn from(value: GameModeUserConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameModeUserConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &GameModeUserConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameModeUserConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &GameModeUserConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameModeUserConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameModeUserConfiguration {}
 unsafe impl ::core::marker::Sync for GameModeUserConfiguration {}
 #[doc = "*Required features: `\"Gaming_Preview_GamesEnumeration\"`*"]

--- a/crates/libs/windows/src/Windows/Gaming/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/UI/mod.rs
@@ -251,36 +251,7 @@ unsafe impl ::windows::core::Interface for GameChatMessageReceivedEventArgs {
 impl ::windows::core::RuntimeName for GameChatMessageReceivedEventArgs {
     const NAME: &'static str = "Windows.Gaming.UI.GameChatMessageReceivedEventArgs";
 }
-impl ::core::convert::From<GameChatMessageReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GameChatMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameChatMessageReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GameChatMessageReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameChatMessageReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GameChatMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameChatMessageReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GameChatMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameChatMessageReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GameChatMessageReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameChatMessageReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GameChatMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameChatMessageReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameChatMessageReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for GameChatMessageReceivedEventArgs {}
 #[doc = "*Required features: `\"Gaming_UI\"`*"]
@@ -346,36 +317,7 @@ unsafe impl ::windows::core::Interface for GameChatOverlay {
 impl ::windows::core::RuntimeName for GameChatOverlay {
     const NAME: &'static str = "Windows.Gaming.UI.GameChatOverlay";
 }
-impl ::core::convert::From<GameChatOverlay> for ::windows::core::IUnknown {
-    fn from(value: GameChatOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameChatOverlay> for ::windows::core::IUnknown {
-    fn from(value: &GameChatOverlay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameChatOverlay> for &::windows::core::IUnknown {
-    fn from(value: &GameChatOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameChatOverlay> for ::windows::core::IInspectable {
-    fn from(value: GameChatOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameChatOverlay> for ::windows::core::IInspectable {
-    fn from(value: &GameChatOverlay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameChatOverlay> for &::windows::core::IInspectable {
-    fn from(value: &GameChatOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameChatOverlay, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameChatOverlay {}
 unsafe impl ::core::marker::Sync for GameChatOverlay {}
 #[doc = "*Required features: `\"Gaming_UI\"`*"]
@@ -443,36 +385,7 @@ unsafe impl ::windows::core::Interface for GameChatOverlayMessageSource {
 impl ::windows::core::RuntimeName for GameChatOverlayMessageSource {
     const NAME: &'static str = "Windows.Gaming.UI.GameChatOverlayMessageSource";
 }
-impl ::core::convert::From<GameChatOverlayMessageSource> for ::windows::core::IUnknown {
-    fn from(value: GameChatOverlayMessageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameChatOverlayMessageSource> for ::windows::core::IUnknown {
-    fn from(value: &GameChatOverlayMessageSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameChatOverlayMessageSource> for &::windows::core::IUnknown {
-    fn from(value: &GameChatOverlayMessageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameChatOverlayMessageSource> for ::windows::core::IInspectable {
-    fn from(value: GameChatOverlayMessageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameChatOverlayMessageSource> for ::windows::core::IInspectable {
-    fn from(value: &GameChatOverlayMessageSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameChatOverlayMessageSource> for &::windows::core::IInspectable {
-    fn from(value: &GameChatOverlayMessageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameChatOverlayMessageSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameChatOverlayMessageSource {}
 unsafe impl ::core::marker::Sync for GameChatOverlayMessageSource {}
 #[doc = "*Required features: `\"Gaming_UI\"`*"]
@@ -554,36 +467,7 @@ unsafe impl ::windows::core::Interface for GameUIProviderActivatedEventArgs {
 impl ::windows::core::RuntimeName for GameUIProviderActivatedEventArgs {
     const NAME: &'static str = "Windows.Gaming.UI.GameUIProviderActivatedEventArgs";
 }
-impl ::core::convert::From<GameUIProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GameUIProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameUIProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GameUIProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameUIProviderActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GameUIProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameUIProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GameUIProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameUIProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GameUIProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameUIProviderActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GameUIProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameUIProviderActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<GameUIProviderActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Gaming/XboxLive/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/XboxLive/Storage/mod.rs
@@ -317,36 +317,7 @@ unsafe impl ::windows::core::Interface for GameSaveBlobGetResult {
 impl ::windows::core::RuntimeName for GameSaveBlobGetResult {
     const NAME: &'static str = "Windows.Gaming.XboxLive.Storage.GameSaveBlobGetResult";
 }
-impl ::core::convert::From<GameSaveBlobGetResult> for ::windows::core::IUnknown {
-    fn from(value: GameSaveBlobGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveBlobGetResult> for ::windows::core::IUnknown {
-    fn from(value: &GameSaveBlobGetResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveBlobGetResult> for &::windows::core::IUnknown {
-    fn from(value: &GameSaveBlobGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameSaveBlobGetResult> for ::windows::core::IInspectable {
-    fn from(value: GameSaveBlobGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveBlobGetResult> for ::windows::core::IInspectable {
-    fn from(value: &GameSaveBlobGetResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveBlobGetResult> for &::windows::core::IInspectable {
-    fn from(value: &GameSaveBlobGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameSaveBlobGetResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameSaveBlobGetResult {}
 unsafe impl ::core::marker::Sync for GameSaveBlobGetResult {}
 #[doc = "*Required features: `\"Gaming_XboxLive_Storage\"`*"]
@@ -400,36 +371,7 @@ unsafe impl ::windows::core::Interface for GameSaveBlobInfo {
 impl ::windows::core::RuntimeName for GameSaveBlobInfo {
     const NAME: &'static str = "Windows.Gaming.XboxLive.Storage.GameSaveBlobInfo";
 }
-impl ::core::convert::From<GameSaveBlobInfo> for ::windows::core::IUnknown {
-    fn from(value: GameSaveBlobInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfo> for ::windows::core::IUnknown {
-    fn from(value: &GameSaveBlobInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfo> for &::windows::core::IUnknown {
-    fn from(value: &GameSaveBlobInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameSaveBlobInfo> for ::windows::core::IInspectable {
-    fn from(value: GameSaveBlobInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfo> for ::windows::core::IInspectable {
-    fn from(value: &GameSaveBlobInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfo> for &::windows::core::IInspectable {
-    fn from(value: &GameSaveBlobInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameSaveBlobInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameSaveBlobInfo {}
 unsafe impl ::core::marker::Sync for GameSaveBlobInfo {}
 #[doc = "*Required features: `\"Gaming_XboxLive_Storage\"`*"]
@@ -485,36 +427,7 @@ unsafe impl ::windows::core::Interface for GameSaveBlobInfoGetResult {
 impl ::windows::core::RuntimeName for GameSaveBlobInfoGetResult {
     const NAME: &'static str = "Windows.Gaming.XboxLive.Storage.GameSaveBlobInfoGetResult";
 }
-impl ::core::convert::From<GameSaveBlobInfoGetResult> for ::windows::core::IUnknown {
-    fn from(value: GameSaveBlobInfoGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfoGetResult> for ::windows::core::IUnknown {
-    fn from(value: &GameSaveBlobInfoGetResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfoGetResult> for &::windows::core::IUnknown {
-    fn from(value: &GameSaveBlobInfoGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameSaveBlobInfoGetResult> for ::windows::core::IInspectable {
-    fn from(value: GameSaveBlobInfoGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfoGetResult> for ::windows::core::IInspectable {
-    fn from(value: &GameSaveBlobInfoGetResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfoGetResult> for &::windows::core::IInspectable {
-    fn from(value: &GameSaveBlobInfoGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameSaveBlobInfoGetResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameSaveBlobInfoGetResult {}
 unsafe impl ::core::marker::Sync for GameSaveBlobInfoGetResult {}
 #[doc = "*Required features: `\"Gaming_XboxLive_Storage\"`*"]
@@ -581,36 +494,7 @@ unsafe impl ::windows::core::Interface for GameSaveBlobInfoQuery {
 impl ::windows::core::RuntimeName for GameSaveBlobInfoQuery {
     const NAME: &'static str = "Windows.Gaming.XboxLive.Storage.GameSaveBlobInfoQuery";
 }
-impl ::core::convert::From<GameSaveBlobInfoQuery> for ::windows::core::IUnknown {
-    fn from(value: GameSaveBlobInfoQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfoQuery> for ::windows::core::IUnknown {
-    fn from(value: &GameSaveBlobInfoQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfoQuery> for &::windows::core::IUnknown {
-    fn from(value: &GameSaveBlobInfoQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameSaveBlobInfoQuery> for ::windows::core::IInspectable {
-    fn from(value: GameSaveBlobInfoQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfoQuery> for ::windows::core::IInspectable {
-    fn from(value: &GameSaveBlobInfoQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveBlobInfoQuery> for &::windows::core::IInspectable {
-    fn from(value: &GameSaveBlobInfoQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameSaveBlobInfoQuery, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameSaveBlobInfoQuery {}
 unsafe impl ::core::marker::Sync for GameSaveBlobInfoQuery {}
 #[doc = "*Required features: `\"Gaming_XboxLive_Storage\"`*"]
@@ -727,36 +611,7 @@ unsafe impl ::windows::core::Interface for GameSaveContainer {
 impl ::windows::core::RuntimeName for GameSaveContainer {
     const NAME: &'static str = "Windows.Gaming.XboxLive.Storage.GameSaveContainer";
 }
-impl ::core::convert::From<GameSaveContainer> for ::windows::core::IUnknown {
-    fn from(value: GameSaveContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveContainer> for ::windows::core::IUnknown {
-    fn from(value: &GameSaveContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveContainer> for &::windows::core::IUnknown {
-    fn from(value: &GameSaveContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameSaveContainer> for ::windows::core::IInspectable {
-    fn from(value: GameSaveContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveContainer> for ::windows::core::IInspectable {
-    fn from(value: &GameSaveContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveContainer> for &::windows::core::IInspectable {
-    fn from(value: &GameSaveContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameSaveContainer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameSaveContainer {}
 unsafe impl ::core::marker::Sync for GameSaveContainer {}
 #[doc = "*Required features: `\"Gaming_XboxLive_Storage\"`*"]
@@ -833,36 +688,7 @@ unsafe impl ::windows::core::Interface for GameSaveContainerInfo {
 impl ::windows::core::RuntimeName for GameSaveContainerInfo {
     const NAME: &'static str = "Windows.Gaming.XboxLive.Storage.GameSaveContainerInfo";
 }
-impl ::core::convert::From<GameSaveContainerInfo> for ::windows::core::IUnknown {
-    fn from(value: GameSaveContainerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfo> for ::windows::core::IUnknown {
-    fn from(value: &GameSaveContainerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfo> for &::windows::core::IUnknown {
-    fn from(value: &GameSaveContainerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameSaveContainerInfo> for ::windows::core::IInspectable {
-    fn from(value: GameSaveContainerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfo> for ::windows::core::IInspectable {
-    fn from(value: &GameSaveContainerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfo> for &::windows::core::IInspectable {
-    fn from(value: &GameSaveContainerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameSaveContainerInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameSaveContainerInfo {}
 unsafe impl ::core::marker::Sync for GameSaveContainerInfo {}
 #[doc = "*Required features: `\"Gaming_XboxLive_Storage\"`*"]
@@ -918,36 +744,7 @@ unsafe impl ::windows::core::Interface for GameSaveContainerInfoGetResult {
 impl ::windows::core::RuntimeName for GameSaveContainerInfoGetResult {
     const NAME: &'static str = "Windows.Gaming.XboxLive.Storage.GameSaveContainerInfoGetResult";
 }
-impl ::core::convert::From<GameSaveContainerInfoGetResult> for ::windows::core::IUnknown {
-    fn from(value: GameSaveContainerInfoGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfoGetResult> for ::windows::core::IUnknown {
-    fn from(value: &GameSaveContainerInfoGetResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfoGetResult> for &::windows::core::IUnknown {
-    fn from(value: &GameSaveContainerInfoGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameSaveContainerInfoGetResult> for ::windows::core::IInspectable {
-    fn from(value: GameSaveContainerInfoGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfoGetResult> for ::windows::core::IInspectable {
-    fn from(value: &GameSaveContainerInfoGetResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfoGetResult> for &::windows::core::IInspectable {
-    fn from(value: &GameSaveContainerInfoGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameSaveContainerInfoGetResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameSaveContainerInfoGetResult {}
 unsafe impl ::core::marker::Sync for GameSaveContainerInfoGetResult {}
 #[doc = "*Required features: `\"Gaming_XboxLive_Storage\"`*"]
@@ -1014,36 +811,7 @@ unsafe impl ::windows::core::Interface for GameSaveContainerInfoQuery {
 impl ::windows::core::RuntimeName for GameSaveContainerInfoQuery {
     const NAME: &'static str = "Windows.Gaming.XboxLive.Storage.GameSaveContainerInfoQuery";
 }
-impl ::core::convert::From<GameSaveContainerInfoQuery> for ::windows::core::IUnknown {
-    fn from(value: GameSaveContainerInfoQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfoQuery> for ::windows::core::IUnknown {
-    fn from(value: &GameSaveContainerInfoQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfoQuery> for &::windows::core::IUnknown {
-    fn from(value: &GameSaveContainerInfoQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameSaveContainerInfoQuery> for ::windows::core::IInspectable {
-    fn from(value: GameSaveContainerInfoQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfoQuery> for ::windows::core::IInspectable {
-    fn from(value: &GameSaveContainerInfoQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveContainerInfoQuery> for &::windows::core::IInspectable {
-    fn from(value: &GameSaveContainerInfoQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameSaveContainerInfoQuery, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameSaveContainerInfoQuery {}
 unsafe impl ::core::marker::Sync for GameSaveContainerInfoQuery {}
 #[doc = "*Required features: `\"Gaming_XboxLive_Storage\"`*"]
@@ -1090,36 +858,7 @@ unsafe impl ::windows::core::Interface for GameSaveOperationResult {
 impl ::windows::core::RuntimeName for GameSaveOperationResult {
     const NAME: &'static str = "Windows.Gaming.XboxLive.Storage.GameSaveOperationResult";
 }
-impl ::core::convert::From<GameSaveOperationResult> for ::windows::core::IUnknown {
-    fn from(value: GameSaveOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveOperationResult> for ::windows::core::IUnknown {
-    fn from(value: &GameSaveOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveOperationResult> for &::windows::core::IUnknown {
-    fn from(value: &GameSaveOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameSaveOperationResult> for ::windows::core::IInspectable {
-    fn from(value: GameSaveOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveOperationResult> for ::windows::core::IInspectable {
-    fn from(value: &GameSaveOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveOperationResult> for &::windows::core::IInspectable {
-    fn from(value: &GameSaveOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameSaveOperationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameSaveOperationResult {}
 unsafe impl ::core::marker::Sync for GameSaveOperationResult {}
 #[doc = "*Required features: `\"Gaming_XboxLive_Storage\"`*"]
@@ -1237,36 +976,7 @@ unsafe impl ::windows::core::Interface for GameSaveProvider {
 impl ::windows::core::RuntimeName for GameSaveProvider {
     const NAME: &'static str = "Windows.Gaming.XboxLive.Storage.GameSaveProvider";
 }
-impl ::core::convert::From<GameSaveProvider> for ::windows::core::IUnknown {
-    fn from(value: GameSaveProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveProvider> for ::windows::core::IUnknown {
-    fn from(value: &GameSaveProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveProvider> for &::windows::core::IUnknown {
-    fn from(value: &GameSaveProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameSaveProvider> for ::windows::core::IInspectable {
-    fn from(value: GameSaveProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveProvider> for ::windows::core::IInspectable {
-    fn from(value: &GameSaveProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveProvider> for &::windows::core::IInspectable {
-    fn from(value: &GameSaveProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameSaveProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameSaveProvider {}
 unsafe impl ::core::marker::Sync for GameSaveProvider {}
 #[doc = "*Required features: `\"Gaming_XboxLive_Storage\"`*"]
@@ -1320,36 +1030,7 @@ unsafe impl ::windows::core::Interface for GameSaveProviderGetResult {
 impl ::windows::core::RuntimeName for GameSaveProviderGetResult {
     const NAME: &'static str = "Windows.Gaming.XboxLive.Storage.GameSaveProviderGetResult";
 }
-impl ::core::convert::From<GameSaveProviderGetResult> for ::windows::core::IUnknown {
-    fn from(value: GameSaveProviderGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveProviderGetResult> for ::windows::core::IUnknown {
-    fn from(value: &GameSaveProviderGetResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveProviderGetResult> for &::windows::core::IUnknown {
-    fn from(value: &GameSaveProviderGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameSaveProviderGetResult> for ::windows::core::IInspectable {
-    fn from(value: GameSaveProviderGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameSaveProviderGetResult> for ::windows::core::IInspectable {
-    fn from(value: &GameSaveProviderGetResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameSaveProviderGetResult> for &::windows::core::IInspectable {
-    fn from(value: &GameSaveProviderGetResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameSaveProviderGetResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameSaveProviderGetResult {}
 unsafe impl ::core::marker::Sync for GameSaveProviderGetResult {}
 #[doc = "*Required features: `\"Gaming_XboxLive_Storage\"`*"]

--- a/crates/libs/windows/src/Windows/Globalization/Collation/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/Collation/mod.rs
@@ -95,36 +95,7 @@ unsafe impl ::windows::core::Interface for CharacterGrouping {
 impl ::windows::core::RuntimeName for CharacterGrouping {
     const NAME: &'static str = "Windows.Globalization.Collation.CharacterGrouping";
 }
-impl ::core::convert::From<CharacterGrouping> for ::windows::core::IUnknown {
-    fn from(value: CharacterGrouping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CharacterGrouping> for ::windows::core::IUnknown {
-    fn from(value: &CharacterGrouping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CharacterGrouping> for &::windows::core::IUnknown {
-    fn from(value: &CharacterGrouping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CharacterGrouping> for ::windows::core::IInspectable {
-    fn from(value: CharacterGrouping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CharacterGrouping> for ::windows::core::IInspectable {
-    fn from(value: &CharacterGrouping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CharacterGrouping> for &::windows::core::IInspectable {
-    fn from(value: &CharacterGrouping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CharacterGrouping, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CharacterGrouping {}
 unsafe impl ::core::marker::Sync for CharacterGrouping {}
 #[doc = "*Required features: `\"Globalization_Collation\"`*"]
@@ -250,36 +221,7 @@ impl ::core::iter::IntoIterator for &CharacterGroupings {
         super::super::Foundation::Collections::VectorViewIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<CharacterGroupings> for ::windows::core::IUnknown {
-    fn from(value: CharacterGroupings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CharacterGroupings> for ::windows::core::IUnknown {
-    fn from(value: &CharacterGroupings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CharacterGroupings> for &::windows::core::IUnknown {
-    fn from(value: &CharacterGroupings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CharacterGroupings> for ::windows::core::IInspectable {
-    fn from(value: CharacterGroupings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CharacterGroupings> for ::windows::core::IInspectable {
-    fn from(value: &CharacterGroupings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CharacterGroupings> for &::windows::core::IInspectable {
-    fn from(value: &CharacterGroupings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CharacterGroupings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<CharacterGroupings> for super::super::Foundation::Collections::IIterable<CharacterGrouping> {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Globalization/DateTimeFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/DateTimeFormatting/mod.rs
@@ -383,36 +383,7 @@ unsafe impl ::windows::core::Interface for DateTimeFormatter {
 impl ::windows::core::RuntimeName for DateTimeFormatter {
     const NAME: &'static str = "Windows.Globalization.DateTimeFormatting.DateTimeFormatter";
 }
-impl ::core::convert::From<DateTimeFormatter> for ::windows::core::IUnknown {
-    fn from(value: DateTimeFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DateTimeFormatter> for ::windows::core::IUnknown {
-    fn from(value: &DateTimeFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DateTimeFormatter> for &::windows::core::IUnknown {
-    fn from(value: &DateTimeFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DateTimeFormatter> for ::windows::core::IInspectable {
-    fn from(value: DateTimeFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DateTimeFormatter> for ::windows::core::IInspectable {
-    fn from(value: &DateTimeFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DateTimeFormatter> for &::windows::core::IInspectable {
-    fn from(value: &DateTimeFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DateTimeFormatter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DateTimeFormatter {}
 unsafe impl ::core::marker::Sync for DateTimeFormatter {}
 #[doc = "*Required features: `\"Globalization_DateTimeFormatting\"`*"]

--- a/crates/libs/windows/src/Windows/Globalization/Fonts/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/Fonts/mod.rs
@@ -144,36 +144,7 @@ unsafe impl ::windows::core::Interface for LanguageFont {
 impl ::windows::core::RuntimeName for LanguageFont {
     const NAME: &'static str = "Windows.Globalization.Fonts.LanguageFont";
 }
-impl ::core::convert::From<LanguageFont> for ::windows::core::IUnknown {
-    fn from(value: LanguageFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LanguageFont> for ::windows::core::IUnknown {
-    fn from(value: &LanguageFont) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LanguageFont> for &::windows::core::IUnknown {
-    fn from(value: &LanguageFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LanguageFont> for ::windows::core::IInspectable {
-    fn from(value: LanguageFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LanguageFont> for ::windows::core::IInspectable {
-    fn from(value: &LanguageFont) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LanguageFont> for &::windows::core::IInspectable {
-    fn from(value: &LanguageFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LanguageFont, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LanguageFont {}
 unsafe impl ::core::marker::Sync for LanguageFont {}
 #[doc = "*Required features: `\"Globalization_Fonts\"`*"]
@@ -301,36 +272,7 @@ unsafe impl ::windows::core::Interface for LanguageFontGroup {
 impl ::windows::core::RuntimeName for LanguageFontGroup {
     const NAME: &'static str = "Windows.Globalization.Fonts.LanguageFontGroup";
 }
-impl ::core::convert::From<LanguageFontGroup> for ::windows::core::IUnknown {
-    fn from(value: LanguageFontGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LanguageFontGroup> for ::windows::core::IUnknown {
-    fn from(value: &LanguageFontGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LanguageFontGroup> for &::windows::core::IUnknown {
-    fn from(value: &LanguageFontGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LanguageFontGroup> for ::windows::core::IInspectable {
-    fn from(value: LanguageFontGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LanguageFontGroup> for ::windows::core::IInspectable {
-    fn from(value: &LanguageFontGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LanguageFontGroup> for &::windows::core::IInspectable {
-    fn from(value: &LanguageFontGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LanguageFontGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LanguageFontGroup {}
 unsafe impl ::core::marker::Sync for LanguageFontGroup {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Globalization/NumberFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/NumberFormatting/mod.rs
@@ -115,36 +115,7 @@ impl INumberFormatter {
         }
     }
 }
-impl ::core::convert::From<INumberFormatter> for ::windows::core::IUnknown {
-    fn from(value: INumberFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberFormatter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INumberFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberFormatter> for ::windows::core::IUnknown {
-    fn from(value: &INumberFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INumberFormatter> for ::windows::core::IInspectable {
-    fn from(value: INumberFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberFormatter> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INumberFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberFormatter> for ::windows::core::IInspectable {
-    fn from(value: &INumberFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INumberFormatter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for INumberFormatter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -208,36 +179,7 @@ impl INumberFormatter2 {
         }
     }
 }
-impl ::core::convert::From<INumberFormatter2> for ::windows::core::IUnknown {
-    fn from(value: INumberFormatter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberFormatter2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INumberFormatter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberFormatter2> for ::windows::core::IUnknown {
-    fn from(value: &INumberFormatter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INumberFormatter2> for ::windows::core::IInspectable {
-    fn from(value: INumberFormatter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberFormatter2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INumberFormatter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberFormatter2> for ::windows::core::IInspectable {
-    fn from(value: &INumberFormatter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INumberFormatter2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for INumberFormatter2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -365,36 +307,7 @@ impl INumberFormatterOptions {
         }
     }
 }
-impl ::core::convert::From<INumberFormatterOptions> for ::windows::core::IUnknown {
-    fn from(value: INumberFormatterOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberFormatterOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INumberFormatterOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberFormatterOptions> for ::windows::core::IUnknown {
-    fn from(value: &INumberFormatterOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INumberFormatterOptions> for ::windows::core::IInspectable {
-    fn from(value: INumberFormatterOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberFormatterOptions> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INumberFormatterOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberFormatterOptions> for ::windows::core::IInspectable {
-    fn from(value: &INumberFormatterOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INumberFormatterOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for INumberFormatterOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -478,36 +391,7 @@ impl INumberParser {
         }
     }
 }
-impl ::core::convert::From<INumberParser> for ::windows::core::IUnknown {
-    fn from(value: INumberParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberParser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INumberParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberParser> for ::windows::core::IUnknown {
-    fn from(value: &INumberParser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INumberParser> for ::windows::core::IInspectable {
-    fn from(value: INumberParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberParser> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INumberParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberParser> for ::windows::core::IInspectable {
-    fn from(value: &INumberParser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INumberParser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for INumberParser {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -601,36 +485,7 @@ impl INumberRounder {
         }
     }
 }
-impl ::core::convert::From<INumberRounder> for ::windows::core::IUnknown {
-    fn from(value: INumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberRounder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberRounder> for ::windows::core::IUnknown {
-    fn from(value: &INumberRounder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INumberRounder> for ::windows::core::IInspectable {
-    fn from(value: INumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberRounder> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberRounder> for ::windows::core::IInspectable {
-    fn from(value: &INumberRounder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INumberRounder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for INumberRounder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -691,36 +546,7 @@ impl INumberRounderOption {
         unsafe { (::windows::core::Vtable::vtable(this).SetNumberRounder)(::windows::core::Vtable::as_raw(this), value.try_into().map_err(|e| e.into())?.abi()).ok() }
     }
 }
-impl ::core::convert::From<INumberRounderOption> for ::windows::core::IUnknown {
-    fn from(value: INumberRounderOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberRounderOption> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INumberRounderOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberRounderOption> for ::windows::core::IUnknown {
-    fn from(value: &INumberRounderOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INumberRounderOption> for ::windows::core::IInspectable {
-    fn from(value: INumberRounderOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INumberRounderOption> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INumberRounderOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INumberRounderOption> for ::windows::core::IInspectable {
-    fn from(value: &INumberRounderOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INumberRounderOption, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for INumberRounderOption {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -849,36 +675,7 @@ impl ISignedZeroOption {
         unsafe { (::windows::core::Vtable::vtable(this).SetIsZeroSigned)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<ISignedZeroOption> for ::windows::core::IUnknown {
-    fn from(value: ISignedZeroOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISignedZeroOption> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISignedZeroOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISignedZeroOption> for ::windows::core::IUnknown {
-    fn from(value: &ISignedZeroOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISignedZeroOption> for ::windows::core::IInspectable {
-    fn from(value: ISignedZeroOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISignedZeroOption> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISignedZeroOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISignedZeroOption> for ::windows::core::IInspectable {
-    fn from(value: &ISignedZeroOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISignedZeroOption, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISignedZeroOption {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -949,36 +746,7 @@ impl ISignificantDigitsOption {
         unsafe { (::windows::core::Vtable::vtable(this).SetSignificantDigits)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<ISignificantDigitsOption> for ::windows::core::IUnknown {
-    fn from(value: ISignificantDigitsOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISignificantDigitsOption> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISignificantDigitsOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISignificantDigitsOption> for ::windows::core::IUnknown {
-    fn from(value: &ISignificantDigitsOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISignificantDigitsOption> for ::windows::core::IInspectable {
-    fn from(value: ISignificantDigitsOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISignificantDigitsOption> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISignificantDigitsOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISignificantDigitsOption> for ::windows::core::IInspectable {
-    fn from(value: &ISignificantDigitsOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISignificantDigitsOption, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISignificantDigitsOption {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1294,36 +1062,7 @@ unsafe impl ::windows::core::Interface for CurrencyFormatter {
 impl ::windows::core::RuntimeName for CurrencyFormatter {
     const NAME: &'static str = "Windows.Globalization.NumberFormatting.CurrencyFormatter";
 }
-impl ::core::convert::From<CurrencyFormatter> for ::windows::core::IUnknown {
-    fn from(value: CurrencyFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CurrencyFormatter> for ::windows::core::IUnknown {
-    fn from(value: &CurrencyFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CurrencyFormatter> for &::windows::core::IUnknown {
-    fn from(value: &CurrencyFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CurrencyFormatter> for ::windows::core::IInspectable {
-    fn from(value: CurrencyFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CurrencyFormatter> for ::windows::core::IInspectable {
-    fn from(value: &CurrencyFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CurrencyFormatter> for &::windows::core::IInspectable {
-    fn from(value: &CurrencyFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CurrencyFormatter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CurrencyFormatter> for INumberFormatter {
     type Error = ::windows::core::Error;
     fn try_from(value: CurrencyFormatter) -> ::windows::core::Result<Self> {
@@ -1711,36 +1450,7 @@ unsafe impl ::windows::core::Interface for DecimalFormatter {
 impl ::windows::core::RuntimeName for DecimalFormatter {
     const NAME: &'static str = "Windows.Globalization.NumberFormatting.DecimalFormatter";
 }
-impl ::core::convert::From<DecimalFormatter> for ::windows::core::IUnknown {
-    fn from(value: DecimalFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DecimalFormatter> for ::windows::core::IUnknown {
-    fn from(value: &DecimalFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DecimalFormatter> for &::windows::core::IUnknown {
-    fn from(value: &DecimalFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DecimalFormatter> for ::windows::core::IInspectable {
-    fn from(value: DecimalFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DecimalFormatter> for ::windows::core::IInspectable {
-    fn from(value: &DecimalFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DecimalFormatter> for &::windows::core::IInspectable {
-    fn from(value: &DecimalFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DecimalFormatter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DecimalFormatter> for INumberFormatter {
     type Error = ::windows::core::Error;
     fn try_from(value: DecimalFormatter) -> ::windows::core::Result<Self> {
@@ -1984,36 +1694,7 @@ unsafe impl ::windows::core::Interface for IncrementNumberRounder {
 impl ::windows::core::RuntimeName for IncrementNumberRounder {
     const NAME: &'static str = "Windows.Globalization.NumberFormatting.IncrementNumberRounder";
 }
-impl ::core::convert::From<IncrementNumberRounder> for ::windows::core::IUnknown {
-    fn from(value: IncrementNumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IncrementNumberRounder> for ::windows::core::IUnknown {
-    fn from(value: &IncrementNumberRounder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IncrementNumberRounder> for &::windows::core::IUnknown {
-    fn from(value: &IncrementNumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IncrementNumberRounder> for ::windows::core::IInspectable {
-    fn from(value: IncrementNumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IncrementNumberRounder> for ::windows::core::IInspectable {
-    fn from(value: &IncrementNumberRounder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IncrementNumberRounder> for &::windows::core::IInspectable {
-    fn from(value: &IncrementNumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IncrementNumberRounder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IncrementNumberRounder> for INumberRounder {
     type Error = ::windows::core::Error;
     fn try_from(value: IncrementNumberRounder) -> ::windows::core::Result<Self> {
@@ -2130,36 +1811,7 @@ unsafe impl ::windows::core::Interface for NumeralSystemTranslator {
 impl ::windows::core::RuntimeName for NumeralSystemTranslator {
     const NAME: &'static str = "Windows.Globalization.NumberFormatting.NumeralSystemTranslator";
 }
-impl ::core::convert::From<NumeralSystemTranslator> for ::windows::core::IUnknown {
-    fn from(value: NumeralSystemTranslator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NumeralSystemTranslator> for ::windows::core::IUnknown {
-    fn from(value: &NumeralSystemTranslator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NumeralSystemTranslator> for &::windows::core::IUnknown {
-    fn from(value: &NumeralSystemTranslator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NumeralSystemTranslator> for ::windows::core::IInspectable {
-    fn from(value: NumeralSystemTranslator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NumeralSystemTranslator> for ::windows::core::IInspectable {
-    fn from(value: &NumeralSystemTranslator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NumeralSystemTranslator> for &::windows::core::IInspectable {
-    fn from(value: &NumeralSystemTranslator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NumeralSystemTranslator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NumeralSystemTranslator {}
 unsafe impl ::core::marker::Sync for NumeralSystemTranslator {}
 #[doc = "*Required features: `\"Globalization_NumberFormatting\"`*"]
@@ -2414,36 +2066,7 @@ unsafe impl ::windows::core::Interface for PercentFormatter {
 impl ::windows::core::RuntimeName for PercentFormatter {
     const NAME: &'static str = "Windows.Globalization.NumberFormatting.PercentFormatter";
 }
-impl ::core::convert::From<PercentFormatter> for ::windows::core::IUnknown {
-    fn from(value: PercentFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PercentFormatter> for ::windows::core::IUnknown {
-    fn from(value: &PercentFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PercentFormatter> for &::windows::core::IUnknown {
-    fn from(value: &PercentFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PercentFormatter> for ::windows::core::IInspectable {
-    fn from(value: PercentFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PercentFormatter> for ::windows::core::IInspectable {
-    fn from(value: &PercentFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PercentFormatter> for &::windows::core::IInspectable {
-    fn from(value: &PercentFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PercentFormatter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PercentFormatter> for INumberFormatter {
     type Error = ::windows::core::Error;
     fn try_from(value: PercentFormatter) -> ::windows::core::Result<Self> {
@@ -2831,36 +2454,7 @@ unsafe impl ::windows::core::Interface for PermilleFormatter {
 impl ::windows::core::RuntimeName for PermilleFormatter {
     const NAME: &'static str = "Windows.Globalization.NumberFormatting.PermilleFormatter";
 }
-impl ::core::convert::From<PermilleFormatter> for ::windows::core::IUnknown {
-    fn from(value: PermilleFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PermilleFormatter> for ::windows::core::IUnknown {
-    fn from(value: &PermilleFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PermilleFormatter> for &::windows::core::IUnknown {
-    fn from(value: &PermilleFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PermilleFormatter> for ::windows::core::IInspectable {
-    fn from(value: PermilleFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PermilleFormatter> for ::windows::core::IInspectable {
-    fn from(value: &PermilleFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PermilleFormatter> for &::windows::core::IInspectable {
-    fn from(value: &PermilleFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PermilleFormatter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PermilleFormatter> for INumberFormatter {
     type Error = ::windows::core::Error;
     fn try_from(value: PermilleFormatter) -> ::windows::core::Result<Self> {
@@ -3104,36 +2698,7 @@ unsafe impl ::windows::core::Interface for SignificantDigitsNumberRounder {
 impl ::windows::core::RuntimeName for SignificantDigitsNumberRounder {
     const NAME: &'static str = "Windows.Globalization.NumberFormatting.SignificantDigitsNumberRounder";
 }
-impl ::core::convert::From<SignificantDigitsNumberRounder> for ::windows::core::IUnknown {
-    fn from(value: SignificantDigitsNumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SignificantDigitsNumberRounder> for ::windows::core::IUnknown {
-    fn from(value: &SignificantDigitsNumberRounder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SignificantDigitsNumberRounder> for &::windows::core::IUnknown {
-    fn from(value: &SignificantDigitsNumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SignificantDigitsNumberRounder> for ::windows::core::IInspectable {
-    fn from(value: SignificantDigitsNumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SignificantDigitsNumberRounder> for ::windows::core::IInspectable {
-    fn from(value: &SignificantDigitsNumberRounder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SignificantDigitsNumberRounder> for &::windows::core::IInspectable {
-    fn from(value: &SignificantDigitsNumberRounder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SignificantDigitsNumberRounder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SignificantDigitsNumberRounder> for INumberRounder {
     type Error = ::windows::core::Error;
     fn try_from(value: SignificantDigitsNumberRounder) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Globalization/PhoneNumberFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/PhoneNumberFormatting/mod.rs
@@ -193,36 +193,7 @@ unsafe impl ::windows::core::Interface for PhoneNumberFormatter {
 impl ::windows::core::RuntimeName for PhoneNumberFormatter {
     const NAME: &'static str = "Windows.Globalization.PhoneNumberFormatting.PhoneNumberFormatter";
 }
-impl ::core::convert::From<PhoneNumberFormatter> for ::windows::core::IUnknown {
-    fn from(value: PhoneNumberFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneNumberFormatter> for ::windows::core::IUnknown {
-    fn from(value: &PhoneNumberFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneNumberFormatter> for &::windows::core::IUnknown {
-    fn from(value: &PhoneNumberFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneNumberFormatter> for ::windows::core::IInspectable {
-    fn from(value: PhoneNumberFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneNumberFormatter> for ::windows::core::IInspectable {
-    fn from(value: &PhoneNumberFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneNumberFormatter> for &::windows::core::IInspectable {
-    fn from(value: &PhoneNumberFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneNumberFormatter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhoneNumberFormatter {}
 unsafe impl ::core::marker::Sync for PhoneNumberFormatter {}
 #[doc = "*Required features: `\"Globalization_PhoneNumberFormatting\"`*"]
@@ -355,36 +326,7 @@ unsafe impl ::windows::core::Interface for PhoneNumberInfo {
 impl ::windows::core::RuntimeName for PhoneNumberInfo {
     const NAME: &'static str = "Windows.Globalization.PhoneNumberFormatting.PhoneNumberInfo";
 }
-impl ::core::convert::From<PhoneNumberInfo> for ::windows::core::IUnknown {
-    fn from(value: PhoneNumberInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneNumberInfo> for ::windows::core::IUnknown {
-    fn from(value: &PhoneNumberInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneNumberInfo> for &::windows::core::IUnknown {
-    fn from(value: &PhoneNumberInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneNumberInfo> for ::windows::core::IInspectable {
-    fn from(value: PhoneNumberInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneNumberInfo> for ::windows::core::IInspectable {
-    fn from(value: &PhoneNumberInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneNumberInfo> for &::windows::core::IInspectable {
-    fn from(value: &PhoneNumberInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneNumberInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<PhoneNumberInfo> for super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/mod.rs
@@ -1617,36 +1617,7 @@ unsafe impl ::windows::core::Interface for Calendar {
 impl ::windows::core::RuntimeName for Calendar {
     const NAME: &'static str = "Windows.Globalization.Calendar";
 }
-impl ::core::convert::From<Calendar> for ::windows::core::IUnknown {
-    fn from(value: Calendar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Calendar> for ::windows::core::IUnknown {
-    fn from(value: &Calendar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Calendar> for &::windows::core::IUnknown {
-    fn from(value: &Calendar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Calendar> for ::windows::core::IInspectable {
-    fn from(value: Calendar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Calendar> for ::windows::core::IInspectable {
-    fn from(value: &Calendar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Calendar> for &::windows::core::IInspectable {
-    fn from(value: &Calendar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Calendar, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Calendar {}
 unsafe impl ::core::marker::Sync for Calendar {}
 #[doc = "*Required features: `\"Globalization\"`*"]
@@ -1847,36 +1818,7 @@ unsafe impl ::windows::core::Interface for CurrencyAmount {
 impl ::windows::core::RuntimeName for CurrencyAmount {
     const NAME: &'static str = "Windows.Globalization.CurrencyAmount";
 }
-impl ::core::convert::From<CurrencyAmount> for ::windows::core::IUnknown {
-    fn from(value: CurrencyAmount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CurrencyAmount> for ::windows::core::IUnknown {
-    fn from(value: &CurrencyAmount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CurrencyAmount> for &::windows::core::IUnknown {
-    fn from(value: &CurrencyAmount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CurrencyAmount> for ::windows::core::IInspectable {
-    fn from(value: CurrencyAmount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CurrencyAmount> for ::windows::core::IInspectable {
-    fn from(value: &CurrencyAmount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CurrencyAmount> for &::windows::core::IInspectable {
-    fn from(value: &CurrencyAmount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CurrencyAmount, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CurrencyAmount {}
 unsafe impl ::core::marker::Sync for CurrencyAmount {}
 #[doc = "*Required features: `\"Globalization\"`*"]
@@ -2990,36 +2932,7 @@ unsafe impl ::windows::core::Interface for GeographicRegion {
 impl ::windows::core::RuntimeName for GeographicRegion {
     const NAME: &'static str = "Windows.Globalization.GeographicRegion";
 }
-impl ::core::convert::From<GeographicRegion> for ::windows::core::IUnknown {
-    fn from(value: GeographicRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeographicRegion> for ::windows::core::IUnknown {
-    fn from(value: &GeographicRegion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeographicRegion> for &::windows::core::IUnknown {
-    fn from(value: &GeographicRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GeographicRegion> for ::windows::core::IInspectable {
-    fn from(value: GeographicRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GeographicRegion> for ::windows::core::IInspectable {
-    fn from(value: &GeographicRegion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GeographicRegion> for &::windows::core::IInspectable {
-    fn from(value: &GeographicRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GeographicRegion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GeographicRegion {}
 unsafe impl ::core::marker::Sync for GeographicRegion {}
 #[doc = "*Required features: `\"Globalization\"`*"]
@@ -3080,36 +2993,7 @@ unsafe impl ::windows::core::Interface for JapanesePhoneme {
 impl ::windows::core::RuntimeName for JapanesePhoneme {
     const NAME: &'static str = "Windows.Globalization.JapanesePhoneme";
 }
-impl ::core::convert::From<JapanesePhoneme> for ::windows::core::IUnknown {
-    fn from(value: JapanesePhoneme) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JapanesePhoneme> for ::windows::core::IUnknown {
-    fn from(value: &JapanesePhoneme) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JapanesePhoneme> for &::windows::core::IUnknown {
-    fn from(value: &JapanesePhoneme) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<JapanesePhoneme> for ::windows::core::IInspectable {
-    fn from(value: JapanesePhoneme) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JapanesePhoneme> for ::windows::core::IInspectable {
-    fn from(value: &JapanesePhoneme) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JapanesePhoneme> for &::windows::core::IInspectable {
-    fn from(value: &JapanesePhoneme) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(JapanesePhoneme, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Globalization\"`*"]
 pub struct JapanesePhoneticAnalyzer;
 impl JapanesePhoneticAnalyzer {
@@ -3282,36 +3166,7 @@ unsafe impl ::windows::core::Interface for Language {
 impl ::windows::core::RuntimeName for Language {
     const NAME: &'static str = "Windows.Globalization.Language";
 }
-impl ::core::convert::From<Language> for ::windows::core::IUnknown {
-    fn from(value: Language) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Language> for ::windows::core::IUnknown {
-    fn from(value: &Language) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Language> for &::windows::core::IUnknown {
-    fn from(value: &Language) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Language> for ::windows::core::IInspectable {
-    fn from(value: Language) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Language> for ::windows::core::IInspectable {
-    fn from(value: &Language) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Language> for &::windows::core::IInspectable {
-    fn from(value: &Language) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Language, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Language {}
 unsafe impl ::core::marker::Sync for Language {}
 #[doc = "*Required features: `\"Globalization\"`*"]

--- a/crates/libs/windows/src/Windows/Graphics/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Capture/mod.rs
@@ -316,36 +316,7 @@ unsafe impl ::windows::core::Interface for Direct3D11CaptureFrame {
 impl ::windows::core::RuntimeName for Direct3D11CaptureFrame {
     const NAME: &'static str = "Windows.Graphics.Capture.Direct3D11CaptureFrame";
 }
-impl ::core::convert::From<Direct3D11CaptureFrame> for ::windows::core::IUnknown {
-    fn from(value: Direct3D11CaptureFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Direct3D11CaptureFrame> for ::windows::core::IUnknown {
-    fn from(value: &Direct3D11CaptureFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Direct3D11CaptureFrame> for &::windows::core::IUnknown {
-    fn from(value: &Direct3D11CaptureFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Direct3D11CaptureFrame> for ::windows::core::IInspectable {
-    fn from(value: Direct3D11CaptureFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Direct3D11CaptureFrame> for ::windows::core::IInspectable {
-    fn from(value: &Direct3D11CaptureFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Direct3D11CaptureFrame> for &::windows::core::IInspectable {
-    fn from(value: &Direct3D11CaptureFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Direct3D11CaptureFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<Direct3D11CaptureFrame> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -495,36 +466,7 @@ unsafe impl ::windows::core::Interface for Direct3D11CaptureFramePool {
 impl ::windows::core::RuntimeName for Direct3D11CaptureFramePool {
     const NAME: &'static str = "Windows.Graphics.Capture.Direct3D11CaptureFramePool";
 }
-impl ::core::convert::From<Direct3D11CaptureFramePool> for ::windows::core::IUnknown {
-    fn from(value: Direct3D11CaptureFramePool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Direct3D11CaptureFramePool> for ::windows::core::IUnknown {
-    fn from(value: &Direct3D11CaptureFramePool) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Direct3D11CaptureFramePool> for &::windows::core::IUnknown {
-    fn from(value: &Direct3D11CaptureFramePool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Direct3D11CaptureFramePool> for ::windows::core::IInspectable {
-    fn from(value: Direct3D11CaptureFramePool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Direct3D11CaptureFramePool> for ::windows::core::IInspectable {
-    fn from(value: &Direct3D11CaptureFramePool) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Direct3D11CaptureFramePool> for &::windows::core::IInspectable {
-    fn from(value: &Direct3D11CaptureFramePool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Direct3D11CaptureFramePool, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<Direct3D11CaptureFramePool> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -670,36 +612,7 @@ unsafe impl ::windows::core::Interface for GraphicsCaptureItem {
 impl ::windows::core::RuntimeName for GraphicsCaptureItem {
     const NAME: &'static str = "Windows.Graphics.Capture.GraphicsCaptureItem";
 }
-impl ::core::convert::From<GraphicsCaptureItem> for ::windows::core::IUnknown {
-    fn from(value: GraphicsCaptureItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GraphicsCaptureItem> for ::windows::core::IUnknown {
-    fn from(value: &GraphicsCaptureItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GraphicsCaptureItem> for &::windows::core::IUnknown {
-    fn from(value: &GraphicsCaptureItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GraphicsCaptureItem> for ::windows::core::IInspectable {
-    fn from(value: GraphicsCaptureItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GraphicsCaptureItem> for ::windows::core::IInspectable {
-    fn from(value: &GraphicsCaptureItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GraphicsCaptureItem> for &::windows::core::IInspectable {
-    fn from(value: &GraphicsCaptureItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GraphicsCaptureItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GraphicsCaptureItem {}
 unsafe impl ::core::marker::Sync for GraphicsCaptureItem {}
 #[doc = "*Required features: `\"Graphics_Capture\"`*"]
@@ -755,36 +668,7 @@ unsafe impl ::windows::core::Interface for GraphicsCapturePicker {
 impl ::windows::core::RuntimeName for GraphicsCapturePicker {
     const NAME: &'static str = "Windows.Graphics.Capture.GraphicsCapturePicker";
 }
-impl ::core::convert::From<GraphicsCapturePicker> for ::windows::core::IUnknown {
-    fn from(value: GraphicsCapturePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GraphicsCapturePicker> for ::windows::core::IUnknown {
-    fn from(value: &GraphicsCapturePicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GraphicsCapturePicker> for &::windows::core::IUnknown {
-    fn from(value: &GraphicsCapturePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GraphicsCapturePicker> for ::windows::core::IInspectable {
-    fn from(value: GraphicsCapturePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GraphicsCapturePicker> for ::windows::core::IInspectable {
-    fn from(value: &GraphicsCapturePicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GraphicsCapturePicker> for &::windows::core::IInspectable {
-    fn from(value: &GraphicsCapturePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GraphicsCapturePicker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GraphicsCapturePicker {}
 unsafe impl ::core::marker::Sync for GraphicsCapturePicker {}
 #[doc = "*Required features: `\"Graphics_Capture\"`*"]
@@ -867,36 +751,7 @@ unsafe impl ::windows::core::Interface for GraphicsCaptureSession {
 impl ::windows::core::RuntimeName for GraphicsCaptureSession {
     const NAME: &'static str = "Windows.Graphics.Capture.GraphicsCaptureSession";
 }
-impl ::core::convert::From<GraphicsCaptureSession> for ::windows::core::IUnknown {
-    fn from(value: GraphicsCaptureSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GraphicsCaptureSession> for ::windows::core::IUnknown {
-    fn from(value: &GraphicsCaptureSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GraphicsCaptureSession> for &::windows::core::IUnknown {
-    fn from(value: &GraphicsCaptureSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GraphicsCaptureSession> for ::windows::core::IInspectable {
-    fn from(value: GraphicsCaptureSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GraphicsCaptureSession> for ::windows::core::IInspectable {
-    fn from(value: &GraphicsCaptureSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GraphicsCaptureSession> for &::windows::core::IInspectable {
-    fn from(value: &GraphicsCaptureSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GraphicsCaptureSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<GraphicsCaptureSession> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/mod.rs
@@ -13,36 +13,7 @@ impl IDirect3DDevice {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IDirect3DDevice> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DDevice> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DDevice> for ::windows::core::IInspectable {
-    fn from(value: IDirect3DDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DDevice> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IDirect3DDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DDevice> for ::windows::core::IInspectable {
-    fn from(value: &IDirect3DDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IDirect3DDevice> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -118,36 +89,7 @@ impl IDirect3DSurface {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IDirect3DSurface> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DSurface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DSurface> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DSurface> for ::windows::core::IInspectable {
-    fn from(value: IDirect3DSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DSurface> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IDirect3DSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DSurface> for ::windows::core::IInspectable {
-    fn from(value: &IDirect3DSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DSurface, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IDirect3DSurface> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Graphics/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/Core/mod.rs
@@ -211,36 +211,7 @@ unsafe impl ::windows::core::Interface for HdmiDisplayInformation {
 impl ::windows::core::RuntimeName for HdmiDisplayInformation {
     const NAME: &'static str = "Windows.Graphics.Display.Core.HdmiDisplayInformation";
 }
-impl ::core::convert::From<HdmiDisplayInformation> for ::windows::core::IUnknown {
-    fn from(value: HdmiDisplayInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HdmiDisplayInformation> for ::windows::core::IUnknown {
-    fn from(value: &HdmiDisplayInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HdmiDisplayInformation> for &::windows::core::IUnknown {
-    fn from(value: &HdmiDisplayInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HdmiDisplayInformation> for ::windows::core::IInspectable {
-    fn from(value: HdmiDisplayInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HdmiDisplayInformation> for ::windows::core::IInspectable {
-    fn from(value: &HdmiDisplayInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HdmiDisplayInformation> for &::windows::core::IInspectable {
-    fn from(value: &HdmiDisplayInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HdmiDisplayInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HdmiDisplayInformation {}
 unsafe impl ::core::marker::Sync for HdmiDisplayInformation {}
 #[doc = "*Required features: `\"Graphics_Display_Core\"`*"]
@@ -364,36 +335,7 @@ unsafe impl ::windows::core::Interface for HdmiDisplayMode {
 impl ::windows::core::RuntimeName for HdmiDisplayMode {
     const NAME: &'static str = "Windows.Graphics.Display.Core.HdmiDisplayMode";
 }
-impl ::core::convert::From<HdmiDisplayMode> for ::windows::core::IUnknown {
-    fn from(value: HdmiDisplayMode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HdmiDisplayMode> for ::windows::core::IUnknown {
-    fn from(value: &HdmiDisplayMode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HdmiDisplayMode> for &::windows::core::IUnknown {
-    fn from(value: &HdmiDisplayMode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HdmiDisplayMode> for ::windows::core::IInspectable {
-    fn from(value: HdmiDisplayMode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HdmiDisplayMode> for ::windows::core::IInspectable {
-    fn from(value: &HdmiDisplayMode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HdmiDisplayMode> for &::windows::core::IInspectable {
-    fn from(value: &HdmiDisplayMode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HdmiDisplayMode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HdmiDisplayMode {}
 unsafe impl ::core::marker::Sync for HdmiDisplayMode {}
 #[doc = "*Required features: `\"Graphics_Display_Core\"`*"]

--- a/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
@@ -658,36 +658,7 @@ unsafe impl ::windows::core::Interface for AdvancedColorInfo {
 impl ::windows::core::RuntimeName for AdvancedColorInfo {
     const NAME: &'static str = "Windows.Graphics.Display.AdvancedColorInfo";
 }
-impl ::core::convert::From<AdvancedColorInfo> for ::windows::core::IUnknown {
-    fn from(value: AdvancedColorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvancedColorInfo> for ::windows::core::IUnknown {
-    fn from(value: &AdvancedColorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvancedColorInfo> for &::windows::core::IUnknown {
-    fn from(value: &AdvancedColorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdvancedColorInfo> for ::windows::core::IInspectable {
-    fn from(value: AdvancedColorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvancedColorInfo> for ::windows::core::IInspectable {
-    fn from(value: &AdvancedColorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvancedColorInfo> for &::windows::core::IInspectable {
-    fn from(value: &AdvancedColorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdvancedColorInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdvancedColorInfo {}
 unsafe impl ::core::marker::Sync for AdvancedColorInfo {}
 #[doc = "*Required features: `\"Graphics_Display\"`*"]
@@ -841,36 +812,7 @@ unsafe impl ::windows::core::Interface for BrightnessOverride {
 impl ::windows::core::RuntimeName for BrightnessOverride {
     const NAME: &'static str = "Windows.Graphics.Display.BrightnessOverride";
 }
-impl ::core::convert::From<BrightnessOverride> for ::windows::core::IUnknown {
-    fn from(value: BrightnessOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BrightnessOverride> for ::windows::core::IUnknown {
-    fn from(value: &BrightnessOverride) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BrightnessOverride> for &::windows::core::IUnknown {
-    fn from(value: &BrightnessOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BrightnessOverride> for ::windows::core::IInspectable {
-    fn from(value: BrightnessOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BrightnessOverride> for ::windows::core::IInspectable {
-    fn from(value: &BrightnessOverride) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BrightnessOverride> for &::windows::core::IInspectable {
-    fn from(value: &BrightnessOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BrightnessOverride, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BrightnessOverride {}
 unsafe impl ::core::marker::Sync for BrightnessOverride {}
 #[doc = "*Required features: `\"Graphics_Display\"`*"]
@@ -947,36 +889,7 @@ unsafe impl ::windows::core::Interface for BrightnessOverrideSettings {
 impl ::windows::core::RuntimeName for BrightnessOverrideSettings {
     const NAME: &'static str = "Windows.Graphics.Display.BrightnessOverrideSettings";
 }
-impl ::core::convert::From<BrightnessOverrideSettings> for ::windows::core::IUnknown {
-    fn from(value: BrightnessOverrideSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BrightnessOverrideSettings> for ::windows::core::IUnknown {
-    fn from(value: &BrightnessOverrideSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BrightnessOverrideSettings> for &::windows::core::IUnknown {
-    fn from(value: &BrightnessOverrideSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BrightnessOverrideSettings> for ::windows::core::IInspectable {
-    fn from(value: BrightnessOverrideSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BrightnessOverrideSettings> for ::windows::core::IInspectable {
-    fn from(value: &BrightnessOverrideSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BrightnessOverrideSettings> for &::windows::core::IInspectable {
-    fn from(value: &BrightnessOverrideSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BrightnessOverrideSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BrightnessOverrideSettings {}
 unsafe impl ::core::marker::Sync for BrightnessOverrideSettings {}
 #[doc = "*Required features: `\"Graphics_Display\"`*"]
@@ -1034,36 +947,7 @@ unsafe impl ::windows::core::Interface for ColorOverrideSettings {
 impl ::windows::core::RuntimeName for ColorOverrideSettings {
     const NAME: &'static str = "Windows.Graphics.Display.ColorOverrideSettings";
 }
-impl ::core::convert::From<ColorOverrideSettings> for ::windows::core::IUnknown {
-    fn from(value: ColorOverrideSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ColorOverrideSettings> for ::windows::core::IUnknown {
-    fn from(value: &ColorOverrideSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ColorOverrideSettings> for &::windows::core::IUnknown {
-    fn from(value: &ColorOverrideSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ColorOverrideSettings> for ::windows::core::IInspectable {
-    fn from(value: ColorOverrideSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ColorOverrideSettings> for ::windows::core::IInspectable {
-    fn from(value: &ColorOverrideSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ColorOverrideSettings> for &::windows::core::IInspectable {
-    fn from(value: &ColorOverrideSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ColorOverrideSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ColorOverrideSettings {}
 unsafe impl ::core::marker::Sync for ColorOverrideSettings {}
 #[doc = "*Required features: `\"Graphics_Display\"`*"]
@@ -1210,36 +1094,7 @@ unsafe impl ::windows::core::Interface for DisplayEnhancementOverride {
 impl ::windows::core::RuntimeName for DisplayEnhancementOverride {
     const NAME: &'static str = "Windows.Graphics.Display.DisplayEnhancementOverride";
 }
-impl ::core::convert::From<DisplayEnhancementOverride> for ::windows::core::IUnknown {
-    fn from(value: DisplayEnhancementOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverride> for ::windows::core::IUnknown {
-    fn from(value: &DisplayEnhancementOverride) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverride> for &::windows::core::IUnknown {
-    fn from(value: &DisplayEnhancementOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayEnhancementOverride> for ::windows::core::IInspectable {
-    fn from(value: DisplayEnhancementOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverride> for ::windows::core::IInspectable {
-    fn from(value: &DisplayEnhancementOverride) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverride> for &::windows::core::IInspectable {
-    fn from(value: &DisplayEnhancementOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayEnhancementOverride, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayEnhancementOverride {}
 unsafe impl ::core::marker::Sync for DisplayEnhancementOverride {}
 #[doc = "*Required features: `\"Graphics_Display\"`*"]
@@ -1302,36 +1157,7 @@ unsafe impl ::windows::core::Interface for DisplayEnhancementOverrideCapabilitie
 impl ::windows::core::RuntimeName for DisplayEnhancementOverrideCapabilities {
     const NAME: &'static str = "Windows.Graphics.Display.DisplayEnhancementOverrideCapabilities";
 }
-impl ::core::convert::From<DisplayEnhancementOverrideCapabilities> for ::windows::core::IUnknown {
-    fn from(value: DisplayEnhancementOverrideCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverrideCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &DisplayEnhancementOverrideCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverrideCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &DisplayEnhancementOverrideCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayEnhancementOverrideCapabilities> for ::windows::core::IInspectable {
-    fn from(value: DisplayEnhancementOverrideCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverrideCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &DisplayEnhancementOverrideCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverrideCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &DisplayEnhancementOverrideCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayEnhancementOverrideCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayEnhancementOverrideCapabilities {}
 unsafe impl ::core::marker::Sync for DisplayEnhancementOverrideCapabilities {}
 #[doc = "*Required features: `\"Graphics_Display\"`*"]
@@ -1378,36 +1204,7 @@ unsafe impl ::windows::core::Interface for DisplayEnhancementOverrideCapabilitie
 impl ::windows::core::RuntimeName for DisplayEnhancementOverrideCapabilitiesChangedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Display.DisplayEnhancementOverrideCapabilitiesChangedEventArgs";
 }
-impl ::core::convert::From<DisplayEnhancementOverrideCapabilitiesChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DisplayEnhancementOverrideCapabilitiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverrideCapabilitiesChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DisplayEnhancementOverrideCapabilitiesChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverrideCapabilitiesChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DisplayEnhancementOverrideCapabilitiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayEnhancementOverrideCapabilitiesChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DisplayEnhancementOverrideCapabilitiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverrideCapabilitiesChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DisplayEnhancementOverrideCapabilitiesChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayEnhancementOverrideCapabilitiesChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DisplayEnhancementOverrideCapabilitiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayEnhancementOverrideCapabilitiesChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayEnhancementOverrideCapabilitiesChangedEventArgs {}
 unsafe impl ::core::marker::Sync for DisplayEnhancementOverrideCapabilitiesChangedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Display\"`*"]
@@ -1650,36 +1447,7 @@ unsafe impl ::windows::core::Interface for DisplayInformation {
 impl ::windows::core::RuntimeName for DisplayInformation {
     const NAME: &'static str = "Windows.Graphics.Display.DisplayInformation";
 }
-impl ::core::convert::From<DisplayInformation> for ::windows::core::IUnknown {
-    fn from(value: DisplayInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayInformation> for ::windows::core::IUnknown {
-    fn from(value: &DisplayInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayInformation> for &::windows::core::IUnknown {
-    fn from(value: &DisplayInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayInformation> for ::windows::core::IInspectable {
-    fn from(value: DisplayInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayInformation> for ::windows::core::IInspectable {
-    fn from(value: &DisplayInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayInformation> for &::windows::core::IInspectable {
-    fn from(value: &DisplayInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayInformation {}
 unsafe impl ::core::marker::Sync for DisplayInformation {}
 #[doc = "*Required features: `\"Graphics_Display\"`, `\"deprecated\"`*"]
@@ -1872,36 +1640,7 @@ unsafe impl ::windows::core::Interface for DisplayServices {
 impl ::windows::core::RuntimeName for DisplayServices {
     const NAME: &'static str = "Windows.Graphics.Display.DisplayServices";
 }
-impl ::core::convert::From<DisplayServices> for ::windows::core::IUnknown {
-    fn from(value: DisplayServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayServices> for ::windows::core::IUnknown {
-    fn from(value: &DisplayServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayServices> for &::windows::core::IUnknown {
-    fn from(value: &DisplayServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayServices> for ::windows::core::IInspectable {
-    fn from(value: DisplayServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayServices> for ::windows::core::IInspectable {
-    fn from(value: &DisplayServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayServices> for &::windows::core::IInspectable {
-    fn from(value: &DisplayServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayServices, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayServices {}
 unsafe impl ::core::marker::Sync for DisplayServices {}
 #[doc = "*Required features: `\"Graphics_Display\"`*"]

--- a/crates/libs/windows/src/Windows/Graphics/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Effects/mod.rs
@@ -14,36 +14,7 @@ impl IGraphicsEffect {
         unsafe { (::windows::core::Vtable::vtable(this).SetName)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(name)).ok() }
     }
 }
-impl ::core::convert::From<IGraphicsEffect> for ::windows::core::IUnknown {
-    fn from(value: IGraphicsEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGraphicsEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGraphicsEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGraphicsEffect> for ::windows::core::IUnknown {
-    fn from(value: &IGraphicsEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGraphicsEffect> for ::windows::core::IInspectable {
-    fn from(value: IGraphicsEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGraphicsEffect> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGraphicsEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGraphicsEffect> for ::windows::core::IInspectable {
-    fn from(value: &IGraphicsEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGraphicsEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IGraphicsEffect> for IGraphicsEffectSource {
     type Error = ::windows::core::Error;
     fn try_from(value: IGraphicsEffect) -> ::windows::core::Result<Self> {
@@ -103,36 +74,7 @@ pub struct IGraphicsEffect_Vtbl {
 #[repr(transparent)]
 pub struct IGraphicsEffectSource(::windows::core::IUnknown);
 impl IGraphicsEffectSource {}
-impl ::core::convert::From<IGraphicsEffectSource> for ::windows::core::IUnknown {
-    fn from(value: IGraphicsEffectSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGraphicsEffectSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGraphicsEffectSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGraphicsEffectSource> for ::windows::core::IUnknown {
-    fn from(value: &IGraphicsEffectSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGraphicsEffectSource> for ::windows::core::IInspectable {
-    fn from(value: IGraphicsEffectSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGraphicsEffectSource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGraphicsEffectSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGraphicsEffectSource> for ::windows::core::IInspectable {
-    fn from(value: &IGraphicsEffectSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGraphicsEffectSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGraphicsEffectSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Graphics/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Holographic/mod.rs
@@ -1060,36 +1060,7 @@ unsafe impl ::windows::core::Interface for HolographicCamera {
 impl ::windows::core::RuntimeName for HolographicCamera {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicCamera";
 }
-impl ::core::convert::From<HolographicCamera> for ::windows::core::IUnknown {
-    fn from(value: HolographicCamera) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicCamera> for ::windows::core::IUnknown {
-    fn from(value: &HolographicCamera) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicCamera> for &::windows::core::IUnknown {
-    fn from(value: &HolographicCamera) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicCamera> for ::windows::core::IInspectable {
-    fn from(value: HolographicCamera) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicCamera> for ::windows::core::IInspectable {
-    fn from(value: &HolographicCamera) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicCamera> for &::windows::core::IInspectable {
-    fn from(value: &HolographicCamera) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicCamera, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicCamera {}
 unsafe impl ::core::marker::Sync for HolographicCamera {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -1213,36 +1184,7 @@ unsafe impl ::windows::core::Interface for HolographicCameraPose {
 impl ::windows::core::RuntimeName for HolographicCameraPose {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicCameraPose";
 }
-impl ::core::convert::From<HolographicCameraPose> for ::windows::core::IUnknown {
-    fn from(value: HolographicCameraPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicCameraPose> for ::windows::core::IUnknown {
-    fn from(value: &HolographicCameraPose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicCameraPose> for &::windows::core::IUnknown {
-    fn from(value: &HolographicCameraPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicCameraPose> for ::windows::core::IInspectable {
-    fn from(value: HolographicCameraPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicCameraPose> for ::windows::core::IInspectable {
-    fn from(value: &HolographicCameraPose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicCameraPose> for &::windows::core::IInspectable {
-    fn from(value: &HolographicCameraPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicCameraPose, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicCameraPose {}
 unsafe impl ::core::marker::Sync for HolographicCameraPose {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -1361,36 +1303,7 @@ unsafe impl ::windows::core::Interface for HolographicCameraRenderingParameters 
 impl ::windows::core::RuntimeName for HolographicCameraRenderingParameters {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicCameraRenderingParameters";
 }
-impl ::core::convert::From<HolographicCameraRenderingParameters> for ::windows::core::IUnknown {
-    fn from(value: HolographicCameraRenderingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicCameraRenderingParameters> for ::windows::core::IUnknown {
-    fn from(value: &HolographicCameraRenderingParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicCameraRenderingParameters> for &::windows::core::IUnknown {
-    fn from(value: &HolographicCameraRenderingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicCameraRenderingParameters> for ::windows::core::IInspectable {
-    fn from(value: HolographicCameraRenderingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicCameraRenderingParameters> for ::windows::core::IInspectable {
-    fn from(value: &HolographicCameraRenderingParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicCameraRenderingParameters> for &::windows::core::IInspectable {
-    fn from(value: &HolographicCameraRenderingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicCameraRenderingParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicCameraRenderingParameters {}
 unsafe impl ::core::marker::Sync for HolographicCameraRenderingParameters {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -1448,36 +1361,7 @@ unsafe impl ::windows::core::Interface for HolographicCameraViewportParameters {
 impl ::windows::core::RuntimeName for HolographicCameraViewportParameters {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicCameraViewportParameters";
 }
-impl ::core::convert::From<HolographicCameraViewportParameters> for ::windows::core::IUnknown {
-    fn from(value: HolographicCameraViewportParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicCameraViewportParameters> for ::windows::core::IUnknown {
-    fn from(value: &HolographicCameraViewportParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicCameraViewportParameters> for &::windows::core::IUnknown {
-    fn from(value: &HolographicCameraViewportParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicCameraViewportParameters> for ::windows::core::IInspectable {
-    fn from(value: HolographicCameraViewportParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicCameraViewportParameters> for ::windows::core::IInspectable {
-    fn from(value: &HolographicCameraViewportParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicCameraViewportParameters> for &::windows::core::IInspectable {
-    fn from(value: &HolographicCameraViewportParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicCameraViewportParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicCameraViewportParameters {}
 unsafe impl ::core::marker::Sync for HolographicCameraViewportParameters {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -1588,36 +1472,7 @@ unsafe impl ::windows::core::Interface for HolographicDisplay {
 impl ::windows::core::RuntimeName for HolographicDisplay {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicDisplay";
 }
-impl ::core::convert::From<HolographicDisplay> for ::windows::core::IUnknown {
-    fn from(value: HolographicDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicDisplay> for ::windows::core::IUnknown {
-    fn from(value: &HolographicDisplay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicDisplay> for &::windows::core::IUnknown {
-    fn from(value: &HolographicDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicDisplay> for ::windows::core::IInspectable {
-    fn from(value: HolographicDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicDisplay> for ::windows::core::IInspectable {
-    fn from(value: &HolographicDisplay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicDisplay> for &::windows::core::IInspectable {
-    fn from(value: &HolographicDisplay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicDisplay, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicDisplay {}
 unsafe impl ::core::marker::Sync for HolographicDisplay {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -1734,36 +1589,7 @@ unsafe impl ::windows::core::Interface for HolographicFrame {
 impl ::windows::core::RuntimeName for HolographicFrame {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicFrame";
 }
-impl ::core::convert::From<HolographicFrame> for ::windows::core::IUnknown {
-    fn from(value: HolographicFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicFrame> for ::windows::core::IUnknown {
-    fn from(value: &HolographicFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicFrame> for &::windows::core::IUnknown {
-    fn from(value: &HolographicFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicFrame> for ::windows::core::IInspectable {
-    fn from(value: HolographicFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicFrame> for ::windows::core::IInspectable {
-    fn from(value: &HolographicFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicFrame> for &::windows::core::IInspectable {
-    fn from(value: &HolographicFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicFrame {}
 unsafe impl ::core::marker::Sync for HolographicFrame {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -1821,36 +1647,7 @@ unsafe impl ::windows::core::Interface for HolographicFramePrediction {
 impl ::windows::core::RuntimeName for HolographicFramePrediction {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicFramePrediction";
 }
-impl ::core::convert::From<HolographicFramePrediction> for ::windows::core::IUnknown {
-    fn from(value: HolographicFramePrediction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicFramePrediction> for ::windows::core::IUnknown {
-    fn from(value: &HolographicFramePrediction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicFramePrediction> for &::windows::core::IUnknown {
-    fn from(value: &HolographicFramePrediction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicFramePrediction> for ::windows::core::IInspectable {
-    fn from(value: HolographicFramePrediction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicFramePrediction> for ::windows::core::IInspectable {
-    fn from(value: &HolographicFramePrediction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicFramePrediction> for &::windows::core::IInspectable {
-    fn from(value: &HolographicFramePrediction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicFramePrediction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicFramePrediction {}
 unsafe impl ::core::marker::Sync for HolographicFramePrediction {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`, `\"deprecated\"`*"]
@@ -1916,41 +1713,7 @@ impl ::windows::core::RuntimeName for HolographicFramePresentationMonitor {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicFramePresentationMonitor";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<HolographicFramePresentationMonitor> for ::windows::core::IUnknown {
-    fn from(value: HolographicFramePresentationMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicFramePresentationMonitor> for ::windows::core::IUnknown {
-    fn from(value: &HolographicFramePresentationMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicFramePresentationMonitor> for &::windows::core::IUnknown {
-    fn from(value: &HolographicFramePresentationMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<HolographicFramePresentationMonitor> for ::windows::core::IInspectable {
-    fn from(value: HolographicFramePresentationMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicFramePresentationMonitor> for ::windows::core::IInspectable {
-    fn from(value: &HolographicFramePresentationMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicFramePresentationMonitor> for &::windows::core::IInspectable {
-    fn from(value: &HolographicFramePresentationMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicFramePresentationMonitor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<HolographicFramePresentationMonitor> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2070,41 +1833,7 @@ impl ::windows::core::RuntimeName for HolographicFramePresentationReport {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicFramePresentationReport";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<HolographicFramePresentationReport> for ::windows::core::IUnknown {
-    fn from(value: HolographicFramePresentationReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicFramePresentationReport> for ::windows::core::IUnknown {
-    fn from(value: &HolographicFramePresentationReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicFramePresentationReport> for &::windows::core::IUnknown {
-    fn from(value: &HolographicFramePresentationReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<HolographicFramePresentationReport> for ::windows::core::IInspectable {
-    fn from(value: HolographicFramePresentationReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicFramePresentationReport> for ::windows::core::IInspectable {
-    fn from(value: &HolographicFramePresentationReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&HolographicFramePresentationReport> for &::windows::core::IInspectable {
-    fn from(value: &HolographicFramePresentationReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicFramePresentationReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for HolographicFramePresentationReport {}
 #[cfg(feature = "deprecated")]
@@ -2187,36 +1916,7 @@ unsafe impl ::windows::core::Interface for HolographicFrameRenderingReport {
 impl ::windows::core::RuntimeName for HolographicFrameRenderingReport {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicFrameRenderingReport";
 }
-impl ::core::convert::From<HolographicFrameRenderingReport> for ::windows::core::IUnknown {
-    fn from(value: HolographicFrameRenderingReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicFrameRenderingReport> for ::windows::core::IUnknown {
-    fn from(value: &HolographicFrameRenderingReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicFrameRenderingReport> for &::windows::core::IUnknown {
-    fn from(value: &HolographicFrameRenderingReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicFrameRenderingReport> for ::windows::core::IInspectable {
-    fn from(value: HolographicFrameRenderingReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicFrameRenderingReport> for ::windows::core::IInspectable {
-    fn from(value: &HolographicFrameRenderingReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicFrameRenderingReport> for &::windows::core::IInspectable {
-    fn from(value: &HolographicFrameRenderingReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicFrameRenderingReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicFrameRenderingReport {}
 unsafe impl ::core::marker::Sync for HolographicFrameRenderingReport {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -2271,36 +1971,7 @@ unsafe impl ::windows::core::Interface for HolographicFrameScanoutMonitor {
 impl ::windows::core::RuntimeName for HolographicFrameScanoutMonitor {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicFrameScanoutMonitor";
 }
-impl ::core::convert::From<HolographicFrameScanoutMonitor> for ::windows::core::IUnknown {
-    fn from(value: HolographicFrameScanoutMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicFrameScanoutMonitor> for ::windows::core::IUnknown {
-    fn from(value: &HolographicFrameScanoutMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicFrameScanoutMonitor> for &::windows::core::IUnknown {
-    fn from(value: &HolographicFrameScanoutMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicFrameScanoutMonitor> for ::windows::core::IInspectable {
-    fn from(value: HolographicFrameScanoutMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicFrameScanoutMonitor> for ::windows::core::IInspectable {
-    fn from(value: &HolographicFrameScanoutMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicFrameScanoutMonitor> for &::windows::core::IInspectable {
-    fn from(value: &HolographicFrameScanoutMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicFrameScanoutMonitor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HolographicFrameScanoutMonitor> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2403,36 +2074,7 @@ unsafe impl ::windows::core::Interface for HolographicFrameScanoutReport {
 impl ::windows::core::RuntimeName for HolographicFrameScanoutReport {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicFrameScanoutReport";
 }
-impl ::core::convert::From<HolographicFrameScanoutReport> for ::windows::core::IUnknown {
-    fn from(value: HolographicFrameScanoutReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicFrameScanoutReport> for ::windows::core::IUnknown {
-    fn from(value: &HolographicFrameScanoutReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicFrameScanoutReport> for &::windows::core::IUnknown {
-    fn from(value: &HolographicFrameScanoutReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicFrameScanoutReport> for ::windows::core::IInspectable {
-    fn from(value: HolographicFrameScanoutReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicFrameScanoutReport> for ::windows::core::IInspectable {
-    fn from(value: &HolographicFrameScanoutReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicFrameScanoutReport> for &::windows::core::IInspectable {
-    fn from(value: &HolographicFrameScanoutReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicFrameScanoutReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicFrameScanoutReport {}
 unsafe impl ::core::marker::Sync for HolographicFrameScanoutReport {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -2517,36 +2159,7 @@ unsafe impl ::windows::core::Interface for HolographicQuadLayer {
 impl ::windows::core::RuntimeName for HolographicQuadLayer {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicQuadLayer";
 }
-impl ::core::convert::From<HolographicQuadLayer> for ::windows::core::IUnknown {
-    fn from(value: HolographicQuadLayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicQuadLayer> for ::windows::core::IUnknown {
-    fn from(value: &HolographicQuadLayer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicQuadLayer> for &::windows::core::IUnknown {
-    fn from(value: &HolographicQuadLayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicQuadLayer> for ::windows::core::IInspectable {
-    fn from(value: HolographicQuadLayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicQuadLayer> for ::windows::core::IInspectable {
-    fn from(value: &HolographicQuadLayer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicQuadLayer> for &::windows::core::IInspectable {
-    fn from(value: &HolographicQuadLayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicQuadLayer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HolographicQuadLayer> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2661,36 +2274,7 @@ unsafe impl ::windows::core::Interface for HolographicQuadLayerUpdateParameters 
 impl ::windows::core::RuntimeName for HolographicQuadLayerUpdateParameters {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicQuadLayerUpdateParameters";
 }
-impl ::core::convert::From<HolographicQuadLayerUpdateParameters> for ::windows::core::IUnknown {
-    fn from(value: HolographicQuadLayerUpdateParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicQuadLayerUpdateParameters> for ::windows::core::IUnknown {
-    fn from(value: &HolographicQuadLayerUpdateParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicQuadLayerUpdateParameters> for &::windows::core::IUnknown {
-    fn from(value: &HolographicQuadLayerUpdateParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicQuadLayerUpdateParameters> for ::windows::core::IInspectable {
-    fn from(value: HolographicQuadLayerUpdateParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicQuadLayerUpdateParameters> for ::windows::core::IInspectable {
-    fn from(value: &HolographicQuadLayerUpdateParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicQuadLayerUpdateParameters> for &::windows::core::IInspectable {
-    fn from(value: &HolographicQuadLayerUpdateParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicQuadLayerUpdateParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicQuadLayerUpdateParameters {}
 unsafe impl ::core::marker::Sync for HolographicQuadLayerUpdateParameters {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -2886,36 +2470,7 @@ unsafe impl ::windows::core::Interface for HolographicSpace {
 impl ::windows::core::RuntimeName for HolographicSpace {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicSpace";
 }
-impl ::core::convert::From<HolographicSpace> for ::windows::core::IUnknown {
-    fn from(value: HolographicSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicSpace> for ::windows::core::IUnknown {
-    fn from(value: &HolographicSpace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicSpace> for &::windows::core::IUnknown {
-    fn from(value: &HolographicSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicSpace> for ::windows::core::IInspectable {
-    fn from(value: HolographicSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicSpace> for ::windows::core::IInspectable {
-    fn from(value: &HolographicSpace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicSpace> for &::windows::core::IInspectable {
-    fn from(value: &HolographicSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicSpace, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicSpace {}
 unsafe impl ::core::marker::Sync for HolographicSpace {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -2971,36 +2526,7 @@ unsafe impl ::windows::core::Interface for HolographicSpaceCameraAddedEventArgs 
 impl ::windows::core::RuntimeName for HolographicSpaceCameraAddedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicSpaceCameraAddedEventArgs";
 }
-impl ::core::convert::From<HolographicSpaceCameraAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: HolographicSpaceCameraAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicSpaceCameraAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &HolographicSpaceCameraAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicSpaceCameraAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &HolographicSpaceCameraAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicSpaceCameraAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: HolographicSpaceCameraAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicSpaceCameraAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &HolographicSpaceCameraAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicSpaceCameraAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &HolographicSpaceCameraAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicSpaceCameraAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicSpaceCameraAddedEventArgs {}
 unsafe impl ::core::marker::Sync for HolographicSpaceCameraAddedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -3047,36 +2573,7 @@ unsafe impl ::windows::core::Interface for HolographicSpaceCameraRemovedEventArg
 impl ::windows::core::RuntimeName for HolographicSpaceCameraRemovedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicSpaceCameraRemovedEventArgs";
 }
-impl ::core::convert::From<HolographicSpaceCameraRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: HolographicSpaceCameraRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicSpaceCameraRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &HolographicSpaceCameraRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicSpaceCameraRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &HolographicSpaceCameraRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicSpaceCameraRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: HolographicSpaceCameraRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicSpaceCameraRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &HolographicSpaceCameraRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicSpaceCameraRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &HolographicSpaceCameraRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicSpaceCameraRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicSpaceCameraRemovedEventArgs {}
 unsafe impl ::core::marker::Sync for HolographicSpaceCameraRemovedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]
@@ -3215,36 +2712,7 @@ unsafe impl ::windows::core::Interface for HolographicViewConfiguration {
 impl ::windows::core::RuntimeName for HolographicViewConfiguration {
     const NAME: &'static str = "Windows.Graphics.Holographic.HolographicViewConfiguration";
 }
-impl ::core::convert::From<HolographicViewConfiguration> for ::windows::core::IUnknown {
-    fn from(value: HolographicViewConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicViewConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &HolographicViewConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicViewConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &HolographicViewConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HolographicViewConfiguration> for ::windows::core::IInspectable {
-    fn from(value: HolographicViewConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HolographicViewConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &HolographicViewConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HolographicViewConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &HolographicViewConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HolographicViewConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HolographicViewConfiguration {}
 unsafe impl ::core::marker::Sync for HolographicViewConfiguration {}
 #[doc = "*Required features: `\"Graphics_Holographic\"`*"]

--- a/crates/libs/windows/src/Windows/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Imaging/mod.rs
@@ -314,36 +314,7 @@ impl IBitmapFrame {
         }
     }
 }
-impl ::core::convert::From<IBitmapFrame> for ::windows::core::IUnknown {
-    fn from(value: IBitmapFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBitmapFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBitmapFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBitmapFrame> for ::windows::core::IUnknown {
-    fn from(value: &IBitmapFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBitmapFrame> for ::windows::core::IInspectable {
-    fn from(value: IBitmapFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBitmapFrame> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBitmapFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBitmapFrame> for ::windows::core::IInspectable {
-    fn from(value: &IBitmapFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBitmapFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBitmapFrame {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -521,36 +492,7 @@ impl IBitmapFrameWithSoftwareBitmap {
         }
     }
 }
-impl ::core::convert::From<IBitmapFrameWithSoftwareBitmap> for ::windows::core::IUnknown {
-    fn from(value: IBitmapFrameWithSoftwareBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBitmapFrameWithSoftwareBitmap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBitmapFrameWithSoftwareBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBitmapFrameWithSoftwareBitmap> for ::windows::core::IUnknown {
-    fn from(value: &IBitmapFrameWithSoftwareBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBitmapFrameWithSoftwareBitmap> for ::windows::core::IInspectable {
-    fn from(value: IBitmapFrameWithSoftwareBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBitmapFrameWithSoftwareBitmap> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBitmapFrameWithSoftwareBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBitmapFrameWithSoftwareBitmap> for ::windows::core::IInspectable {
-    fn from(value: &IBitmapFrameWithSoftwareBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBitmapFrameWithSoftwareBitmap, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IBitmapFrameWithSoftwareBitmap> for IBitmapFrame {
     type Error = ::windows::core::Error;
     fn try_from(value: IBitmapFrameWithSoftwareBitmap) -> ::windows::core::Result<Self> {
@@ -652,36 +594,7 @@ impl IBitmapPropertiesView {
         }
     }
 }
-impl ::core::convert::From<IBitmapPropertiesView> for ::windows::core::IUnknown {
-    fn from(value: IBitmapPropertiesView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBitmapPropertiesView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBitmapPropertiesView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBitmapPropertiesView> for ::windows::core::IUnknown {
-    fn from(value: &IBitmapPropertiesView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBitmapPropertiesView> for ::windows::core::IInspectable {
-    fn from(value: IBitmapPropertiesView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBitmapPropertiesView> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBitmapPropertiesView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBitmapPropertiesView> for ::windows::core::IInspectable {
-    fn from(value: &IBitmapPropertiesView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBitmapPropertiesView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBitmapPropertiesView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -947,36 +860,7 @@ unsafe impl ::windows::core::Interface for BitmapBuffer {
 impl ::windows::core::RuntimeName for BitmapBuffer {
     const NAME: &'static str = "Windows.Graphics.Imaging.BitmapBuffer";
 }
-impl ::core::convert::From<BitmapBuffer> for ::windows::core::IUnknown {
-    fn from(value: BitmapBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapBuffer> for ::windows::core::IUnknown {
-    fn from(value: &BitmapBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapBuffer> for &::windows::core::IUnknown {
-    fn from(value: &BitmapBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BitmapBuffer> for ::windows::core::IInspectable {
-    fn from(value: BitmapBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapBuffer> for ::windows::core::IInspectable {
-    fn from(value: &BitmapBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapBuffer> for &::windows::core::IInspectable {
-    fn from(value: &BitmapBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BitmapBuffer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<BitmapBuffer> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1092,36 +976,7 @@ unsafe impl ::windows::core::Interface for BitmapCodecInformation {
 impl ::windows::core::RuntimeName for BitmapCodecInformation {
     const NAME: &'static str = "Windows.Graphics.Imaging.BitmapCodecInformation";
 }
-impl ::core::convert::From<BitmapCodecInformation> for ::windows::core::IUnknown {
-    fn from(value: BitmapCodecInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapCodecInformation> for ::windows::core::IUnknown {
-    fn from(value: &BitmapCodecInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapCodecInformation> for &::windows::core::IUnknown {
-    fn from(value: &BitmapCodecInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BitmapCodecInformation> for ::windows::core::IInspectable {
-    fn from(value: BitmapCodecInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapCodecInformation> for ::windows::core::IInspectable {
-    fn from(value: &BitmapCodecInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapCodecInformation> for &::windows::core::IInspectable {
-    fn from(value: &BitmapCodecInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BitmapCodecInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BitmapCodecInformation {}
 unsafe impl ::core::marker::Sync for BitmapCodecInformation {}
 #[doc = "*Required features: `\"Graphics_Imaging\"`*"]
@@ -1413,36 +1268,7 @@ unsafe impl ::windows::core::Interface for BitmapDecoder {
 impl ::windows::core::RuntimeName for BitmapDecoder {
     const NAME: &'static str = "Windows.Graphics.Imaging.BitmapDecoder";
 }
-impl ::core::convert::From<BitmapDecoder> for ::windows::core::IUnknown {
-    fn from(value: BitmapDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapDecoder> for ::windows::core::IUnknown {
-    fn from(value: &BitmapDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapDecoder> for &::windows::core::IUnknown {
-    fn from(value: &BitmapDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BitmapDecoder> for ::windows::core::IInspectable {
-    fn from(value: BitmapDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapDecoder> for ::windows::core::IInspectable {
-    fn from(value: &BitmapDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapDecoder> for &::windows::core::IInspectable {
-    fn from(value: &BitmapDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BitmapDecoder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BitmapDecoder> for IBitmapFrame {
     type Error = ::windows::core::Error;
     fn try_from(value: BitmapDecoder) -> ::windows::core::Result<Self> {
@@ -1726,36 +1552,7 @@ unsafe impl ::windows::core::Interface for BitmapEncoder {
 impl ::windows::core::RuntimeName for BitmapEncoder {
     const NAME: &'static str = "Windows.Graphics.Imaging.BitmapEncoder";
 }
-impl ::core::convert::From<BitmapEncoder> for ::windows::core::IUnknown {
-    fn from(value: BitmapEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapEncoder> for ::windows::core::IUnknown {
-    fn from(value: &BitmapEncoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapEncoder> for &::windows::core::IUnknown {
-    fn from(value: &BitmapEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BitmapEncoder> for ::windows::core::IInspectable {
-    fn from(value: BitmapEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapEncoder> for ::windows::core::IInspectable {
-    fn from(value: &BitmapEncoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapEncoder> for &::windows::core::IInspectable {
-    fn from(value: &BitmapEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BitmapEncoder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BitmapEncoder {}
 unsafe impl ::core::marker::Sync for BitmapEncoder {}
 #[doc = "*Required features: `\"Graphics_Imaging\"`*"]
@@ -1912,36 +1709,7 @@ unsafe impl ::windows::core::Interface for BitmapFrame {
 impl ::windows::core::RuntimeName for BitmapFrame {
     const NAME: &'static str = "Windows.Graphics.Imaging.BitmapFrame";
 }
-impl ::core::convert::From<BitmapFrame> for ::windows::core::IUnknown {
-    fn from(value: BitmapFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapFrame> for ::windows::core::IUnknown {
-    fn from(value: &BitmapFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapFrame> for &::windows::core::IUnknown {
-    fn from(value: &BitmapFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BitmapFrame> for ::windows::core::IInspectable {
-    fn from(value: BitmapFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapFrame> for ::windows::core::IInspectable {
-    fn from(value: &BitmapFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapFrame> for &::windows::core::IInspectable {
-    fn from(value: &BitmapFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BitmapFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BitmapFrame> for IBitmapFrame {
     type Error = ::windows::core::Error;
     fn try_from(value: BitmapFrame) -> ::windows::core::Result<Self> {
@@ -2045,36 +1813,7 @@ unsafe impl ::windows::core::Interface for BitmapProperties {
 impl ::windows::core::RuntimeName for BitmapProperties {
     const NAME: &'static str = "Windows.Graphics.Imaging.BitmapProperties";
 }
-impl ::core::convert::From<BitmapProperties> for ::windows::core::IUnknown {
-    fn from(value: BitmapProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapProperties> for ::windows::core::IUnknown {
-    fn from(value: &BitmapProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapProperties> for &::windows::core::IUnknown {
-    fn from(value: &BitmapProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BitmapProperties> for ::windows::core::IInspectable {
-    fn from(value: BitmapProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapProperties> for ::windows::core::IInspectable {
-    fn from(value: &BitmapProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapProperties> for &::windows::core::IInspectable {
-    fn from(value: &BitmapProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BitmapProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BitmapProperties> for IBitmapPropertiesView {
     type Error = ::windows::core::Error;
     fn try_from(value: BitmapProperties) -> ::windows::core::Result<Self> {
@@ -2146,36 +1885,7 @@ unsafe impl ::windows::core::Interface for BitmapPropertiesView {
 impl ::windows::core::RuntimeName for BitmapPropertiesView {
     const NAME: &'static str = "Windows.Graphics.Imaging.BitmapPropertiesView";
 }
-impl ::core::convert::From<BitmapPropertiesView> for ::windows::core::IUnknown {
-    fn from(value: BitmapPropertiesView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapPropertiesView> for ::windows::core::IUnknown {
-    fn from(value: &BitmapPropertiesView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapPropertiesView> for &::windows::core::IUnknown {
-    fn from(value: &BitmapPropertiesView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BitmapPropertiesView> for ::windows::core::IInspectable {
-    fn from(value: BitmapPropertiesView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapPropertiesView> for ::windows::core::IInspectable {
-    fn from(value: &BitmapPropertiesView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapPropertiesView> for &::windows::core::IInspectable {
-    fn from(value: &BitmapPropertiesView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BitmapPropertiesView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BitmapPropertiesView> for IBitmapPropertiesView {
     type Error = ::windows::core::Error;
     fn try_from(value: BitmapPropertiesView) -> ::windows::core::Result<Self> {
@@ -2334,41 +2044,7 @@ impl ::core::iter::IntoIterator for &BitmapPropertySet {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<BitmapPropertySet> for ::windows::core::IUnknown {
-    fn from(value: BitmapPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&BitmapPropertySet> for ::windows::core::IUnknown {
-    fn from(value: &BitmapPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&BitmapPropertySet> for &::windows::core::IUnknown {
-    fn from(value: &BitmapPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<BitmapPropertySet> for ::windows::core::IInspectable {
-    fn from(value: BitmapPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&BitmapPropertySet> for ::windows::core::IInspectable {
-    fn from(value: &BitmapPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&BitmapPropertySet> for &::windows::core::IInspectable {
-    fn from(value: &BitmapPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BitmapPropertySet, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<BitmapPropertySet> for super::super::Foundation::Collections::IIterable<super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, BitmapTypedValue>> {
     type Error = ::windows::core::Error;
@@ -2527,36 +2203,7 @@ unsafe impl ::windows::core::Interface for BitmapTransform {
 impl ::windows::core::RuntimeName for BitmapTransform {
     const NAME: &'static str = "Windows.Graphics.Imaging.BitmapTransform";
 }
-impl ::core::convert::From<BitmapTransform> for ::windows::core::IUnknown {
-    fn from(value: BitmapTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapTransform> for ::windows::core::IUnknown {
-    fn from(value: &BitmapTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapTransform> for &::windows::core::IUnknown {
-    fn from(value: &BitmapTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BitmapTransform> for ::windows::core::IInspectable {
-    fn from(value: BitmapTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapTransform> for ::windows::core::IInspectable {
-    fn from(value: &BitmapTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapTransform> for &::windows::core::IInspectable {
-    fn from(value: &BitmapTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BitmapTransform, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BitmapTransform {}
 unsafe impl ::core::marker::Sync for BitmapTransform {}
 #[doc = "*Required features: `\"Graphics_Imaging\"`*"]
@@ -2628,36 +2275,7 @@ unsafe impl ::windows::core::Interface for BitmapTypedValue {
 impl ::windows::core::RuntimeName for BitmapTypedValue {
     const NAME: &'static str = "Windows.Graphics.Imaging.BitmapTypedValue";
 }
-impl ::core::convert::From<BitmapTypedValue> for ::windows::core::IUnknown {
-    fn from(value: BitmapTypedValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapTypedValue> for ::windows::core::IUnknown {
-    fn from(value: &BitmapTypedValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapTypedValue> for &::windows::core::IUnknown {
-    fn from(value: &BitmapTypedValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BitmapTypedValue> for ::windows::core::IInspectable {
-    fn from(value: BitmapTypedValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BitmapTypedValue> for ::windows::core::IInspectable {
-    fn from(value: &BitmapTypedValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BitmapTypedValue> for &::windows::core::IInspectable {
-    fn from(value: &BitmapTypedValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BitmapTypedValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BitmapTypedValue {}
 unsafe impl ::core::marker::Sync for BitmapTypedValue {}
 #[doc = "*Required features: `\"Graphics_Imaging\"`, `\"Storage_Streams\"`*"]
@@ -2833,41 +2451,7 @@ impl ::windows::core::RuntimeName for ImageStream {
     const NAME: &'static str = "Windows.Graphics.Imaging.ImageStream";
 }
 #[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<ImageStream> for ::windows::core::IUnknown {
-    fn from(value: ImageStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&ImageStream> for ::windows::core::IUnknown {
-    fn from(value: &ImageStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&ImageStream> for &::windows::core::IUnknown {
-    fn from(value: &ImageStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<ImageStream> for ::windows::core::IInspectable {
-    fn from(value: ImageStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&ImageStream> for ::windows::core::IInspectable {
-    fn from(value: &ImageStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&ImageStream> for &::windows::core::IInspectable {
-    fn from(value: &ImageStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 impl ::core::convert::TryFrom<ImageStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3048,36 +2632,7 @@ unsafe impl ::windows::core::Interface for PixelDataProvider {
 impl ::windows::core::RuntimeName for PixelDataProvider {
     const NAME: &'static str = "Windows.Graphics.Imaging.PixelDataProvider";
 }
-impl ::core::convert::From<PixelDataProvider> for ::windows::core::IUnknown {
-    fn from(value: PixelDataProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PixelDataProvider> for ::windows::core::IUnknown {
-    fn from(value: &PixelDataProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PixelDataProvider> for &::windows::core::IUnknown {
-    fn from(value: &PixelDataProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PixelDataProvider> for ::windows::core::IInspectable {
-    fn from(value: PixelDataProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PixelDataProvider> for ::windows::core::IInspectable {
-    fn from(value: &PixelDataProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PixelDataProvider> for &::windows::core::IInspectable {
-    fn from(value: &PixelDataProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PixelDataProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PixelDataProvider {}
 unsafe impl ::core::marker::Sync for PixelDataProvider {}
 #[doc = "*Required features: `\"Graphics_Imaging\"`*"]
@@ -3306,36 +2861,7 @@ unsafe impl ::windows::core::Interface for SoftwareBitmap {
 impl ::windows::core::RuntimeName for SoftwareBitmap {
     const NAME: &'static str = "Windows.Graphics.Imaging.SoftwareBitmap";
 }
-impl ::core::convert::From<SoftwareBitmap> for ::windows::core::IUnknown {
-    fn from(value: SoftwareBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SoftwareBitmap> for ::windows::core::IUnknown {
-    fn from(value: &SoftwareBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SoftwareBitmap> for &::windows::core::IUnknown {
-    fn from(value: &SoftwareBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SoftwareBitmap> for ::windows::core::IInspectable {
-    fn from(value: SoftwareBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SoftwareBitmap> for ::windows::core::IInspectable {
-    fn from(value: &SoftwareBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SoftwareBitmap> for &::windows::core::IInspectable {
-    fn from(value: &SoftwareBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SoftwareBitmap, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<SoftwareBitmap> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
@@ -225,36 +225,7 @@ impl IPrintCustomOptionDetails {
         }
     }
 }
-impl ::core::convert::From<IPrintCustomOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: IPrintCustomOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCustomOptionDetails> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintCustomOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCustomOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &IPrintCustomOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintCustomOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: IPrintCustomOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCustomOptionDetails> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrintCustomOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCustomOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &IPrintCustomOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintCustomOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPrintCustomOptionDetails> for IPrintOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: IPrintCustomOptionDetails) -> ::windows::core::Result<Self> {
@@ -465,36 +436,7 @@ impl IPrintItemListOptionDetails {
         }
     }
 }
-impl ::core::convert::From<IPrintItemListOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: IPrintItemListOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintItemListOptionDetails> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintItemListOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintItemListOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &IPrintItemListOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintItemListOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: IPrintItemListOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintItemListOptionDetails> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrintItemListOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintItemListOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &IPrintItemListOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintItemListOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPrintItemListOptionDetails> for IPrintOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: IPrintItemListOptionDetails) -> ::windows::core::Result<Self> {
@@ -660,36 +602,7 @@ impl IPrintNumberOptionDetails {
         }
     }
 }
-impl ::core::convert::From<IPrintNumberOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: IPrintNumberOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintNumberOptionDetails> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintNumberOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintNumberOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &IPrintNumberOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintNumberOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: IPrintNumberOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintNumberOptionDetails> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrintNumberOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintNumberOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &IPrintNumberOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintNumberOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPrintNumberOptionDetails> for IPrintOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: IPrintNumberOptionDetails) -> ::windows::core::Result<Self> {
@@ -803,36 +716,7 @@ impl IPrintOptionDetails {
         }
     }
 }
-impl ::core::convert::From<IPrintOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: IPrintOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintOptionDetails> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &IPrintOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: IPrintOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintOptionDetails> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrintOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &IPrintOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPrintOptionDetails {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1093,36 +977,7 @@ impl IPrintTextOptionDetails {
         }
     }
 }
-impl ::core::convert::From<IPrintTextOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: IPrintTextOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTextOptionDetails> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintTextOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTextOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &IPrintTextOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintTextOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: IPrintTextOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTextOptionDetails> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrintTextOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTextOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &IPrintTextOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintTextOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPrintTextOptionDetails> for IPrintOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: IPrintTextOptionDetails) -> ::windows::core::Result<Self> {
@@ -1298,36 +1153,7 @@ unsafe impl ::windows::core::Interface for PrintBindingOptionDetails {
 impl ::windows::core::RuntimeName for PrintBindingOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintBindingOptionDetails";
 }
-impl ::core::convert::From<PrintBindingOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintBindingOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintBindingOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintBindingOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintBindingOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintBindingOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintBindingOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintBindingOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintBindingOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintBindingOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintBindingOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintBindingOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintBindingOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintBindingOptionDetails> for IPrintItemListOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintBindingOptionDetails) -> ::windows::core::Result<Self> {
@@ -1489,36 +1315,7 @@ unsafe impl ::windows::core::Interface for PrintBorderingOptionDetails {
 impl ::windows::core::RuntimeName for PrintBorderingOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintBorderingOptionDetails";
 }
-impl ::core::convert::From<PrintBorderingOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintBorderingOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintBorderingOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintBorderingOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintBorderingOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintBorderingOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintBorderingOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintBorderingOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintBorderingOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintBorderingOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintBorderingOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintBorderingOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintBorderingOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintBorderingOptionDetails> for IPrintItemListOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintBorderingOptionDetails) -> ::windows::core::Result<Self> {
@@ -1680,36 +1477,7 @@ unsafe impl ::windows::core::Interface for PrintCollationOptionDetails {
 impl ::windows::core::RuntimeName for PrintCollationOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintCollationOptionDetails";
 }
-impl ::core::convert::From<PrintCollationOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintCollationOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCollationOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintCollationOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCollationOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintCollationOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintCollationOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintCollationOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCollationOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintCollationOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCollationOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintCollationOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintCollationOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintCollationOptionDetails> for IPrintItemListOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintCollationOptionDetails) -> ::windows::core::Result<Self> {
@@ -1871,36 +1639,7 @@ unsafe impl ::windows::core::Interface for PrintColorModeOptionDetails {
 impl ::windows::core::RuntimeName for PrintColorModeOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintColorModeOptionDetails";
 }
-impl ::core::convert::From<PrintColorModeOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintColorModeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintColorModeOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintColorModeOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintColorModeOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintColorModeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintColorModeOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintColorModeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintColorModeOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintColorModeOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintColorModeOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintColorModeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintColorModeOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintColorModeOptionDetails> for IPrintItemListOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintColorModeOptionDetails) -> ::windows::core::Result<Self> {
@@ -2067,36 +1806,7 @@ unsafe impl ::windows::core::Interface for PrintCopiesOptionDetails {
 impl ::windows::core::RuntimeName for PrintCopiesOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintCopiesOptionDetails";
 }
-impl ::core::convert::From<PrintCopiesOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintCopiesOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCopiesOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintCopiesOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCopiesOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintCopiesOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintCopiesOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintCopiesOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCopiesOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintCopiesOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCopiesOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintCopiesOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintCopiesOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintCopiesOptionDetails> for IPrintNumberOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintCopiesOptionDetails) -> ::windows::core::Result<Self> {
@@ -2192,36 +1902,7 @@ unsafe impl ::windows::core::Interface for PrintCustomItemDetails {
 impl ::windows::core::RuntimeName for PrintCustomItemDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintCustomItemDetails";
 }
-impl ::core::convert::From<PrintCustomItemDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintCustomItemDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCustomItemDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintCustomItemDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCustomItemDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintCustomItemDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintCustomItemDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintCustomItemDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCustomItemDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintCustomItemDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCustomItemDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintCustomItemDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintCustomItemDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintCustomItemDetails {}
 unsafe impl ::core::marker::Sync for PrintCustomItemDetails {}
 #[doc = "*Required features: `\"Graphics_Printing_OptionDetails\"`*"]
@@ -2370,36 +2051,7 @@ unsafe impl ::windows::core::Interface for PrintCustomItemListOptionDetails {
 impl ::windows::core::RuntimeName for PrintCustomItemListOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintCustomItemListOptionDetails";
 }
-impl ::core::convert::From<PrintCustomItemListOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintCustomItemListOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCustomItemListOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintCustomItemListOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCustomItemListOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintCustomItemListOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintCustomItemListOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintCustomItemListOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCustomItemListOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintCustomItemListOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCustomItemListOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintCustomItemListOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintCustomItemListOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintCustomItemListOptionDetails> for IPrintCustomOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintCustomItemListOptionDetails) -> ::windows::core::Result<Self> {
@@ -2593,36 +2245,7 @@ unsafe impl ::windows::core::Interface for PrintCustomTextOptionDetails {
 impl ::windows::core::RuntimeName for PrintCustomTextOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintCustomTextOptionDetails";
 }
-impl ::core::convert::From<PrintCustomTextOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintCustomTextOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCustomTextOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintCustomTextOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCustomTextOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintCustomTextOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintCustomTextOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintCustomTextOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCustomTextOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintCustomTextOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCustomTextOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintCustomTextOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintCustomTextOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintCustomTextOptionDetails> for IPrintCustomOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintCustomTextOptionDetails) -> ::windows::core::Result<Self> {
@@ -2786,36 +2409,7 @@ unsafe impl ::windows::core::Interface for PrintCustomToggleOptionDetails {
 impl ::windows::core::RuntimeName for PrintCustomToggleOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintCustomToggleOptionDetails";
 }
-impl ::core::convert::From<PrintCustomToggleOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintCustomToggleOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCustomToggleOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintCustomToggleOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCustomToggleOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintCustomToggleOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintCustomToggleOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintCustomToggleOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintCustomToggleOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintCustomToggleOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintCustomToggleOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintCustomToggleOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintCustomToggleOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintCustomToggleOptionDetails> for IPrintCustomOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintCustomToggleOptionDetails) -> ::windows::core::Result<Self> {
@@ -2977,36 +2571,7 @@ unsafe impl ::windows::core::Interface for PrintDuplexOptionDetails {
 impl ::windows::core::RuntimeName for PrintDuplexOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintDuplexOptionDetails";
 }
-impl ::core::convert::From<PrintDuplexOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintDuplexOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintDuplexOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintDuplexOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintDuplexOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintDuplexOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintDuplexOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintDuplexOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintDuplexOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintDuplexOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintDuplexOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintDuplexOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintDuplexOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintDuplexOptionDetails> for IPrintItemListOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintDuplexOptionDetails) -> ::windows::core::Result<Self> {
@@ -3168,36 +2733,7 @@ unsafe impl ::windows::core::Interface for PrintHolePunchOptionDetails {
 impl ::windows::core::RuntimeName for PrintHolePunchOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintHolePunchOptionDetails";
 }
-impl ::core::convert::From<PrintHolePunchOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintHolePunchOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintHolePunchOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintHolePunchOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintHolePunchOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintHolePunchOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintHolePunchOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintHolePunchOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintHolePunchOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintHolePunchOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintHolePunchOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintHolePunchOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintHolePunchOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintHolePunchOptionDetails> for IPrintItemListOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintHolePunchOptionDetails) -> ::windows::core::Result<Self> {
@@ -3359,36 +2895,7 @@ unsafe impl ::windows::core::Interface for PrintMediaSizeOptionDetails {
 impl ::windows::core::RuntimeName for PrintMediaSizeOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintMediaSizeOptionDetails";
 }
-impl ::core::convert::From<PrintMediaSizeOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintMediaSizeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintMediaSizeOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintMediaSizeOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintMediaSizeOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintMediaSizeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintMediaSizeOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintMediaSizeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintMediaSizeOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintMediaSizeOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintMediaSizeOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintMediaSizeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintMediaSizeOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintMediaSizeOptionDetails> for IPrintItemListOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintMediaSizeOptionDetails) -> ::windows::core::Result<Self> {
@@ -3550,36 +3057,7 @@ unsafe impl ::windows::core::Interface for PrintMediaTypeOptionDetails {
 impl ::windows::core::RuntimeName for PrintMediaTypeOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintMediaTypeOptionDetails";
 }
-impl ::core::convert::From<PrintMediaTypeOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintMediaTypeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintMediaTypeOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintMediaTypeOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintMediaTypeOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintMediaTypeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintMediaTypeOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintMediaTypeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintMediaTypeOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintMediaTypeOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintMediaTypeOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintMediaTypeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintMediaTypeOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintMediaTypeOptionDetails> for IPrintItemListOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintMediaTypeOptionDetails) -> ::windows::core::Result<Self> {
@@ -3741,36 +3219,7 @@ unsafe impl ::windows::core::Interface for PrintOrientationOptionDetails {
 impl ::windows::core::RuntimeName for PrintOrientationOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintOrientationOptionDetails";
 }
-impl ::core::convert::From<PrintOrientationOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintOrientationOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintOrientationOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintOrientationOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintOrientationOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintOrientationOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintOrientationOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintOrientationOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintOrientationOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintOrientationOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintOrientationOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintOrientationOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintOrientationOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintOrientationOptionDetails> for IPrintItemListOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintOrientationOptionDetails) -> ::windows::core::Result<Self> {
@@ -3923,36 +3372,7 @@ unsafe impl ::windows::core::Interface for PrintPageRangeOptionDetails {
 impl ::windows::core::RuntimeName for PrintPageRangeOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintPageRangeOptionDetails";
 }
-impl ::core::convert::From<PrintPageRangeOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintPageRangeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintPageRangeOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintPageRangeOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintPageRangeOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintPageRangeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintPageRangeOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintPageRangeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintPageRangeOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintPageRangeOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintPageRangeOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintPageRangeOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintPageRangeOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintPageRangeOptionDetails> for IPrintOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintPageRangeOptionDetails) -> ::windows::core::Result<Self> {
@@ -4095,36 +3515,7 @@ unsafe impl ::windows::core::Interface for PrintQualityOptionDetails {
 impl ::windows::core::RuntimeName for PrintQualityOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintQualityOptionDetails";
 }
-impl ::core::convert::From<PrintQualityOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintQualityOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintQualityOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintQualityOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintQualityOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintQualityOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintQualityOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintQualityOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintQualityOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintQualityOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintQualityOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintQualityOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintQualityOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintQualityOptionDetails> for IPrintItemListOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintQualityOptionDetails) -> ::windows::core::Result<Self> {
@@ -4286,36 +3677,7 @@ unsafe impl ::windows::core::Interface for PrintStapleOptionDetails {
 impl ::windows::core::RuntimeName for PrintStapleOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintStapleOptionDetails";
 }
-impl ::core::convert::From<PrintStapleOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintStapleOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintStapleOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintStapleOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintStapleOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintStapleOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintStapleOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintStapleOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintStapleOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintStapleOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintStapleOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintStapleOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintStapleOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintStapleOptionDetails> for IPrintItemListOptionDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintStapleOptionDetails) -> ::windows::core::Result<Self> {
@@ -4400,36 +3762,7 @@ unsafe impl ::windows::core::Interface for PrintTaskOptionChangedEventArgs {
 impl ::windows::core::RuntimeName for PrintTaskOptionChangedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintTaskOptionChangedEventArgs";
 }
-impl ::core::convert::From<PrintTaskOptionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskOptionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskOptionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskOptionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskOptionChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskOptionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskOptionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskOptionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskOptionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskOptionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskOptionChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskOptionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskOptionChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTaskOptionChangedEventArgs {}
 unsafe impl ::core::marker::Sync for PrintTaskOptionChangedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing_OptionDetails\"`*"]
@@ -4558,36 +3891,7 @@ unsafe impl ::windows::core::Interface for PrintTaskOptionDetails {
 impl ::windows::core::RuntimeName for PrintTaskOptionDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.OptionDetails.PrintTaskOptionDetails";
 }
-impl ::core::convert::From<PrintTaskOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskOptionDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskOptionDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskOptionDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskOptionDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskOptionDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskOptionDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskOptionDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintTaskOptionDetails> for super::IPrintTaskOptionsCore {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintTaskOptionDetails) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Graphics/Printing/PrintSupport/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/PrintSupport/mod.rs
@@ -243,36 +243,7 @@ unsafe impl ::windows::core::Interface for PrintSupportExtensionSession {
 impl ::windows::core::RuntimeName for PrintSupportExtensionSession {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintSupport.PrintSupportExtensionSession";
 }
-impl ::core::convert::From<PrintSupportExtensionSession> for ::windows::core::IUnknown {
-    fn from(value: PrintSupportExtensionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportExtensionSession> for ::windows::core::IUnknown {
-    fn from(value: &PrintSupportExtensionSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportExtensionSession> for &::windows::core::IUnknown {
-    fn from(value: &PrintSupportExtensionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintSupportExtensionSession> for ::windows::core::IInspectable {
-    fn from(value: PrintSupportExtensionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportExtensionSession> for ::windows::core::IInspectable {
-    fn from(value: &PrintSupportExtensionSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportExtensionSession> for &::windows::core::IInspectable {
-    fn from(value: &PrintSupportExtensionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintSupportExtensionSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintSupportExtensionSession {}
 unsafe impl ::core::marker::Sync for PrintSupportExtensionSession {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintSupport\"`*"]
@@ -319,36 +290,7 @@ unsafe impl ::windows::core::Interface for PrintSupportExtensionTriggerDetails {
 impl ::windows::core::RuntimeName for PrintSupportExtensionTriggerDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintSupport.PrintSupportExtensionTriggerDetails";
 }
-impl ::core::convert::From<PrintSupportExtensionTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintSupportExtensionTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportExtensionTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintSupportExtensionTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportExtensionTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintSupportExtensionTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintSupportExtensionTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintSupportExtensionTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportExtensionTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintSupportExtensionTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportExtensionTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintSupportExtensionTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintSupportExtensionTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintSupportExtensionTriggerDetails {}
 unsafe impl ::core::marker::Sync for PrintSupportExtensionTriggerDetails {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintSupport\"`*"]
@@ -412,36 +354,7 @@ unsafe impl ::windows::core::Interface for PrintSupportPrintDeviceCapabilitiesCh
 impl ::windows::core::RuntimeName for PrintSupportPrintDeviceCapabilitiesChangedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintSupport.PrintSupportPrintDeviceCapabilitiesChangedEventArgs";
 }
-impl ::core::convert::From<PrintSupportPrintDeviceCapabilitiesChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintSupportPrintDeviceCapabilitiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportPrintDeviceCapabilitiesChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintSupportPrintDeviceCapabilitiesChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportPrintDeviceCapabilitiesChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintSupportPrintDeviceCapabilitiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintSupportPrintDeviceCapabilitiesChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintSupportPrintDeviceCapabilitiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportPrintDeviceCapabilitiesChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintSupportPrintDeviceCapabilitiesChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportPrintDeviceCapabilitiesChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintSupportPrintDeviceCapabilitiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintSupportPrintDeviceCapabilitiesChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintSupportPrintDeviceCapabilitiesChangedEventArgs {}
 unsafe impl ::core::marker::Sync for PrintSupportPrintDeviceCapabilitiesChangedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintSupport\"`*"]
@@ -503,36 +416,7 @@ unsafe impl ::windows::core::Interface for PrintSupportPrintTicketValidationRequ
 impl ::windows::core::RuntimeName for PrintSupportPrintTicketValidationRequestedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintSupport.PrintSupportPrintTicketValidationRequestedEventArgs";
 }
-impl ::core::convert::From<PrintSupportPrintTicketValidationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintSupportPrintTicketValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportPrintTicketValidationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintSupportPrintTicketValidationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportPrintTicketValidationRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintSupportPrintTicketValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintSupportPrintTicketValidationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintSupportPrintTicketValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportPrintTicketValidationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintSupportPrintTicketValidationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportPrintTicketValidationRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintSupportPrintTicketValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintSupportPrintTicketValidationRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintSupportPrintTicketValidationRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for PrintSupportPrintTicketValidationRequestedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintSupport\"`*"]
@@ -590,36 +474,7 @@ unsafe impl ::windows::core::Interface for PrintSupportSessionInfo {
 impl ::windows::core::RuntimeName for PrintSupportSessionInfo {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintSupport.PrintSupportSessionInfo";
 }
-impl ::core::convert::From<PrintSupportSessionInfo> for ::windows::core::IUnknown {
-    fn from(value: PrintSupportSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportSessionInfo> for ::windows::core::IUnknown {
-    fn from(value: &PrintSupportSessionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportSessionInfo> for &::windows::core::IUnknown {
-    fn from(value: &PrintSupportSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintSupportSessionInfo> for ::windows::core::IInspectable {
-    fn from(value: PrintSupportSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportSessionInfo> for ::windows::core::IInspectable {
-    fn from(value: &PrintSupportSessionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportSessionInfo> for &::windows::core::IInspectable {
-    fn from(value: &PrintSupportSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintSupportSessionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintSupportSessionInfo {}
 unsafe impl ::core::marker::Sync for PrintSupportSessionInfo {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintSupport\"`*"]
@@ -711,36 +566,7 @@ unsafe impl ::windows::core::Interface for PrintSupportSettingsActivatedEventArg
 impl ::windows::core::RuntimeName for PrintSupportSettingsActivatedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintSupport.PrintSupportSettingsActivatedEventArgs";
 }
-impl ::core::convert::From<PrintSupportSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintSupportSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintSupportSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportSettingsActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintSupportSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintSupportSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintSupportSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintSupportSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportSettingsActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintSupportSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintSupportSettingsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<PrintSupportSettingsActivatedEventArgs> for super::super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -860,36 +686,7 @@ unsafe impl ::windows::core::Interface for PrintSupportSettingsUISession {
 impl ::windows::core::RuntimeName for PrintSupportSettingsUISession {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintSupport.PrintSupportSettingsUISession";
 }
-impl ::core::convert::From<PrintSupportSettingsUISession> for ::windows::core::IUnknown {
-    fn from(value: PrintSupportSettingsUISession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportSettingsUISession> for ::windows::core::IUnknown {
-    fn from(value: &PrintSupportSettingsUISession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportSettingsUISession> for &::windows::core::IUnknown {
-    fn from(value: &PrintSupportSettingsUISession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintSupportSettingsUISession> for ::windows::core::IInspectable {
-    fn from(value: PrintSupportSettingsUISession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintSupportSettingsUISession> for ::windows::core::IInspectable {
-    fn from(value: &PrintSupportSettingsUISession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintSupportSettingsUISession> for &::windows::core::IInspectable {
-    fn from(value: &PrintSupportSettingsUISession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintSupportSettingsUISession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintSupportSettingsUISession {}
 unsafe impl ::core::marker::Sync for PrintSupportSettingsUISession {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintSupport\"`*"]

--- a/crates/libs/windows/src/Windows/Graphics/Printing/PrintTicket/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/PrintTicket/mod.rs
@@ -402,36 +402,7 @@ unsafe impl ::windows::core::Interface for PrintTicketCapabilities {
 impl ::windows::core::RuntimeName for PrintTicketCapabilities {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTicket.PrintTicketCapabilities";
 }
-impl ::core::convert::From<PrintTicketCapabilities> for ::windows::core::IUnknown {
-    fn from(value: PrintTicketCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &PrintTicketCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &PrintTicketCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTicketCapabilities> for ::windows::core::IInspectable {
-    fn from(value: PrintTicketCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &PrintTicketCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &PrintTicketCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTicketCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTicketCapabilities {}
 unsafe impl ::core::marker::Sync for PrintTicketCapabilities {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintTicket\"`*"]
@@ -535,36 +506,7 @@ unsafe impl ::windows::core::Interface for PrintTicketFeature {
 impl ::windows::core::RuntimeName for PrintTicketFeature {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTicket.PrintTicketFeature";
 }
-impl ::core::convert::From<PrintTicketFeature> for ::windows::core::IUnknown {
-    fn from(value: PrintTicketFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketFeature> for ::windows::core::IUnknown {
-    fn from(value: &PrintTicketFeature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketFeature> for &::windows::core::IUnknown {
-    fn from(value: &PrintTicketFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTicketFeature> for ::windows::core::IInspectable {
-    fn from(value: PrintTicketFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketFeature> for ::windows::core::IInspectable {
-    fn from(value: &PrintTicketFeature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketFeature> for &::windows::core::IInspectable {
-    fn from(value: &PrintTicketFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTicketFeature, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTicketFeature {}
 unsafe impl ::core::marker::Sync for PrintTicketFeature {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintTicket\"`*"]
@@ -666,36 +608,7 @@ unsafe impl ::windows::core::Interface for PrintTicketOption {
 impl ::windows::core::RuntimeName for PrintTicketOption {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTicket.PrintTicketOption";
 }
-impl ::core::convert::From<PrintTicketOption> for ::windows::core::IUnknown {
-    fn from(value: PrintTicketOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketOption> for ::windows::core::IUnknown {
-    fn from(value: &PrintTicketOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketOption> for &::windows::core::IUnknown {
-    fn from(value: &PrintTicketOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTicketOption> for ::windows::core::IInspectable {
-    fn from(value: PrintTicketOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketOption> for ::windows::core::IInspectable {
-    fn from(value: &PrintTicketOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketOption> for &::windows::core::IInspectable {
-    fn from(value: &PrintTicketOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTicketOption, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTicketOption {}
 unsafe impl ::core::marker::Sync for PrintTicketOption {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintTicket\"`*"]
@@ -786,36 +699,7 @@ unsafe impl ::windows::core::Interface for PrintTicketParameterDefinition {
 impl ::windows::core::RuntimeName for PrintTicketParameterDefinition {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTicket.PrintTicketParameterDefinition";
 }
-impl ::core::convert::From<PrintTicketParameterDefinition> for ::windows::core::IUnknown {
-    fn from(value: PrintTicketParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketParameterDefinition> for ::windows::core::IUnknown {
-    fn from(value: &PrintTicketParameterDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketParameterDefinition> for &::windows::core::IUnknown {
-    fn from(value: &PrintTicketParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTicketParameterDefinition> for ::windows::core::IInspectable {
-    fn from(value: PrintTicketParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketParameterDefinition> for ::windows::core::IInspectable {
-    fn from(value: &PrintTicketParameterDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketParameterDefinition> for &::windows::core::IInspectable {
-    fn from(value: &PrintTicketParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTicketParameterDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTicketParameterDefinition {}
 unsafe impl ::core::marker::Sync for PrintTicketParameterDefinition {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintTicket\"`*"]
@@ -889,36 +773,7 @@ unsafe impl ::windows::core::Interface for PrintTicketParameterInitializer {
 impl ::windows::core::RuntimeName for PrintTicketParameterInitializer {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTicket.PrintTicketParameterInitializer";
 }
-impl ::core::convert::From<PrintTicketParameterInitializer> for ::windows::core::IUnknown {
-    fn from(value: PrintTicketParameterInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketParameterInitializer> for ::windows::core::IUnknown {
-    fn from(value: &PrintTicketParameterInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketParameterInitializer> for &::windows::core::IUnknown {
-    fn from(value: &PrintTicketParameterInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTicketParameterInitializer> for ::windows::core::IInspectable {
-    fn from(value: PrintTicketParameterInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketParameterInitializer> for ::windows::core::IInspectable {
-    fn from(value: &PrintTicketParameterInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketParameterInitializer> for &::windows::core::IInspectable {
-    fn from(value: &PrintTicketParameterInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTicketParameterInitializer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTicketParameterInitializer {}
 unsafe impl ::core::marker::Sync for PrintTicketParameterInitializer {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintTicket\"`*"]
@@ -979,36 +834,7 @@ unsafe impl ::windows::core::Interface for PrintTicketValue {
 impl ::windows::core::RuntimeName for PrintTicketValue {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTicket.PrintTicketValue";
 }
-impl ::core::convert::From<PrintTicketValue> for ::windows::core::IUnknown {
-    fn from(value: PrintTicketValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketValue> for ::windows::core::IUnknown {
-    fn from(value: &PrintTicketValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketValue> for &::windows::core::IUnknown {
-    fn from(value: &PrintTicketValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTicketValue> for ::windows::core::IInspectable {
-    fn from(value: PrintTicketValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTicketValue> for ::windows::core::IInspectable {
-    fn from(value: &PrintTicketValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTicketValue> for &::windows::core::IInspectable {
-    fn from(value: &PrintTicketValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTicketValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTicketValue {}
 unsafe impl ::core::marker::Sync for PrintTicketValue {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintTicket\"`*"]
@@ -1236,36 +1062,7 @@ unsafe impl ::windows::core::Interface for WorkflowPrintTicket {
 impl ::windows::core::RuntimeName for WorkflowPrintTicket {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTicket.WorkflowPrintTicket";
 }
-impl ::core::convert::From<WorkflowPrintTicket> for ::windows::core::IUnknown {
-    fn from(value: WorkflowPrintTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WorkflowPrintTicket> for ::windows::core::IUnknown {
-    fn from(value: &WorkflowPrintTicket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WorkflowPrintTicket> for &::windows::core::IUnknown {
-    fn from(value: &WorkflowPrintTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WorkflowPrintTicket> for ::windows::core::IInspectable {
-    fn from(value: WorkflowPrintTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WorkflowPrintTicket> for ::windows::core::IInspectable {
-    fn from(value: &WorkflowPrintTicket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WorkflowPrintTicket> for &::windows::core::IInspectable {
-    fn from(value: &WorkflowPrintTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WorkflowPrintTicket, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WorkflowPrintTicket {}
 unsafe impl ::core::marker::Sync for WorkflowPrintTicket {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintTicket\"`*"]
@@ -1319,36 +1116,7 @@ unsafe impl ::windows::core::Interface for WorkflowPrintTicketValidationResult {
 impl ::windows::core::RuntimeName for WorkflowPrintTicketValidationResult {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTicket.WorkflowPrintTicketValidationResult";
 }
-impl ::core::convert::From<WorkflowPrintTicketValidationResult> for ::windows::core::IUnknown {
-    fn from(value: WorkflowPrintTicketValidationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WorkflowPrintTicketValidationResult> for ::windows::core::IUnknown {
-    fn from(value: &WorkflowPrintTicketValidationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WorkflowPrintTicketValidationResult> for &::windows::core::IUnknown {
-    fn from(value: &WorkflowPrintTicketValidationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WorkflowPrintTicketValidationResult> for ::windows::core::IInspectable {
-    fn from(value: WorkflowPrintTicketValidationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WorkflowPrintTicketValidationResult> for ::windows::core::IInspectable {
-    fn from(value: &WorkflowPrintTicketValidationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WorkflowPrintTicketValidationResult> for &::windows::core::IInspectable {
-    fn from(value: &WorkflowPrintTicketValidationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WorkflowPrintTicketValidationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WorkflowPrintTicketValidationResult {}
 unsafe impl ::core::marker::Sync for WorkflowPrintTicketValidationResult {}
 #[doc = "*Required features: `\"Graphics_Printing_PrintTicket\"`*"]

--- a/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
@@ -736,36 +736,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowBackgroundSession {
 impl ::windows::core::RuntimeName for PrintWorkflowBackgroundSession {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowBackgroundSession";
 }
-impl ::core::convert::From<PrintWorkflowBackgroundSession> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowBackgroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowBackgroundSession> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowBackgroundSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowBackgroundSession> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowBackgroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowBackgroundSession> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowBackgroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowBackgroundSession> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowBackgroundSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowBackgroundSession> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowBackgroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowBackgroundSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowBackgroundSession {}
 unsafe impl ::core::marker::Sync for PrintWorkflowBackgroundSession {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -834,36 +805,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowBackgroundSetupRequested
 impl ::windows::core::RuntimeName for PrintWorkflowBackgroundSetupRequestedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowBackgroundSetupRequestedEventArgs";
 }
-impl ::core::convert::From<PrintWorkflowBackgroundSetupRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowBackgroundSetupRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowBackgroundSetupRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowBackgroundSetupRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowBackgroundSetupRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowBackgroundSetupRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowBackgroundSetupRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowBackgroundSetupRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowBackgroundSetupRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowBackgroundSetupRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowBackgroundSetupRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowBackgroundSetupRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowBackgroundSetupRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowBackgroundSetupRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for PrintWorkflowBackgroundSetupRequestedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -928,36 +870,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowConfiguration {
 impl ::windows::core::RuntimeName for PrintWorkflowConfiguration {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowConfiguration";
 }
-impl ::core::convert::From<PrintWorkflowConfiguration> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowConfiguration> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowConfiguration {}
 unsafe impl ::core::marker::Sync for PrintWorkflowConfiguration {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -1038,36 +951,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowForegroundSession {
 impl ::windows::core::RuntimeName for PrintWorkflowForegroundSession {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowForegroundSession";
 }
-impl ::core::convert::From<PrintWorkflowForegroundSession> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowForegroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowForegroundSession> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowForegroundSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowForegroundSession> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowForegroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowForegroundSession> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowForegroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowForegroundSession> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowForegroundSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowForegroundSession> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowForegroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowForegroundSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowForegroundSession {}
 unsafe impl ::core::marker::Sync for PrintWorkflowForegroundSession {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -1132,36 +1016,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowForegroundSetupRequested
 impl ::windows::core::RuntimeName for PrintWorkflowForegroundSetupRequestedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowForegroundSetupRequestedEventArgs";
 }
-impl ::core::convert::From<PrintWorkflowForegroundSetupRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowForegroundSetupRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowForegroundSetupRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowForegroundSetupRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowForegroundSetupRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowForegroundSetupRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowForegroundSetupRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowForegroundSetupRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowForegroundSetupRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowForegroundSetupRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowForegroundSetupRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowForegroundSetupRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowForegroundSetupRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowForegroundSetupRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for PrintWorkflowForegroundSetupRequestedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -1244,36 +1099,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowJobActivatedEventArgs {
 impl ::windows::core::RuntimeName for PrintWorkflowJobActivatedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowJobActivatedEventArgs";
 }
-impl ::core::convert::From<PrintWorkflowJobActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowJobActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowJobActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowJobActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowJobActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<PrintWorkflowJobActivatedEventArgs> for super::super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -1398,36 +1224,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowJobBackgroundSession {
 impl ::windows::core::RuntimeName for PrintWorkflowJobBackgroundSession {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowJobBackgroundSession";
 }
-impl ::core::convert::From<PrintWorkflowJobBackgroundSession> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowJobBackgroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobBackgroundSession> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobBackgroundSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobBackgroundSession> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobBackgroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowJobBackgroundSession> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowJobBackgroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobBackgroundSession> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobBackgroundSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobBackgroundSession> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobBackgroundSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowJobBackgroundSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowJobBackgroundSession {}
 unsafe impl ::core::marker::Sync for PrintWorkflowJobBackgroundSession {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -1490,36 +1287,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowJobNotificationEventArgs
 impl ::windows::core::RuntimeName for PrintWorkflowJobNotificationEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowJobNotificationEventArgs";
 }
-impl ::core::convert::From<PrintWorkflowJobNotificationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowJobNotificationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobNotificationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobNotificationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobNotificationEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobNotificationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowJobNotificationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowJobNotificationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobNotificationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobNotificationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobNotificationEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobNotificationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowJobNotificationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowJobNotificationEventArgs {}
 unsafe impl ::core::marker::Sync for PrintWorkflowJobNotificationEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -1588,36 +1356,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowJobStartingEventArgs {
 impl ::windows::core::RuntimeName for PrintWorkflowJobStartingEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowJobStartingEventArgs";
 }
-impl ::core::convert::From<PrintWorkflowJobStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowJobStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobStartingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowJobStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowJobStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobStartingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowJobStartingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowJobStartingEventArgs {}
 unsafe impl ::core::marker::Sync for PrintWorkflowJobStartingEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -1664,36 +1403,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowJobTriggerDetails {
 impl ::windows::core::RuntimeName for PrintWorkflowJobTriggerDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowJobTriggerDetails";
 }
-impl ::core::convert::From<PrintWorkflowJobTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowJobTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowJobTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowJobTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowJobTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowJobTriggerDetails {}
 unsafe impl ::core::marker::Sync for PrintWorkflowJobTriggerDetails {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -1774,36 +1484,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowJobUISession {
 impl ::windows::core::RuntimeName for PrintWorkflowJobUISession {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowJobUISession";
 }
-impl ::core::convert::From<PrintWorkflowJobUISession> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowJobUISession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobUISession> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobUISession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobUISession> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowJobUISession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowJobUISession> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowJobUISession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobUISession> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobUISession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowJobUISession> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowJobUISession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowJobUISession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowJobUISession {}
 unsafe impl ::core::marker::Sync for PrintWorkflowJobUISession {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -1860,36 +1541,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowObjectModelSourceFileCon
 impl ::windows::core::RuntimeName for PrintWorkflowObjectModelSourceFileContent {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowObjectModelSourceFileContent";
 }
-impl ::core::convert::From<PrintWorkflowObjectModelSourceFileContent> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowObjectModelSourceFileContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowObjectModelSourceFileContent> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowObjectModelSourceFileContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowObjectModelSourceFileContent> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowObjectModelSourceFileContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowObjectModelSourceFileContent> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowObjectModelSourceFileContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowObjectModelSourceFileContent> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowObjectModelSourceFileContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowObjectModelSourceFileContent> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowObjectModelSourceFileContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowObjectModelSourceFileContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowObjectModelSourceFileContent {}
 unsafe impl ::core::marker::Sync for PrintWorkflowObjectModelSourceFileContent {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -1928,36 +1580,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowObjectModelTargetPackage
 impl ::windows::core::RuntimeName for PrintWorkflowObjectModelTargetPackage {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowObjectModelTargetPackage";
 }
-impl ::core::convert::From<PrintWorkflowObjectModelTargetPackage> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowObjectModelTargetPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowObjectModelTargetPackage> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowObjectModelTargetPackage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowObjectModelTargetPackage> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowObjectModelTargetPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowObjectModelTargetPackage> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowObjectModelTargetPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowObjectModelTargetPackage> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowObjectModelTargetPackage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowObjectModelTargetPackage> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowObjectModelTargetPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowObjectModelTargetPackage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowObjectModelTargetPackage {}
 unsafe impl ::core::marker::Sync for PrintWorkflowObjectModelTargetPackage {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -2012,36 +1635,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowPdlConverter {
 impl ::windows::core::RuntimeName for PrintWorkflowPdlConverter {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowPdlConverter";
 }
-impl ::core::convert::From<PrintWorkflowPdlConverter> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowPdlConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlConverter> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPdlConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlConverter> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPdlConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowPdlConverter> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowPdlConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlConverter> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPdlConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlConverter> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPdlConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowPdlConverter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowPdlConverter {}
 unsafe impl ::core::marker::Sync for PrintWorkflowPdlConverter {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -2111,36 +1705,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowPdlDataAvailableEventArg
 impl ::windows::core::RuntimeName for PrintWorkflowPdlDataAvailableEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowPdlDataAvailableEventArgs";
 }
-impl ::core::convert::From<PrintWorkflowPdlDataAvailableEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowPdlDataAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlDataAvailableEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPdlDataAvailableEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlDataAvailableEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPdlDataAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowPdlDataAvailableEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowPdlDataAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlDataAvailableEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPdlDataAvailableEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlDataAvailableEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPdlDataAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowPdlDataAvailableEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowPdlDataAvailableEventArgs {}
 unsafe impl ::core::marker::Sync for PrintWorkflowPdlDataAvailableEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -2257,36 +1822,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowPdlModificationRequested
 impl ::windows::core::RuntimeName for PrintWorkflowPdlModificationRequestedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowPdlModificationRequestedEventArgs";
 }
-impl ::core::convert::From<PrintWorkflowPdlModificationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowPdlModificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlModificationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPdlModificationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlModificationRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPdlModificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowPdlModificationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowPdlModificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlModificationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPdlModificationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlModificationRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPdlModificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowPdlModificationRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowPdlModificationRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for PrintWorkflowPdlModificationRequestedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -2351,36 +1887,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowPdlSourceContent {
 impl ::windows::core::RuntimeName for PrintWorkflowPdlSourceContent {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowPdlSourceContent";
 }
-impl ::core::convert::From<PrintWorkflowPdlSourceContent> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowPdlSourceContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlSourceContent> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPdlSourceContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlSourceContent> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPdlSourceContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowPdlSourceContent> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowPdlSourceContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlSourceContent> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPdlSourceContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlSourceContent> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPdlSourceContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowPdlSourceContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowPdlSourceContent {}
 unsafe impl ::core::marker::Sync for PrintWorkflowPdlSourceContent {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -2433,36 +1940,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowPdlTargetStream {
 impl ::windows::core::RuntimeName for PrintWorkflowPdlTargetStream {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowPdlTargetStream";
 }
-impl ::core::convert::From<PrintWorkflowPdlTargetStream> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowPdlTargetStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlTargetStream> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPdlTargetStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlTargetStream> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPdlTargetStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowPdlTargetStream> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowPdlTargetStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlTargetStream> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPdlTargetStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPdlTargetStream> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPdlTargetStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowPdlTargetStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowPdlTargetStream {}
 unsafe impl ::core::marker::Sync for PrintWorkflowPdlTargetStream {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -2586,36 +2064,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowPrinterJob {
 impl ::windows::core::RuntimeName for PrintWorkflowPrinterJob {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowPrinterJob";
 }
-impl ::core::convert::From<PrintWorkflowPrinterJob> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowPrinterJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPrinterJob> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPrinterJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPrinterJob> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowPrinterJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowPrinterJob> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowPrinterJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPrinterJob> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPrinterJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowPrinterJob> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowPrinterJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowPrinterJob, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowPrinterJob {}
 unsafe impl ::core::marker::Sync for PrintWorkflowPrinterJob {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -2678,36 +2127,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowSourceContent {
 impl ::windows::core::RuntimeName for PrintWorkflowSourceContent {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowSourceContent";
 }
-impl ::core::convert::From<PrintWorkflowSourceContent> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowSourceContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSourceContent> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowSourceContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSourceContent> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowSourceContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowSourceContent> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowSourceContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSourceContent> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowSourceContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSourceContent> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowSourceContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowSourceContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowSourceContent {}
 unsafe impl ::core::marker::Sync for PrintWorkflowSourceContent {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -2756,36 +2176,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowSpoolStreamContent {
 impl ::windows::core::RuntimeName for PrintWorkflowSpoolStreamContent {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowSpoolStreamContent";
 }
-impl ::core::convert::From<PrintWorkflowSpoolStreamContent> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowSpoolStreamContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSpoolStreamContent> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowSpoolStreamContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSpoolStreamContent> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowSpoolStreamContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowSpoolStreamContent> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowSpoolStreamContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSpoolStreamContent> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowSpoolStreamContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSpoolStreamContent> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowSpoolStreamContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowSpoolStreamContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowSpoolStreamContent {}
 unsafe impl ::core::marker::Sync for PrintWorkflowSpoolStreamContent {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -2834,36 +2225,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowStreamTarget {
 impl ::windows::core::RuntimeName for PrintWorkflowStreamTarget {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowStreamTarget";
 }
-impl ::core::convert::From<PrintWorkflowStreamTarget> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowStreamTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowStreamTarget> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowStreamTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowStreamTarget> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowStreamTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowStreamTarget> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowStreamTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowStreamTarget> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowStreamTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowStreamTarget> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowStreamTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowStreamTarget, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowStreamTarget {}
 unsafe impl ::core::marker::Sync for PrintWorkflowStreamTarget {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -2928,36 +2290,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowSubmittedEventArgs {
 impl ::windows::core::RuntimeName for PrintWorkflowSubmittedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowSubmittedEventArgs";
 }
-impl ::core::convert::From<PrintWorkflowSubmittedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowSubmittedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSubmittedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowSubmittedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSubmittedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowSubmittedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowSubmittedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowSubmittedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSubmittedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowSubmittedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSubmittedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowSubmittedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowSubmittedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowSubmittedEventArgs {}
 unsafe impl ::core::marker::Sync for PrintWorkflowSubmittedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -3015,36 +2348,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowSubmittedOperation {
 impl ::windows::core::RuntimeName for PrintWorkflowSubmittedOperation {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowSubmittedOperation";
 }
-impl ::core::convert::From<PrintWorkflowSubmittedOperation> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowSubmittedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSubmittedOperation> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowSubmittedOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSubmittedOperation> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowSubmittedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowSubmittedOperation> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowSubmittedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSubmittedOperation> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowSubmittedOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowSubmittedOperation> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowSubmittedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowSubmittedOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowSubmittedOperation {}
 unsafe impl ::core::marker::Sync for PrintWorkflowSubmittedOperation {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -3098,36 +2402,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowTarget {
 impl ::windows::core::RuntimeName for PrintWorkflowTarget {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowTarget";
 }
-impl ::core::convert::From<PrintWorkflowTarget> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowTarget> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowTarget> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowTarget> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowTarget> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowTarget> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowTarget, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowTarget {}
 unsafe impl ::core::marker::Sync for PrintWorkflowTarget {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -3174,36 +2449,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowTriggerDetails {
 impl ::windows::core::RuntimeName for PrintWorkflowTriggerDetails {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowTriggerDetails";
 }
-impl ::core::convert::From<PrintWorkflowTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowTriggerDetails {}
 unsafe impl ::core::marker::Sync for PrintWorkflowTriggerDetails {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -3286,36 +2532,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowUIActivatedEventArgs {
 impl ::windows::core::RuntimeName for PrintWorkflowUIActivatedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowUIActivatedEventArgs";
 }
-impl ::core::convert::From<PrintWorkflowUIActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowUIActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowUIActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowUIActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowUIActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowUIActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowUIActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowUIActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowUIActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowUIActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowUIActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowUIActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowUIActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<PrintWorkflowUIActivatedEventArgs> for super::super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -3415,36 +2632,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowUILauncher {
 impl ::windows::core::RuntimeName for PrintWorkflowUILauncher {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowUILauncher";
 }
-impl ::core::convert::From<PrintWorkflowUILauncher> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowUILauncher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowUILauncher> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowUILauncher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowUILauncher> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowUILauncher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowUILauncher> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowUILauncher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowUILauncher> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowUILauncher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowUILauncher> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowUILauncher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowUILauncher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowUILauncher {}
 unsafe impl ::core::marker::Sync for PrintWorkflowUILauncher {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]
@@ -3500,36 +2688,7 @@ unsafe impl ::windows::core::Interface for PrintWorkflowXpsDataAvailableEventArg
 impl ::windows::core::RuntimeName for PrintWorkflowXpsDataAvailableEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.Workflow.PrintWorkflowXpsDataAvailableEventArgs";
 }
-impl ::core::convert::From<PrintWorkflowXpsDataAvailableEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintWorkflowXpsDataAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowXpsDataAvailableEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowXpsDataAvailableEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowXpsDataAvailableEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintWorkflowXpsDataAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintWorkflowXpsDataAvailableEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintWorkflowXpsDataAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintWorkflowXpsDataAvailableEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowXpsDataAvailableEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintWorkflowXpsDataAvailableEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintWorkflowXpsDataAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintWorkflowXpsDataAvailableEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintWorkflowXpsDataAvailableEventArgs {}
 unsafe impl ::core::marker::Sync for PrintWorkflowXpsDataAvailableEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing_Workflow\"`*"]

--- a/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
@@ -10,36 +10,7 @@ pub mod Workflow;
 #[repr(transparent)]
 pub struct IPrintDocumentSource(::windows::core::IUnknown);
 impl IPrintDocumentSource {}
-impl ::core::convert::From<IPrintDocumentSource> for ::windows::core::IUnknown {
-    fn from(value: IPrintDocumentSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintDocumentSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintDocumentSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintDocumentSource> for ::windows::core::IUnknown {
-    fn from(value: &IPrintDocumentSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintDocumentSource> for ::windows::core::IInspectable {
-    fn from(value: IPrintDocumentSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintDocumentSource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrintDocumentSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintDocumentSource> for ::windows::core::IInspectable {
-    fn from(value: &IPrintDocumentSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintDocumentSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPrintDocumentSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -348,36 +319,7 @@ impl IPrintTaskOptionsCore {
         }
     }
 }
-impl ::core::convert::From<IPrintTaskOptionsCore> for ::windows::core::IUnknown {
-    fn from(value: IPrintTaskOptionsCore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTaskOptionsCore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintTaskOptionsCore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTaskOptionsCore> for ::windows::core::IUnknown {
-    fn from(value: &IPrintTaskOptionsCore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintTaskOptionsCore> for ::windows::core::IInspectable {
-    fn from(value: IPrintTaskOptionsCore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTaskOptionsCore> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrintTaskOptionsCore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTaskOptionsCore> for ::windows::core::IInspectable {
-    fn from(value: &IPrintTaskOptionsCore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintTaskOptionsCore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPrintTaskOptionsCore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -556,36 +498,7 @@ impl IPrintTaskOptionsCoreProperties {
         }
     }
 }
-impl ::core::convert::From<IPrintTaskOptionsCoreProperties> for ::windows::core::IUnknown {
-    fn from(value: IPrintTaskOptionsCoreProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTaskOptionsCoreProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintTaskOptionsCoreProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTaskOptionsCoreProperties> for ::windows::core::IUnknown {
-    fn from(value: &IPrintTaskOptionsCoreProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintTaskOptionsCoreProperties> for ::windows::core::IInspectable {
-    fn from(value: IPrintTaskOptionsCoreProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTaskOptionsCoreProperties> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrintTaskOptionsCoreProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTaskOptionsCoreProperties> for ::windows::core::IInspectable {
-    fn from(value: &IPrintTaskOptionsCoreProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintTaskOptionsCoreProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPrintTaskOptionsCoreProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -658,36 +571,7 @@ impl IPrintTaskOptionsCoreUIConfiguration {
         }
     }
 }
-impl ::core::convert::From<IPrintTaskOptionsCoreUIConfiguration> for ::windows::core::IUnknown {
-    fn from(value: IPrintTaskOptionsCoreUIConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTaskOptionsCoreUIConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintTaskOptionsCoreUIConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTaskOptionsCoreUIConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &IPrintTaskOptionsCoreUIConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintTaskOptionsCoreUIConfiguration> for ::windows::core::IInspectable {
-    fn from(value: IPrintTaskOptionsCoreUIConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTaskOptionsCoreUIConfiguration> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrintTaskOptionsCoreUIConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTaskOptionsCoreUIConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &IPrintTaskOptionsCoreUIConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintTaskOptionsCoreUIConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPrintTaskOptionsCoreUIConfiguration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -983,36 +867,7 @@ unsafe impl ::windows::core::Interface for PrintManager {
 impl ::windows::core::RuntimeName for PrintManager {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintManager";
 }
-impl ::core::convert::From<PrintManager> for ::windows::core::IUnknown {
-    fn from(value: PrintManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintManager> for ::windows::core::IUnknown {
-    fn from(value: &PrintManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintManager> for &::windows::core::IUnknown {
-    fn from(value: &PrintManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintManager> for ::windows::core::IInspectable {
-    fn from(value: PrintManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintManager> for ::windows::core::IInspectable {
-    fn from(value: &PrintManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintManager> for &::windows::core::IInspectable {
-    fn from(value: &PrintManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintManager {}
 unsafe impl ::core::marker::Sync for PrintManager {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]
@@ -1118,36 +973,7 @@ unsafe impl ::windows::core::Interface for PrintPageInfo {
 impl ::windows::core::RuntimeName for PrintPageInfo {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintPageInfo";
 }
-impl ::core::convert::From<PrintPageInfo> for ::windows::core::IUnknown {
-    fn from(value: PrintPageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintPageInfo> for ::windows::core::IUnknown {
-    fn from(value: &PrintPageInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintPageInfo> for &::windows::core::IUnknown {
-    fn from(value: &PrintPageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintPageInfo> for ::windows::core::IInspectable {
-    fn from(value: PrintPageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintPageInfo> for ::windows::core::IInspectable {
-    fn from(value: &PrintPageInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintPageInfo> for &::windows::core::IInspectable {
-    fn from(value: &PrintPageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintPageInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintPageInfo {}
 unsafe impl ::core::marker::Sync for PrintPageInfo {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]
@@ -1218,36 +1044,7 @@ unsafe impl ::windows::core::Interface for PrintPageRange {
 impl ::windows::core::RuntimeName for PrintPageRange {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintPageRange";
 }
-impl ::core::convert::From<PrintPageRange> for ::windows::core::IUnknown {
-    fn from(value: PrintPageRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintPageRange> for ::windows::core::IUnknown {
-    fn from(value: &PrintPageRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintPageRange> for &::windows::core::IUnknown {
-    fn from(value: &PrintPageRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintPageRange> for ::windows::core::IInspectable {
-    fn from(value: PrintPageRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintPageRange> for ::windows::core::IInspectable {
-    fn from(value: &PrintPageRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintPageRange> for &::windows::core::IInspectable {
-    fn from(value: &PrintPageRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintPageRange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintPageRange {}
 unsafe impl ::core::marker::Sync for PrintPageRange {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]
@@ -1320,36 +1117,7 @@ unsafe impl ::windows::core::Interface for PrintPageRangeOptions {
 impl ::windows::core::RuntimeName for PrintPageRangeOptions {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintPageRangeOptions";
 }
-impl ::core::convert::From<PrintPageRangeOptions> for ::windows::core::IUnknown {
-    fn from(value: PrintPageRangeOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintPageRangeOptions> for ::windows::core::IUnknown {
-    fn from(value: &PrintPageRangeOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintPageRangeOptions> for &::windows::core::IUnknown {
-    fn from(value: &PrintPageRangeOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintPageRangeOptions> for ::windows::core::IInspectable {
-    fn from(value: PrintPageRangeOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintPageRangeOptions> for ::windows::core::IInspectable {
-    fn from(value: &PrintPageRangeOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintPageRangeOptions> for &::windows::core::IInspectable {
-    fn from(value: &PrintPageRangeOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintPageRangeOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintPageRangeOptions {}
 unsafe impl ::core::marker::Sync for PrintPageRangeOptions {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]
@@ -1505,36 +1273,7 @@ unsafe impl ::windows::core::Interface for PrintTask {
 impl ::windows::core::RuntimeName for PrintTask {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTask";
 }
-impl ::core::convert::From<PrintTask> for ::windows::core::IUnknown {
-    fn from(value: PrintTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTask> for ::windows::core::IUnknown {
-    fn from(value: &PrintTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTask> for &::windows::core::IUnknown {
-    fn from(value: &PrintTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTask> for ::windows::core::IInspectable {
-    fn from(value: PrintTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTask> for ::windows::core::IInspectable {
-    fn from(value: &PrintTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTask> for &::windows::core::IInspectable {
-    fn from(value: &PrintTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTask, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTask {}
 unsafe impl ::core::marker::Sync for PrintTask {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]
@@ -1581,36 +1320,7 @@ unsafe impl ::windows::core::Interface for PrintTaskCompletedEventArgs {
 impl ::windows::core::RuntimeName for PrintTaskCompletedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTaskCompletedEventArgs";
 }
-impl ::core::convert::From<PrintTaskCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTaskCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for PrintTaskCompletedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]
@@ -1839,36 +1549,7 @@ unsafe impl ::windows::core::Interface for PrintTaskOptions {
 impl ::windows::core::RuntimeName for PrintTaskOptions {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTaskOptions";
 }
-impl ::core::convert::From<PrintTaskOptions> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskOptions> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskOptions> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskOptions> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskOptions> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskOptions> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PrintTaskOptions> for IPrintTaskOptionsCore {
     type Error = ::windows::core::Error;
     fn try_from(value: PrintTaskOptions) -> ::windows::core::Result<Self> {
@@ -1972,36 +1653,7 @@ unsafe impl ::windows::core::Interface for PrintTaskProgressingEventArgs {
 impl ::windows::core::RuntimeName for PrintTaskProgressingEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTaskProgressingEventArgs";
 }
-impl ::core::convert::From<PrintTaskProgressingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskProgressingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskProgressingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskProgressingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskProgressingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskProgressingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskProgressingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskProgressingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskProgressingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskProgressingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskProgressingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskProgressingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskProgressingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTaskProgressingEventArgs {}
 unsafe impl ::core::marker::Sync for PrintTaskProgressingEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]
@@ -2064,36 +1716,7 @@ unsafe impl ::windows::core::Interface for PrintTaskRequest {
 impl ::windows::core::RuntimeName for PrintTaskRequest {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTaskRequest";
 }
-impl ::core::convert::From<PrintTaskRequest> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskRequest> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskRequest> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskRequest> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskRequest> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskRequest> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTaskRequest {}
 unsafe impl ::core::marker::Sync for PrintTaskRequest {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]
@@ -2137,36 +1760,7 @@ unsafe impl ::windows::core::Interface for PrintTaskRequestedDeferral {
 impl ::windows::core::RuntimeName for PrintTaskRequestedDeferral {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTaskRequestedDeferral";
 }
-impl ::core::convert::From<PrintTaskRequestedDeferral> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskRequestedDeferral> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskRequestedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskRequestedDeferral> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskRequestedDeferral> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskRequestedDeferral> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskRequestedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskRequestedDeferral> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskRequestedDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTaskRequestedDeferral {}
 unsafe impl ::core::marker::Sync for PrintTaskRequestedDeferral {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]
@@ -2213,36 +1807,7 @@ unsafe impl ::windows::core::Interface for PrintTaskRequestedEventArgs {
 impl ::windows::core::RuntimeName for PrintTaskRequestedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTaskRequestedEventArgs";
 }
-impl ::core::convert::From<PrintTaskRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTaskRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for PrintTaskRequestedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]
@@ -2306,36 +1871,7 @@ unsafe impl ::windows::core::Interface for PrintTaskSourceRequestedArgs {
 impl ::windows::core::RuntimeName for PrintTaskSourceRequestedArgs {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTaskSourceRequestedArgs";
 }
-impl ::core::convert::From<PrintTaskSourceRequestedArgs> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskSourceRequestedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskSourceRequestedArgs> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskSourceRequestedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskSourceRequestedArgs> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskSourceRequestedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskSourceRequestedArgs> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskSourceRequestedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskSourceRequestedArgs> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskSourceRequestedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskSourceRequestedArgs> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskSourceRequestedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskSourceRequestedArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTaskSourceRequestedArgs {}
 unsafe impl ::core::marker::Sync for PrintTaskSourceRequestedArgs {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]
@@ -2379,36 +1915,7 @@ unsafe impl ::windows::core::Interface for PrintTaskSourceRequestedDeferral {
 impl ::windows::core::RuntimeName for PrintTaskSourceRequestedDeferral {
     const NAME: &'static str = "Windows.Graphics.Printing.PrintTaskSourceRequestedDeferral";
 }
-impl ::core::convert::From<PrintTaskSourceRequestedDeferral> for ::windows::core::IUnknown {
-    fn from(value: PrintTaskSourceRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskSourceRequestedDeferral> for ::windows::core::IUnknown {
-    fn from(value: &PrintTaskSourceRequestedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskSourceRequestedDeferral> for &::windows::core::IUnknown {
-    fn from(value: &PrintTaskSourceRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrintTaskSourceRequestedDeferral> for ::windows::core::IInspectable {
-    fn from(value: PrintTaskSourceRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrintTaskSourceRequestedDeferral> for ::windows::core::IInspectable {
-    fn from(value: &PrintTaskSourceRequestedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrintTaskSourceRequestedDeferral> for &::windows::core::IInspectable {
-    fn from(value: &PrintTaskSourceRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrintTaskSourceRequestedDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrintTaskSourceRequestedDeferral {}
 unsafe impl ::core::marker::Sync for PrintTaskSourceRequestedDeferral {}
 #[doc = "*Required features: `\"Graphics_Printing\"`*"]

--- a/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
@@ -961,36 +961,7 @@ unsafe impl ::windows::core::Interface for Print3DManager {
 impl ::windows::core::RuntimeName for Print3DManager {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Print3DManager";
 }
-impl ::core::convert::From<Print3DManager> for ::windows::core::IUnknown {
-    fn from(value: Print3DManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DManager> for ::windows::core::IUnknown {
-    fn from(value: &Print3DManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DManager> for &::windows::core::IUnknown {
-    fn from(value: &Print3DManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DManager> for ::windows::core::IInspectable {
-    fn from(value: Print3DManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DManager> for ::windows::core::IInspectable {
-    fn from(value: &Print3DManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DManager> for &::windows::core::IInspectable {
-    fn from(value: &Print3DManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Print3DManager {}
 unsafe impl ::core::marker::Sync for Print3DManager {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -1082,36 +1053,7 @@ unsafe impl ::windows::core::Interface for Print3DTask {
 impl ::windows::core::RuntimeName for Print3DTask {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Print3DTask";
 }
-impl ::core::convert::From<Print3DTask> for ::windows::core::IUnknown {
-    fn from(value: Print3DTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTask> for ::windows::core::IUnknown {
-    fn from(value: &Print3DTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTask> for &::windows::core::IUnknown {
-    fn from(value: &Print3DTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DTask> for ::windows::core::IInspectable {
-    fn from(value: Print3DTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTask> for ::windows::core::IInspectable {
-    fn from(value: &Print3DTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTask> for &::windows::core::IInspectable {
-    fn from(value: &Print3DTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DTask, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Print3DTask {}
 unsafe impl ::core::marker::Sync for Print3DTask {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -1165,36 +1107,7 @@ unsafe impl ::windows::core::Interface for Print3DTaskCompletedEventArgs {
 impl ::windows::core::RuntimeName for Print3DTaskCompletedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Print3DTaskCompletedEventArgs";
 }
-impl ::core::convert::From<Print3DTaskCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: Print3DTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTaskCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &Print3DTaskCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTaskCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &Print3DTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DTaskCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: Print3DTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTaskCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &Print3DTaskCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTaskCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &Print3DTaskCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DTaskCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Print3DTaskCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for Print3DTaskCompletedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -1241,36 +1154,7 @@ unsafe impl ::windows::core::Interface for Print3DTaskRequest {
 impl ::windows::core::RuntimeName for Print3DTaskRequest {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Print3DTaskRequest";
 }
-impl ::core::convert::From<Print3DTaskRequest> for ::windows::core::IUnknown {
-    fn from(value: Print3DTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTaskRequest> for ::windows::core::IUnknown {
-    fn from(value: &Print3DTaskRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTaskRequest> for &::windows::core::IUnknown {
-    fn from(value: &Print3DTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DTaskRequest> for ::windows::core::IInspectable {
-    fn from(value: Print3DTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTaskRequest> for ::windows::core::IInspectable {
-    fn from(value: &Print3DTaskRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTaskRequest> for &::windows::core::IInspectable {
-    fn from(value: &Print3DTaskRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DTaskRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Print3DTaskRequest {}
 unsafe impl ::core::marker::Sync for Print3DTaskRequest {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -1317,36 +1201,7 @@ unsafe impl ::windows::core::Interface for Print3DTaskRequestedEventArgs {
 impl ::windows::core::RuntimeName for Print3DTaskRequestedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Print3DTaskRequestedEventArgs";
 }
-impl ::core::convert::From<Print3DTaskRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: Print3DTaskRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTaskRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &Print3DTaskRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTaskRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &Print3DTaskRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DTaskRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: Print3DTaskRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTaskRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &Print3DTaskRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTaskRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &Print3DTaskRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DTaskRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Print3DTaskRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for Print3DTaskRequestedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -1393,36 +1248,7 @@ unsafe impl ::windows::core::Interface for Print3DTaskSourceChangedEventArgs {
 impl ::windows::core::RuntimeName for Print3DTaskSourceChangedEventArgs {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Print3DTaskSourceChangedEventArgs";
 }
-impl ::core::convert::From<Print3DTaskSourceChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: Print3DTaskSourceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTaskSourceChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &Print3DTaskSourceChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTaskSourceChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &Print3DTaskSourceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DTaskSourceChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: Print3DTaskSourceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTaskSourceChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &Print3DTaskSourceChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTaskSourceChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &Print3DTaskSourceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DTaskSourceChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Print3DTaskSourceChangedEventArgs {}
 unsafe impl ::core::marker::Sync for Print3DTaskSourceChangedEventArgs {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -1466,36 +1292,7 @@ unsafe impl ::windows::core::Interface for Print3DTaskSourceRequestedArgs {
 impl ::windows::core::RuntimeName for Print3DTaskSourceRequestedArgs {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Print3DTaskSourceRequestedArgs";
 }
-impl ::core::convert::From<Print3DTaskSourceRequestedArgs> for ::windows::core::IUnknown {
-    fn from(value: Print3DTaskSourceRequestedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTaskSourceRequestedArgs> for ::windows::core::IUnknown {
-    fn from(value: &Print3DTaskSourceRequestedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTaskSourceRequestedArgs> for &::windows::core::IUnknown {
-    fn from(value: &Print3DTaskSourceRequestedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Print3DTaskSourceRequestedArgs> for ::windows::core::IInspectable {
-    fn from(value: Print3DTaskSourceRequestedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Print3DTaskSourceRequestedArgs> for ::windows::core::IInspectable {
-    fn from(value: &Print3DTaskSourceRequestedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Print3DTaskSourceRequestedArgs> for &::windows::core::IInspectable {
-    fn from(value: &Print3DTaskSourceRequestedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Print3DTaskSourceRequestedArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Print3DTaskSourceRequestedArgs {}
 unsafe impl ::core::marker::Sync for Print3DTaskSourceRequestedArgs {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -1659,36 +1456,7 @@ unsafe impl ::windows::core::Interface for Printing3D3MFPackage {
 impl ::windows::core::RuntimeName for Printing3D3MFPackage {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3D3MFPackage";
 }
-impl ::core::convert::From<Printing3D3MFPackage> for ::windows::core::IUnknown {
-    fn from(value: Printing3D3MFPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3D3MFPackage> for ::windows::core::IUnknown {
-    fn from(value: &Printing3D3MFPackage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3D3MFPackage> for &::windows::core::IUnknown {
-    fn from(value: &Printing3D3MFPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3D3MFPackage> for ::windows::core::IInspectable {
-    fn from(value: Printing3D3MFPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3D3MFPackage> for ::windows::core::IInspectable {
-    fn from(value: &Printing3D3MFPackage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3D3MFPackage> for &::windows::core::IInspectable {
-    fn from(value: &Printing3D3MFPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3D3MFPackage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3D3MFPackage {}
 unsafe impl ::core::marker::Sync for Printing3D3MFPackage {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -1774,36 +1542,7 @@ unsafe impl ::windows::core::Interface for Printing3DBaseMaterial {
 impl ::windows::core::RuntimeName for Printing3DBaseMaterial {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DBaseMaterial";
 }
-impl ::core::convert::From<Printing3DBaseMaterial> for ::windows::core::IUnknown {
-    fn from(value: Printing3DBaseMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DBaseMaterial> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DBaseMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DBaseMaterial> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DBaseMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DBaseMaterial> for ::windows::core::IInspectable {
-    fn from(value: Printing3DBaseMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DBaseMaterial> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DBaseMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DBaseMaterial> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DBaseMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DBaseMaterial, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DBaseMaterial {}
 unsafe impl ::core::marker::Sync for Printing3DBaseMaterial {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -1870,36 +1609,7 @@ unsafe impl ::windows::core::Interface for Printing3DBaseMaterialGroup {
 impl ::windows::core::RuntimeName for Printing3DBaseMaterialGroup {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DBaseMaterialGroup";
 }
-impl ::core::convert::From<Printing3DBaseMaterialGroup> for ::windows::core::IUnknown {
-    fn from(value: Printing3DBaseMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DBaseMaterialGroup> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DBaseMaterialGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DBaseMaterialGroup> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DBaseMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DBaseMaterialGroup> for ::windows::core::IInspectable {
-    fn from(value: Printing3DBaseMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DBaseMaterialGroup> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DBaseMaterialGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DBaseMaterialGroup> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DBaseMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DBaseMaterialGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DBaseMaterialGroup {}
 unsafe impl ::core::marker::Sync for Printing3DBaseMaterialGroup {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -1972,36 +1682,7 @@ unsafe impl ::windows::core::Interface for Printing3DColorMaterial {
 impl ::windows::core::RuntimeName for Printing3DColorMaterial {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DColorMaterial";
 }
-impl ::core::convert::From<Printing3DColorMaterial> for ::windows::core::IUnknown {
-    fn from(value: Printing3DColorMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DColorMaterial> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DColorMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DColorMaterial> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DColorMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DColorMaterial> for ::windows::core::IInspectable {
-    fn from(value: Printing3DColorMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DColorMaterial> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DColorMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DColorMaterial> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DColorMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DColorMaterial, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DColorMaterial {}
 unsafe impl ::core::marker::Sync for Printing3DColorMaterial {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -2068,36 +1749,7 @@ unsafe impl ::windows::core::Interface for Printing3DColorMaterialGroup {
 impl ::windows::core::RuntimeName for Printing3DColorMaterialGroup {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DColorMaterialGroup";
 }
-impl ::core::convert::From<Printing3DColorMaterialGroup> for ::windows::core::IUnknown {
-    fn from(value: Printing3DColorMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DColorMaterialGroup> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DColorMaterialGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DColorMaterialGroup> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DColorMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DColorMaterialGroup> for ::windows::core::IInspectable {
-    fn from(value: Printing3DColorMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DColorMaterialGroup> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DColorMaterialGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DColorMaterialGroup> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DColorMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DColorMaterialGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DColorMaterialGroup {}
 unsafe impl ::core::marker::Sync for Printing3DColorMaterialGroup {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -2208,36 +1860,7 @@ unsafe impl ::windows::core::Interface for Printing3DComponent {
 impl ::windows::core::RuntimeName for Printing3DComponent {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DComponent";
 }
-impl ::core::convert::From<Printing3DComponent> for ::windows::core::IUnknown {
-    fn from(value: Printing3DComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DComponent> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DComponent> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DComponent> for ::windows::core::IInspectable {
-    fn from(value: Printing3DComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DComponent> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DComponent> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DComponent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DComponent {}
 unsafe impl ::core::marker::Sync for Printing3DComponent {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -2310,36 +1933,7 @@ unsafe impl ::windows::core::Interface for Printing3DComponentWithMatrix {
 impl ::windows::core::RuntimeName for Printing3DComponentWithMatrix {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DComponentWithMatrix";
 }
-impl ::core::convert::From<Printing3DComponentWithMatrix> for ::windows::core::IUnknown {
-    fn from(value: Printing3DComponentWithMatrix) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DComponentWithMatrix> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DComponentWithMatrix) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DComponentWithMatrix> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DComponentWithMatrix) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DComponentWithMatrix> for ::windows::core::IInspectable {
-    fn from(value: Printing3DComponentWithMatrix) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DComponentWithMatrix> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DComponentWithMatrix) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DComponentWithMatrix> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DComponentWithMatrix) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DComponentWithMatrix, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DComponentWithMatrix {}
 unsafe impl ::core::marker::Sync for Printing3DComponentWithMatrix {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -2395,36 +1989,7 @@ unsafe impl ::windows::core::Interface for Printing3DCompositeMaterial {
 impl ::windows::core::RuntimeName for Printing3DCompositeMaterial {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DCompositeMaterial";
 }
-impl ::core::convert::From<Printing3DCompositeMaterial> for ::windows::core::IUnknown {
-    fn from(value: Printing3DCompositeMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DCompositeMaterial> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DCompositeMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DCompositeMaterial> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DCompositeMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DCompositeMaterial> for ::windows::core::IInspectable {
-    fn from(value: Printing3DCompositeMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DCompositeMaterial> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DCompositeMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DCompositeMaterial> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DCompositeMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DCompositeMaterial, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DCompositeMaterial {}
 unsafe impl ::core::marker::Sync for Printing3DCompositeMaterial {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -2511,36 +2076,7 @@ unsafe impl ::windows::core::Interface for Printing3DCompositeMaterialGroup {
 impl ::windows::core::RuntimeName for Printing3DCompositeMaterialGroup {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DCompositeMaterialGroup";
 }
-impl ::core::convert::From<Printing3DCompositeMaterialGroup> for ::windows::core::IUnknown {
-    fn from(value: Printing3DCompositeMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DCompositeMaterialGroup> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DCompositeMaterialGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DCompositeMaterialGroup> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DCompositeMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DCompositeMaterialGroup> for ::windows::core::IInspectable {
-    fn from(value: Printing3DCompositeMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DCompositeMaterialGroup> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DCompositeMaterialGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DCompositeMaterialGroup> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DCompositeMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DCompositeMaterialGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DCompositeMaterialGroup {}
 unsafe impl ::core::marker::Sync for Printing3DCompositeMaterialGroup {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -2620,36 +2156,7 @@ unsafe impl ::windows::core::Interface for Printing3DFaceReductionOptions {
 impl ::windows::core::RuntimeName for Printing3DFaceReductionOptions {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DFaceReductionOptions";
 }
-impl ::core::convert::From<Printing3DFaceReductionOptions> for ::windows::core::IUnknown {
-    fn from(value: Printing3DFaceReductionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DFaceReductionOptions> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DFaceReductionOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DFaceReductionOptions> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DFaceReductionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DFaceReductionOptions> for ::windows::core::IInspectable {
-    fn from(value: Printing3DFaceReductionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DFaceReductionOptions> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DFaceReductionOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DFaceReductionOptions> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DFaceReductionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DFaceReductionOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DFaceReductionOptions {}
 unsafe impl ::core::marker::Sync for Printing3DFaceReductionOptions {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -2741,36 +2248,7 @@ unsafe impl ::windows::core::Interface for Printing3DMaterial {
 impl ::windows::core::RuntimeName for Printing3DMaterial {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DMaterial";
 }
-impl ::core::convert::From<Printing3DMaterial> for ::windows::core::IUnknown {
-    fn from(value: Printing3DMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DMaterial> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DMaterial> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DMaterial> for ::windows::core::IInspectable {
-    fn from(value: Printing3DMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DMaterial> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DMaterial> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DMaterial, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DMaterial {}
 unsafe impl ::core::marker::Sync for Printing3DMaterial {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -2962,36 +2440,7 @@ unsafe impl ::windows::core::Interface for Printing3DMesh {
 impl ::windows::core::RuntimeName for Printing3DMesh {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DMesh";
 }
-impl ::core::convert::From<Printing3DMesh> for ::windows::core::IUnknown {
-    fn from(value: Printing3DMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DMesh> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DMesh) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DMesh> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DMesh> for ::windows::core::IInspectable {
-    fn from(value: Printing3DMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DMesh> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DMesh) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DMesh> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DMesh, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DMesh {}
 unsafe impl ::core::marker::Sync for Printing3DMesh {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -3056,36 +2505,7 @@ unsafe impl ::windows::core::Interface for Printing3DMeshVerificationResult {
 impl ::windows::core::RuntimeName for Printing3DMeshVerificationResult {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DMeshVerificationResult";
 }
-impl ::core::convert::From<Printing3DMeshVerificationResult> for ::windows::core::IUnknown {
-    fn from(value: Printing3DMeshVerificationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DMeshVerificationResult> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DMeshVerificationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DMeshVerificationResult> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DMeshVerificationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DMeshVerificationResult> for ::windows::core::IInspectable {
-    fn from(value: Printing3DMeshVerificationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DMeshVerificationResult> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DMeshVerificationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DMeshVerificationResult> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DMeshVerificationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DMeshVerificationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DMeshVerificationResult {}
 unsafe impl ::core::marker::Sync for Printing3DMeshVerificationResult {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -3291,36 +2711,7 @@ unsafe impl ::windows::core::Interface for Printing3DModel {
 impl ::windows::core::RuntimeName for Printing3DModel {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DModel";
 }
-impl ::core::convert::From<Printing3DModel> for ::windows::core::IUnknown {
-    fn from(value: Printing3DModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DModel> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DModel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DModel> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DModel> for ::windows::core::IInspectable {
-    fn from(value: Printing3DModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DModel> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DModel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DModel> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DModel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DModel {}
 unsafe impl ::core::marker::Sync for Printing3DModel {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -3400,36 +2791,7 @@ unsafe impl ::windows::core::Interface for Printing3DModelTexture {
 impl ::windows::core::RuntimeName for Printing3DModelTexture {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DModelTexture";
 }
-impl ::core::convert::From<Printing3DModelTexture> for ::windows::core::IUnknown {
-    fn from(value: Printing3DModelTexture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DModelTexture> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DModelTexture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DModelTexture> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DModelTexture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DModelTexture> for ::windows::core::IInspectable {
-    fn from(value: Printing3DModelTexture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DModelTexture> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DModelTexture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DModelTexture> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DModelTexture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DModelTexture, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DModelTexture {}
 unsafe impl ::core::marker::Sync for Printing3DModelTexture {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -3485,36 +2847,7 @@ unsafe impl ::windows::core::Interface for Printing3DMultiplePropertyMaterial {
 impl ::windows::core::RuntimeName for Printing3DMultiplePropertyMaterial {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DMultiplePropertyMaterial";
 }
-impl ::core::convert::From<Printing3DMultiplePropertyMaterial> for ::windows::core::IUnknown {
-    fn from(value: Printing3DMultiplePropertyMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DMultiplePropertyMaterial> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DMultiplePropertyMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DMultiplePropertyMaterial> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DMultiplePropertyMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DMultiplePropertyMaterial> for ::windows::core::IInspectable {
-    fn from(value: Printing3DMultiplePropertyMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DMultiplePropertyMaterial> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DMultiplePropertyMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DMultiplePropertyMaterial> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DMultiplePropertyMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DMultiplePropertyMaterial, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DMultiplePropertyMaterial {}
 unsafe impl ::core::marker::Sync for Printing3DMultiplePropertyMaterial {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -3590,36 +2923,7 @@ unsafe impl ::windows::core::Interface for Printing3DMultiplePropertyMaterialGro
 impl ::windows::core::RuntimeName for Printing3DMultiplePropertyMaterialGroup {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DMultiplePropertyMaterialGroup";
 }
-impl ::core::convert::From<Printing3DMultiplePropertyMaterialGroup> for ::windows::core::IUnknown {
-    fn from(value: Printing3DMultiplePropertyMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DMultiplePropertyMaterialGroup> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DMultiplePropertyMaterialGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DMultiplePropertyMaterialGroup> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DMultiplePropertyMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DMultiplePropertyMaterialGroup> for ::windows::core::IInspectable {
-    fn from(value: Printing3DMultiplePropertyMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DMultiplePropertyMaterialGroup> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DMultiplePropertyMaterialGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DMultiplePropertyMaterialGroup> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DMultiplePropertyMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DMultiplePropertyMaterialGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DMultiplePropertyMaterialGroup {}
 unsafe impl ::core::marker::Sync for Printing3DMultiplePropertyMaterialGroup {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -3699,36 +3003,7 @@ unsafe impl ::windows::core::Interface for Printing3DTexture2CoordMaterial {
 impl ::windows::core::RuntimeName for Printing3DTexture2CoordMaterial {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DTexture2CoordMaterial";
 }
-impl ::core::convert::From<Printing3DTexture2CoordMaterial> for ::windows::core::IUnknown {
-    fn from(value: Printing3DTexture2CoordMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DTexture2CoordMaterial> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DTexture2CoordMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DTexture2CoordMaterial> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DTexture2CoordMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DTexture2CoordMaterial> for ::windows::core::IInspectable {
-    fn from(value: Printing3DTexture2CoordMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DTexture2CoordMaterial> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DTexture2CoordMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DTexture2CoordMaterial> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DTexture2CoordMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DTexture2CoordMaterial, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DTexture2CoordMaterial {}
 unsafe impl ::core::marker::Sync for Printing3DTexture2CoordMaterial {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -3806,36 +3081,7 @@ unsafe impl ::windows::core::Interface for Printing3DTexture2CoordMaterialGroup 
 impl ::windows::core::RuntimeName for Printing3DTexture2CoordMaterialGroup {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DTexture2CoordMaterialGroup";
 }
-impl ::core::convert::From<Printing3DTexture2CoordMaterialGroup> for ::windows::core::IUnknown {
-    fn from(value: Printing3DTexture2CoordMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DTexture2CoordMaterialGroup> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DTexture2CoordMaterialGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DTexture2CoordMaterialGroup> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DTexture2CoordMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DTexture2CoordMaterialGroup> for ::windows::core::IInspectable {
-    fn from(value: Printing3DTexture2CoordMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DTexture2CoordMaterialGroup> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DTexture2CoordMaterialGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DTexture2CoordMaterialGroup> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DTexture2CoordMaterialGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DTexture2CoordMaterialGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DTexture2CoordMaterialGroup {}
 unsafe impl ::core::marker::Sync for Printing3DTexture2CoordMaterialGroup {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]
@@ -3912,36 +3158,7 @@ unsafe impl ::windows::core::Interface for Printing3DTextureResource {
 impl ::windows::core::RuntimeName for Printing3DTextureResource {
     const NAME: &'static str = "Windows.Graphics.Printing3D.Printing3DTextureResource";
 }
-impl ::core::convert::From<Printing3DTextureResource> for ::windows::core::IUnknown {
-    fn from(value: Printing3DTextureResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DTextureResource> for ::windows::core::IUnknown {
-    fn from(value: &Printing3DTextureResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DTextureResource> for &::windows::core::IUnknown {
-    fn from(value: &Printing3DTextureResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Printing3DTextureResource> for ::windows::core::IInspectable {
-    fn from(value: Printing3DTextureResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Printing3DTextureResource> for ::windows::core::IInspectable {
-    fn from(value: &Printing3DTextureResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Printing3DTextureResource> for &::windows::core::IInspectable {
-    fn from(value: &Printing3DTextureResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Printing3DTextureResource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Printing3DTextureResource {}
 unsafe impl ::core::marker::Sync for Printing3DTextureResource {}
 #[doc = "*Required features: `\"Graphics_Printing3D\"`*"]

--- a/crates/libs/windows/src/Windows/Graphics/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/mod.rs
@@ -18,36 +18,7 @@ pub mod Printing3D;
 #[repr(transparent)]
 pub struct IGeometrySource2D(::windows::core::IUnknown);
 impl IGeometrySource2D {}
-impl ::core::convert::From<IGeometrySource2D> for ::windows::core::IUnknown {
-    fn from(value: IGeometrySource2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGeometrySource2D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGeometrySource2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGeometrySource2D> for ::windows::core::IUnknown {
-    fn from(value: &IGeometrySource2D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IGeometrySource2D> for ::windows::core::IInspectable {
-    fn from(value: IGeometrySource2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGeometrySource2D> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IGeometrySource2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGeometrySource2D> for ::windows::core::IInspectable {
-    fn from(value: &IGeometrySource2D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGeometrySource2D, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IGeometrySource2D {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Management/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Core/mod.rs
@@ -80,36 +80,7 @@ unsafe impl ::windows::core::Interface for ApplicationDataManager {
 impl ::windows::core::RuntimeName for ApplicationDataManager {
     const NAME: &'static str = "Windows.Management.Core.ApplicationDataManager";
 }
-impl ::core::convert::From<ApplicationDataManager> for ::windows::core::IUnknown {
-    fn from(value: ApplicationDataManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationDataManager> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationDataManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationDataManager> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationDataManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ApplicationDataManager> for ::windows::core::IInspectable {
-    fn from(value: ApplicationDataManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationDataManager> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationDataManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationDataManager> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationDataManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationDataManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ApplicationDataManager {}
 unsafe impl ::core::marker::Sync for ApplicationDataManager {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Management/Deployment/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Deployment/Preview/mod.rs
@@ -98,36 +98,7 @@ unsafe impl ::windows::core::Interface for InstalledClassicAppInfo {
 impl ::windows::core::RuntimeName for InstalledClassicAppInfo {
     const NAME: &'static str = "Windows.Management.Deployment.Preview.InstalledClassicAppInfo";
 }
-impl ::core::convert::From<InstalledClassicAppInfo> for ::windows::core::IUnknown {
-    fn from(value: InstalledClassicAppInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InstalledClassicAppInfo> for ::windows::core::IUnknown {
-    fn from(value: &InstalledClassicAppInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InstalledClassicAppInfo> for &::windows::core::IUnknown {
-    fn from(value: &InstalledClassicAppInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InstalledClassicAppInfo> for ::windows::core::IInspectable {
-    fn from(value: InstalledClassicAppInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InstalledClassicAppInfo> for ::windows::core::IInspectable {
-    fn from(value: &InstalledClassicAppInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InstalledClassicAppInfo> for &::windows::core::IInspectable {
-    fn from(value: &InstalledClassicAppInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InstalledClassicAppInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InstalledClassicAppInfo {}
 unsafe impl ::core::marker::Sync for InstalledClassicAppInfo {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
@@ -1273,36 +1273,7 @@ unsafe impl ::windows::core::Interface for AddPackageOptions {
 impl ::windows::core::RuntimeName for AddPackageOptions {
     const NAME: &'static str = "Windows.Management.Deployment.AddPackageOptions";
 }
-impl ::core::convert::From<AddPackageOptions> for ::windows::core::IUnknown {
-    fn from(value: AddPackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AddPackageOptions> for ::windows::core::IUnknown {
-    fn from(value: &AddPackageOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AddPackageOptions> for &::windows::core::IUnknown {
-    fn from(value: &AddPackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AddPackageOptions> for ::windows::core::IInspectable {
-    fn from(value: AddPackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AddPackageOptions> for ::windows::core::IInspectable {
-    fn from(value: &AddPackageOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AddPackageOptions> for &::windows::core::IInspectable {
-    fn from(value: &AddPackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AddPackageOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AddPackageOptions {}
 unsafe impl ::core::marker::Sync for AddPackageOptions {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -1373,36 +1344,7 @@ unsafe impl ::windows::core::Interface for AppInstallerManager {
 impl ::windows::core::RuntimeName for AppInstallerManager {
     const NAME: &'static str = "Windows.Management.Deployment.AppInstallerManager";
 }
-impl ::core::convert::From<AppInstallerManager> for ::windows::core::IUnknown {
-    fn from(value: AppInstallerManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallerManager> for ::windows::core::IUnknown {
-    fn from(value: &AppInstallerManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallerManager> for &::windows::core::IUnknown {
-    fn from(value: &AppInstallerManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppInstallerManager> for ::windows::core::IInspectable {
-    fn from(value: AppInstallerManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppInstallerManager> for ::windows::core::IInspectable {
-    fn from(value: &AppInstallerManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppInstallerManager> for &::windows::core::IInspectable {
-    fn from(value: &AppInstallerManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppInstallerManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppInstallerManager {}
 unsafe impl ::core::marker::Sync for AppInstallerManager {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -1605,36 +1547,7 @@ unsafe impl ::windows::core::Interface for AutoUpdateSettingsOptions {
 impl ::windows::core::RuntimeName for AutoUpdateSettingsOptions {
     const NAME: &'static str = "Windows.Management.Deployment.AutoUpdateSettingsOptions";
 }
-impl ::core::convert::From<AutoUpdateSettingsOptions> for ::windows::core::IUnknown {
-    fn from(value: AutoUpdateSettingsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutoUpdateSettingsOptions> for ::windows::core::IUnknown {
-    fn from(value: &AutoUpdateSettingsOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutoUpdateSettingsOptions> for &::windows::core::IUnknown {
-    fn from(value: &AutoUpdateSettingsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AutoUpdateSettingsOptions> for ::windows::core::IInspectable {
-    fn from(value: AutoUpdateSettingsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutoUpdateSettingsOptions> for ::windows::core::IInspectable {
-    fn from(value: &AutoUpdateSettingsOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutoUpdateSettingsOptions> for &::windows::core::IInspectable {
-    fn from(value: &AutoUpdateSettingsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AutoUpdateSettingsOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AutoUpdateSettingsOptions {}
 unsafe impl ::core::marker::Sync for AutoUpdateSettingsOptions {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -1712,36 +1625,7 @@ unsafe impl ::windows::core::Interface for CreateSharedPackageContainerOptions {
 impl ::windows::core::RuntimeName for CreateSharedPackageContainerOptions {
     const NAME: &'static str = "Windows.Management.Deployment.CreateSharedPackageContainerOptions";
 }
-impl ::core::convert::From<CreateSharedPackageContainerOptions> for ::windows::core::IUnknown {
-    fn from(value: CreateSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateSharedPackageContainerOptions> for ::windows::core::IUnknown {
-    fn from(value: &CreateSharedPackageContainerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateSharedPackageContainerOptions> for &::windows::core::IUnknown {
-    fn from(value: &CreateSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CreateSharedPackageContainerOptions> for ::windows::core::IInspectable {
-    fn from(value: CreateSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateSharedPackageContainerOptions> for ::windows::core::IInspectable {
-    fn from(value: &CreateSharedPackageContainerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateSharedPackageContainerOptions> for &::windows::core::IInspectable {
-    fn from(value: &CreateSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CreateSharedPackageContainerOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CreateSharedPackageContainerOptions {}
 unsafe impl ::core::marker::Sync for CreateSharedPackageContainerOptions {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -1802,36 +1686,7 @@ unsafe impl ::windows::core::Interface for CreateSharedPackageContainerResult {
 impl ::windows::core::RuntimeName for CreateSharedPackageContainerResult {
     const NAME: &'static str = "Windows.Management.Deployment.CreateSharedPackageContainerResult";
 }
-impl ::core::convert::From<CreateSharedPackageContainerResult> for ::windows::core::IUnknown {
-    fn from(value: CreateSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateSharedPackageContainerResult> for ::windows::core::IUnknown {
-    fn from(value: &CreateSharedPackageContainerResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateSharedPackageContainerResult> for &::windows::core::IUnknown {
-    fn from(value: &CreateSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CreateSharedPackageContainerResult> for ::windows::core::IInspectable {
-    fn from(value: CreateSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateSharedPackageContainerResult> for ::windows::core::IInspectable {
-    fn from(value: &CreateSharedPackageContainerResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateSharedPackageContainerResult> for &::windows::core::IInspectable {
-    fn from(value: &CreateSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CreateSharedPackageContainerResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CreateSharedPackageContainerResult {}
 unsafe impl ::core::marker::Sync for CreateSharedPackageContainerResult {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -1900,36 +1755,7 @@ unsafe impl ::windows::core::Interface for DeleteSharedPackageContainerOptions {
 impl ::windows::core::RuntimeName for DeleteSharedPackageContainerOptions {
     const NAME: &'static str = "Windows.Management.Deployment.DeleteSharedPackageContainerOptions";
 }
-impl ::core::convert::From<DeleteSharedPackageContainerOptions> for ::windows::core::IUnknown {
-    fn from(value: DeleteSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeleteSharedPackageContainerOptions> for ::windows::core::IUnknown {
-    fn from(value: &DeleteSharedPackageContainerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeleteSharedPackageContainerOptions> for &::windows::core::IUnknown {
-    fn from(value: &DeleteSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeleteSharedPackageContainerOptions> for ::windows::core::IInspectable {
-    fn from(value: DeleteSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeleteSharedPackageContainerOptions> for ::windows::core::IInspectable {
-    fn from(value: &DeleteSharedPackageContainerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeleteSharedPackageContainerOptions> for &::windows::core::IInspectable {
-    fn from(value: &DeleteSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeleteSharedPackageContainerOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeleteSharedPackageContainerOptions {}
 unsafe impl ::core::marker::Sync for DeleteSharedPackageContainerOptions {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -1983,36 +1809,7 @@ unsafe impl ::windows::core::Interface for DeleteSharedPackageContainerResult {
 impl ::windows::core::RuntimeName for DeleteSharedPackageContainerResult {
     const NAME: &'static str = "Windows.Management.Deployment.DeleteSharedPackageContainerResult";
 }
-impl ::core::convert::From<DeleteSharedPackageContainerResult> for ::windows::core::IUnknown {
-    fn from(value: DeleteSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeleteSharedPackageContainerResult> for ::windows::core::IUnknown {
-    fn from(value: &DeleteSharedPackageContainerResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeleteSharedPackageContainerResult> for &::windows::core::IUnknown {
-    fn from(value: &DeleteSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeleteSharedPackageContainerResult> for ::windows::core::IInspectable {
-    fn from(value: DeleteSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeleteSharedPackageContainerResult> for ::windows::core::IInspectable {
-    fn from(value: &DeleteSharedPackageContainerResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeleteSharedPackageContainerResult> for &::windows::core::IInspectable {
-    fn from(value: &DeleteSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeleteSharedPackageContainerResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeleteSharedPackageContainerResult {}
 unsafe impl ::core::marker::Sync for DeleteSharedPackageContainerResult {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -2080,36 +1877,7 @@ unsafe impl ::windows::core::Interface for DeploymentResult {
 impl ::windows::core::RuntimeName for DeploymentResult {
     const NAME: &'static str = "Windows.Management.Deployment.DeploymentResult";
 }
-impl ::core::convert::From<DeploymentResult> for ::windows::core::IUnknown {
-    fn from(value: DeploymentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeploymentResult> for ::windows::core::IUnknown {
-    fn from(value: &DeploymentResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeploymentResult> for &::windows::core::IUnknown {
-    fn from(value: &DeploymentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DeploymentResult> for ::windows::core::IInspectable {
-    fn from(value: DeploymentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DeploymentResult> for ::windows::core::IInspectable {
-    fn from(value: &DeploymentResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DeploymentResult> for &::windows::core::IInspectable {
-    fn from(value: &DeploymentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DeploymentResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DeploymentResult {}
 unsafe impl ::core::marker::Sync for DeploymentResult {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -2178,36 +1946,7 @@ unsafe impl ::windows::core::Interface for FindSharedPackageContainerOptions {
 impl ::windows::core::RuntimeName for FindSharedPackageContainerOptions {
     const NAME: &'static str = "Windows.Management.Deployment.FindSharedPackageContainerOptions";
 }
-impl ::core::convert::From<FindSharedPackageContainerOptions> for ::windows::core::IUnknown {
-    fn from(value: FindSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FindSharedPackageContainerOptions> for ::windows::core::IUnknown {
-    fn from(value: &FindSharedPackageContainerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FindSharedPackageContainerOptions> for &::windows::core::IUnknown {
-    fn from(value: &FindSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FindSharedPackageContainerOptions> for ::windows::core::IInspectable {
-    fn from(value: FindSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FindSharedPackageContainerOptions> for ::windows::core::IInspectable {
-    fn from(value: &FindSharedPackageContainerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FindSharedPackageContainerOptions> for &::windows::core::IInspectable {
-    fn from(value: &FindSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FindSharedPackageContainerOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FindSharedPackageContainerOptions {}
 unsafe impl ::core::marker::Sync for FindSharedPackageContainerOptions {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -2272,36 +2011,7 @@ unsafe impl ::windows::core::Interface for PackageAllUserProvisioningOptions {
 impl ::windows::core::RuntimeName for PackageAllUserProvisioningOptions {
     const NAME: &'static str = "Windows.Management.Deployment.PackageAllUserProvisioningOptions";
 }
-impl ::core::convert::From<PackageAllUserProvisioningOptions> for ::windows::core::IUnknown {
-    fn from(value: PackageAllUserProvisioningOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageAllUserProvisioningOptions> for ::windows::core::IUnknown {
-    fn from(value: &PackageAllUserProvisioningOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageAllUserProvisioningOptions> for &::windows::core::IUnknown {
-    fn from(value: &PackageAllUserProvisioningOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageAllUserProvisioningOptions> for ::windows::core::IInspectable {
-    fn from(value: PackageAllUserProvisioningOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageAllUserProvisioningOptions> for ::windows::core::IInspectable {
-    fn from(value: &PackageAllUserProvisioningOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageAllUserProvisioningOptions> for &::windows::core::IInspectable {
-    fn from(value: &PackageAllUserProvisioningOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageAllUserProvisioningOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageAllUserProvisioningOptions {}
 unsafe impl ::core::marker::Sync for PackageAllUserProvisioningOptions {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -2973,36 +2683,7 @@ unsafe impl ::windows::core::Interface for PackageManager {
 impl ::windows::core::RuntimeName for PackageManager {
     const NAME: &'static str = "Windows.Management.Deployment.PackageManager";
 }
-impl ::core::convert::From<PackageManager> for ::windows::core::IUnknown {
-    fn from(value: PackageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageManager> for ::windows::core::IUnknown {
-    fn from(value: &PackageManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageManager> for &::windows::core::IUnknown {
-    fn from(value: &PackageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageManager> for ::windows::core::IInspectable {
-    fn from(value: PackageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageManager> for ::windows::core::IInspectable {
-    fn from(value: &PackageManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageManager> for &::windows::core::IInspectable {
-    fn from(value: &PackageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageManager {}
 unsafe impl ::core::marker::Sync for PackageManager {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -3060,36 +2741,7 @@ unsafe impl ::windows::core::Interface for PackageManagerDebugSettings {
 impl ::windows::core::RuntimeName for PackageManagerDebugSettings {
     const NAME: &'static str = "Windows.Management.Deployment.PackageManagerDebugSettings";
 }
-impl ::core::convert::From<PackageManagerDebugSettings> for ::windows::core::IUnknown {
-    fn from(value: PackageManagerDebugSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageManagerDebugSettings> for ::windows::core::IUnknown {
-    fn from(value: &PackageManagerDebugSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageManagerDebugSettings> for &::windows::core::IUnknown {
-    fn from(value: &PackageManagerDebugSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageManagerDebugSettings> for ::windows::core::IInspectable {
-    fn from(value: PackageManagerDebugSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageManagerDebugSettings> for ::windows::core::IInspectable {
-    fn from(value: &PackageManagerDebugSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageManagerDebugSettings> for &::windows::core::IInspectable {
-    fn from(value: &PackageManagerDebugSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageManagerDebugSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageManagerDebugSettings {}
 unsafe impl ::core::marker::Sync for PackageManagerDebugSettings {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -3143,36 +2795,7 @@ unsafe impl ::windows::core::Interface for PackageUserInformation {
 impl ::windows::core::RuntimeName for PackageUserInformation {
     const NAME: &'static str = "Windows.Management.Deployment.PackageUserInformation";
 }
-impl ::core::convert::From<PackageUserInformation> for ::windows::core::IUnknown {
-    fn from(value: PackageUserInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageUserInformation> for ::windows::core::IUnknown {
-    fn from(value: &PackageUserInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageUserInformation> for &::windows::core::IUnknown {
-    fn from(value: &PackageUserInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageUserInformation> for ::windows::core::IInspectable {
-    fn from(value: PackageUserInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageUserInformation> for ::windows::core::IInspectable {
-    fn from(value: &PackageUserInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageUserInformation> for &::windows::core::IInspectable {
-    fn from(value: &PackageUserInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageUserInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageUserInformation {}
 unsafe impl ::core::marker::Sync for PackageUserInformation {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -3403,36 +3026,7 @@ unsafe impl ::windows::core::Interface for PackageVolume {
 impl ::windows::core::RuntimeName for PackageVolume {
     const NAME: &'static str = "Windows.Management.Deployment.PackageVolume";
 }
-impl ::core::convert::From<PackageVolume> for ::windows::core::IUnknown {
-    fn from(value: PackageVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageVolume> for ::windows::core::IUnknown {
-    fn from(value: &PackageVolume) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageVolume> for &::windows::core::IUnknown {
-    fn from(value: &PackageVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageVolume> for ::windows::core::IInspectable {
-    fn from(value: PackageVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageVolume> for ::windows::core::IInspectable {
-    fn from(value: &PackageVolume) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageVolume> for &::windows::core::IInspectable {
-    fn from(value: &PackageVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageVolume, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PackageVolume {}
 unsafe impl ::core::marker::Sync for PackageVolume {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -3611,36 +3205,7 @@ unsafe impl ::windows::core::Interface for RegisterPackageOptions {
 impl ::windows::core::RuntimeName for RegisterPackageOptions {
     const NAME: &'static str = "Windows.Management.Deployment.RegisterPackageOptions";
 }
-impl ::core::convert::From<RegisterPackageOptions> for ::windows::core::IUnknown {
-    fn from(value: RegisterPackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RegisterPackageOptions> for ::windows::core::IUnknown {
-    fn from(value: &RegisterPackageOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RegisterPackageOptions> for &::windows::core::IUnknown {
-    fn from(value: &RegisterPackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RegisterPackageOptions> for ::windows::core::IInspectable {
-    fn from(value: RegisterPackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RegisterPackageOptions> for ::windows::core::IInspectable {
-    fn from(value: &RegisterPackageOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RegisterPackageOptions> for &::windows::core::IInspectable {
-    fn from(value: &RegisterPackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RegisterPackageOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RegisterPackageOptions {}
 unsafe impl ::core::marker::Sync for RegisterPackageOptions {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -3717,36 +3282,7 @@ unsafe impl ::windows::core::Interface for SharedPackageContainer {
 impl ::windows::core::RuntimeName for SharedPackageContainer {
     const NAME: &'static str = "Windows.Management.Deployment.SharedPackageContainer";
 }
-impl ::core::convert::From<SharedPackageContainer> for ::windows::core::IUnknown {
-    fn from(value: SharedPackageContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SharedPackageContainer> for ::windows::core::IUnknown {
-    fn from(value: &SharedPackageContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SharedPackageContainer> for &::windows::core::IUnknown {
-    fn from(value: &SharedPackageContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SharedPackageContainer> for ::windows::core::IInspectable {
-    fn from(value: SharedPackageContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SharedPackageContainer> for ::windows::core::IInspectable {
-    fn from(value: &SharedPackageContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SharedPackageContainer> for &::windows::core::IInspectable {
-    fn from(value: &SharedPackageContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SharedPackageContainer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SharedPackageContainer {}
 unsafe impl ::core::marker::Sync for SharedPackageContainer {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -3848,36 +3384,7 @@ unsafe impl ::windows::core::Interface for SharedPackageContainerManager {
 impl ::windows::core::RuntimeName for SharedPackageContainerManager {
     const NAME: &'static str = "Windows.Management.Deployment.SharedPackageContainerManager";
 }
-impl ::core::convert::From<SharedPackageContainerManager> for ::windows::core::IUnknown {
-    fn from(value: SharedPackageContainerManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SharedPackageContainerManager> for ::windows::core::IUnknown {
-    fn from(value: &SharedPackageContainerManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SharedPackageContainerManager> for &::windows::core::IUnknown {
-    fn from(value: &SharedPackageContainerManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SharedPackageContainerManager> for ::windows::core::IInspectable {
-    fn from(value: SharedPackageContainerManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SharedPackageContainerManager> for ::windows::core::IInspectable {
-    fn from(value: &SharedPackageContainerManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SharedPackageContainerManager> for &::windows::core::IInspectable {
-    fn from(value: &SharedPackageContainerManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SharedPackageContainerManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SharedPackageContainerManager {}
 unsafe impl ::core::marker::Sync for SharedPackageContainerManager {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -3935,36 +3442,7 @@ unsafe impl ::windows::core::Interface for SharedPackageContainerMember {
 impl ::windows::core::RuntimeName for SharedPackageContainerMember {
     const NAME: &'static str = "Windows.Management.Deployment.SharedPackageContainerMember";
 }
-impl ::core::convert::From<SharedPackageContainerMember> for ::windows::core::IUnknown {
-    fn from(value: SharedPackageContainerMember) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SharedPackageContainerMember> for ::windows::core::IUnknown {
-    fn from(value: &SharedPackageContainerMember) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SharedPackageContainerMember> for &::windows::core::IUnknown {
-    fn from(value: &SharedPackageContainerMember) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SharedPackageContainerMember> for ::windows::core::IInspectable {
-    fn from(value: SharedPackageContainerMember) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SharedPackageContainerMember> for ::windows::core::IInspectable {
-    fn from(value: &SharedPackageContainerMember) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SharedPackageContainerMember> for &::windows::core::IInspectable {
-    fn from(value: &SharedPackageContainerMember) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SharedPackageContainerMember, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SharedPackageContainerMember {}
 unsafe impl ::core::marker::Sync for SharedPackageContainerMember {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -4150,36 +3628,7 @@ unsafe impl ::windows::core::Interface for StagePackageOptions {
 impl ::windows::core::RuntimeName for StagePackageOptions {
     const NAME: &'static str = "Windows.Management.Deployment.StagePackageOptions";
 }
-impl ::core::convert::From<StagePackageOptions> for ::windows::core::IUnknown {
-    fn from(value: StagePackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StagePackageOptions> for ::windows::core::IUnknown {
-    fn from(value: &StagePackageOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StagePackageOptions> for &::windows::core::IUnknown {
-    fn from(value: &StagePackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StagePackageOptions> for ::windows::core::IInspectable {
-    fn from(value: StagePackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StagePackageOptions> for ::windows::core::IInspectable {
-    fn from(value: &StagePackageOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StagePackageOptions> for &::windows::core::IInspectable {
-    fn from(value: &StagePackageOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StagePackageOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StagePackageOptions {}
 unsafe impl ::core::marker::Sync for StagePackageOptions {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -4248,36 +3697,7 @@ unsafe impl ::windows::core::Interface for UpdateSharedPackageContainerOptions {
 impl ::windows::core::RuntimeName for UpdateSharedPackageContainerOptions {
     const NAME: &'static str = "Windows.Management.Deployment.UpdateSharedPackageContainerOptions";
 }
-impl ::core::convert::From<UpdateSharedPackageContainerOptions> for ::windows::core::IUnknown {
-    fn from(value: UpdateSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UpdateSharedPackageContainerOptions> for ::windows::core::IUnknown {
-    fn from(value: &UpdateSharedPackageContainerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UpdateSharedPackageContainerOptions> for &::windows::core::IUnknown {
-    fn from(value: &UpdateSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UpdateSharedPackageContainerOptions> for ::windows::core::IInspectable {
-    fn from(value: UpdateSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UpdateSharedPackageContainerOptions> for ::windows::core::IInspectable {
-    fn from(value: &UpdateSharedPackageContainerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UpdateSharedPackageContainerOptions> for &::windows::core::IInspectable {
-    fn from(value: &UpdateSharedPackageContainerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UpdateSharedPackageContainerOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UpdateSharedPackageContainerOptions {}
 unsafe impl ::core::marker::Sync for UpdateSharedPackageContainerOptions {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]
@@ -4331,36 +3751,7 @@ unsafe impl ::windows::core::Interface for UpdateSharedPackageContainerResult {
 impl ::windows::core::RuntimeName for UpdateSharedPackageContainerResult {
     const NAME: &'static str = "Windows.Management.Deployment.UpdateSharedPackageContainerResult";
 }
-impl ::core::convert::From<UpdateSharedPackageContainerResult> for ::windows::core::IUnknown {
-    fn from(value: UpdateSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UpdateSharedPackageContainerResult> for ::windows::core::IUnknown {
-    fn from(value: &UpdateSharedPackageContainerResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UpdateSharedPackageContainerResult> for &::windows::core::IUnknown {
-    fn from(value: &UpdateSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UpdateSharedPackageContainerResult> for ::windows::core::IInspectable {
-    fn from(value: UpdateSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UpdateSharedPackageContainerResult> for ::windows::core::IInspectable {
-    fn from(value: &UpdateSharedPackageContainerResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UpdateSharedPackageContainerResult> for &::windows::core::IInspectable {
-    fn from(value: &UpdateSharedPackageContainerResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UpdateSharedPackageContainerResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UpdateSharedPackageContainerResult {}
 unsafe impl ::core::marker::Sync for UpdateSharedPackageContainerResult {}
 #[doc = "*Required features: `\"Management_Deployment\"`*"]

--- a/crates/libs/windows/src/Windows/Management/Policies/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Policies/mod.rs
@@ -215,36 +215,7 @@ unsafe impl ::windows::core::Interface for NamedPolicyData {
 impl ::windows::core::RuntimeName for NamedPolicyData {
     const NAME: &'static str = "Windows.Management.Policies.NamedPolicyData";
 }
-impl ::core::convert::From<NamedPolicyData> for ::windows::core::IUnknown {
-    fn from(value: NamedPolicyData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NamedPolicyData> for ::windows::core::IUnknown {
-    fn from(value: &NamedPolicyData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NamedPolicyData> for &::windows::core::IUnknown {
-    fn from(value: &NamedPolicyData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NamedPolicyData> for ::windows::core::IInspectable {
-    fn from(value: NamedPolicyData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NamedPolicyData> for ::windows::core::IInspectable {
-    fn from(value: &NamedPolicyData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NamedPolicyData> for &::windows::core::IInspectable {
-    fn from(value: &NamedPolicyData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NamedPolicyData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NamedPolicyData {}
 unsafe impl ::core::marker::Sync for NamedPolicyData {}
 #[doc = "*Required features: `\"Management_Policies\"`*"]

--- a/crates/libs/windows/src/Windows/Management/Update/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Update/mod.rs
@@ -134,36 +134,7 @@ unsafe impl ::windows::core::Interface for PreviewBuildsManager {
 impl ::windows::core::RuntimeName for PreviewBuildsManager {
     const NAME: &'static str = "Windows.Management.Update.PreviewBuildsManager";
 }
-impl ::core::convert::From<PreviewBuildsManager> for ::windows::core::IUnknown {
-    fn from(value: PreviewBuildsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PreviewBuildsManager> for ::windows::core::IUnknown {
-    fn from(value: &PreviewBuildsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PreviewBuildsManager> for &::windows::core::IUnknown {
-    fn from(value: &PreviewBuildsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PreviewBuildsManager> for ::windows::core::IInspectable {
-    fn from(value: PreviewBuildsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PreviewBuildsManager> for ::windows::core::IInspectable {
-    fn from(value: &PreviewBuildsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PreviewBuildsManager> for &::windows::core::IInspectable {
-    fn from(value: &PreviewBuildsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PreviewBuildsManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PreviewBuildsManager {}
 unsafe impl ::core::marker::Sync for PreviewBuildsManager {}
 #[doc = "*Required features: `\"Management_Update\"`*"]
@@ -212,36 +183,7 @@ unsafe impl ::windows::core::Interface for PreviewBuildsState {
 impl ::windows::core::RuntimeName for PreviewBuildsState {
     const NAME: &'static str = "Windows.Management.Update.PreviewBuildsState";
 }
-impl ::core::convert::From<PreviewBuildsState> for ::windows::core::IUnknown {
-    fn from(value: PreviewBuildsState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PreviewBuildsState> for ::windows::core::IUnknown {
-    fn from(value: &PreviewBuildsState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PreviewBuildsState> for &::windows::core::IUnknown {
-    fn from(value: &PreviewBuildsState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PreviewBuildsState> for ::windows::core::IInspectable {
-    fn from(value: PreviewBuildsState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PreviewBuildsState> for ::windows::core::IInspectable {
-    fn from(value: &PreviewBuildsState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PreviewBuildsState> for &::windows::core::IInspectable {
-    fn from(value: &PreviewBuildsState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PreviewBuildsState, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PreviewBuildsState {}
 unsafe impl ::core::marker::Sync for PreviewBuildsState {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/mod.rs
@@ -207,36 +207,7 @@ unsafe impl ::windows::core::Interface for MdmAlert {
 impl ::windows::core::RuntimeName for MdmAlert {
     const NAME: &'static str = "Windows.Management.MdmAlert";
 }
-impl ::core::convert::From<MdmAlert> for ::windows::core::IUnknown {
-    fn from(value: MdmAlert) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MdmAlert> for ::windows::core::IUnknown {
-    fn from(value: &MdmAlert) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MdmAlert> for &::windows::core::IUnknown {
-    fn from(value: &MdmAlert) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MdmAlert> for ::windows::core::IInspectable {
-    fn from(value: MdmAlert) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MdmAlert> for ::windows::core::IInspectable {
-    fn from(value: &MdmAlert) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MdmAlert> for &::windows::core::IInspectable {
-    fn from(value: &MdmAlert) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MdmAlert, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Management\"`*"]
 #[repr(transparent)]
 pub struct MdmSession(::windows::core::IUnknown);
@@ -339,36 +310,7 @@ unsafe impl ::windows::core::Interface for MdmSession {
 impl ::windows::core::RuntimeName for MdmSession {
     const NAME: &'static str = "Windows.Management.MdmSession";
 }
-impl ::core::convert::From<MdmSession> for ::windows::core::IUnknown {
-    fn from(value: MdmSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MdmSession> for ::windows::core::IUnknown {
-    fn from(value: &MdmSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MdmSession> for &::windows::core::IUnknown {
-    fn from(value: &MdmSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MdmSession> for ::windows::core::IInspectable {
-    fn from(value: MdmSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MdmSession> for ::windows::core::IInspectable {
-    fn from(value: &MdmSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MdmSession> for &::windows::core::IInspectable {
-    fn from(value: &MdmSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MdmSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Management\"`*"]
 pub struct MdmSessionManager;
 impl MdmSessionManager {

--- a/crates/libs/windows/src/Windows/Media/AppBroadcasting/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/AppBroadcasting/mod.rs
@@ -160,36 +160,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastingMonitor {
 impl ::windows::core::RuntimeName for AppBroadcastingMonitor {
     const NAME: &'static str = "Windows.Media.AppBroadcasting.AppBroadcastingMonitor";
 }
-impl ::core::convert::From<AppBroadcastingMonitor> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastingMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastingMonitor> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastingMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastingMonitor> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastingMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastingMonitor> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastingMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastingMonitor> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastingMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastingMonitor> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastingMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastingMonitor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastingMonitor {}
 unsafe impl ::core::marker::Sync for AppBroadcastingMonitor {}
 #[doc = "*Required features: `\"Media_AppBroadcasting\"`*"]
@@ -243,36 +214,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastingStatus {
 impl ::windows::core::RuntimeName for AppBroadcastingStatus {
     const NAME: &'static str = "Windows.Media.AppBroadcasting.AppBroadcastingStatus";
 }
-impl ::core::convert::From<AppBroadcastingStatus> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastingStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastingStatus> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastingStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastingStatus> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastingStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastingStatus> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastingStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastingStatus> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastingStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastingStatus> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastingStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastingStatus, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastingStatus {}
 unsafe impl ::core::marker::Sync for AppBroadcastingStatus {}
 #[doc = "*Required features: `\"Media_AppBroadcasting\"`*"]
@@ -368,36 +310,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastingStatusDetails {
 impl ::windows::core::RuntimeName for AppBroadcastingStatusDetails {
     const NAME: &'static str = "Windows.Media.AppBroadcasting.AppBroadcastingStatusDetails";
 }
-impl ::core::convert::From<AppBroadcastingStatusDetails> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastingStatusDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastingStatusDetails> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastingStatusDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastingStatusDetails> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastingStatusDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastingStatusDetails> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastingStatusDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastingStatusDetails> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastingStatusDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastingStatusDetails> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastingStatusDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastingStatusDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastingStatusDetails {}
 unsafe impl ::core::marker::Sync for AppBroadcastingStatusDetails {}
 #[doc = "*Required features: `\"Media_AppBroadcasting\"`*"]
@@ -467,36 +380,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastingUI {
 impl ::windows::core::RuntimeName for AppBroadcastingUI {
     const NAME: &'static str = "Windows.Media.AppBroadcasting.AppBroadcastingUI";
 }
-impl ::core::convert::From<AppBroadcastingUI> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastingUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastingUI> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastingUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastingUI> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastingUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastingUI> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastingUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastingUI> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastingUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastingUI> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastingUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastingUI, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastingUI {}
 unsafe impl ::core::marker::Sync for AppBroadcastingUI {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Media/AppRecording/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/AppRecording/mod.rs
@@ -243,36 +243,7 @@ unsafe impl ::windows::core::Interface for AppRecordingManager {
 impl ::windows::core::RuntimeName for AppRecordingManager {
     const NAME: &'static str = "Windows.Media.AppRecording.AppRecordingManager";
 }
-impl ::core::convert::From<AppRecordingManager> for ::windows::core::IUnknown {
-    fn from(value: AppRecordingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingManager> for ::windows::core::IUnknown {
-    fn from(value: &AppRecordingManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingManager> for &::windows::core::IUnknown {
-    fn from(value: &AppRecordingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppRecordingManager> for ::windows::core::IInspectable {
-    fn from(value: AppRecordingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingManager> for ::windows::core::IInspectable {
-    fn from(value: &AppRecordingManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingManager> for &::windows::core::IInspectable {
-    fn from(value: &AppRecordingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppRecordingManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppRecordingManager {}
 unsafe impl ::core::marker::Sync for AppRecordingManager {}
 #[doc = "*Required features: `\"Media_AppRecording\"`*"]
@@ -342,36 +313,7 @@ unsafe impl ::windows::core::Interface for AppRecordingResult {
 impl ::windows::core::RuntimeName for AppRecordingResult {
     const NAME: &'static str = "Windows.Media.AppRecording.AppRecordingResult";
 }
-impl ::core::convert::From<AppRecordingResult> for ::windows::core::IUnknown {
-    fn from(value: AppRecordingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingResult> for ::windows::core::IUnknown {
-    fn from(value: &AppRecordingResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingResult> for &::windows::core::IUnknown {
-    fn from(value: &AppRecordingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppRecordingResult> for ::windows::core::IInspectable {
-    fn from(value: AppRecordingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingResult> for ::windows::core::IInspectable {
-    fn from(value: &AppRecordingResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingResult> for &::windows::core::IInspectable {
-    fn from(value: &AppRecordingResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppRecordingResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppRecordingResult {}
 unsafe impl ::core::marker::Sync for AppRecordingResult {}
 #[doc = "*Required features: `\"Media_AppRecording\"`*"]
@@ -434,36 +376,7 @@ unsafe impl ::windows::core::Interface for AppRecordingSaveScreenshotResult {
 impl ::windows::core::RuntimeName for AppRecordingSaveScreenshotResult {
     const NAME: &'static str = "Windows.Media.AppRecording.AppRecordingSaveScreenshotResult";
 }
-impl ::core::convert::From<AppRecordingSaveScreenshotResult> for ::windows::core::IUnknown {
-    fn from(value: AppRecordingSaveScreenshotResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingSaveScreenshotResult> for ::windows::core::IUnknown {
-    fn from(value: &AppRecordingSaveScreenshotResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingSaveScreenshotResult> for &::windows::core::IUnknown {
-    fn from(value: &AppRecordingSaveScreenshotResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppRecordingSaveScreenshotResult> for ::windows::core::IInspectable {
-    fn from(value: AppRecordingSaveScreenshotResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingSaveScreenshotResult> for ::windows::core::IInspectable {
-    fn from(value: &AppRecordingSaveScreenshotResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingSaveScreenshotResult> for &::windows::core::IInspectable {
-    fn from(value: &AppRecordingSaveScreenshotResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppRecordingSaveScreenshotResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppRecordingSaveScreenshotResult {}
 unsafe impl ::core::marker::Sync for AppRecordingSaveScreenshotResult {}
 #[doc = "*Required features: `\"Media_AppRecording\"`*"]
@@ -519,36 +432,7 @@ unsafe impl ::windows::core::Interface for AppRecordingSavedScreenshotInfo {
 impl ::windows::core::RuntimeName for AppRecordingSavedScreenshotInfo {
     const NAME: &'static str = "Windows.Media.AppRecording.AppRecordingSavedScreenshotInfo";
 }
-impl ::core::convert::From<AppRecordingSavedScreenshotInfo> for ::windows::core::IUnknown {
-    fn from(value: AppRecordingSavedScreenshotInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingSavedScreenshotInfo> for ::windows::core::IUnknown {
-    fn from(value: &AppRecordingSavedScreenshotInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingSavedScreenshotInfo> for &::windows::core::IUnknown {
-    fn from(value: &AppRecordingSavedScreenshotInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppRecordingSavedScreenshotInfo> for ::windows::core::IInspectable {
-    fn from(value: AppRecordingSavedScreenshotInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingSavedScreenshotInfo> for ::windows::core::IInspectable {
-    fn from(value: &AppRecordingSavedScreenshotInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingSavedScreenshotInfo> for &::windows::core::IInspectable {
-    fn from(value: &AppRecordingSavedScreenshotInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppRecordingSavedScreenshotInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppRecordingSavedScreenshotInfo {}
 unsafe impl ::core::marker::Sync for AppRecordingSavedScreenshotInfo {}
 #[doc = "*Required features: `\"Media_AppRecording\"`*"]
@@ -618,36 +502,7 @@ unsafe impl ::windows::core::Interface for AppRecordingStatus {
 impl ::windows::core::RuntimeName for AppRecordingStatus {
     const NAME: &'static str = "Windows.Media.AppRecording.AppRecordingStatus";
 }
-impl ::core::convert::From<AppRecordingStatus> for ::windows::core::IUnknown {
-    fn from(value: AppRecordingStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingStatus> for ::windows::core::IUnknown {
-    fn from(value: &AppRecordingStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingStatus> for &::windows::core::IUnknown {
-    fn from(value: &AppRecordingStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppRecordingStatus> for ::windows::core::IInspectable {
-    fn from(value: AppRecordingStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingStatus> for ::windows::core::IInspectable {
-    fn from(value: &AppRecordingStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingStatus> for &::windows::core::IInspectable {
-    fn from(value: &AppRecordingStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppRecordingStatus, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppRecordingStatus {}
 unsafe impl ::core::marker::Sync for AppRecordingStatus {}
 #[doc = "*Required features: `\"Media_AppRecording\"`*"]
@@ -750,36 +605,7 @@ unsafe impl ::windows::core::Interface for AppRecordingStatusDetails {
 impl ::windows::core::RuntimeName for AppRecordingStatusDetails {
     const NAME: &'static str = "Windows.Media.AppRecording.AppRecordingStatusDetails";
 }
-impl ::core::convert::From<AppRecordingStatusDetails> for ::windows::core::IUnknown {
-    fn from(value: AppRecordingStatusDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingStatusDetails> for ::windows::core::IUnknown {
-    fn from(value: &AppRecordingStatusDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingStatusDetails> for &::windows::core::IUnknown {
-    fn from(value: &AppRecordingStatusDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppRecordingStatusDetails> for ::windows::core::IInspectable {
-    fn from(value: AppRecordingStatusDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppRecordingStatusDetails> for ::windows::core::IInspectable {
-    fn from(value: &AppRecordingStatusDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppRecordingStatusDetails> for &::windows::core::IInspectable {
-    fn from(value: &AppRecordingStatusDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppRecordingStatusDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppRecordingStatusDetails {}
 unsafe impl ::core::marker::Sync for AppRecordingStatusDetails {}
 #[doc = "*Required features: `\"Media_AppRecording\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Audio/mod.rs
@@ -585,36 +585,7 @@ impl IAudioInputNode {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IAudioInputNode> for ::windows::core::IUnknown {
-    fn from(value: IAudioInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioInputNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioInputNode> for ::windows::core::IUnknown {
-    fn from(value: &IAudioInputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioInputNode> for ::windows::core::IInspectable {
-    fn from(value: IAudioInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioInputNode> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAudioInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioInputNode> for ::windows::core::IInspectable {
-    fn from(value: &IAudioInputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioInputNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IAudioInputNode> for IAudioNode {
     type Error = ::windows::core::Error;
     fn try_from(value: IAudioInputNode) -> ::windows::core::Result<Self> {
@@ -820,36 +791,7 @@ impl IAudioInputNode2 {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IAudioInputNode2> for ::windows::core::IUnknown {
-    fn from(value: IAudioInputNode2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioInputNode2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioInputNode2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioInputNode2> for ::windows::core::IUnknown {
-    fn from(value: &IAudioInputNode2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioInputNode2> for ::windows::core::IInspectable {
-    fn from(value: IAudioInputNode2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioInputNode2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAudioInputNode2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioInputNode2> for ::windows::core::IInspectable {
-    fn from(value: &IAudioInputNode2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioInputNode2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IAudioInputNode2> for IAudioInputNode {
     type Error = ::windows::core::Error;
     fn try_from(value: IAudioInputNode2) -> ::windows::core::Result<Self> {
@@ -1028,36 +970,7 @@ impl IAudioNode {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IAudioNode> for ::windows::core::IUnknown {
-    fn from(value: IAudioNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioNode> for ::windows::core::IUnknown {
-    fn from(value: &IAudioNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioNode> for ::windows::core::IInspectable {
-    fn from(value: IAudioNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioNode> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAudioNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioNode> for ::windows::core::IInspectable {
-    fn from(value: &IAudioNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IAudioNode> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1448,36 +1361,7 @@ impl IAudioNodeWithListener {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IAudioNodeWithListener> for ::windows::core::IUnknown {
-    fn from(value: IAudioNodeWithListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioNodeWithListener> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioNodeWithListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioNodeWithListener> for ::windows::core::IUnknown {
-    fn from(value: &IAudioNodeWithListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioNodeWithListener> for ::windows::core::IInspectable {
-    fn from(value: IAudioNodeWithListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioNodeWithListener> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAudioNodeWithListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioNodeWithListener> for ::windows::core::IInspectable {
-    fn from(value: &IAudioNodeWithListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioNodeWithListener, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IAudioNodeWithListener> for IAudioNode {
     type Error = ::windows::core::Error;
     fn try_from(value: IAudioNodeWithListener) -> ::windows::core::Result<Self> {
@@ -2444,36 +2328,7 @@ unsafe impl ::windows::core::Interface for AudioDeviceInputNode {
 impl ::windows::core::RuntimeName for AudioDeviceInputNode {
     const NAME: &'static str = "Windows.Media.Audio.AudioDeviceInputNode";
 }
-impl ::core::convert::From<AudioDeviceInputNode> for ::windows::core::IUnknown {
-    fn from(value: AudioDeviceInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceInputNode> for ::windows::core::IUnknown {
-    fn from(value: &AudioDeviceInputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceInputNode> for &::windows::core::IUnknown {
-    fn from(value: &AudioDeviceInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioDeviceInputNode> for ::windows::core::IInspectable {
-    fn from(value: AudioDeviceInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceInputNode> for ::windows::core::IInspectable {
-    fn from(value: &AudioDeviceInputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceInputNode> for &::windows::core::IInspectable {
-    fn from(value: &AudioDeviceInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioDeviceInputNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioDeviceInputNode> for IAudioInputNode {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioDeviceInputNode) -> ::windows::core::Result<Self> {
@@ -2690,36 +2545,7 @@ unsafe impl ::windows::core::Interface for AudioDeviceOutputNode {
 impl ::windows::core::RuntimeName for AudioDeviceOutputNode {
     const NAME: &'static str = "Windows.Media.Audio.AudioDeviceOutputNode";
 }
-impl ::core::convert::From<AudioDeviceOutputNode> for ::windows::core::IUnknown {
-    fn from(value: AudioDeviceOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceOutputNode> for ::windows::core::IUnknown {
-    fn from(value: &AudioDeviceOutputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceOutputNode> for &::windows::core::IUnknown {
-    fn from(value: &AudioDeviceOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioDeviceOutputNode> for ::windows::core::IInspectable {
-    fn from(value: AudioDeviceOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceOutputNode> for ::windows::core::IInspectable {
-    fn from(value: &AudioDeviceOutputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceOutputNode> for &::windows::core::IInspectable {
-    fn from(value: &AudioDeviceOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioDeviceOutputNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioDeviceOutputNode> for IAudioNode {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioDeviceOutputNode) -> ::windows::core::Result<Self> {
@@ -3053,36 +2879,7 @@ unsafe impl ::windows::core::Interface for AudioFileInputNode {
 impl ::windows::core::RuntimeName for AudioFileInputNode {
     const NAME: &'static str = "Windows.Media.Audio.AudioFileInputNode";
 }
-impl ::core::convert::From<AudioFileInputNode> for ::windows::core::IUnknown {
-    fn from(value: AudioFileInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFileInputNode> for ::windows::core::IUnknown {
-    fn from(value: &AudioFileInputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFileInputNode> for &::windows::core::IUnknown {
-    fn from(value: &AudioFileInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioFileInputNode> for ::windows::core::IInspectable {
-    fn from(value: AudioFileInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFileInputNode> for ::windows::core::IInspectable {
-    fn from(value: &AudioFileInputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFileInputNode> for &::windows::core::IInspectable {
-    fn from(value: &AudioFileInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioFileInputNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioFileInputNode> for IAudioInputNode {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioFileInputNode) -> ::windows::core::Result<Self> {
@@ -3306,36 +3103,7 @@ unsafe impl ::windows::core::Interface for AudioFileOutputNode {
 impl ::windows::core::RuntimeName for AudioFileOutputNode {
     const NAME: &'static str = "Windows.Media.Audio.AudioFileOutputNode";
 }
-impl ::core::convert::From<AudioFileOutputNode> for ::windows::core::IUnknown {
-    fn from(value: AudioFileOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFileOutputNode> for ::windows::core::IUnknown {
-    fn from(value: &AudioFileOutputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFileOutputNode> for &::windows::core::IUnknown {
-    fn from(value: &AudioFileOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioFileOutputNode> for ::windows::core::IInspectable {
-    fn from(value: AudioFileOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFileOutputNode> for ::windows::core::IInspectable {
-    fn from(value: &AudioFileOutputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFileOutputNode> for &::windows::core::IInspectable {
-    fn from(value: &AudioFileOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioFileOutputNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioFileOutputNode> for IAudioNode {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioFileOutputNode) -> ::windows::core::Result<Self> {
@@ -3423,36 +3191,7 @@ unsafe impl ::windows::core::Interface for AudioFrameCompletedEventArgs {
 impl ::windows::core::RuntimeName for AudioFrameCompletedEventArgs {
     const NAME: &'static str = "Windows.Media.Audio.AudioFrameCompletedEventArgs";
 }
-impl ::core::convert::From<AudioFrameCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AudioFrameCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFrameCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AudioFrameCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFrameCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AudioFrameCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioFrameCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AudioFrameCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFrameCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AudioFrameCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFrameCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AudioFrameCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioFrameCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioFrameCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for AudioFrameCompletedEventArgs {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -3666,36 +3405,7 @@ unsafe impl ::windows::core::Interface for AudioFrameInputNode {
 impl ::windows::core::RuntimeName for AudioFrameInputNode {
     const NAME: &'static str = "Windows.Media.Audio.AudioFrameInputNode";
 }
-impl ::core::convert::From<AudioFrameInputNode> for ::windows::core::IUnknown {
-    fn from(value: AudioFrameInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFrameInputNode> for ::windows::core::IUnknown {
-    fn from(value: &AudioFrameInputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFrameInputNode> for &::windows::core::IUnknown {
-    fn from(value: &AudioFrameInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioFrameInputNode> for ::windows::core::IInspectable {
-    fn from(value: AudioFrameInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFrameInputNode> for ::windows::core::IInspectable {
-    fn from(value: &AudioFrameInputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFrameInputNode> for &::windows::core::IInspectable {
-    fn from(value: &AudioFrameInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioFrameInputNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioFrameInputNode> for IAudioInputNode {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioFrameInputNode) -> ::windows::core::Result<Self> {
@@ -3899,36 +3609,7 @@ unsafe impl ::windows::core::Interface for AudioFrameOutputNode {
 impl ::windows::core::RuntimeName for AudioFrameOutputNode {
     const NAME: &'static str = "Windows.Media.Audio.AudioFrameOutputNode";
 }
-impl ::core::convert::From<AudioFrameOutputNode> for ::windows::core::IUnknown {
-    fn from(value: AudioFrameOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFrameOutputNode> for ::windows::core::IUnknown {
-    fn from(value: &AudioFrameOutputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFrameOutputNode> for &::windows::core::IUnknown {
-    fn from(value: &AudioFrameOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioFrameOutputNode> for ::windows::core::IInspectable {
-    fn from(value: AudioFrameOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFrameOutputNode> for ::windows::core::IInspectable {
-    fn from(value: &AudioFrameOutputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFrameOutputNode> for &::windows::core::IInspectable {
-    fn from(value: &AudioFrameOutputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioFrameOutputNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioFrameOutputNode> for IAudioNode {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioFrameOutputNode) -> ::windows::core::Result<Self> {
@@ -4321,36 +4002,7 @@ unsafe impl ::windows::core::Interface for AudioGraph {
 impl ::windows::core::RuntimeName for AudioGraph {
     const NAME: &'static str = "Windows.Media.Audio.AudioGraph";
 }
-impl ::core::convert::From<AudioGraph> for ::windows::core::IUnknown {
-    fn from(value: AudioGraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioGraph> for ::windows::core::IUnknown {
-    fn from(value: &AudioGraph) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioGraph> for &::windows::core::IUnknown {
-    fn from(value: &AudioGraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioGraph> for ::windows::core::IInspectable {
-    fn from(value: AudioGraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioGraph> for ::windows::core::IInspectable {
-    fn from(value: &AudioGraph) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioGraph> for &::windows::core::IInspectable {
-    fn from(value: &AudioGraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioGraph, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<AudioGraph> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4429,41 +4081,7 @@ impl ::windows::core::RuntimeName for AudioGraphBatchUpdater {
     const NAME: &'static str = "Windows.Media.Audio.AudioGraphBatchUpdater";
 }
 #[cfg(feature = "Foundation")]
-impl ::core::convert::From<AudioGraphBatchUpdater> for ::windows::core::IUnknown {
-    fn from(value: AudioGraphBatchUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&AudioGraphBatchUpdater> for ::windows::core::IUnknown {
-    fn from(value: &AudioGraphBatchUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&AudioGraphBatchUpdater> for &::windows::core::IUnknown {
-    fn from(value: &AudioGraphBatchUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<AudioGraphBatchUpdater> for ::windows::core::IInspectable {
-    fn from(value: AudioGraphBatchUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&AudioGraphBatchUpdater> for ::windows::core::IInspectable {
-    fn from(value: &AudioGraphBatchUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&AudioGraphBatchUpdater> for &::windows::core::IInspectable {
-    fn from(value: &AudioGraphBatchUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioGraphBatchUpdater, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<AudioGraphBatchUpdater> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4545,36 +4163,7 @@ unsafe impl ::windows::core::Interface for AudioGraphConnection {
 impl ::windows::core::RuntimeName for AudioGraphConnection {
     const NAME: &'static str = "Windows.Media.Audio.AudioGraphConnection";
 }
-impl ::core::convert::From<AudioGraphConnection> for ::windows::core::IUnknown {
-    fn from(value: AudioGraphConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioGraphConnection> for ::windows::core::IUnknown {
-    fn from(value: &AudioGraphConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioGraphConnection> for &::windows::core::IUnknown {
-    fn from(value: &AudioGraphConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioGraphConnection> for ::windows::core::IInspectable {
-    fn from(value: AudioGraphConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioGraphConnection> for ::windows::core::IInspectable {
-    fn from(value: &AudioGraphConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioGraphConnection> for &::windows::core::IInspectable {
-    fn from(value: &AudioGraphConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioGraphConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioGraphConnection {}
 unsafe impl ::core::marker::Sync for AudioGraphConnection {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -4716,36 +4305,7 @@ unsafe impl ::windows::core::Interface for AudioGraphSettings {
 impl ::windows::core::RuntimeName for AudioGraphSettings {
     const NAME: &'static str = "Windows.Media.Audio.AudioGraphSettings";
 }
-impl ::core::convert::From<AudioGraphSettings> for ::windows::core::IUnknown {
-    fn from(value: AudioGraphSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioGraphSettings> for ::windows::core::IUnknown {
-    fn from(value: &AudioGraphSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioGraphSettings> for &::windows::core::IUnknown {
-    fn from(value: &AudioGraphSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioGraphSettings> for ::windows::core::IInspectable {
-    fn from(value: AudioGraphSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioGraphSettings> for ::windows::core::IInspectable {
-    fn from(value: &AudioGraphSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioGraphSettings> for &::windows::core::IInspectable {
-    fn from(value: &AudioGraphSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioGraphSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioGraphSettings {}
 unsafe impl ::core::marker::Sync for AudioGraphSettings {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -4792,36 +4352,7 @@ unsafe impl ::windows::core::Interface for AudioGraphUnrecoverableErrorOccurredE
 impl ::windows::core::RuntimeName for AudioGraphUnrecoverableErrorOccurredEventArgs {
     const NAME: &'static str = "Windows.Media.Audio.AudioGraphUnrecoverableErrorOccurredEventArgs";
 }
-impl ::core::convert::From<AudioGraphUnrecoverableErrorOccurredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AudioGraphUnrecoverableErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioGraphUnrecoverableErrorOccurredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AudioGraphUnrecoverableErrorOccurredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioGraphUnrecoverableErrorOccurredEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AudioGraphUnrecoverableErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioGraphUnrecoverableErrorOccurredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AudioGraphUnrecoverableErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioGraphUnrecoverableErrorOccurredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AudioGraphUnrecoverableErrorOccurredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioGraphUnrecoverableErrorOccurredEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AudioGraphUnrecoverableErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioGraphUnrecoverableErrorOccurredEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioGraphUnrecoverableErrorOccurredEventArgs {}
 unsafe impl ::core::marker::Sync for AudioGraphUnrecoverableErrorOccurredEventArgs {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -4989,36 +4520,7 @@ unsafe impl ::windows::core::Interface for AudioNodeEmitter {
 impl ::windows::core::RuntimeName for AudioNodeEmitter {
     const NAME: &'static str = "Windows.Media.Audio.AudioNodeEmitter";
 }
-impl ::core::convert::From<AudioNodeEmitter> for ::windows::core::IUnknown {
-    fn from(value: AudioNodeEmitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitter> for ::windows::core::IUnknown {
-    fn from(value: &AudioNodeEmitter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitter> for &::windows::core::IUnknown {
-    fn from(value: &AudioNodeEmitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioNodeEmitter> for ::windows::core::IInspectable {
-    fn from(value: AudioNodeEmitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitter> for ::windows::core::IInspectable {
-    fn from(value: &AudioNodeEmitter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitter> for &::windows::core::IInspectable {
-    fn from(value: &AudioNodeEmitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioNodeEmitter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioNodeEmitter {}
 unsafe impl ::core::marker::Sync for AudioNodeEmitter {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -5079,36 +4581,7 @@ unsafe impl ::windows::core::Interface for AudioNodeEmitterConeProperties {
 impl ::windows::core::RuntimeName for AudioNodeEmitterConeProperties {
     const NAME: &'static str = "Windows.Media.Audio.AudioNodeEmitterConeProperties";
 }
-impl ::core::convert::From<AudioNodeEmitterConeProperties> for ::windows::core::IUnknown {
-    fn from(value: AudioNodeEmitterConeProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterConeProperties> for ::windows::core::IUnknown {
-    fn from(value: &AudioNodeEmitterConeProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterConeProperties> for &::windows::core::IUnknown {
-    fn from(value: &AudioNodeEmitterConeProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioNodeEmitterConeProperties> for ::windows::core::IInspectable {
-    fn from(value: AudioNodeEmitterConeProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterConeProperties> for ::windows::core::IInspectable {
-    fn from(value: &AudioNodeEmitterConeProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterConeProperties> for &::windows::core::IInspectable {
-    fn from(value: &AudioNodeEmitterConeProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioNodeEmitterConeProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioNodeEmitterConeProperties {}
 unsafe impl ::core::marker::Sync for AudioNodeEmitterConeProperties {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -5193,36 +4666,7 @@ unsafe impl ::windows::core::Interface for AudioNodeEmitterDecayModel {
 impl ::windows::core::RuntimeName for AudioNodeEmitterDecayModel {
     const NAME: &'static str = "Windows.Media.Audio.AudioNodeEmitterDecayModel";
 }
-impl ::core::convert::From<AudioNodeEmitterDecayModel> for ::windows::core::IUnknown {
-    fn from(value: AudioNodeEmitterDecayModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterDecayModel> for ::windows::core::IUnknown {
-    fn from(value: &AudioNodeEmitterDecayModel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterDecayModel> for &::windows::core::IUnknown {
-    fn from(value: &AudioNodeEmitterDecayModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioNodeEmitterDecayModel> for ::windows::core::IInspectable {
-    fn from(value: AudioNodeEmitterDecayModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterDecayModel> for ::windows::core::IInspectable {
-    fn from(value: &AudioNodeEmitterDecayModel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterDecayModel> for &::windows::core::IInspectable {
-    fn from(value: &AudioNodeEmitterDecayModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioNodeEmitterDecayModel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioNodeEmitterDecayModel {}
 unsafe impl ::core::marker::Sync for AudioNodeEmitterDecayModel {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -5276,36 +4720,7 @@ unsafe impl ::windows::core::Interface for AudioNodeEmitterNaturalDecayModelProp
 impl ::windows::core::RuntimeName for AudioNodeEmitterNaturalDecayModelProperties {
     const NAME: &'static str = "Windows.Media.Audio.AudioNodeEmitterNaturalDecayModelProperties";
 }
-impl ::core::convert::From<AudioNodeEmitterNaturalDecayModelProperties> for ::windows::core::IUnknown {
-    fn from(value: AudioNodeEmitterNaturalDecayModelProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterNaturalDecayModelProperties> for ::windows::core::IUnknown {
-    fn from(value: &AudioNodeEmitterNaturalDecayModelProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterNaturalDecayModelProperties> for &::windows::core::IUnknown {
-    fn from(value: &AudioNodeEmitterNaturalDecayModelProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioNodeEmitterNaturalDecayModelProperties> for ::windows::core::IInspectable {
-    fn from(value: AudioNodeEmitterNaturalDecayModelProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterNaturalDecayModelProperties> for ::windows::core::IInspectable {
-    fn from(value: &AudioNodeEmitterNaturalDecayModelProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterNaturalDecayModelProperties> for &::windows::core::IInspectable {
-    fn from(value: &AudioNodeEmitterNaturalDecayModelProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioNodeEmitterNaturalDecayModelProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioNodeEmitterNaturalDecayModelProperties {}
 unsafe impl ::core::marker::Sync for AudioNodeEmitterNaturalDecayModelProperties {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -5376,36 +4791,7 @@ unsafe impl ::windows::core::Interface for AudioNodeEmitterShape {
 impl ::windows::core::RuntimeName for AudioNodeEmitterShape {
     const NAME: &'static str = "Windows.Media.Audio.AudioNodeEmitterShape";
 }
-impl ::core::convert::From<AudioNodeEmitterShape> for ::windows::core::IUnknown {
-    fn from(value: AudioNodeEmitterShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterShape> for ::windows::core::IUnknown {
-    fn from(value: &AudioNodeEmitterShape) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterShape> for &::windows::core::IUnknown {
-    fn from(value: &AudioNodeEmitterShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioNodeEmitterShape> for ::windows::core::IInspectable {
-    fn from(value: AudioNodeEmitterShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterShape> for ::windows::core::IInspectable {
-    fn from(value: &AudioNodeEmitterShape) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeEmitterShape> for &::windows::core::IInspectable {
-    fn from(value: &AudioNodeEmitterShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioNodeEmitterShape, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioNodeEmitterShape {}
 unsafe impl ::core::marker::Sync for AudioNodeEmitterShape {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -5508,36 +4894,7 @@ unsafe impl ::windows::core::Interface for AudioNodeListener {
 impl ::windows::core::RuntimeName for AudioNodeListener {
     const NAME: &'static str = "Windows.Media.Audio.AudioNodeListener";
 }
-impl ::core::convert::From<AudioNodeListener> for ::windows::core::IUnknown {
-    fn from(value: AudioNodeListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeListener> for ::windows::core::IUnknown {
-    fn from(value: &AudioNodeListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeListener> for &::windows::core::IUnknown {
-    fn from(value: &AudioNodeListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioNodeListener> for ::windows::core::IInspectable {
-    fn from(value: AudioNodeListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioNodeListener> for ::windows::core::IInspectable {
-    fn from(value: &AudioNodeListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioNodeListener> for &::windows::core::IInspectable {
-    fn from(value: &AudioNodeListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioNodeListener, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioNodeListener {}
 unsafe impl ::core::marker::Sync for AudioNodeListener {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -5658,36 +5015,7 @@ unsafe impl ::windows::core::Interface for AudioPlaybackConnection {
 impl ::windows::core::RuntimeName for AudioPlaybackConnection {
     const NAME: &'static str = "Windows.Media.Audio.AudioPlaybackConnection";
 }
-impl ::core::convert::From<AudioPlaybackConnection> for ::windows::core::IUnknown {
-    fn from(value: AudioPlaybackConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioPlaybackConnection> for ::windows::core::IUnknown {
-    fn from(value: &AudioPlaybackConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioPlaybackConnection> for &::windows::core::IUnknown {
-    fn from(value: &AudioPlaybackConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioPlaybackConnection> for ::windows::core::IInspectable {
-    fn from(value: AudioPlaybackConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioPlaybackConnection> for ::windows::core::IInspectable {
-    fn from(value: &AudioPlaybackConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioPlaybackConnection> for &::windows::core::IInspectable {
-    fn from(value: &AudioPlaybackConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioPlaybackConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<AudioPlaybackConnection> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5763,36 +5091,7 @@ unsafe impl ::windows::core::Interface for AudioPlaybackConnectionOpenResult {
 impl ::windows::core::RuntimeName for AudioPlaybackConnectionOpenResult {
     const NAME: &'static str = "Windows.Media.Audio.AudioPlaybackConnectionOpenResult";
 }
-impl ::core::convert::From<AudioPlaybackConnectionOpenResult> for ::windows::core::IUnknown {
-    fn from(value: AudioPlaybackConnectionOpenResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioPlaybackConnectionOpenResult> for ::windows::core::IUnknown {
-    fn from(value: &AudioPlaybackConnectionOpenResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioPlaybackConnectionOpenResult> for &::windows::core::IUnknown {
-    fn from(value: &AudioPlaybackConnectionOpenResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioPlaybackConnectionOpenResult> for ::windows::core::IInspectable {
-    fn from(value: AudioPlaybackConnectionOpenResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioPlaybackConnectionOpenResult> for ::windows::core::IInspectable {
-    fn from(value: &AudioPlaybackConnectionOpenResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioPlaybackConnectionOpenResult> for &::windows::core::IInspectable {
-    fn from(value: &AudioPlaybackConnectionOpenResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioPlaybackConnectionOpenResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioPlaybackConnectionOpenResult {}
 unsafe impl ::core::marker::Sync for AudioPlaybackConnectionOpenResult {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -5919,36 +5218,7 @@ unsafe impl ::windows::core::Interface for AudioStateMonitor {
 impl ::windows::core::RuntimeName for AudioStateMonitor {
     const NAME: &'static str = "Windows.Media.Audio.AudioStateMonitor";
 }
-impl ::core::convert::From<AudioStateMonitor> for ::windows::core::IUnknown {
-    fn from(value: AudioStateMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioStateMonitor> for ::windows::core::IUnknown {
-    fn from(value: &AudioStateMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioStateMonitor> for &::windows::core::IUnknown {
-    fn from(value: &AudioStateMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioStateMonitor> for ::windows::core::IInspectable {
-    fn from(value: AudioStateMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioStateMonitor> for ::windows::core::IInspectable {
-    fn from(value: &AudioStateMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioStateMonitor> for &::windows::core::IInspectable {
-    fn from(value: &AudioStateMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioStateMonitor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioStateMonitor {}
 unsafe impl ::core::marker::Sync for AudioStateMonitor {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -6106,36 +5376,7 @@ unsafe impl ::windows::core::Interface for AudioSubmixNode {
 impl ::windows::core::RuntimeName for AudioSubmixNode {
     const NAME: &'static str = "Windows.Media.Audio.AudioSubmixNode";
 }
-impl ::core::convert::From<AudioSubmixNode> for ::windows::core::IUnknown {
-    fn from(value: AudioSubmixNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioSubmixNode> for ::windows::core::IUnknown {
-    fn from(value: &AudioSubmixNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioSubmixNode> for &::windows::core::IUnknown {
-    fn from(value: &AudioSubmixNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioSubmixNode> for ::windows::core::IInspectable {
-    fn from(value: AudioSubmixNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioSubmixNode> for ::windows::core::IInspectable {
-    fn from(value: &AudioSubmixNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioSubmixNode> for &::windows::core::IInspectable {
-    fn from(value: &AudioSubmixNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioSubmixNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioSubmixNode> for IAudioInputNode {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioSubmixNode) -> ::windows::core::Result<Self> {
@@ -6275,36 +5516,7 @@ unsafe impl ::windows::core::Interface for CreateAudioDeviceInputNodeResult {
 impl ::windows::core::RuntimeName for CreateAudioDeviceInputNodeResult {
     const NAME: &'static str = "Windows.Media.Audio.CreateAudioDeviceInputNodeResult";
 }
-impl ::core::convert::From<CreateAudioDeviceInputNodeResult> for ::windows::core::IUnknown {
-    fn from(value: CreateAudioDeviceInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateAudioDeviceInputNodeResult> for ::windows::core::IUnknown {
-    fn from(value: &CreateAudioDeviceInputNodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateAudioDeviceInputNodeResult> for &::windows::core::IUnknown {
-    fn from(value: &CreateAudioDeviceInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CreateAudioDeviceInputNodeResult> for ::windows::core::IInspectable {
-    fn from(value: CreateAudioDeviceInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateAudioDeviceInputNodeResult> for ::windows::core::IInspectable {
-    fn from(value: &CreateAudioDeviceInputNodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateAudioDeviceInputNodeResult> for &::windows::core::IInspectable {
-    fn from(value: &CreateAudioDeviceInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CreateAudioDeviceInputNodeResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CreateAudioDeviceInputNodeResult {}
 unsafe impl ::core::marker::Sync for CreateAudioDeviceInputNodeResult {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -6365,36 +5577,7 @@ unsafe impl ::windows::core::Interface for CreateAudioDeviceOutputNodeResult {
 impl ::windows::core::RuntimeName for CreateAudioDeviceOutputNodeResult {
     const NAME: &'static str = "Windows.Media.Audio.CreateAudioDeviceOutputNodeResult";
 }
-impl ::core::convert::From<CreateAudioDeviceOutputNodeResult> for ::windows::core::IUnknown {
-    fn from(value: CreateAudioDeviceOutputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateAudioDeviceOutputNodeResult> for ::windows::core::IUnknown {
-    fn from(value: &CreateAudioDeviceOutputNodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateAudioDeviceOutputNodeResult> for &::windows::core::IUnknown {
-    fn from(value: &CreateAudioDeviceOutputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CreateAudioDeviceOutputNodeResult> for ::windows::core::IInspectable {
-    fn from(value: CreateAudioDeviceOutputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateAudioDeviceOutputNodeResult> for ::windows::core::IInspectable {
-    fn from(value: &CreateAudioDeviceOutputNodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateAudioDeviceOutputNodeResult> for &::windows::core::IInspectable {
-    fn from(value: &CreateAudioDeviceOutputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CreateAudioDeviceOutputNodeResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CreateAudioDeviceOutputNodeResult {}
 unsafe impl ::core::marker::Sync for CreateAudioDeviceOutputNodeResult {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -6455,36 +5638,7 @@ unsafe impl ::windows::core::Interface for CreateAudioFileInputNodeResult {
 impl ::windows::core::RuntimeName for CreateAudioFileInputNodeResult {
     const NAME: &'static str = "Windows.Media.Audio.CreateAudioFileInputNodeResult";
 }
-impl ::core::convert::From<CreateAudioFileInputNodeResult> for ::windows::core::IUnknown {
-    fn from(value: CreateAudioFileInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateAudioFileInputNodeResult> for ::windows::core::IUnknown {
-    fn from(value: &CreateAudioFileInputNodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateAudioFileInputNodeResult> for &::windows::core::IUnknown {
-    fn from(value: &CreateAudioFileInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CreateAudioFileInputNodeResult> for ::windows::core::IInspectable {
-    fn from(value: CreateAudioFileInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateAudioFileInputNodeResult> for ::windows::core::IInspectable {
-    fn from(value: &CreateAudioFileInputNodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateAudioFileInputNodeResult> for &::windows::core::IInspectable {
-    fn from(value: &CreateAudioFileInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CreateAudioFileInputNodeResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CreateAudioFileInputNodeResult {}
 unsafe impl ::core::marker::Sync for CreateAudioFileInputNodeResult {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -6545,36 +5699,7 @@ unsafe impl ::windows::core::Interface for CreateAudioFileOutputNodeResult {
 impl ::windows::core::RuntimeName for CreateAudioFileOutputNodeResult {
     const NAME: &'static str = "Windows.Media.Audio.CreateAudioFileOutputNodeResult";
 }
-impl ::core::convert::From<CreateAudioFileOutputNodeResult> for ::windows::core::IUnknown {
-    fn from(value: CreateAudioFileOutputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateAudioFileOutputNodeResult> for ::windows::core::IUnknown {
-    fn from(value: &CreateAudioFileOutputNodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateAudioFileOutputNodeResult> for &::windows::core::IUnknown {
-    fn from(value: &CreateAudioFileOutputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CreateAudioFileOutputNodeResult> for ::windows::core::IInspectable {
-    fn from(value: CreateAudioFileOutputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateAudioFileOutputNodeResult> for ::windows::core::IInspectable {
-    fn from(value: &CreateAudioFileOutputNodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateAudioFileOutputNodeResult> for &::windows::core::IInspectable {
-    fn from(value: &CreateAudioFileOutputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CreateAudioFileOutputNodeResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CreateAudioFileOutputNodeResult {}
 unsafe impl ::core::marker::Sync for CreateAudioFileOutputNodeResult {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -6635,36 +5760,7 @@ unsafe impl ::windows::core::Interface for CreateAudioGraphResult {
 impl ::windows::core::RuntimeName for CreateAudioGraphResult {
     const NAME: &'static str = "Windows.Media.Audio.CreateAudioGraphResult";
 }
-impl ::core::convert::From<CreateAudioGraphResult> for ::windows::core::IUnknown {
-    fn from(value: CreateAudioGraphResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateAudioGraphResult> for ::windows::core::IUnknown {
-    fn from(value: &CreateAudioGraphResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateAudioGraphResult> for &::windows::core::IUnknown {
-    fn from(value: &CreateAudioGraphResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CreateAudioGraphResult> for ::windows::core::IInspectable {
-    fn from(value: CreateAudioGraphResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateAudioGraphResult> for ::windows::core::IInspectable {
-    fn from(value: &CreateAudioGraphResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateAudioGraphResult> for &::windows::core::IInspectable {
-    fn from(value: &CreateAudioGraphResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CreateAudioGraphResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CreateAudioGraphResult {}
 unsafe impl ::core::marker::Sync for CreateAudioGraphResult {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -6725,36 +5821,7 @@ unsafe impl ::windows::core::Interface for CreateMediaSourceAudioInputNodeResult
 impl ::windows::core::RuntimeName for CreateMediaSourceAudioInputNodeResult {
     const NAME: &'static str = "Windows.Media.Audio.CreateMediaSourceAudioInputNodeResult";
 }
-impl ::core::convert::From<CreateMediaSourceAudioInputNodeResult> for ::windows::core::IUnknown {
-    fn from(value: CreateMediaSourceAudioInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateMediaSourceAudioInputNodeResult> for ::windows::core::IUnknown {
-    fn from(value: &CreateMediaSourceAudioInputNodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateMediaSourceAudioInputNodeResult> for &::windows::core::IUnknown {
-    fn from(value: &CreateMediaSourceAudioInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CreateMediaSourceAudioInputNodeResult> for ::windows::core::IInspectable {
-    fn from(value: CreateMediaSourceAudioInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CreateMediaSourceAudioInputNodeResult> for ::windows::core::IInspectable {
-    fn from(value: &CreateMediaSourceAudioInputNodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CreateMediaSourceAudioInputNodeResult> for &::windows::core::IInspectable {
-    fn from(value: &CreateMediaSourceAudioInputNodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CreateMediaSourceAudioInputNodeResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CreateMediaSourceAudioInputNodeResult {}
 unsafe impl ::core::marker::Sync for CreateMediaSourceAudioInputNodeResult {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -6856,36 +5923,7 @@ unsafe impl ::windows::core::Interface for EchoEffectDefinition {
 impl ::windows::core::RuntimeName for EchoEffectDefinition {
     const NAME: &'static str = "Windows.Media.Audio.EchoEffectDefinition";
 }
-impl ::core::convert::From<EchoEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: EchoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EchoEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &EchoEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EchoEffectDefinition> for &::windows::core::IUnknown {
-    fn from(value: &EchoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EchoEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: EchoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EchoEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &EchoEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EchoEffectDefinition> for &::windows::core::IInspectable {
-    fn from(value: &EchoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EchoEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Media_Effects")]
 impl ::core::convert::TryFrom<EchoEffectDefinition> for super::Effects::IAudioEffectDefinition {
     type Error = ::windows::core::Error;
@@ -6980,36 +6018,7 @@ unsafe impl ::windows::core::Interface for EqualizerBand {
 impl ::windows::core::RuntimeName for EqualizerBand {
     const NAME: &'static str = "Windows.Media.Audio.EqualizerBand";
 }
-impl ::core::convert::From<EqualizerBand> for ::windows::core::IUnknown {
-    fn from(value: EqualizerBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EqualizerBand> for ::windows::core::IUnknown {
-    fn from(value: &EqualizerBand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EqualizerBand> for &::windows::core::IUnknown {
-    fn from(value: &EqualizerBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EqualizerBand> for ::windows::core::IInspectable {
-    fn from(value: EqualizerBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EqualizerBand> for ::windows::core::IInspectable {
-    fn from(value: &EqualizerBand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EqualizerBand> for &::windows::core::IInspectable {
-    fn from(value: &EqualizerBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EqualizerBand, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EqualizerBand {}
 unsafe impl ::core::marker::Sync for EqualizerBand {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -7087,36 +6096,7 @@ unsafe impl ::windows::core::Interface for EqualizerEffectDefinition {
 impl ::windows::core::RuntimeName for EqualizerEffectDefinition {
     const NAME: &'static str = "Windows.Media.Audio.EqualizerEffectDefinition";
 }
-impl ::core::convert::From<EqualizerEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: EqualizerEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EqualizerEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &EqualizerEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EqualizerEffectDefinition> for &::windows::core::IUnknown {
-    fn from(value: &EqualizerEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EqualizerEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: EqualizerEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EqualizerEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &EqualizerEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EqualizerEffectDefinition> for &::windows::core::IInspectable {
-    fn from(value: &EqualizerEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EqualizerEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Media_Effects")]
 impl ::core::convert::TryFrom<EqualizerEffectDefinition> for super::Effects::IAudioEffectDefinition {
     type Error = ::windows::core::Error;
@@ -7185,36 +6165,7 @@ unsafe impl ::windows::core::Interface for FrameInputNodeQuantumStartedEventArgs
 impl ::windows::core::RuntimeName for FrameInputNodeQuantumStartedEventArgs {
     const NAME: &'static str = "Windows.Media.Audio.FrameInputNodeQuantumStartedEventArgs";
 }
-impl ::core::convert::From<FrameInputNodeQuantumStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: FrameInputNodeQuantumStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameInputNodeQuantumStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &FrameInputNodeQuantumStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameInputNodeQuantumStartedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &FrameInputNodeQuantumStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameInputNodeQuantumStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: FrameInputNodeQuantumStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameInputNodeQuantumStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &FrameInputNodeQuantumStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameInputNodeQuantumStartedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &FrameInputNodeQuantumStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameInputNodeQuantumStartedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FrameInputNodeQuantumStartedEventArgs {}
 unsafe impl ::core::marker::Sync for FrameInputNodeQuantumStartedEventArgs {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -7305,36 +6256,7 @@ unsafe impl ::windows::core::Interface for LimiterEffectDefinition {
 impl ::windows::core::RuntimeName for LimiterEffectDefinition {
     const NAME: &'static str = "Windows.Media.Audio.LimiterEffectDefinition";
 }
-impl ::core::convert::From<LimiterEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: LimiterEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LimiterEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &LimiterEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LimiterEffectDefinition> for &::windows::core::IUnknown {
-    fn from(value: &LimiterEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LimiterEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: LimiterEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LimiterEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &LimiterEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LimiterEffectDefinition> for &::windows::core::IInspectable {
-    fn from(value: &LimiterEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LimiterEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Media_Effects")]
 impl ::core::convert::TryFrom<LimiterEffectDefinition> for super::Effects::IAudioEffectDefinition {
     type Error = ::windows::core::Error;
@@ -7630,36 +6552,7 @@ unsafe impl ::windows::core::Interface for MediaSourceAudioInputNode {
 impl ::windows::core::RuntimeName for MediaSourceAudioInputNode {
     const NAME: &'static str = "Windows.Media.Audio.MediaSourceAudioInputNode";
 }
-impl ::core::convert::From<MediaSourceAudioInputNode> for ::windows::core::IUnknown {
-    fn from(value: MediaSourceAudioInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSourceAudioInputNode> for ::windows::core::IUnknown {
-    fn from(value: &MediaSourceAudioInputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSourceAudioInputNode> for &::windows::core::IUnknown {
-    fn from(value: &MediaSourceAudioInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaSourceAudioInputNode> for ::windows::core::IInspectable {
-    fn from(value: MediaSourceAudioInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSourceAudioInputNode> for ::windows::core::IInspectable {
-    fn from(value: &MediaSourceAudioInputNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSourceAudioInputNode> for &::windows::core::IInspectable {
-    fn from(value: &MediaSourceAudioInputNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaSourceAudioInputNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MediaSourceAudioInputNode> for IAudioInputNode {
     type Error = ::windows::core::Error;
     fn try_from(value: MediaSourceAudioInputNode) -> ::windows::core::Result<Self> {
@@ -8060,36 +6953,7 @@ unsafe impl ::windows::core::Interface for ReverbEffectDefinition {
 impl ::windows::core::RuntimeName for ReverbEffectDefinition {
     const NAME: &'static str = "Windows.Media.Audio.ReverbEffectDefinition";
 }
-impl ::core::convert::From<ReverbEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: ReverbEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ReverbEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &ReverbEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ReverbEffectDefinition> for &::windows::core::IUnknown {
-    fn from(value: &ReverbEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ReverbEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: ReverbEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ReverbEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &ReverbEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ReverbEffectDefinition> for &::windows::core::IInspectable {
-    fn from(value: &ReverbEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ReverbEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Media_Effects")]
 impl ::core::convert::TryFrom<ReverbEffectDefinition> for super::Effects::IAudioEffectDefinition {
     type Error = ::windows::core::Error;
@@ -8158,36 +7022,7 @@ unsafe impl ::windows::core::Interface for SetDefaultSpatialAudioFormatResult {
 impl ::windows::core::RuntimeName for SetDefaultSpatialAudioFormatResult {
     const NAME: &'static str = "Windows.Media.Audio.SetDefaultSpatialAudioFormatResult";
 }
-impl ::core::convert::From<SetDefaultSpatialAudioFormatResult> for ::windows::core::IUnknown {
-    fn from(value: SetDefaultSpatialAudioFormatResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SetDefaultSpatialAudioFormatResult> for ::windows::core::IUnknown {
-    fn from(value: &SetDefaultSpatialAudioFormatResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SetDefaultSpatialAudioFormatResult> for &::windows::core::IUnknown {
-    fn from(value: &SetDefaultSpatialAudioFormatResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SetDefaultSpatialAudioFormatResult> for ::windows::core::IInspectable {
-    fn from(value: SetDefaultSpatialAudioFormatResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SetDefaultSpatialAudioFormatResult> for ::windows::core::IInspectable {
-    fn from(value: &SetDefaultSpatialAudioFormatResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SetDefaultSpatialAudioFormatResult> for &::windows::core::IInspectable {
-    fn from(value: &SetDefaultSpatialAudioFormatResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SetDefaultSpatialAudioFormatResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SetDefaultSpatialAudioFormatResult {}
 unsafe impl ::core::marker::Sync for SetDefaultSpatialAudioFormatResult {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -8297,36 +7132,7 @@ unsafe impl ::windows::core::Interface for SpatialAudioDeviceConfiguration {
 impl ::windows::core::RuntimeName for SpatialAudioDeviceConfiguration {
     const NAME: &'static str = "Windows.Media.Audio.SpatialAudioDeviceConfiguration";
 }
-impl ::core::convert::From<SpatialAudioDeviceConfiguration> for ::windows::core::IUnknown {
-    fn from(value: SpatialAudioDeviceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAudioDeviceConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &SpatialAudioDeviceConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAudioDeviceConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &SpatialAudioDeviceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialAudioDeviceConfiguration> for ::windows::core::IInspectable {
-    fn from(value: SpatialAudioDeviceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAudioDeviceConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &SpatialAudioDeviceConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAudioDeviceConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &SpatialAudioDeviceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialAudioDeviceConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialAudioDeviceConfiguration {}
 unsafe impl ::core::marker::Sync for SpatialAudioDeviceConfiguration {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]
@@ -8406,36 +7212,7 @@ unsafe impl ::windows::core::Interface for SpatialAudioFormatConfiguration {
 impl ::windows::core::RuntimeName for SpatialAudioFormatConfiguration {
     const NAME: &'static str = "Windows.Media.Audio.SpatialAudioFormatConfiguration";
 }
-impl ::core::convert::From<SpatialAudioFormatConfiguration> for ::windows::core::IUnknown {
-    fn from(value: SpatialAudioFormatConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAudioFormatConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &SpatialAudioFormatConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAudioFormatConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &SpatialAudioFormatConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialAudioFormatConfiguration> for ::windows::core::IInspectable {
-    fn from(value: SpatialAudioFormatConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAudioFormatConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &SpatialAudioFormatConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAudioFormatConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &SpatialAudioFormatConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialAudioFormatConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialAudioFormatConfiguration {}
 unsafe impl ::core::marker::Sync for SpatialAudioFormatConfiguration {}
 #[doc = "*Required features: `\"Media_Audio\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Capture/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/Core/mod.rs
@@ -151,36 +151,7 @@ unsafe impl ::windows::core::Interface for VariablePhotoCapturedEventArgs {
 impl ::windows::core::RuntimeName for VariablePhotoCapturedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.Core.VariablePhotoCapturedEventArgs";
 }
-impl ::core::convert::From<VariablePhotoCapturedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: VariablePhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VariablePhotoCapturedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &VariablePhotoCapturedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VariablePhotoCapturedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &VariablePhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VariablePhotoCapturedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: VariablePhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VariablePhotoCapturedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &VariablePhotoCapturedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VariablePhotoCapturedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &VariablePhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VariablePhotoCapturedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VariablePhotoCapturedEventArgs {}
 unsafe impl ::core::marker::Sync for VariablePhotoCapturedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture_Core\"`*"]
@@ -286,35 +257,6 @@ unsafe impl ::windows::core::Interface for VariablePhotoSequenceCapture {
 impl ::windows::core::RuntimeName for VariablePhotoSequenceCapture {
     const NAME: &'static str = "Windows.Media.Capture.Core.VariablePhotoSequenceCapture";
 }
-impl ::core::convert::From<VariablePhotoSequenceCapture> for ::windows::core::IUnknown {
-    fn from(value: VariablePhotoSequenceCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VariablePhotoSequenceCapture> for ::windows::core::IUnknown {
-    fn from(value: &VariablePhotoSequenceCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VariablePhotoSequenceCapture> for &::windows::core::IUnknown {
-    fn from(value: &VariablePhotoSequenceCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VariablePhotoSequenceCapture> for ::windows::core::IInspectable {
-    fn from(value: VariablePhotoSequenceCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VariablePhotoSequenceCapture> for ::windows::core::IInspectable {
-    fn from(value: &VariablePhotoSequenceCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VariablePhotoSequenceCapture> for &::windows::core::IInspectable {
-    fn from(value: &VariablePhotoSequenceCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VariablePhotoSequenceCapture, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "implement")]
 ::core::include!("impl.rs");

--- a/crates/libs/windows/src/Windows/Media/Capture/Frames/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/Frames/mod.rs
@@ -674,36 +674,7 @@ unsafe impl ::windows::core::Interface for AudioMediaFrame {
 impl ::windows::core::RuntimeName for AudioMediaFrame {
     const NAME: &'static str = "Windows.Media.Capture.Frames.AudioMediaFrame";
 }
-impl ::core::convert::From<AudioMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: AudioMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: &AudioMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioMediaFrame> for &::windows::core::IUnknown {
-    fn from(value: &AudioMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: AudioMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: &AudioMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioMediaFrame> for &::windows::core::IInspectable {
-    fn from(value: &AudioMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioMediaFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioMediaFrame {}
 unsafe impl ::core::marker::Sync for AudioMediaFrame {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -759,36 +730,7 @@ unsafe impl ::windows::core::Interface for BufferMediaFrame {
 impl ::windows::core::RuntimeName for BufferMediaFrame {
     const NAME: &'static str = "Windows.Media.Capture.Frames.BufferMediaFrame";
 }
-impl ::core::convert::From<BufferMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: BufferMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BufferMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: &BufferMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BufferMediaFrame> for &::windows::core::IUnknown {
-    fn from(value: &BufferMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BufferMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: BufferMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BufferMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: &BufferMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BufferMediaFrame> for &::windows::core::IInspectable {
-    fn from(value: &BufferMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BufferMediaFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BufferMediaFrame {}
 unsafe impl ::core::marker::Sync for BufferMediaFrame {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -872,36 +814,7 @@ unsafe impl ::windows::core::Interface for DepthMediaFrame {
 impl ::windows::core::RuntimeName for DepthMediaFrame {
     const NAME: &'static str = "Windows.Media.Capture.Frames.DepthMediaFrame";
 }
-impl ::core::convert::From<DepthMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: DepthMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DepthMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: &DepthMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DepthMediaFrame> for &::windows::core::IUnknown {
-    fn from(value: &DepthMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DepthMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: DepthMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DepthMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: &DepthMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DepthMediaFrame> for &::windows::core::IInspectable {
-    fn from(value: &DepthMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DepthMediaFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DepthMediaFrame {}
 unsafe impl ::core::marker::Sync for DepthMediaFrame {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -955,36 +868,7 @@ unsafe impl ::windows::core::Interface for DepthMediaFrameFormat {
 impl ::windows::core::RuntimeName for DepthMediaFrameFormat {
     const NAME: &'static str = "Windows.Media.Capture.Frames.DepthMediaFrameFormat";
 }
-impl ::core::convert::From<DepthMediaFrameFormat> for ::windows::core::IUnknown {
-    fn from(value: DepthMediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DepthMediaFrameFormat> for ::windows::core::IUnknown {
-    fn from(value: &DepthMediaFrameFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DepthMediaFrameFormat> for &::windows::core::IUnknown {
-    fn from(value: &DepthMediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DepthMediaFrameFormat> for ::windows::core::IInspectable {
-    fn from(value: DepthMediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DepthMediaFrameFormat> for ::windows::core::IInspectable {
-    fn from(value: &DepthMediaFrameFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DepthMediaFrameFormat> for &::windows::core::IInspectable {
-    fn from(value: &DepthMediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DepthMediaFrameFormat, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DepthMediaFrameFormat {}
 unsafe impl ::core::marker::Sync for DepthMediaFrameFormat {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -1045,36 +929,7 @@ unsafe impl ::windows::core::Interface for InfraredMediaFrame {
 impl ::windows::core::RuntimeName for InfraredMediaFrame {
     const NAME: &'static str = "Windows.Media.Capture.Frames.InfraredMediaFrame";
 }
-impl ::core::convert::From<InfraredMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: InfraredMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InfraredMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: &InfraredMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InfraredMediaFrame> for &::windows::core::IUnknown {
-    fn from(value: &InfraredMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InfraredMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: InfraredMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InfraredMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: &InfraredMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InfraredMediaFrame> for &::windows::core::IInspectable {
-    fn from(value: &InfraredMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InfraredMediaFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InfraredMediaFrame {}
 unsafe impl ::core::marker::Sync for InfraredMediaFrame {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -1113,36 +968,7 @@ unsafe impl ::windows::core::Interface for MediaFrameArrivedEventArgs {
 impl ::windows::core::RuntimeName for MediaFrameArrivedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MediaFrameArrivedEventArgs";
 }
-impl ::core::convert::From<MediaFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameArrivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameArrivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaFrameArrivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaFrameArrivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaFrameArrivedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -1230,36 +1056,7 @@ unsafe impl ::windows::core::Interface for MediaFrameFormat {
 impl ::windows::core::RuntimeName for MediaFrameFormat {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MediaFrameFormat";
 }
-impl ::core::convert::From<MediaFrameFormat> for ::windows::core::IUnknown {
-    fn from(value: MediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameFormat> for ::windows::core::IUnknown {
-    fn from(value: &MediaFrameFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameFormat> for &::windows::core::IUnknown {
-    fn from(value: &MediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaFrameFormat> for ::windows::core::IInspectable {
-    fn from(value: MediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameFormat> for ::windows::core::IInspectable {
-    fn from(value: &MediaFrameFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameFormat> for &::windows::core::IInspectable {
-    fn from(value: &MediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaFrameFormat, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaFrameFormat {}
 unsafe impl ::core::marker::Sync for MediaFrameFormat {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -1356,36 +1153,7 @@ unsafe impl ::windows::core::Interface for MediaFrameReader {
 impl ::windows::core::RuntimeName for MediaFrameReader {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MediaFrameReader";
 }
-impl ::core::convert::From<MediaFrameReader> for ::windows::core::IUnknown {
-    fn from(value: MediaFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameReader> for ::windows::core::IUnknown {
-    fn from(value: &MediaFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameReader> for &::windows::core::IUnknown {
-    fn from(value: &MediaFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaFrameReader> for ::windows::core::IInspectable {
-    fn from(value: MediaFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameReader> for ::windows::core::IInspectable {
-    fn from(value: &MediaFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameReader> for &::windows::core::IInspectable {
-    fn from(value: &MediaFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaFrameReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MediaFrameReader> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1524,36 +1292,7 @@ unsafe impl ::windows::core::Interface for MediaFrameReference {
 impl ::windows::core::RuntimeName for MediaFrameReference {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MediaFrameReference";
 }
-impl ::core::convert::From<MediaFrameReference> for ::windows::core::IUnknown {
-    fn from(value: MediaFrameReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameReference> for ::windows::core::IUnknown {
-    fn from(value: &MediaFrameReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameReference> for &::windows::core::IUnknown {
-    fn from(value: &MediaFrameReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaFrameReference> for ::windows::core::IInspectable {
-    fn from(value: MediaFrameReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameReference> for ::windows::core::IInspectable {
-    fn from(value: &MediaFrameReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameReference> for &::windows::core::IInspectable {
-    fn from(value: &MediaFrameReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaFrameReference, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MediaFrameReference> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1678,36 +1417,7 @@ unsafe impl ::windows::core::Interface for MediaFrameSource {
 impl ::windows::core::RuntimeName for MediaFrameSource {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MediaFrameSource";
 }
-impl ::core::convert::From<MediaFrameSource> for ::windows::core::IUnknown {
-    fn from(value: MediaFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameSource> for ::windows::core::IUnknown {
-    fn from(value: &MediaFrameSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameSource> for &::windows::core::IUnknown {
-    fn from(value: &MediaFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaFrameSource> for ::windows::core::IInspectable {
-    fn from(value: MediaFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameSource> for ::windows::core::IInspectable {
-    fn from(value: &MediaFrameSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameSource> for &::windows::core::IInspectable {
-    fn from(value: &MediaFrameSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaFrameSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaFrameSource {}
 unsafe impl ::core::marker::Sync for MediaFrameSource {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -1808,36 +1518,7 @@ unsafe impl ::windows::core::Interface for MediaFrameSourceController {
 impl ::windows::core::RuntimeName for MediaFrameSourceController {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MediaFrameSourceController";
 }
-impl ::core::convert::From<MediaFrameSourceController> for ::windows::core::IUnknown {
-    fn from(value: MediaFrameSourceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceController> for ::windows::core::IUnknown {
-    fn from(value: &MediaFrameSourceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceController> for &::windows::core::IUnknown {
-    fn from(value: &MediaFrameSourceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaFrameSourceController> for ::windows::core::IInspectable {
-    fn from(value: MediaFrameSourceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceController> for ::windows::core::IInspectable {
-    fn from(value: &MediaFrameSourceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceController> for &::windows::core::IInspectable {
-    fn from(value: &MediaFrameSourceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaFrameSourceController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaFrameSourceController {}
 unsafe impl ::core::marker::Sync for MediaFrameSourceController {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -1891,36 +1572,7 @@ unsafe impl ::windows::core::Interface for MediaFrameSourceGetPropertyResult {
 impl ::windows::core::RuntimeName for MediaFrameSourceGetPropertyResult {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MediaFrameSourceGetPropertyResult";
 }
-impl ::core::convert::From<MediaFrameSourceGetPropertyResult> for ::windows::core::IUnknown {
-    fn from(value: MediaFrameSourceGetPropertyResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceGetPropertyResult> for ::windows::core::IUnknown {
-    fn from(value: &MediaFrameSourceGetPropertyResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceGetPropertyResult> for &::windows::core::IUnknown {
-    fn from(value: &MediaFrameSourceGetPropertyResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaFrameSourceGetPropertyResult> for ::windows::core::IInspectable {
-    fn from(value: MediaFrameSourceGetPropertyResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceGetPropertyResult> for ::windows::core::IInspectable {
-    fn from(value: &MediaFrameSourceGetPropertyResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceGetPropertyResult> for &::windows::core::IInspectable {
-    fn from(value: &MediaFrameSourceGetPropertyResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaFrameSourceGetPropertyResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaFrameSourceGetPropertyResult {}
 unsafe impl ::core::marker::Sync for MediaFrameSourceGetPropertyResult {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -2010,36 +1662,7 @@ unsafe impl ::windows::core::Interface for MediaFrameSourceGroup {
 impl ::windows::core::RuntimeName for MediaFrameSourceGroup {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MediaFrameSourceGroup";
 }
-impl ::core::convert::From<MediaFrameSourceGroup> for ::windows::core::IUnknown {
-    fn from(value: MediaFrameSourceGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceGroup> for ::windows::core::IUnknown {
-    fn from(value: &MediaFrameSourceGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceGroup> for &::windows::core::IUnknown {
-    fn from(value: &MediaFrameSourceGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaFrameSourceGroup> for ::windows::core::IInspectable {
-    fn from(value: MediaFrameSourceGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceGroup> for ::windows::core::IInspectable {
-    fn from(value: &MediaFrameSourceGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceGroup> for &::windows::core::IInspectable {
-    fn from(value: &MediaFrameSourceGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaFrameSourceGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaFrameSourceGroup {}
 unsafe impl ::core::marker::Sync for MediaFrameSourceGroup {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -2159,36 +1782,7 @@ unsafe impl ::windows::core::Interface for MediaFrameSourceInfo {
 impl ::windows::core::RuntimeName for MediaFrameSourceInfo {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MediaFrameSourceInfo";
 }
-impl ::core::convert::From<MediaFrameSourceInfo> for ::windows::core::IUnknown {
-    fn from(value: MediaFrameSourceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceInfo> for ::windows::core::IUnknown {
-    fn from(value: &MediaFrameSourceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceInfo> for &::windows::core::IUnknown {
-    fn from(value: &MediaFrameSourceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaFrameSourceInfo> for ::windows::core::IInspectable {
-    fn from(value: MediaFrameSourceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceInfo> for ::windows::core::IInspectable {
-    fn from(value: &MediaFrameSourceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaFrameSourceInfo> for &::windows::core::IInspectable {
-    fn from(value: &MediaFrameSourceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaFrameSourceInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaFrameSourceInfo {}
 unsafe impl ::core::marker::Sync for MediaFrameSourceInfo {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -2227,36 +1821,7 @@ unsafe impl ::windows::core::Interface for MultiSourceMediaFrameArrivedEventArgs
 impl ::windows::core::RuntimeName for MultiSourceMediaFrameArrivedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MultiSourceMediaFrameArrivedEventArgs";
 }
-impl ::core::convert::From<MultiSourceMediaFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MultiSourceMediaFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameArrivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MultiSourceMediaFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameArrivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MultiSourceMediaFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MultiSourceMediaFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MultiSourceMediaFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameArrivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MultiSourceMediaFrameArrivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameArrivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MultiSourceMediaFrameArrivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MultiSourceMediaFrameArrivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MultiSourceMediaFrameArrivedEventArgs {}
 unsafe impl ::core::marker::Sync for MultiSourceMediaFrameArrivedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -2353,36 +1918,7 @@ unsafe impl ::windows::core::Interface for MultiSourceMediaFrameReader {
 impl ::windows::core::RuntimeName for MultiSourceMediaFrameReader {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MultiSourceMediaFrameReader";
 }
-impl ::core::convert::From<MultiSourceMediaFrameReader> for ::windows::core::IUnknown {
-    fn from(value: MultiSourceMediaFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameReader> for ::windows::core::IUnknown {
-    fn from(value: &MultiSourceMediaFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameReader> for &::windows::core::IUnknown {
-    fn from(value: &MultiSourceMediaFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MultiSourceMediaFrameReader> for ::windows::core::IInspectable {
-    fn from(value: MultiSourceMediaFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameReader> for ::windows::core::IInspectable {
-    fn from(value: &MultiSourceMediaFrameReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameReader> for &::windows::core::IInspectable {
-    fn from(value: &MultiSourceMediaFrameReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MultiSourceMediaFrameReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MultiSourceMediaFrameReader> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2457,36 +1993,7 @@ unsafe impl ::windows::core::Interface for MultiSourceMediaFrameReference {
 impl ::windows::core::RuntimeName for MultiSourceMediaFrameReference {
     const NAME: &'static str = "Windows.Media.Capture.Frames.MultiSourceMediaFrameReference";
 }
-impl ::core::convert::From<MultiSourceMediaFrameReference> for ::windows::core::IUnknown {
-    fn from(value: MultiSourceMediaFrameReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameReference> for ::windows::core::IUnknown {
-    fn from(value: &MultiSourceMediaFrameReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameReference> for &::windows::core::IUnknown {
-    fn from(value: &MultiSourceMediaFrameReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MultiSourceMediaFrameReference> for ::windows::core::IInspectable {
-    fn from(value: MultiSourceMediaFrameReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameReference> for ::windows::core::IInspectable {
-    fn from(value: &MultiSourceMediaFrameReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MultiSourceMediaFrameReference> for &::windows::core::IInspectable {
-    fn from(value: &MultiSourceMediaFrameReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MultiSourceMediaFrameReference, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MultiSourceMediaFrameReference> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2610,36 +2117,7 @@ unsafe impl ::windows::core::Interface for VideoMediaFrame {
 impl ::windows::core::RuntimeName for VideoMediaFrame {
     const NAME: &'static str = "Windows.Media.Capture.Frames.VideoMediaFrame";
 }
-impl ::core::convert::From<VideoMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: VideoMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: &VideoMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoMediaFrame> for &::windows::core::IUnknown {
-    fn from(value: &VideoMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: VideoMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: &VideoMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoMediaFrame> for &::windows::core::IInspectable {
-    fn from(value: &VideoMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoMediaFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VideoMediaFrame {}
 unsafe impl ::core::marker::Sync for VideoMediaFrame {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]
@@ -2707,36 +2185,7 @@ unsafe impl ::windows::core::Interface for VideoMediaFrameFormat {
 impl ::windows::core::RuntimeName for VideoMediaFrameFormat {
     const NAME: &'static str = "Windows.Media.Capture.Frames.VideoMediaFrameFormat";
 }
-impl ::core::convert::From<VideoMediaFrameFormat> for ::windows::core::IUnknown {
-    fn from(value: VideoMediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoMediaFrameFormat> for ::windows::core::IUnknown {
-    fn from(value: &VideoMediaFrameFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoMediaFrameFormat> for &::windows::core::IUnknown {
-    fn from(value: &VideoMediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoMediaFrameFormat> for ::windows::core::IInspectable {
-    fn from(value: VideoMediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoMediaFrameFormat> for ::windows::core::IInspectable {
-    fn from(value: &VideoMediaFrameFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoMediaFrameFormat> for &::windows::core::IInspectable {
-    fn from(value: &VideoMediaFrameFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoMediaFrameFormat, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VideoMediaFrameFormat {}
 unsafe impl ::core::marker::Sync for VideoMediaFrameFormat {}
 #[doc = "*Required features: `\"Media_Capture_Frames\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/mod.rs
@@ -3064,36 +3064,7 @@ unsafe impl ::windows::core::Interface for AdvancedCapturedPhoto {
 impl ::windows::core::RuntimeName for AdvancedCapturedPhoto {
     const NAME: &'static str = "Windows.Media.Capture.AdvancedCapturedPhoto";
 }
-impl ::core::convert::From<AdvancedCapturedPhoto> for ::windows::core::IUnknown {
-    fn from(value: AdvancedCapturedPhoto) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvancedCapturedPhoto> for ::windows::core::IUnknown {
-    fn from(value: &AdvancedCapturedPhoto) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvancedCapturedPhoto> for &::windows::core::IUnknown {
-    fn from(value: &AdvancedCapturedPhoto) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdvancedCapturedPhoto> for ::windows::core::IInspectable {
-    fn from(value: AdvancedCapturedPhoto) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvancedCapturedPhoto> for ::windows::core::IInspectable {
-    fn from(value: &AdvancedCapturedPhoto) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvancedCapturedPhoto> for &::windows::core::IInspectable {
-    fn from(value: &AdvancedCapturedPhoto) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdvancedCapturedPhoto, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdvancedCapturedPhoto {}
 unsafe impl ::core::marker::Sync for AdvancedCapturedPhoto {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -3193,36 +3164,7 @@ unsafe impl ::windows::core::Interface for AdvancedPhotoCapture {
 impl ::windows::core::RuntimeName for AdvancedPhotoCapture {
     const NAME: &'static str = "Windows.Media.Capture.AdvancedPhotoCapture";
 }
-impl ::core::convert::From<AdvancedPhotoCapture> for ::windows::core::IUnknown {
-    fn from(value: AdvancedPhotoCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoCapture> for ::windows::core::IUnknown {
-    fn from(value: &AdvancedPhotoCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoCapture> for &::windows::core::IUnknown {
-    fn from(value: &AdvancedPhotoCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdvancedPhotoCapture> for ::windows::core::IInspectable {
-    fn from(value: AdvancedPhotoCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoCapture> for ::windows::core::IInspectable {
-    fn from(value: &AdvancedPhotoCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoCapture> for &::windows::core::IInspectable {
-    fn from(value: &AdvancedPhotoCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdvancedPhotoCapture, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdvancedPhotoCapture {}
 unsafe impl ::core::marker::Sync for AdvancedPhotoCapture {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -3417,36 +3359,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastBackgroundService {
 impl ::windows::core::RuntimeName for AppBroadcastBackgroundService {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastBackgroundService";
 }
-impl ::core::convert::From<AppBroadcastBackgroundService> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastBackgroundService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundService> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastBackgroundService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundService> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastBackgroundService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastBackgroundService> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastBackgroundService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundService> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastBackgroundService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundService> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastBackgroundService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastBackgroundService, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastBackgroundServiceSignInInfo(::windows::core::IUnknown);
@@ -3571,36 +3484,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastBackgroundServiceSignInIn
 impl ::windows::core::RuntimeName for AppBroadcastBackgroundServiceSignInInfo {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastBackgroundServiceSignInInfo";
 }
-impl ::core::convert::From<AppBroadcastBackgroundServiceSignInInfo> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastBackgroundServiceSignInInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundServiceSignInInfo> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastBackgroundServiceSignInInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundServiceSignInInfo> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastBackgroundServiceSignInInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastBackgroundServiceSignInInfo> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastBackgroundServiceSignInInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundServiceSignInInfo> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastBackgroundServiceSignInInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundServiceSignInInfo> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastBackgroundServiceSignInInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastBackgroundServiceSignInInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastBackgroundServiceStreamInfo(::windows::core::IUnknown);
@@ -3734,36 +3618,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastBackgroundServiceStreamIn
 impl ::windows::core::RuntimeName for AppBroadcastBackgroundServiceStreamInfo {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastBackgroundServiceStreamInfo";
 }
-impl ::core::convert::From<AppBroadcastBackgroundServiceStreamInfo> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastBackgroundServiceStreamInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundServiceStreamInfo> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastBackgroundServiceStreamInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundServiceStreamInfo> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastBackgroundServiceStreamInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastBackgroundServiceStreamInfo> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastBackgroundServiceStreamInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundServiceStreamInfo> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastBackgroundServiceStreamInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastBackgroundServiceStreamInfo> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastBackgroundServiceStreamInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastBackgroundServiceStreamInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastCameraCaptureStateChangedEventArgs(::windows::core::IUnknown);
@@ -3815,36 +3670,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastCameraCaptureStateChanged
 impl ::windows::core::RuntimeName for AppBroadcastCameraCaptureStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastCameraCaptureStateChangedEventArgs";
 }
-impl ::core::convert::From<AppBroadcastCameraCaptureStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastCameraCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastCameraCaptureStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastCameraCaptureStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastCameraCaptureStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastCameraCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastCameraCaptureStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastCameraCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastCameraCaptureStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastCameraCaptureStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastCameraCaptureStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastCameraCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastCameraCaptureStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastCameraCaptureStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppBroadcastCameraCaptureStateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -4022,36 +3848,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastGlobalSettings {
 impl ::windows::core::RuntimeName for AppBroadcastGlobalSettings {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastGlobalSettings";
 }
-impl ::core::convert::From<AppBroadcastGlobalSettings> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastGlobalSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastGlobalSettings> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastGlobalSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastGlobalSettings> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastGlobalSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastGlobalSettings> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastGlobalSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastGlobalSettings> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastGlobalSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastGlobalSettings> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastGlobalSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastGlobalSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastHeartbeatRequestedEventArgs(::windows::core::IUnknown);
@@ -4100,36 +3897,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastHeartbeatRequestedEventAr
 impl ::windows::core::RuntimeName for AppBroadcastHeartbeatRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastHeartbeatRequestedEventArgs";
 }
-impl ::core::convert::From<AppBroadcastHeartbeatRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastHeartbeatRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastHeartbeatRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastHeartbeatRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastHeartbeatRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastHeartbeatRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastHeartbeatRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastHeartbeatRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastHeartbeatRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastHeartbeatRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastHeartbeatRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastHeartbeatRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastHeartbeatRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 pub struct AppBroadcastManager;
 impl AppBroadcastManager {
@@ -4211,36 +3979,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastMicrophoneCaptureStateCha
 impl ::windows::core::RuntimeName for AppBroadcastMicrophoneCaptureStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastMicrophoneCaptureStateChangedEventArgs";
 }
-impl ::core::convert::From<AppBroadcastMicrophoneCaptureStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastMicrophoneCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastMicrophoneCaptureStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastMicrophoneCaptureStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastMicrophoneCaptureStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastMicrophoneCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastMicrophoneCaptureStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastMicrophoneCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastMicrophoneCaptureStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastMicrophoneCaptureStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastMicrophoneCaptureStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastMicrophoneCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastMicrophoneCaptureStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastMicrophoneCaptureStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppBroadcastMicrophoneCaptureStateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -4310,36 +4049,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastPlugIn {
 impl ::windows::core::RuntimeName for AppBroadcastPlugIn {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastPlugIn";
 }
-impl ::core::convert::From<AppBroadcastPlugIn> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugIn> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPlugIn) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugIn> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastPlugIn> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugIn> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPlugIn) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugIn> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastPlugIn, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastPlugIn {}
 unsafe impl ::core::marker::Sync for AppBroadcastPlugIn {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -4425,36 +4135,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastPlugInManager {
 impl ::windows::core::RuntimeName for AppBroadcastPlugInManager {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastPlugInManager";
 }
-impl ::core::convert::From<AppBroadcastPlugInManager> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastPlugInManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugInManager> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPlugInManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugInManager> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPlugInManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastPlugInManager> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastPlugInManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugInManager> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPlugInManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugInManager> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPlugInManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastPlugInManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastPlugInManager {}
 unsafe impl ::core::marker::Sync for AppBroadcastPlugInManager {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -4501,36 +4182,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastPlugInStateChangedEventAr
 impl ::windows::core::RuntimeName for AppBroadcastPlugInStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastPlugInStateChangedEventArgs";
 }
-impl ::core::convert::From<AppBroadcastPlugInStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastPlugInStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugInStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPlugInStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugInStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPlugInStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastPlugInStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastPlugInStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugInStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPlugInStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPlugInStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPlugInStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastPlugInStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastPlugInStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppBroadcastPlugInStateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -4612,36 +4264,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastPreview {
 impl ::windows::core::RuntimeName for AppBroadcastPreview {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastPreview";
 }
-impl ::core::convert::From<AppBroadcastPreview> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreview> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreview> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastPreview> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreview> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreview> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastPreview {}
 unsafe impl ::core::marker::Sync for AppBroadcastPreview {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -4695,36 +4318,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastPreviewStateChangedEventA
 impl ::windows::core::RuntimeName for AppBroadcastPreviewStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastPreviewStateChangedEventArgs";
 }
-impl ::core::convert::From<AppBroadcastPreviewStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastPreviewStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPreviewStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPreviewStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastPreviewStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastPreviewStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPreviewStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPreviewStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastPreviewStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastPreviewStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppBroadcastPreviewStateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -4825,36 +4419,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastPreviewStreamReader {
 impl ::windows::core::RuntimeName for AppBroadcastPreviewStreamReader {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastPreviewStreamReader";
 }
-impl ::core::convert::From<AppBroadcastPreviewStreamReader> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastPreviewStreamReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamReader> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPreviewStreamReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamReader> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPreviewStreamReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastPreviewStreamReader> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastPreviewStreamReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamReader> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPreviewStreamReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamReader> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPreviewStreamReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastPreviewStreamReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastPreviewStreamReader {}
 unsafe impl ::core::marker::Sync for AppBroadcastPreviewStreamReader {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -4910,36 +4475,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastPreviewStreamVideoFrame {
 impl ::windows::core::RuntimeName for AppBroadcastPreviewStreamVideoFrame {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastPreviewStreamVideoFrame";
 }
-impl ::core::convert::From<AppBroadcastPreviewStreamVideoFrame> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastPreviewStreamVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamVideoFrame> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPreviewStreamVideoFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamVideoFrame> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPreviewStreamVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastPreviewStreamVideoFrame> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastPreviewStreamVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamVideoFrame> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPreviewStreamVideoFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamVideoFrame> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPreviewStreamVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastPreviewStreamVideoFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastPreviewStreamVideoFrame {}
 unsafe impl ::core::marker::Sync for AppBroadcastPreviewStreamVideoFrame {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -5013,36 +4549,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastPreviewStreamVideoHeader 
 impl ::windows::core::RuntimeName for AppBroadcastPreviewStreamVideoHeader {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastPreviewStreamVideoHeader";
 }
-impl ::core::convert::From<AppBroadcastPreviewStreamVideoHeader> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastPreviewStreamVideoHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamVideoHeader> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPreviewStreamVideoHeader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamVideoHeader> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastPreviewStreamVideoHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastPreviewStreamVideoHeader> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastPreviewStreamVideoHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamVideoHeader> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPreviewStreamVideoHeader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastPreviewStreamVideoHeader> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastPreviewStreamVideoHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastPreviewStreamVideoHeader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastPreviewStreamVideoHeader {}
 unsafe impl ::core::marker::Sync for AppBroadcastPreviewStreamVideoHeader {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -5159,36 +4666,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastProviderSettings {
 impl ::windows::core::RuntimeName for AppBroadcastProviderSettings {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastProviderSettings";
 }
-impl ::core::convert::From<AppBroadcastProviderSettings> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastProviderSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastProviderSettings> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastProviderSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastProviderSettings> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastProviderSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastProviderSettings> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastProviderSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastProviderSettings> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastProviderSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastProviderSettings> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastProviderSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastProviderSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastServices(::windows::core::IUnknown);
@@ -5314,36 +4792,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastServices {
 impl ::windows::core::RuntimeName for AppBroadcastServices {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastServices";
 }
-impl ::core::convert::From<AppBroadcastServices> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastServices> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastServices> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastServices> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastServices> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastServices> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastServices, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastServices {}
 unsafe impl ::core::marker::Sync for AppBroadcastServices {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -5397,36 +4846,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastSignInStateChangedEventAr
 impl ::windows::core::RuntimeName for AppBroadcastSignInStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastSignInStateChangedEventArgs";
 }
-impl ::core::convert::From<AppBroadcastSignInStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastSignInStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastSignInStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastSignInStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastSignInStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastSignInStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastSignInStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastSignInStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastSignInStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastSignInStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastSignInStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastSignInStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastSignInStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastState(::windows::core::IUnknown);
@@ -5707,36 +5127,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastState {
 impl ::windows::core::RuntimeName for AppBroadcastState {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastState";
 }
-impl ::core::convert::From<AppBroadcastState> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastState> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastState> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastState> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastState> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastState> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastState, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastState {}
 unsafe impl ::core::marker::Sync for AppBroadcastState {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -5792,36 +5183,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastStreamAudioFrame {
 impl ::windows::core::RuntimeName for AppBroadcastStreamAudioFrame {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamAudioFrame";
 }
-impl ::core::convert::From<AppBroadcastStreamAudioFrame> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastStreamAudioFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamAudioFrame> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamAudioFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamAudioFrame> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamAudioFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastStreamAudioFrame> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastStreamAudioFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamAudioFrame> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamAudioFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamAudioFrame> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamAudioFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastStreamAudioFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastStreamAudioHeader(::windows::core::IUnknown);
@@ -5900,36 +5262,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastStreamAudioHeader {
 impl ::windows::core::RuntimeName for AppBroadcastStreamAudioHeader {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamAudioHeader";
 }
-impl ::core::convert::From<AppBroadcastStreamAudioHeader> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastStreamAudioHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamAudioHeader> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamAudioHeader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamAudioHeader> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamAudioHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastStreamAudioHeader> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastStreamAudioHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamAudioHeader> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamAudioHeader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamAudioHeader> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamAudioHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastStreamAudioHeader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastStreamReader(::windows::core::IUnknown);
@@ -6062,36 +5395,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastStreamReader {
 impl ::windows::core::RuntimeName for AppBroadcastStreamReader {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamReader";
 }
-impl ::core::convert::From<AppBroadcastStreamReader> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastStreamReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamReader> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamReader> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastStreamReader> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastStreamReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamReader> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamReader> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastStreamReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastStreamStateChangedEventArgs(::windows::core::IUnknown);
@@ -6136,36 +5440,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastStreamStateChangedEventAr
 impl ::windows::core::RuntimeName for AppBroadcastStreamStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamStateChangedEventArgs";
 }
-impl ::core::convert::From<AppBroadcastStreamStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastStreamStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastStreamStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastStreamStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastStreamStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastStreamVideoFrame(::windows::core::IUnknown);
@@ -6219,36 +5494,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastStreamVideoFrame {
 impl ::windows::core::RuntimeName for AppBroadcastStreamVideoFrame {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamVideoFrame";
 }
-impl ::core::convert::From<AppBroadcastStreamVideoFrame> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastStreamVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamVideoFrame> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamVideoFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamVideoFrame> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastStreamVideoFrame> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastStreamVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamVideoFrame> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamVideoFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamVideoFrame> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamVideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastStreamVideoFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastStreamVideoHeader(::windows::core::IUnknown);
@@ -6334,36 +5580,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastStreamVideoHeader {
 impl ::windows::core::RuntimeName for AppBroadcastStreamVideoHeader {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamVideoHeader";
 }
-impl ::core::convert::From<AppBroadcastStreamVideoHeader> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastStreamVideoHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamVideoHeader> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamVideoHeader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamVideoHeader> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastStreamVideoHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastStreamVideoHeader> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastStreamVideoHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamVideoHeader> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamVideoHeader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastStreamVideoHeader> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastStreamVideoHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastStreamVideoHeader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastTriggerDetails(::windows::core::IUnknown);
@@ -6408,36 +5625,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastTriggerDetails {
 impl ::windows::core::RuntimeName for AppBroadcastTriggerDetails {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastTriggerDetails";
 }
-impl ::core::convert::From<AppBroadcastTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppBroadcastViewerCountChangedEventArgs(::windows::core::IUnknown);
@@ -6482,36 +5670,7 @@ unsafe impl ::windows::core::Interface for AppBroadcastViewerCountChangedEventAr
 impl ::windows::core::RuntimeName for AppBroadcastViewerCountChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastViewerCountChangedEventArgs";
 }
-impl ::core::convert::From<AppBroadcastViewerCountChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppBroadcastViewerCountChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastViewerCountChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppBroadcastViewerCountChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastViewerCountChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppBroadcastViewerCountChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppBroadcastViewerCountChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppBroadcastViewerCountChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppBroadcastViewerCountChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppBroadcastViewerCountChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppBroadcastViewerCountChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppBroadcastViewerCountChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppBroadcastViewerCountChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppBroadcastViewerCountChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppBroadcastViewerCountChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -6604,36 +5763,7 @@ unsafe impl ::windows::core::Interface for AppCapture {
 impl ::windows::core::RuntimeName for AppCapture {
     const NAME: &'static str = "Windows.Media.Capture.AppCapture";
 }
-impl ::core::convert::From<AppCapture> for ::windows::core::IUnknown {
-    fn from(value: AppCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCapture> for ::windows::core::IUnknown {
-    fn from(value: &AppCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCapture> for &::windows::core::IUnknown {
-    fn from(value: &AppCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCapture> for ::windows::core::IInspectable {
-    fn from(value: AppCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCapture> for ::windows::core::IInspectable {
-    fn from(value: &AppCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCapture> for &::windows::core::IInspectable {
-    fn from(value: &AppCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCapture, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppCaptureAlternateShortcutKeys(::windows::core::IUnknown);
@@ -6911,36 +6041,7 @@ unsafe impl ::windows::core::Interface for AppCaptureAlternateShortcutKeys {
 impl ::windows::core::RuntimeName for AppCaptureAlternateShortcutKeys {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureAlternateShortcutKeys";
 }
-impl ::core::convert::From<AppCaptureAlternateShortcutKeys> for ::windows::core::IUnknown {
-    fn from(value: AppCaptureAlternateShortcutKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureAlternateShortcutKeys> for ::windows::core::IUnknown {
-    fn from(value: &AppCaptureAlternateShortcutKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureAlternateShortcutKeys> for &::windows::core::IUnknown {
-    fn from(value: &AppCaptureAlternateShortcutKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCaptureAlternateShortcutKeys> for ::windows::core::IInspectable {
-    fn from(value: AppCaptureAlternateShortcutKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureAlternateShortcutKeys> for ::windows::core::IInspectable {
-    fn from(value: &AppCaptureAlternateShortcutKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureAlternateShortcutKeys> for &::windows::core::IInspectable {
-    fn from(value: &AppCaptureAlternateShortcutKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCaptureAlternateShortcutKeys, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppCaptureDurationGeneratedEventArgs(::windows::core::IUnknown);
@@ -6987,36 +6088,7 @@ unsafe impl ::windows::core::Interface for AppCaptureDurationGeneratedEventArgs 
 impl ::windows::core::RuntimeName for AppCaptureDurationGeneratedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureDurationGeneratedEventArgs";
 }
-impl ::core::convert::From<AppCaptureDurationGeneratedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppCaptureDurationGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureDurationGeneratedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppCaptureDurationGeneratedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureDurationGeneratedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppCaptureDurationGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCaptureDurationGeneratedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppCaptureDurationGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureDurationGeneratedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppCaptureDurationGeneratedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureDurationGeneratedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppCaptureDurationGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCaptureDurationGeneratedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppCaptureDurationGeneratedEventArgs {}
 unsafe impl ::core::marker::Sync for AppCaptureDurationGeneratedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -7065,36 +6137,7 @@ unsafe impl ::windows::core::Interface for AppCaptureFileGeneratedEventArgs {
 impl ::windows::core::RuntimeName for AppCaptureFileGeneratedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureFileGeneratedEventArgs";
 }
-impl ::core::convert::From<AppCaptureFileGeneratedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppCaptureFileGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureFileGeneratedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppCaptureFileGeneratedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureFileGeneratedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppCaptureFileGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCaptureFileGeneratedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppCaptureFileGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureFileGeneratedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppCaptureFileGeneratedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureFileGeneratedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppCaptureFileGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCaptureFileGeneratedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppCaptureFileGeneratedEventArgs {}
 unsafe impl ::core::marker::Sync for AppCaptureFileGeneratedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -7222,36 +6265,7 @@ unsafe impl ::windows::core::Interface for AppCaptureMetadataWriter {
 impl ::windows::core::RuntimeName for AppCaptureMetadataWriter {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureMetadataWriter";
 }
-impl ::core::convert::From<AppCaptureMetadataWriter> for ::windows::core::IUnknown {
-    fn from(value: AppCaptureMetadataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureMetadataWriter> for ::windows::core::IUnknown {
-    fn from(value: &AppCaptureMetadataWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureMetadataWriter> for &::windows::core::IUnknown {
-    fn from(value: &AppCaptureMetadataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCaptureMetadataWriter> for ::windows::core::IInspectable {
-    fn from(value: AppCaptureMetadataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureMetadataWriter> for ::windows::core::IInspectable {
-    fn from(value: &AppCaptureMetadataWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureMetadataWriter> for &::windows::core::IInspectable {
-    fn from(value: &AppCaptureMetadataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCaptureMetadataWriter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<AppCaptureMetadataWriter> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -7327,36 +6341,7 @@ unsafe impl ::windows::core::Interface for AppCaptureMicrophoneCaptureStateChang
 impl ::windows::core::RuntimeName for AppCaptureMicrophoneCaptureStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureMicrophoneCaptureStateChangedEventArgs";
 }
-impl ::core::convert::From<AppCaptureMicrophoneCaptureStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppCaptureMicrophoneCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureMicrophoneCaptureStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppCaptureMicrophoneCaptureStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureMicrophoneCaptureStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppCaptureMicrophoneCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCaptureMicrophoneCaptureStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppCaptureMicrophoneCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureMicrophoneCaptureStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppCaptureMicrophoneCaptureStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureMicrophoneCaptureStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppCaptureMicrophoneCaptureStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCaptureMicrophoneCaptureStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppCaptureMicrophoneCaptureStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppCaptureMicrophoneCaptureStateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -7488,36 +6473,7 @@ unsafe impl ::windows::core::Interface for AppCaptureRecordOperation {
 impl ::windows::core::RuntimeName for AppCaptureRecordOperation {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureRecordOperation";
 }
-impl ::core::convert::From<AppCaptureRecordOperation> for ::windows::core::IUnknown {
-    fn from(value: AppCaptureRecordOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureRecordOperation> for ::windows::core::IUnknown {
-    fn from(value: &AppCaptureRecordOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureRecordOperation> for &::windows::core::IUnknown {
-    fn from(value: &AppCaptureRecordOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCaptureRecordOperation> for ::windows::core::IInspectable {
-    fn from(value: AppCaptureRecordOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureRecordOperation> for ::windows::core::IInspectable {
-    fn from(value: &AppCaptureRecordOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureRecordOperation> for &::windows::core::IInspectable {
-    fn from(value: &AppCaptureRecordOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCaptureRecordOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppCaptureRecordOperation {}
 unsafe impl ::core::marker::Sync for AppCaptureRecordOperation {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -7571,36 +6527,7 @@ unsafe impl ::windows::core::Interface for AppCaptureRecordingStateChangedEventA
 impl ::windows::core::RuntimeName for AppCaptureRecordingStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureRecordingStateChangedEventArgs";
 }
-impl ::core::convert::From<AppCaptureRecordingStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppCaptureRecordingStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureRecordingStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppCaptureRecordingStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureRecordingStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppCaptureRecordingStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCaptureRecordingStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppCaptureRecordingStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureRecordingStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppCaptureRecordingStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureRecordingStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppCaptureRecordingStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCaptureRecordingStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppCaptureRecordingStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppCaptureRecordingStateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -7670,36 +6597,7 @@ unsafe impl ::windows::core::Interface for AppCaptureServices {
 impl ::windows::core::RuntimeName for AppCaptureServices {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureServices";
 }
-impl ::core::convert::From<AppCaptureServices> for ::windows::core::IUnknown {
-    fn from(value: AppCaptureServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureServices> for ::windows::core::IUnknown {
-    fn from(value: &AppCaptureServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureServices> for &::windows::core::IUnknown {
-    fn from(value: &AppCaptureServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCaptureServices> for ::windows::core::IInspectable {
-    fn from(value: AppCaptureServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureServices> for ::windows::core::IInspectable {
-    fn from(value: &AppCaptureServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureServices> for &::windows::core::IInspectable {
-    fn from(value: &AppCaptureServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCaptureServices, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppCaptureServices {}
 unsafe impl ::core::marker::Sync for AppCaptureServices {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -8046,36 +6944,7 @@ unsafe impl ::windows::core::Interface for AppCaptureSettings {
 impl ::windows::core::RuntimeName for AppCaptureSettings {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureSettings";
 }
-impl ::core::convert::From<AppCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: AppCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: &AppCaptureSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureSettings> for &::windows::core::IUnknown {
-    fn from(value: &AppCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCaptureSettings> for ::windows::core::IInspectable {
-    fn from(value: AppCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureSettings> for ::windows::core::IInspectable {
-    fn from(value: &AppCaptureSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureSettings> for &::windows::core::IInspectable {
-    fn from(value: &AppCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCaptureSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct AppCaptureState(::windows::core::IUnknown);
@@ -8186,36 +7055,7 @@ unsafe impl ::windows::core::Interface for AppCaptureState {
 impl ::windows::core::RuntimeName for AppCaptureState {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureState";
 }
-impl ::core::convert::From<AppCaptureState> for ::windows::core::IUnknown {
-    fn from(value: AppCaptureState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureState> for ::windows::core::IUnknown {
-    fn from(value: &AppCaptureState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureState> for &::windows::core::IUnknown {
-    fn from(value: &AppCaptureState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCaptureState> for ::windows::core::IInspectable {
-    fn from(value: AppCaptureState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCaptureState> for ::windows::core::IInspectable {
-    fn from(value: &AppCaptureState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCaptureState> for &::windows::core::IInspectable {
-    fn from(value: &AppCaptureState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCaptureState, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppCaptureState {}
 unsafe impl ::core::marker::Sync for AppCaptureState {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -8285,36 +7125,7 @@ unsafe impl ::windows::core::Interface for CameraCaptureUI {
 impl ::windows::core::RuntimeName for CameraCaptureUI {
     const NAME: &'static str = "Windows.Media.Capture.CameraCaptureUI";
 }
-impl ::core::convert::From<CameraCaptureUI> for ::windows::core::IUnknown {
-    fn from(value: CameraCaptureUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraCaptureUI> for ::windows::core::IUnknown {
-    fn from(value: &CameraCaptureUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraCaptureUI> for &::windows::core::IUnknown {
-    fn from(value: &CameraCaptureUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CameraCaptureUI> for ::windows::core::IInspectable {
-    fn from(value: CameraCaptureUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraCaptureUI> for ::windows::core::IInspectable {
-    fn from(value: &CameraCaptureUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraCaptureUI> for &::windows::core::IInspectable {
-    fn from(value: &CameraCaptureUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CameraCaptureUI, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct CameraCaptureUIPhotoCaptureSettings(::windows::core::IUnknown);
@@ -8415,36 +7226,7 @@ unsafe impl ::windows::core::Interface for CameraCaptureUIPhotoCaptureSettings {
 impl ::windows::core::RuntimeName for CameraCaptureUIPhotoCaptureSettings {
     const NAME: &'static str = "Windows.Media.Capture.CameraCaptureUIPhotoCaptureSettings";
 }
-impl ::core::convert::From<CameraCaptureUIPhotoCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: CameraCaptureUIPhotoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraCaptureUIPhotoCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: &CameraCaptureUIPhotoCaptureSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraCaptureUIPhotoCaptureSettings> for &::windows::core::IUnknown {
-    fn from(value: &CameraCaptureUIPhotoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CameraCaptureUIPhotoCaptureSettings> for ::windows::core::IInspectable {
-    fn from(value: CameraCaptureUIPhotoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraCaptureUIPhotoCaptureSettings> for ::windows::core::IInspectable {
-    fn from(value: &CameraCaptureUIPhotoCaptureSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraCaptureUIPhotoCaptureSettings> for &::windows::core::IInspectable {
-    fn from(value: &CameraCaptureUIPhotoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CameraCaptureUIPhotoCaptureSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CameraCaptureUIPhotoCaptureSettings {}
 unsafe impl ::core::marker::Sync for CameraCaptureUIPhotoCaptureSettings {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -8528,36 +7310,7 @@ unsafe impl ::windows::core::Interface for CameraCaptureUIVideoCaptureSettings {
 impl ::windows::core::RuntimeName for CameraCaptureUIVideoCaptureSettings {
     const NAME: &'static str = "Windows.Media.Capture.CameraCaptureUIVideoCaptureSettings";
 }
-impl ::core::convert::From<CameraCaptureUIVideoCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: CameraCaptureUIVideoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraCaptureUIVideoCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: &CameraCaptureUIVideoCaptureSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraCaptureUIVideoCaptureSettings> for &::windows::core::IUnknown {
-    fn from(value: &CameraCaptureUIVideoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CameraCaptureUIVideoCaptureSettings> for ::windows::core::IInspectable {
-    fn from(value: CameraCaptureUIVideoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraCaptureUIVideoCaptureSettings> for ::windows::core::IInspectable {
-    fn from(value: &CameraCaptureUIVideoCaptureSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraCaptureUIVideoCaptureSettings> for &::windows::core::IInspectable {
-    fn from(value: &CameraCaptureUIVideoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CameraCaptureUIVideoCaptureSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CameraCaptureUIVideoCaptureSettings {}
 unsafe impl ::core::marker::Sync for CameraCaptureUIVideoCaptureSettings {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -8776,36 +7529,7 @@ unsafe impl ::windows::core::Interface for CapturedFrame {
 impl ::windows::core::RuntimeName for CapturedFrame {
     const NAME: &'static str = "Windows.Media.Capture.CapturedFrame";
 }
-impl ::core::convert::From<CapturedFrame> for ::windows::core::IUnknown {
-    fn from(value: CapturedFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CapturedFrame> for ::windows::core::IUnknown {
-    fn from(value: &CapturedFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CapturedFrame> for &::windows::core::IUnknown {
-    fn from(value: &CapturedFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CapturedFrame> for ::windows::core::IInspectable {
-    fn from(value: CapturedFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CapturedFrame> for ::windows::core::IInspectable {
-    fn from(value: &CapturedFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CapturedFrame> for &::windows::core::IInspectable {
-    fn from(value: &CapturedFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CapturedFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<CapturedFrame> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -9103,36 +7827,7 @@ unsafe impl ::windows::core::Interface for CapturedFrameControlValues {
 impl ::windows::core::RuntimeName for CapturedFrameControlValues {
     const NAME: &'static str = "Windows.Media.Capture.CapturedFrameControlValues";
 }
-impl ::core::convert::From<CapturedFrameControlValues> for ::windows::core::IUnknown {
-    fn from(value: CapturedFrameControlValues) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CapturedFrameControlValues> for ::windows::core::IUnknown {
-    fn from(value: &CapturedFrameControlValues) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CapturedFrameControlValues> for &::windows::core::IUnknown {
-    fn from(value: &CapturedFrameControlValues) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CapturedFrameControlValues> for ::windows::core::IInspectable {
-    fn from(value: CapturedFrameControlValues) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CapturedFrameControlValues> for ::windows::core::IInspectable {
-    fn from(value: &CapturedFrameControlValues) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CapturedFrameControlValues> for &::windows::core::IInspectable {
-    fn from(value: &CapturedFrameControlValues) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CapturedFrameControlValues, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CapturedFrameControlValues {}
 unsafe impl ::core::marker::Sync for CapturedFrameControlValues {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -9186,36 +7881,7 @@ unsafe impl ::windows::core::Interface for CapturedPhoto {
 impl ::windows::core::RuntimeName for CapturedPhoto {
     const NAME: &'static str = "Windows.Media.Capture.CapturedPhoto";
 }
-impl ::core::convert::From<CapturedPhoto> for ::windows::core::IUnknown {
-    fn from(value: CapturedPhoto) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CapturedPhoto> for ::windows::core::IUnknown {
-    fn from(value: &CapturedPhoto) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CapturedPhoto> for &::windows::core::IUnknown {
-    fn from(value: &CapturedPhoto) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CapturedPhoto> for ::windows::core::IInspectable {
-    fn from(value: CapturedPhoto) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CapturedPhoto> for ::windows::core::IInspectable {
-    fn from(value: &CapturedPhoto) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CapturedPhoto> for &::windows::core::IInspectable {
-    fn from(value: &CapturedPhoto) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CapturedPhoto, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CapturedPhoto {}
 unsafe impl ::core::marker::Sync for CapturedPhoto {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -9313,36 +7979,7 @@ unsafe impl ::windows::core::Interface for GameBarServices {
 impl ::windows::core::RuntimeName for GameBarServices {
     const NAME: &'static str = "Windows.Media.Capture.GameBarServices";
 }
-impl ::core::convert::From<GameBarServices> for ::windows::core::IUnknown {
-    fn from(value: GameBarServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameBarServices> for ::windows::core::IUnknown {
-    fn from(value: &GameBarServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameBarServices> for &::windows::core::IUnknown {
-    fn from(value: &GameBarServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameBarServices> for ::windows::core::IInspectable {
-    fn from(value: GameBarServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameBarServices> for ::windows::core::IInspectable {
-    fn from(value: &GameBarServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameBarServices> for &::windows::core::IInspectable {
-    fn from(value: &GameBarServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameBarServices, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameBarServices {}
 unsafe impl ::core::marker::Sync for GameBarServices {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -9396,36 +8033,7 @@ unsafe impl ::windows::core::Interface for GameBarServicesCommandEventArgs {
 impl ::windows::core::RuntimeName for GameBarServicesCommandEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.GameBarServicesCommandEventArgs";
 }
-impl ::core::convert::From<GameBarServicesCommandEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GameBarServicesCommandEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameBarServicesCommandEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GameBarServicesCommandEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameBarServicesCommandEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GameBarServicesCommandEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameBarServicesCommandEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GameBarServicesCommandEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameBarServicesCommandEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GameBarServicesCommandEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameBarServicesCommandEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GameBarServicesCommandEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameBarServicesCommandEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameBarServicesCommandEventArgs {}
 unsafe impl ::core::marker::Sync for GameBarServicesCommandEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -9491,36 +8099,7 @@ unsafe impl ::windows::core::Interface for GameBarServicesManager {
 impl ::windows::core::RuntimeName for GameBarServicesManager {
     const NAME: &'static str = "Windows.Media.Capture.GameBarServicesManager";
 }
-impl ::core::convert::From<GameBarServicesManager> for ::windows::core::IUnknown {
-    fn from(value: GameBarServicesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameBarServicesManager> for ::windows::core::IUnknown {
-    fn from(value: &GameBarServicesManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameBarServicesManager> for &::windows::core::IUnknown {
-    fn from(value: &GameBarServicesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameBarServicesManager> for ::windows::core::IInspectable {
-    fn from(value: GameBarServicesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameBarServicesManager> for ::windows::core::IInspectable {
-    fn from(value: &GameBarServicesManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameBarServicesManager> for &::windows::core::IInspectable {
-    fn from(value: &GameBarServicesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameBarServicesManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameBarServicesManager {}
 unsafe impl ::core::marker::Sync for GameBarServicesManager {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -9567,36 +8146,7 @@ unsafe impl ::windows::core::Interface for GameBarServicesManagerGameBarServices
 impl ::windows::core::RuntimeName for GameBarServicesManagerGameBarServicesCreatedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.GameBarServicesManagerGameBarServicesCreatedEventArgs";
 }
-impl ::core::convert::From<GameBarServicesManagerGameBarServicesCreatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GameBarServicesManagerGameBarServicesCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameBarServicesManagerGameBarServicesCreatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GameBarServicesManagerGameBarServicesCreatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameBarServicesManagerGameBarServicesCreatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GameBarServicesManagerGameBarServicesCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameBarServicesManagerGameBarServicesCreatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GameBarServicesManagerGameBarServicesCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameBarServicesManagerGameBarServicesCreatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GameBarServicesManagerGameBarServicesCreatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameBarServicesManagerGameBarServicesCreatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GameBarServicesManagerGameBarServicesCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameBarServicesManagerGameBarServicesCreatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameBarServicesManagerGameBarServicesCreatedEventArgs {}
 unsafe impl ::core::marker::Sync for GameBarServicesManagerGameBarServicesCreatedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -9664,36 +8214,7 @@ unsafe impl ::windows::core::Interface for GameBarServicesTargetInfo {
 impl ::windows::core::RuntimeName for GameBarServicesTargetInfo {
     const NAME: &'static str = "Windows.Media.Capture.GameBarServicesTargetInfo";
 }
-impl ::core::convert::From<GameBarServicesTargetInfo> for ::windows::core::IUnknown {
-    fn from(value: GameBarServicesTargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameBarServicesTargetInfo> for ::windows::core::IUnknown {
-    fn from(value: &GameBarServicesTargetInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameBarServicesTargetInfo> for &::windows::core::IUnknown {
-    fn from(value: &GameBarServicesTargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameBarServicesTargetInfo> for ::windows::core::IInspectable {
-    fn from(value: GameBarServicesTargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameBarServicesTargetInfo> for ::windows::core::IInspectable {
-    fn from(value: &GameBarServicesTargetInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameBarServicesTargetInfo> for &::windows::core::IInspectable {
-    fn from(value: &GameBarServicesTargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameBarServicesTargetInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameBarServicesTargetInfo {}
 unsafe impl ::core::marker::Sync for GameBarServicesTargetInfo {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -9796,36 +8317,7 @@ unsafe impl ::windows::core::Interface for LowLagMediaRecording {
 impl ::windows::core::RuntimeName for LowLagMediaRecording {
     const NAME: &'static str = "Windows.Media.Capture.LowLagMediaRecording";
 }
-impl ::core::convert::From<LowLagMediaRecording> for ::windows::core::IUnknown {
-    fn from(value: LowLagMediaRecording) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLagMediaRecording> for ::windows::core::IUnknown {
-    fn from(value: &LowLagMediaRecording) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLagMediaRecording> for &::windows::core::IUnknown {
-    fn from(value: &LowLagMediaRecording) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LowLagMediaRecording> for ::windows::core::IInspectable {
-    fn from(value: LowLagMediaRecording) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLagMediaRecording> for ::windows::core::IInspectable {
-    fn from(value: &LowLagMediaRecording) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLagMediaRecording> for &::windows::core::IInspectable {
-    fn from(value: &LowLagMediaRecording) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LowLagMediaRecording, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct LowLagPhotoCapture(::windows::core::IUnknown);
@@ -9881,36 +8373,7 @@ unsafe impl ::windows::core::Interface for LowLagPhotoCapture {
 impl ::windows::core::RuntimeName for LowLagPhotoCapture {
     const NAME: &'static str = "Windows.Media.Capture.LowLagPhotoCapture";
 }
-impl ::core::convert::From<LowLagPhotoCapture> for ::windows::core::IUnknown {
-    fn from(value: LowLagPhotoCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLagPhotoCapture> for ::windows::core::IUnknown {
-    fn from(value: &LowLagPhotoCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLagPhotoCapture> for &::windows::core::IUnknown {
-    fn from(value: &LowLagPhotoCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LowLagPhotoCapture> for ::windows::core::IInspectable {
-    fn from(value: LowLagPhotoCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLagPhotoCapture> for ::windows::core::IInspectable {
-    fn from(value: &LowLagPhotoCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLagPhotoCapture> for &::windows::core::IInspectable {
-    fn from(value: &LowLagPhotoCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LowLagPhotoCapture, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct LowLagPhotoSequenceCapture(::windows::core::IUnknown);
@@ -9990,36 +8453,7 @@ unsafe impl ::windows::core::Interface for LowLagPhotoSequenceCapture {
 impl ::windows::core::RuntimeName for LowLagPhotoSequenceCapture {
     const NAME: &'static str = "Windows.Media.Capture.LowLagPhotoSequenceCapture";
 }
-impl ::core::convert::From<LowLagPhotoSequenceCapture> for ::windows::core::IUnknown {
-    fn from(value: LowLagPhotoSequenceCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLagPhotoSequenceCapture> for ::windows::core::IUnknown {
-    fn from(value: &LowLagPhotoSequenceCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLagPhotoSequenceCapture> for &::windows::core::IUnknown {
-    fn from(value: &LowLagPhotoSequenceCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LowLagPhotoSequenceCapture> for ::windows::core::IInspectable {
-    fn from(value: LowLagPhotoSequenceCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLagPhotoSequenceCapture> for ::windows::core::IInspectable {
-    fn from(value: &LowLagPhotoSequenceCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLagPhotoSequenceCapture> for &::windows::core::IInspectable {
-    fn from(value: &LowLagPhotoSequenceCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LowLagPhotoSequenceCapture, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct MediaCapture(::windows::core::IUnknown);
@@ -10721,36 +9155,7 @@ unsafe impl ::windows::core::Interface for MediaCapture {
 impl ::windows::core::RuntimeName for MediaCapture {
     const NAME: &'static str = "Windows.Media.Capture.MediaCapture";
 }
-impl ::core::convert::From<MediaCapture> for ::windows::core::IUnknown {
-    fn from(value: MediaCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCapture> for ::windows::core::IUnknown {
-    fn from(value: &MediaCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCapture> for &::windows::core::IUnknown {
-    fn from(value: &MediaCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCapture> for ::windows::core::IInspectable {
-    fn from(value: MediaCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCapture> for ::windows::core::IInspectable {
-    fn from(value: &MediaCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCapture> for &::windows::core::IInspectable {
-    fn from(value: &MediaCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCapture, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MediaCapture> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -10824,36 +9229,7 @@ unsafe impl ::windows::core::Interface for MediaCaptureDeviceExclusiveControlSta
 impl ::windows::core::RuntimeName for MediaCaptureDeviceExclusiveControlStatusChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureDeviceExclusiveControlStatusChangedEventArgs";
 }
-impl ::core::convert::From<MediaCaptureDeviceExclusiveControlStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaCaptureDeviceExclusiveControlStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureDeviceExclusiveControlStatusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaCaptureDeviceExclusiveControlStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureDeviceExclusiveControlStatusChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaCaptureDeviceExclusiveControlStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCaptureDeviceExclusiveControlStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaCaptureDeviceExclusiveControlStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureDeviceExclusiveControlStatusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaCaptureDeviceExclusiveControlStatusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureDeviceExclusiveControlStatusChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaCaptureDeviceExclusiveControlStatusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCaptureDeviceExclusiveControlStatusChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaCaptureDeviceExclusiveControlStatusChangedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaCaptureDeviceExclusiveControlStatusChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -10907,36 +9283,7 @@ unsafe impl ::windows::core::Interface for MediaCaptureFailedEventArgs {
 impl ::windows::core::RuntimeName for MediaCaptureFailedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureFailedEventArgs";
 }
-impl ::core::convert::From<MediaCaptureFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaCaptureFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaCaptureFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureFailedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaCaptureFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCaptureFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaCaptureFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaCaptureFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureFailedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaCaptureFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCaptureFailedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct MediaCaptureFocusChangedEventArgs(::windows::core::IUnknown);
@@ -10983,36 +9330,7 @@ unsafe impl ::windows::core::Interface for MediaCaptureFocusChangedEventArgs {
 impl ::windows::core::RuntimeName for MediaCaptureFocusChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureFocusChangedEventArgs";
 }
-impl ::core::convert::From<MediaCaptureFocusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaCaptureFocusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureFocusChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaCaptureFocusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureFocusChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaCaptureFocusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCaptureFocusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaCaptureFocusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureFocusChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaCaptureFocusChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureFocusChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaCaptureFocusChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCaptureFocusChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaCaptureFocusChangedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaCaptureFocusChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -11285,36 +9603,7 @@ unsafe impl ::windows::core::Interface for MediaCaptureInitializationSettings {
 impl ::windows::core::RuntimeName for MediaCaptureInitializationSettings {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureInitializationSettings";
 }
-impl ::core::convert::From<MediaCaptureInitializationSettings> for ::windows::core::IUnknown {
-    fn from(value: MediaCaptureInitializationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureInitializationSettings> for ::windows::core::IUnknown {
-    fn from(value: &MediaCaptureInitializationSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureInitializationSettings> for &::windows::core::IUnknown {
-    fn from(value: &MediaCaptureInitializationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCaptureInitializationSettings> for ::windows::core::IInspectable {
-    fn from(value: MediaCaptureInitializationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureInitializationSettings> for ::windows::core::IInspectable {
-    fn from(value: &MediaCaptureInitializationSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureInitializationSettings> for &::windows::core::IInspectable {
-    fn from(value: &MediaCaptureInitializationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCaptureInitializationSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaCaptureInitializationSettings {}
 unsafe impl ::core::marker::Sync for MediaCaptureInitializationSettings {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -11376,36 +9665,7 @@ unsafe impl ::windows::core::Interface for MediaCapturePauseResult {
 impl ::windows::core::RuntimeName for MediaCapturePauseResult {
     const NAME: &'static str = "Windows.Media.Capture.MediaCapturePauseResult";
 }
-impl ::core::convert::From<MediaCapturePauseResult> for ::windows::core::IUnknown {
-    fn from(value: MediaCapturePauseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCapturePauseResult> for ::windows::core::IUnknown {
-    fn from(value: &MediaCapturePauseResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCapturePauseResult> for &::windows::core::IUnknown {
-    fn from(value: &MediaCapturePauseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCapturePauseResult> for ::windows::core::IInspectable {
-    fn from(value: MediaCapturePauseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCapturePauseResult> for ::windows::core::IInspectable {
-    fn from(value: &MediaCapturePauseResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCapturePauseResult> for &::windows::core::IInspectable {
-    fn from(value: &MediaCapturePauseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCapturePauseResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MediaCapturePauseResult> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -11503,36 +9763,7 @@ unsafe impl ::windows::core::Interface for MediaCaptureRelativePanelWatcher {
 impl ::windows::core::RuntimeName for MediaCaptureRelativePanelWatcher {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureRelativePanelWatcher";
 }
-impl ::core::convert::From<MediaCaptureRelativePanelWatcher> for ::windows::core::IUnknown {
-    fn from(value: MediaCaptureRelativePanelWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureRelativePanelWatcher> for ::windows::core::IUnknown {
-    fn from(value: &MediaCaptureRelativePanelWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureRelativePanelWatcher> for &::windows::core::IUnknown {
-    fn from(value: &MediaCaptureRelativePanelWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCaptureRelativePanelWatcher> for ::windows::core::IInspectable {
-    fn from(value: MediaCaptureRelativePanelWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureRelativePanelWatcher> for ::windows::core::IInspectable {
-    fn from(value: &MediaCaptureRelativePanelWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureRelativePanelWatcher> for &::windows::core::IInspectable {
-    fn from(value: &MediaCaptureRelativePanelWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCaptureRelativePanelWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MediaCaptureRelativePanelWatcher> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -11700,36 +9931,7 @@ unsafe impl ::windows::core::Interface for MediaCaptureSettings {
 impl ::windows::core::RuntimeName for MediaCaptureSettings {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureSettings";
 }
-impl ::core::convert::From<MediaCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: MediaCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: &MediaCaptureSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureSettings> for &::windows::core::IUnknown {
-    fn from(value: &MediaCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCaptureSettings> for ::windows::core::IInspectable {
-    fn from(value: MediaCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureSettings> for ::windows::core::IInspectable {
-    fn from(value: &MediaCaptureSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureSettings> for &::windows::core::IInspectable {
-    fn from(value: &MediaCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCaptureSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Capture\"`*"]
 #[repr(transparent)]
 pub struct MediaCaptureStopResult(::windows::core::IUnknown);
@@ -11789,36 +9991,7 @@ unsafe impl ::windows::core::Interface for MediaCaptureStopResult {
 impl ::windows::core::RuntimeName for MediaCaptureStopResult {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureStopResult";
 }
-impl ::core::convert::From<MediaCaptureStopResult> for ::windows::core::IUnknown {
-    fn from(value: MediaCaptureStopResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureStopResult> for ::windows::core::IUnknown {
-    fn from(value: &MediaCaptureStopResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureStopResult> for &::windows::core::IUnknown {
-    fn from(value: &MediaCaptureStopResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCaptureStopResult> for ::windows::core::IInspectable {
-    fn from(value: MediaCaptureStopResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureStopResult> for ::windows::core::IInspectable {
-    fn from(value: &MediaCaptureStopResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureStopResult> for &::windows::core::IInspectable {
-    fn from(value: &MediaCaptureStopResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCaptureStopResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MediaCaptureStopResult> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -11946,36 +10119,7 @@ unsafe impl ::windows::core::Interface for MediaCaptureVideoProfile {
 impl ::windows::core::RuntimeName for MediaCaptureVideoProfile {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureVideoProfile";
 }
-impl ::core::convert::From<MediaCaptureVideoProfile> for ::windows::core::IUnknown {
-    fn from(value: MediaCaptureVideoProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureVideoProfile> for ::windows::core::IUnknown {
-    fn from(value: &MediaCaptureVideoProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureVideoProfile> for &::windows::core::IUnknown {
-    fn from(value: &MediaCaptureVideoProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCaptureVideoProfile> for ::windows::core::IInspectable {
-    fn from(value: MediaCaptureVideoProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureVideoProfile> for ::windows::core::IInspectable {
-    fn from(value: &MediaCaptureVideoProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureVideoProfile> for &::windows::core::IInspectable {
-    fn from(value: &MediaCaptureVideoProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCaptureVideoProfile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaCaptureVideoProfile {}
 unsafe impl ::core::marker::Sync for MediaCaptureVideoProfile {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -12070,36 +10214,7 @@ unsafe impl ::windows::core::Interface for MediaCaptureVideoProfileMediaDescript
 impl ::windows::core::RuntimeName for MediaCaptureVideoProfileMediaDescription {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureVideoProfileMediaDescription";
 }
-impl ::core::convert::From<MediaCaptureVideoProfileMediaDescription> for ::windows::core::IUnknown {
-    fn from(value: MediaCaptureVideoProfileMediaDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureVideoProfileMediaDescription> for ::windows::core::IUnknown {
-    fn from(value: &MediaCaptureVideoProfileMediaDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureVideoProfileMediaDescription> for &::windows::core::IUnknown {
-    fn from(value: &MediaCaptureVideoProfileMediaDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCaptureVideoProfileMediaDescription> for ::windows::core::IInspectable {
-    fn from(value: MediaCaptureVideoProfileMediaDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCaptureVideoProfileMediaDescription> for ::windows::core::IInspectable {
-    fn from(value: &MediaCaptureVideoProfileMediaDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCaptureVideoProfileMediaDescription> for &::windows::core::IInspectable {
-    fn from(value: &MediaCaptureVideoProfileMediaDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCaptureVideoProfileMediaDescription, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaCaptureVideoProfileMediaDescription {}
 unsafe impl ::core::marker::Sync for MediaCaptureVideoProfileMediaDescription {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -12153,36 +10268,7 @@ unsafe impl ::windows::core::Interface for OptionalReferencePhotoCapturedEventAr
 impl ::windows::core::RuntimeName for OptionalReferencePhotoCapturedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.OptionalReferencePhotoCapturedEventArgs";
 }
-impl ::core::convert::From<OptionalReferencePhotoCapturedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: OptionalReferencePhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OptionalReferencePhotoCapturedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &OptionalReferencePhotoCapturedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OptionalReferencePhotoCapturedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &OptionalReferencePhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OptionalReferencePhotoCapturedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: OptionalReferencePhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OptionalReferencePhotoCapturedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &OptionalReferencePhotoCapturedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OptionalReferencePhotoCapturedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &OptionalReferencePhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OptionalReferencePhotoCapturedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OptionalReferencePhotoCapturedEventArgs {}
 unsafe impl ::core::marker::Sync for OptionalReferencePhotoCapturedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -12245,36 +10331,7 @@ unsafe impl ::windows::core::Interface for PhotoCapturedEventArgs {
 impl ::windows::core::RuntimeName for PhotoCapturedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.PhotoCapturedEventArgs";
 }
-impl ::core::convert::From<PhotoCapturedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoCapturedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PhotoCapturedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoCapturedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoCapturedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoCapturedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PhotoCapturedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoCapturedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PhotoCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoCapturedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoCapturedEventArgs {}
 unsafe impl ::core::marker::Sync for PhotoCapturedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -12330,36 +10387,7 @@ unsafe impl ::windows::core::Interface for PhotoConfirmationCapturedEventArgs {
 impl ::windows::core::RuntimeName for PhotoConfirmationCapturedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.PhotoConfirmationCapturedEventArgs";
 }
-impl ::core::convert::From<PhotoConfirmationCapturedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PhotoConfirmationCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoConfirmationCapturedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PhotoConfirmationCapturedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoConfirmationCapturedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PhotoConfirmationCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoConfirmationCapturedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PhotoConfirmationCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoConfirmationCapturedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PhotoConfirmationCapturedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoConfirmationCapturedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PhotoConfirmationCapturedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoConfirmationCapturedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoConfirmationCapturedEventArgs {}
 unsafe impl ::core::marker::Sync for PhotoConfirmationCapturedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -12457,36 +10485,7 @@ unsafe impl ::windows::core::Interface for ScreenCapture {
 impl ::windows::core::RuntimeName for ScreenCapture {
     const NAME: &'static str = "Windows.Media.Capture.ScreenCapture";
 }
-impl ::core::convert::From<ScreenCapture> for ::windows::core::IUnknown {
-    fn from(value: ScreenCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScreenCapture> for ::windows::core::IUnknown {
-    fn from(value: &ScreenCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScreenCapture> for &::windows::core::IUnknown {
-    fn from(value: &ScreenCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ScreenCapture> for ::windows::core::IInspectable {
-    fn from(value: ScreenCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScreenCapture> for ::windows::core::IInspectable {
-    fn from(value: &ScreenCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScreenCapture> for &::windows::core::IInspectable {
-    fn from(value: &ScreenCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ScreenCapture, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ScreenCapture {}
 unsafe impl ::core::marker::Sync for ScreenCapture {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -12540,36 +10539,7 @@ unsafe impl ::windows::core::Interface for SourceSuspensionChangedEventArgs {
 impl ::windows::core::RuntimeName for SourceSuspensionChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.SourceSuspensionChangedEventArgs";
 }
-impl ::core::convert::From<SourceSuspensionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SourceSuspensionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SourceSuspensionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SourceSuspensionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SourceSuspensionChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SourceSuspensionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SourceSuspensionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SourceSuspensionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SourceSuspensionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SourceSuspensionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SourceSuspensionChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SourceSuspensionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SourceSuspensionChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SourceSuspensionChangedEventArgs {}
 unsafe impl ::core::marker::Sync for SourceSuspensionChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -12627,36 +10597,7 @@ unsafe impl ::windows::core::Interface for VideoStreamConfiguration {
 impl ::windows::core::RuntimeName for VideoStreamConfiguration {
     const NAME: &'static str = "Windows.Media.Capture.VideoStreamConfiguration";
 }
-impl ::core::convert::From<VideoStreamConfiguration> for ::windows::core::IUnknown {
-    fn from(value: VideoStreamConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoStreamConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &VideoStreamConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoStreamConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &VideoStreamConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoStreamConfiguration> for ::windows::core::IInspectable {
-    fn from(value: VideoStreamConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoStreamConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &VideoStreamConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoStreamConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &VideoStreamConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoStreamConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VideoStreamConfiguration {}
 unsafe impl ::core::marker::Sync for VideoStreamConfiguration {}
 #[doc = "*Required features: `\"Media_Capture\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Casting/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Casting/mod.rs
@@ -329,36 +329,7 @@ unsafe impl ::windows::core::Interface for CastingConnection {
 impl ::windows::core::RuntimeName for CastingConnection {
     const NAME: &'static str = "Windows.Media.Casting.CastingConnection";
 }
-impl ::core::convert::From<CastingConnection> for ::windows::core::IUnknown {
-    fn from(value: CastingConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingConnection> for ::windows::core::IUnknown {
-    fn from(value: &CastingConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingConnection> for &::windows::core::IUnknown {
-    fn from(value: &CastingConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CastingConnection> for ::windows::core::IInspectable {
-    fn from(value: CastingConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingConnection> for ::windows::core::IInspectable {
-    fn from(value: &CastingConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingConnection> for &::windows::core::IInspectable {
-    fn from(value: &CastingConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CastingConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<CastingConnection> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -434,36 +405,7 @@ unsafe impl ::windows::core::Interface for CastingConnectionErrorOccurredEventAr
 impl ::windows::core::RuntimeName for CastingConnectionErrorOccurredEventArgs {
     const NAME: &'static str = "Windows.Media.Casting.CastingConnectionErrorOccurredEventArgs";
 }
-impl ::core::convert::From<CastingConnectionErrorOccurredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CastingConnectionErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingConnectionErrorOccurredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CastingConnectionErrorOccurredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingConnectionErrorOccurredEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CastingConnectionErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CastingConnectionErrorOccurredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CastingConnectionErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingConnectionErrorOccurredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CastingConnectionErrorOccurredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingConnectionErrorOccurredEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CastingConnectionErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CastingConnectionErrorOccurredEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CastingConnectionErrorOccurredEventArgs {}
 unsafe impl ::core::marker::Sync for CastingConnectionErrorOccurredEventArgs {}
 #[doc = "*Required features: `\"Media_Casting\"`*"]
@@ -577,36 +519,7 @@ unsafe impl ::windows::core::Interface for CastingDevice {
 impl ::windows::core::RuntimeName for CastingDevice {
     const NAME: &'static str = "Windows.Media.Casting.CastingDevice";
 }
-impl ::core::convert::From<CastingDevice> for ::windows::core::IUnknown {
-    fn from(value: CastingDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingDevice> for ::windows::core::IUnknown {
-    fn from(value: &CastingDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingDevice> for &::windows::core::IUnknown {
-    fn from(value: &CastingDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CastingDevice> for ::windows::core::IInspectable {
-    fn from(value: CastingDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingDevice> for ::windows::core::IInspectable {
-    fn from(value: &CastingDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingDevice> for &::windows::core::IInspectable {
-    fn from(value: &CastingDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CastingDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CastingDevice {}
 unsafe impl ::core::marker::Sync for CastingDevice {}
 #[doc = "*Required features: `\"Media_Casting\"`*"]
@@ -715,36 +628,7 @@ unsafe impl ::windows::core::Interface for CastingDevicePicker {
 impl ::windows::core::RuntimeName for CastingDevicePicker {
     const NAME: &'static str = "Windows.Media.Casting.CastingDevicePicker";
 }
-impl ::core::convert::From<CastingDevicePicker> for ::windows::core::IUnknown {
-    fn from(value: CastingDevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingDevicePicker> for ::windows::core::IUnknown {
-    fn from(value: &CastingDevicePicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingDevicePicker> for &::windows::core::IUnknown {
-    fn from(value: &CastingDevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CastingDevicePicker> for ::windows::core::IInspectable {
-    fn from(value: CastingDevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingDevicePicker> for ::windows::core::IInspectable {
-    fn from(value: &CastingDevicePicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingDevicePicker> for &::windows::core::IInspectable {
-    fn from(value: &CastingDevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CastingDevicePicker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CastingDevicePicker {}
 unsafe impl ::core::marker::Sync for CastingDevicePicker {}
 #[doc = "*Required features: `\"Media_Casting\"`*"]
@@ -826,36 +710,7 @@ unsafe impl ::windows::core::Interface for CastingDevicePickerFilter {
 impl ::windows::core::RuntimeName for CastingDevicePickerFilter {
     const NAME: &'static str = "Windows.Media.Casting.CastingDevicePickerFilter";
 }
-impl ::core::convert::From<CastingDevicePickerFilter> for ::windows::core::IUnknown {
-    fn from(value: CastingDevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingDevicePickerFilter> for ::windows::core::IUnknown {
-    fn from(value: &CastingDevicePickerFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingDevicePickerFilter> for &::windows::core::IUnknown {
-    fn from(value: &CastingDevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CastingDevicePickerFilter> for ::windows::core::IInspectable {
-    fn from(value: CastingDevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingDevicePickerFilter> for ::windows::core::IInspectable {
-    fn from(value: &CastingDevicePickerFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingDevicePickerFilter> for &::windows::core::IInspectable {
-    fn from(value: &CastingDevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CastingDevicePickerFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CastingDevicePickerFilter {}
 unsafe impl ::core::marker::Sync for CastingDevicePickerFilter {}
 #[doc = "*Required features: `\"Media_Casting\"`*"]
@@ -902,36 +757,7 @@ unsafe impl ::windows::core::Interface for CastingDeviceSelectedEventArgs {
 impl ::windows::core::RuntimeName for CastingDeviceSelectedEventArgs {
     const NAME: &'static str = "Windows.Media.Casting.CastingDeviceSelectedEventArgs";
 }
-impl ::core::convert::From<CastingDeviceSelectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CastingDeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingDeviceSelectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CastingDeviceSelectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingDeviceSelectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CastingDeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CastingDeviceSelectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CastingDeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingDeviceSelectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CastingDeviceSelectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingDeviceSelectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CastingDeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CastingDeviceSelectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CastingDeviceSelectedEventArgs {}
 unsafe impl ::core::marker::Sync for CastingDeviceSelectedEventArgs {}
 #[doc = "*Required features: `\"Media_Casting\"`*"]
@@ -986,36 +812,7 @@ unsafe impl ::windows::core::Interface for CastingSource {
 impl ::windows::core::RuntimeName for CastingSource {
     const NAME: &'static str = "Windows.Media.Casting.CastingSource";
 }
-impl ::core::convert::From<CastingSource> for ::windows::core::IUnknown {
-    fn from(value: CastingSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingSource> for ::windows::core::IUnknown {
-    fn from(value: &CastingSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingSource> for &::windows::core::IUnknown {
-    fn from(value: &CastingSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CastingSource> for ::windows::core::IInspectable {
-    fn from(value: CastingSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CastingSource> for ::windows::core::IInspectable {
-    fn from(value: &CastingSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CastingSource> for &::windows::core::IInspectable {
-    fn from(value: &CastingSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CastingSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CastingSource {}
 unsafe impl ::core::marker::Sync for CastingSource {}
 #[doc = "*Required features: `\"Media_Casting\"`*"]

--- a/crates/libs/windows/src/Windows/Media/ContentRestrictions/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/ContentRestrictions/mod.rs
@@ -183,36 +183,7 @@ unsafe impl ::windows::core::Interface for ContentRestrictionsBrowsePolicy {
 impl ::windows::core::RuntimeName for ContentRestrictionsBrowsePolicy {
     const NAME: &'static str = "Windows.Media.ContentRestrictions.ContentRestrictionsBrowsePolicy";
 }
-impl ::core::convert::From<ContentRestrictionsBrowsePolicy> for ::windows::core::IUnknown {
-    fn from(value: ContentRestrictionsBrowsePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContentRestrictionsBrowsePolicy> for ::windows::core::IUnknown {
-    fn from(value: &ContentRestrictionsBrowsePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContentRestrictionsBrowsePolicy> for &::windows::core::IUnknown {
-    fn from(value: &ContentRestrictionsBrowsePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContentRestrictionsBrowsePolicy> for ::windows::core::IInspectable {
-    fn from(value: ContentRestrictionsBrowsePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContentRestrictionsBrowsePolicy> for ::windows::core::IInspectable {
-    fn from(value: &ContentRestrictionsBrowsePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContentRestrictionsBrowsePolicy> for &::windows::core::IInspectable {
-    fn from(value: &ContentRestrictionsBrowsePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContentRestrictionsBrowsePolicy, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContentRestrictionsBrowsePolicy {}
 unsafe impl ::core::marker::Sync for ContentRestrictionsBrowsePolicy {}
 #[doc = "*Required features: `\"Media_ContentRestrictions\"`*"]
@@ -334,36 +305,7 @@ unsafe impl ::windows::core::Interface for RatedContentDescription {
 impl ::windows::core::RuntimeName for RatedContentDescription {
     const NAME: &'static str = "Windows.Media.ContentRestrictions.RatedContentDescription";
 }
-impl ::core::convert::From<RatedContentDescription> for ::windows::core::IUnknown {
-    fn from(value: RatedContentDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RatedContentDescription> for ::windows::core::IUnknown {
-    fn from(value: &RatedContentDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RatedContentDescription> for &::windows::core::IUnknown {
-    fn from(value: &RatedContentDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RatedContentDescription> for ::windows::core::IInspectable {
-    fn from(value: RatedContentDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RatedContentDescription> for ::windows::core::IInspectable {
-    fn from(value: &RatedContentDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RatedContentDescription> for &::windows::core::IInspectable {
-    fn from(value: &RatedContentDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RatedContentDescription, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RatedContentDescription {}
 unsafe impl ::core::marker::Sync for RatedContentDescription {}
 #[doc = "*Required features: `\"Media_ContentRestrictions\"`*"]
@@ -463,36 +405,7 @@ unsafe impl ::windows::core::Interface for RatedContentRestrictions {
 impl ::windows::core::RuntimeName for RatedContentRestrictions {
     const NAME: &'static str = "Windows.Media.ContentRestrictions.RatedContentRestrictions";
 }
-impl ::core::convert::From<RatedContentRestrictions> for ::windows::core::IUnknown {
-    fn from(value: RatedContentRestrictions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RatedContentRestrictions> for ::windows::core::IUnknown {
-    fn from(value: &RatedContentRestrictions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RatedContentRestrictions> for &::windows::core::IUnknown {
-    fn from(value: &RatedContentRestrictions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RatedContentRestrictions> for ::windows::core::IInspectable {
-    fn from(value: RatedContentRestrictions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RatedContentRestrictions> for ::windows::core::IInspectable {
-    fn from(value: &RatedContentRestrictions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RatedContentRestrictions> for &::windows::core::IInspectable {
-    fn from(value: &RatedContentRestrictions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RatedContentRestrictions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RatedContentRestrictions {}
 unsafe impl ::core::marker::Sync for RatedContentRestrictions {}
 #[doc = "*Required features: `\"Media_ContentRestrictions\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Control/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Control/mod.rs
@@ -394,36 +394,7 @@ unsafe impl ::windows::core::Interface for CurrentSessionChangedEventArgs {
 impl ::windows::core::RuntimeName for CurrentSessionChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Control.CurrentSessionChangedEventArgs";
 }
-impl ::core::convert::From<CurrentSessionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CurrentSessionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CurrentSessionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CurrentSessionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CurrentSessionChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CurrentSessionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CurrentSessionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CurrentSessionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CurrentSessionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CurrentSessionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CurrentSessionChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CurrentSessionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CurrentSessionChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CurrentSessionChangedEventArgs {}
 unsafe impl ::core::marker::Sync for CurrentSessionChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Control\"`*"]
@@ -673,36 +644,7 @@ unsafe impl ::windows::core::Interface for GlobalSystemMediaTransportControlsSes
 impl ::windows::core::RuntimeName for GlobalSystemMediaTransportControlsSession {
     const NAME: &'static str = "Windows.Media.Control.GlobalSystemMediaTransportControlsSession";
 }
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSession> for ::windows::core::IUnknown {
-    fn from(value: GlobalSystemMediaTransportControlsSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSession> for ::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSession> for &::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSession> for ::windows::core::IInspectable {
-    fn from(value: GlobalSystemMediaTransportControlsSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSession> for ::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSession> for &::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GlobalSystemMediaTransportControlsSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GlobalSystemMediaTransportControlsSession {}
 unsafe impl ::core::marker::Sync for GlobalSystemMediaTransportControlsSession {}
 #[doc = "*Required features: `\"Media_Control\"`*"]
@@ -801,36 +743,7 @@ unsafe impl ::windows::core::Interface for GlobalSystemMediaTransportControlsSes
 impl ::windows::core::RuntimeName for GlobalSystemMediaTransportControlsSessionManager {
     const NAME: &'static str = "Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager";
 }
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSessionManager> for ::windows::core::IUnknown {
-    fn from(value: GlobalSystemMediaTransportControlsSessionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionManager> for ::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionManager> for &::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSessionManager> for ::windows::core::IInspectable {
-    fn from(value: GlobalSystemMediaTransportControlsSessionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionManager> for ::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionManager> for &::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GlobalSystemMediaTransportControlsSessionManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GlobalSystemMediaTransportControlsSessionManager {}
 unsafe impl ::core::marker::Sync for GlobalSystemMediaTransportControlsSessionManager {}
 #[doc = "*Required features: `\"Media_Control\"`*"]
@@ -946,36 +859,7 @@ unsafe impl ::windows::core::Interface for GlobalSystemMediaTransportControlsSes
 impl ::windows::core::RuntimeName for GlobalSystemMediaTransportControlsSessionMediaProperties {
     const NAME: &'static str = "Windows.Media.Control.GlobalSystemMediaTransportControlsSessionMediaProperties";
 }
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSessionMediaProperties> for ::windows::core::IUnknown {
-    fn from(value: GlobalSystemMediaTransportControlsSessionMediaProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionMediaProperties> for ::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionMediaProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionMediaProperties> for &::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionMediaProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSessionMediaProperties> for ::windows::core::IInspectable {
-    fn from(value: GlobalSystemMediaTransportControlsSessionMediaProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionMediaProperties> for ::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionMediaProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionMediaProperties> for &::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionMediaProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GlobalSystemMediaTransportControlsSessionMediaProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GlobalSystemMediaTransportControlsSessionMediaProperties {}
 unsafe impl ::core::marker::Sync for GlobalSystemMediaTransportControlsSessionMediaProperties {}
 #[doc = "*Required features: `\"Media_Control\"`*"]
@@ -1120,36 +1004,7 @@ unsafe impl ::windows::core::Interface for GlobalSystemMediaTransportControlsSes
 impl ::windows::core::RuntimeName for GlobalSystemMediaTransportControlsSessionPlaybackControls {
     const NAME: &'static str = "Windows.Media.Control.GlobalSystemMediaTransportControlsSessionPlaybackControls";
 }
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSessionPlaybackControls> for ::windows::core::IUnknown {
-    fn from(value: GlobalSystemMediaTransportControlsSessionPlaybackControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionPlaybackControls> for ::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionPlaybackControls) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionPlaybackControls> for &::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionPlaybackControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSessionPlaybackControls> for ::windows::core::IInspectable {
-    fn from(value: GlobalSystemMediaTransportControlsSessionPlaybackControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionPlaybackControls> for ::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionPlaybackControls) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionPlaybackControls> for &::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionPlaybackControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GlobalSystemMediaTransportControlsSessionPlaybackControls, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GlobalSystemMediaTransportControlsSessionPlaybackControls {}
 unsafe impl ::core::marker::Sync for GlobalSystemMediaTransportControlsSessionPlaybackControls {}
 #[doc = "*Required features: `\"Media_Control\"`*"]
@@ -1239,36 +1094,7 @@ unsafe impl ::windows::core::Interface for GlobalSystemMediaTransportControlsSes
 impl ::windows::core::RuntimeName for GlobalSystemMediaTransportControlsSessionPlaybackInfo {
     const NAME: &'static str = "Windows.Media.Control.GlobalSystemMediaTransportControlsSessionPlaybackInfo";
 }
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSessionPlaybackInfo> for ::windows::core::IUnknown {
-    fn from(value: GlobalSystemMediaTransportControlsSessionPlaybackInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionPlaybackInfo> for ::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionPlaybackInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionPlaybackInfo> for &::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionPlaybackInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSessionPlaybackInfo> for ::windows::core::IInspectable {
-    fn from(value: GlobalSystemMediaTransportControlsSessionPlaybackInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionPlaybackInfo> for ::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionPlaybackInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionPlaybackInfo> for &::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionPlaybackInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GlobalSystemMediaTransportControlsSessionPlaybackInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GlobalSystemMediaTransportControlsSessionPlaybackInfo {}
 unsafe impl ::core::marker::Sync for GlobalSystemMediaTransportControlsSessionPlaybackInfo {}
 #[doc = "*Required features: `\"Media_Control\"`*"]
@@ -1362,36 +1188,7 @@ unsafe impl ::windows::core::Interface for GlobalSystemMediaTransportControlsSes
 impl ::windows::core::RuntimeName for GlobalSystemMediaTransportControlsSessionTimelineProperties {
     const NAME: &'static str = "Windows.Media.Control.GlobalSystemMediaTransportControlsSessionTimelineProperties";
 }
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSessionTimelineProperties> for ::windows::core::IUnknown {
-    fn from(value: GlobalSystemMediaTransportControlsSessionTimelineProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionTimelineProperties> for ::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionTimelineProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionTimelineProperties> for &::windows::core::IUnknown {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionTimelineProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GlobalSystemMediaTransportControlsSessionTimelineProperties> for ::windows::core::IInspectable {
-    fn from(value: GlobalSystemMediaTransportControlsSessionTimelineProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionTimelineProperties> for ::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionTimelineProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalSystemMediaTransportControlsSessionTimelineProperties> for &::windows::core::IInspectable {
-    fn from(value: &GlobalSystemMediaTransportControlsSessionTimelineProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GlobalSystemMediaTransportControlsSessionTimelineProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GlobalSystemMediaTransportControlsSessionTimelineProperties {}
 unsafe impl ::core::marker::Sync for GlobalSystemMediaTransportControlsSessionTimelineProperties {}
 #[doc = "*Required features: `\"Media_Control\"`*"]
@@ -1430,36 +1227,7 @@ unsafe impl ::windows::core::Interface for MediaPropertiesChangedEventArgs {
 impl ::windows::core::RuntimeName for MediaPropertiesChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Control.MediaPropertiesChangedEventArgs";
 }
-impl ::core::convert::From<MediaPropertiesChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPropertiesChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPropertiesChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPropertiesChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPropertiesChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPropertiesChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPropertiesChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPropertiesChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPropertiesChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPropertiesChangedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPropertiesChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Control\"`*"]
@@ -1498,36 +1266,7 @@ unsafe impl ::windows::core::Interface for PlaybackInfoChangedEventArgs {
 impl ::windows::core::RuntimeName for PlaybackInfoChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Control.PlaybackInfoChangedEventArgs";
 }
-impl ::core::convert::From<PlaybackInfoChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PlaybackInfoChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackInfoChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PlaybackInfoChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackInfoChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PlaybackInfoChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlaybackInfoChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PlaybackInfoChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackInfoChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PlaybackInfoChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackInfoChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PlaybackInfoChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlaybackInfoChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PlaybackInfoChangedEventArgs {}
 unsafe impl ::core::marker::Sync for PlaybackInfoChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Control\"`*"]
@@ -1566,36 +1305,7 @@ unsafe impl ::windows::core::Interface for SessionsChangedEventArgs {
 impl ::windows::core::RuntimeName for SessionsChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Control.SessionsChangedEventArgs";
 }
-impl ::core::convert::From<SessionsChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SessionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SessionsChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SessionsChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SessionsChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SessionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SessionsChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SessionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SessionsChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SessionsChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SessionsChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SessionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SessionsChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SessionsChangedEventArgs {}
 unsafe impl ::core::marker::Sync for SessionsChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Control\"`*"]
@@ -1634,36 +1344,7 @@ unsafe impl ::windows::core::Interface for TimelinePropertiesChangedEventArgs {
 impl ::windows::core::RuntimeName for TimelinePropertiesChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Control.TimelinePropertiesChangedEventArgs";
 }
-impl ::core::convert::From<TimelinePropertiesChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TimelinePropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimelinePropertiesChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TimelinePropertiesChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimelinePropertiesChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TimelinePropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimelinePropertiesChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TimelinePropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimelinePropertiesChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TimelinePropertiesChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimelinePropertiesChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TimelinePropertiesChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimelinePropertiesChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimelinePropertiesChangedEventArgs {}
 unsafe impl ::core::marker::Sync for TimelinePropertiesChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Control\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Core/mod.rs
@@ -665,36 +665,7 @@ impl IMediaCue {
         }
     }
 }
-impl ::core::convert::From<IMediaCue> for ::windows::core::IUnknown {
-    fn from(value: IMediaCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaCue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaCue> for ::windows::core::IUnknown {
-    fn from(value: &IMediaCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaCue> for ::windows::core::IInspectable {
-    fn from(value: IMediaCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaCue> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaCue> for ::windows::core::IInspectable {
-    fn from(value: &IMediaCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaCue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMediaCue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -766,36 +737,7 @@ pub struct IMediaCueEventArgs_Vtbl {
 #[repr(transparent)]
 pub struct IMediaSource(::windows::core::IUnknown);
 impl IMediaSource {}
-impl ::core::convert::From<IMediaSource> for ::windows::core::IUnknown {
-    fn from(value: IMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaSource> for ::windows::core::IUnknown {
-    fn from(value: &IMediaSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaSource> for ::windows::core::IInspectable {
-    fn from(value: IMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaSource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaSource> for ::windows::core::IInspectable {
-    fn from(value: &IMediaSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMediaSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1148,36 +1090,7 @@ impl IMediaStreamDescriptor {
         }
     }
 }
-impl ::core::convert::From<IMediaStreamDescriptor> for ::windows::core::IUnknown {
-    fn from(value: IMediaStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaStreamDescriptor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaStreamDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &IMediaStreamDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaStreamDescriptor> for ::windows::core::IInspectable {
-    fn from(value: IMediaStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaStreamDescriptor> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaStreamDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &IMediaStreamDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaStreamDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMediaStreamDescriptor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1262,36 +1175,7 @@ impl IMediaStreamDescriptor2 {
         }
     }
 }
-impl ::core::convert::From<IMediaStreamDescriptor2> for ::windows::core::IUnknown {
-    fn from(value: IMediaStreamDescriptor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaStreamDescriptor2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaStreamDescriptor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaStreamDescriptor2> for ::windows::core::IUnknown {
-    fn from(value: &IMediaStreamDescriptor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaStreamDescriptor2> for ::windows::core::IInspectable {
-    fn from(value: IMediaStreamDescriptor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaStreamDescriptor2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaStreamDescriptor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaStreamDescriptor2> for ::windows::core::IInspectable {
-    fn from(value: &IMediaStreamDescriptor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaStreamDescriptor2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IMediaStreamDescriptor2> for IMediaStreamDescriptor {
     type Error = ::windows::core::Error;
     fn try_from(value: IMediaStreamDescriptor2) -> ::windows::core::Result<Self> {
@@ -1893,36 +1777,7 @@ impl IMediaTrack {
         }
     }
 }
-impl ::core::convert::From<IMediaTrack> for ::windows::core::IUnknown {
-    fn from(value: IMediaTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaTrack> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaTrack> for ::windows::core::IUnknown {
-    fn from(value: &IMediaTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaTrack> for ::windows::core::IInspectable {
-    fn from(value: IMediaTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaTrack> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaTrack> for ::windows::core::IInspectable {
-    fn from(value: &IMediaTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaTrack, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMediaTrack {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2298,36 +2153,7 @@ impl ISingleSelectMediaTrackList {
         }
     }
 }
-impl ::core::convert::From<ISingleSelectMediaTrackList> for ::windows::core::IUnknown {
-    fn from(value: ISingleSelectMediaTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISingleSelectMediaTrackList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISingleSelectMediaTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISingleSelectMediaTrackList> for ::windows::core::IUnknown {
-    fn from(value: &ISingleSelectMediaTrackList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISingleSelectMediaTrackList> for ::windows::core::IInspectable {
-    fn from(value: ISingleSelectMediaTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISingleSelectMediaTrackList> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISingleSelectMediaTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISingleSelectMediaTrackList> for ::windows::core::IInspectable {
-    fn from(value: &ISingleSelectMediaTrackList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISingleSelectMediaTrackList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISingleSelectMediaTrackList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2570,36 +2396,7 @@ impl ITimedMetadataTrackProvider {
         }
     }
 }
-impl ::core::convert::From<ITimedMetadataTrackProvider> for ::windows::core::IUnknown {
-    fn from(value: ITimedMetadataTrackProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITimedMetadataTrackProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITimedMetadataTrackProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITimedMetadataTrackProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITimedMetadataTrackProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITimedMetadataTrackProvider> for ::windows::core::IInspectable {
-    fn from(value: ITimedMetadataTrackProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITimedMetadataTrackProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ITimedMetadataTrackProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITimedMetadataTrackProvider> for ::windows::core::IInspectable {
-    fn from(value: &ITimedMetadataTrackProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITimedMetadataTrackProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ITimedMetadataTrackProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3292,36 +3089,7 @@ unsafe impl ::windows::core::Interface for AudioStreamDescriptor {
 impl ::windows::core::RuntimeName for AudioStreamDescriptor {
     const NAME: &'static str = "Windows.Media.Core.AudioStreamDescriptor";
 }
-impl ::core::convert::From<AudioStreamDescriptor> for ::windows::core::IUnknown {
-    fn from(value: AudioStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioStreamDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &AudioStreamDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioStreamDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &AudioStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioStreamDescriptor> for ::windows::core::IInspectable {
-    fn from(value: AudioStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioStreamDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &AudioStreamDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioStreamDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &AudioStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioStreamDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioStreamDescriptor> for IMediaStreamDescriptor {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioStreamDescriptor) -> ::windows::core::Result<Self> {
@@ -3478,36 +3246,7 @@ unsafe impl ::windows::core::Interface for AudioTrack {
 impl ::windows::core::RuntimeName for AudioTrack {
     const NAME: &'static str = "Windows.Media.Core.AudioTrack";
 }
-impl ::core::convert::From<AudioTrack> for ::windows::core::IUnknown {
-    fn from(value: AudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioTrack> for ::windows::core::IUnknown {
-    fn from(value: &AudioTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioTrack> for &::windows::core::IUnknown {
-    fn from(value: &AudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioTrack> for ::windows::core::IInspectable {
-    fn from(value: AudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioTrack> for ::windows::core::IInspectable {
-    fn from(value: &AudioTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioTrack> for &::windows::core::IInspectable {
-    fn from(value: &AudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioTrack, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioTrack> for IMediaTrack {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioTrack) -> ::windows::core::Result<Self> {
@@ -3573,36 +3312,7 @@ unsafe impl ::windows::core::Interface for AudioTrackOpenFailedEventArgs {
 impl ::windows::core::RuntimeName for AudioTrackOpenFailedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.AudioTrackOpenFailedEventArgs";
 }
-impl ::core::convert::From<AudioTrackOpenFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AudioTrackOpenFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioTrackOpenFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AudioTrackOpenFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioTrackOpenFailedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AudioTrackOpenFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioTrackOpenFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AudioTrackOpenFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioTrackOpenFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AudioTrackOpenFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioTrackOpenFailedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AudioTrackOpenFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioTrackOpenFailedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioTrackOpenFailedEventArgs {}
 unsafe impl ::core::marker::Sync for AudioTrackOpenFailedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -3670,36 +3380,7 @@ unsafe impl ::windows::core::Interface for AudioTrackSupportInfo {
 impl ::windows::core::RuntimeName for AudioTrackSupportInfo {
     const NAME: &'static str = "Windows.Media.Core.AudioTrackSupportInfo";
 }
-impl ::core::convert::From<AudioTrackSupportInfo> for ::windows::core::IUnknown {
-    fn from(value: AudioTrackSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioTrackSupportInfo> for ::windows::core::IUnknown {
-    fn from(value: &AudioTrackSupportInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioTrackSupportInfo> for &::windows::core::IUnknown {
-    fn from(value: &AudioTrackSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioTrackSupportInfo> for ::windows::core::IInspectable {
-    fn from(value: AudioTrackSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioTrackSupportInfo> for ::windows::core::IInspectable {
-    fn from(value: &AudioTrackSupportInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioTrackSupportInfo> for &::windows::core::IInspectable {
-    fn from(value: &AudioTrackSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioTrackSupportInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioTrackSupportInfo {}
 unsafe impl ::core::marker::Sync for AudioTrackSupportInfo {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -3798,36 +3479,7 @@ unsafe impl ::windows::core::Interface for ChapterCue {
 impl ::windows::core::RuntimeName for ChapterCue {
     const NAME: &'static str = "Windows.Media.Core.ChapterCue";
 }
-impl ::core::convert::From<ChapterCue> for ::windows::core::IUnknown {
-    fn from(value: ChapterCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChapterCue> for ::windows::core::IUnknown {
-    fn from(value: &ChapterCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChapterCue> for &::windows::core::IUnknown {
-    fn from(value: &ChapterCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChapterCue> for ::windows::core::IInspectable {
-    fn from(value: ChapterCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChapterCue> for ::windows::core::IInspectable {
-    fn from(value: &ChapterCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChapterCue> for &::windows::core::IInspectable {
-    fn from(value: &ChapterCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChapterCue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ChapterCue> for IMediaCue {
     type Error = ::windows::core::Error;
     fn try_from(value: ChapterCue) -> ::windows::core::Result<Self> {
@@ -3923,36 +3575,7 @@ unsafe impl ::windows::core::Interface for CodecInfo {
 impl ::windows::core::RuntimeName for CodecInfo {
     const NAME: &'static str = "Windows.Media.Core.CodecInfo";
 }
-impl ::core::convert::From<CodecInfo> for ::windows::core::IUnknown {
-    fn from(value: CodecInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CodecInfo> for ::windows::core::IUnknown {
-    fn from(value: &CodecInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CodecInfo> for &::windows::core::IUnknown {
-    fn from(value: &CodecInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CodecInfo> for ::windows::core::IInspectable {
-    fn from(value: CodecInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CodecInfo> for ::windows::core::IInspectable {
-    fn from(value: &CodecInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CodecInfo> for &::windows::core::IInspectable {
-    fn from(value: &CodecInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CodecInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CodecInfo {}
 unsafe impl ::core::marker::Sync for CodecInfo {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -4008,36 +3631,7 @@ unsafe impl ::windows::core::Interface for CodecQuery {
 impl ::windows::core::RuntimeName for CodecQuery {
     const NAME: &'static str = "Windows.Media.Core.CodecQuery";
 }
-impl ::core::convert::From<CodecQuery> for ::windows::core::IUnknown {
-    fn from(value: CodecQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CodecQuery> for ::windows::core::IUnknown {
-    fn from(value: &CodecQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CodecQuery> for &::windows::core::IUnknown {
-    fn from(value: &CodecQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CodecQuery> for ::windows::core::IInspectable {
-    fn from(value: CodecQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CodecQuery> for ::windows::core::IInspectable {
-    fn from(value: &CodecQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CodecQuery> for &::windows::core::IInspectable {
-    fn from(value: &CodecQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CodecQuery, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CodecQuery {}
 unsafe impl ::core::marker::Sync for CodecQuery {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -4471,36 +4065,7 @@ unsafe impl ::windows::core::Interface for DataCue {
 impl ::windows::core::RuntimeName for DataCue {
     const NAME: &'static str = "Windows.Media.Core.DataCue";
 }
-impl ::core::convert::From<DataCue> for ::windows::core::IUnknown {
-    fn from(value: DataCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataCue> for ::windows::core::IUnknown {
-    fn from(value: &DataCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataCue> for &::windows::core::IUnknown {
-    fn from(value: &DataCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataCue> for ::windows::core::IInspectable {
-    fn from(value: DataCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataCue> for ::windows::core::IInspectable {
-    fn from(value: &DataCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataCue> for &::windows::core::IInspectable {
-    fn from(value: &DataCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataCue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DataCue> for IMediaCue {
     type Error = ::windows::core::Error;
     fn try_from(value: DataCue) -> ::windows::core::Result<Self> {
@@ -4566,36 +4131,7 @@ unsafe impl ::windows::core::Interface for FaceDetectedEventArgs {
 impl ::windows::core::RuntimeName for FaceDetectedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.FaceDetectedEventArgs";
 }
-impl ::core::convert::From<FaceDetectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: FaceDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FaceDetectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &FaceDetectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FaceDetectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &FaceDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FaceDetectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: FaceDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FaceDetectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &FaceDetectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FaceDetectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &FaceDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FaceDetectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FaceDetectedEventArgs {}
 unsafe impl ::core::marker::Sync for FaceDetectedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -4686,36 +4222,7 @@ unsafe impl ::windows::core::Interface for FaceDetectionEffect {
 impl ::windows::core::RuntimeName for FaceDetectionEffect {
     const NAME: &'static str = "Windows.Media.Core.FaceDetectionEffect";
 }
-impl ::core::convert::From<FaceDetectionEffect> for ::windows::core::IUnknown {
-    fn from(value: FaceDetectionEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FaceDetectionEffect> for ::windows::core::IUnknown {
-    fn from(value: &FaceDetectionEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FaceDetectionEffect> for &::windows::core::IUnknown {
-    fn from(value: &FaceDetectionEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FaceDetectionEffect> for ::windows::core::IInspectable {
-    fn from(value: FaceDetectionEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FaceDetectionEffect> for ::windows::core::IInspectable {
-    fn from(value: &FaceDetectionEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FaceDetectionEffect> for &::windows::core::IInspectable {
-    fn from(value: &FaceDetectionEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FaceDetectionEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<FaceDetectionEffect> for super::IMediaExtension {
     type Error = ::windows::core::Error;
     fn try_from(value: FaceDetectionEffect) -> ::windows::core::Result<Self> {
@@ -4832,41 +4339,7 @@ impl ::windows::core::RuntimeName for FaceDetectionEffectDefinition {
     const NAME: &'static str = "Windows.Media.Core.FaceDetectionEffectDefinition";
 }
 #[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<FaceDetectionEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: FaceDetectionEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&FaceDetectionEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &FaceDetectionEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&FaceDetectionEffectDefinition> for &::windows::core::IUnknown {
-    fn from(value: &FaceDetectionEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<FaceDetectionEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: FaceDetectionEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&FaceDetectionEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &FaceDetectionEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&FaceDetectionEffectDefinition> for &::windows::core::IInspectable {
-    fn from(value: &FaceDetectionEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FaceDetectionEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Media_Effects")]
 impl ::core::convert::TryFrom<FaceDetectionEffectDefinition> for super::Effects::IVideoEffectDefinition {
     type Error = ::windows::core::Error;
@@ -5036,36 +4509,7 @@ unsafe impl ::windows::core::Interface for FaceDetectionEffectFrame {
 impl ::windows::core::RuntimeName for FaceDetectionEffectFrame {
     const NAME: &'static str = "Windows.Media.Core.FaceDetectionEffectFrame";
 }
-impl ::core::convert::From<FaceDetectionEffectFrame> for ::windows::core::IUnknown {
-    fn from(value: FaceDetectionEffectFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FaceDetectionEffectFrame> for ::windows::core::IUnknown {
-    fn from(value: &FaceDetectionEffectFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FaceDetectionEffectFrame> for &::windows::core::IUnknown {
-    fn from(value: &FaceDetectionEffectFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FaceDetectionEffectFrame> for ::windows::core::IInspectable {
-    fn from(value: FaceDetectionEffectFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FaceDetectionEffectFrame> for ::windows::core::IInspectable {
-    fn from(value: &FaceDetectionEffectFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FaceDetectionEffectFrame> for &::windows::core::IInspectable {
-    fn from(value: &FaceDetectionEffectFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FaceDetectionEffectFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<FaceDetectionEffectFrame> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5157,36 +4601,7 @@ unsafe impl ::windows::core::Interface for HighDynamicRangeControl {
 impl ::windows::core::RuntimeName for HighDynamicRangeControl {
     const NAME: &'static str = "Windows.Media.Core.HighDynamicRangeControl";
 }
-impl ::core::convert::From<HighDynamicRangeControl> for ::windows::core::IUnknown {
-    fn from(value: HighDynamicRangeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HighDynamicRangeControl> for ::windows::core::IUnknown {
-    fn from(value: &HighDynamicRangeControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HighDynamicRangeControl> for &::windows::core::IUnknown {
-    fn from(value: &HighDynamicRangeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HighDynamicRangeControl> for ::windows::core::IInspectable {
-    fn from(value: HighDynamicRangeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HighDynamicRangeControl> for ::windows::core::IInspectable {
-    fn from(value: &HighDynamicRangeControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HighDynamicRangeControl> for &::windows::core::IInspectable {
-    fn from(value: &HighDynamicRangeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HighDynamicRangeControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HighDynamicRangeControl {}
 unsafe impl ::core::marker::Sync for HighDynamicRangeControl {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -5242,36 +4657,7 @@ unsafe impl ::windows::core::Interface for HighDynamicRangeOutput {
 impl ::windows::core::RuntimeName for HighDynamicRangeOutput {
     const NAME: &'static str = "Windows.Media.Core.HighDynamicRangeOutput";
 }
-impl ::core::convert::From<HighDynamicRangeOutput> for ::windows::core::IUnknown {
-    fn from(value: HighDynamicRangeOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HighDynamicRangeOutput> for ::windows::core::IUnknown {
-    fn from(value: &HighDynamicRangeOutput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HighDynamicRangeOutput> for &::windows::core::IUnknown {
-    fn from(value: &HighDynamicRangeOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HighDynamicRangeOutput> for ::windows::core::IInspectable {
-    fn from(value: HighDynamicRangeOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HighDynamicRangeOutput> for ::windows::core::IInspectable {
-    fn from(value: &HighDynamicRangeOutput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HighDynamicRangeOutput> for &::windows::core::IInspectable {
-    fn from(value: &HighDynamicRangeOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HighDynamicRangeOutput, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HighDynamicRangeOutput {}
 unsafe impl ::core::marker::Sync for HighDynamicRangeOutput {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -5396,36 +4782,7 @@ unsafe impl ::windows::core::Interface for ImageCue {
 impl ::windows::core::RuntimeName for ImageCue {
     const NAME: &'static str = "Windows.Media.Core.ImageCue";
 }
-impl ::core::convert::From<ImageCue> for ::windows::core::IUnknown {
-    fn from(value: ImageCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageCue> for ::windows::core::IUnknown {
-    fn from(value: &ImageCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageCue> for &::windows::core::IUnknown {
-    fn from(value: &ImageCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageCue> for ::windows::core::IInspectable {
-    fn from(value: ImageCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageCue> for ::windows::core::IInspectable {
-    fn from(value: &ImageCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageCue> for &::windows::core::IInspectable {
-    fn from(value: &ImageCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageCue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ImageCue> for IMediaCue {
     type Error = ::windows::core::Error;
     fn try_from(value: ImageCue) -> ::windows::core::Result<Self> {
@@ -5509,36 +4866,7 @@ unsafe impl ::windows::core::Interface for InitializeMediaStreamSourceRequestedE
 impl ::windows::core::RuntimeName for InitializeMediaStreamSourceRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.InitializeMediaStreamSourceRequestedEventArgs";
 }
-impl ::core::convert::From<InitializeMediaStreamSourceRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: InitializeMediaStreamSourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InitializeMediaStreamSourceRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &InitializeMediaStreamSourceRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InitializeMediaStreamSourceRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &InitializeMediaStreamSourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InitializeMediaStreamSourceRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: InitializeMediaStreamSourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InitializeMediaStreamSourceRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &InitializeMediaStreamSourceRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InitializeMediaStreamSourceRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &InitializeMediaStreamSourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InitializeMediaStreamSourceRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InitializeMediaStreamSourceRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for InitializeMediaStreamSourceRequestedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -5631,36 +4959,7 @@ unsafe impl ::windows::core::Interface for LowLightFusionResult {
 impl ::windows::core::RuntimeName for LowLightFusionResult {
     const NAME: &'static str = "Windows.Media.Core.LowLightFusionResult";
 }
-impl ::core::convert::From<LowLightFusionResult> for ::windows::core::IUnknown {
-    fn from(value: LowLightFusionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLightFusionResult> for ::windows::core::IUnknown {
-    fn from(value: &LowLightFusionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLightFusionResult> for &::windows::core::IUnknown {
-    fn from(value: &LowLightFusionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LowLightFusionResult> for ::windows::core::IInspectable {
-    fn from(value: LowLightFusionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLightFusionResult> for ::windows::core::IInspectable {
-    fn from(value: &LowLightFusionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLightFusionResult> for &::windows::core::IInspectable {
-    fn from(value: &LowLightFusionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LowLightFusionResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<LowLightFusionResult> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5762,36 +5061,7 @@ unsafe impl ::windows::core::Interface for MediaBinder {
 impl ::windows::core::RuntimeName for MediaBinder {
     const NAME: &'static str = "Windows.Media.Core.MediaBinder";
 }
-impl ::core::convert::From<MediaBinder> for ::windows::core::IUnknown {
-    fn from(value: MediaBinder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBinder> for ::windows::core::IUnknown {
-    fn from(value: &MediaBinder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBinder> for &::windows::core::IUnknown {
-    fn from(value: &MediaBinder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaBinder> for ::windows::core::IInspectable {
-    fn from(value: MediaBinder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBinder> for ::windows::core::IInspectable {
-    fn from(value: &MediaBinder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBinder> for &::windows::core::IInspectable {
-    fn from(value: &MediaBinder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaBinder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaBinder {}
 unsafe impl ::core::marker::Sync for MediaBinder {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -5910,36 +5180,7 @@ unsafe impl ::windows::core::Interface for MediaBindingEventArgs {
 impl ::windows::core::RuntimeName for MediaBindingEventArgs {
     const NAME: &'static str = "Windows.Media.Core.MediaBindingEventArgs";
 }
-impl ::core::convert::From<MediaBindingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaBindingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBindingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaBindingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBindingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaBindingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaBindingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaBindingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBindingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaBindingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBindingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaBindingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaBindingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaBindingEventArgs {}
 unsafe impl ::core::marker::Sync for MediaBindingEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -5986,36 +5227,7 @@ unsafe impl ::windows::core::Interface for MediaCueEventArgs {
 impl ::windows::core::RuntimeName for MediaCueEventArgs {
     const NAME: &'static str = "Windows.Media.Core.MediaCueEventArgs";
 }
-impl ::core::convert::From<MediaCueEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaCueEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCueEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaCueEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCueEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaCueEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaCueEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaCueEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaCueEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaCueEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaCueEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaCueEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaCueEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaCueEventArgs {}
 unsafe impl ::core::marker::Sync for MediaCueEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -6311,36 +5523,7 @@ unsafe impl ::windows::core::Interface for MediaSource {
 impl ::windows::core::RuntimeName for MediaSource {
     const NAME: &'static str = "Windows.Media.Core.MediaSource";
 }
-impl ::core::convert::From<MediaSource> for ::windows::core::IUnknown {
-    fn from(value: MediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSource> for ::windows::core::IUnknown {
-    fn from(value: &MediaSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSource> for &::windows::core::IUnknown {
-    fn from(value: &MediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaSource> for ::windows::core::IInspectable {
-    fn from(value: MediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSource> for ::windows::core::IInspectable {
-    fn from(value: &MediaSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSource> for &::windows::core::IInspectable {
-    fn from(value: &MediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MediaSource> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -6456,36 +5639,7 @@ unsafe impl ::windows::core::Interface for MediaSourceAppServiceConnection {
 impl ::windows::core::RuntimeName for MediaSourceAppServiceConnection {
     const NAME: &'static str = "Windows.Media.Core.MediaSourceAppServiceConnection";
 }
-impl ::core::convert::From<MediaSourceAppServiceConnection> for ::windows::core::IUnknown {
-    fn from(value: MediaSourceAppServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSourceAppServiceConnection> for ::windows::core::IUnknown {
-    fn from(value: &MediaSourceAppServiceConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSourceAppServiceConnection> for &::windows::core::IUnknown {
-    fn from(value: &MediaSourceAppServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaSourceAppServiceConnection> for ::windows::core::IInspectable {
-    fn from(value: MediaSourceAppServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSourceAppServiceConnection> for ::windows::core::IInspectable {
-    fn from(value: &MediaSourceAppServiceConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSourceAppServiceConnection> for &::windows::core::IInspectable {
-    fn from(value: &MediaSourceAppServiceConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaSourceAppServiceConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Core\"`*"]
 #[repr(transparent)]
 pub struct MediaSourceError(::windows::core::IUnknown);
@@ -6530,36 +5684,7 @@ unsafe impl ::windows::core::Interface for MediaSourceError {
 impl ::windows::core::RuntimeName for MediaSourceError {
     const NAME: &'static str = "Windows.Media.Core.MediaSourceError";
 }
-impl ::core::convert::From<MediaSourceError> for ::windows::core::IUnknown {
-    fn from(value: MediaSourceError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSourceError> for ::windows::core::IUnknown {
-    fn from(value: &MediaSourceError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSourceError> for &::windows::core::IUnknown {
-    fn from(value: &MediaSourceError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaSourceError> for ::windows::core::IInspectable {
-    fn from(value: MediaSourceError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSourceError> for ::windows::core::IInspectable {
-    fn from(value: &MediaSourceError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSourceError> for &::windows::core::IInspectable {
-    fn from(value: &MediaSourceError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaSourceError, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaSourceError {}
 unsafe impl ::core::marker::Sync for MediaSourceError {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -6606,36 +5731,7 @@ unsafe impl ::windows::core::Interface for MediaSourceOpenOperationCompletedEven
 impl ::windows::core::RuntimeName for MediaSourceOpenOperationCompletedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.MediaSourceOpenOperationCompletedEventArgs";
 }
-impl ::core::convert::From<MediaSourceOpenOperationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaSourceOpenOperationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSourceOpenOperationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaSourceOpenOperationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSourceOpenOperationCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaSourceOpenOperationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaSourceOpenOperationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaSourceOpenOperationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSourceOpenOperationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaSourceOpenOperationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSourceOpenOperationCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaSourceOpenOperationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaSourceOpenOperationCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaSourceOpenOperationCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaSourceOpenOperationCompletedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -6689,36 +5785,7 @@ unsafe impl ::windows::core::Interface for MediaSourceStateChangedEventArgs {
 impl ::windows::core::RuntimeName for MediaSourceStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.MediaSourceStateChangedEventArgs";
 }
-impl ::core::convert::From<MediaSourceStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaSourceStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSourceStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaSourceStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSourceStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaSourceStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaSourceStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaSourceStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaSourceStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaSourceStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaSourceStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaSourceStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaSourceStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaSourceStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaSourceStateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -6914,36 +5981,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSample {
 impl ::windows::core::RuntimeName for MediaStreamSample {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSample";
 }
-impl ::core::convert::From<MediaStreamSample> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSample> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSample) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSample> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSample> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSample> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSample) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSample> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSample, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSample {}
 unsafe impl ::core::marker::Sync for MediaStreamSample {}
 #[doc = "*Required features: `\"Media_Core\"`, `\"Foundation_Collections\"`*"]
@@ -7079,41 +6117,7 @@ impl ::core::iter::IntoIterator for &MediaStreamSamplePropertySet {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<MediaStreamSamplePropertySet> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSamplePropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&MediaStreamSamplePropertySet> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSamplePropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&MediaStreamSamplePropertySet> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSamplePropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<MediaStreamSamplePropertySet> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSamplePropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&MediaStreamSamplePropertySet> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSamplePropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&MediaStreamSamplePropertySet> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSamplePropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSamplePropertySet, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<MediaStreamSamplePropertySet> for super::super::Foundation::Collections::IIterable<super::super::Foundation::Collections::IKeyValuePair<::windows::core::GUID, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
@@ -7223,36 +6227,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSampleProtectionProperties
 impl ::windows::core::RuntimeName for MediaStreamSampleProtectionProperties {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSampleProtectionProperties";
 }
-impl ::core::convert::From<MediaStreamSampleProtectionProperties> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSampleProtectionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSampleProtectionProperties> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSampleProtectionProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSampleProtectionProperties> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSampleProtectionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSampleProtectionProperties> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSampleProtectionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSampleProtectionProperties> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSampleProtectionProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSampleProtectionProperties> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSampleProtectionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSampleProtectionProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSampleProtectionProperties {}
 unsafe impl ::core::marker::Sync for MediaStreamSampleProtectionProperties {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -7558,36 +6533,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSource {
 impl ::windows::core::RuntimeName for MediaStreamSource {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSource";
 }
-impl ::core::convert::From<MediaStreamSource> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSource> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSource> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSource> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSource> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSource> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MediaStreamSource> for IMediaSource {
     type Error = ::windows::core::Error;
     fn try_from(value: MediaStreamSource) -> ::windows::core::Result<Self> {
@@ -7653,36 +6599,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceClosedEventArgs {
 impl ::windows::core::RuntimeName for MediaStreamSourceClosedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceClosedEventArgs";
 }
-impl ::core::convert::From<MediaStreamSourceClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceClosedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceClosedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceClosedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceClosedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceClosedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -7729,36 +6646,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceClosedRequest {
 impl ::windows::core::RuntimeName for MediaStreamSourceClosedRequest {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceClosedRequest";
 }
-impl ::core::convert::From<MediaStreamSourceClosedRequest> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceClosedRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceClosedRequest> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceClosedRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceClosedRequest> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceClosedRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceClosedRequest> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceClosedRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceClosedRequest> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceClosedRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceClosedRequest> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceClosedRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceClosedRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceClosedRequest {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceClosedRequest {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -7807,36 +6695,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceSampleRenderedEventA
 impl ::windows::core::RuntimeName for MediaStreamSourceSampleRenderedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceSampleRenderedEventArgs";
 }
-impl ::core::convert::From<MediaStreamSourceSampleRenderedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceSampleRenderedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRenderedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSampleRenderedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRenderedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSampleRenderedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceSampleRenderedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceSampleRenderedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRenderedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSampleRenderedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRenderedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSampleRenderedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceSampleRenderedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceSampleRenderedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceSampleRenderedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -7905,36 +6764,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceSampleRequest {
 impl ::windows::core::RuntimeName for MediaStreamSourceSampleRequest {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceSampleRequest";
 }
-impl ::core::convert::From<MediaStreamSourceSampleRequest> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceSampleRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequest> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSampleRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequest> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSampleRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceSampleRequest> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceSampleRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequest> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSampleRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequest> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSampleRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceSampleRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceSampleRequest {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceSampleRequest {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -7978,36 +6808,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceSampleRequestDeferra
 impl ::windows::core::RuntimeName for MediaStreamSourceSampleRequestDeferral {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceSampleRequestDeferral";
 }
-impl ::core::convert::From<MediaStreamSourceSampleRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceSampleRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSampleRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequestDeferral> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSampleRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceSampleRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceSampleRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSampleRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequestDeferral> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSampleRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceSampleRequestDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceSampleRequestDeferral {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceSampleRequestDeferral {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -8054,36 +6855,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceSampleRequestedEvent
 impl ::windows::core::RuntimeName for MediaStreamSourceSampleRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceSampleRequestedEventArgs";
 }
-impl ::core::convert::From<MediaStreamSourceSampleRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceSampleRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSampleRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSampleRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceSampleRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceSampleRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSampleRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSampleRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSampleRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceSampleRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceSampleRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceSampleRequestedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -8130,36 +6902,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceStartingEventArgs {
 impl ::windows::core::RuntimeName for MediaStreamSourceStartingEventArgs {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceStartingEventArgs";
 }
-impl ::core::convert::From<MediaStreamSourceStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceStartingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceStartingEventArgs {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceStartingEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -8221,36 +6964,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceStartingRequest {
 impl ::windows::core::RuntimeName for MediaStreamSourceStartingRequest {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceStartingRequest";
 }
-impl ::core::convert::From<MediaStreamSourceStartingRequest> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceStartingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingRequest> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceStartingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingRequest> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceStartingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceStartingRequest> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceStartingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingRequest> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceStartingRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingRequest> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceStartingRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceStartingRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceStartingRequest {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceStartingRequest {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -8294,36 +7008,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceStartingRequestDefer
 impl ::windows::core::RuntimeName for MediaStreamSourceStartingRequestDeferral {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceStartingRequestDeferral";
 }
-impl ::core::convert::From<MediaStreamSourceStartingRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceStartingRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceStartingRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingRequestDeferral> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceStartingRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceStartingRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceStartingRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceStartingRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceStartingRequestDeferral> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceStartingRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceStartingRequestDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceStartingRequestDeferral {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceStartingRequestDeferral {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -8384,36 +7069,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceSwitchStreamsRequest
 impl ::windows::core::RuntimeName for MediaStreamSourceSwitchStreamsRequest {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceSwitchStreamsRequest";
 }
-impl ::core::convert::From<MediaStreamSourceSwitchStreamsRequest> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceSwitchStreamsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequest> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequest> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceSwitchStreamsRequest> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceSwitchStreamsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequest> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequest> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceSwitchStreamsRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceSwitchStreamsRequest {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceSwitchStreamsRequest {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -8457,36 +7113,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceSwitchStreamsRequest
 impl ::windows::core::RuntimeName for MediaStreamSourceSwitchStreamsRequestDeferral {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceSwitchStreamsRequestDeferral";
 }
-impl ::core::convert::From<MediaStreamSourceSwitchStreamsRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceSwitchStreamsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequestDeferral> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceSwitchStreamsRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceSwitchStreamsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequestDeferral> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceSwitchStreamsRequestDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceSwitchStreamsRequestDeferral {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceSwitchStreamsRequestDeferral {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -8533,36 +7160,7 @@ unsafe impl ::windows::core::Interface for MediaStreamSourceSwitchStreamsRequest
 impl ::windows::core::RuntimeName for MediaStreamSourceSwitchStreamsRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.MediaStreamSourceSwitchStreamsRequestedEventArgs";
 }
-impl ::core::convert::From<MediaStreamSourceSwitchStreamsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaStreamSourceSwitchStreamsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaStreamSourceSwitchStreamsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaStreamSourceSwitchStreamsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaStreamSourceSwitchStreamsRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaStreamSourceSwitchStreamsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaStreamSourceSwitchStreamsRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaStreamSourceSwitchStreamsRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceSwitchStreamsRequestedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -8797,36 +7395,7 @@ unsafe impl ::windows::core::Interface for MseSourceBuffer {
 impl ::windows::core::RuntimeName for MseSourceBuffer {
     const NAME: &'static str = "Windows.Media.Core.MseSourceBuffer";
 }
-impl ::core::convert::From<MseSourceBuffer> for ::windows::core::IUnknown {
-    fn from(value: MseSourceBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MseSourceBuffer> for ::windows::core::IUnknown {
-    fn from(value: &MseSourceBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MseSourceBuffer> for &::windows::core::IUnknown {
-    fn from(value: &MseSourceBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MseSourceBuffer> for ::windows::core::IInspectable {
-    fn from(value: MseSourceBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MseSourceBuffer> for ::windows::core::IInspectable {
-    fn from(value: &MseSourceBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MseSourceBuffer> for &::windows::core::IInspectable {
-    fn from(value: &MseSourceBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MseSourceBuffer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MseSourceBuffer {}
 unsafe impl ::core::marker::Sync for MseSourceBuffer {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -8905,36 +7474,7 @@ unsafe impl ::windows::core::Interface for MseSourceBufferList {
 impl ::windows::core::RuntimeName for MseSourceBufferList {
     const NAME: &'static str = "Windows.Media.Core.MseSourceBufferList";
 }
-impl ::core::convert::From<MseSourceBufferList> for ::windows::core::IUnknown {
-    fn from(value: MseSourceBufferList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MseSourceBufferList> for ::windows::core::IUnknown {
-    fn from(value: &MseSourceBufferList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MseSourceBufferList> for &::windows::core::IUnknown {
-    fn from(value: &MseSourceBufferList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MseSourceBufferList> for ::windows::core::IInspectable {
-    fn from(value: MseSourceBufferList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MseSourceBufferList> for ::windows::core::IInspectable {
-    fn from(value: &MseSourceBufferList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MseSourceBufferList> for &::windows::core::IInspectable {
-    fn from(value: &MseSourceBufferList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MseSourceBufferList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MseSourceBufferList {}
 unsafe impl ::core::marker::Sync for MseSourceBufferList {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -9111,36 +7651,7 @@ unsafe impl ::windows::core::Interface for MseStreamSource {
 impl ::windows::core::RuntimeName for MseStreamSource {
     const NAME: &'static str = "Windows.Media.Core.MseStreamSource";
 }
-impl ::core::convert::From<MseStreamSource> for ::windows::core::IUnknown {
-    fn from(value: MseStreamSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MseStreamSource> for ::windows::core::IUnknown {
-    fn from(value: &MseStreamSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MseStreamSource> for &::windows::core::IUnknown {
-    fn from(value: &MseStreamSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MseStreamSource> for ::windows::core::IInspectable {
-    fn from(value: MseStreamSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MseStreamSource> for ::windows::core::IInspectable {
-    fn from(value: &MseStreamSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MseStreamSource> for &::windows::core::IInspectable {
-    fn from(value: &MseStreamSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MseStreamSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MseStreamSource> for IMediaSource {
     type Error = ::windows::core::Error;
     fn try_from(value: MseStreamSource) -> ::windows::core::Result<Self> {
@@ -9246,36 +7757,7 @@ unsafe impl ::windows::core::Interface for SceneAnalysisEffect {
 impl ::windows::core::RuntimeName for SceneAnalysisEffect {
     const NAME: &'static str = "Windows.Media.Core.SceneAnalysisEffect";
 }
-impl ::core::convert::From<SceneAnalysisEffect> for ::windows::core::IUnknown {
-    fn from(value: SceneAnalysisEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneAnalysisEffect> for ::windows::core::IUnknown {
-    fn from(value: &SceneAnalysisEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneAnalysisEffect> for &::windows::core::IUnknown {
-    fn from(value: &SceneAnalysisEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneAnalysisEffect> for ::windows::core::IInspectable {
-    fn from(value: SceneAnalysisEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneAnalysisEffect> for ::windows::core::IInspectable {
-    fn from(value: &SceneAnalysisEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneAnalysisEffect> for &::windows::core::IInspectable {
-    fn from(value: &SceneAnalysisEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneAnalysisEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneAnalysisEffect> for super::IMediaExtension {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneAnalysisEffect) -> ::windows::core::Result<Self> {
@@ -9370,41 +7852,7 @@ impl ::windows::core::RuntimeName for SceneAnalysisEffectDefinition {
     const NAME: &'static str = "Windows.Media.Core.SceneAnalysisEffectDefinition";
 }
 #[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<SceneAnalysisEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: SceneAnalysisEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&SceneAnalysisEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &SceneAnalysisEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&SceneAnalysisEffectDefinition> for &::windows::core::IUnknown {
-    fn from(value: &SceneAnalysisEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<SceneAnalysisEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: SceneAnalysisEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&SceneAnalysisEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &SceneAnalysisEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&SceneAnalysisEffectDefinition> for &::windows::core::IInspectable {
-    fn from(value: &SceneAnalysisEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneAnalysisEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Media_Effects")]
 impl ::core::convert::TryFrom<SceneAnalysisEffectDefinition> for super::Effects::IVideoEffectDefinition {
     type Error = ::windows::core::Error;
@@ -9588,36 +8036,7 @@ unsafe impl ::windows::core::Interface for SceneAnalysisEffectFrame {
 impl ::windows::core::RuntimeName for SceneAnalysisEffectFrame {
     const NAME: &'static str = "Windows.Media.Core.SceneAnalysisEffectFrame";
 }
-impl ::core::convert::From<SceneAnalysisEffectFrame> for ::windows::core::IUnknown {
-    fn from(value: SceneAnalysisEffectFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneAnalysisEffectFrame> for ::windows::core::IUnknown {
-    fn from(value: &SceneAnalysisEffectFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneAnalysisEffectFrame> for &::windows::core::IUnknown {
-    fn from(value: &SceneAnalysisEffectFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneAnalysisEffectFrame> for ::windows::core::IInspectable {
-    fn from(value: SceneAnalysisEffectFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneAnalysisEffectFrame> for ::windows::core::IInspectable {
-    fn from(value: &SceneAnalysisEffectFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneAnalysisEffectFrame> for &::windows::core::IInspectable {
-    fn from(value: &SceneAnalysisEffectFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneAnalysisEffectFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<SceneAnalysisEffectFrame> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -9705,36 +8124,7 @@ unsafe impl ::windows::core::Interface for SceneAnalyzedEventArgs {
 impl ::windows::core::RuntimeName for SceneAnalyzedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.SceneAnalyzedEventArgs";
 }
-impl ::core::convert::From<SceneAnalyzedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SceneAnalyzedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneAnalyzedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SceneAnalyzedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneAnalyzedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SceneAnalyzedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneAnalyzedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SceneAnalyzedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneAnalyzedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SceneAnalyzedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneAnalyzedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SceneAnalyzedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneAnalyzedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SceneAnalyzedEventArgs {}
 unsafe impl ::core::marker::Sync for SceneAnalyzedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -9871,36 +8261,7 @@ unsafe impl ::windows::core::Interface for SpeechCue {
 impl ::windows::core::RuntimeName for SpeechCue {
     const NAME: &'static str = "Windows.Media.Core.SpeechCue";
 }
-impl ::core::convert::From<SpeechCue> for ::windows::core::IUnknown {
-    fn from(value: SpeechCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechCue> for ::windows::core::IUnknown {
-    fn from(value: &SpeechCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechCue> for &::windows::core::IUnknown {
-    fn from(value: &SpeechCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechCue> for ::windows::core::IInspectable {
-    fn from(value: SpeechCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechCue> for ::windows::core::IInspectable {
-    fn from(value: &SpeechCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechCue> for &::windows::core::IInspectable {
-    fn from(value: &SpeechCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechCue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SpeechCue> for IMediaCue {
     type Error = ::windows::core::Error;
     fn try_from(value: SpeechCue) -> ::windows::core::Result<Self> {
@@ -10028,36 +8389,7 @@ unsafe impl ::windows::core::Interface for TimedMetadataStreamDescriptor {
 impl ::windows::core::RuntimeName for TimedMetadataStreamDescriptor {
     const NAME: &'static str = "Windows.Media.Core.TimedMetadataStreamDescriptor";
 }
-impl ::core::convert::From<TimedMetadataStreamDescriptor> for ::windows::core::IUnknown {
-    fn from(value: TimedMetadataStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataStreamDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &TimedMetadataStreamDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataStreamDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &TimedMetadataStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedMetadataStreamDescriptor> for ::windows::core::IInspectable {
-    fn from(value: TimedMetadataStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataStreamDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &TimedMetadataStreamDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataStreamDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &TimedMetadataStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedMetadataStreamDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<TimedMetadataStreamDescriptor> for IMediaStreamDescriptor {
     type Error = ::windows::core::Error;
     fn try_from(value: TimedMetadataStreamDescriptor) -> ::windows::core::Result<Self> {
@@ -10287,36 +8619,7 @@ unsafe impl ::windows::core::Interface for TimedMetadataTrack {
 impl ::windows::core::RuntimeName for TimedMetadataTrack {
     const NAME: &'static str = "Windows.Media.Core.TimedMetadataTrack";
 }
-impl ::core::convert::From<TimedMetadataTrack> for ::windows::core::IUnknown {
-    fn from(value: TimedMetadataTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrack> for ::windows::core::IUnknown {
-    fn from(value: &TimedMetadataTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrack> for &::windows::core::IUnknown {
-    fn from(value: &TimedMetadataTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedMetadataTrack> for ::windows::core::IInspectable {
-    fn from(value: TimedMetadataTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrack> for ::windows::core::IInspectable {
-    fn from(value: &TimedMetadataTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrack> for &::windows::core::IInspectable {
-    fn from(value: &TimedMetadataTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedMetadataTrack, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<TimedMetadataTrack> for IMediaTrack {
     type Error = ::windows::core::Error;
     fn try_from(value: TimedMetadataTrack) -> ::windows::core::Result<Self> {
@@ -10389,36 +8692,7 @@ unsafe impl ::windows::core::Interface for TimedMetadataTrackError {
 impl ::windows::core::RuntimeName for TimedMetadataTrackError {
     const NAME: &'static str = "Windows.Media.Core.TimedMetadataTrackError";
 }
-impl ::core::convert::From<TimedMetadataTrackError> for ::windows::core::IUnknown {
-    fn from(value: TimedMetadataTrackError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrackError> for ::windows::core::IUnknown {
-    fn from(value: &TimedMetadataTrackError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrackError> for &::windows::core::IUnknown {
-    fn from(value: &TimedMetadataTrackError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedMetadataTrackError> for ::windows::core::IInspectable {
-    fn from(value: TimedMetadataTrackError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrackError> for ::windows::core::IInspectable {
-    fn from(value: &TimedMetadataTrackError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrackError> for &::windows::core::IInspectable {
-    fn from(value: &TimedMetadataTrackError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedMetadataTrackError, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimedMetadataTrackError {}
 unsafe impl ::core::marker::Sync for TimedMetadataTrackError {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -10465,36 +8739,7 @@ unsafe impl ::windows::core::Interface for TimedMetadataTrackFailedEventArgs {
 impl ::windows::core::RuntimeName for TimedMetadataTrackFailedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.TimedMetadataTrackFailedEventArgs";
 }
-impl ::core::convert::From<TimedMetadataTrackFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TimedMetadataTrackFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrackFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TimedMetadataTrackFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrackFailedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TimedMetadataTrackFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedMetadataTrackFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TimedMetadataTrackFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrackFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TimedMetadataTrackFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataTrackFailedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TimedMetadataTrackFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedMetadataTrackFailedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimedMetadataTrackFailedEventArgs {}
 unsafe impl ::core::marker::Sync for TimedMetadataTrackFailedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -10571,36 +8816,7 @@ unsafe impl ::windows::core::Interface for TimedTextBouten {
 impl ::windows::core::RuntimeName for TimedTextBouten {
     const NAME: &'static str = "Windows.Media.Core.TimedTextBouten";
 }
-impl ::core::convert::From<TimedTextBouten> for ::windows::core::IUnknown {
-    fn from(value: TimedTextBouten) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextBouten> for ::windows::core::IUnknown {
-    fn from(value: &TimedTextBouten) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextBouten> for &::windows::core::IUnknown {
-    fn from(value: &TimedTextBouten) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedTextBouten> for ::windows::core::IInspectable {
-    fn from(value: TimedTextBouten) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextBouten> for ::windows::core::IInspectable {
-    fn from(value: &TimedTextBouten) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextBouten> for &::windows::core::IInspectable {
-    fn from(value: &TimedTextBouten) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedTextBouten, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimedTextBouten {}
 unsafe impl ::core::marker::Sync for TimedTextBouten {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -10719,36 +8935,7 @@ unsafe impl ::windows::core::Interface for TimedTextCue {
 impl ::windows::core::RuntimeName for TimedTextCue {
     const NAME: &'static str = "Windows.Media.Core.TimedTextCue";
 }
-impl ::core::convert::From<TimedTextCue> for ::windows::core::IUnknown {
-    fn from(value: TimedTextCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextCue> for ::windows::core::IUnknown {
-    fn from(value: &TimedTextCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextCue> for &::windows::core::IUnknown {
-    fn from(value: &TimedTextCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedTextCue> for ::windows::core::IInspectable {
-    fn from(value: TimedTextCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextCue> for ::windows::core::IInspectable {
-    fn from(value: &TimedTextCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextCue> for &::windows::core::IInspectable {
-    fn from(value: &TimedTextCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedTextCue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<TimedTextCue> for IMediaCue {
     type Error = ::windows::core::Error;
     fn try_from(value: TimedTextCue) -> ::windows::core::Result<Self> {
@@ -10834,36 +9021,7 @@ unsafe impl ::windows::core::Interface for TimedTextLine {
 impl ::windows::core::RuntimeName for TimedTextLine {
     const NAME: &'static str = "Windows.Media.Core.TimedTextLine";
 }
-impl ::core::convert::From<TimedTextLine> for ::windows::core::IUnknown {
-    fn from(value: TimedTextLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextLine> for ::windows::core::IUnknown {
-    fn from(value: &TimedTextLine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextLine> for &::windows::core::IUnknown {
-    fn from(value: &TimedTextLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedTextLine> for ::windows::core::IInspectable {
-    fn from(value: TimedTextLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextLine> for ::windows::core::IInspectable {
-    fn from(value: &TimedTextLine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextLine> for &::windows::core::IInspectable {
-    fn from(value: &TimedTextLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedTextLine, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimedTextLine {}
 unsafe impl ::core::marker::Sync for TimedTextLine {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -11046,36 +9204,7 @@ unsafe impl ::windows::core::Interface for TimedTextRegion {
 impl ::windows::core::RuntimeName for TimedTextRegion {
     const NAME: &'static str = "Windows.Media.Core.TimedTextRegion";
 }
-impl ::core::convert::From<TimedTextRegion> for ::windows::core::IUnknown {
-    fn from(value: TimedTextRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextRegion> for ::windows::core::IUnknown {
-    fn from(value: &TimedTextRegion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextRegion> for &::windows::core::IUnknown {
-    fn from(value: &TimedTextRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedTextRegion> for ::windows::core::IInspectable {
-    fn from(value: TimedTextRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextRegion> for ::windows::core::IInspectable {
-    fn from(value: &TimedTextRegion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextRegion> for &::windows::core::IInspectable {
-    fn from(value: &TimedTextRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedTextRegion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimedTextRegion {}
 unsafe impl ::core::marker::Sync for TimedTextRegion {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -11159,36 +9288,7 @@ unsafe impl ::windows::core::Interface for TimedTextRuby {
 impl ::windows::core::RuntimeName for TimedTextRuby {
     const NAME: &'static str = "Windows.Media.Core.TimedTextRuby";
 }
-impl ::core::convert::From<TimedTextRuby> for ::windows::core::IUnknown {
-    fn from(value: TimedTextRuby) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextRuby> for ::windows::core::IUnknown {
-    fn from(value: &TimedTextRuby) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextRuby> for &::windows::core::IUnknown {
-    fn from(value: &TimedTextRuby) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedTextRuby> for ::windows::core::IInspectable {
-    fn from(value: TimedTextRuby) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextRuby> for ::windows::core::IInspectable {
-    fn from(value: &TimedTextRuby) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextRuby> for &::windows::core::IInspectable {
-    fn from(value: &TimedTextRuby) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedTextRuby, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimedTextRuby {}
 unsafe impl ::core::marker::Sync for TimedTextRuby {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -11337,36 +9437,7 @@ unsafe impl ::windows::core::Interface for TimedTextSource {
 impl ::windows::core::RuntimeName for TimedTextSource {
     const NAME: &'static str = "Windows.Media.Core.TimedTextSource";
 }
-impl ::core::convert::From<TimedTextSource> for ::windows::core::IUnknown {
-    fn from(value: TimedTextSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextSource> for ::windows::core::IUnknown {
-    fn from(value: &TimedTextSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextSource> for &::windows::core::IUnknown {
-    fn from(value: &TimedTextSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedTextSource> for ::windows::core::IInspectable {
-    fn from(value: TimedTextSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextSource> for ::windows::core::IInspectable {
-    fn from(value: &TimedTextSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextSource> for &::windows::core::IInspectable {
-    fn from(value: &TimedTextSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedTextSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimedTextSource {}
 unsafe impl ::core::marker::Sync for TimedTextSource {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -11422,36 +9493,7 @@ unsafe impl ::windows::core::Interface for TimedTextSourceResolveResultEventArgs
 impl ::windows::core::RuntimeName for TimedTextSourceResolveResultEventArgs {
     const NAME: &'static str = "Windows.Media.Core.TimedTextSourceResolveResultEventArgs";
 }
-impl ::core::convert::From<TimedTextSourceResolveResultEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TimedTextSourceResolveResultEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextSourceResolveResultEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TimedTextSourceResolveResultEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextSourceResolveResultEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TimedTextSourceResolveResultEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedTextSourceResolveResultEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TimedTextSourceResolveResultEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextSourceResolveResultEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TimedTextSourceResolveResultEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextSourceResolveResultEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TimedTextSourceResolveResultEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedTextSourceResolveResultEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimedTextSourceResolveResultEventArgs {}
 unsafe impl ::core::marker::Sync for TimedTextSourceResolveResultEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -11722,36 +9764,7 @@ unsafe impl ::windows::core::Interface for TimedTextStyle {
 impl ::windows::core::RuntimeName for TimedTextStyle {
     const NAME: &'static str = "Windows.Media.Core.TimedTextStyle";
 }
-impl ::core::convert::From<TimedTextStyle> for ::windows::core::IUnknown {
-    fn from(value: TimedTextStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextStyle> for ::windows::core::IUnknown {
-    fn from(value: &TimedTextStyle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextStyle> for &::windows::core::IUnknown {
-    fn from(value: &TimedTextStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedTextStyle> for ::windows::core::IInspectable {
-    fn from(value: TimedTextStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextStyle> for ::windows::core::IInspectable {
-    fn from(value: &TimedTextStyle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextStyle> for &::windows::core::IInspectable {
-    fn from(value: &TimedTextStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedTextStyle, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimedTextStyle {}
 unsafe impl ::core::marker::Sync for TimedTextStyle {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -11831,36 +9844,7 @@ unsafe impl ::windows::core::Interface for TimedTextSubformat {
 impl ::windows::core::RuntimeName for TimedTextSubformat {
     const NAME: &'static str = "Windows.Media.Core.TimedTextSubformat";
 }
-impl ::core::convert::From<TimedTextSubformat> for ::windows::core::IUnknown {
-    fn from(value: TimedTextSubformat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextSubformat> for ::windows::core::IUnknown {
-    fn from(value: &TimedTextSubformat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextSubformat> for &::windows::core::IUnknown {
-    fn from(value: &TimedTextSubformat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedTextSubformat> for ::windows::core::IInspectable {
-    fn from(value: TimedTextSubformat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedTextSubformat> for ::windows::core::IInspectable {
-    fn from(value: &TimedTextSubformat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedTextSubformat> for &::windows::core::IInspectable {
-    fn from(value: &TimedTextSubformat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedTextSubformat, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimedTextSubformat {}
 unsafe impl ::core::marker::Sync for TimedTextSubformat {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -11945,36 +9929,7 @@ unsafe impl ::windows::core::Interface for VideoStabilizationEffect {
 impl ::windows::core::RuntimeName for VideoStabilizationEffect {
     const NAME: &'static str = "Windows.Media.Core.VideoStabilizationEffect";
 }
-impl ::core::convert::From<VideoStabilizationEffect> for ::windows::core::IUnknown {
-    fn from(value: VideoStabilizationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoStabilizationEffect> for ::windows::core::IUnknown {
-    fn from(value: &VideoStabilizationEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoStabilizationEffect> for &::windows::core::IUnknown {
-    fn from(value: &VideoStabilizationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoStabilizationEffect> for ::windows::core::IInspectable {
-    fn from(value: VideoStabilizationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoStabilizationEffect> for ::windows::core::IInspectable {
-    fn from(value: &VideoStabilizationEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoStabilizationEffect> for &::windows::core::IInspectable {
-    fn from(value: &VideoStabilizationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoStabilizationEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VideoStabilizationEffect> for super::IMediaExtension {
     type Error = ::windows::core::Error;
     fn try_from(value: VideoStabilizationEffect) -> ::windows::core::Result<Self> {
@@ -12069,41 +10024,7 @@ impl ::windows::core::RuntimeName for VideoStabilizationEffectDefinition {
     const NAME: &'static str = "Windows.Media.Core.VideoStabilizationEffectDefinition";
 }
 #[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<VideoStabilizationEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: VideoStabilizationEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&VideoStabilizationEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &VideoStabilizationEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&VideoStabilizationEffectDefinition> for &::windows::core::IUnknown {
-    fn from(value: &VideoStabilizationEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<VideoStabilizationEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: VideoStabilizationEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&VideoStabilizationEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &VideoStabilizationEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Media_Effects")]
-impl ::core::convert::From<&VideoStabilizationEffectDefinition> for &::windows::core::IInspectable {
-    fn from(value: &VideoStabilizationEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoStabilizationEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Media_Effects")]
 impl ::core::convert::TryFrom<VideoStabilizationEffectDefinition> for super::Effects::IVideoEffectDefinition {
     type Error = ::windows::core::Error;
@@ -12174,36 +10095,7 @@ unsafe impl ::windows::core::Interface for VideoStabilizationEffectEnabledChange
 impl ::windows::core::RuntimeName for VideoStabilizationEffectEnabledChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.VideoStabilizationEffectEnabledChangedEventArgs";
 }
-impl ::core::convert::From<VideoStabilizationEffectEnabledChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: VideoStabilizationEffectEnabledChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoStabilizationEffectEnabledChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &VideoStabilizationEffectEnabledChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoStabilizationEffectEnabledChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &VideoStabilizationEffectEnabledChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoStabilizationEffectEnabledChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: VideoStabilizationEffectEnabledChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoStabilizationEffectEnabledChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &VideoStabilizationEffectEnabledChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoStabilizationEffectEnabledChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &VideoStabilizationEffectEnabledChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoStabilizationEffectEnabledChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VideoStabilizationEffectEnabledChangedEventArgs {}
 unsafe impl ::core::marker::Sync for VideoStabilizationEffectEnabledChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -12312,36 +10204,7 @@ unsafe impl ::windows::core::Interface for VideoStreamDescriptor {
 impl ::windows::core::RuntimeName for VideoStreamDescriptor {
     const NAME: &'static str = "Windows.Media.Core.VideoStreamDescriptor";
 }
-impl ::core::convert::From<VideoStreamDescriptor> for ::windows::core::IUnknown {
-    fn from(value: VideoStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoStreamDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &VideoStreamDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoStreamDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &VideoStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoStreamDescriptor> for ::windows::core::IInspectable {
-    fn from(value: VideoStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoStreamDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &VideoStreamDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoStreamDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &VideoStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoStreamDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VideoStreamDescriptor> for IMediaStreamDescriptor {
     type Error = ::windows::core::Error;
     fn try_from(value: VideoStreamDescriptor) -> ::windows::core::Result<Self> {
@@ -12498,36 +10361,7 @@ unsafe impl ::windows::core::Interface for VideoTrack {
 impl ::windows::core::RuntimeName for VideoTrack {
     const NAME: &'static str = "Windows.Media.Core.VideoTrack";
 }
-impl ::core::convert::From<VideoTrack> for ::windows::core::IUnknown {
-    fn from(value: VideoTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTrack> for ::windows::core::IUnknown {
-    fn from(value: &VideoTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTrack> for &::windows::core::IUnknown {
-    fn from(value: &VideoTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoTrack> for ::windows::core::IInspectable {
-    fn from(value: VideoTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTrack> for ::windows::core::IInspectable {
-    fn from(value: &VideoTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTrack> for &::windows::core::IInspectable {
-    fn from(value: &VideoTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoTrack, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VideoTrack> for IMediaTrack {
     type Error = ::windows::core::Error;
     fn try_from(value: VideoTrack) -> ::windows::core::Result<Self> {
@@ -12593,36 +10427,7 @@ unsafe impl ::windows::core::Interface for VideoTrackOpenFailedEventArgs {
 impl ::windows::core::RuntimeName for VideoTrackOpenFailedEventArgs {
     const NAME: &'static str = "Windows.Media.Core.VideoTrackOpenFailedEventArgs";
 }
-impl ::core::convert::From<VideoTrackOpenFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: VideoTrackOpenFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTrackOpenFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &VideoTrackOpenFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTrackOpenFailedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &VideoTrackOpenFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoTrackOpenFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: VideoTrackOpenFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTrackOpenFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &VideoTrackOpenFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTrackOpenFailedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &VideoTrackOpenFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoTrackOpenFailedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VideoTrackOpenFailedEventArgs {}
 unsafe impl ::core::marker::Sync for VideoTrackOpenFailedEventArgs {}
 #[doc = "*Required features: `\"Media_Core\"`*"]
@@ -12676,36 +10481,7 @@ unsafe impl ::windows::core::Interface for VideoTrackSupportInfo {
 impl ::windows::core::RuntimeName for VideoTrackSupportInfo {
     const NAME: &'static str = "Windows.Media.Core.VideoTrackSupportInfo";
 }
-impl ::core::convert::From<VideoTrackSupportInfo> for ::windows::core::IUnknown {
-    fn from(value: VideoTrackSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTrackSupportInfo> for ::windows::core::IUnknown {
-    fn from(value: &VideoTrackSupportInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTrackSupportInfo> for &::windows::core::IUnknown {
-    fn from(value: &VideoTrackSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoTrackSupportInfo> for ::windows::core::IInspectable {
-    fn from(value: VideoTrackSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTrackSupportInfo> for ::windows::core::IInspectable {
-    fn from(value: &VideoTrackSupportInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTrackSupportInfo> for &::windows::core::IInspectable {
-    fn from(value: &VideoTrackSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoTrackSupportInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VideoTrackSupportInfo {}
 unsafe impl ::core::marker::Sync for VideoTrackSupportInfo {}
 #[doc = "*Required features: `\"Media_Core\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Devices/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/Core/mod.rs
@@ -615,36 +615,7 @@ unsafe impl ::windows::core::Interface for CameraIntrinsics {
 impl ::windows::core::RuntimeName for CameraIntrinsics {
     const NAME: &'static str = "Windows.Media.Devices.Core.CameraIntrinsics";
 }
-impl ::core::convert::From<CameraIntrinsics> for ::windows::core::IUnknown {
-    fn from(value: CameraIntrinsics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraIntrinsics> for ::windows::core::IUnknown {
-    fn from(value: &CameraIntrinsics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraIntrinsics> for &::windows::core::IUnknown {
-    fn from(value: &CameraIntrinsics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CameraIntrinsics> for ::windows::core::IInspectable {
-    fn from(value: CameraIntrinsics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraIntrinsics> for ::windows::core::IInspectable {
-    fn from(value: &CameraIntrinsics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraIntrinsics> for &::windows::core::IInspectable {
-    fn from(value: &CameraIntrinsics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CameraIntrinsics, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CameraIntrinsics {}
 unsafe impl ::core::marker::Sync for CameraIntrinsics {}
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
@@ -720,36 +691,7 @@ unsafe impl ::windows::core::Interface for DepthCorrelatedCoordinateMapper {
 impl ::windows::core::RuntimeName for DepthCorrelatedCoordinateMapper {
     const NAME: &'static str = "Windows.Media.Devices.Core.DepthCorrelatedCoordinateMapper";
 }
-impl ::core::convert::From<DepthCorrelatedCoordinateMapper> for ::windows::core::IUnknown {
-    fn from(value: DepthCorrelatedCoordinateMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DepthCorrelatedCoordinateMapper> for ::windows::core::IUnknown {
-    fn from(value: &DepthCorrelatedCoordinateMapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DepthCorrelatedCoordinateMapper> for &::windows::core::IUnknown {
-    fn from(value: &DepthCorrelatedCoordinateMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DepthCorrelatedCoordinateMapper> for ::windows::core::IInspectable {
-    fn from(value: DepthCorrelatedCoordinateMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DepthCorrelatedCoordinateMapper> for ::windows::core::IInspectable {
-    fn from(value: &DepthCorrelatedCoordinateMapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DepthCorrelatedCoordinateMapper> for &::windows::core::IInspectable {
-    fn from(value: &DepthCorrelatedCoordinateMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DepthCorrelatedCoordinateMapper, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<DepthCorrelatedCoordinateMapper> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -853,36 +795,7 @@ unsafe impl ::windows::core::Interface for FrameControlCapabilities {
 impl ::windows::core::RuntimeName for FrameControlCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameControlCapabilities";
 }
-impl ::core::convert::From<FrameControlCapabilities> for ::windows::core::IUnknown {
-    fn from(value: FrameControlCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameControlCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &FrameControlCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameControlCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &FrameControlCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameControlCapabilities> for ::windows::core::IInspectable {
-    fn from(value: FrameControlCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameControlCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &FrameControlCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameControlCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &FrameControlCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameControlCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 pub struct FrameController(::windows::core::IUnknown);
@@ -981,36 +894,7 @@ unsafe impl ::windows::core::Interface for FrameController {
 impl ::windows::core::RuntimeName for FrameController {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameController";
 }
-impl ::core::convert::From<FrameController> for ::windows::core::IUnknown {
-    fn from(value: FrameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameController> for ::windows::core::IUnknown {
-    fn from(value: &FrameController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameController> for &::windows::core::IUnknown {
-    fn from(value: &FrameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameController> for ::windows::core::IInspectable {
-    fn from(value: FrameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameController> for ::windows::core::IInspectable {
-    fn from(value: &FrameController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameController> for &::windows::core::IInspectable {
-    fn from(value: &FrameController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FrameController {}
 unsafe impl ::core::marker::Sync for FrameController {}
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
@@ -1084,36 +968,7 @@ unsafe impl ::windows::core::Interface for FrameExposureCapabilities {
 impl ::windows::core::RuntimeName for FrameExposureCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameExposureCapabilities";
 }
-impl ::core::convert::From<FrameExposureCapabilities> for ::windows::core::IUnknown {
-    fn from(value: FrameExposureCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameExposureCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &FrameExposureCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameExposureCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &FrameExposureCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameExposureCapabilities> for ::windows::core::IInspectable {
-    fn from(value: FrameExposureCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameExposureCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &FrameExposureCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameExposureCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &FrameExposureCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameExposureCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 pub struct FrameExposureCompensationCapabilities(::windows::core::IUnknown);
@@ -1179,36 +1034,7 @@ unsafe impl ::windows::core::Interface for FrameExposureCompensationCapabilities
 impl ::windows::core::RuntimeName for FrameExposureCompensationCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameExposureCompensationCapabilities";
 }
-impl ::core::convert::From<FrameExposureCompensationCapabilities> for ::windows::core::IUnknown {
-    fn from(value: FrameExposureCompensationCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameExposureCompensationCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &FrameExposureCompensationCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameExposureCompensationCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &FrameExposureCompensationCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameExposureCompensationCapabilities> for ::windows::core::IInspectable {
-    fn from(value: FrameExposureCompensationCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameExposureCompensationCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &FrameExposureCompensationCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameExposureCompensationCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &FrameExposureCompensationCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameExposureCompensationCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 pub struct FrameExposureCompensationControl(::windows::core::IUnknown);
@@ -1265,36 +1091,7 @@ unsafe impl ::windows::core::Interface for FrameExposureCompensationControl {
 impl ::windows::core::RuntimeName for FrameExposureCompensationControl {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameExposureCompensationControl";
 }
-impl ::core::convert::From<FrameExposureCompensationControl> for ::windows::core::IUnknown {
-    fn from(value: FrameExposureCompensationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameExposureCompensationControl> for ::windows::core::IUnknown {
-    fn from(value: &FrameExposureCompensationControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameExposureCompensationControl> for &::windows::core::IUnknown {
-    fn from(value: &FrameExposureCompensationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameExposureCompensationControl> for ::windows::core::IInspectable {
-    fn from(value: FrameExposureCompensationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameExposureCompensationControl> for ::windows::core::IInspectable {
-    fn from(value: &FrameExposureCompensationControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameExposureCompensationControl> for &::windows::core::IInspectable {
-    fn from(value: &FrameExposureCompensationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameExposureCompensationControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 pub struct FrameExposureControl(::windows::core::IUnknown);
@@ -1362,36 +1159,7 @@ unsafe impl ::windows::core::Interface for FrameExposureControl {
 impl ::windows::core::RuntimeName for FrameExposureControl {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameExposureControl";
 }
-impl ::core::convert::From<FrameExposureControl> for ::windows::core::IUnknown {
-    fn from(value: FrameExposureControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameExposureControl> for ::windows::core::IUnknown {
-    fn from(value: &FrameExposureControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameExposureControl> for &::windows::core::IUnknown {
-    fn from(value: &FrameExposureControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameExposureControl> for ::windows::core::IInspectable {
-    fn from(value: FrameExposureControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameExposureControl> for ::windows::core::IInspectable {
-    fn from(value: &FrameExposureControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameExposureControl> for &::windows::core::IInspectable {
-    fn from(value: &FrameExposureControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameExposureControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 pub struct FrameFlashCapabilities(::windows::core::IUnknown);
@@ -1450,36 +1218,7 @@ unsafe impl ::windows::core::Interface for FrameFlashCapabilities {
 impl ::windows::core::RuntimeName for FrameFlashCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameFlashCapabilities";
 }
-impl ::core::convert::From<FrameFlashCapabilities> for ::windows::core::IUnknown {
-    fn from(value: FrameFlashCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameFlashCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &FrameFlashCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameFlashCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &FrameFlashCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameFlashCapabilities> for ::windows::core::IInspectable {
-    fn from(value: FrameFlashCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameFlashCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &FrameFlashCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameFlashCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &FrameFlashCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameFlashCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 pub struct FrameFlashControl(::windows::core::IUnknown);
@@ -1561,36 +1300,7 @@ unsafe impl ::windows::core::Interface for FrameFlashControl {
 impl ::windows::core::RuntimeName for FrameFlashControl {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameFlashControl";
 }
-impl ::core::convert::From<FrameFlashControl> for ::windows::core::IUnknown {
-    fn from(value: FrameFlashControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameFlashControl> for ::windows::core::IUnknown {
-    fn from(value: &FrameFlashControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameFlashControl> for &::windows::core::IUnknown {
-    fn from(value: &FrameFlashControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameFlashControl> for ::windows::core::IInspectable {
-    fn from(value: FrameFlashControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameFlashControl> for ::windows::core::IInspectable {
-    fn from(value: &FrameFlashControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameFlashControl> for &::windows::core::IInspectable {
-    fn from(value: &FrameFlashControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameFlashControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 pub struct FrameFocusCapabilities(::windows::core::IUnknown);
@@ -1656,36 +1366,7 @@ unsafe impl ::windows::core::Interface for FrameFocusCapabilities {
 impl ::windows::core::RuntimeName for FrameFocusCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameFocusCapabilities";
 }
-impl ::core::convert::From<FrameFocusCapabilities> for ::windows::core::IUnknown {
-    fn from(value: FrameFocusCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameFocusCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &FrameFocusCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameFocusCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &FrameFocusCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameFocusCapabilities> for ::windows::core::IInspectable {
-    fn from(value: FrameFocusCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameFocusCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &FrameFocusCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameFocusCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &FrameFocusCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameFocusCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 pub struct FrameFocusControl(::windows::core::IUnknown);
@@ -1742,36 +1423,7 @@ unsafe impl ::windows::core::Interface for FrameFocusControl {
 impl ::windows::core::RuntimeName for FrameFocusControl {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameFocusControl";
 }
-impl ::core::convert::From<FrameFocusControl> for ::windows::core::IUnknown {
-    fn from(value: FrameFocusControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameFocusControl> for ::windows::core::IUnknown {
-    fn from(value: &FrameFocusControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameFocusControl> for &::windows::core::IUnknown {
-    fn from(value: &FrameFocusControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameFocusControl> for ::windows::core::IInspectable {
-    fn from(value: FrameFocusControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameFocusControl> for ::windows::core::IInspectable {
-    fn from(value: &FrameFocusControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameFocusControl> for &::windows::core::IInspectable {
-    fn from(value: &FrameFocusControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameFocusControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 pub struct FrameIsoSpeedCapabilities(::windows::core::IUnknown);
@@ -1837,36 +1489,7 @@ unsafe impl ::windows::core::Interface for FrameIsoSpeedCapabilities {
 impl ::windows::core::RuntimeName for FrameIsoSpeedCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameIsoSpeedCapabilities";
 }
-impl ::core::convert::From<FrameIsoSpeedCapabilities> for ::windows::core::IUnknown {
-    fn from(value: FrameIsoSpeedCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameIsoSpeedCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &FrameIsoSpeedCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameIsoSpeedCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &FrameIsoSpeedCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameIsoSpeedCapabilities> for ::windows::core::IInspectable {
-    fn from(value: FrameIsoSpeedCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameIsoSpeedCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &FrameIsoSpeedCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameIsoSpeedCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &FrameIsoSpeedCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameIsoSpeedCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 pub struct FrameIsoSpeedControl(::windows::core::IUnknown);
@@ -1934,36 +1557,7 @@ unsafe impl ::windows::core::Interface for FrameIsoSpeedControl {
 impl ::windows::core::RuntimeName for FrameIsoSpeedControl {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameIsoSpeedControl";
 }
-impl ::core::convert::From<FrameIsoSpeedControl> for ::windows::core::IUnknown {
-    fn from(value: FrameIsoSpeedControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameIsoSpeedControl> for ::windows::core::IUnknown {
-    fn from(value: &FrameIsoSpeedControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameIsoSpeedControl> for &::windows::core::IUnknown {
-    fn from(value: &FrameIsoSpeedControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FrameIsoSpeedControl> for ::windows::core::IInspectable {
-    fn from(value: FrameIsoSpeedControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FrameIsoSpeedControl> for ::windows::core::IInspectable {
-    fn from(value: &FrameIsoSpeedControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FrameIsoSpeedControl> for &::windows::core::IInspectable {
-    fn from(value: &FrameIsoSpeedControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FrameIsoSpeedControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 pub struct VariablePhotoSequenceController(::windows::core::IUnknown);
@@ -2064,36 +1658,7 @@ unsafe impl ::windows::core::Interface for VariablePhotoSequenceController {
 impl ::windows::core::RuntimeName for VariablePhotoSequenceController {
     const NAME: &'static str = "Windows.Media.Devices.Core.VariablePhotoSequenceController";
 }
-impl ::core::convert::From<VariablePhotoSequenceController> for ::windows::core::IUnknown {
-    fn from(value: VariablePhotoSequenceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VariablePhotoSequenceController> for ::windows::core::IUnknown {
-    fn from(value: &VariablePhotoSequenceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VariablePhotoSequenceController> for &::windows::core::IUnknown {
-    fn from(value: &VariablePhotoSequenceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VariablePhotoSequenceController> for ::windows::core::IInspectable {
-    fn from(value: VariablePhotoSequenceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VariablePhotoSequenceController> for ::windows::core::IInspectable {
-    fn from(value: &VariablePhotoSequenceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VariablePhotoSequenceController> for &::windows::core::IInspectable {
-    fn from(value: &VariablePhotoSequenceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VariablePhotoSequenceController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices_Core\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/Media/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/mod.rs
@@ -482,36 +482,7 @@ impl IDefaultAudioDeviceChangedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IDefaultAudioDeviceChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IDefaultAudioDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDefaultAudioDeviceChangedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDefaultAudioDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDefaultAudioDeviceChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IDefaultAudioDeviceChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDefaultAudioDeviceChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IDefaultAudioDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDefaultAudioDeviceChangedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IDefaultAudioDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDefaultAudioDeviceChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IDefaultAudioDeviceChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDefaultAudioDeviceChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IDefaultAudioDeviceChangedEventArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1139,36 +1110,7 @@ impl IMediaDeviceController {
         }
     }
 }
-impl ::core::convert::From<IMediaDeviceController> for ::windows::core::IUnknown {
-    fn from(value: IMediaDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaDeviceController> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaDeviceController> for ::windows::core::IUnknown {
-    fn from(value: &IMediaDeviceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaDeviceController> for ::windows::core::IInspectable {
-    fn from(value: IMediaDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaDeviceController> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaDeviceController> for ::windows::core::IInspectable {
-    fn from(value: &IMediaDeviceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaDeviceController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMediaDeviceController {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1685,36 +1627,7 @@ unsafe impl ::windows::core::Interface for AdvancedPhotoCaptureSettings {
 impl ::windows::core::RuntimeName for AdvancedPhotoCaptureSettings {
     const NAME: &'static str = "Windows.Media.Devices.AdvancedPhotoCaptureSettings";
 }
-impl ::core::convert::From<AdvancedPhotoCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: AdvancedPhotoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: &AdvancedPhotoCaptureSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoCaptureSettings> for &::windows::core::IUnknown {
-    fn from(value: &AdvancedPhotoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdvancedPhotoCaptureSettings> for ::windows::core::IInspectable {
-    fn from(value: AdvancedPhotoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoCaptureSettings> for ::windows::core::IInspectable {
-    fn from(value: &AdvancedPhotoCaptureSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoCaptureSettings> for &::windows::core::IInspectable {
-    fn from(value: &AdvancedPhotoCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdvancedPhotoCaptureSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdvancedPhotoCaptureSettings {}
 unsafe impl ::core::marker::Sync for AdvancedPhotoCaptureSettings {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -1781,36 +1694,7 @@ unsafe impl ::windows::core::Interface for AdvancedPhotoControl {
 impl ::windows::core::RuntimeName for AdvancedPhotoControl {
     const NAME: &'static str = "Windows.Media.Devices.AdvancedPhotoControl";
 }
-impl ::core::convert::From<AdvancedPhotoControl> for ::windows::core::IUnknown {
-    fn from(value: AdvancedPhotoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoControl> for ::windows::core::IUnknown {
-    fn from(value: &AdvancedPhotoControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoControl> for &::windows::core::IUnknown {
-    fn from(value: &AdvancedPhotoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdvancedPhotoControl> for ::windows::core::IInspectable {
-    fn from(value: AdvancedPhotoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoControl> for ::windows::core::IInspectable {
-    fn from(value: &AdvancedPhotoControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvancedPhotoControl> for &::windows::core::IInspectable {
-    fn from(value: &AdvancedPhotoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdvancedPhotoControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdvancedPhotoControl {}
 unsafe impl ::core::marker::Sync for AdvancedPhotoControl {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -1903,36 +1787,7 @@ unsafe impl ::windows::core::Interface for AudioDeviceController {
 impl ::windows::core::RuntimeName for AudioDeviceController {
     const NAME: &'static str = "Windows.Media.Devices.AudioDeviceController";
 }
-impl ::core::convert::From<AudioDeviceController> for ::windows::core::IUnknown {
-    fn from(value: AudioDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceController> for ::windows::core::IUnknown {
-    fn from(value: &AudioDeviceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceController> for &::windows::core::IUnknown {
-    fn from(value: &AudioDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioDeviceController> for ::windows::core::IInspectable {
-    fn from(value: AudioDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceController> for ::windows::core::IInspectable {
-    fn from(value: &AudioDeviceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceController> for &::windows::core::IInspectable {
-    fn from(value: &AudioDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioDeviceController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioDeviceController> for IMediaDeviceController {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioDeviceController) -> ::windows::core::Result<Self> {
@@ -2037,36 +1892,7 @@ unsafe impl ::windows::core::Interface for AudioDeviceModule {
 impl ::windows::core::RuntimeName for AudioDeviceModule {
     const NAME: &'static str = "Windows.Media.Devices.AudioDeviceModule";
 }
-impl ::core::convert::From<AudioDeviceModule> for ::windows::core::IUnknown {
-    fn from(value: AudioDeviceModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceModule> for ::windows::core::IUnknown {
-    fn from(value: &AudioDeviceModule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceModule> for &::windows::core::IUnknown {
-    fn from(value: &AudioDeviceModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioDeviceModule> for ::windows::core::IInspectable {
-    fn from(value: AudioDeviceModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceModule> for ::windows::core::IInspectable {
-    fn from(value: &AudioDeviceModule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceModule> for &::windows::core::IInspectable {
-    fn from(value: &AudioDeviceModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioDeviceModule, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct AudioDeviceModuleNotificationEventArgs(::windows::core::IUnknown);
@@ -2120,36 +1946,7 @@ unsafe impl ::windows::core::Interface for AudioDeviceModuleNotificationEventArg
 impl ::windows::core::RuntimeName for AudioDeviceModuleNotificationEventArgs {
     const NAME: &'static str = "Windows.Media.Devices.AudioDeviceModuleNotificationEventArgs";
 }
-impl ::core::convert::From<AudioDeviceModuleNotificationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AudioDeviceModuleNotificationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceModuleNotificationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AudioDeviceModuleNotificationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceModuleNotificationEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AudioDeviceModuleNotificationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioDeviceModuleNotificationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AudioDeviceModuleNotificationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceModuleNotificationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AudioDeviceModuleNotificationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceModuleNotificationEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AudioDeviceModuleNotificationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioDeviceModuleNotificationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioDeviceModuleNotificationEventArgs {}
 unsafe impl ::core::marker::Sync for AudioDeviceModuleNotificationEventArgs {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -2233,36 +2030,7 @@ unsafe impl ::windows::core::Interface for AudioDeviceModulesManager {
 impl ::windows::core::RuntimeName for AudioDeviceModulesManager {
     const NAME: &'static str = "Windows.Media.Devices.AudioDeviceModulesManager";
 }
-impl ::core::convert::From<AudioDeviceModulesManager> for ::windows::core::IUnknown {
-    fn from(value: AudioDeviceModulesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceModulesManager> for ::windows::core::IUnknown {
-    fn from(value: &AudioDeviceModulesManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceModulesManager> for &::windows::core::IUnknown {
-    fn from(value: &AudioDeviceModulesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioDeviceModulesManager> for ::windows::core::IInspectable {
-    fn from(value: AudioDeviceModulesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioDeviceModulesManager> for ::windows::core::IInspectable {
-    fn from(value: &AudioDeviceModulesManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioDeviceModulesManager> for &::windows::core::IInspectable {
-    fn from(value: &AudioDeviceModulesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioDeviceModulesManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioDeviceModulesManager {}
 unsafe impl ::core::marker::Sync for AudioDeviceModulesManager {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -2438,36 +2206,7 @@ unsafe impl ::windows::core::Interface for CallControl {
 impl ::windows::core::RuntimeName for CallControl {
     const NAME: &'static str = "Windows.Media.Devices.CallControl";
 }
-impl ::core::convert::From<CallControl> for ::windows::core::IUnknown {
-    fn from(value: CallControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CallControl> for ::windows::core::IUnknown {
-    fn from(value: &CallControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CallControl> for &::windows::core::IUnknown {
-    fn from(value: &CallControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CallControl> for ::windows::core::IInspectable {
-    fn from(value: CallControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CallControl> for ::windows::core::IInspectable {
-    fn from(value: &CallControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CallControl> for &::windows::core::IInspectable {
-    fn from(value: &CallControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CallControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CallControl {}
 unsafe impl ::core::marker::Sync for CallControl {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -2536,36 +2275,7 @@ unsafe impl ::windows::core::Interface for CameraOcclusionInfo {
 impl ::windows::core::RuntimeName for CameraOcclusionInfo {
     const NAME: &'static str = "Windows.Media.Devices.CameraOcclusionInfo";
 }
-impl ::core::convert::From<CameraOcclusionInfo> for ::windows::core::IUnknown {
-    fn from(value: CameraOcclusionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraOcclusionInfo> for ::windows::core::IUnknown {
-    fn from(value: &CameraOcclusionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraOcclusionInfo> for &::windows::core::IUnknown {
-    fn from(value: &CameraOcclusionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CameraOcclusionInfo> for ::windows::core::IInspectable {
-    fn from(value: CameraOcclusionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraOcclusionInfo> for ::windows::core::IInspectable {
-    fn from(value: &CameraOcclusionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraOcclusionInfo> for &::windows::core::IInspectable {
-    fn from(value: &CameraOcclusionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CameraOcclusionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CameraOcclusionInfo {}
 unsafe impl ::core::marker::Sync for CameraOcclusionInfo {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -2619,36 +2329,7 @@ unsafe impl ::windows::core::Interface for CameraOcclusionState {
 impl ::windows::core::RuntimeName for CameraOcclusionState {
     const NAME: &'static str = "Windows.Media.Devices.CameraOcclusionState";
 }
-impl ::core::convert::From<CameraOcclusionState> for ::windows::core::IUnknown {
-    fn from(value: CameraOcclusionState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraOcclusionState> for ::windows::core::IUnknown {
-    fn from(value: &CameraOcclusionState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraOcclusionState> for &::windows::core::IUnknown {
-    fn from(value: &CameraOcclusionState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CameraOcclusionState> for ::windows::core::IInspectable {
-    fn from(value: CameraOcclusionState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraOcclusionState> for ::windows::core::IInspectable {
-    fn from(value: &CameraOcclusionState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraOcclusionState> for &::windows::core::IInspectable {
-    fn from(value: &CameraOcclusionState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CameraOcclusionState, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CameraOcclusionState {}
 unsafe impl ::core::marker::Sync for CameraOcclusionState {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -2695,36 +2376,7 @@ unsafe impl ::windows::core::Interface for CameraOcclusionStateChangedEventArgs 
 impl ::windows::core::RuntimeName for CameraOcclusionStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Devices.CameraOcclusionStateChangedEventArgs";
 }
-impl ::core::convert::From<CameraOcclusionStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CameraOcclusionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraOcclusionStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CameraOcclusionStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraOcclusionStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CameraOcclusionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CameraOcclusionStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CameraOcclusionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraOcclusionStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CameraOcclusionStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraOcclusionStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CameraOcclusionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CameraOcclusionStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CameraOcclusionStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for CameraOcclusionStateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -2778,36 +2430,7 @@ unsafe impl ::windows::core::Interface for DefaultAudioCaptureDeviceChangedEvent
 impl ::windows::core::RuntimeName for DefaultAudioCaptureDeviceChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Devices.DefaultAudioCaptureDeviceChangedEventArgs";
 }
-impl ::core::convert::From<DefaultAudioCaptureDeviceChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DefaultAudioCaptureDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DefaultAudioCaptureDeviceChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DefaultAudioCaptureDeviceChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DefaultAudioCaptureDeviceChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DefaultAudioCaptureDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DefaultAudioCaptureDeviceChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DefaultAudioCaptureDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DefaultAudioCaptureDeviceChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DefaultAudioCaptureDeviceChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DefaultAudioCaptureDeviceChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DefaultAudioCaptureDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DefaultAudioCaptureDeviceChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DefaultAudioCaptureDeviceChangedEventArgs> for IDefaultAudioDeviceChangedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: DefaultAudioCaptureDeviceChangedEventArgs) -> ::windows::core::Result<Self> {
@@ -2880,36 +2503,7 @@ unsafe impl ::windows::core::Interface for DefaultAudioRenderDeviceChangedEventA
 impl ::windows::core::RuntimeName for DefaultAudioRenderDeviceChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Devices.DefaultAudioRenderDeviceChangedEventArgs";
 }
-impl ::core::convert::From<DefaultAudioRenderDeviceChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DefaultAudioRenderDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DefaultAudioRenderDeviceChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DefaultAudioRenderDeviceChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DefaultAudioRenderDeviceChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DefaultAudioRenderDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DefaultAudioRenderDeviceChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DefaultAudioRenderDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DefaultAudioRenderDeviceChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DefaultAudioRenderDeviceChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DefaultAudioRenderDeviceChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DefaultAudioRenderDeviceChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DefaultAudioRenderDeviceChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DefaultAudioRenderDeviceChangedEventArgs> for IDefaultAudioDeviceChangedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: DefaultAudioRenderDeviceChangedEventArgs) -> ::windows::core::Result<Self> {
@@ -2979,36 +2573,7 @@ unsafe impl ::windows::core::Interface for DialRequestedEventArgs {
 impl ::windows::core::RuntimeName for DialRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.Devices.DialRequestedEventArgs";
 }
-impl ::core::convert::From<DialRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DialRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DialRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DialRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DialRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DialRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DialRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DialRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DialRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DialRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for DialRequestedEventArgs {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -3088,36 +2653,7 @@ unsafe impl ::windows::core::Interface for DigitalWindowBounds {
 impl ::windows::core::RuntimeName for DigitalWindowBounds {
     const NAME: &'static str = "Windows.Media.Devices.DigitalWindowBounds";
 }
-impl ::core::convert::From<DigitalWindowBounds> for ::windows::core::IUnknown {
-    fn from(value: DigitalWindowBounds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DigitalWindowBounds> for ::windows::core::IUnknown {
-    fn from(value: &DigitalWindowBounds) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DigitalWindowBounds> for &::windows::core::IUnknown {
-    fn from(value: &DigitalWindowBounds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DigitalWindowBounds> for ::windows::core::IInspectable {
-    fn from(value: DigitalWindowBounds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DigitalWindowBounds> for ::windows::core::IInspectable {
-    fn from(value: &DigitalWindowBounds) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DigitalWindowBounds> for &::windows::core::IInspectable {
-    fn from(value: &DigitalWindowBounds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DigitalWindowBounds, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DigitalWindowBounds {}
 unsafe impl ::core::marker::Sync for DigitalWindowBounds {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -3201,36 +2737,7 @@ unsafe impl ::windows::core::Interface for DigitalWindowCapability {
 impl ::windows::core::RuntimeName for DigitalWindowCapability {
     const NAME: &'static str = "Windows.Media.Devices.DigitalWindowCapability";
 }
-impl ::core::convert::From<DigitalWindowCapability> for ::windows::core::IUnknown {
-    fn from(value: DigitalWindowCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DigitalWindowCapability> for ::windows::core::IUnknown {
-    fn from(value: &DigitalWindowCapability) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DigitalWindowCapability> for &::windows::core::IUnknown {
-    fn from(value: &DigitalWindowCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DigitalWindowCapability> for ::windows::core::IInspectable {
-    fn from(value: DigitalWindowCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DigitalWindowCapability> for ::windows::core::IInspectable {
-    fn from(value: &DigitalWindowCapability) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DigitalWindowCapability> for &::windows::core::IInspectable {
-    fn from(value: &DigitalWindowCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DigitalWindowCapability, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DigitalWindowCapability {}
 unsafe impl ::core::marker::Sync for DigitalWindowCapability {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -3322,36 +2829,7 @@ unsafe impl ::windows::core::Interface for DigitalWindowControl {
 impl ::windows::core::RuntimeName for DigitalWindowControl {
     const NAME: &'static str = "Windows.Media.Devices.DigitalWindowControl";
 }
-impl ::core::convert::From<DigitalWindowControl> for ::windows::core::IUnknown {
-    fn from(value: DigitalWindowControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DigitalWindowControl> for ::windows::core::IUnknown {
-    fn from(value: &DigitalWindowControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DigitalWindowControl> for &::windows::core::IUnknown {
-    fn from(value: &DigitalWindowControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DigitalWindowControl> for ::windows::core::IInspectable {
-    fn from(value: DigitalWindowControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DigitalWindowControl> for ::windows::core::IInspectable {
-    fn from(value: &DigitalWindowControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DigitalWindowControl> for &::windows::core::IInspectable {
-    fn from(value: &DigitalWindowControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DigitalWindowControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DigitalWindowControl {}
 unsafe impl ::core::marker::Sync for DigitalWindowControl {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -3435,36 +2913,7 @@ unsafe impl ::windows::core::Interface for ExposureCompensationControl {
 impl ::windows::core::RuntimeName for ExposureCompensationControl {
     const NAME: &'static str = "Windows.Media.Devices.ExposureCompensationControl";
 }
-impl ::core::convert::From<ExposureCompensationControl> for ::windows::core::IUnknown {
-    fn from(value: ExposureCompensationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExposureCompensationControl> for ::windows::core::IUnknown {
-    fn from(value: &ExposureCompensationControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExposureCompensationControl> for &::windows::core::IUnknown {
-    fn from(value: &ExposureCompensationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ExposureCompensationControl> for ::windows::core::IInspectable {
-    fn from(value: ExposureCompensationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExposureCompensationControl> for ::windows::core::IInspectable {
-    fn from(value: &ExposureCompensationControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExposureCompensationControl> for &::windows::core::IInspectable {
-    fn from(value: &ExposureCompensationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ExposureCompensationControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct ExposureControl(::windows::core::IUnknown);
@@ -3570,36 +3019,7 @@ unsafe impl ::windows::core::Interface for ExposureControl {
 impl ::windows::core::RuntimeName for ExposureControl {
     const NAME: &'static str = "Windows.Media.Devices.ExposureControl";
 }
-impl ::core::convert::From<ExposureControl> for ::windows::core::IUnknown {
-    fn from(value: ExposureControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExposureControl> for ::windows::core::IUnknown {
-    fn from(value: &ExposureControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExposureControl> for &::windows::core::IUnknown {
-    fn from(value: &ExposureControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ExposureControl> for ::windows::core::IInspectable {
-    fn from(value: ExposureControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExposureControl> for ::windows::core::IInspectable {
-    fn from(value: &ExposureControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExposureControl> for &::windows::core::IInspectable {
-    fn from(value: &ExposureControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ExposureControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct ExposurePriorityVideoControl(::windows::core::IUnknown);
@@ -3655,36 +3075,7 @@ unsafe impl ::windows::core::Interface for ExposurePriorityVideoControl {
 impl ::windows::core::RuntimeName for ExposurePriorityVideoControl {
     const NAME: &'static str = "Windows.Media.Devices.ExposurePriorityVideoControl";
 }
-impl ::core::convert::From<ExposurePriorityVideoControl> for ::windows::core::IUnknown {
-    fn from(value: ExposurePriorityVideoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExposurePriorityVideoControl> for ::windows::core::IUnknown {
-    fn from(value: &ExposurePriorityVideoControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExposurePriorityVideoControl> for &::windows::core::IUnknown {
-    fn from(value: &ExposurePriorityVideoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ExposurePriorityVideoControl> for ::windows::core::IInspectable {
-    fn from(value: ExposurePriorityVideoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExposurePriorityVideoControl> for ::windows::core::IInspectable {
-    fn from(value: &ExposurePriorityVideoControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExposurePriorityVideoControl> for &::windows::core::IInspectable {
-    fn from(value: &ExposurePriorityVideoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ExposurePriorityVideoControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ExposurePriorityVideoControl {}
 unsafe impl ::core::marker::Sync for ExposurePriorityVideoControl {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -3807,36 +3198,7 @@ unsafe impl ::windows::core::Interface for FlashControl {
 impl ::windows::core::RuntimeName for FlashControl {
     const NAME: &'static str = "Windows.Media.Devices.FlashControl";
 }
-impl ::core::convert::From<FlashControl> for ::windows::core::IUnknown {
-    fn from(value: FlashControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FlashControl> for ::windows::core::IUnknown {
-    fn from(value: &FlashControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FlashControl> for &::windows::core::IUnknown {
-    fn from(value: &FlashControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FlashControl> for ::windows::core::IInspectable {
-    fn from(value: FlashControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FlashControl> for ::windows::core::IInspectable {
-    fn from(value: &FlashControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FlashControl> for &::windows::core::IInspectable {
-    fn from(value: &FlashControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FlashControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct FocusControl(::windows::core::IUnknown);
@@ -4038,36 +3400,7 @@ unsafe impl ::windows::core::Interface for FocusControl {
 impl ::windows::core::RuntimeName for FocusControl {
     const NAME: &'static str = "Windows.Media.Devices.FocusControl";
 }
-impl ::core::convert::From<FocusControl> for ::windows::core::IUnknown {
-    fn from(value: FocusControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FocusControl> for ::windows::core::IUnknown {
-    fn from(value: &FocusControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FocusControl> for &::windows::core::IUnknown {
-    fn from(value: &FocusControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FocusControl> for ::windows::core::IInspectable {
-    fn from(value: FocusControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FocusControl> for ::windows::core::IInspectable {
-    fn from(value: &FocusControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FocusControl> for &::windows::core::IInspectable {
-    fn from(value: &FocusControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FocusControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct FocusSettings(::windows::core::IUnknown);
@@ -4194,36 +3527,7 @@ unsafe impl ::windows::core::Interface for FocusSettings {
 impl ::windows::core::RuntimeName for FocusSettings {
     const NAME: &'static str = "Windows.Media.Devices.FocusSettings";
 }
-impl ::core::convert::From<FocusSettings> for ::windows::core::IUnknown {
-    fn from(value: FocusSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FocusSettings> for ::windows::core::IUnknown {
-    fn from(value: &FocusSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FocusSettings> for &::windows::core::IUnknown {
-    fn from(value: &FocusSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FocusSettings> for ::windows::core::IInspectable {
-    fn from(value: FocusSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FocusSettings> for ::windows::core::IInspectable {
-    fn from(value: &FocusSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FocusSettings> for &::windows::core::IInspectable {
-    fn from(value: &FocusSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FocusSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FocusSettings {}
 unsafe impl ::core::marker::Sync for FocusSettings {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -4290,36 +3594,7 @@ unsafe impl ::windows::core::Interface for HdrVideoControl {
 impl ::windows::core::RuntimeName for HdrVideoControl {
     const NAME: &'static str = "Windows.Media.Devices.HdrVideoControl";
 }
-impl ::core::convert::From<HdrVideoControl> for ::windows::core::IUnknown {
-    fn from(value: HdrVideoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HdrVideoControl> for ::windows::core::IUnknown {
-    fn from(value: &HdrVideoControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HdrVideoControl> for &::windows::core::IUnknown {
-    fn from(value: &HdrVideoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HdrVideoControl> for ::windows::core::IInspectable {
-    fn from(value: HdrVideoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HdrVideoControl> for ::windows::core::IInspectable {
-    fn from(value: &HdrVideoControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HdrVideoControl> for &::windows::core::IInspectable {
-    fn from(value: &HdrVideoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HdrVideoControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HdrVideoControl {}
 unsafe impl ::core::marker::Sync for HdrVideoControl {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -4418,36 +3693,7 @@ unsafe impl ::windows::core::Interface for InfraredTorchControl {
 impl ::windows::core::RuntimeName for InfraredTorchControl {
     const NAME: &'static str = "Windows.Media.Devices.InfraredTorchControl";
 }
-impl ::core::convert::From<InfraredTorchControl> for ::windows::core::IUnknown {
-    fn from(value: InfraredTorchControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InfraredTorchControl> for ::windows::core::IUnknown {
-    fn from(value: &InfraredTorchControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InfraredTorchControl> for &::windows::core::IUnknown {
-    fn from(value: &InfraredTorchControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InfraredTorchControl> for ::windows::core::IInspectable {
-    fn from(value: InfraredTorchControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InfraredTorchControl> for ::windows::core::IInspectable {
-    fn from(value: &InfraredTorchControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InfraredTorchControl> for &::windows::core::IInspectable {
-    fn from(value: &InfraredTorchControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InfraredTorchControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InfraredTorchControl {}
 unsafe impl ::core::marker::Sync for InfraredTorchControl {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -4574,36 +3820,7 @@ unsafe impl ::windows::core::Interface for IsoSpeedControl {
 impl ::windows::core::RuntimeName for IsoSpeedControl {
     const NAME: &'static str = "Windows.Media.Devices.IsoSpeedControl";
 }
-impl ::core::convert::From<IsoSpeedControl> for ::windows::core::IUnknown {
-    fn from(value: IsoSpeedControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsoSpeedControl> for ::windows::core::IUnknown {
-    fn from(value: &IsoSpeedControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsoSpeedControl> for &::windows::core::IUnknown {
-    fn from(value: &IsoSpeedControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsoSpeedControl> for ::windows::core::IInspectable {
-    fn from(value: IsoSpeedControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsoSpeedControl> for ::windows::core::IInspectable {
-    fn from(value: &IsoSpeedControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsoSpeedControl> for &::windows::core::IInspectable {
-    fn from(value: &IsoSpeedControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsoSpeedControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct KeypadPressedEventArgs(::windows::core::IUnknown);
@@ -4648,36 +3865,7 @@ unsafe impl ::windows::core::Interface for KeypadPressedEventArgs {
 impl ::windows::core::RuntimeName for KeypadPressedEventArgs {
     const NAME: &'static str = "Windows.Media.Devices.KeypadPressedEventArgs";
 }
-impl ::core::convert::From<KeypadPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: KeypadPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeypadPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &KeypadPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeypadPressedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &KeypadPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<KeypadPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: KeypadPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeypadPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &KeypadPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeypadPressedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &KeypadPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(KeypadPressedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for KeypadPressedEventArgs {}
 unsafe impl ::core::marker::Sync for KeypadPressedEventArgs {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -4783,36 +3971,7 @@ unsafe impl ::windows::core::Interface for LowLagPhotoControl {
 impl ::windows::core::RuntimeName for LowLagPhotoControl {
     const NAME: &'static str = "Windows.Media.Devices.LowLagPhotoControl";
 }
-impl ::core::convert::From<LowLagPhotoControl> for ::windows::core::IUnknown {
-    fn from(value: LowLagPhotoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLagPhotoControl> for ::windows::core::IUnknown {
-    fn from(value: &LowLagPhotoControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLagPhotoControl> for &::windows::core::IUnknown {
-    fn from(value: &LowLagPhotoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LowLagPhotoControl> for ::windows::core::IInspectable {
-    fn from(value: LowLagPhotoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLagPhotoControl> for ::windows::core::IInspectable {
-    fn from(value: &LowLagPhotoControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLagPhotoControl> for &::windows::core::IInspectable {
-    fn from(value: &LowLagPhotoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LowLagPhotoControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct LowLagPhotoSequenceControl(::windows::core::IUnknown);
@@ -4959,36 +4118,7 @@ unsafe impl ::windows::core::Interface for LowLagPhotoSequenceControl {
 impl ::windows::core::RuntimeName for LowLagPhotoSequenceControl {
     const NAME: &'static str = "Windows.Media.Devices.LowLagPhotoSequenceControl";
 }
-impl ::core::convert::From<LowLagPhotoSequenceControl> for ::windows::core::IUnknown {
-    fn from(value: LowLagPhotoSequenceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLagPhotoSequenceControl> for ::windows::core::IUnknown {
-    fn from(value: &LowLagPhotoSequenceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLagPhotoSequenceControl> for &::windows::core::IUnknown {
-    fn from(value: &LowLagPhotoSequenceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LowLagPhotoSequenceControl> for ::windows::core::IInspectable {
-    fn from(value: LowLagPhotoSequenceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LowLagPhotoSequenceControl> for ::windows::core::IInspectable {
-    fn from(value: &LowLagPhotoSequenceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LowLagPhotoSequenceControl> for &::windows::core::IInspectable {
-    fn from(value: &LowLagPhotoSequenceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LowLagPhotoSequenceControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 pub struct MediaDevice;
 impl MediaDevice {
@@ -5129,36 +4259,7 @@ unsafe impl ::windows::core::Interface for MediaDeviceControl {
 impl ::windows::core::RuntimeName for MediaDeviceControl {
     const NAME: &'static str = "Windows.Media.Devices.MediaDeviceControl";
 }
-impl ::core::convert::From<MediaDeviceControl> for ::windows::core::IUnknown {
-    fn from(value: MediaDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaDeviceControl> for ::windows::core::IUnknown {
-    fn from(value: &MediaDeviceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaDeviceControl> for &::windows::core::IUnknown {
-    fn from(value: &MediaDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaDeviceControl> for ::windows::core::IInspectable {
-    fn from(value: MediaDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaDeviceControl> for ::windows::core::IInspectable {
-    fn from(value: &MediaDeviceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaDeviceControl> for &::windows::core::IInspectable {
-    fn from(value: &MediaDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaDeviceControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct MediaDeviceControlCapabilities(::windows::core::IUnknown);
@@ -5238,36 +4339,7 @@ unsafe impl ::windows::core::Interface for MediaDeviceControlCapabilities {
 impl ::windows::core::RuntimeName for MediaDeviceControlCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.MediaDeviceControlCapabilities";
 }
-impl ::core::convert::From<MediaDeviceControlCapabilities> for ::windows::core::IUnknown {
-    fn from(value: MediaDeviceControlCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaDeviceControlCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &MediaDeviceControlCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaDeviceControlCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &MediaDeviceControlCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaDeviceControlCapabilities> for ::windows::core::IInspectable {
-    fn from(value: MediaDeviceControlCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaDeviceControlCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &MediaDeviceControlCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaDeviceControlCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &MediaDeviceControlCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaDeviceControlCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct ModuleCommandResult(::windows::core::IUnknown);
@@ -5321,36 +4393,7 @@ unsafe impl ::windows::core::Interface for ModuleCommandResult {
 impl ::windows::core::RuntimeName for ModuleCommandResult {
     const NAME: &'static str = "Windows.Media.Devices.ModuleCommandResult";
 }
-impl ::core::convert::From<ModuleCommandResult> for ::windows::core::IUnknown {
-    fn from(value: ModuleCommandResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ModuleCommandResult> for ::windows::core::IUnknown {
-    fn from(value: &ModuleCommandResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ModuleCommandResult> for &::windows::core::IUnknown {
-    fn from(value: &ModuleCommandResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ModuleCommandResult> for ::windows::core::IInspectable {
-    fn from(value: ModuleCommandResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ModuleCommandResult> for ::windows::core::IInspectable {
-    fn from(value: &ModuleCommandResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ModuleCommandResult> for &::windows::core::IInspectable {
-    fn from(value: &ModuleCommandResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ModuleCommandResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct OpticalImageStabilizationControl(::windows::core::IUnknown);
@@ -5415,36 +4458,7 @@ unsafe impl ::windows::core::Interface for OpticalImageStabilizationControl {
 impl ::windows::core::RuntimeName for OpticalImageStabilizationControl {
     const NAME: &'static str = "Windows.Media.Devices.OpticalImageStabilizationControl";
 }
-impl ::core::convert::From<OpticalImageStabilizationControl> for ::windows::core::IUnknown {
-    fn from(value: OpticalImageStabilizationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OpticalImageStabilizationControl> for ::windows::core::IUnknown {
-    fn from(value: &OpticalImageStabilizationControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OpticalImageStabilizationControl> for &::windows::core::IUnknown {
-    fn from(value: &OpticalImageStabilizationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OpticalImageStabilizationControl> for ::windows::core::IInspectable {
-    fn from(value: OpticalImageStabilizationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OpticalImageStabilizationControl> for ::windows::core::IInspectable {
-    fn from(value: &OpticalImageStabilizationControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OpticalImageStabilizationControl> for &::windows::core::IInspectable {
-    fn from(value: &OpticalImageStabilizationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OpticalImageStabilizationControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OpticalImageStabilizationControl {}
 unsafe impl ::core::marker::Sync for OpticalImageStabilizationControl {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -5506,36 +4520,7 @@ unsafe impl ::windows::core::Interface for PanelBasedOptimizationControl {
 impl ::windows::core::RuntimeName for PanelBasedOptimizationControl {
     const NAME: &'static str = "Windows.Media.Devices.PanelBasedOptimizationControl";
 }
-impl ::core::convert::From<PanelBasedOptimizationControl> for ::windows::core::IUnknown {
-    fn from(value: PanelBasedOptimizationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PanelBasedOptimizationControl> for ::windows::core::IUnknown {
-    fn from(value: &PanelBasedOptimizationControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PanelBasedOptimizationControl> for &::windows::core::IUnknown {
-    fn from(value: &PanelBasedOptimizationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PanelBasedOptimizationControl> for ::windows::core::IInspectable {
-    fn from(value: PanelBasedOptimizationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PanelBasedOptimizationControl> for ::windows::core::IInspectable {
-    fn from(value: &PanelBasedOptimizationControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PanelBasedOptimizationControl> for &::windows::core::IInspectable {
-    fn from(value: &PanelBasedOptimizationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PanelBasedOptimizationControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PanelBasedOptimizationControl {}
 unsafe impl ::core::marker::Sync for PanelBasedOptimizationControl {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -5608,36 +4593,7 @@ unsafe impl ::windows::core::Interface for PhotoConfirmationControl {
 impl ::windows::core::RuntimeName for PhotoConfirmationControl {
     const NAME: &'static str = "Windows.Media.Devices.PhotoConfirmationControl";
 }
-impl ::core::convert::From<PhotoConfirmationControl> for ::windows::core::IUnknown {
-    fn from(value: PhotoConfirmationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoConfirmationControl> for ::windows::core::IUnknown {
-    fn from(value: &PhotoConfirmationControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoConfirmationControl> for &::windows::core::IUnknown {
-    fn from(value: &PhotoConfirmationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoConfirmationControl> for ::windows::core::IInspectable {
-    fn from(value: PhotoConfirmationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoConfirmationControl> for ::windows::core::IInspectable {
-    fn from(value: &PhotoConfirmationControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoConfirmationControl> for &::windows::core::IInspectable {
-    fn from(value: &PhotoConfirmationControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoConfirmationControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct RedialRequestedEventArgs(::windows::core::IUnknown);
@@ -5679,36 +4635,7 @@ unsafe impl ::windows::core::Interface for RedialRequestedEventArgs {
 impl ::windows::core::RuntimeName for RedialRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.Devices.RedialRequestedEventArgs";
 }
-impl ::core::convert::From<RedialRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RedialRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RedialRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RedialRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RedialRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RedialRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RedialRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RedialRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RedialRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RedialRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RedialRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RedialRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RedialRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RedialRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for RedialRequestedEventArgs {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -5836,36 +4763,7 @@ unsafe impl ::windows::core::Interface for RegionOfInterest {
 impl ::windows::core::RuntimeName for RegionOfInterest {
     const NAME: &'static str = "Windows.Media.Devices.RegionOfInterest";
 }
-impl ::core::convert::From<RegionOfInterest> for ::windows::core::IUnknown {
-    fn from(value: RegionOfInterest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RegionOfInterest> for ::windows::core::IUnknown {
-    fn from(value: &RegionOfInterest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RegionOfInterest> for &::windows::core::IUnknown {
-    fn from(value: &RegionOfInterest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RegionOfInterest> for ::windows::core::IInspectable {
-    fn from(value: RegionOfInterest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RegionOfInterest> for ::windows::core::IInspectable {
-    fn from(value: &RegionOfInterest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RegionOfInterest> for &::windows::core::IInspectable {
-    fn from(value: &RegionOfInterest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RegionOfInterest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RegionOfInterest {}
 unsafe impl ::core::marker::Sync for RegionOfInterest {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -5968,36 +4866,7 @@ unsafe impl ::windows::core::Interface for RegionsOfInterestControl {
 impl ::windows::core::RuntimeName for RegionsOfInterestControl {
     const NAME: &'static str = "Windows.Media.Devices.RegionsOfInterestControl";
 }
-impl ::core::convert::From<RegionsOfInterestControl> for ::windows::core::IUnknown {
-    fn from(value: RegionsOfInterestControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RegionsOfInterestControl> for ::windows::core::IUnknown {
-    fn from(value: &RegionsOfInterestControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RegionsOfInterestControl> for &::windows::core::IUnknown {
-    fn from(value: &RegionsOfInterestControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RegionsOfInterestControl> for ::windows::core::IInspectable {
-    fn from(value: RegionsOfInterestControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RegionsOfInterestControl> for ::windows::core::IInspectable {
-    fn from(value: &RegionsOfInterestControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RegionsOfInterestControl> for &::windows::core::IInspectable {
-    fn from(value: &RegionsOfInterestControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RegionsOfInterestControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct SceneModeControl(::windows::core::IUnknown);
@@ -6060,36 +4929,7 @@ unsafe impl ::windows::core::Interface for SceneModeControl {
 impl ::windows::core::RuntimeName for SceneModeControl {
     const NAME: &'static str = "Windows.Media.Devices.SceneModeControl";
 }
-impl ::core::convert::From<SceneModeControl> for ::windows::core::IUnknown {
-    fn from(value: SceneModeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneModeControl> for ::windows::core::IUnknown {
-    fn from(value: &SceneModeControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneModeControl> for &::windows::core::IUnknown {
-    fn from(value: &SceneModeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneModeControl> for ::windows::core::IInspectable {
-    fn from(value: SceneModeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneModeControl> for ::windows::core::IInspectable {
-    fn from(value: &SceneModeControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneModeControl> for &::windows::core::IInspectable {
-    fn from(value: &SceneModeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneModeControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct TorchControl(::windows::core::IUnknown);
@@ -6163,36 +5003,7 @@ unsafe impl ::windows::core::Interface for TorchControl {
 impl ::windows::core::RuntimeName for TorchControl {
     const NAME: &'static str = "Windows.Media.Devices.TorchControl";
 }
-impl ::core::convert::From<TorchControl> for ::windows::core::IUnknown {
-    fn from(value: TorchControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TorchControl> for ::windows::core::IUnknown {
-    fn from(value: &TorchControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TorchControl> for &::windows::core::IUnknown {
-    fn from(value: &TorchControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TorchControl> for ::windows::core::IInspectable {
-    fn from(value: TorchControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TorchControl> for ::windows::core::IInspectable {
-    fn from(value: &TorchControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TorchControl> for &::windows::core::IInspectable {
-    fn from(value: &TorchControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TorchControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct VideoDeviceController(::windows::core::IUnknown);
@@ -6605,36 +5416,7 @@ unsafe impl ::windows::core::Interface for VideoDeviceController {
 impl ::windows::core::RuntimeName for VideoDeviceController {
     const NAME: &'static str = "Windows.Media.Devices.VideoDeviceController";
 }
-impl ::core::convert::From<VideoDeviceController> for ::windows::core::IUnknown {
-    fn from(value: VideoDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoDeviceController> for ::windows::core::IUnknown {
-    fn from(value: &VideoDeviceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoDeviceController> for &::windows::core::IUnknown {
-    fn from(value: &VideoDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoDeviceController> for ::windows::core::IInspectable {
-    fn from(value: VideoDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoDeviceController> for ::windows::core::IInspectable {
-    fn from(value: &VideoDeviceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoDeviceController> for &::windows::core::IInspectable {
-    fn from(value: &VideoDeviceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoDeviceController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VideoDeviceController> for IMediaDeviceController {
     type Error = ::windows::core::Error;
     fn try_from(value: VideoDeviceController) -> ::windows::core::Result<Self> {
@@ -6705,36 +5487,7 @@ unsafe impl ::windows::core::Interface for VideoDeviceControllerGetDevicePropert
 impl ::windows::core::RuntimeName for VideoDeviceControllerGetDevicePropertyResult {
     const NAME: &'static str = "Windows.Media.Devices.VideoDeviceControllerGetDevicePropertyResult";
 }
-impl ::core::convert::From<VideoDeviceControllerGetDevicePropertyResult> for ::windows::core::IUnknown {
-    fn from(value: VideoDeviceControllerGetDevicePropertyResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoDeviceControllerGetDevicePropertyResult> for ::windows::core::IUnknown {
-    fn from(value: &VideoDeviceControllerGetDevicePropertyResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoDeviceControllerGetDevicePropertyResult> for &::windows::core::IUnknown {
-    fn from(value: &VideoDeviceControllerGetDevicePropertyResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoDeviceControllerGetDevicePropertyResult> for ::windows::core::IInspectable {
-    fn from(value: VideoDeviceControllerGetDevicePropertyResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoDeviceControllerGetDevicePropertyResult> for ::windows::core::IInspectable {
-    fn from(value: &VideoDeviceControllerGetDevicePropertyResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoDeviceControllerGetDevicePropertyResult> for &::windows::core::IInspectable {
-    fn from(value: &VideoDeviceControllerGetDevicePropertyResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoDeviceControllerGetDevicePropertyResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VideoDeviceControllerGetDevicePropertyResult {}
 unsafe impl ::core::marker::Sync for VideoDeviceControllerGetDevicePropertyResult {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -6801,36 +5554,7 @@ unsafe impl ::windows::core::Interface for VideoTemporalDenoisingControl {
 impl ::windows::core::RuntimeName for VideoTemporalDenoisingControl {
     const NAME: &'static str = "Windows.Media.Devices.VideoTemporalDenoisingControl";
 }
-impl ::core::convert::From<VideoTemporalDenoisingControl> for ::windows::core::IUnknown {
-    fn from(value: VideoTemporalDenoisingControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTemporalDenoisingControl> for ::windows::core::IUnknown {
-    fn from(value: &VideoTemporalDenoisingControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTemporalDenoisingControl> for &::windows::core::IUnknown {
-    fn from(value: &VideoTemporalDenoisingControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoTemporalDenoisingControl> for ::windows::core::IInspectable {
-    fn from(value: VideoTemporalDenoisingControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTemporalDenoisingControl> for ::windows::core::IInspectable {
-    fn from(value: &VideoTemporalDenoisingControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTemporalDenoisingControl> for &::windows::core::IInspectable {
-    fn from(value: &VideoTemporalDenoisingControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoTemporalDenoisingControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VideoTemporalDenoisingControl {}
 unsafe impl ::core::marker::Sync for VideoTemporalDenoisingControl {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -6930,36 +5654,7 @@ unsafe impl ::windows::core::Interface for WhiteBalanceControl {
 impl ::windows::core::RuntimeName for WhiteBalanceControl {
     const NAME: &'static str = "Windows.Media.Devices.WhiteBalanceControl";
 }
-impl ::core::convert::From<WhiteBalanceControl> for ::windows::core::IUnknown {
-    fn from(value: WhiteBalanceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WhiteBalanceControl> for ::windows::core::IUnknown {
-    fn from(value: &WhiteBalanceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WhiteBalanceControl> for &::windows::core::IUnknown {
-    fn from(value: &WhiteBalanceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WhiteBalanceControl> for ::windows::core::IInspectable {
-    fn from(value: WhiteBalanceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WhiteBalanceControl> for ::windows::core::IInspectable {
-    fn from(value: &WhiteBalanceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WhiteBalanceControl> for &::windows::core::IInspectable {
-    fn from(value: &WhiteBalanceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WhiteBalanceControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct ZoomControl(::windows::core::IUnknown);
@@ -7056,36 +5751,7 @@ unsafe impl ::windows::core::Interface for ZoomControl {
 impl ::windows::core::RuntimeName for ZoomControl {
     const NAME: &'static str = "Windows.Media.Devices.ZoomControl";
 }
-impl ::core::convert::From<ZoomControl> for ::windows::core::IUnknown {
-    fn from(value: ZoomControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ZoomControl> for ::windows::core::IUnknown {
-    fn from(value: &ZoomControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ZoomControl> for &::windows::core::IUnknown {
-    fn from(value: &ZoomControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ZoomControl> for ::windows::core::IInspectable {
-    fn from(value: ZoomControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ZoomControl> for ::windows::core::IInspectable {
-    fn from(value: &ZoomControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ZoomControl> for &::windows::core::IInspectable {
-    fn from(value: &ZoomControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ZoomControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Devices\"`*"]
 #[repr(transparent)]
 pub struct ZoomSettings(::windows::core::IUnknown);
@@ -7152,36 +5818,7 @@ unsafe impl ::windows::core::Interface for ZoomSettings {
 impl ::windows::core::RuntimeName for ZoomSettings {
     const NAME: &'static str = "Windows.Media.Devices.ZoomSettings";
 }
-impl ::core::convert::From<ZoomSettings> for ::windows::core::IUnknown {
-    fn from(value: ZoomSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ZoomSettings> for ::windows::core::IUnknown {
-    fn from(value: &ZoomSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ZoomSettings> for &::windows::core::IUnknown {
-    fn from(value: &ZoomSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ZoomSettings> for ::windows::core::IInspectable {
-    fn from(value: ZoomSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ZoomSettings> for ::windows::core::IInspectable {
-    fn from(value: &ZoomSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ZoomSettings> for &::windows::core::IInspectable {
-    fn from(value: &ZoomSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ZoomSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ZoomSettings {}
 unsafe impl ::core::marker::Sync for ZoomSettings {}
 #[doc = "*Required features: `\"Media_Devices\"`*"]

--- a/crates/libs/windows/src/Windows/Media/DialProtocol/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/DialProtocol/mod.rs
@@ -334,36 +334,7 @@ unsafe impl ::windows::core::Interface for DialApp {
 impl ::windows::core::RuntimeName for DialApp {
     const NAME: &'static str = "Windows.Media.DialProtocol.DialApp";
 }
-impl ::core::convert::From<DialApp> for ::windows::core::IUnknown {
-    fn from(value: DialApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialApp> for ::windows::core::IUnknown {
-    fn from(value: &DialApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialApp> for &::windows::core::IUnknown {
-    fn from(value: &DialApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DialApp> for ::windows::core::IInspectable {
-    fn from(value: DialApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialApp> for ::windows::core::IInspectable {
-    fn from(value: &DialApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialApp> for &::windows::core::IInspectable {
-    fn from(value: &DialApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DialApp, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DialApp {}
 unsafe impl ::core::marker::Sync for DialApp {}
 #[doc = "*Required features: `\"Media_DialProtocol\"`*"]
@@ -417,36 +388,7 @@ unsafe impl ::windows::core::Interface for DialAppStateDetails {
 impl ::windows::core::RuntimeName for DialAppStateDetails {
     const NAME: &'static str = "Windows.Media.DialProtocol.DialAppStateDetails";
 }
-impl ::core::convert::From<DialAppStateDetails> for ::windows::core::IUnknown {
-    fn from(value: DialAppStateDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialAppStateDetails> for ::windows::core::IUnknown {
-    fn from(value: &DialAppStateDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialAppStateDetails> for &::windows::core::IUnknown {
-    fn from(value: &DialAppStateDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DialAppStateDetails> for ::windows::core::IInspectable {
-    fn from(value: DialAppStateDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialAppStateDetails> for ::windows::core::IInspectable {
-    fn from(value: &DialAppStateDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialAppStateDetails> for &::windows::core::IInspectable {
-    fn from(value: &DialAppStateDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DialAppStateDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DialAppStateDetails {}
 unsafe impl ::core::marker::Sync for DialAppStateDetails {}
 #[doc = "*Required features: `\"Media_DialProtocol\"`*"]
@@ -543,36 +485,7 @@ unsafe impl ::windows::core::Interface for DialDevice {
 impl ::windows::core::RuntimeName for DialDevice {
     const NAME: &'static str = "Windows.Media.DialProtocol.DialDevice";
 }
-impl ::core::convert::From<DialDevice> for ::windows::core::IUnknown {
-    fn from(value: DialDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialDevice> for ::windows::core::IUnknown {
-    fn from(value: &DialDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialDevice> for &::windows::core::IUnknown {
-    fn from(value: &DialDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DialDevice> for ::windows::core::IInspectable {
-    fn from(value: DialDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialDevice> for ::windows::core::IInspectable {
-    fn from(value: &DialDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialDevice> for &::windows::core::IInspectable {
-    fn from(value: &DialDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DialDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DialDevice {}
 unsafe impl ::core::marker::Sync for DialDevice {}
 #[doc = "*Required features: `\"Media_DialProtocol\"`*"]
@@ -718,36 +631,7 @@ unsafe impl ::windows::core::Interface for DialDevicePicker {
 impl ::windows::core::RuntimeName for DialDevicePicker {
     const NAME: &'static str = "Windows.Media.DialProtocol.DialDevicePicker";
 }
-impl ::core::convert::From<DialDevicePicker> for ::windows::core::IUnknown {
-    fn from(value: DialDevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialDevicePicker> for ::windows::core::IUnknown {
-    fn from(value: &DialDevicePicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialDevicePicker> for &::windows::core::IUnknown {
-    fn from(value: &DialDevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DialDevicePicker> for ::windows::core::IInspectable {
-    fn from(value: DialDevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialDevicePicker> for ::windows::core::IInspectable {
-    fn from(value: &DialDevicePicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialDevicePicker> for &::windows::core::IInspectable {
-    fn from(value: &DialDevicePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DialDevicePicker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DialDevicePicker {}
 unsafe impl ::core::marker::Sync for DialDevicePicker {}
 #[doc = "*Required features: `\"Media_DialProtocol\"`*"]
@@ -796,36 +680,7 @@ unsafe impl ::windows::core::Interface for DialDevicePickerFilter {
 impl ::windows::core::RuntimeName for DialDevicePickerFilter {
     const NAME: &'static str = "Windows.Media.DialProtocol.DialDevicePickerFilter";
 }
-impl ::core::convert::From<DialDevicePickerFilter> for ::windows::core::IUnknown {
-    fn from(value: DialDevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialDevicePickerFilter> for ::windows::core::IUnknown {
-    fn from(value: &DialDevicePickerFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialDevicePickerFilter> for &::windows::core::IUnknown {
-    fn from(value: &DialDevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DialDevicePickerFilter> for ::windows::core::IInspectable {
-    fn from(value: DialDevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialDevicePickerFilter> for ::windows::core::IInspectable {
-    fn from(value: &DialDevicePickerFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialDevicePickerFilter> for &::windows::core::IInspectable {
-    fn from(value: &DialDevicePickerFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DialDevicePickerFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DialDevicePickerFilter {}
 unsafe impl ::core::marker::Sync for DialDevicePickerFilter {}
 #[doc = "*Required features: `\"Media_DialProtocol\"`*"]
@@ -872,36 +727,7 @@ unsafe impl ::windows::core::Interface for DialDeviceSelectedEventArgs {
 impl ::windows::core::RuntimeName for DialDeviceSelectedEventArgs {
     const NAME: &'static str = "Windows.Media.DialProtocol.DialDeviceSelectedEventArgs";
 }
-impl ::core::convert::From<DialDeviceSelectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DialDeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialDeviceSelectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DialDeviceSelectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialDeviceSelectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DialDeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DialDeviceSelectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DialDeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialDeviceSelectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DialDeviceSelectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialDeviceSelectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DialDeviceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DialDeviceSelectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DialDeviceSelectedEventArgs {}
 unsafe impl ::core::marker::Sync for DialDeviceSelectedEventArgs {}
 #[doc = "*Required features: `\"Media_DialProtocol\"`*"]
@@ -948,36 +774,7 @@ unsafe impl ::windows::core::Interface for DialDisconnectButtonClickedEventArgs 
 impl ::windows::core::RuntimeName for DialDisconnectButtonClickedEventArgs {
     const NAME: &'static str = "Windows.Media.DialProtocol.DialDisconnectButtonClickedEventArgs";
 }
-impl ::core::convert::From<DialDisconnectButtonClickedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DialDisconnectButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialDisconnectButtonClickedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DialDisconnectButtonClickedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialDisconnectButtonClickedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DialDisconnectButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DialDisconnectButtonClickedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DialDisconnectButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialDisconnectButtonClickedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DialDisconnectButtonClickedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialDisconnectButtonClickedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DialDisconnectButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DialDisconnectButtonClickedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DialDisconnectButtonClickedEventArgs {}
 unsafe impl ::core::marker::Sync for DialDisconnectButtonClickedEventArgs {}
 #[doc = "*Required features: `\"Media_DialProtocol\"`*"]
@@ -1059,36 +856,7 @@ unsafe impl ::windows::core::Interface for DialReceiverApp {
 impl ::windows::core::RuntimeName for DialReceiverApp {
     const NAME: &'static str = "Windows.Media.DialProtocol.DialReceiverApp";
 }
-impl ::core::convert::From<DialReceiverApp> for ::windows::core::IUnknown {
-    fn from(value: DialReceiverApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialReceiverApp> for ::windows::core::IUnknown {
-    fn from(value: &DialReceiverApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialReceiverApp> for &::windows::core::IUnknown {
-    fn from(value: &DialReceiverApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DialReceiverApp> for ::windows::core::IInspectable {
-    fn from(value: DialReceiverApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DialReceiverApp> for ::windows::core::IInspectable {
-    fn from(value: &DialReceiverApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DialReceiverApp> for &::windows::core::IInspectable {
-    fn from(value: &DialReceiverApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DialReceiverApp, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DialReceiverApp {}
 unsafe impl ::core::marker::Sync for DialReceiverApp {}
 #[doc = "*Required features: `\"Media_DialProtocol\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Editing/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Editing/mod.rs
@@ -582,36 +582,7 @@ unsafe impl ::windows::core::Interface for BackgroundAudioTrack {
 impl ::windows::core::RuntimeName for BackgroundAudioTrack {
     const NAME: &'static str = "Windows.Media.Editing.BackgroundAudioTrack";
 }
-impl ::core::convert::From<BackgroundAudioTrack> for ::windows::core::IUnknown {
-    fn from(value: BackgroundAudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundAudioTrack> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundAudioTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundAudioTrack> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundAudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundAudioTrack> for ::windows::core::IInspectable {
-    fn from(value: BackgroundAudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundAudioTrack> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundAudioTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundAudioTrack> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundAudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundAudioTrack, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackgroundAudioTrack {}
 unsafe impl ::core::marker::Sync for BackgroundAudioTrack {}
 #[doc = "*Required features: `\"Media_Editing\"`*"]
@@ -660,36 +631,7 @@ unsafe impl ::windows::core::Interface for EmbeddedAudioTrack {
 impl ::windows::core::RuntimeName for EmbeddedAudioTrack {
     const NAME: &'static str = "Windows.Media.Editing.EmbeddedAudioTrack";
 }
-impl ::core::convert::From<EmbeddedAudioTrack> for ::windows::core::IUnknown {
-    fn from(value: EmbeddedAudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmbeddedAudioTrack> for ::windows::core::IUnknown {
-    fn from(value: &EmbeddedAudioTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmbeddedAudioTrack> for &::windows::core::IUnknown {
-    fn from(value: &EmbeddedAudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmbeddedAudioTrack> for ::windows::core::IInspectable {
-    fn from(value: EmbeddedAudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmbeddedAudioTrack> for ::windows::core::IInspectable {
-    fn from(value: &EmbeddedAudioTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmbeddedAudioTrack> for &::windows::core::IInspectable {
-    fn from(value: &EmbeddedAudioTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmbeddedAudioTrack, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EmbeddedAudioTrack {}
 unsafe impl ::core::marker::Sync for EmbeddedAudioTrack {}
 #[doc = "*Required features: `\"Media_Editing\"`*"]
@@ -923,36 +865,7 @@ unsafe impl ::windows::core::Interface for MediaClip {
 impl ::windows::core::RuntimeName for MediaClip {
     const NAME: &'static str = "Windows.Media.Editing.MediaClip";
 }
-impl ::core::convert::From<MediaClip> for ::windows::core::IUnknown {
-    fn from(value: MediaClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaClip> for ::windows::core::IUnknown {
-    fn from(value: &MediaClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaClip> for &::windows::core::IUnknown {
-    fn from(value: &MediaClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaClip> for ::windows::core::IInspectable {
-    fn from(value: MediaClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaClip> for ::windows::core::IInspectable {
-    fn from(value: &MediaClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaClip> for &::windows::core::IInspectable {
-    fn from(value: &MediaClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaClip, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaClip {}
 unsafe impl ::core::marker::Sync for MediaClip {}
 #[doc = "*Required features: `\"Media_Editing\"`*"]
@@ -1174,36 +1087,7 @@ unsafe impl ::windows::core::Interface for MediaComposition {
 impl ::windows::core::RuntimeName for MediaComposition {
     const NAME: &'static str = "Windows.Media.Editing.MediaComposition";
 }
-impl ::core::convert::From<MediaComposition> for ::windows::core::IUnknown {
-    fn from(value: MediaComposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaComposition> for ::windows::core::IUnknown {
-    fn from(value: &MediaComposition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaComposition> for &::windows::core::IUnknown {
-    fn from(value: &MediaComposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaComposition> for ::windows::core::IInspectable {
-    fn from(value: MediaComposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaComposition> for ::windows::core::IInspectable {
-    fn from(value: &MediaComposition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaComposition> for &::windows::core::IInspectable {
-    fn from(value: &MediaComposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaComposition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaComposition {}
 unsafe impl ::core::marker::Sync for MediaComposition {}
 #[doc = "*Required features: `\"Media_Editing\"`*"]
@@ -1328,36 +1212,7 @@ unsafe impl ::windows::core::Interface for MediaOverlay {
 impl ::windows::core::RuntimeName for MediaOverlay {
     const NAME: &'static str = "Windows.Media.Editing.MediaOverlay";
 }
-impl ::core::convert::From<MediaOverlay> for ::windows::core::IUnknown {
-    fn from(value: MediaOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaOverlay> for ::windows::core::IUnknown {
-    fn from(value: &MediaOverlay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaOverlay> for &::windows::core::IUnknown {
-    fn from(value: &MediaOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaOverlay> for ::windows::core::IInspectable {
-    fn from(value: MediaOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaOverlay> for ::windows::core::IInspectable {
-    fn from(value: &MediaOverlay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaOverlay> for &::windows::core::IInspectable {
-    fn from(value: &MediaOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaOverlay, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaOverlay {}
 unsafe impl ::core::marker::Sync for MediaOverlay {}
 #[doc = "*Required features: `\"Media_Editing\"`*"]
@@ -1446,36 +1301,7 @@ unsafe impl ::windows::core::Interface for MediaOverlayLayer {
 impl ::windows::core::RuntimeName for MediaOverlayLayer {
     const NAME: &'static str = "Windows.Media.Editing.MediaOverlayLayer";
 }
-impl ::core::convert::From<MediaOverlayLayer> for ::windows::core::IUnknown {
-    fn from(value: MediaOverlayLayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaOverlayLayer> for ::windows::core::IUnknown {
-    fn from(value: &MediaOverlayLayer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaOverlayLayer> for &::windows::core::IUnknown {
-    fn from(value: &MediaOverlayLayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaOverlayLayer> for ::windows::core::IInspectable {
-    fn from(value: MediaOverlayLayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaOverlayLayer> for ::windows::core::IInspectable {
-    fn from(value: &MediaOverlayLayer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaOverlayLayer> for &::windows::core::IInspectable {
-    fn from(value: &MediaOverlayLayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaOverlayLayer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaOverlayLayer {}
 unsafe impl ::core::marker::Sync for MediaOverlayLayer {}
 #[doc = "*Required features: `\"Media_Editing\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Effects/mod.rs
@@ -60,36 +60,7 @@ impl IAudioEffectDefinition {
         }
     }
 }
-impl ::core::convert::From<IAudioEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: IAudioEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEffectDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: IAudioEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEffectDefinition> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAudioEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &IAudioEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAudioEffectDefinition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -283,36 +254,7 @@ impl IBasicAudioEffect {
         unsafe { (::windows::core::Vtable::vtable(this).SetProperties)(::windows::core::Vtable::as_raw(this), configuration.try_into().map_err(|e| e.into())?.abi()).ok() }
     }
 }
-impl ::core::convert::From<IBasicAudioEffect> for ::windows::core::IUnknown {
-    fn from(value: IBasicAudioEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBasicAudioEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBasicAudioEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBasicAudioEffect> for ::windows::core::IUnknown {
-    fn from(value: &IBasicAudioEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBasicAudioEffect> for ::windows::core::IInspectable {
-    fn from(value: IBasicAudioEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBasicAudioEffect> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBasicAudioEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBasicAudioEffect> for ::windows::core::IInspectable {
-    fn from(value: &IBasicAudioEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBasicAudioEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IBasicAudioEffect> for super::IMediaExtension {
     type Error = ::windows::core::Error;
     fn try_from(value: IBasicAudioEffect) -> ::windows::core::Result<Self> {
@@ -445,36 +387,7 @@ impl IBasicVideoEffect {
         unsafe { (::windows::core::Vtable::vtable(this).SetProperties)(::windows::core::Vtable::as_raw(this), configuration.try_into().map_err(|e| e.into())?.abi()).ok() }
     }
 }
-impl ::core::convert::From<IBasicVideoEffect> for ::windows::core::IUnknown {
-    fn from(value: IBasicVideoEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBasicVideoEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBasicVideoEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBasicVideoEffect> for ::windows::core::IUnknown {
-    fn from(value: &IBasicVideoEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBasicVideoEffect> for ::windows::core::IInspectable {
-    fn from(value: IBasicVideoEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBasicVideoEffect> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBasicVideoEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBasicVideoEffect> for ::windows::core::IInspectable {
-    fn from(value: &IBasicVideoEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBasicVideoEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IBasicVideoEffect> for super::IMediaExtension {
     type Error = ::windows::core::Error;
     fn try_from(value: IBasicVideoEffect) -> ::windows::core::Result<Self> {
@@ -658,36 +571,7 @@ impl IVideoCompositor {
         unsafe { (::windows::core::Vtable::vtable(this).SetProperties)(::windows::core::Vtable::as_raw(this), configuration.try_into().map_err(|e| e.into())?.abi()).ok() }
     }
 }
-impl ::core::convert::From<IVideoCompositor> for ::windows::core::IUnknown {
-    fn from(value: IVideoCompositor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVideoCompositor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVideoCompositor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVideoCompositor> for ::windows::core::IUnknown {
-    fn from(value: &IVideoCompositor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVideoCompositor> for ::windows::core::IInspectable {
-    fn from(value: IVideoCompositor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVideoCompositor> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVideoCompositor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVideoCompositor> for ::windows::core::IInspectable {
-    fn from(value: &IVideoCompositor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVideoCompositor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IVideoCompositor> for super::IMediaExtension {
     type Error = ::windows::core::Error;
     fn try_from(value: IVideoCompositor) -> ::windows::core::Result<Self> {
@@ -770,36 +654,7 @@ impl IVideoCompositorDefinition {
         }
     }
 }
-impl ::core::convert::From<IVideoCompositorDefinition> for ::windows::core::IUnknown {
-    fn from(value: IVideoCompositorDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVideoCompositorDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVideoCompositorDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVideoCompositorDefinition> for ::windows::core::IUnknown {
-    fn from(value: &IVideoCompositorDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVideoCompositorDefinition> for ::windows::core::IInspectable {
-    fn from(value: IVideoCompositorDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVideoCompositorDefinition> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVideoCompositorDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVideoCompositorDefinition> for ::windows::core::IInspectable {
-    fn from(value: &IVideoCompositorDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVideoCompositorDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVideoCompositorDefinition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -879,36 +734,7 @@ impl IVideoEffectDefinition {
         }
     }
 }
-impl ::core::convert::From<IVideoEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: IVideoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVideoEffectDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVideoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVideoEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &IVideoEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVideoEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: IVideoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVideoEffectDefinition> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVideoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVideoEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &IVideoEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVideoEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVideoEffectDefinition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1147,36 +973,7 @@ unsafe impl ::windows::core::Interface for AudioCaptureEffectsManager {
 impl ::windows::core::RuntimeName for AudioCaptureEffectsManager {
     const NAME: &'static str = "Windows.Media.Effects.AudioCaptureEffectsManager";
 }
-impl ::core::convert::From<AudioCaptureEffectsManager> for ::windows::core::IUnknown {
-    fn from(value: AudioCaptureEffectsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioCaptureEffectsManager> for ::windows::core::IUnknown {
-    fn from(value: &AudioCaptureEffectsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioCaptureEffectsManager> for &::windows::core::IUnknown {
-    fn from(value: &AudioCaptureEffectsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioCaptureEffectsManager> for ::windows::core::IInspectable {
-    fn from(value: AudioCaptureEffectsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioCaptureEffectsManager> for ::windows::core::IInspectable {
-    fn from(value: &AudioCaptureEffectsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioCaptureEffectsManager> for &::windows::core::IInspectable {
-    fn from(value: &AudioCaptureEffectsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioCaptureEffectsManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioCaptureEffectsManager {}
 unsafe impl ::core::marker::Sync for AudioCaptureEffectsManager {}
 #[doc = "*Required features: `\"Media_Effects\"`*"]
@@ -1223,36 +1020,7 @@ unsafe impl ::windows::core::Interface for AudioEffect {
 impl ::windows::core::RuntimeName for AudioEffect {
     const NAME: &'static str = "Windows.Media.Effects.AudioEffect";
 }
-impl ::core::convert::From<AudioEffect> for ::windows::core::IUnknown {
-    fn from(value: AudioEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioEffect> for ::windows::core::IUnknown {
-    fn from(value: &AudioEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioEffect> for &::windows::core::IUnknown {
-    fn from(value: &AudioEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioEffect> for ::windows::core::IInspectable {
-    fn from(value: AudioEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioEffect> for ::windows::core::IInspectable {
-    fn from(value: &AudioEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioEffect> for &::windows::core::IInspectable {
-    fn from(value: &AudioEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioEffect {}
 unsafe impl ::core::marker::Sync for AudioEffect {}
 #[doc = "*Required features: `\"Media_Effects\"`*"]
@@ -1331,36 +1099,7 @@ unsafe impl ::windows::core::Interface for AudioEffectDefinition {
 impl ::windows::core::RuntimeName for AudioEffectDefinition {
     const NAME: &'static str = "Windows.Media.Effects.AudioEffectDefinition";
 }
-impl ::core::convert::From<AudioEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: AudioEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &AudioEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioEffectDefinition> for &::windows::core::IUnknown {
-    fn from(value: &AudioEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: AudioEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &AudioEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioEffectDefinition> for &::windows::core::IInspectable {
-    fn from(value: &AudioEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioEffectDefinition> for IAudioEffectDefinition {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioEffectDefinition) -> ::windows::core::Result<Self> {
@@ -1511,36 +1250,7 @@ unsafe impl ::windows::core::Interface for AudioRenderEffectsManager {
 impl ::windows::core::RuntimeName for AudioRenderEffectsManager {
     const NAME: &'static str = "Windows.Media.Effects.AudioRenderEffectsManager";
 }
-impl ::core::convert::From<AudioRenderEffectsManager> for ::windows::core::IUnknown {
-    fn from(value: AudioRenderEffectsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioRenderEffectsManager> for ::windows::core::IUnknown {
-    fn from(value: &AudioRenderEffectsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioRenderEffectsManager> for &::windows::core::IUnknown {
-    fn from(value: &AudioRenderEffectsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioRenderEffectsManager> for ::windows::core::IInspectable {
-    fn from(value: AudioRenderEffectsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioRenderEffectsManager> for ::windows::core::IInspectable {
-    fn from(value: &AudioRenderEffectsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioRenderEffectsManager> for &::windows::core::IInspectable {
-    fn from(value: &AudioRenderEffectsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioRenderEffectsManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioRenderEffectsManager {}
 unsafe impl ::core::marker::Sync for AudioRenderEffectsManager {}
 #[doc = "*Required features: `\"Media_Effects\"`*"]
@@ -1616,36 +1326,7 @@ unsafe impl ::windows::core::Interface for CompositeVideoFrameContext {
 impl ::windows::core::RuntimeName for CompositeVideoFrameContext {
     const NAME: &'static str = "Windows.Media.Effects.CompositeVideoFrameContext";
 }
-impl ::core::convert::From<CompositeVideoFrameContext> for ::windows::core::IUnknown {
-    fn from(value: CompositeVideoFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositeVideoFrameContext> for ::windows::core::IUnknown {
-    fn from(value: &CompositeVideoFrameContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositeVideoFrameContext> for &::windows::core::IUnknown {
-    fn from(value: &CompositeVideoFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositeVideoFrameContext> for ::windows::core::IInspectable {
-    fn from(value: CompositeVideoFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositeVideoFrameContext> for ::windows::core::IInspectable {
-    fn from(value: &CompositeVideoFrameContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositeVideoFrameContext> for &::windows::core::IInspectable {
-    fn from(value: &CompositeVideoFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositeVideoFrameContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CompositeVideoFrameContext {}
 unsafe impl ::core::marker::Sync for CompositeVideoFrameContext {}
 #[doc = "*Required features: `\"Media_Effects\"`*"]
@@ -1699,36 +1380,7 @@ unsafe impl ::windows::core::Interface for ProcessAudioFrameContext {
 impl ::windows::core::RuntimeName for ProcessAudioFrameContext {
     const NAME: &'static str = "Windows.Media.Effects.ProcessAudioFrameContext";
 }
-impl ::core::convert::From<ProcessAudioFrameContext> for ::windows::core::IUnknown {
-    fn from(value: ProcessAudioFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessAudioFrameContext> for ::windows::core::IUnknown {
-    fn from(value: &ProcessAudioFrameContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessAudioFrameContext> for &::windows::core::IUnknown {
-    fn from(value: &ProcessAudioFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessAudioFrameContext> for ::windows::core::IInspectable {
-    fn from(value: ProcessAudioFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessAudioFrameContext> for ::windows::core::IInspectable {
-    fn from(value: &ProcessAudioFrameContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessAudioFrameContext> for &::windows::core::IInspectable {
-    fn from(value: &ProcessAudioFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessAudioFrameContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessAudioFrameContext {}
 unsafe impl ::core::marker::Sync for ProcessAudioFrameContext {}
 #[doc = "*Required features: `\"Media_Effects\"`*"]
@@ -1782,36 +1434,7 @@ unsafe impl ::windows::core::Interface for ProcessVideoFrameContext {
 impl ::windows::core::RuntimeName for ProcessVideoFrameContext {
     const NAME: &'static str = "Windows.Media.Effects.ProcessVideoFrameContext";
 }
-impl ::core::convert::From<ProcessVideoFrameContext> for ::windows::core::IUnknown {
-    fn from(value: ProcessVideoFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessVideoFrameContext> for ::windows::core::IUnknown {
-    fn from(value: &ProcessVideoFrameContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessVideoFrameContext> for &::windows::core::IUnknown {
-    fn from(value: &ProcessVideoFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessVideoFrameContext> for ::windows::core::IInspectable {
-    fn from(value: ProcessVideoFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessVideoFrameContext> for ::windows::core::IInspectable {
-    fn from(value: &ProcessVideoFrameContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessVideoFrameContext> for &::windows::core::IInspectable {
-    fn from(value: &ProcessVideoFrameContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessVideoFrameContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessVideoFrameContext {}
 unsafe impl ::core::marker::Sync for ProcessVideoFrameContext {}
 #[doc = "*Required features: `\"Media_Effects\"`*"]
@@ -1885,36 +1508,7 @@ unsafe impl ::windows::core::Interface for SlowMotionEffectDefinition {
 impl ::windows::core::RuntimeName for SlowMotionEffectDefinition {
     const NAME: &'static str = "Windows.Media.Effects.SlowMotionEffectDefinition";
 }
-impl ::core::convert::From<SlowMotionEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: SlowMotionEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SlowMotionEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &SlowMotionEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SlowMotionEffectDefinition> for &::windows::core::IUnknown {
-    fn from(value: &SlowMotionEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SlowMotionEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: SlowMotionEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SlowMotionEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &SlowMotionEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SlowMotionEffectDefinition> for &::windows::core::IInspectable {
-    fn from(value: &SlowMotionEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SlowMotionEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SlowMotionEffectDefinition> for IVideoEffectDefinition {
     type Error = ::windows::core::Error;
     fn try_from(value: SlowMotionEffectDefinition) -> ::windows::core::Result<Self> {
@@ -2012,36 +1606,7 @@ unsafe impl ::windows::core::Interface for VideoCompositorDefinition {
 impl ::windows::core::RuntimeName for VideoCompositorDefinition {
     const NAME: &'static str = "Windows.Media.Effects.VideoCompositorDefinition";
 }
-impl ::core::convert::From<VideoCompositorDefinition> for ::windows::core::IUnknown {
-    fn from(value: VideoCompositorDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoCompositorDefinition> for ::windows::core::IUnknown {
-    fn from(value: &VideoCompositorDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoCompositorDefinition> for &::windows::core::IUnknown {
-    fn from(value: &VideoCompositorDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoCompositorDefinition> for ::windows::core::IInspectable {
-    fn from(value: VideoCompositorDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoCompositorDefinition> for ::windows::core::IInspectable {
-    fn from(value: &VideoCompositorDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoCompositorDefinition> for &::windows::core::IInspectable {
-    fn from(value: &VideoCompositorDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoCompositorDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VideoCompositorDefinition> for IVideoCompositorDefinition {
     type Error = ::windows::core::Error;
     fn try_from(value: VideoCompositorDefinition) -> ::windows::core::Result<Self> {
@@ -2139,36 +1704,7 @@ unsafe impl ::windows::core::Interface for VideoEffectDefinition {
 impl ::windows::core::RuntimeName for VideoEffectDefinition {
     const NAME: &'static str = "Windows.Media.Effects.VideoEffectDefinition";
 }
-impl ::core::convert::From<VideoEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: VideoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &VideoEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoEffectDefinition> for &::windows::core::IUnknown {
-    fn from(value: &VideoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: VideoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &VideoEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoEffectDefinition> for &::windows::core::IInspectable {
-    fn from(value: &VideoEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VideoEffectDefinition> for IVideoEffectDefinition {
     type Error = ::windows::core::Error;
     fn try_from(value: VideoEffectDefinition) -> ::windows::core::Result<Self> {
@@ -2347,36 +1883,7 @@ unsafe impl ::windows::core::Interface for VideoTransformEffectDefinition {
 impl ::windows::core::RuntimeName for VideoTransformEffectDefinition {
     const NAME: &'static str = "Windows.Media.Effects.VideoTransformEffectDefinition";
 }
-impl ::core::convert::From<VideoTransformEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: VideoTransformEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTransformEffectDefinition> for ::windows::core::IUnknown {
-    fn from(value: &VideoTransformEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTransformEffectDefinition> for &::windows::core::IUnknown {
-    fn from(value: &VideoTransformEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoTransformEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: VideoTransformEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTransformEffectDefinition> for ::windows::core::IInspectable {
-    fn from(value: &VideoTransformEffectDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTransformEffectDefinition> for &::windows::core::IInspectable {
-    fn from(value: &VideoTransformEffectDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoTransformEffectDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VideoTransformEffectDefinition> for IVideoEffectDefinition {
     type Error = ::windows::core::Error;
     fn try_from(value: VideoTransformEffectDefinition) -> ::windows::core::Result<Self> {
@@ -2502,36 +2009,7 @@ unsafe impl ::windows::core::Interface for VideoTransformSphericalProjection {
 impl ::windows::core::RuntimeName for VideoTransformSphericalProjection {
     const NAME: &'static str = "Windows.Media.Effects.VideoTransformSphericalProjection";
 }
-impl ::core::convert::From<VideoTransformSphericalProjection> for ::windows::core::IUnknown {
-    fn from(value: VideoTransformSphericalProjection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTransformSphericalProjection> for ::windows::core::IUnknown {
-    fn from(value: &VideoTransformSphericalProjection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTransformSphericalProjection> for &::windows::core::IUnknown {
-    fn from(value: &VideoTransformSphericalProjection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoTransformSphericalProjection> for ::windows::core::IInspectable {
-    fn from(value: VideoTransformSphericalProjection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoTransformSphericalProjection> for ::windows::core::IInspectable {
-    fn from(value: &VideoTransformSphericalProjection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoTransformSphericalProjection> for &::windows::core::IInspectable {
-    fn from(value: &VideoTransformSphericalProjection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoTransformSphericalProjection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VideoTransformSphericalProjection {}
 unsafe impl ::core::marker::Sync for VideoTransformSphericalProjection {}
 #[doc = "*Required features: `\"Media_Effects\"`*"]

--- a/crates/libs/windows/src/Windows/Media/FaceAnalysis/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/FaceAnalysis/mod.rs
@@ -188,36 +188,7 @@ unsafe impl ::windows::core::Interface for DetectedFace {
 impl ::windows::core::RuntimeName for DetectedFace {
     const NAME: &'static str = "Windows.Media.FaceAnalysis.DetectedFace";
 }
-impl ::core::convert::From<DetectedFace> for ::windows::core::IUnknown {
-    fn from(value: DetectedFace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DetectedFace> for ::windows::core::IUnknown {
-    fn from(value: &DetectedFace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DetectedFace> for &::windows::core::IUnknown {
-    fn from(value: &DetectedFace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DetectedFace> for ::windows::core::IInspectable {
-    fn from(value: DetectedFace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DetectedFace> for ::windows::core::IInspectable {
-    fn from(value: &DetectedFace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DetectedFace> for &::windows::core::IInspectable {
-    fn from(value: &DetectedFace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DetectedFace, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DetectedFace {}
 unsafe impl ::core::marker::Sync for DetectedFace {}
 #[doc = "*Required features: `\"Media_FaceAnalysis\"`*"]
@@ -340,36 +311,7 @@ unsafe impl ::windows::core::Interface for FaceDetector {
 impl ::windows::core::RuntimeName for FaceDetector {
     const NAME: &'static str = "Windows.Media.FaceAnalysis.FaceDetector";
 }
-impl ::core::convert::From<FaceDetector> for ::windows::core::IUnknown {
-    fn from(value: FaceDetector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FaceDetector> for ::windows::core::IUnknown {
-    fn from(value: &FaceDetector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FaceDetector> for &::windows::core::IUnknown {
-    fn from(value: &FaceDetector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FaceDetector> for ::windows::core::IInspectable {
-    fn from(value: FaceDetector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FaceDetector> for ::windows::core::IInspectable {
-    fn from(value: &FaceDetector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FaceDetector> for &::windows::core::IInspectable {
-    fn from(value: &FaceDetector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FaceDetector, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FaceDetector {}
 unsafe impl ::core::marker::Sync for FaceDetector {}
 #[doc = "*Required features: `\"Media_FaceAnalysis\"`*"]
@@ -483,36 +425,7 @@ unsafe impl ::windows::core::Interface for FaceTracker {
 impl ::windows::core::RuntimeName for FaceTracker {
     const NAME: &'static str = "Windows.Media.FaceAnalysis.FaceTracker";
 }
-impl ::core::convert::From<FaceTracker> for ::windows::core::IUnknown {
-    fn from(value: FaceTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FaceTracker> for ::windows::core::IUnknown {
-    fn from(value: &FaceTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FaceTracker> for &::windows::core::IUnknown {
-    fn from(value: &FaceTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FaceTracker> for ::windows::core::IInspectable {
-    fn from(value: FaceTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FaceTracker> for ::windows::core::IInspectable {
-    fn from(value: &FaceTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FaceTracker> for &::windows::core::IInspectable {
-    fn from(value: &FaceTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FaceTracker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FaceTracker {}
 unsafe impl ::core::marker::Sync for FaceTracker {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Media/Import/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Import/mod.rs
@@ -609,36 +609,7 @@ unsafe impl ::windows::core::Interface for PhotoImportDeleteImportedItemsFromSou
 impl ::windows::core::RuntimeName for PhotoImportDeleteImportedItemsFromSourceResult {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportDeleteImportedItemsFromSourceResult";
 }
-impl ::core::convert::From<PhotoImportDeleteImportedItemsFromSourceResult> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportDeleteImportedItemsFromSourceResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportDeleteImportedItemsFromSourceResult> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportDeleteImportedItemsFromSourceResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportDeleteImportedItemsFromSourceResult> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportDeleteImportedItemsFromSourceResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportDeleteImportedItemsFromSourceResult> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportDeleteImportedItemsFromSourceResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportDeleteImportedItemsFromSourceResult> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportDeleteImportedItemsFromSourceResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportDeleteImportedItemsFromSourceResult> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportDeleteImportedItemsFromSourceResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportDeleteImportedItemsFromSourceResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoImportDeleteImportedItemsFromSourceResult {}
 unsafe impl ::core::marker::Sync for PhotoImportDeleteImportedItemsFromSourceResult {}
 #[doc = "*Required features: `\"Media_Import\"`*"]
@@ -914,36 +885,7 @@ unsafe impl ::windows::core::Interface for PhotoImportFindItemsResult {
 impl ::windows::core::RuntimeName for PhotoImportFindItemsResult {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportFindItemsResult";
 }
-impl ::core::convert::From<PhotoImportFindItemsResult> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportFindItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportFindItemsResult> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportFindItemsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportFindItemsResult> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportFindItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportFindItemsResult> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportFindItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportFindItemsResult> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportFindItemsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportFindItemsResult> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportFindItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportFindItemsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoImportFindItemsResult {}
 unsafe impl ::core::marker::Sync for PhotoImportFindItemsResult {}
 #[doc = "*Required features: `\"Media_Import\"`*"]
@@ -1085,36 +1027,7 @@ unsafe impl ::windows::core::Interface for PhotoImportImportItemsResult {
 impl ::windows::core::RuntimeName for PhotoImportImportItemsResult {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportImportItemsResult";
 }
-impl ::core::convert::From<PhotoImportImportItemsResult> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportImportItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportImportItemsResult> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportImportItemsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportImportItemsResult> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportImportItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportImportItemsResult> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportImportItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportImportItemsResult> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportImportItemsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportImportItemsResult> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportImportItemsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportImportItemsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoImportImportItemsResult {}
 unsafe impl ::core::marker::Sync for PhotoImportImportItemsResult {}
 #[doc = "*Required features: `\"Media_Import\"`*"]
@@ -1261,36 +1174,7 @@ unsafe impl ::windows::core::Interface for PhotoImportItem {
 impl ::windows::core::RuntimeName for PhotoImportItem {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportItem";
 }
-impl ::core::convert::From<PhotoImportItem> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportItem> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportItem> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportItem> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportItem> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportItem> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoImportItem {}
 unsafe impl ::core::marker::Sync for PhotoImportItem {}
 #[doc = "*Required features: `\"Media_Import\"`*"]
@@ -1337,36 +1221,7 @@ unsafe impl ::windows::core::Interface for PhotoImportItemImportedEventArgs {
 impl ::windows::core::RuntimeName for PhotoImportItemImportedEventArgs {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportItemImportedEventArgs";
 }
-impl ::core::convert::From<PhotoImportItemImportedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportItemImportedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportItemImportedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportItemImportedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportItemImportedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportItemImportedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportItemImportedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportItemImportedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportItemImportedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportItemImportedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportItemImportedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportItemImportedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportItemImportedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoImportItemImportedEventArgs {}
 unsafe impl ::core::marker::Sync for PhotoImportItemImportedEventArgs {}
 #[doc = "*Required features: `\"Media_Import\"`*"]
@@ -1483,36 +1338,7 @@ unsafe impl ::windows::core::Interface for PhotoImportOperation {
 impl ::windows::core::RuntimeName for PhotoImportOperation {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportOperation";
 }
-impl ::core::convert::From<PhotoImportOperation> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportOperation> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportOperation> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportOperation> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportOperation> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportOperation> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoImportOperation {}
 unsafe impl ::core::marker::Sync for PhotoImportOperation {}
 #[doc = "*Required features: `\"Media_Import\"`*"]
@@ -1559,36 +1385,7 @@ unsafe impl ::windows::core::Interface for PhotoImportSelectionChangedEventArgs 
 impl ::windows::core::RuntimeName for PhotoImportSelectionChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportSelectionChangedEventArgs";
 }
-impl ::core::convert::From<PhotoImportSelectionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportSelectionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportSelectionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportSelectionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportSelectionChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportSelectionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportSelectionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportSelectionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportSelectionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportSelectionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportSelectionChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportSelectionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportSelectionChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoImportSelectionChangedEventArgs {}
 unsafe impl ::core::marker::Sync for PhotoImportSelectionChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Import\"`*"]
@@ -1731,36 +1528,7 @@ unsafe impl ::windows::core::Interface for PhotoImportSession {
 impl ::windows::core::RuntimeName for PhotoImportSession {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportSession";
 }
-impl ::core::convert::From<PhotoImportSession> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportSession> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportSession> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportSession> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportSession> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportSession> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<PhotoImportSession> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1845,36 +1613,7 @@ unsafe impl ::windows::core::Interface for PhotoImportSidecar {
 impl ::windows::core::RuntimeName for PhotoImportSidecar {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportSidecar";
 }
-impl ::core::convert::From<PhotoImportSidecar> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportSidecar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportSidecar> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportSidecar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportSidecar> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportSidecar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportSidecar> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportSidecar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportSidecar> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportSidecar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportSidecar> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportSidecar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportSidecar, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoImportSidecar {}
 unsafe impl ::core::marker::Sync for PhotoImportSidecar {}
 #[doc = "*Required features: `\"Media_Import\"`*"]
@@ -2068,36 +1807,7 @@ unsafe impl ::windows::core::Interface for PhotoImportSource {
 impl ::windows::core::RuntimeName for PhotoImportSource {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportSource";
 }
-impl ::core::convert::From<PhotoImportSource> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportSource> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportSource> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportSource> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportSource> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportSource> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoImportSource {}
 unsafe impl ::core::marker::Sync for PhotoImportSource {}
 #[doc = "*Required features: `\"Media_Import\"`*"]
@@ -2190,36 +1900,7 @@ unsafe impl ::windows::core::Interface for PhotoImportStorageMedium {
 impl ::windows::core::RuntimeName for PhotoImportStorageMedium {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportStorageMedium";
 }
-impl ::core::convert::From<PhotoImportStorageMedium> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportStorageMedium) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportStorageMedium> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportStorageMedium) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportStorageMedium> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportStorageMedium) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportStorageMedium> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportStorageMedium) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportStorageMedium> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportStorageMedium) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportStorageMedium> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportStorageMedium) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportStorageMedium, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoImportStorageMedium {}
 unsafe impl ::core::marker::Sync for PhotoImportStorageMedium {}
 #[doc = "*Required features: `\"Media_Import\"`*"]
@@ -2298,36 +1979,7 @@ unsafe impl ::windows::core::Interface for PhotoImportVideoSegment {
 impl ::windows::core::RuntimeName for PhotoImportVideoSegment {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportVideoSegment";
 }
-impl ::core::convert::From<PhotoImportVideoSegment> for ::windows::core::IUnknown {
-    fn from(value: PhotoImportVideoSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportVideoSegment> for ::windows::core::IUnknown {
-    fn from(value: &PhotoImportVideoSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportVideoSegment> for &::windows::core::IUnknown {
-    fn from(value: &PhotoImportVideoSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhotoImportVideoSegment> for ::windows::core::IInspectable {
-    fn from(value: PhotoImportVideoSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhotoImportVideoSegment> for ::windows::core::IInspectable {
-    fn from(value: &PhotoImportVideoSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhotoImportVideoSegment> for &::windows::core::IInspectable {
-    fn from(value: &PhotoImportVideoSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhotoImportVideoSegment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PhotoImportVideoSegment {}
 unsafe impl ::core::marker::Sync for PhotoImportVideoSegment {}
 #[doc = "*Required features: `\"Media_Import\"`*"]

--- a/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
@@ -399,36 +399,7 @@ impl IMediaEncodingProperties {
         }
     }
 }
-impl ::core::convert::From<IMediaEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: IMediaEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaEncodingProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: &IMediaEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: IMediaEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaEncodingProperties> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: &IMediaEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaEncodingProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMediaEncodingProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -984,36 +955,7 @@ unsafe impl ::windows::core::Interface for AudioEncodingProperties {
 impl ::windows::core::RuntimeName for AudioEncodingProperties {
     const NAME: &'static str = "Windows.Media.MediaProperties.AudioEncodingProperties";
 }
-impl ::core::convert::From<AudioEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: AudioEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: &AudioEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioEncodingProperties> for &::windows::core::IUnknown {
-    fn from(value: &AudioEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: AudioEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: &AudioEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioEncodingProperties> for &::windows::core::IInspectable {
-    fn from(value: &AudioEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioEncodingProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AudioEncodingProperties> for IMediaEncodingProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: AudioEncodingProperties) -> ::windows::core::Result<Self> {
@@ -1113,36 +1055,7 @@ unsafe impl ::windows::core::Interface for ContainerEncodingProperties {
 impl ::windows::core::RuntimeName for ContainerEncodingProperties {
     const NAME: &'static str = "Windows.Media.MediaProperties.ContainerEncodingProperties";
 }
-impl ::core::convert::From<ContainerEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: ContainerEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContainerEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: &ContainerEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContainerEncodingProperties> for &::windows::core::IUnknown {
-    fn from(value: &ContainerEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContainerEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: ContainerEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContainerEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: &ContainerEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContainerEncodingProperties> for &::windows::core::IInspectable {
-    fn from(value: &ContainerEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContainerEncodingProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContainerEncodingProperties> for IMediaEncodingProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: ContainerEncodingProperties) -> ::windows::core::Result<Self> {
@@ -1387,36 +1300,7 @@ unsafe impl ::windows::core::Interface for ImageEncodingProperties {
 impl ::windows::core::RuntimeName for ImageEncodingProperties {
     const NAME: &'static str = "Windows.Media.MediaProperties.ImageEncodingProperties";
 }
-impl ::core::convert::From<ImageEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: ImageEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: &ImageEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageEncodingProperties> for &::windows::core::IUnknown {
-    fn from(value: &ImageEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: ImageEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: &ImageEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageEncodingProperties> for &::windows::core::IInspectable {
-    fn from(value: &ImageEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageEncodingProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ImageEncodingProperties> for IMediaEncodingProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: ImageEncodingProperties) -> ::windows::core::Result<Self> {
@@ -1671,36 +1555,7 @@ unsafe impl ::windows::core::Interface for MediaEncodingProfile {
 impl ::windows::core::RuntimeName for MediaEncodingProfile {
     const NAME: &'static str = "Windows.Media.MediaProperties.MediaEncodingProfile";
 }
-impl ::core::convert::From<MediaEncodingProfile> for ::windows::core::IUnknown {
-    fn from(value: MediaEncodingProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaEncodingProfile> for ::windows::core::IUnknown {
-    fn from(value: &MediaEncodingProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaEncodingProfile> for &::windows::core::IUnknown {
-    fn from(value: &MediaEncodingProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaEncodingProfile> for ::windows::core::IInspectable {
-    fn from(value: MediaEncodingProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaEncodingProfile> for ::windows::core::IInspectable {
-    fn from(value: &MediaEncodingProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaEncodingProfile> for &::windows::core::IInspectable {
-    fn from(value: &MediaEncodingProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaEncodingProfile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaEncodingProfile {}
 unsafe impl ::core::marker::Sync for MediaEncodingProfile {}
 #[doc = "*Required features: `\"Media_MediaProperties\"`*"]
@@ -2192,41 +2047,7 @@ impl ::core::iter::IntoIterator for &MediaPropertySet {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<MediaPropertySet> for ::windows::core::IUnknown {
-    fn from(value: MediaPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&MediaPropertySet> for ::windows::core::IUnknown {
-    fn from(value: &MediaPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&MediaPropertySet> for &::windows::core::IUnknown {
-    fn from(value: &MediaPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<MediaPropertySet> for ::windows::core::IInspectable {
-    fn from(value: MediaPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&MediaPropertySet> for ::windows::core::IInspectable {
-    fn from(value: &MediaPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&MediaPropertySet> for &::windows::core::IInspectable {
-    fn from(value: &MediaPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPropertySet, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<MediaPropertySet> for super::super::Foundation::Collections::IIterable<super::super::Foundation::Collections::IKeyValuePair<::windows::core::GUID, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
@@ -2334,36 +2155,7 @@ unsafe impl ::windows::core::Interface for MediaRatio {
 impl ::windows::core::RuntimeName for MediaRatio {
     const NAME: &'static str = "Windows.Media.MediaProperties.MediaRatio";
 }
-impl ::core::convert::From<MediaRatio> for ::windows::core::IUnknown {
-    fn from(value: MediaRatio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaRatio> for ::windows::core::IUnknown {
-    fn from(value: &MediaRatio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaRatio> for &::windows::core::IUnknown {
-    fn from(value: &MediaRatio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaRatio> for ::windows::core::IInspectable {
-    fn from(value: MediaRatio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaRatio> for ::windows::core::IInspectable {
-    fn from(value: &MediaRatio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaRatio> for &::windows::core::IInspectable {
-    fn from(value: &MediaRatio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaRatio, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaRatio {}
 unsafe impl ::core::marker::Sync for MediaRatio {}
 #[doc = "*Required features: `\"Media_MediaProperties\"`*"]
@@ -2523,36 +2315,7 @@ unsafe impl ::windows::core::Interface for TimedMetadataEncodingProperties {
 impl ::windows::core::RuntimeName for TimedMetadataEncodingProperties {
     const NAME: &'static str = "Windows.Media.MediaProperties.TimedMetadataEncodingProperties";
 }
-impl ::core::convert::From<TimedMetadataEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: TimedMetadataEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: &TimedMetadataEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataEncodingProperties> for &::windows::core::IUnknown {
-    fn from(value: &TimedMetadataEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedMetadataEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: TimedMetadataEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: &TimedMetadataEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataEncodingProperties> for &::windows::core::IInspectable {
-    fn from(value: &TimedMetadataEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedMetadataEncodingProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<TimedMetadataEncodingProperties> for IMediaEncodingProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: TimedMetadataEncodingProperties) -> ::windows::core::Result<Self> {
@@ -2766,36 +2529,7 @@ unsafe impl ::windows::core::Interface for VideoEncodingProperties {
 impl ::windows::core::RuntimeName for VideoEncodingProperties {
     const NAME: &'static str = "Windows.Media.MediaProperties.VideoEncodingProperties";
 }
-impl ::core::convert::From<VideoEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: VideoEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoEncodingProperties> for ::windows::core::IUnknown {
-    fn from(value: &VideoEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoEncodingProperties> for &::windows::core::IUnknown {
-    fn from(value: &VideoEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: VideoEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoEncodingProperties> for ::windows::core::IInspectable {
-    fn from(value: &VideoEncodingProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoEncodingProperties> for &::windows::core::IInspectable {
-    fn from(value: &VideoEncodingProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoEncodingProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VideoEncodingProperties> for IMediaEncodingProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: VideoEncodingProperties) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Media/Miracast/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Miracast/mod.rs
@@ -614,36 +614,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiver {
 impl ::windows::core::RuntimeName for MiracastReceiver {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiver";
 }
-impl ::core::convert::From<MiracastReceiver> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiver> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiver> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiver> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiver> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiver> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiver, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiver {}
 unsafe impl ::core::marker::Sync for MiracastReceiver {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -697,36 +668,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverApplySettingsResult {
 impl ::windows::core::RuntimeName for MiracastReceiverApplySettingsResult {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverApplySettingsResult";
 }
-impl ::core::convert::From<MiracastReceiverApplySettingsResult> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverApplySettingsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverApplySettingsResult> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverApplySettingsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverApplySettingsResult> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverApplySettingsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverApplySettingsResult> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverApplySettingsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverApplySettingsResult> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverApplySettingsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverApplySettingsResult> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverApplySettingsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverApplySettingsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverApplySettingsResult {}
 unsafe impl ::core::marker::Sync for MiracastReceiverApplySettingsResult {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -834,36 +776,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverConnection {
 impl ::windows::core::RuntimeName for MiracastReceiverConnection {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverConnection";
 }
-impl ::core::convert::From<MiracastReceiverConnection> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverConnection> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverConnection> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverConnection> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverConnection> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverConnection> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MiracastReceiverConnection> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -948,36 +861,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverConnectionCreatedEven
 impl ::windows::core::RuntimeName for MiracastReceiverConnectionCreatedEventArgs {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverConnectionCreatedEventArgs";
 }
-impl ::core::convert::From<MiracastReceiverConnectionCreatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverConnectionCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverConnectionCreatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverConnectionCreatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverConnectionCreatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverConnectionCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverConnectionCreatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverConnectionCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverConnectionCreatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverConnectionCreatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverConnectionCreatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverConnectionCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverConnectionCreatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverConnectionCreatedEventArgs {}
 unsafe impl ::core::marker::Sync for MiracastReceiverConnectionCreatedEventArgs {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -1081,36 +965,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverCursorImageChannel {
 impl ::windows::core::RuntimeName for MiracastReceiverCursorImageChannel {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverCursorImageChannel";
 }
-impl ::core::convert::From<MiracastReceiverCursorImageChannel> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverCursorImageChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverCursorImageChannel> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverCursorImageChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverCursorImageChannel> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverCursorImageChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverCursorImageChannel> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverCursorImageChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverCursorImageChannel> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverCursorImageChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverCursorImageChannel> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverCursorImageChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverCursorImageChannel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverCursorImageChannel {}
 unsafe impl ::core::marker::Sync for MiracastReceiverCursorImageChannel {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -1176,36 +1031,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverCursorImageChannelSet
 impl ::windows::core::RuntimeName for MiracastReceiverCursorImageChannelSettings {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverCursorImageChannelSettings";
 }
-impl ::core::convert::From<MiracastReceiverCursorImageChannelSettings> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverCursorImageChannelSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverCursorImageChannelSettings> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverCursorImageChannelSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverCursorImageChannelSettings> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverCursorImageChannelSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverCursorImageChannelSettings> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverCursorImageChannelSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverCursorImageChannelSettings> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverCursorImageChannelSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverCursorImageChannelSettings> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverCursorImageChannelSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverCursorImageChannelSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverCursorImageChannelSettings {}
 unsafe impl ::core::marker::Sync for MiracastReceiverCursorImageChannelSettings {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -1252,36 +1078,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverDisconnectedEventArgs
 impl ::windows::core::RuntimeName for MiracastReceiverDisconnectedEventArgs {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverDisconnectedEventArgs";
 }
-impl ::core::convert::From<MiracastReceiverDisconnectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverDisconnectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverDisconnectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverDisconnectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverDisconnectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverDisconnectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverDisconnectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverDisconnectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverDisconnectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverDisconnectedEventArgs {}
 unsafe impl ::core::marker::Sync for MiracastReceiverDisconnectedEventArgs {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -1372,36 +1169,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverGameControllerDevice 
 impl ::windows::core::RuntimeName for MiracastReceiverGameControllerDevice {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverGameControllerDevice";
 }
-impl ::core::convert::From<MiracastReceiverGameControllerDevice> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverGameControllerDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverGameControllerDevice> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverGameControllerDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverGameControllerDevice> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverGameControllerDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverGameControllerDevice> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverGameControllerDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverGameControllerDevice> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverGameControllerDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverGameControllerDevice> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverGameControllerDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverGameControllerDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverGameControllerDevice {}
 unsafe impl ::core::marker::Sync for MiracastReceiverGameControllerDevice {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -1455,36 +1223,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverInputDevices {
 impl ::windows::core::RuntimeName for MiracastReceiverInputDevices {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverInputDevices";
 }
-impl ::core::convert::From<MiracastReceiverInputDevices> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverInputDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverInputDevices> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverInputDevices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverInputDevices> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverInputDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverInputDevices> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverInputDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverInputDevices> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverInputDevices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverInputDevices> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverInputDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverInputDevices, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverInputDevices {}
 unsafe impl ::core::marker::Sync for MiracastReceiverInputDevices {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -1564,36 +1303,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverKeyboardDevice {
 impl ::windows::core::RuntimeName for MiracastReceiverKeyboardDevice {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverKeyboardDevice";
 }
-impl ::core::convert::From<MiracastReceiverKeyboardDevice> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverKeyboardDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverKeyboardDevice> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverKeyboardDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverKeyboardDevice> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverKeyboardDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverKeyboardDevice> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverKeyboardDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverKeyboardDevice> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverKeyboardDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverKeyboardDevice> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverKeyboardDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverKeyboardDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverKeyboardDevice {}
 unsafe impl ::core::marker::Sync for MiracastReceiverKeyboardDevice {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -1665,36 +1375,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverMediaSourceCreatedEve
 impl ::windows::core::RuntimeName for MiracastReceiverMediaSourceCreatedEventArgs {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverMediaSourceCreatedEventArgs";
 }
-impl ::core::convert::From<MiracastReceiverMediaSourceCreatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverMediaSourceCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverMediaSourceCreatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverMediaSourceCreatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverMediaSourceCreatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverMediaSourceCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverMediaSourceCreatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverMediaSourceCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverMediaSourceCreatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverMediaSourceCreatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverMediaSourceCreatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverMediaSourceCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverMediaSourceCreatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverMediaSourceCreatedEventArgs {}
 unsafe impl ::core::marker::Sync for MiracastReceiverMediaSourceCreatedEventArgs {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -1823,36 +1504,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverSession {
 impl ::windows::core::RuntimeName for MiracastReceiverSession {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverSession";
 }
-impl ::core::convert::From<MiracastReceiverSession> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSession> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSession> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverSession> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSession> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSession> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MiracastReceiverSession> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1928,36 +1580,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverSessionStartResult {
 impl ::windows::core::RuntimeName for MiracastReceiverSessionStartResult {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverSessionStartResult";
 }
-impl ::core::convert::From<MiracastReceiverSessionStartResult> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverSessionStartResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSessionStartResult> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverSessionStartResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSessionStartResult> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverSessionStartResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverSessionStartResult> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverSessionStartResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSessionStartResult> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverSessionStartResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSessionStartResult> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverSessionStartResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverSessionStartResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverSessionStartResult {}
 unsafe impl ::core::marker::Sync for MiracastReceiverSessionStartResult {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -2052,36 +1675,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverSettings {
 impl ::windows::core::RuntimeName for MiracastReceiverSettings {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverSettings";
 }
-impl ::core::convert::From<MiracastReceiverSettings> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSettings> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSettings> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverSettings> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSettings> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverSettings> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverSettings {}
 unsafe impl ::core::marker::Sync for MiracastReceiverSettings {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -2158,36 +1752,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverStatus {
 impl ::windows::core::RuntimeName for MiracastReceiverStatus {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverStatus";
 }
-impl ::core::convert::From<MiracastReceiverStatus> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverStatus> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverStatus> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverStatus> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverStatus> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverStatus> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverStatus, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverStatus {}
 unsafe impl ::core::marker::Sync for MiracastReceiverStatus {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -2267,36 +1832,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverStreamControl {
 impl ::windows::core::RuntimeName for MiracastReceiverStreamControl {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverStreamControl";
 }
-impl ::core::convert::From<MiracastReceiverStreamControl> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverStreamControl> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverStreamControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverStreamControl> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverStreamControl> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverStreamControl> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverStreamControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverStreamControl> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverStreamControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverStreamControl {}
 unsafe impl ::core::marker::Sync for MiracastReceiverStreamControl {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -2362,36 +1898,7 @@ unsafe impl ::windows::core::Interface for MiracastReceiverVideoStreamSettings {
 impl ::windows::core::RuntimeName for MiracastReceiverVideoStreamSettings {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastReceiverVideoStreamSettings";
 }
-impl ::core::convert::From<MiracastReceiverVideoStreamSettings> for ::windows::core::IUnknown {
-    fn from(value: MiracastReceiverVideoStreamSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverVideoStreamSettings> for ::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverVideoStreamSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverVideoStreamSettings> for &::windows::core::IUnknown {
-    fn from(value: &MiracastReceiverVideoStreamSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastReceiverVideoStreamSettings> for ::windows::core::IInspectable {
-    fn from(value: MiracastReceiverVideoStreamSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastReceiverVideoStreamSettings> for ::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverVideoStreamSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastReceiverVideoStreamSettings> for &::windows::core::IInspectable {
-    fn from(value: &MiracastReceiverVideoStreamSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastReceiverVideoStreamSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastReceiverVideoStreamSettings {}
 unsafe impl ::core::marker::Sync for MiracastReceiverVideoStreamSettings {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]
@@ -2478,36 +1985,7 @@ unsafe impl ::windows::core::Interface for MiracastTransmitter {
 impl ::windows::core::RuntimeName for MiracastTransmitter {
     const NAME: &'static str = "Windows.Media.Miracast.MiracastTransmitter";
 }
-impl ::core::convert::From<MiracastTransmitter> for ::windows::core::IUnknown {
-    fn from(value: MiracastTransmitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastTransmitter> for ::windows::core::IUnknown {
-    fn from(value: &MiracastTransmitter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastTransmitter> for &::windows::core::IUnknown {
-    fn from(value: &MiracastTransmitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MiracastTransmitter> for ::windows::core::IInspectable {
-    fn from(value: MiracastTransmitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MiracastTransmitter> for ::windows::core::IInspectable {
-    fn from(value: &MiracastTransmitter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MiracastTransmitter> for &::windows::core::IInspectable {
-    fn from(value: &MiracastTransmitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MiracastTransmitter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MiracastTransmitter {}
 unsafe impl ::core::marker::Sync for MiracastTransmitter {}
 #[doc = "*Required features: `\"Media_Miracast\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Ocr/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Ocr/mod.rs
@@ -205,36 +205,7 @@ unsafe impl ::windows::core::Interface for OcrEngine {
 impl ::windows::core::RuntimeName for OcrEngine {
     const NAME: &'static str = "Windows.Media.Ocr.OcrEngine";
 }
-impl ::core::convert::From<OcrEngine> for ::windows::core::IUnknown {
-    fn from(value: OcrEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OcrEngine> for ::windows::core::IUnknown {
-    fn from(value: &OcrEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OcrEngine> for &::windows::core::IUnknown {
-    fn from(value: &OcrEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OcrEngine> for ::windows::core::IInspectable {
-    fn from(value: OcrEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OcrEngine> for ::windows::core::IInspectable {
-    fn from(value: &OcrEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OcrEngine> for &::windows::core::IInspectable {
-    fn from(value: &OcrEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OcrEngine, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OcrEngine {}
 unsafe impl ::core::marker::Sync for OcrEngine {}
 #[doc = "*Required features: `\"Media_Ocr\"`*"]
@@ -290,36 +261,7 @@ unsafe impl ::windows::core::Interface for OcrLine {
 impl ::windows::core::RuntimeName for OcrLine {
     const NAME: &'static str = "Windows.Media.Ocr.OcrLine";
 }
-impl ::core::convert::From<OcrLine> for ::windows::core::IUnknown {
-    fn from(value: OcrLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OcrLine> for ::windows::core::IUnknown {
-    fn from(value: &OcrLine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OcrLine> for &::windows::core::IUnknown {
-    fn from(value: &OcrLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OcrLine> for ::windows::core::IInspectable {
-    fn from(value: OcrLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OcrLine> for ::windows::core::IInspectable {
-    fn from(value: &OcrLine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OcrLine> for &::windows::core::IInspectable {
-    fn from(value: &OcrLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OcrLine, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OcrLine {}
 unsafe impl ::core::marker::Sync for OcrLine {}
 #[doc = "*Required features: `\"Media_Ocr\"`*"]
@@ -384,36 +326,7 @@ unsafe impl ::windows::core::Interface for OcrResult {
 impl ::windows::core::RuntimeName for OcrResult {
     const NAME: &'static str = "Windows.Media.Ocr.OcrResult";
 }
-impl ::core::convert::From<OcrResult> for ::windows::core::IUnknown {
-    fn from(value: OcrResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OcrResult> for ::windows::core::IUnknown {
-    fn from(value: &OcrResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OcrResult> for &::windows::core::IUnknown {
-    fn from(value: &OcrResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OcrResult> for ::windows::core::IInspectable {
-    fn from(value: OcrResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OcrResult> for ::windows::core::IInspectable {
-    fn from(value: &OcrResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OcrResult> for &::windows::core::IInspectable {
-    fn from(value: &OcrResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OcrResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OcrResult {}
 unsafe impl ::core::marker::Sync for OcrResult {}
 #[doc = "*Required features: `\"Media_Ocr\"`*"]
@@ -469,36 +382,7 @@ unsafe impl ::windows::core::Interface for OcrWord {
 impl ::windows::core::RuntimeName for OcrWord {
     const NAME: &'static str = "Windows.Media.Ocr.OcrWord";
 }
-impl ::core::convert::From<OcrWord> for ::windows::core::IUnknown {
-    fn from(value: OcrWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OcrWord> for ::windows::core::IUnknown {
-    fn from(value: &OcrWord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OcrWord> for &::windows::core::IUnknown {
-    fn from(value: &OcrWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OcrWord> for ::windows::core::IInspectable {
-    fn from(value: OcrWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OcrWord> for ::windows::core::IInspectable {
-    fn from(value: &OcrWord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OcrWord> for &::windows::core::IInspectable {
-    fn from(value: &OcrWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OcrWord, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OcrWord {}
 unsafe impl ::core::marker::Sync for OcrWord {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Media/PlayTo/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/PlayTo/mod.rs
@@ -638,36 +638,7 @@ unsafe impl ::windows::core::Interface for CurrentTimeChangeRequestedEventArgs {
 impl ::windows::core::RuntimeName for CurrentTimeChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.CurrentTimeChangeRequestedEventArgs";
 }
-impl ::core::convert::From<CurrentTimeChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CurrentTimeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CurrentTimeChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CurrentTimeChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CurrentTimeChangeRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CurrentTimeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CurrentTimeChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CurrentTimeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CurrentTimeChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CurrentTimeChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CurrentTimeChangeRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CurrentTimeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CurrentTimeChangeRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_PlayTo\"`*"]
 #[repr(transparent)]
 pub struct MuteChangeRequestedEventArgs(::windows::core::IUnknown);
@@ -712,36 +683,7 @@ unsafe impl ::windows::core::Interface for MuteChangeRequestedEventArgs {
 impl ::windows::core::RuntimeName for MuteChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.MuteChangeRequestedEventArgs";
 }
-impl ::core::convert::From<MuteChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MuteChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MuteChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MuteChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MuteChangeRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MuteChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MuteChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MuteChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MuteChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MuteChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MuteChangeRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MuteChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MuteChangeRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_PlayTo\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -844,41 +786,7 @@ impl ::windows::core::RuntimeName for PlayToConnection {
     const NAME: &'static str = "Windows.Media.PlayTo.PlayToConnection";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToConnection> for ::windows::core::IUnknown {
-    fn from(value: PlayToConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnection> for ::windows::core::IUnknown {
-    fn from(value: &PlayToConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnection> for &::windows::core::IUnknown {
-    fn from(value: &PlayToConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToConnection> for ::windows::core::IInspectable {
-    fn from(value: PlayToConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnection> for ::windows::core::IInspectable {
-    fn from(value: &PlayToConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnection> for &::windows::core::IInspectable {
-    fn from(value: &PlayToConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayToConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PlayToConnection {}
 #[cfg(feature = "deprecated")]
@@ -949,41 +857,7 @@ impl ::windows::core::RuntimeName for PlayToConnectionErrorEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.PlayToConnectionErrorEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToConnectionErrorEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PlayToConnectionErrorEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionErrorEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PlayToConnectionErrorEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionErrorEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PlayToConnectionErrorEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToConnectionErrorEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PlayToConnectionErrorEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionErrorEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PlayToConnectionErrorEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionErrorEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PlayToConnectionErrorEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayToConnectionErrorEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PlayToConnectionErrorEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -1054,41 +928,7 @@ impl ::windows::core::RuntimeName for PlayToConnectionStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.PlayToConnectionStateChangedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToConnectionStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PlayToConnectionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PlayToConnectionStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PlayToConnectionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToConnectionStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PlayToConnectionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PlayToConnectionStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PlayToConnectionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayToConnectionStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PlayToConnectionStateChangedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -1159,41 +999,7 @@ impl ::windows::core::RuntimeName for PlayToConnectionTransferredEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.PlayToConnectionTransferredEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToConnectionTransferredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PlayToConnectionTransferredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionTransferredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PlayToConnectionTransferredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionTransferredEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PlayToConnectionTransferredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToConnectionTransferredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PlayToConnectionTransferredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionTransferredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PlayToConnectionTransferredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToConnectionTransferredEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PlayToConnectionTransferredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayToConnectionTransferredEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PlayToConnectionTransferredEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -1310,41 +1116,7 @@ impl ::windows::core::RuntimeName for PlayToManager {
     const NAME: &'static str = "Windows.Media.PlayTo.PlayToManager";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToManager> for ::windows::core::IUnknown {
-    fn from(value: PlayToManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToManager> for ::windows::core::IUnknown {
-    fn from(value: &PlayToManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToManager> for &::windows::core::IUnknown {
-    fn from(value: &PlayToManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToManager> for ::windows::core::IInspectable {
-    fn from(value: PlayToManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToManager> for ::windows::core::IInspectable {
-    fn from(value: &PlayToManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToManager> for &::windows::core::IInspectable {
-    fn from(value: &PlayToManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayToManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PlayToManager {}
 #[cfg(feature = "deprecated")]
@@ -1651,36 +1423,7 @@ unsafe impl ::windows::core::Interface for PlayToReceiver {
 impl ::windows::core::RuntimeName for PlayToReceiver {
     const NAME: &'static str = "Windows.Media.PlayTo.PlayToReceiver";
 }
-impl ::core::convert::From<PlayToReceiver> for ::windows::core::IUnknown {
-    fn from(value: PlayToReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayToReceiver> for ::windows::core::IUnknown {
-    fn from(value: &PlayToReceiver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayToReceiver> for &::windows::core::IUnknown {
-    fn from(value: &PlayToReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayToReceiver> for ::windows::core::IInspectable {
-    fn from(value: PlayToReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayToReceiver> for ::windows::core::IInspectable {
-    fn from(value: &PlayToReceiver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayToReceiver> for &::windows::core::IInspectable {
-    fn from(value: &PlayToReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayToReceiver, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_PlayTo\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -1774,41 +1517,7 @@ impl ::windows::core::RuntimeName for PlayToSource {
     const NAME: &'static str = "Windows.Media.PlayTo.PlayToSource";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToSource> for ::windows::core::IUnknown {
-    fn from(value: PlayToSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSource> for ::windows::core::IUnknown {
-    fn from(value: &PlayToSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSource> for &::windows::core::IUnknown {
-    fn from(value: &PlayToSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToSource> for ::windows::core::IInspectable {
-    fn from(value: PlayToSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSource> for ::windows::core::IInspectable {
-    fn from(value: &PlayToSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSource> for &::windows::core::IInspectable {
-    fn from(value: &PlayToSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayToSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PlayToSource {}
 #[cfg(feature = "deprecated")]
@@ -1867,41 +1576,7 @@ impl ::windows::core::RuntimeName for PlayToSourceDeferral {
     const NAME: &'static str = "Windows.Media.PlayTo.PlayToSourceDeferral";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToSourceDeferral> for ::windows::core::IUnknown {
-    fn from(value: PlayToSourceDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceDeferral> for ::windows::core::IUnknown {
-    fn from(value: &PlayToSourceDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceDeferral> for &::windows::core::IUnknown {
-    fn from(value: &PlayToSourceDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToSourceDeferral> for ::windows::core::IInspectable {
-    fn from(value: PlayToSourceDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceDeferral> for ::windows::core::IInspectable {
-    fn from(value: &PlayToSourceDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceDeferral> for &::windows::core::IInspectable {
-    fn from(value: &PlayToSourceDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayToSourceDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PlayToSourceDeferral {}
 #[cfg(feature = "deprecated")]
@@ -1984,41 +1659,7 @@ impl ::windows::core::RuntimeName for PlayToSourceRequest {
     const NAME: &'static str = "Windows.Media.PlayTo.PlayToSourceRequest";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToSourceRequest> for ::windows::core::IUnknown {
-    fn from(value: PlayToSourceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceRequest> for ::windows::core::IUnknown {
-    fn from(value: &PlayToSourceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceRequest> for &::windows::core::IUnknown {
-    fn from(value: &PlayToSourceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToSourceRequest> for ::windows::core::IInspectable {
-    fn from(value: PlayToSourceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceRequest> for ::windows::core::IInspectable {
-    fn from(value: &PlayToSourceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceRequest> for &::windows::core::IInspectable {
-    fn from(value: &PlayToSourceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayToSourceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PlayToSourceRequest {}
 #[cfg(feature = "deprecated")]
@@ -2080,41 +1721,7 @@ impl ::windows::core::RuntimeName for PlayToSourceRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.PlayToSourceRequestedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToSourceRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PlayToSourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PlayToSourceRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PlayToSourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToSourceRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PlayToSourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PlayToSourceRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PlayToSourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayToSourceRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PlayToSourceRequestedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -2212,41 +1819,7 @@ impl ::windows::core::RuntimeName for PlayToSourceSelectedEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.PlayToSourceSelectedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToSourceSelectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PlayToSourceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceSelectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PlayToSourceSelectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceSelectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PlayToSourceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<PlayToSourceSelectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PlayToSourceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceSelectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PlayToSourceSelectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&PlayToSourceSelectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PlayToSourceSelectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayToSourceSelectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for PlayToSourceSelectedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -2295,36 +1868,7 @@ unsafe impl ::windows::core::Interface for PlaybackRateChangeRequestedEventArgs 
 impl ::windows::core::RuntimeName for PlaybackRateChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.PlaybackRateChangeRequestedEventArgs";
 }
-impl ::core::convert::From<PlaybackRateChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PlaybackRateChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackRateChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PlaybackRateChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackRateChangeRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PlaybackRateChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlaybackRateChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PlaybackRateChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackRateChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PlaybackRateChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackRateChangeRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PlaybackRateChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlaybackRateChangeRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_PlayTo\"`*"]
 #[repr(transparent)]
 pub struct SourceChangeRequestedEventArgs(::windows::core::IUnknown);
@@ -2442,36 +1986,7 @@ unsafe impl ::windows::core::Interface for SourceChangeRequestedEventArgs {
 impl ::windows::core::RuntimeName for SourceChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.SourceChangeRequestedEventArgs";
 }
-impl ::core::convert::From<SourceChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SourceChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SourceChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SourceChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SourceChangeRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SourceChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SourceChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SourceChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SourceChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SourceChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SourceChangeRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SourceChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SourceChangeRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_PlayTo\"`*"]
 #[repr(transparent)]
 pub struct VolumeChangeRequestedEventArgs(::windows::core::IUnknown);
@@ -2516,36 +2031,7 @@ unsafe impl ::windows::core::Interface for VolumeChangeRequestedEventArgs {
 impl ::windows::core::RuntimeName for VolumeChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.VolumeChangeRequestedEventArgs";
 }
-impl ::core::convert::From<VolumeChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: VolumeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VolumeChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &VolumeChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VolumeChangeRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &VolumeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VolumeChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: VolumeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VolumeChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &VolumeChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VolumeChangeRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &VolumeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VolumeChangeRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_PlayTo\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Media/Playback/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Playback/mod.rs
@@ -309,41 +309,7 @@ impl IMediaEnginePlaybackSource {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<IMediaEnginePlaybackSource> for ::windows::core::IUnknown {
-    fn from(value: IMediaEnginePlaybackSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IMediaEnginePlaybackSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaEnginePlaybackSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IMediaEnginePlaybackSource> for ::windows::core::IUnknown {
-    fn from(value: &IMediaEnginePlaybackSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<IMediaEnginePlaybackSource> for ::windows::core::IInspectable {
-    fn from(value: IMediaEnginePlaybackSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a IMediaEnginePlaybackSource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaEnginePlaybackSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&IMediaEnginePlaybackSource> for ::windows::core::IInspectable {
-    fn from(value: &IMediaEnginePlaybackSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaEnginePlaybackSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for IMediaEnginePlaybackSource {
     fn clone(&self) -> Self {
@@ -1323,36 +1289,7 @@ pub struct IMediaPlaybackSessionOutputDegradationPolicyState_Vtbl {
 #[repr(transparent)]
 pub struct IMediaPlaybackSource(::windows::core::IUnknown);
 impl IMediaPlaybackSource {}
-impl ::core::convert::From<IMediaPlaybackSource> for ::windows::core::IUnknown {
-    fn from(value: IMediaPlaybackSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaPlaybackSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaPlaybackSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaPlaybackSource> for ::windows::core::IUnknown {
-    fn from(value: &IMediaPlaybackSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaPlaybackSource> for ::windows::core::IInspectable {
-    fn from(value: IMediaPlaybackSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaPlaybackSource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaPlaybackSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaPlaybackSource> for ::windows::core::IInspectable {
-    fn from(value: &IMediaPlaybackSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaPlaybackSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMediaPlaybackSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2172,36 +2109,7 @@ unsafe impl ::windows::core::Interface for CurrentMediaPlaybackItemChangedEventA
 impl ::windows::core::RuntimeName for CurrentMediaPlaybackItemChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.CurrentMediaPlaybackItemChangedEventArgs";
 }
-impl ::core::convert::From<CurrentMediaPlaybackItemChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CurrentMediaPlaybackItemChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CurrentMediaPlaybackItemChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CurrentMediaPlaybackItemChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CurrentMediaPlaybackItemChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CurrentMediaPlaybackItemChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CurrentMediaPlaybackItemChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CurrentMediaPlaybackItemChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CurrentMediaPlaybackItemChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CurrentMediaPlaybackItemChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CurrentMediaPlaybackItemChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CurrentMediaPlaybackItemChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CurrentMediaPlaybackItemChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CurrentMediaPlaybackItemChangedEventArgs {}
 unsafe impl ::core::marker::Sync for CurrentMediaPlaybackItemChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -2303,36 +2211,7 @@ unsafe impl ::windows::core::Interface for MediaBreak {
 impl ::windows::core::RuntimeName for MediaBreak {
     const NAME: &'static str = "Windows.Media.Playback.MediaBreak";
 }
-impl ::core::convert::From<MediaBreak> for ::windows::core::IUnknown {
-    fn from(value: MediaBreak) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreak> for ::windows::core::IUnknown {
-    fn from(value: &MediaBreak) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreak> for &::windows::core::IUnknown {
-    fn from(value: &MediaBreak) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaBreak> for ::windows::core::IInspectable {
-    fn from(value: MediaBreak) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreak> for ::windows::core::IInspectable {
-    fn from(value: &MediaBreak) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreak> for &::windows::core::IInspectable {
-    fn from(value: &MediaBreak) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaBreak, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaBreak {}
 unsafe impl ::core::marker::Sync for MediaBreak {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -2379,36 +2258,7 @@ unsafe impl ::windows::core::Interface for MediaBreakEndedEventArgs {
 impl ::windows::core::RuntimeName for MediaBreakEndedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaBreakEndedEventArgs";
 }
-impl ::core::convert::From<MediaBreakEndedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaBreakEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakEndedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaBreakEndedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakEndedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaBreakEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaBreakEndedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaBreakEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakEndedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaBreakEndedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakEndedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaBreakEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaBreakEndedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaBreakEndedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaBreakEndedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -2530,36 +2380,7 @@ unsafe impl ::windows::core::Interface for MediaBreakManager {
 impl ::windows::core::RuntimeName for MediaBreakManager {
     const NAME: &'static str = "Windows.Media.Playback.MediaBreakManager";
 }
-impl ::core::convert::From<MediaBreakManager> for ::windows::core::IUnknown {
-    fn from(value: MediaBreakManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakManager> for ::windows::core::IUnknown {
-    fn from(value: &MediaBreakManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakManager> for &::windows::core::IUnknown {
-    fn from(value: &MediaBreakManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaBreakManager> for ::windows::core::IInspectable {
-    fn from(value: MediaBreakManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakManager> for ::windows::core::IInspectable {
-    fn from(value: &MediaBreakManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakManager> for &::windows::core::IInspectable {
-    fn from(value: &MediaBreakManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaBreakManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaBreakManager {}
 unsafe impl ::core::marker::Sync for MediaBreakManager {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -2660,36 +2481,7 @@ unsafe impl ::windows::core::Interface for MediaBreakSchedule {
 impl ::windows::core::RuntimeName for MediaBreakSchedule {
     const NAME: &'static str = "Windows.Media.Playback.MediaBreakSchedule";
 }
-impl ::core::convert::From<MediaBreakSchedule> for ::windows::core::IUnknown {
-    fn from(value: MediaBreakSchedule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakSchedule> for ::windows::core::IUnknown {
-    fn from(value: &MediaBreakSchedule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakSchedule> for &::windows::core::IUnknown {
-    fn from(value: &MediaBreakSchedule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaBreakSchedule> for ::windows::core::IInspectable {
-    fn from(value: MediaBreakSchedule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakSchedule> for ::windows::core::IInspectable {
-    fn from(value: &MediaBreakSchedule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakSchedule> for &::windows::core::IInspectable {
-    fn from(value: &MediaBreakSchedule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaBreakSchedule, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaBreakSchedule {}
 unsafe impl ::core::marker::Sync for MediaBreakSchedule {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -2756,36 +2548,7 @@ unsafe impl ::windows::core::Interface for MediaBreakSeekedOverEventArgs {
 impl ::windows::core::RuntimeName for MediaBreakSeekedOverEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaBreakSeekedOverEventArgs";
 }
-impl ::core::convert::From<MediaBreakSeekedOverEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaBreakSeekedOverEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakSeekedOverEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaBreakSeekedOverEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakSeekedOverEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaBreakSeekedOverEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaBreakSeekedOverEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaBreakSeekedOverEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakSeekedOverEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaBreakSeekedOverEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakSeekedOverEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaBreakSeekedOverEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaBreakSeekedOverEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaBreakSeekedOverEventArgs {}
 unsafe impl ::core::marker::Sync for MediaBreakSeekedOverEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -2832,36 +2595,7 @@ unsafe impl ::windows::core::Interface for MediaBreakSkippedEventArgs {
 impl ::windows::core::RuntimeName for MediaBreakSkippedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaBreakSkippedEventArgs";
 }
-impl ::core::convert::From<MediaBreakSkippedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaBreakSkippedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakSkippedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaBreakSkippedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakSkippedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaBreakSkippedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaBreakSkippedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaBreakSkippedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakSkippedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaBreakSkippedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakSkippedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaBreakSkippedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaBreakSkippedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaBreakSkippedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaBreakSkippedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -2908,36 +2642,7 @@ unsafe impl ::windows::core::Interface for MediaBreakStartedEventArgs {
 impl ::windows::core::RuntimeName for MediaBreakStartedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaBreakStartedEventArgs";
 }
-impl ::core::convert::From<MediaBreakStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaBreakStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaBreakStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakStartedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaBreakStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaBreakStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaBreakStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaBreakStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaBreakStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaBreakStartedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaBreakStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaBreakStartedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaBreakStartedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaBreakStartedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -3021,36 +2726,7 @@ unsafe impl ::windows::core::Interface for MediaItemDisplayProperties {
 impl ::windows::core::RuntimeName for MediaItemDisplayProperties {
     const NAME: &'static str = "Windows.Media.Playback.MediaItemDisplayProperties";
 }
-impl ::core::convert::From<MediaItemDisplayProperties> for ::windows::core::IUnknown {
-    fn from(value: MediaItemDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaItemDisplayProperties> for ::windows::core::IUnknown {
-    fn from(value: &MediaItemDisplayProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaItemDisplayProperties> for &::windows::core::IUnknown {
-    fn from(value: &MediaItemDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaItemDisplayProperties> for ::windows::core::IInspectable {
-    fn from(value: MediaItemDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaItemDisplayProperties> for ::windows::core::IInspectable {
-    fn from(value: &MediaItemDisplayProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaItemDisplayProperties> for &::windows::core::IInspectable {
-    fn from(value: &MediaItemDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaItemDisplayProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaItemDisplayProperties {}
 unsafe impl ::core::marker::Sync for MediaItemDisplayProperties {}
 #[doc = "*Required features: `\"Media_Playback\"`, `\"Foundation_Collections\"`, `\"Media_Core\"`*"]
@@ -3192,41 +2868,7 @@ impl ::core::iter::IntoIterator for &MediaPlaybackAudioTrackList {
     }
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<MediaPlaybackAudioTrackList> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackAudioTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackAudioTrackList> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackAudioTrackList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackAudioTrackList> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackAudioTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<MediaPlaybackAudioTrackList> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackAudioTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackAudioTrackList> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackAudioTrackList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackAudioTrackList> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackAudioTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackAudioTrackList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 impl ::core::convert::TryFrom<MediaPlaybackAudioTrackList> for super::super::Foundation::Collections::IIterable<super::Core::AudioTrack> {
     type Error = ::windows::core::Error;
@@ -3572,36 +3214,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManager {
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManager {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManager";
 }
-impl ::core::convert::From<MediaPlaybackCommandManager> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManager> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManager> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManager> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManager> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManager> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManager {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManager {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -3668,36 +3281,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManagerAutoRepeat
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -3777,36 +3361,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManagerCommandBeh
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManagerCommandBehavior {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManagerCommandBehavior";
 }
-impl ::core::convert::From<MediaPlaybackCommandManagerCommandBehavior> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManagerCommandBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerCommandBehavior> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerCommandBehavior) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerCommandBehavior> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerCommandBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManagerCommandBehavior> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManagerCommandBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerCommandBehavior> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerCommandBehavior) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerCommandBehavior> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerCommandBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManagerCommandBehavior, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManagerCommandBehavior {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManagerCommandBehavior {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -3866,36 +3421,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManagerFastForwar
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManagerFastForwardReceivedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManagerFastForwardReceivedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackCommandManagerFastForwardReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManagerFastForwardReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerFastForwardReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerFastForwardReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerFastForwardReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerFastForwardReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManagerFastForwardReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManagerFastForwardReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerFastForwardReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerFastForwardReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerFastForwardReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerFastForwardReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManagerFastForwardReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManagerFastForwardReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManagerFastForwardReceivedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -3955,36 +3481,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManagerNextReceiv
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManagerNextReceivedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManagerNextReceivedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackCommandManagerNextReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManagerNextReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerNextReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerNextReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerNextReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerNextReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManagerNextReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManagerNextReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerNextReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerNextReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerNextReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerNextReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManagerNextReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManagerNextReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManagerNextReceivedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -4044,36 +3541,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManagerPauseRecei
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManagerPauseReceivedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManagerPauseReceivedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackCommandManagerPauseReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManagerPauseReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPauseReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerPauseReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPauseReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerPauseReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManagerPauseReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManagerPauseReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPauseReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerPauseReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPauseReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerPauseReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManagerPauseReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManagerPauseReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManagerPauseReceivedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -4133,36 +3601,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManagerPlayReceiv
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManagerPlayReceivedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManagerPlayReceivedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackCommandManagerPlayReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManagerPlayReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPlayReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerPlayReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPlayReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerPlayReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManagerPlayReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManagerPlayReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPlayReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerPlayReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPlayReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerPlayReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManagerPlayReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManagerPlayReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManagerPlayReceivedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -4231,36 +3670,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManagerPositionRe
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManagerPositionReceivedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManagerPositionReceivedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackCommandManagerPositionReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManagerPositionReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPositionReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerPositionReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPositionReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerPositionReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManagerPositionReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManagerPositionReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPositionReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerPositionReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPositionReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerPositionReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManagerPositionReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManagerPositionReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManagerPositionReceivedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -4320,36 +3730,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManagerPreviousRe
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManagerPreviousReceivedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManagerPreviousReceivedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackCommandManagerPreviousReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManagerPreviousReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPreviousReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerPreviousReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPreviousReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerPreviousReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManagerPreviousReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManagerPreviousReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPreviousReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerPreviousReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerPreviousReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerPreviousReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManagerPreviousReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManagerPreviousReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManagerPreviousReceivedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -4416,36 +3797,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManagerRateReceiv
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManagerRateReceivedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManagerRateReceivedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackCommandManagerRateReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManagerRateReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerRateReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerRateReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerRateReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerRateReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManagerRateReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManagerRateReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerRateReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerRateReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerRateReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerRateReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManagerRateReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManagerRateReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManagerRateReceivedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -4505,36 +3857,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManagerRewindRece
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManagerRewindReceivedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManagerRewindReceivedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackCommandManagerRewindReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManagerRewindReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerRewindReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerRewindReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerRewindReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerRewindReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManagerRewindReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManagerRewindReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerRewindReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerRewindReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerRewindReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerRewindReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManagerRewindReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManagerRewindReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManagerRewindReceivedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -4601,36 +3924,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackCommandManagerShuffleRec
 impl ::windows::core::RuntimeName for MediaPlaybackCommandManagerShuffleReceivedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackCommandManagerShuffleReceivedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackCommandManagerShuffleReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackCommandManagerShuffleReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerShuffleReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerShuffleReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerShuffleReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackCommandManagerShuffleReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackCommandManagerShuffleReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackCommandManagerShuffleReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerShuffleReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerShuffleReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackCommandManagerShuffleReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackCommandManagerShuffleReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackCommandManagerShuffleReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackCommandManagerShuffleReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackCommandManagerShuffleReceivedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -4874,36 +4168,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackItem {
 impl ::windows::core::RuntimeName for MediaPlaybackItem {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackItem";
 }
-impl ::core::convert::From<MediaPlaybackItem> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItem> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItem> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackItem> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItem> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItem> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MediaPlaybackItem> for IMediaPlaybackSource {
     type Error = ::windows::core::Error;
     fn try_from(value: MediaPlaybackItem) -> ::windows::core::Result<Self> {
@@ -4976,36 +4241,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackItemError {
 impl ::windows::core::RuntimeName for MediaPlaybackItemError {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackItemError";
 }
-impl ::core::convert::From<MediaPlaybackItemError> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackItemError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemError> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackItemError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemError> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackItemError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackItemError> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackItemError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemError> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackItemError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemError> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackItemError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackItemError, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackItemError {}
 unsafe impl ::core::marker::Sync for MediaPlaybackItemError {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -5059,36 +4295,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackItemFailedEventArgs {
 impl ::windows::core::RuntimeName for MediaPlaybackItemFailedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackItemFailedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackItemFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackItemFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackItemFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemFailedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackItemFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackItemFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackItemFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackItemFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemFailedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackItemFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackItemFailedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackItemFailedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackItemFailedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -5135,36 +4342,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackItemOpenedEventArgs {
 impl ::windows::core::RuntimeName for MediaPlaybackItemOpenedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackItemOpenedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackItemOpenedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackItemOpenedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemOpenedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackItemOpenedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemOpenedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackItemOpenedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackItemOpenedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackItemOpenedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemOpenedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackItemOpenedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackItemOpenedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackItemOpenedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackItemOpenedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackItemOpenedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackItemOpenedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -5390,36 +4568,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackList {
 impl ::windows::core::RuntimeName for MediaPlaybackList {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackList";
 }
-impl ::core::convert::From<MediaPlaybackList> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackList> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackList> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackList> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackList> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackList> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MediaPlaybackList> for IMediaPlaybackSource {
     type Error = ::windows::core::Error;
     fn try_from(value: MediaPlaybackList) -> ::windows::core::Result<Self> {
@@ -5890,36 +5039,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackSession {
 impl ::windows::core::RuntimeName for MediaPlaybackSession {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackSession";
 }
-impl ::core::convert::From<MediaPlaybackSession> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSession> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSession> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackSession> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSession> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSession> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackSession {}
 unsafe impl ::core::marker::Sync for MediaPlaybackSession {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -5966,36 +5086,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackSessionBufferingStartedE
 impl ::windows::core::RuntimeName for MediaPlaybackSessionBufferingStartedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackSessionBufferingStartedEventArgs";
 }
-impl ::core::convert::From<MediaPlaybackSessionBufferingStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackSessionBufferingStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSessionBufferingStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackSessionBufferingStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSessionBufferingStartedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackSessionBufferingStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackSessionBufferingStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackSessionBufferingStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSessionBufferingStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackSessionBufferingStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSessionBufferingStartedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackSessionBufferingStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackSessionBufferingStartedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackSessionBufferingStartedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlaybackSessionBufferingStartedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -6042,36 +5133,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackSessionOutputDegradation
 impl ::windows::core::RuntimeName for MediaPlaybackSessionOutputDegradationPolicyState {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackSessionOutputDegradationPolicyState";
 }
-impl ::core::convert::From<MediaPlaybackSessionOutputDegradationPolicyState> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackSessionOutputDegradationPolicyState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSessionOutputDegradationPolicyState> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackSessionOutputDegradationPolicyState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSessionOutputDegradationPolicyState> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackSessionOutputDegradationPolicyState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackSessionOutputDegradationPolicyState> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackSessionOutputDegradationPolicyState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSessionOutputDegradationPolicyState> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackSessionOutputDegradationPolicyState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSessionOutputDegradationPolicyState> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackSessionOutputDegradationPolicyState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackSessionOutputDegradationPolicyState, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackSessionOutputDegradationPolicyState {}
 unsafe impl ::core::marker::Sync for MediaPlaybackSessionOutputDegradationPolicyState {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -6174,36 +5236,7 @@ unsafe impl ::windows::core::Interface for MediaPlaybackSphericalVideoProjection
 impl ::windows::core::RuntimeName for MediaPlaybackSphericalVideoProjection {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlaybackSphericalVideoProjection";
 }
-impl ::core::convert::From<MediaPlaybackSphericalVideoProjection> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackSphericalVideoProjection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSphericalVideoProjection> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackSphericalVideoProjection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSphericalVideoProjection> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackSphericalVideoProjection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlaybackSphericalVideoProjection> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackSphericalVideoProjection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSphericalVideoProjection> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackSphericalVideoProjection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlaybackSphericalVideoProjection> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackSphericalVideoProjection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackSphericalVideoProjection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlaybackSphericalVideoProjection {}
 unsafe impl ::core::marker::Sync for MediaPlaybackSphericalVideoProjection {}
 #[doc = "*Required features: `\"Media_Playback\"`, `\"Foundation_Collections\"`, `\"Media_Core\"`*"]
@@ -6341,41 +5374,7 @@ impl ::core::iter::IntoIterator for &MediaPlaybackTimedMetadataTrackList {
     }
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<MediaPlaybackTimedMetadataTrackList> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackTimedMetadataTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackTimedMetadataTrackList> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackTimedMetadataTrackList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackTimedMetadataTrackList> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackTimedMetadataTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<MediaPlaybackTimedMetadataTrackList> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackTimedMetadataTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackTimedMetadataTrackList> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackTimedMetadataTrackList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackTimedMetadataTrackList> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackTimedMetadataTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackTimedMetadataTrackList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 impl ::core::convert::TryFrom<MediaPlaybackTimedMetadataTrackList> for super::super::Foundation::Collections::IIterable<super::Core::TimedMetadataTrack> {
     type Error = ::windows::core::Error;
@@ -6563,41 +5562,7 @@ impl ::core::iter::IntoIterator for &MediaPlaybackVideoTrackList {
     }
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<MediaPlaybackVideoTrackList> for ::windows::core::IUnknown {
-    fn from(value: MediaPlaybackVideoTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackVideoTrackList> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackVideoTrackList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackVideoTrackList> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlaybackVideoTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<MediaPlaybackVideoTrackList> for ::windows::core::IInspectable {
-    fn from(value: MediaPlaybackVideoTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackVideoTrackList> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackVideoTrackList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
-impl ::core::convert::From<&MediaPlaybackVideoTrackList> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlaybackVideoTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlaybackVideoTrackList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 impl ::core::convert::TryFrom<MediaPlaybackVideoTrackList> for super::super::Foundation::Collections::IIterable<super::Core::VideoTrack> {
     type Error = ::windows::core::Error;
@@ -7397,36 +6362,7 @@ unsafe impl ::windows::core::Interface for MediaPlayer {
 impl ::windows::core::RuntimeName for MediaPlayer {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlayer";
 }
-impl ::core::convert::From<MediaPlayer> for ::windows::core::IUnknown {
-    fn from(value: MediaPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlayer> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlayer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlayer> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlayer> for ::windows::core::IInspectable {
-    fn from(value: MediaPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlayer> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlayer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlayer> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlayer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MediaPlayer> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -7497,36 +6433,7 @@ unsafe impl ::windows::core::Interface for MediaPlayerDataReceivedEventArgs {
 impl ::windows::core::RuntimeName for MediaPlayerDataReceivedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlayerDataReceivedEventArgs";
 }
-impl ::core::convert::From<MediaPlayerDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlayerDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlayerDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlayerDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlayerDataReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlayerDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlayerDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlayerDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlayerDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlayerDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlayerDataReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlayerDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlayerDataReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlayerDataReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlayerDataReceivedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -7587,36 +6494,7 @@ unsafe impl ::windows::core::Interface for MediaPlayerFailedEventArgs {
 impl ::windows::core::RuntimeName for MediaPlayerFailedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlayerFailedEventArgs";
 }
-impl ::core::convert::From<MediaPlayerFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlayerFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlayerFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlayerFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlayerFailedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlayerFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlayerFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlayerFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlayerFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlayerFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlayerFailedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlayerFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlayerFailedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlayerFailedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlayerFailedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -7663,36 +6541,7 @@ unsafe impl ::windows::core::Interface for MediaPlayerRateChangedEventArgs {
 impl ::windows::core::RuntimeName for MediaPlayerRateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlayerRateChangedEventArgs";
 }
-impl ::core::convert::From<MediaPlayerRateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaPlayerRateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlayerRateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlayerRateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlayerRateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlayerRateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlayerRateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaPlayerRateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlayerRateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlayerRateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlayerRateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlayerRateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlayerRateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaPlayerRateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlayerRateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -7763,36 +6612,7 @@ unsafe impl ::windows::core::Interface for MediaPlayerSurface {
 impl ::windows::core::RuntimeName for MediaPlayerSurface {
     const NAME: &'static str = "Windows.Media.Playback.MediaPlayerSurface";
 }
-impl ::core::convert::From<MediaPlayerSurface> for ::windows::core::IUnknown {
-    fn from(value: MediaPlayerSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlayerSurface> for ::windows::core::IUnknown {
-    fn from(value: &MediaPlayerSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlayerSurface> for &::windows::core::IUnknown {
-    fn from(value: &MediaPlayerSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaPlayerSurface> for ::windows::core::IInspectable {
-    fn from(value: MediaPlayerSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaPlayerSurface> for ::windows::core::IInspectable {
-    fn from(value: &MediaPlayerSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaPlayerSurface> for &::windows::core::IInspectable {
-    fn from(value: &MediaPlayerSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaPlayerSurface, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MediaPlayerSurface> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -7898,36 +6718,7 @@ unsafe impl ::windows::core::Interface for PlaybackMediaMarker {
 impl ::windows::core::RuntimeName for PlaybackMediaMarker {
     const NAME: &'static str = "Windows.Media.Playback.PlaybackMediaMarker";
 }
-impl ::core::convert::From<PlaybackMediaMarker> for ::windows::core::IUnknown {
-    fn from(value: PlaybackMediaMarker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarker> for ::windows::core::IUnknown {
-    fn from(value: &PlaybackMediaMarker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarker> for &::windows::core::IUnknown {
-    fn from(value: &PlaybackMediaMarker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlaybackMediaMarker> for ::windows::core::IInspectable {
-    fn from(value: PlaybackMediaMarker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarker> for ::windows::core::IInspectable {
-    fn from(value: &PlaybackMediaMarker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarker> for &::windows::core::IInspectable {
-    fn from(value: &PlaybackMediaMarker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlaybackMediaMarker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PlaybackMediaMarker {}
 unsafe impl ::core::marker::Sync for PlaybackMediaMarker {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -7974,36 +6765,7 @@ unsafe impl ::windows::core::Interface for PlaybackMediaMarkerReachedEventArgs {
 impl ::windows::core::RuntimeName for PlaybackMediaMarkerReachedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.PlaybackMediaMarkerReachedEventArgs";
 }
-impl ::core::convert::From<PlaybackMediaMarkerReachedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PlaybackMediaMarkerReachedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarkerReachedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PlaybackMediaMarkerReachedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarkerReachedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PlaybackMediaMarkerReachedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlaybackMediaMarkerReachedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PlaybackMediaMarkerReachedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarkerReachedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PlaybackMediaMarkerReachedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarkerReachedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PlaybackMediaMarkerReachedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlaybackMediaMarkerReachedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PlaybackMediaMarkerReachedEventArgs {}
 unsafe impl ::core::marker::Sync for PlaybackMediaMarkerReachedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]
@@ -8083,36 +6845,7 @@ impl ::core::iter::IntoIterator for &PlaybackMediaMarkerSequence {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<PlaybackMediaMarkerSequence> for ::windows::core::IUnknown {
-    fn from(value: PlaybackMediaMarkerSequence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarkerSequence> for ::windows::core::IUnknown {
-    fn from(value: &PlaybackMediaMarkerSequence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarkerSequence> for &::windows::core::IUnknown {
-    fn from(value: &PlaybackMediaMarkerSequence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlaybackMediaMarkerSequence> for ::windows::core::IInspectable {
-    fn from(value: PlaybackMediaMarkerSequence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarkerSequence> for ::windows::core::IInspectable {
-    fn from(value: &PlaybackMediaMarkerSequence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackMediaMarkerSequence> for &::windows::core::IInspectable {
-    fn from(value: &PlaybackMediaMarkerSequence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlaybackMediaMarkerSequence, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<PlaybackMediaMarkerSequence> for super::super::Foundation::Collections::IIterable<PlaybackMediaMarker> {
     type Error = ::windows::core::Error;
@@ -8197,36 +6930,7 @@ unsafe impl ::windows::core::Interface for TimedMetadataPresentationModeChangedE
 impl ::windows::core::RuntimeName for TimedMetadataPresentationModeChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Playback.TimedMetadataPresentationModeChangedEventArgs";
 }
-impl ::core::convert::From<TimedMetadataPresentationModeChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TimedMetadataPresentationModeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataPresentationModeChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TimedMetadataPresentationModeChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataPresentationModeChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TimedMetadataPresentationModeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TimedMetadataPresentationModeChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TimedMetadataPresentationModeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TimedMetadataPresentationModeChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TimedMetadataPresentationModeChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TimedMetadataPresentationModeChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TimedMetadataPresentationModeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TimedMetadataPresentationModeChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TimedMetadataPresentationModeChangedEventArgs {}
 unsafe impl ::core::marker::Sync for TimedMetadataPresentationModeChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Playback\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Playlists/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Playlists/mod.rs
@@ -151,36 +151,7 @@ unsafe impl ::windows::core::Interface for Playlist {
 impl ::windows::core::RuntimeName for Playlist {
     const NAME: &'static str = "Windows.Media.Playlists.Playlist";
 }
-impl ::core::convert::From<Playlist> for ::windows::core::IUnknown {
-    fn from(value: Playlist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Playlist> for ::windows::core::IUnknown {
-    fn from(value: &Playlist) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Playlist> for &::windows::core::IUnknown {
-    fn from(value: &Playlist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Playlist> for ::windows::core::IInspectable {
-    fn from(value: Playlist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Playlist> for ::windows::core::IInspectable {
-    fn from(value: &Playlist) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Playlist> for &::windows::core::IInspectable {
-    fn from(value: &Playlist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Playlist, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Playlists\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/Media/Protection/PlayReady/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/PlayReady/mod.rs
@@ -129,41 +129,7 @@ impl INDClosedCaptionDataReceivedEventArgs {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDClosedCaptionDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: INDClosedCaptionDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDClosedCaptionDataReceivedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDClosedCaptionDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDClosedCaptionDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &INDClosedCaptionDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDClosedCaptionDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: INDClosedCaptionDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDClosedCaptionDataReceivedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDClosedCaptionDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDClosedCaptionDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &INDClosedCaptionDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDClosedCaptionDataReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDClosedCaptionDataReceivedEventArgs {
     fn clone(&self) -> Self {
@@ -244,41 +210,7 @@ impl INDCustomData {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDCustomData> for ::windows::core::IUnknown {
-    fn from(value: INDCustomData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDCustomData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDCustomData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDCustomData> for ::windows::core::IUnknown {
-    fn from(value: &INDCustomData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDCustomData> for ::windows::core::IInspectable {
-    fn from(value: INDCustomData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDCustomData> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDCustomData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDCustomData> for ::windows::core::IInspectable {
-    fn from(value: &INDCustomData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDCustomData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDCustomData {
     fn clone(&self) -> Self {
@@ -425,41 +357,7 @@ impl INDDownloadEngine {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDDownloadEngine> for ::windows::core::IUnknown {
-    fn from(value: INDDownloadEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDDownloadEngine> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDDownloadEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDDownloadEngine> for ::windows::core::IUnknown {
-    fn from(value: &INDDownloadEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDDownloadEngine> for ::windows::core::IInspectable {
-    fn from(value: INDDownloadEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDDownloadEngine> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDDownloadEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDDownloadEngine> for ::windows::core::IInspectable {
-    fn from(value: &INDDownloadEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDDownloadEngine, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDDownloadEngine {
     fn clone(&self) -> Self {
@@ -586,41 +484,7 @@ impl INDDownloadEngineNotifier {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDDownloadEngineNotifier> for ::windows::core::IUnknown {
-    fn from(value: INDDownloadEngineNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDDownloadEngineNotifier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDDownloadEngineNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDDownloadEngineNotifier> for ::windows::core::IUnknown {
-    fn from(value: &INDDownloadEngineNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDDownloadEngineNotifier> for ::windows::core::IInspectable {
-    fn from(value: INDDownloadEngineNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDDownloadEngineNotifier> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDDownloadEngineNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDDownloadEngineNotifier> for ::windows::core::IInspectable {
-    fn from(value: &INDDownloadEngineNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDDownloadEngineNotifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDDownloadEngineNotifier {
     fn clone(&self) -> Self {
@@ -704,41 +568,7 @@ impl INDLicenseFetchCompletedEventArgs {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDLicenseFetchCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: INDLicenseFetchCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDLicenseFetchCompletedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDLicenseFetchCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDLicenseFetchCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &INDLicenseFetchCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDLicenseFetchCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: INDLicenseFetchCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDLicenseFetchCompletedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDLicenseFetchCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDLicenseFetchCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &INDLicenseFetchCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDLicenseFetchCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDLicenseFetchCompletedEventArgs {
     fn clone(&self) -> Self {
@@ -830,41 +660,7 @@ impl INDLicenseFetchDescriptor {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDLicenseFetchDescriptor> for ::windows::core::IUnknown {
-    fn from(value: INDLicenseFetchDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDLicenseFetchDescriptor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDLicenseFetchDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDLicenseFetchDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &INDLicenseFetchDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDLicenseFetchDescriptor> for ::windows::core::IInspectable {
-    fn from(value: INDLicenseFetchDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDLicenseFetchDescriptor> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDLicenseFetchDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDLicenseFetchDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &INDLicenseFetchDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDLicenseFetchDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDLicenseFetchDescriptor {
     fn clone(&self) -> Self {
@@ -962,41 +758,7 @@ impl INDLicenseFetchResult {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDLicenseFetchResult> for ::windows::core::IUnknown {
-    fn from(value: INDLicenseFetchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDLicenseFetchResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDLicenseFetchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDLicenseFetchResult> for ::windows::core::IUnknown {
-    fn from(value: &INDLicenseFetchResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDLicenseFetchResult> for ::windows::core::IInspectable {
-    fn from(value: INDLicenseFetchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDLicenseFetchResult> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDLicenseFetchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDLicenseFetchResult> for ::windows::core::IInspectable {
-    fn from(value: &INDLicenseFetchResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDLicenseFetchResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDLicenseFetchResult {
     fn clone(&self) -> Self {
@@ -1087,41 +849,7 @@ impl INDMessenger {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDMessenger> for ::windows::core::IUnknown {
-    fn from(value: INDMessenger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDMessenger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDMessenger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDMessenger> for ::windows::core::IUnknown {
-    fn from(value: &INDMessenger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDMessenger> for ::windows::core::IInspectable {
-    fn from(value: INDMessenger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDMessenger> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDMessenger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDMessenger> for ::windows::core::IInspectable {
-    fn from(value: &INDMessenger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDMessenger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDMessenger {
     fn clone(&self) -> Self {
@@ -1197,41 +925,7 @@ impl INDProximityDetectionCompletedEventArgs {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDProximityDetectionCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: INDProximityDetectionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDProximityDetectionCompletedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDProximityDetectionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDProximityDetectionCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &INDProximityDetectionCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDProximityDetectionCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: INDProximityDetectionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDProximityDetectionCompletedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDProximityDetectionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDProximityDetectionCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &INDProximityDetectionCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDProximityDetectionCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDProximityDetectionCompletedEventArgs {
     fn clone(&self) -> Self {
@@ -1319,41 +1013,7 @@ impl INDRegistrationCompletedEventArgs {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDRegistrationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: INDRegistrationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDRegistrationCompletedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDRegistrationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDRegistrationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &INDRegistrationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDRegistrationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: INDRegistrationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDRegistrationCompletedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDRegistrationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDRegistrationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &INDRegistrationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDRegistrationCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDRegistrationCompletedEventArgs {
     fn clone(&self) -> Self {
@@ -1429,41 +1089,7 @@ impl INDSendResult {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDSendResult> for ::windows::core::IUnknown {
-    fn from(value: INDSendResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDSendResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDSendResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDSendResult> for ::windows::core::IUnknown {
-    fn from(value: &INDSendResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDSendResult> for ::windows::core::IInspectable {
-    fn from(value: INDSendResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDSendResult> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDSendResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDSendResult> for ::windows::core::IInspectable {
-    fn from(value: &INDSendResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDSendResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDSendResult {
     fn clone(&self) -> Self {
@@ -1527,41 +1153,7 @@ impl INDStartResult {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDStartResult> for ::windows::core::IUnknown {
-    fn from(value: INDStartResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDStartResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDStartResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDStartResult> for ::windows::core::IUnknown {
-    fn from(value: &INDStartResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDStartResult> for ::windows::core::IInspectable {
-    fn from(value: INDStartResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDStartResult> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDStartResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDStartResult> for ::windows::core::IInspectable {
-    fn from(value: &INDStartResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDStartResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDStartResult {
     fn clone(&self) -> Self {
@@ -1629,41 +1221,7 @@ impl INDStorageFileHelper {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDStorageFileHelper> for ::windows::core::IUnknown {
-    fn from(value: INDStorageFileHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDStorageFileHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDStorageFileHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDStorageFileHelper> for ::windows::core::IUnknown {
-    fn from(value: &INDStorageFileHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDStorageFileHelper> for ::windows::core::IInspectable {
-    fn from(value: INDStorageFileHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDStorageFileHelper> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDStorageFileHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDStorageFileHelper> for ::windows::core::IInspectable {
-    fn from(value: &INDStorageFileHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDStorageFileHelper, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDStorageFileHelper {
     fn clone(&self) -> Self {
@@ -1758,41 +1316,7 @@ impl INDStreamParser {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDStreamParser> for ::windows::core::IUnknown {
-    fn from(value: INDStreamParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDStreamParser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDStreamParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDStreamParser> for ::windows::core::IUnknown {
-    fn from(value: &INDStreamParser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDStreamParser> for ::windows::core::IInspectable {
-    fn from(value: INDStreamParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDStreamParser> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDStreamParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDStreamParser> for ::windows::core::IInspectable {
-    fn from(value: &INDStreamParser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDStreamParser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDStreamParser {
     fn clone(&self) -> Self {
@@ -1901,41 +1425,7 @@ impl INDStreamParserNotifier {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDStreamParserNotifier> for ::windows::core::IUnknown {
-    fn from(value: INDStreamParserNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDStreamParserNotifier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDStreamParserNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDStreamParserNotifier> for ::windows::core::IUnknown {
-    fn from(value: &INDStreamParserNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDStreamParserNotifier> for ::windows::core::IInspectable {
-    fn from(value: INDStreamParserNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDStreamParserNotifier> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDStreamParserNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDStreamParserNotifier> for ::windows::core::IInspectable {
-    fn from(value: &INDStreamParserNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDStreamParserNotifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDStreamParserNotifier {
     fn clone(&self) -> Self {
@@ -2123,41 +1613,7 @@ impl INDTransmitterProperties {
     }
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDTransmitterProperties> for ::windows::core::IUnknown {
-    fn from(value: INDTransmitterProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDTransmitterProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDTransmitterProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDTransmitterProperties> for ::windows::core::IUnknown {
-    fn from(value: &INDTransmitterProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<INDTransmitterProperties> for ::windows::core::IInspectable {
-    fn from(value: INDTransmitterProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl<'a> ::core::convert::From<&'a INDTransmitterProperties> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a INDTransmitterProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&INDTransmitterProperties> for ::windows::core::IInspectable {
-    fn from(value: &INDTransmitterProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDTransmitterProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::clone::Clone for INDTransmitterProperties {
     fn clone(&self) -> Self {
@@ -2388,36 +1844,7 @@ impl IPlayReadyDomain {
         }
     }
 }
-impl ::core::convert::From<IPlayReadyDomain> for ::windows::core::IUnknown {
-    fn from(value: IPlayReadyDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyDomain> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlayReadyDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyDomain> for ::windows::core::IUnknown {
-    fn from(value: &IPlayReadyDomain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPlayReadyDomain> for ::windows::core::IInspectable {
-    fn from(value: IPlayReadyDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyDomain> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPlayReadyDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyDomain> for ::windows::core::IInspectable {
-    fn from(value: &IPlayReadyDomain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlayReadyDomain, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPlayReadyDomain {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2604,36 +2031,7 @@ impl IPlayReadyLicense {
         }
     }
 }
-impl ::core::convert::From<IPlayReadyLicense> for ::windows::core::IUnknown {
-    fn from(value: IPlayReadyLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyLicense> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlayReadyLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyLicense> for ::windows::core::IUnknown {
-    fn from(value: &IPlayReadyLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPlayReadyLicense> for ::windows::core::IInspectable {
-    fn from(value: IPlayReadyLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyLicense> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPlayReadyLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyLicense> for ::windows::core::IInspectable {
-    fn from(value: &IPlayReadyLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlayReadyLicense, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPlayReadyLicense {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2800,36 +2198,7 @@ impl IPlayReadyLicenseAcquisitionServiceRequest {
         }
     }
 }
-impl ::core::convert::From<IPlayReadyLicenseAcquisitionServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: IPlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyLicenseAcquisitionServiceRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyLicenseAcquisitionServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &IPlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPlayReadyLicenseAcquisitionServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: IPlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyLicenseAcquisitionServiceRequest> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyLicenseAcquisitionServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &IPlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlayReadyLicenseAcquisitionServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPlayReadyLicenseAcquisitionServiceRequest> for super::IMediaProtectionServiceRequest {
     type Error = ::windows::core::Error;
     fn try_from(value: IPlayReadyLicenseAcquisitionServiceRequest) -> ::windows::core::Result<Self> {
@@ -2991,36 +2360,7 @@ impl IPlayReadyLicenseSession {
         unsafe { (::windows::core::Vtable::vtable(this).ConfigureMediaProtectionManager)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(mpm)).ok() }
     }
 }
-impl ::core::convert::From<IPlayReadyLicenseSession> for ::windows::core::IUnknown {
-    fn from(value: IPlayReadyLicenseSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyLicenseSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlayReadyLicenseSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyLicenseSession> for ::windows::core::IUnknown {
-    fn from(value: &IPlayReadyLicenseSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPlayReadyLicenseSession> for ::windows::core::IInspectable {
-    fn from(value: IPlayReadyLicenseSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyLicenseSession> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPlayReadyLicenseSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyLicenseSession> for ::windows::core::IInspectable {
-    fn from(value: &IPlayReadyLicenseSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlayReadyLicenseSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPlayReadyLicenseSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3082,36 +2422,7 @@ impl IPlayReadyLicenseSession2 {
         unsafe { (::windows::core::Vtable::vtable(this).ConfigureMediaProtectionManager)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(mpm)).ok() }
     }
 }
-impl ::core::convert::From<IPlayReadyLicenseSession2> for ::windows::core::IUnknown {
-    fn from(value: IPlayReadyLicenseSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyLicenseSession2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlayReadyLicenseSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyLicenseSession2> for ::windows::core::IUnknown {
-    fn from(value: &IPlayReadyLicenseSession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPlayReadyLicenseSession2> for ::windows::core::IInspectable {
-    fn from(value: IPlayReadyLicenseSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyLicenseSession2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPlayReadyLicenseSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyLicenseSession2> for ::windows::core::IInspectable {
-    fn from(value: &IPlayReadyLicenseSession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlayReadyLicenseSession2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPlayReadyLicenseSession2> for IPlayReadyLicenseSession {
     type Error = ::windows::core::Error;
     fn try_from(value: IPlayReadyLicenseSession2) -> ::windows::core::Result<Self> {
@@ -3356,36 +2667,7 @@ impl IPlayReadySecureStopServiceRequest {
         }
     }
 }
-impl ::core::convert::From<IPlayReadySecureStopServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: IPlayReadySecureStopServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadySecureStopServiceRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlayReadySecureStopServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadySecureStopServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &IPlayReadySecureStopServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPlayReadySecureStopServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: IPlayReadySecureStopServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadySecureStopServiceRequest> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPlayReadySecureStopServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadySecureStopServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &IPlayReadySecureStopServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlayReadySecureStopServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPlayReadySecureStopServiceRequest> for super::IMediaProtectionServiceRequest {
     type Error = ::windows::core::Error;
     fn try_from(value: IPlayReadySecureStopServiceRequest) -> ::windows::core::Result<Self> {
@@ -3567,36 +2849,7 @@ impl IPlayReadyServiceRequest {
         }
     }
 }
-impl ::core::convert::From<IPlayReadyServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: IPlayReadyServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyServiceRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlayReadyServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &IPlayReadyServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPlayReadyServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: IPlayReadyServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayReadyServiceRequest> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPlayReadyServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayReadyServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &IPlayReadyServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlayReadyServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IPlayReadyServiceRequest> for super::IMediaProtectionServiceRequest {
     type Error = ::windows::core::Error;
     fn try_from(value: IPlayReadyServiceRequest) -> ::windows::core::Result<Self> {
@@ -3975,41 +3228,7 @@ impl ::windows::core::RuntimeName for NDClient {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.NDClient";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDClient> for ::windows::core::IUnknown {
-    fn from(value: NDClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDClient> for ::windows::core::IUnknown {
-    fn from(value: &NDClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDClient> for &::windows::core::IUnknown {
-    fn from(value: &NDClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDClient> for ::windows::core::IInspectable {
-    fn from(value: NDClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDClient> for ::windows::core::IInspectable {
-    fn from(value: &NDClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDClient> for &::windows::core::IInspectable {
-    fn from(value: &NDClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NDClient, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -4090,41 +3309,7 @@ impl ::windows::core::RuntimeName for NDCustomData {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.NDCustomData";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDCustomData> for ::windows::core::IUnknown {
-    fn from(value: NDCustomData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDCustomData> for ::windows::core::IUnknown {
-    fn from(value: &NDCustomData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDCustomData> for &::windows::core::IUnknown {
-    fn from(value: &NDCustomData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDCustomData> for ::windows::core::IInspectable {
-    fn from(value: NDCustomData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDCustomData> for ::windows::core::IInspectable {
-    fn from(value: &NDCustomData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDCustomData> for &::windows::core::IInspectable {
-    fn from(value: &NDCustomData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NDCustomData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<NDCustomData> for INDCustomData {
     type Error = ::windows::core::Error;
@@ -4242,41 +3427,7 @@ impl ::windows::core::RuntimeName for NDDownloadEngineNotifier {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.NDDownloadEngineNotifier";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDDownloadEngineNotifier> for ::windows::core::IUnknown {
-    fn from(value: NDDownloadEngineNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDDownloadEngineNotifier> for ::windows::core::IUnknown {
-    fn from(value: &NDDownloadEngineNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDDownloadEngineNotifier> for &::windows::core::IUnknown {
-    fn from(value: &NDDownloadEngineNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDDownloadEngineNotifier> for ::windows::core::IInspectable {
-    fn from(value: NDDownloadEngineNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDDownloadEngineNotifier> for ::windows::core::IInspectable {
-    fn from(value: &NDDownloadEngineNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDDownloadEngineNotifier> for &::windows::core::IInspectable {
-    fn from(value: &NDDownloadEngineNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NDDownloadEngineNotifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<NDDownloadEngineNotifier> for INDDownloadEngineNotifier {
     type Error = ::windows::core::Error;
@@ -4402,41 +3553,7 @@ impl ::windows::core::RuntimeName for NDLicenseFetchDescriptor {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.NDLicenseFetchDescriptor";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDLicenseFetchDescriptor> for ::windows::core::IUnknown {
-    fn from(value: NDLicenseFetchDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDLicenseFetchDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &NDLicenseFetchDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDLicenseFetchDescriptor> for &::windows::core::IUnknown {
-    fn from(value: &NDLicenseFetchDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDLicenseFetchDescriptor> for ::windows::core::IInspectable {
-    fn from(value: NDLicenseFetchDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDLicenseFetchDescriptor> for ::windows::core::IInspectable {
-    fn from(value: &NDLicenseFetchDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDLicenseFetchDescriptor> for &::windows::core::IInspectable {
-    fn from(value: &NDLicenseFetchDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NDLicenseFetchDescriptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<NDLicenseFetchDescriptor> for INDLicenseFetchDescriptor {
     type Error = ::windows::core::Error;
@@ -4527,41 +3644,7 @@ impl ::windows::core::RuntimeName for NDStorageFileHelper {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.NDStorageFileHelper";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDStorageFileHelper> for ::windows::core::IUnknown {
-    fn from(value: NDStorageFileHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDStorageFileHelper> for ::windows::core::IUnknown {
-    fn from(value: &NDStorageFileHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDStorageFileHelper> for &::windows::core::IUnknown {
-    fn from(value: &NDStorageFileHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDStorageFileHelper> for ::windows::core::IInspectable {
-    fn from(value: NDStorageFileHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDStorageFileHelper> for ::windows::core::IInspectable {
-    fn from(value: &NDStorageFileHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDStorageFileHelper> for &::windows::core::IInspectable {
-    fn from(value: &NDStorageFileHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NDStorageFileHelper, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<NDStorageFileHelper> for INDStorageFileHelper {
     type Error = ::windows::core::Error;
@@ -4677,41 +3760,7 @@ impl ::windows::core::RuntimeName for NDStreamParserNotifier {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.NDStreamParserNotifier";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDStreamParserNotifier> for ::windows::core::IUnknown {
-    fn from(value: NDStreamParserNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDStreamParserNotifier> for ::windows::core::IUnknown {
-    fn from(value: &NDStreamParserNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDStreamParserNotifier> for &::windows::core::IUnknown {
-    fn from(value: &NDStreamParserNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDStreamParserNotifier> for ::windows::core::IInspectable {
-    fn from(value: NDStreamParserNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDStreamParserNotifier> for ::windows::core::IInspectable {
-    fn from(value: &NDStreamParserNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDStreamParserNotifier> for &::windows::core::IInspectable {
-    fn from(value: &NDStreamParserNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NDStreamParserNotifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<NDStreamParserNotifier> for INDStreamParserNotifier {
     type Error = ::windows::core::Error;
@@ -4832,41 +3881,7 @@ impl ::windows::core::RuntimeName for NDTCPMessenger {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.NDTCPMessenger";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDTCPMessenger> for ::windows::core::IUnknown {
-    fn from(value: NDTCPMessenger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDTCPMessenger> for ::windows::core::IUnknown {
-    fn from(value: &NDTCPMessenger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDTCPMessenger> for &::windows::core::IUnknown {
-    fn from(value: &NDTCPMessenger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<NDTCPMessenger> for ::windows::core::IInspectable {
-    fn from(value: NDTCPMessenger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDTCPMessenger> for ::windows::core::IInspectable {
-    fn from(value: &NDTCPMessenger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&NDTCPMessenger> for &::windows::core::IInspectable {
-    fn from(value: &NDTCPMessenger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NDTCPMessenger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 impl ::core::convert::TryFrom<NDTCPMessenger> for INDMessenger {
     type Error = ::windows::core::Error;
@@ -5054,36 +4069,7 @@ unsafe impl ::windows::core::Interface for PlayReadyContentHeader {
 impl ::windows::core::RuntimeName for PlayReadyContentHeader {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyContentHeader";
 }
-impl ::core::convert::From<PlayReadyContentHeader> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyContentHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyContentHeader> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyContentHeader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyContentHeader> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyContentHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadyContentHeader> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyContentHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyContentHeader> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyContentHeader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyContentHeader> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyContentHeader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyContentHeader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Protection_PlayReady\"`*"]
 pub struct PlayReadyContentResolver;
 impl PlayReadyContentResolver {
@@ -5176,36 +4162,7 @@ unsafe impl ::windows::core::Interface for PlayReadyDomain {
 impl ::windows::core::RuntimeName for PlayReadyDomain {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyDomain";
 }
-impl ::core::convert::From<PlayReadyDomain> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyDomain> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyDomain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyDomain> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadyDomain> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyDomain> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyDomain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyDomain> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyDomain, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PlayReadyDomain> for IPlayReadyDomain {
     type Error = ::windows::core::Error;
     fn try_from(value: PlayReadyDomain) -> ::windows::core::Result<Self> {
@@ -5311,41 +4268,7 @@ impl ::core::iter::IntoIterator for &PlayReadyDomainIterable {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadyDomainIterable> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyDomainIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyDomainIterable> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyDomainIterable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyDomainIterable> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyDomainIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadyDomainIterable> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyDomainIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyDomainIterable> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyDomainIterable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyDomainIterable> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyDomainIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyDomainIterable, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<PlayReadyDomainIterable> for super::super::super::Foundation::Collections::IIterable<IPlayReadyDomain> {
     type Error = ::windows::core::Error;
@@ -5452,41 +4375,7 @@ impl ::windows::core::RuntimeName for PlayReadyDomainIterator {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyDomainIterator";
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadyDomainIterator> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyDomainIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyDomainIterator> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyDomainIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyDomainIterator> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyDomainIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadyDomainIterator> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyDomainIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyDomainIterator> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyDomainIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyDomainIterator> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyDomainIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyDomainIterator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<PlayReadyDomainIterator> for super::super::super::Foundation::Collections::IIterator<IPlayReadyDomain> {
     type Error = ::windows::core::Error;
@@ -5663,36 +4552,7 @@ unsafe impl ::windows::core::Interface for PlayReadyDomainJoinServiceRequest {
 impl ::windows::core::RuntimeName for PlayReadyDomainJoinServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyDomainJoinServiceRequest";
 }
-impl ::core::convert::From<PlayReadyDomainJoinServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyDomainJoinServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyDomainJoinServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyDomainJoinServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyDomainJoinServiceRequest> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyDomainJoinServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadyDomainJoinServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyDomainJoinServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyDomainJoinServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyDomainJoinServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyDomainJoinServiceRequest> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyDomainJoinServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyDomainJoinServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PlayReadyDomainJoinServiceRequest> for super::IMediaProtectionServiceRequest {
     type Error = ::windows::core::Error;
     fn try_from(value: PlayReadyDomainJoinServiceRequest) -> ::windows::core::Result<Self> {
@@ -5874,36 +4734,7 @@ unsafe impl ::windows::core::Interface for PlayReadyDomainLeaveServiceRequest {
 impl ::windows::core::RuntimeName for PlayReadyDomainLeaveServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyDomainLeaveServiceRequest";
 }
-impl ::core::convert::From<PlayReadyDomainLeaveServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyDomainLeaveServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyDomainLeaveServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyDomainLeaveServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyDomainLeaveServiceRequest> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyDomainLeaveServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadyDomainLeaveServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyDomainLeaveServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyDomainLeaveServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyDomainLeaveServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyDomainLeaveServiceRequest> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyDomainLeaveServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyDomainLeaveServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PlayReadyDomainLeaveServiceRequest> for super::IMediaProtectionServiceRequest {
     type Error = ::windows::core::Error;
     fn try_from(value: PlayReadyDomainLeaveServiceRequest) -> ::windows::core::Result<Self> {
@@ -5999,36 +4830,7 @@ unsafe impl ::windows::core::Interface for PlayReadyITADataGenerator {
 impl ::windows::core::RuntimeName for PlayReadyITADataGenerator {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyITADataGenerator";
 }
-impl ::core::convert::From<PlayReadyITADataGenerator> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyITADataGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyITADataGenerator> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyITADataGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyITADataGenerator> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyITADataGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadyITADataGenerator> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyITADataGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyITADataGenerator> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyITADataGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyITADataGenerator> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyITADataGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyITADataGenerator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Protection_PlayReady\"`*"]
 #[repr(transparent)]
 pub struct PlayReadyIndividualizationServiceRequest(::windows::core::IUnknown);
@@ -6150,36 +4952,7 @@ unsafe impl ::windows::core::Interface for PlayReadyIndividualizationServiceRequ
 impl ::windows::core::RuntimeName for PlayReadyIndividualizationServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyIndividualizationServiceRequest";
 }
-impl ::core::convert::From<PlayReadyIndividualizationServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyIndividualizationServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyIndividualizationServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyIndividualizationServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyIndividualizationServiceRequest> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyIndividualizationServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadyIndividualizationServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyIndividualizationServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyIndividualizationServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyIndividualizationServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyIndividualizationServiceRequest> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyIndividualizationServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyIndividualizationServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PlayReadyIndividualizationServiceRequest> for super::IMediaProtectionServiceRequest {
     type Error = ::windows::core::Error;
     fn try_from(value: PlayReadyIndividualizationServiceRequest) -> ::windows::core::Result<Self> {
@@ -6334,36 +5107,7 @@ unsafe impl ::windows::core::Interface for PlayReadyLicense {
 impl ::windows::core::RuntimeName for PlayReadyLicense {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyLicense";
 }
-impl ::core::convert::From<PlayReadyLicense> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyLicense> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyLicense> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadyLicense> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyLicense> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyLicense> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyLicense, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PlayReadyLicense> for IPlayReadyLicense {
     type Error = ::windows::core::Error;
     fn try_from(value: PlayReadyLicense) -> ::windows::core::Result<Self> {
@@ -6542,36 +5286,7 @@ unsafe impl ::windows::core::Interface for PlayReadyLicenseAcquisitionServiceReq
 impl ::windows::core::RuntimeName for PlayReadyLicenseAcquisitionServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyLicenseAcquisitionServiceRequest";
 }
-impl ::core::convert::From<PlayReadyLicenseAcquisitionServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyLicenseAcquisitionServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyLicenseAcquisitionServiceRequest> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadyLicenseAcquisitionServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyLicenseAcquisitionServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyLicenseAcquisitionServiceRequest> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyLicenseAcquisitionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyLicenseAcquisitionServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PlayReadyLicenseAcquisitionServiceRequest> for super::IMediaProtectionServiceRequest {
     type Error = ::windows::core::Error;
     fn try_from(value: PlayReadyLicenseAcquisitionServiceRequest) -> ::windows::core::Result<Self> {
@@ -6722,41 +5437,7 @@ impl ::core::iter::IntoIterator for &PlayReadyLicenseIterable {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadyLicenseIterable> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyLicenseIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyLicenseIterable> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyLicenseIterable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyLicenseIterable> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyLicenseIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadyLicenseIterable> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyLicenseIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyLicenseIterable> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyLicenseIterable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyLicenseIterable> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyLicenseIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyLicenseIterable, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<PlayReadyLicenseIterable> for super::super::super::Foundation::Collections::IIterable<IPlayReadyLicense> {
     type Error = ::windows::core::Error;
@@ -6863,41 +5544,7 @@ impl ::windows::core::RuntimeName for PlayReadyLicenseIterator {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyLicenseIterator";
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadyLicenseIterator> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyLicenseIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyLicenseIterator> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyLicenseIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyLicenseIterator> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyLicenseIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadyLicenseIterator> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyLicenseIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyLicenseIterator> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyLicenseIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadyLicenseIterator> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyLicenseIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyLicenseIterator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<PlayReadyLicenseIterator> for super::super::super::Foundation::Collections::IIterator<IPlayReadyLicense> {
     type Error = ::windows::core::Error;
@@ -7014,36 +5661,7 @@ unsafe impl ::windows::core::Interface for PlayReadyLicenseSession {
 impl ::windows::core::RuntimeName for PlayReadyLicenseSession {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyLicenseSession";
 }
-impl ::core::convert::From<PlayReadyLicenseSession> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyLicenseSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyLicenseSession> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyLicenseSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyLicenseSession> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyLicenseSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadyLicenseSession> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyLicenseSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyLicenseSession> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyLicenseSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyLicenseSession> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyLicenseSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyLicenseSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PlayReadyLicenseSession> for IPlayReadyLicenseSession {
     type Error = ::windows::core::Error;
     fn try_from(value: PlayReadyLicenseSession) -> ::windows::core::Result<Self> {
@@ -7214,36 +5832,7 @@ unsafe impl ::windows::core::Interface for PlayReadyMeteringReportServiceRequest
 impl ::windows::core::RuntimeName for PlayReadyMeteringReportServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyMeteringReportServiceRequest";
 }
-impl ::core::convert::From<PlayReadyMeteringReportServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyMeteringReportServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyMeteringReportServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyMeteringReportServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyMeteringReportServiceRequest> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyMeteringReportServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadyMeteringReportServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyMeteringReportServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyMeteringReportServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyMeteringReportServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyMeteringReportServiceRequest> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyMeteringReportServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyMeteringReportServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PlayReadyMeteringReportServiceRequest> for super::IMediaProtectionServiceRequest {
     type Error = ::windows::core::Error;
     fn try_from(value: PlayReadyMeteringReportServiceRequest) -> ::windows::core::Result<Self> {
@@ -7403,36 +5992,7 @@ unsafe impl ::windows::core::Interface for PlayReadyRevocationServiceRequest {
 impl ::windows::core::RuntimeName for PlayReadyRevocationServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyRevocationServiceRequest";
 }
-impl ::core::convert::From<PlayReadyRevocationServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: PlayReadyRevocationServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyRevocationServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadyRevocationServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyRevocationServiceRequest> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadyRevocationServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadyRevocationServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: PlayReadyRevocationServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadyRevocationServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadyRevocationServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadyRevocationServiceRequest> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadyRevocationServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadyRevocationServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PlayReadyRevocationServiceRequest> for super::IMediaProtectionServiceRequest {
     type Error = ::windows::core::Error;
     fn try_from(value: PlayReadyRevocationServiceRequest) -> ::windows::core::Result<Self> {
@@ -7557,41 +6117,7 @@ impl ::core::iter::IntoIterator for &PlayReadySecureStopIterable {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadySecureStopIterable> for ::windows::core::IUnknown {
-    fn from(value: PlayReadySecureStopIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadySecureStopIterable> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadySecureStopIterable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadySecureStopIterable> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadySecureStopIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadySecureStopIterable> for ::windows::core::IInspectable {
-    fn from(value: PlayReadySecureStopIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadySecureStopIterable> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadySecureStopIterable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadySecureStopIterable> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadySecureStopIterable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadySecureStopIterable, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<PlayReadySecureStopIterable> for super::super::super::Foundation::Collections::IIterable<IPlayReadySecureStopServiceRequest> {
     type Error = ::windows::core::Error;
@@ -7698,41 +6224,7 @@ impl ::windows::core::RuntimeName for PlayReadySecureStopIterator {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadySecureStopIterator";
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadySecureStopIterator> for ::windows::core::IUnknown {
-    fn from(value: PlayReadySecureStopIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadySecureStopIterator> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadySecureStopIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadySecureStopIterator> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadySecureStopIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PlayReadySecureStopIterator> for ::windows::core::IInspectable {
-    fn from(value: PlayReadySecureStopIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadySecureStopIterator> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadySecureStopIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PlayReadySecureStopIterator> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadySecureStopIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadySecureStopIterator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<PlayReadySecureStopIterator> for super::super::super::Foundation::Collections::IIterator<IPlayReadySecureStopServiceRequest> {
     type Error = ::windows::core::Error;
@@ -7925,36 +6417,7 @@ unsafe impl ::windows::core::Interface for PlayReadySecureStopServiceRequest {
 impl ::windows::core::RuntimeName for PlayReadySecureStopServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadySecureStopServiceRequest";
 }
-impl ::core::convert::From<PlayReadySecureStopServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: PlayReadySecureStopServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadySecureStopServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadySecureStopServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadySecureStopServiceRequest> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadySecureStopServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadySecureStopServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: PlayReadySecureStopServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadySecureStopServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadySecureStopServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadySecureStopServiceRequest> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadySecureStopServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadySecureStopServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PlayReadySecureStopServiceRequest> for super::IMediaProtectionServiceRequest {
     type Error = ::windows::core::Error;
     fn try_from(value: PlayReadySecureStopServiceRequest) -> ::windows::core::Result<Self> {
@@ -8074,36 +6537,7 @@ unsafe impl ::windows::core::Interface for PlayReadySoapMessage {
 impl ::windows::core::RuntimeName for PlayReadySoapMessage {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadySoapMessage";
 }
-impl ::core::convert::From<PlayReadySoapMessage> for ::windows::core::IUnknown {
-    fn from(value: PlayReadySoapMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadySoapMessage> for ::windows::core::IUnknown {
-    fn from(value: &PlayReadySoapMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadySoapMessage> for &::windows::core::IUnknown {
-    fn from(value: &PlayReadySoapMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlayReadySoapMessage> for ::windows::core::IInspectable {
-    fn from(value: PlayReadySoapMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlayReadySoapMessage> for ::windows::core::IInspectable {
-    fn from(value: &PlayReadySoapMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlayReadySoapMessage> for &::windows::core::IInspectable {
-    fn from(value: &PlayReadySoapMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlayReadySoapMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Media_Protection_PlayReady\"`*"]
 pub struct PlayReadyStatics;
 impl PlayReadyStatics {

--- a/crates/libs/windows/src/Windows/Media/Protection/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/mod.rs
@@ -177,36 +177,7 @@ impl IMediaProtectionServiceRequest {
         }
     }
 }
-impl ::core::convert::From<IMediaProtectionServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: IMediaProtectionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaProtectionServiceRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaProtectionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaProtectionServiceRequest> for ::windows::core::IUnknown {
-    fn from(value: &IMediaProtectionServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaProtectionServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: IMediaProtectionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaProtectionServiceRequest> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaProtectionServiceRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaProtectionServiceRequest> for ::windows::core::IInspectable {
-    fn from(value: &IMediaProtectionServiceRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaProtectionServiceRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMediaProtectionServiceRequest {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -380,36 +351,7 @@ unsafe impl ::windows::core::Interface for ComponentLoadFailedEventArgs {
 impl ::windows::core::RuntimeName for ComponentLoadFailedEventArgs {
     const NAME: &'static str = "Windows.Media.Protection.ComponentLoadFailedEventArgs";
 }
-impl ::core::convert::From<ComponentLoadFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ComponentLoadFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ComponentLoadFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ComponentLoadFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ComponentLoadFailedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ComponentLoadFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ComponentLoadFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ComponentLoadFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ComponentLoadFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ComponentLoadFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ComponentLoadFailedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ComponentLoadFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ComponentLoadFailedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ComponentLoadFailedEventArgs {}
 unsafe impl ::core::marker::Sync for ComponentLoadFailedEventArgs {}
 #[doc = "*Required features: `\"Media_Protection\"`*"]
@@ -522,36 +464,7 @@ unsafe impl ::windows::core::Interface for HdcpSession {
 impl ::windows::core::RuntimeName for HdcpSession {
     const NAME: &'static str = "Windows.Media.Protection.HdcpSession";
 }
-impl ::core::convert::From<HdcpSession> for ::windows::core::IUnknown {
-    fn from(value: HdcpSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HdcpSession> for ::windows::core::IUnknown {
-    fn from(value: &HdcpSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HdcpSession> for &::windows::core::IUnknown {
-    fn from(value: &HdcpSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HdcpSession> for ::windows::core::IInspectable {
-    fn from(value: HdcpSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HdcpSession> for ::windows::core::IInspectable {
-    fn from(value: &HdcpSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HdcpSession> for &::windows::core::IInspectable {
-    fn from(value: &HdcpSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HdcpSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HdcpSession> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -674,36 +587,7 @@ unsafe impl ::windows::core::Interface for MediaProtectionManager {
 impl ::windows::core::RuntimeName for MediaProtectionManager {
     const NAME: &'static str = "Windows.Media.Protection.MediaProtectionManager";
 }
-impl ::core::convert::From<MediaProtectionManager> for ::windows::core::IUnknown {
-    fn from(value: MediaProtectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaProtectionManager> for ::windows::core::IUnknown {
-    fn from(value: &MediaProtectionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaProtectionManager> for &::windows::core::IUnknown {
-    fn from(value: &MediaProtectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaProtectionManager> for ::windows::core::IInspectable {
-    fn from(value: MediaProtectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaProtectionManager> for ::windows::core::IInspectable {
-    fn from(value: &MediaProtectionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaProtectionManager> for &::windows::core::IInspectable {
-    fn from(value: &MediaProtectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaProtectionManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaProtectionManager {}
 unsafe impl ::core::marker::Sync for MediaProtectionManager {}
 #[doc = "*Required features: `\"Media_Protection\"`*"]
@@ -769,36 +653,7 @@ unsafe impl ::windows::core::Interface for MediaProtectionPMPServer {
 impl ::windows::core::RuntimeName for MediaProtectionPMPServer {
     const NAME: &'static str = "Windows.Media.Protection.MediaProtectionPMPServer";
 }
-impl ::core::convert::From<MediaProtectionPMPServer> for ::windows::core::IUnknown {
-    fn from(value: MediaProtectionPMPServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaProtectionPMPServer> for ::windows::core::IUnknown {
-    fn from(value: &MediaProtectionPMPServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaProtectionPMPServer> for &::windows::core::IUnknown {
-    fn from(value: &MediaProtectionPMPServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaProtectionPMPServer> for ::windows::core::IInspectable {
-    fn from(value: MediaProtectionPMPServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaProtectionPMPServer> for ::windows::core::IInspectable {
-    fn from(value: &MediaProtectionPMPServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaProtectionPMPServer> for &::windows::core::IInspectable {
-    fn from(value: &MediaProtectionPMPServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaProtectionPMPServer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaProtectionPMPServer {}
 unsafe impl ::core::marker::Sync for MediaProtectionPMPServer {}
 #[doc = "*Required features: `\"Media_Protection\"`*"]
@@ -842,36 +697,7 @@ unsafe impl ::windows::core::Interface for MediaProtectionServiceCompletion {
 impl ::windows::core::RuntimeName for MediaProtectionServiceCompletion {
     const NAME: &'static str = "Windows.Media.Protection.MediaProtectionServiceCompletion";
 }
-impl ::core::convert::From<MediaProtectionServiceCompletion> for ::windows::core::IUnknown {
-    fn from(value: MediaProtectionServiceCompletion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaProtectionServiceCompletion> for ::windows::core::IUnknown {
-    fn from(value: &MediaProtectionServiceCompletion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaProtectionServiceCompletion> for &::windows::core::IUnknown {
-    fn from(value: &MediaProtectionServiceCompletion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaProtectionServiceCompletion> for ::windows::core::IInspectable {
-    fn from(value: MediaProtectionServiceCompletion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaProtectionServiceCompletion> for ::windows::core::IInspectable {
-    fn from(value: &MediaProtectionServiceCompletion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaProtectionServiceCompletion> for &::windows::core::IInspectable {
-    fn from(value: &MediaProtectionServiceCompletion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaProtectionServiceCompletion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaProtectionServiceCompletion {}
 unsafe impl ::core::marker::Sync for MediaProtectionServiceCompletion {}
 #[doc = "*Required features: `\"Media_Protection\"`*"]
@@ -925,36 +751,7 @@ unsafe impl ::windows::core::Interface for ProtectionCapabilities {
 impl ::windows::core::RuntimeName for ProtectionCapabilities {
     const NAME: &'static str = "Windows.Media.Protection.ProtectionCapabilities";
 }
-impl ::core::convert::From<ProtectionCapabilities> for ::windows::core::IUnknown {
-    fn from(value: ProtectionCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectionCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &ProtectionCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectionCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &ProtectionCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtectionCapabilities> for ::windows::core::IInspectable {
-    fn from(value: ProtectionCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectionCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &ProtectionCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectionCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &ProtectionCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtectionCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProtectionCapabilities {}
 unsafe impl ::core::marker::Sync for ProtectionCapabilities {}
 #[doc = "*Required features: `\"Media_Protection\"`*"]
@@ -1003,36 +800,7 @@ unsafe impl ::windows::core::Interface for RevocationAndRenewalInformation {
 impl ::windows::core::RuntimeName for RevocationAndRenewalInformation {
     const NAME: &'static str = "Windows.Media.Protection.RevocationAndRenewalInformation";
 }
-impl ::core::convert::From<RevocationAndRenewalInformation> for ::windows::core::IUnknown {
-    fn from(value: RevocationAndRenewalInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RevocationAndRenewalInformation> for ::windows::core::IUnknown {
-    fn from(value: &RevocationAndRenewalInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RevocationAndRenewalInformation> for &::windows::core::IUnknown {
-    fn from(value: &RevocationAndRenewalInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RevocationAndRenewalInformation> for ::windows::core::IInspectable {
-    fn from(value: RevocationAndRenewalInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RevocationAndRenewalInformation> for ::windows::core::IInspectable {
-    fn from(value: &RevocationAndRenewalInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RevocationAndRenewalInformation> for &::windows::core::IInspectable {
-    fn from(value: &RevocationAndRenewalInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RevocationAndRenewalInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RevocationAndRenewalInformation {}
 unsafe impl ::core::marker::Sync for RevocationAndRenewalInformation {}
 #[doc = "*Required features: `\"Media_Protection\"`*"]
@@ -1107,36 +875,7 @@ unsafe impl ::windows::core::Interface for RevocationAndRenewalItem {
 impl ::windows::core::RuntimeName for RevocationAndRenewalItem {
     const NAME: &'static str = "Windows.Media.Protection.RevocationAndRenewalItem";
 }
-impl ::core::convert::From<RevocationAndRenewalItem> for ::windows::core::IUnknown {
-    fn from(value: RevocationAndRenewalItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RevocationAndRenewalItem> for ::windows::core::IUnknown {
-    fn from(value: &RevocationAndRenewalItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RevocationAndRenewalItem> for &::windows::core::IUnknown {
-    fn from(value: &RevocationAndRenewalItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RevocationAndRenewalItem> for ::windows::core::IInspectable {
-    fn from(value: RevocationAndRenewalItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RevocationAndRenewalItem> for ::windows::core::IInspectable {
-    fn from(value: &RevocationAndRenewalItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RevocationAndRenewalItem> for &::windows::core::IInspectable {
-    fn from(value: &RevocationAndRenewalItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RevocationAndRenewalItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RevocationAndRenewalItem {}
 unsafe impl ::core::marker::Sync for RevocationAndRenewalItem {}
 #[doc = "*Required features: `\"Media_Protection\"`*"]
@@ -1199,36 +938,7 @@ unsafe impl ::windows::core::Interface for ServiceRequestedEventArgs {
 impl ::windows::core::RuntimeName for ServiceRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.Protection.ServiceRequestedEventArgs";
 }
-impl ::core::convert::From<ServiceRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ServiceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServiceRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ServiceRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServiceRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ServiceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ServiceRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ServiceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServiceRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ServiceRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServiceRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ServiceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ServiceRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ServiceRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for ServiceRequestedEventArgs {}
 #[doc = "*Required features: `\"Media_Protection\"`*"]

--- a/crates/libs/windows/src/Windows/Media/SpeechRecognition/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/SpeechRecognition/mod.rs
@@ -147,36 +147,7 @@ impl ISpeechRecognitionConstraint {
         unsafe { (::windows::core::Vtable::vtable(this).SetProbability)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<ISpeechRecognitionConstraint> for ::windows::core::IUnknown {
-    fn from(value: ISpeechRecognitionConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpeechRecognitionConstraint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechRecognitionConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpeechRecognitionConstraint> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechRecognitionConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpeechRecognitionConstraint> for ::windows::core::IInspectable {
-    fn from(value: ISpeechRecognitionConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpeechRecognitionConstraint> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISpeechRecognitionConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpeechRecognitionConstraint> for ::windows::core::IInspectable {
-    fn from(value: &ISpeechRecognitionConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechRecognitionConstraint, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISpeechRecognitionConstraint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -760,36 +731,7 @@ unsafe impl ::windows::core::Interface for SpeechContinuousRecognitionCompletedE
 impl ::windows::core::RuntimeName for SpeechContinuousRecognitionCompletedEventArgs {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechContinuousRecognitionCompletedEventArgs";
 }
-impl ::core::convert::From<SpeechContinuousRecognitionCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpeechContinuousRecognitionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpeechContinuousRecognitionCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpeechContinuousRecognitionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechContinuousRecognitionCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpeechContinuousRecognitionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpeechContinuousRecognitionCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpeechContinuousRecognitionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechContinuousRecognitionCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechContinuousRecognitionCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for SpeechContinuousRecognitionCompletedEventArgs {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -836,36 +778,7 @@ unsafe impl ::windows::core::Interface for SpeechContinuousRecognitionResultGene
 impl ::windows::core::RuntimeName for SpeechContinuousRecognitionResultGeneratedEventArgs {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechContinuousRecognitionResultGeneratedEventArgs";
 }
-impl ::core::convert::From<SpeechContinuousRecognitionResultGeneratedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpeechContinuousRecognitionResultGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionResultGeneratedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpeechContinuousRecognitionResultGeneratedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionResultGeneratedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpeechContinuousRecognitionResultGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechContinuousRecognitionResultGeneratedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpeechContinuousRecognitionResultGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionResultGeneratedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpeechContinuousRecognitionResultGeneratedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionResultGeneratedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpeechContinuousRecognitionResultGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechContinuousRecognitionResultGeneratedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechContinuousRecognitionResultGeneratedEventArgs {}
 unsafe impl ::core::marker::Sync for SpeechContinuousRecognitionResultGeneratedEventArgs {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -999,36 +912,7 @@ unsafe impl ::windows::core::Interface for SpeechContinuousRecognitionSession {
 impl ::windows::core::RuntimeName for SpeechContinuousRecognitionSession {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechContinuousRecognitionSession";
 }
-impl ::core::convert::From<SpeechContinuousRecognitionSession> for ::windows::core::IUnknown {
-    fn from(value: SpeechContinuousRecognitionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionSession> for ::windows::core::IUnknown {
-    fn from(value: &SpeechContinuousRecognitionSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionSession> for &::windows::core::IUnknown {
-    fn from(value: &SpeechContinuousRecognitionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechContinuousRecognitionSession> for ::windows::core::IInspectable {
-    fn from(value: SpeechContinuousRecognitionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionSession> for ::windows::core::IInspectable {
-    fn from(value: &SpeechContinuousRecognitionSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechContinuousRecognitionSession> for &::windows::core::IInspectable {
-    fn from(value: &SpeechContinuousRecognitionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechContinuousRecognitionSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechContinuousRecognitionSession {}
 unsafe impl ::core::marker::Sync for SpeechContinuousRecognitionSession {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -1075,36 +959,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognitionCompilationResult {
 impl ::windows::core::RuntimeName for SpeechRecognitionCompilationResult {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognitionCompilationResult";
 }
-impl ::core::convert::From<SpeechRecognitionCompilationResult> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognitionCompilationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionCompilationResult> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionCompilationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionCompilationResult> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionCompilationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognitionCompilationResult> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognitionCompilationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionCompilationResult> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionCompilationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionCompilationResult> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionCompilationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognitionCompilationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechRecognitionCompilationResult {}
 unsafe impl ::core::marker::Sync for SpeechRecognitionCompilationResult {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -1214,36 +1069,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognitionGrammarFileConstrain
 impl ::windows::core::RuntimeName for SpeechRecognitionGrammarFileConstraint {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognitionGrammarFileConstraint";
 }
-impl ::core::convert::From<SpeechRecognitionGrammarFileConstraint> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognitionGrammarFileConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionGrammarFileConstraint> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionGrammarFileConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionGrammarFileConstraint> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionGrammarFileConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognitionGrammarFileConstraint> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognitionGrammarFileConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionGrammarFileConstraint> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionGrammarFileConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionGrammarFileConstraint> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionGrammarFileConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognitionGrammarFileConstraint, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SpeechRecognitionGrammarFileConstraint> for ISpeechRecognitionConstraint {
     type Error = ::windows::core::Error;
     fn try_from(value: SpeechRecognitionGrammarFileConstraint) -> ::windows::core::Result<Self> {
@@ -1309,36 +1135,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognitionHypothesis {
 impl ::windows::core::RuntimeName for SpeechRecognitionHypothesis {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognitionHypothesis";
 }
-impl ::core::convert::From<SpeechRecognitionHypothesis> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognitionHypothesis) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionHypothesis> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionHypothesis) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionHypothesis> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionHypothesis) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognitionHypothesis> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognitionHypothesis) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionHypothesis> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionHypothesis) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionHypothesis> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionHypothesis) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognitionHypothesis, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechRecognitionHypothesis {}
 unsafe impl ::core::marker::Sync for SpeechRecognitionHypothesis {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -1385,36 +1182,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognitionHypothesisGeneratedE
 impl ::windows::core::RuntimeName for SpeechRecognitionHypothesisGeneratedEventArgs {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognitionHypothesisGeneratedEventArgs";
 }
-impl ::core::convert::From<SpeechRecognitionHypothesisGeneratedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognitionHypothesisGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionHypothesisGeneratedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionHypothesisGeneratedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionHypothesisGeneratedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionHypothesisGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognitionHypothesisGeneratedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognitionHypothesisGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionHypothesisGeneratedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionHypothesisGeneratedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionHypothesisGeneratedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionHypothesisGeneratedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognitionHypothesisGeneratedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechRecognitionHypothesisGeneratedEventArgs {}
 unsafe impl ::core::marker::Sync for SpeechRecognitionHypothesisGeneratedEventArgs {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -1532,36 +1300,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognitionListConstraint {
 impl ::windows::core::RuntimeName for SpeechRecognitionListConstraint {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognitionListConstraint";
 }
-impl ::core::convert::From<SpeechRecognitionListConstraint> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognitionListConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionListConstraint> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionListConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionListConstraint> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionListConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognitionListConstraint> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognitionListConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionListConstraint> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionListConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionListConstraint> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionListConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognitionListConstraint, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SpeechRecognitionListConstraint> for ISpeechRecognitionConstraint {
     type Error = ::windows::core::Error;
     fn try_from(value: SpeechRecognitionListConstraint) -> ::windows::core::Result<Self> {
@@ -1627,36 +1366,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognitionQualityDegradingEven
 impl ::windows::core::RuntimeName for SpeechRecognitionQualityDegradingEventArgs {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognitionQualityDegradingEventArgs";
 }
-impl ::core::convert::From<SpeechRecognitionQualityDegradingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognitionQualityDegradingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionQualityDegradingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionQualityDegradingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionQualityDegradingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionQualityDegradingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognitionQualityDegradingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognitionQualityDegradingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionQualityDegradingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionQualityDegradingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionQualityDegradingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionQualityDegradingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognitionQualityDegradingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechRecognitionQualityDegradingEventArgs {}
 unsafe impl ::core::marker::Sync for SpeechRecognitionQualityDegradingEventArgs {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -1774,36 +1484,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognitionResult {
 impl ::windows::core::RuntimeName for SpeechRecognitionResult {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognitionResult";
 }
-impl ::core::convert::From<SpeechRecognitionResult> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionResult> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionResult> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognitionResult> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionResult> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionResult> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognitionResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechRecognitionResult {}
 unsafe impl ::core::marker::Sync for SpeechRecognitionResult {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -1852,36 +1533,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognitionSemanticInterpretati
 impl ::windows::core::RuntimeName for SpeechRecognitionSemanticInterpretation {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognitionSemanticInterpretation";
 }
-impl ::core::convert::From<SpeechRecognitionSemanticInterpretation> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognitionSemanticInterpretation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionSemanticInterpretation> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionSemanticInterpretation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionSemanticInterpretation> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionSemanticInterpretation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognitionSemanticInterpretation> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognitionSemanticInterpretation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionSemanticInterpretation> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionSemanticInterpretation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionSemanticInterpretation> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionSemanticInterpretation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognitionSemanticInterpretation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechRecognitionSemanticInterpretation {}
 unsafe impl ::core::marker::Sync for SpeechRecognitionSemanticInterpretation {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -1992,36 +1644,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognitionTopicConstraint {
 impl ::windows::core::RuntimeName for SpeechRecognitionTopicConstraint {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognitionTopicConstraint";
 }
-impl ::core::convert::From<SpeechRecognitionTopicConstraint> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognitionTopicConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionTopicConstraint> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionTopicConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionTopicConstraint> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionTopicConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognitionTopicConstraint> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognitionTopicConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionTopicConstraint> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionTopicConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionTopicConstraint> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionTopicConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognitionTopicConstraint, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SpeechRecognitionTopicConstraint> for ISpeechRecognitionConstraint {
     type Error = ::windows::core::Error;
     fn try_from(value: SpeechRecognitionTopicConstraint) -> ::windows::core::Result<Self> {
@@ -2120,36 +1743,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognitionVoiceCommandDefiniti
 impl ::windows::core::RuntimeName for SpeechRecognitionVoiceCommandDefinitionConstraint {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognitionVoiceCommandDefinitionConstraint";
 }
-impl ::core::convert::From<SpeechRecognitionVoiceCommandDefinitionConstraint> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognitionVoiceCommandDefinitionConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionVoiceCommandDefinitionConstraint> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionVoiceCommandDefinitionConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionVoiceCommandDefinitionConstraint> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognitionVoiceCommandDefinitionConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognitionVoiceCommandDefinitionConstraint> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognitionVoiceCommandDefinitionConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionVoiceCommandDefinitionConstraint> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionVoiceCommandDefinitionConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognitionVoiceCommandDefinitionConstraint> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognitionVoiceCommandDefinitionConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognitionVoiceCommandDefinitionConstraint, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SpeechRecognitionVoiceCommandDefinitionConstraint> for ISpeechRecognitionConstraint {
     type Error = ::windows::core::Error;
     fn try_from(value: SpeechRecognitionVoiceCommandDefinitionConstraint) -> ::windows::core::Result<Self> {
@@ -2403,36 +1997,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognizer {
 impl ::windows::core::RuntimeName for SpeechRecognizer {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognizer";
 }
-impl ::core::convert::From<SpeechRecognizer> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognizer> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognizer> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognizer> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognizer> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognizer> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognizer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<SpeechRecognizer> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2501,36 +2066,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognizerStateChangedEventArgs
 impl ::windows::core::RuntimeName for SpeechRecognizerStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognizerStateChangedEventArgs";
 }
-impl ::core::convert::From<SpeechRecognizerStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognizerStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognizerStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognizerStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognizerStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognizerStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognizerStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognizerStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognizerStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechRecognizerStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for SpeechRecognizerStateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -2615,36 +2151,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognizerTimeouts {
 impl ::windows::core::RuntimeName for SpeechRecognizerTimeouts {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognizerTimeouts";
 }
-impl ::core::convert::From<SpeechRecognizerTimeouts> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognizerTimeouts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerTimeouts> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognizerTimeouts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerTimeouts> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognizerTimeouts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognizerTimeouts> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognizerTimeouts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerTimeouts> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognizerTimeouts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerTimeouts> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognizerTimeouts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognizerTimeouts, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechRecognizerTimeouts {}
 unsafe impl ::core::marker::Sync for SpeechRecognizerTimeouts {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -2728,36 +2235,7 @@ unsafe impl ::windows::core::Interface for SpeechRecognizerUIOptions {
 impl ::windows::core::RuntimeName for SpeechRecognizerUIOptions {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.SpeechRecognizerUIOptions";
 }
-impl ::core::convert::From<SpeechRecognizerUIOptions> for ::windows::core::IUnknown {
-    fn from(value: SpeechRecognizerUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerUIOptions> for ::windows::core::IUnknown {
-    fn from(value: &SpeechRecognizerUIOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerUIOptions> for &::windows::core::IUnknown {
-    fn from(value: &SpeechRecognizerUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechRecognizerUIOptions> for ::windows::core::IInspectable {
-    fn from(value: SpeechRecognizerUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerUIOptions> for ::windows::core::IInspectable {
-    fn from(value: &SpeechRecognizerUIOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechRecognizerUIOptions> for &::windows::core::IInspectable {
-    fn from(value: &SpeechRecognizerUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechRecognizerUIOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechRecognizerUIOptions {}
 unsafe impl ::core::marker::Sync for SpeechRecognizerUIOptions {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]
@@ -2852,36 +2330,7 @@ unsafe impl ::windows::core::Interface for VoiceCommandSet {
 impl ::windows::core::RuntimeName for VoiceCommandSet {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.VoiceCommandSet";
 }
-impl ::core::convert::From<VoiceCommandSet> for ::windows::core::IUnknown {
-    fn from(value: VoiceCommandSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandSet> for ::windows::core::IUnknown {
-    fn from(value: &VoiceCommandSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandSet> for &::windows::core::IUnknown {
-    fn from(value: &VoiceCommandSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceCommandSet> for ::windows::core::IInspectable {
-    fn from(value: VoiceCommandSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceCommandSet> for ::windows::core::IInspectable {
-    fn from(value: &VoiceCommandSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceCommandSet> for &::windows::core::IInspectable {
-    fn from(value: &VoiceCommandSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceCommandSet, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoiceCommandSet {}
 unsafe impl ::core::marker::Sync for VoiceCommandSet {}
 #[doc = "*Required features: `\"Media_SpeechRecognition\"`*"]

--- a/crates/libs/windows/src/Windows/Media/SpeechSynthesis/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/SpeechSynthesis/mod.rs
@@ -347,36 +347,7 @@ unsafe impl ::windows::core::Interface for SpeechSynthesisStream {
 impl ::windows::core::RuntimeName for SpeechSynthesisStream {
     const NAME: &'static str = "Windows.Media.SpeechSynthesis.SpeechSynthesisStream";
 }
-impl ::core::convert::From<SpeechSynthesisStream> for ::windows::core::IUnknown {
-    fn from(value: SpeechSynthesisStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechSynthesisStream> for ::windows::core::IUnknown {
-    fn from(value: &SpeechSynthesisStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechSynthesisStream> for &::windows::core::IUnknown {
-    fn from(value: &SpeechSynthesisStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechSynthesisStream> for ::windows::core::IInspectable {
-    fn from(value: SpeechSynthesisStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechSynthesisStream> for ::windows::core::IInspectable {
-    fn from(value: &SpeechSynthesisStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechSynthesisStream> for &::windows::core::IInspectable {
-    fn from(value: &SpeechSynthesisStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechSynthesisStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<SpeechSynthesisStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -651,36 +622,7 @@ unsafe impl ::windows::core::Interface for SpeechSynthesizer {
 impl ::windows::core::RuntimeName for SpeechSynthesizer {
     const NAME: &'static str = "Windows.Media.SpeechSynthesis.SpeechSynthesizer";
 }
-impl ::core::convert::From<SpeechSynthesizer> for ::windows::core::IUnknown {
-    fn from(value: SpeechSynthesizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechSynthesizer> for ::windows::core::IUnknown {
-    fn from(value: &SpeechSynthesizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechSynthesizer> for &::windows::core::IUnknown {
-    fn from(value: &SpeechSynthesizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechSynthesizer> for ::windows::core::IInspectable {
-    fn from(value: SpeechSynthesizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechSynthesizer> for ::windows::core::IInspectable {
-    fn from(value: &SpeechSynthesizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechSynthesizer> for &::windows::core::IInspectable {
-    fn from(value: &SpeechSynthesizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechSynthesizer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<SpeechSynthesizer> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -819,36 +761,7 @@ unsafe impl ::windows::core::Interface for SpeechSynthesizerOptions {
 impl ::windows::core::RuntimeName for SpeechSynthesizerOptions {
     const NAME: &'static str = "Windows.Media.SpeechSynthesis.SpeechSynthesizerOptions";
 }
-impl ::core::convert::From<SpeechSynthesizerOptions> for ::windows::core::IUnknown {
-    fn from(value: SpeechSynthesizerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechSynthesizerOptions> for ::windows::core::IUnknown {
-    fn from(value: &SpeechSynthesizerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechSynthesizerOptions> for &::windows::core::IUnknown {
-    fn from(value: &SpeechSynthesizerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeechSynthesizerOptions> for ::windows::core::IInspectable {
-    fn from(value: SpeechSynthesizerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeechSynthesizerOptions> for ::windows::core::IInspectable {
-    fn from(value: &SpeechSynthesizerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeechSynthesizerOptions> for &::windows::core::IInspectable {
-    fn from(value: &SpeechSynthesizerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeechSynthesizerOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpeechSynthesizerOptions {}
 unsafe impl ::core::marker::Sync for SpeechSynthesizerOptions {}
 #[doc = "*Required features: `\"Media_SpeechSynthesis\"`*"]
@@ -923,36 +836,7 @@ unsafe impl ::windows::core::Interface for VoiceInformation {
 impl ::windows::core::RuntimeName for VoiceInformation {
     const NAME: &'static str = "Windows.Media.SpeechSynthesis.VoiceInformation";
 }
-impl ::core::convert::From<VoiceInformation> for ::windows::core::IUnknown {
-    fn from(value: VoiceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceInformation> for ::windows::core::IUnknown {
-    fn from(value: &VoiceInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceInformation> for &::windows::core::IUnknown {
-    fn from(value: &VoiceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VoiceInformation> for ::windows::core::IInspectable {
-    fn from(value: VoiceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VoiceInformation> for ::windows::core::IInspectable {
-    fn from(value: &VoiceInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VoiceInformation> for &::windows::core::IInspectable {
-    fn from(value: &VoiceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VoiceInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VoiceInformation {}
 unsafe impl ::core::marker::Sync for VoiceInformation {}
 #[doc = "*Required features: `\"Media_SpeechSynthesis\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Streaming/Adaptive/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Streaming/Adaptive/mod.rs
@@ -1089,36 +1089,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSource {
 impl ::windows::core::RuntimeName for AdaptiveMediaSource {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSource";
 }
-impl ::core::convert::From<AdaptiveMediaSource> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSource> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSource> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSource> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSource> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSource> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<AdaptiveMediaSource> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1251,36 +1222,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceAdvancedSettings {
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceAdvancedSettings {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceAdvancedSettings";
 }
-impl ::core::convert::From<AdaptiveMediaSourceAdvancedSettings> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceAdvancedSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceAdvancedSettings> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceAdvancedSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceAdvancedSettings> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceAdvancedSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceAdvancedSettings> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceAdvancedSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceAdvancedSettings> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceAdvancedSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceAdvancedSettings> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceAdvancedSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceAdvancedSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceAdvancedSettings {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceAdvancedSettings {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -1347,36 +1289,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceCorrelatedTimes {
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceCorrelatedTimes {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceCorrelatedTimes";
 }
-impl ::core::convert::From<AdaptiveMediaSourceCorrelatedTimes> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceCorrelatedTimes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceCorrelatedTimes> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceCorrelatedTimes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceCorrelatedTimes> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceCorrelatedTimes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceCorrelatedTimes> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceCorrelatedTimes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceCorrelatedTimes> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceCorrelatedTimes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceCorrelatedTimes> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceCorrelatedTimes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceCorrelatedTimes, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceCorrelatedTimes {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceCorrelatedTimes {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -1446,36 +1359,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceCreationResult {
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceCreationResult {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceCreationResult";
 }
-impl ::core::convert::From<AdaptiveMediaSourceCreationResult> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceCreationResult> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceCreationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceCreationResult> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceCreationResult> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceCreationResult> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceCreationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceCreationResult> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceCreationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceCreationResult {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceCreationResult {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -1617,36 +1501,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceDiagnosticAvailabl
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceDiagnosticAvailableEventArgs {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDiagnosticAvailableEventArgs";
 }
-impl ::core::convert::From<AdaptiveMediaSourceDiagnosticAvailableEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceDiagnosticAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDiagnosticAvailableEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDiagnosticAvailableEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDiagnosticAvailableEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDiagnosticAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceDiagnosticAvailableEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceDiagnosticAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDiagnosticAvailableEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDiagnosticAvailableEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDiagnosticAvailableEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDiagnosticAvailableEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceDiagnosticAvailableEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceDiagnosticAvailableEventArgs {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceDiagnosticAvailableEventArgs {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -1701,36 +1556,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceDiagnostics {
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceDiagnostics {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDiagnostics";
 }
-impl ::core::convert::From<AdaptiveMediaSourceDiagnostics> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceDiagnostics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDiagnostics> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDiagnostics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDiagnostics> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDiagnostics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceDiagnostics> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceDiagnostics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDiagnostics> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDiagnostics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDiagnostics> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDiagnostics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceDiagnostics, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceDiagnostics {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceDiagnostics {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -1791,36 +1617,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceDownloadBitrateCha
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceDownloadBitrateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadBitrateChangedEventArgs";
 }
-impl ::core::convert::From<AdaptiveMediaSourceDownloadBitrateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceDownloadBitrateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadBitrateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadBitrateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadBitrateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadBitrateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceDownloadBitrateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceDownloadBitrateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadBitrateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadBitrateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadBitrateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadBitrateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceDownloadBitrateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceDownloadBitrateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceDownloadBitrateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -1942,36 +1739,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceDownloadCompletedE
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceDownloadCompletedEventArgs {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadCompletedEventArgs";
 }
-impl ::core::convert::From<AdaptiveMediaSourceDownloadCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceDownloadCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceDownloadCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceDownloadCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceDownloadCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceDownloadCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceDownloadCompletedEventArgs {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -2100,36 +1868,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceDownloadFailedEven
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceDownloadFailedEventArgs {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadFailedEventArgs";
 }
-impl ::core::convert::From<AdaptiveMediaSourceDownloadFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceDownloadFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadFailedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceDownloadFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceDownloadFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadFailedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceDownloadFailedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceDownloadFailedEventArgs {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceDownloadFailedEventArgs {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -2173,36 +1912,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceDownloadRequestedD
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceDownloadRequestedDeferral {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadRequestedDeferral";
 }
-impl ::core::convert::From<AdaptiveMediaSourceDownloadRequestedDeferral> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceDownloadRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadRequestedDeferral> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadRequestedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadRequestedDeferral> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceDownloadRequestedDeferral> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceDownloadRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadRequestedDeferral> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadRequestedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadRequestedDeferral> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadRequestedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceDownloadRequestedDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceDownloadRequestedDeferral {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceDownloadRequestedDeferral {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -2322,36 +2032,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceDownloadRequestedE
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceDownloadRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadRequestedEventArgs";
 }
-impl ::core::convert::From<AdaptiveMediaSourceDownloadRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceDownloadRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceDownloadRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceDownloadRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceDownloadRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceDownloadRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceDownloadRequestedEventArgs {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -2504,36 +2185,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceDownloadResult {
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceDownloadResult {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadResult";
 }
-impl ::core::convert::From<AdaptiveMediaSourceDownloadResult> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadResult> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadResult> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceDownloadResult> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadResult> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadResult> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceDownloadResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceDownloadResult {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceDownloadResult {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -2607,36 +2259,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourceDownloadStatistics
 impl ::windows::core::RuntimeName for AdaptiveMediaSourceDownloadStatistics {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourceDownloadStatistics";
 }
-impl ::core::convert::From<AdaptiveMediaSourceDownloadStatistics> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourceDownloadStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadStatistics> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadStatistics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadStatistics> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourceDownloadStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourceDownloadStatistics> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourceDownloadStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadStatistics> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadStatistics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourceDownloadStatistics> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourceDownloadStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourceDownloadStatistics, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourceDownloadStatistics {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceDownloadStatistics {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]
@@ -2697,36 +2320,7 @@ unsafe impl ::windows::core::Interface for AdaptiveMediaSourcePlaybackBitrateCha
 impl ::windows::core::RuntimeName for AdaptiveMediaSourcePlaybackBitrateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Streaming.Adaptive.AdaptiveMediaSourcePlaybackBitrateChangedEventArgs";
 }
-impl ::core::convert::From<AdaptiveMediaSourcePlaybackBitrateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveMediaSourcePlaybackBitrateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourcePlaybackBitrateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourcePlaybackBitrateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourcePlaybackBitrateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveMediaSourcePlaybackBitrateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveMediaSourcePlaybackBitrateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveMediaSourcePlaybackBitrateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourcePlaybackBitrateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourcePlaybackBitrateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveMediaSourcePlaybackBitrateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveMediaSourcePlaybackBitrateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveMediaSourcePlaybackBitrateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdaptiveMediaSourcePlaybackBitrateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourcePlaybackBitrateChangedEventArgs {}
 #[doc = "*Required features: `\"Media_Streaming_Adaptive\"`*"]

--- a/crates/libs/windows/src/Windows/Media/Transcoding/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Transcoding/mod.rs
@@ -275,36 +275,7 @@ unsafe impl ::windows::core::Interface for MediaTranscoder {
 impl ::windows::core::RuntimeName for MediaTranscoder {
     const NAME: &'static str = "Windows.Media.Transcoding.MediaTranscoder";
 }
-impl ::core::convert::From<MediaTranscoder> for ::windows::core::IUnknown {
-    fn from(value: MediaTranscoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaTranscoder> for ::windows::core::IUnknown {
-    fn from(value: &MediaTranscoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaTranscoder> for &::windows::core::IUnknown {
-    fn from(value: &MediaTranscoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaTranscoder> for ::windows::core::IInspectable {
-    fn from(value: MediaTranscoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaTranscoder> for ::windows::core::IInspectable {
-    fn from(value: &MediaTranscoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaTranscoder> for &::windows::core::IInspectable {
-    fn from(value: &MediaTranscoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaTranscoder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaTranscoder {}
 unsafe impl ::core::marker::Sync for MediaTranscoder {}
 #[doc = "*Required features: `\"Media_Transcoding\"`*"]
@@ -367,36 +338,7 @@ unsafe impl ::windows::core::Interface for PrepareTranscodeResult {
 impl ::windows::core::RuntimeName for PrepareTranscodeResult {
     const NAME: &'static str = "Windows.Media.Transcoding.PrepareTranscodeResult";
 }
-impl ::core::convert::From<PrepareTranscodeResult> for ::windows::core::IUnknown {
-    fn from(value: PrepareTranscodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrepareTranscodeResult> for ::windows::core::IUnknown {
-    fn from(value: &PrepareTranscodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrepareTranscodeResult> for &::windows::core::IUnknown {
-    fn from(value: &PrepareTranscodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PrepareTranscodeResult> for ::windows::core::IInspectable {
-    fn from(value: PrepareTranscodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PrepareTranscodeResult> for ::windows::core::IInspectable {
-    fn from(value: &PrepareTranscodeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PrepareTranscodeResult> for &::windows::core::IInspectable {
-    fn from(value: &PrepareTranscodeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PrepareTranscodeResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PrepareTranscodeResult {}
 unsafe impl ::core::marker::Sync for PrepareTranscodeResult {}
 #[doc = "*Required features: `\"Media_Transcoding\"`*"]

--- a/crates/libs/windows/src/Windows/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/mod.rs
@@ -297,36 +297,7 @@ impl IMediaExtension {
         unsafe { (::windows::core::Vtable::vtable(this).SetProperties)(::windows::core::Vtable::as_raw(this), configuration.try_into().map_err(|e| e.into())?.abi()).ok() }
     }
 }
-impl ::core::convert::From<IMediaExtension> for ::windows::core::IUnknown {
-    fn from(value: IMediaExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaExtension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaExtension> for ::windows::core::IUnknown {
-    fn from(value: &IMediaExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaExtension> for ::windows::core::IInspectable {
-    fn from(value: IMediaExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaExtension> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaExtension> for ::windows::core::IInspectable {
-    fn from(value: &IMediaExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaExtension, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMediaExtension {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -529,36 +500,7 @@ impl IMediaFrame {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: IMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaFrame> for ::windows::core::IUnknown {
-    fn from(value: &IMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: IMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaFrame> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaFrame> for ::windows::core::IInspectable {
-    fn from(value: &IMediaFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IMediaFrame> for super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -675,36 +617,7 @@ impl IMediaMarker {
         }
     }
 }
-impl ::core::convert::From<IMediaMarker> for ::windows::core::IUnknown {
-    fn from(value: IMediaMarker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaMarker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaMarker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaMarker> for ::windows::core::IUnknown {
-    fn from(value: &IMediaMarker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaMarker> for ::windows::core::IInspectable {
-    fn from(value: IMediaMarker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaMarker> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaMarker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaMarker> for ::windows::core::IInspectable {
-    fn from(value: &IMediaMarker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaMarker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMediaMarker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -774,36 +687,7 @@ impl IMediaMarkers {
         }
     }
 }
-impl ::core::convert::From<IMediaMarkers> for ::windows::core::IUnknown {
-    fn from(value: IMediaMarkers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaMarkers> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaMarkers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaMarkers> for ::windows::core::IUnknown {
-    fn from(value: &IMediaMarkers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMediaMarkers> for ::windows::core::IInspectable {
-    fn from(value: IMediaMarkers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaMarkers> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMediaMarkers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaMarkers> for ::windows::core::IInspectable {
-    fn from(value: &IMediaMarkers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaMarkers, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMediaMarkers {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1525,36 +1409,7 @@ unsafe impl ::windows::core::Interface for AudioBuffer {
 impl ::windows::core::RuntimeName for AudioBuffer {
     const NAME: &'static str = "Windows.Media.AudioBuffer";
 }
-impl ::core::convert::From<AudioBuffer> for ::windows::core::IUnknown {
-    fn from(value: AudioBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioBuffer> for ::windows::core::IUnknown {
-    fn from(value: &AudioBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioBuffer> for &::windows::core::IUnknown {
-    fn from(value: &AudioBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioBuffer> for ::windows::core::IInspectable {
-    fn from(value: AudioBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioBuffer> for ::windows::core::IInspectable {
-    fn from(value: &AudioBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioBuffer> for &::windows::core::IInspectable {
-    fn from(value: &AudioBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioBuffer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<AudioBuffer> for super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1753,36 +1608,7 @@ unsafe impl ::windows::core::Interface for AudioFrame {
 impl ::windows::core::RuntimeName for AudioFrame {
     const NAME: &'static str = "Windows.Media.AudioFrame";
 }
-impl ::core::convert::From<AudioFrame> for ::windows::core::IUnknown {
-    fn from(value: AudioFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFrame> for ::windows::core::IUnknown {
-    fn from(value: &AudioFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFrame> for &::windows::core::IUnknown {
-    fn from(value: &AudioFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioFrame> for ::windows::core::IInspectable {
-    fn from(value: AudioFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioFrame> for ::windows::core::IInspectable {
-    fn from(value: &AudioFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioFrame> for &::windows::core::IInspectable {
-    fn from(value: &AudioFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<AudioFrame> for super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1870,36 +1696,7 @@ unsafe impl ::windows::core::Interface for AutoRepeatModeChangeRequestedEventArg
 impl ::windows::core::RuntimeName for AutoRepeatModeChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.AutoRepeatModeChangeRequestedEventArgs";
 }
-impl ::core::convert::From<AutoRepeatModeChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AutoRepeatModeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutoRepeatModeChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AutoRepeatModeChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutoRepeatModeChangeRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AutoRepeatModeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AutoRepeatModeChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AutoRepeatModeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutoRepeatModeChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AutoRepeatModeChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutoRepeatModeChangeRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AutoRepeatModeChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AutoRepeatModeChangeRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AutoRepeatModeChangeRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for AutoRepeatModeChangeRequestedEventArgs {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -1961,36 +1758,7 @@ unsafe impl ::windows::core::Interface for ImageDisplayProperties {
 impl ::windows::core::RuntimeName for ImageDisplayProperties {
     const NAME: &'static str = "Windows.Media.ImageDisplayProperties";
 }
-impl ::core::convert::From<ImageDisplayProperties> for ::windows::core::IUnknown {
-    fn from(value: ImageDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageDisplayProperties> for ::windows::core::IUnknown {
-    fn from(value: &ImageDisplayProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageDisplayProperties> for &::windows::core::IUnknown {
-    fn from(value: &ImageDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageDisplayProperties> for ::windows::core::IInspectable {
-    fn from(value: ImageDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageDisplayProperties> for ::windows::core::IInspectable {
-    fn from(value: &ImageDisplayProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageDisplayProperties> for &::windows::core::IInspectable {
-    fn from(value: &ImageDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageDisplayProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ImageDisplayProperties {}
 unsafe impl ::core::marker::Sync for ImageDisplayProperties {}
 #[doc = "*Required features: `\"Media\"`, `\"deprecated\"`*"]
@@ -2363,36 +2131,7 @@ unsafe impl ::windows::core::Interface for MediaExtensionManager {
 impl ::windows::core::RuntimeName for MediaExtensionManager {
     const NAME: &'static str = "Windows.Media.MediaExtensionManager";
 }
-impl ::core::convert::From<MediaExtensionManager> for ::windows::core::IUnknown {
-    fn from(value: MediaExtensionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaExtensionManager> for ::windows::core::IUnknown {
-    fn from(value: &MediaExtensionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaExtensionManager> for &::windows::core::IUnknown {
-    fn from(value: &MediaExtensionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaExtensionManager> for ::windows::core::IInspectable {
-    fn from(value: MediaExtensionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaExtensionManager> for ::windows::core::IInspectable {
-    fn from(value: &MediaExtensionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaExtensionManager> for &::windows::core::IInspectable {
-    fn from(value: &MediaExtensionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaExtensionManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaExtensionManager {}
 unsafe impl ::core::marker::Sync for MediaExtensionManager {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -2459,36 +2198,7 @@ unsafe impl ::windows::core::Interface for MediaProcessingTriggerDetails {
 impl ::windows::core::RuntimeName for MediaProcessingTriggerDetails {
     const NAME: &'static str = "Windows.Media.MediaProcessingTriggerDetails";
 }
-impl ::core::convert::From<MediaProcessingTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: MediaProcessingTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaProcessingTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &MediaProcessingTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaProcessingTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &MediaProcessingTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaProcessingTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: MediaProcessingTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaProcessingTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &MediaProcessingTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaProcessingTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &MediaProcessingTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaProcessingTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaProcessingTriggerDetails {}
 unsafe impl ::core::marker::Sync for MediaProcessingTriggerDetails {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -2670,36 +2380,7 @@ unsafe impl ::windows::core::Interface for MediaTimelineController {
 impl ::windows::core::RuntimeName for MediaTimelineController {
     const NAME: &'static str = "Windows.Media.MediaTimelineController";
 }
-impl ::core::convert::From<MediaTimelineController> for ::windows::core::IUnknown {
-    fn from(value: MediaTimelineController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaTimelineController> for ::windows::core::IUnknown {
-    fn from(value: &MediaTimelineController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaTimelineController> for &::windows::core::IUnknown {
-    fn from(value: &MediaTimelineController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaTimelineController> for ::windows::core::IInspectable {
-    fn from(value: MediaTimelineController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaTimelineController> for ::windows::core::IInspectable {
-    fn from(value: &MediaTimelineController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaTimelineController> for &::windows::core::IInspectable {
-    fn from(value: &MediaTimelineController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaTimelineController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaTimelineController {}
 unsafe impl ::core::marker::Sync for MediaTimelineController {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -2746,36 +2427,7 @@ unsafe impl ::windows::core::Interface for MediaTimelineControllerFailedEventArg
 impl ::windows::core::RuntimeName for MediaTimelineControllerFailedEventArgs {
     const NAME: &'static str = "Windows.Media.MediaTimelineControllerFailedEventArgs";
 }
-impl ::core::convert::From<MediaTimelineControllerFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MediaTimelineControllerFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaTimelineControllerFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MediaTimelineControllerFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaTimelineControllerFailedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MediaTimelineControllerFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaTimelineControllerFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MediaTimelineControllerFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaTimelineControllerFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MediaTimelineControllerFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaTimelineControllerFailedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MediaTimelineControllerFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaTimelineControllerFailedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MediaTimelineControllerFailedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaTimelineControllerFailedEventArgs {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -2890,36 +2542,7 @@ unsafe impl ::windows::core::Interface for MusicDisplayProperties {
 impl ::windows::core::RuntimeName for MusicDisplayProperties {
     const NAME: &'static str = "Windows.Media.MusicDisplayProperties";
 }
-impl ::core::convert::From<MusicDisplayProperties> for ::windows::core::IUnknown {
-    fn from(value: MusicDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MusicDisplayProperties> for ::windows::core::IUnknown {
-    fn from(value: &MusicDisplayProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MusicDisplayProperties> for &::windows::core::IUnknown {
-    fn from(value: &MusicDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MusicDisplayProperties> for ::windows::core::IInspectable {
-    fn from(value: MusicDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MusicDisplayProperties> for ::windows::core::IInspectable {
-    fn from(value: &MusicDisplayProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MusicDisplayProperties> for &::windows::core::IInspectable {
-    fn from(value: &MusicDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MusicDisplayProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MusicDisplayProperties {}
 unsafe impl ::core::marker::Sync for MusicDisplayProperties {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -2968,36 +2591,7 @@ unsafe impl ::windows::core::Interface for PlaybackPositionChangeRequestedEventA
 impl ::windows::core::RuntimeName for PlaybackPositionChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.PlaybackPositionChangeRequestedEventArgs";
 }
-impl ::core::convert::From<PlaybackPositionChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PlaybackPositionChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackPositionChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PlaybackPositionChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackPositionChangeRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PlaybackPositionChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlaybackPositionChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PlaybackPositionChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackPositionChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PlaybackPositionChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackPositionChangeRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PlaybackPositionChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlaybackPositionChangeRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PlaybackPositionChangeRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for PlaybackPositionChangeRequestedEventArgs {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -3044,36 +2638,7 @@ unsafe impl ::windows::core::Interface for PlaybackRateChangeRequestedEventArgs 
 impl ::windows::core::RuntimeName for PlaybackRateChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.PlaybackRateChangeRequestedEventArgs";
 }
-impl ::core::convert::From<PlaybackRateChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PlaybackRateChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackRateChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PlaybackRateChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackRateChangeRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PlaybackRateChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlaybackRateChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PlaybackRateChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaybackRateChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PlaybackRateChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaybackRateChangeRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PlaybackRateChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlaybackRateChangeRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PlaybackRateChangeRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for PlaybackRateChangeRequestedEventArgs {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -3120,36 +2685,7 @@ unsafe impl ::windows::core::Interface for ShuffleEnabledChangeRequestedEventArg
 impl ::windows::core::RuntimeName for ShuffleEnabledChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.ShuffleEnabledChangeRequestedEventArgs";
 }
-impl ::core::convert::From<ShuffleEnabledChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ShuffleEnabledChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShuffleEnabledChangeRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ShuffleEnabledChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShuffleEnabledChangeRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ShuffleEnabledChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShuffleEnabledChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ShuffleEnabledChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShuffleEnabledChangeRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ShuffleEnabledChangeRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShuffleEnabledChangeRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ShuffleEnabledChangeRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShuffleEnabledChangeRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ShuffleEnabledChangeRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for ShuffleEnabledChangeRequestedEventArgs {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -3473,36 +3009,7 @@ unsafe impl ::windows::core::Interface for SystemMediaTransportControls {
 impl ::windows::core::RuntimeName for SystemMediaTransportControls {
     const NAME: &'static str = "Windows.Media.SystemMediaTransportControls";
 }
-impl ::core::convert::From<SystemMediaTransportControls> for ::windows::core::IUnknown {
-    fn from(value: SystemMediaTransportControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControls> for ::windows::core::IUnknown {
-    fn from(value: &SystemMediaTransportControls) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControls> for &::windows::core::IUnknown {
-    fn from(value: &SystemMediaTransportControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemMediaTransportControls> for ::windows::core::IInspectable {
-    fn from(value: SystemMediaTransportControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControls> for ::windows::core::IInspectable {
-    fn from(value: &SystemMediaTransportControls) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControls> for &::windows::core::IInspectable {
-    fn from(value: &SystemMediaTransportControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemMediaTransportControls, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemMediaTransportControls {}
 unsafe impl ::core::marker::Sync for SystemMediaTransportControls {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -3549,36 +3056,7 @@ unsafe impl ::windows::core::Interface for SystemMediaTransportControlsButtonPre
 impl ::windows::core::RuntimeName for SystemMediaTransportControlsButtonPressedEventArgs {
     const NAME: &'static str = "Windows.Media.SystemMediaTransportControlsButtonPressedEventArgs";
 }
-impl ::core::convert::From<SystemMediaTransportControlsButtonPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SystemMediaTransportControlsButtonPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsButtonPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SystemMediaTransportControlsButtonPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsButtonPressedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SystemMediaTransportControlsButtonPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemMediaTransportControlsButtonPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SystemMediaTransportControlsButtonPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsButtonPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SystemMediaTransportControlsButtonPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsButtonPressedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SystemMediaTransportControlsButtonPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemMediaTransportControlsButtonPressedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemMediaTransportControlsButtonPressedEventArgs {}
 unsafe impl ::core::marker::Sync for SystemMediaTransportControlsButtonPressedEventArgs {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -3693,36 +3171,7 @@ unsafe impl ::windows::core::Interface for SystemMediaTransportControlsDisplayUp
 impl ::windows::core::RuntimeName for SystemMediaTransportControlsDisplayUpdater {
     const NAME: &'static str = "Windows.Media.SystemMediaTransportControlsDisplayUpdater";
 }
-impl ::core::convert::From<SystemMediaTransportControlsDisplayUpdater> for ::windows::core::IUnknown {
-    fn from(value: SystemMediaTransportControlsDisplayUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsDisplayUpdater> for ::windows::core::IUnknown {
-    fn from(value: &SystemMediaTransportControlsDisplayUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsDisplayUpdater> for &::windows::core::IUnknown {
-    fn from(value: &SystemMediaTransportControlsDisplayUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemMediaTransportControlsDisplayUpdater> for ::windows::core::IInspectable {
-    fn from(value: SystemMediaTransportControlsDisplayUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsDisplayUpdater> for ::windows::core::IInspectable {
-    fn from(value: &SystemMediaTransportControlsDisplayUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsDisplayUpdater> for &::windows::core::IInspectable {
-    fn from(value: &SystemMediaTransportControlsDisplayUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemMediaTransportControlsDisplayUpdater, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemMediaTransportControlsDisplayUpdater {}
 unsafe impl ::core::marker::Sync for SystemMediaTransportControlsDisplayUpdater {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -3769,36 +3218,7 @@ unsafe impl ::windows::core::Interface for SystemMediaTransportControlsPropertyC
 impl ::windows::core::RuntimeName for SystemMediaTransportControlsPropertyChangedEventArgs {
     const NAME: &'static str = "Windows.Media.SystemMediaTransportControlsPropertyChangedEventArgs";
 }
-impl ::core::convert::From<SystemMediaTransportControlsPropertyChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SystemMediaTransportControlsPropertyChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsPropertyChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SystemMediaTransportControlsPropertyChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsPropertyChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SystemMediaTransportControlsPropertyChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemMediaTransportControlsPropertyChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SystemMediaTransportControlsPropertyChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsPropertyChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SystemMediaTransportControlsPropertyChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsPropertyChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SystemMediaTransportControlsPropertyChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemMediaTransportControlsPropertyChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemMediaTransportControlsPropertyChangedEventArgs {}
 unsafe impl ::core::marker::Sync for SystemMediaTransportControlsPropertyChangedEventArgs {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -3920,36 +3340,7 @@ unsafe impl ::windows::core::Interface for SystemMediaTransportControlsTimelineP
 impl ::windows::core::RuntimeName for SystemMediaTransportControlsTimelineProperties {
     const NAME: &'static str = "Windows.Media.SystemMediaTransportControlsTimelineProperties";
 }
-impl ::core::convert::From<SystemMediaTransportControlsTimelineProperties> for ::windows::core::IUnknown {
-    fn from(value: SystemMediaTransportControlsTimelineProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsTimelineProperties> for ::windows::core::IUnknown {
-    fn from(value: &SystemMediaTransportControlsTimelineProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsTimelineProperties> for &::windows::core::IUnknown {
-    fn from(value: &SystemMediaTransportControlsTimelineProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemMediaTransportControlsTimelineProperties> for ::windows::core::IInspectable {
-    fn from(value: SystemMediaTransportControlsTimelineProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsTimelineProperties> for ::windows::core::IInspectable {
-    fn from(value: &SystemMediaTransportControlsTimelineProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaTransportControlsTimelineProperties> for &::windows::core::IInspectable {
-    fn from(value: &SystemMediaTransportControlsTimelineProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemMediaTransportControlsTimelineProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemMediaTransportControlsTimelineProperties {}
 unsafe impl ::core::marker::Sync for SystemMediaTransportControlsTimelineProperties {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -4020,36 +3411,7 @@ unsafe impl ::windows::core::Interface for VideoDisplayProperties {
 impl ::windows::core::RuntimeName for VideoDisplayProperties {
     const NAME: &'static str = "Windows.Media.VideoDisplayProperties";
 }
-impl ::core::convert::From<VideoDisplayProperties> for ::windows::core::IUnknown {
-    fn from(value: VideoDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoDisplayProperties> for ::windows::core::IUnknown {
-    fn from(value: &VideoDisplayProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoDisplayProperties> for &::windows::core::IUnknown {
-    fn from(value: &VideoDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoDisplayProperties> for ::windows::core::IInspectable {
-    fn from(value: VideoDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoDisplayProperties> for ::windows::core::IInspectable {
-    fn from(value: &VideoDisplayProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoDisplayProperties> for &::windows::core::IInspectable {
-    fn from(value: &VideoDisplayProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoDisplayProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VideoDisplayProperties {}
 unsafe impl ::core::marker::Sync for VideoDisplayProperties {}
 #[doc = "*Required features: `\"Media\"`*"]
@@ -4312,36 +3674,7 @@ unsafe impl ::windows::core::Interface for VideoFrame {
 impl ::windows::core::RuntimeName for VideoFrame {
     const NAME: &'static str = "Windows.Media.VideoFrame";
 }
-impl ::core::convert::From<VideoFrame> for ::windows::core::IUnknown {
-    fn from(value: VideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoFrame> for ::windows::core::IUnknown {
-    fn from(value: &VideoFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoFrame> for &::windows::core::IUnknown {
-    fn from(value: &VideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoFrame> for ::windows::core::IInspectable {
-    fn from(value: VideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoFrame> for ::windows::core::IInspectable {
-    fn from(value: &VideoFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoFrame> for &::windows::core::IInspectable {
-    fn from(value: &VideoFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<VideoFrame> for super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/mod.rs
@@ -240,36 +240,7 @@ impl IBackgroundTransferBase {
         unsafe { (::windows::core::Vtable::vtable(this).SetCostPolicy)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<IBackgroundTransferBase> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTransferBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTransferBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTransferBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTransferBase> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTransferBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTransferBase> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTransferBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTransferBase> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTransferBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTransferBase> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTransferBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTransferBase, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBackgroundTransferBase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -414,36 +385,7 @@ impl IBackgroundTransferContentPartFactory {
         }
     }
 }
-impl ::core::convert::From<IBackgroundTransferContentPartFactory> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTransferContentPartFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTransferContentPartFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTransferContentPartFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTransferContentPartFactory> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTransferContentPartFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTransferContentPartFactory> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTransferContentPartFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTransferContentPartFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTransferContentPartFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTransferContentPartFactory> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTransferContentPartFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTransferContentPartFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBackgroundTransferContentPartFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -594,36 +536,7 @@ impl IBackgroundTransferOperation {
         }
     }
 }
-impl ::core::convert::From<IBackgroundTransferOperation> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTransferOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTransferOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTransferOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTransferOperation> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTransferOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTransferOperation> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTransferOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTransferOperation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTransferOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTransferOperation> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTransferOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTransferOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBackgroundTransferOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -691,36 +604,7 @@ impl IBackgroundTransferOperationPriority {
         unsafe { (::windows::core::Vtable::vtable(this).SetPriority)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<IBackgroundTransferOperationPriority> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundTransferOperationPriority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTransferOperationPriority> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundTransferOperationPriority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTransferOperationPriority> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundTransferOperationPriority) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundTransferOperationPriority> for ::windows::core::IInspectable {
-    fn from(value: IBackgroundTransferOperationPriority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundTransferOperationPriority> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBackgroundTransferOperationPriority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundTransferOperationPriority> for ::windows::core::IInspectable {
-    fn from(value: &IBackgroundTransferOperationPriority) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundTransferOperationPriority, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBackgroundTransferOperationPriority {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1535,36 +1419,7 @@ unsafe impl ::windows::core::Interface for BackgroundDownloader {
 impl ::windows::core::RuntimeName for BackgroundDownloader {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.BackgroundDownloader";
 }
-impl ::core::convert::From<BackgroundDownloader> for ::windows::core::IUnknown {
-    fn from(value: BackgroundDownloader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundDownloader> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundDownloader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundDownloader> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundDownloader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundDownloader> for ::windows::core::IInspectable {
-    fn from(value: BackgroundDownloader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundDownloader> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundDownloader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundDownloader> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundDownloader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundDownloader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BackgroundDownloader> for IBackgroundTransferBase {
     type Error = ::windows::core::Error;
     fn try_from(value: BackgroundDownloader) -> ::windows::core::Result<Self> {
@@ -1650,36 +1505,7 @@ unsafe impl ::windows::core::Interface for BackgroundTransferCompletionGroup {
 impl ::windows::core::RuntimeName for BackgroundTransferCompletionGroup {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.BackgroundTransferCompletionGroup";
 }
-impl ::core::convert::From<BackgroundTransferCompletionGroup> for ::windows::core::IUnknown {
-    fn from(value: BackgroundTransferCompletionGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTransferCompletionGroup> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundTransferCompletionGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTransferCompletionGroup> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundTransferCompletionGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundTransferCompletionGroup> for ::windows::core::IInspectable {
-    fn from(value: BackgroundTransferCompletionGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTransferCompletionGroup> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundTransferCompletionGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTransferCompletionGroup> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundTransferCompletionGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundTransferCompletionGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackgroundTransferCompletionGroup {}
 unsafe impl ::core::marker::Sync for BackgroundTransferCompletionGroup {}
 #[doc = "*Required features: `\"Networking_BackgroundTransfer\"`*"]
@@ -1737,36 +1563,7 @@ unsafe impl ::windows::core::Interface for BackgroundTransferCompletionGroupTrig
 impl ::windows::core::RuntimeName for BackgroundTransferCompletionGroupTriggerDetails {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.BackgroundTransferCompletionGroupTriggerDetails";
 }
-impl ::core::convert::From<BackgroundTransferCompletionGroupTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: BackgroundTransferCompletionGroupTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTransferCompletionGroupTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundTransferCompletionGroupTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTransferCompletionGroupTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundTransferCompletionGroupTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundTransferCompletionGroupTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: BackgroundTransferCompletionGroupTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTransferCompletionGroupTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundTransferCompletionGroupTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTransferCompletionGroupTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundTransferCompletionGroupTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundTransferCompletionGroupTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackgroundTransferCompletionGroupTriggerDetails {}
 unsafe impl ::core::marker::Sync for BackgroundTransferCompletionGroupTriggerDetails {}
 #[doc = "*Required features: `\"Networking_BackgroundTransfer\"`*"]
@@ -1848,36 +1645,7 @@ unsafe impl ::windows::core::Interface for BackgroundTransferContentPart {
 impl ::windows::core::RuntimeName for BackgroundTransferContentPart {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.BackgroundTransferContentPart";
 }
-impl ::core::convert::From<BackgroundTransferContentPart> for ::windows::core::IUnknown {
-    fn from(value: BackgroundTransferContentPart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTransferContentPart> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundTransferContentPart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTransferContentPart> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundTransferContentPart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundTransferContentPart> for ::windows::core::IInspectable {
-    fn from(value: BackgroundTransferContentPart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTransferContentPart> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundTransferContentPart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTransferContentPart> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundTransferContentPart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundTransferContentPart, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackgroundTransferContentPart {}
 unsafe impl ::core::marker::Sync for BackgroundTransferContentPart {}
 #[doc = "*Required features: `\"Networking_BackgroundTransfer\"`*"]
@@ -1966,36 +1734,7 @@ unsafe impl ::windows::core::Interface for BackgroundTransferGroup {
 impl ::windows::core::RuntimeName for BackgroundTransferGroup {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.BackgroundTransferGroup";
 }
-impl ::core::convert::From<BackgroundTransferGroup> for ::windows::core::IUnknown {
-    fn from(value: BackgroundTransferGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTransferGroup> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundTransferGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTransferGroup> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundTransferGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundTransferGroup> for ::windows::core::IInspectable {
-    fn from(value: BackgroundTransferGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTransferGroup> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundTransferGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTransferGroup> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundTransferGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundTransferGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackgroundTransferGroup {}
 unsafe impl ::core::marker::Sync for BackgroundTransferGroup {}
 #[doc = "*Required features: `\"Networking_BackgroundTransfer\"`*"]
@@ -2060,36 +1799,7 @@ unsafe impl ::windows::core::Interface for BackgroundTransferRangesDownloadedEve
 impl ::windows::core::RuntimeName for BackgroundTransferRangesDownloadedEventArgs {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.BackgroundTransferRangesDownloadedEventArgs";
 }
-impl ::core::convert::From<BackgroundTransferRangesDownloadedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BackgroundTransferRangesDownloadedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTransferRangesDownloadedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundTransferRangesDownloadedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTransferRangesDownloadedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundTransferRangesDownloadedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundTransferRangesDownloadedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BackgroundTransferRangesDownloadedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundTransferRangesDownloadedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundTransferRangesDownloadedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundTransferRangesDownloadedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundTransferRangesDownloadedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundTransferRangesDownloadedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackgroundTransferRangesDownloadedEventArgs {}
 unsafe impl ::core::marker::Sync for BackgroundTransferRangesDownloadedEventArgs {}
 #[doc = "*Required features: `\"Networking_BackgroundTransfer\"`*"]
@@ -2413,36 +2123,7 @@ unsafe impl ::windows::core::Interface for BackgroundUploader {
 impl ::windows::core::RuntimeName for BackgroundUploader {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.BackgroundUploader";
 }
-impl ::core::convert::From<BackgroundUploader> for ::windows::core::IUnknown {
-    fn from(value: BackgroundUploader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundUploader> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundUploader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundUploader> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundUploader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackgroundUploader> for ::windows::core::IInspectable {
-    fn from(value: BackgroundUploader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackgroundUploader> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundUploader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackgroundUploader> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundUploader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundUploader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BackgroundUploader> for IBackgroundTransferBase {
     type Error = ::windows::core::Error;
     fn try_from(value: BackgroundUploader) -> ::windows::core::Result<Self> {
@@ -2746,36 +2427,7 @@ unsafe impl ::windows::core::Interface for DownloadOperation {
 impl ::windows::core::RuntimeName for DownloadOperation {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.DownloadOperation";
 }
-impl ::core::convert::From<DownloadOperation> for ::windows::core::IUnknown {
-    fn from(value: DownloadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DownloadOperation> for ::windows::core::IUnknown {
-    fn from(value: &DownloadOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DownloadOperation> for &::windows::core::IUnknown {
-    fn from(value: &DownloadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DownloadOperation> for ::windows::core::IInspectable {
-    fn from(value: DownloadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DownloadOperation> for ::windows::core::IInspectable {
-    fn from(value: &DownloadOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DownloadOperation> for &::windows::core::IInspectable {
-    fn from(value: &DownloadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DownloadOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DownloadOperation> for IBackgroundTransferOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: DownloadOperation) -> ::windows::core::Result<Self> {
@@ -2885,36 +2537,7 @@ unsafe impl ::windows::core::Interface for ResponseInformation {
 impl ::windows::core::RuntimeName for ResponseInformation {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.ResponseInformation";
 }
-impl ::core::convert::From<ResponseInformation> for ::windows::core::IUnknown {
-    fn from(value: ResponseInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResponseInformation> for ::windows::core::IUnknown {
-    fn from(value: &ResponseInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResponseInformation> for &::windows::core::IUnknown {
-    fn from(value: &ResponseInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ResponseInformation> for ::windows::core::IInspectable {
-    fn from(value: ResponseInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResponseInformation> for ::windows::core::IInspectable {
-    fn from(value: &ResponseInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResponseInformation> for &::windows::core::IInspectable {
-    fn from(value: &ResponseInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResponseInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ResponseInformation {}
 unsafe impl ::core::marker::Sync for ResponseInformation {}
 #[doc = "*Required features: `\"Networking_BackgroundTransfer\"`, `\"deprecated\"`*"]
@@ -2974,41 +2597,7 @@ impl ::windows::core::RuntimeName for UnconstrainedTransferRequestResult {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.UnconstrainedTransferRequestResult";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<UnconstrainedTransferRequestResult> for ::windows::core::IUnknown {
-    fn from(value: UnconstrainedTransferRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&UnconstrainedTransferRequestResult> for ::windows::core::IUnknown {
-    fn from(value: &UnconstrainedTransferRequestResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&UnconstrainedTransferRequestResult> for &::windows::core::IUnknown {
-    fn from(value: &UnconstrainedTransferRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<UnconstrainedTransferRequestResult> for ::windows::core::IInspectable {
-    fn from(value: UnconstrainedTransferRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&UnconstrainedTransferRequestResult> for ::windows::core::IInspectable {
-    fn from(value: &UnconstrainedTransferRequestResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&UnconstrainedTransferRequestResult> for &::windows::core::IInspectable {
-    fn from(value: &UnconstrainedTransferRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UnconstrainedTransferRequestResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for UnconstrainedTransferRequestResult {}
 #[cfg(feature = "deprecated")]
@@ -3173,36 +2762,7 @@ unsafe impl ::windows::core::Interface for UploadOperation {
 impl ::windows::core::RuntimeName for UploadOperation {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.UploadOperation";
 }
-impl ::core::convert::From<UploadOperation> for ::windows::core::IUnknown {
-    fn from(value: UploadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UploadOperation> for ::windows::core::IUnknown {
-    fn from(value: &UploadOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UploadOperation> for &::windows::core::IUnknown {
-    fn from(value: &UploadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UploadOperation> for ::windows::core::IInspectable {
-    fn from(value: UploadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UploadOperation> for ::windows::core::IInspectable {
-    fn from(value: &UploadOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UploadOperation> for &::windows::core::IInspectable {
-    fn from(value: &UploadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UploadOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<UploadOperation> for IBackgroundTransferOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: UploadOperation) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
@@ -869,36 +869,7 @@ unsafe impl ::windows::core::Interface for AttributedNetworkUsage {
 impl ::windows::core::RuntimeName for AttributedNetworkUsage {
     const NAME: &'static str = "Windows.Networking.Connectivity.AttributedNetworkUsage";
 }
-impl ::core::convert::From<AttributedNetworkUsage> for ::windows::core::IUnknown {
-    fn from(value: AttributedNetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AttributedNetworkUsage> for ::windows::core::IUnknown {
-    fn from(value: &AttributedNetworkUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AttributedNetworkUsage> for &::windows::core::IUnknown {
-    fn from(value: &AttributedNetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AttributedNetworkUsage> for ::windows::core::IInspectable {
-    fn from(value: AttributedNetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AttributedNetworkUsage> for ::windows::core::IInspectable {
-    fn from(value: &AttributedNetworkUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AttributedNetworkUsage> for &::windows::core::IInspectable {
-    fn from(value: &AttributedNetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AttributedNetworkUsage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AttributedNetworkUsage {}
 unsafe impl ::core::marker::Sync for AttributedNetworkUsage {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -1022,36 +993,7 @@ unsafe impl ::windows::core::Interface for CellularApnContext {
 impl ::windows::core::RuntimeName for CellularApnContext {
     const NAME: &'static str = "Windows.Networking.Connectivity.CellularApnContext";
 }
-impl ::core::convert::From<CellularApnContext> for ::windows::core::IUnknown {
-    fn from(value: CellularApnContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CellularApnContext> for ::windows::core::IUnknown {
-    fn from(value: &CellularApnContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CellularApnContext> for &::windows::core::IUnknown {
-    fn from(value: &CellularApnContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CellularApnContext> for ::windows::core::IInspectable {
-    fn from(value: CellularApnContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CellularApnContext> for ::windows::core::IInspectable {
-    fn from(value: &CellularApnContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CellularApnContext> for &::windows::core::IInspectable {
-    fn from(value: &CellularApnContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CellularApnContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CellularApnContext {}
 unsafe impl ::core::marker::Sync for CellularApnContext {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -1126,36 +1068,7 @@ unsafe impl ::windows::core::Interface for ConnectionCost {
 impl ::windows::core::RuntimeName for ConnectionCost {
     const NAME: &'static str = "Windows.Networking.Connectivity.ConnectionCost";
 }
-impl ::core::convert::From<ConnectionCost> for ::windows::core::IUnknown {
-    fn from(value: ConnectionCost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectionCost> for ::windows::core::IUnknown {
-    fn from(value: &ConnectionCost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectionCost> for &::windows::core::IUnknown {
-    fn from(value: &ConnectionCost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConnectionCost> for ::windows::core::IInspectable {
-    fn from(value: ConnectionCost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectionCost> for ::windows::core::IInspectable {
-    fn from(value: &ConnectionCost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectionCost> for &::windows::core::IInspectable {
-    fn from(value: &ConnectionCost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConnectionCost, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ConnectionCost {}
 unsafe impl ::core::marker::Sync for ConnectionCost {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -1369,36 +1282,7 @@ unsafe impl ::windows::core::Interface for ConnectionProfile {
 impl ::windows::core::RuntimeName for ConnectionProfile {
     const NAME: &'static str = "Windows.Networking.Connectivity.ConnectionProfile";
 }
-impl ::core::convert::From<ConnectionProfile> for ::windows::core::IUnknown {
-    fn from(value: ConnectionProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectionProfile> for ::windows::core::IUnknown {
-    fn from(value: &ConnectionProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectionProfile> for &::windows::core::IUnknown {
-    fn from(value: &ConnectionProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConnectionProfile> for ::windows::core::IInspectable {
-    fn from(value: ConnectionProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectionProfile> for ::windows::core::IInspectable {
-    fn from(value: &ConnectionProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectionProfile> for &::windows::core::IInspectable {
-    fn from(value: &ConnectionProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConnectionProfile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ConnectionProfile {}
 unsafe impl ::core::marker::Sync for ConnectionProfile {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -1593,36 +1477,7 @@ unsafe impl ::windows::core::Interface for ConnectionProfileFilter {
 impl ::windows::core::RuntimeName for ConnectionProfileFilter {
     const NAME: &'static str = "Windows.Networking.Connectivity.ConnectionProfileFilter";
 }
-impl ::core::convert::From<ConnectionProfileFilter> for ::windows::core::IUnknown {
-    fn from(value: ConnectionProfileFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectionProfileFilter> for ::windows::core::IUnknown {
-    fn from(value: &ConnectionProfileFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectionProfileFilter> for &::windows::core::IUnknown {
-    fn from(value: &ConnectionProfileFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConnectionProfileFilter> for ::windows::core::IInspectable {
-    fn from(value: ConnectionProfileFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectionProfileFilter> for ::windows::core::IInspectable {
-    fn from(value: &ConnectionProfileFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectionProfileFilter> for &::windows::core::IInspectable {
-    fn from(value: &ConnectionProfileFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConnectionProfileFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ConnectionProfileFilter {}
 unsafe impl ::core::marker::Sync for ConnectionProfileFilter {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -1675,36 +1530,7 @@ unsafe impl ::windows::core::Interface for ConnectionSession {
 impl ::windows::core::RuntimeName for ConnectionSession {
     const NAME: &'static str = "Windows.Networking.Connectivity.ConnectionSession";
 }
-impl ::core::convert::From<ConnectionSession> for ::windows::core::IUnknown {
-    fn from(value: ConnectionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectionSession> for ::windows::core::IUnknown {
-    fn from(value: &ConnectionSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectionSession> for &::windows::core::IUnknown {
-    fn from(value: &ConnectionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConnectionSession> for ::windows::core::IInspectable {
-    fn from(value: ConnectionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectionSession> for ::windows::core::IInspectable {
-    fn from(value: &ConnectionSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectionSession> for &::windows::core::IInspectable {
-    fn from(value: &ConnectionSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConnectionSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ConnectionSession> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1784,36 +1610,7 @@ unsafe impl ::windows::core::Interface for ConnectivityInterval {
 impl ::windows::core::RuntimeName for ConnectivityInterval {
     const NAME: &'static str = "Windows.Networking.Connectivity.ConnectivityInterval";
 }
-impl ::core::convert::From<ConnectivityInterval> for ::windows::core::IUnknown {
-    fn from(value: ConnectivityInterval) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectivityInterval> for ::windows::core::IUnknown {
-    fn from(value: &ConnectivityInterval) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectivityInterval> for &::windows::core::IUnknown {
-    fn from(value: &ConnectivityInterval) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConnectivityInterval> for ::windows::core::IInspectable {
-    fn from(value: ConnectivityInterval) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectivityInterval> for ::windows::core::IInspectable {
-    fn from(value: &ConnectivityInterval) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectivityInterval> for &::windows::core::IInspectable {
-    fn from(value: &ConnectivityInterval) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConnectivityInterval, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ConnectivityInterval {}
 unsafe impl ::core::marker::Sync for ConnectivityInterval {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -1931,36 +1728,7 @@ unsafe impl ::windows::core::Interface for DataPlanStatus {
 impl ::windows::core::RuntimeName for DataPlanStatus {
     const NAME: &'static str = "Windows.Networking.Connectivity.DataPlanStatus";
 }
-impl ::core::convert::From<DataPlanStatus> for ::windows::core::IUnknown {
-    fn from(value: DataPlanStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPlanStatus> for ::windows::core::IUnknown {
-    fn from(value: &DataPlanStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPlanStatus> for &::windows::core::IUnknown {
-    fn from(value: &DataPlanStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataPlanStatus> for ::windows::core::IInspectable {
-    fn from(value: DataPlanStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPlanStatus> for ::windows::core::IInspectable {
-    fn from(value: &DataPlanStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPlanStatus> for &::windows::core::IInspectable {
-    fn from(value: &DataPlanStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataPlanStatus, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DataPlanStatus {}
 unsafe impl ::core::marker::Sync for DataPlanStatus {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -2016,36 +1784,7 @@ unsafe impl ::windows::core::Interface for DataPlanUsage {
 impl ::windows::core::RuntimeName for DataPlanUsage {
     const NAME: &'static str = "Windows.Networking.Connectivity.DataPlanUsage";
 }
-impl ::core::convert::From<DataPlanUsage> for ::windows::core::IUnknown {
-    fn from(value: DataPlanUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPlanUsage> for ::windows::core::IUnknown {
-    fn from(value: &DataPlanUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPlanUsage> for &::windows::core::IUnknown {
-    fn from(value: &DataPlanUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataPlanUsage> for ::windows::core::IInspectable {
-    fn from(value: DataPlanUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataPlanUsage> for ::windows::core::IInspectable {
-    fn from(value: &DataPlanUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataPlanUsage> for &::windows::core::IInspectable {
-    fn from(value: &DataPlanUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataPlanUsage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DataPlanUsage {}
 unsafe impl ::core::marker::Sync for DataPlanUsage {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`, `\"deprecated\"`*"]
@@ -2114,41 +1853,7 @@ impl ::windows::core::RuntimeName for DataUsage {
     const NAME: &'static str = "Windows.Networking.Connectivity.DataUsage";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<DataUsage> for ::windows::core::IUnknown {
-    fn from(value: DataUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&DataUsage> for ::windows::core::IUnknown {
-    fn from(value: &DataUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&DataUsage> for &::windows::core::IUnknown {
-    fn from(value: &DataUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<DataUsage> for ::windows::core::IInspectable {
-    fn from(value: DataUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&DataUsage> for ::windows::core::IInspectable {
-    fn from(value: &DataUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&DataUsage> for &::windows::core::IInspectable {
-    fn from(value: &DataUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataUsage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for DataUsage {}
 #[cfg(feature = "deprecated")]
@@ -2206,36 +1911,7 @@ unsafe impl ::windows::core::Interface for IPInformation {
 impl ::windows::core::RuntimeName for IPInformation {
     const NAME: &'static str = "Windows.Networking.Connectivity.IPInformation";
 }
-impl ::core::convert::From<IPInformation> for ::windows::core::IUnknown {
-    fn from(value: IPInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPInformation> for ::windows::core::IUnknown {
-    fn from(value: &IPInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IPInformation> for &::windows::core::IUnknown {
-    fn from(value: &IPInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IPInformation> for ::windows::core::IInspectable {
-    fn from(value: IPInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPInformation> for ::windows::core::IInspectable {
-    fn from(value: &IPInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IPInformation> for &::windows::core::IInspectable {
-    fn from(value: &IPInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IPInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IPInformation {}
 unsafe impl ::core::marker::Sync for IPInformation {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -2296,36 +1972,7 @@ unsafe impl ::windows::core::Interface for LanIdentifier {
 impl ::windows::core::RuntimeName for LanIdentifier {
     const NAME: &'static str = "Windows.Networking.Connectivity.LanIdentifier";
 }
-impl ::core::convert::From<LanIdentifier> for ::windows::core::IUnknown {
-    fn from(value: LanIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LanIdentifier> for ::windows::core::IUnknown {
-    fn from(value: &LanIdentifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LanIdentifier> for &::windows::core::IUnknown {
-    fn from(value: &LanIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LanIdentifier> for ::windows::core::IInspectable {
-    fn from(value: LanIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LanIdentifier> for ::windows::core::IInspectable {
-    fn from(value: &LanIdentifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LanIdentifier> for &::windows::core::IInspectable {
-    fn from(value: &LanIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LanIdentifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LanIdentifier {}
 unsafe impl ::core::marker::Sync for LanIdentifier {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -2381,36 +2028,7 @@ unsafe impl ::windows::core::Interface for LanIdentifierData {
 impl ::windows::core::RuntimeName for LanIdentifierData {
     const NAME: &'static str = "Windows.Networking.Connectivity.LanIdentifierData";
 }
-impl ::core::convert::From<LanIdentifierData> for ::windows::core::IUnknown {
-    fn from(value: LanIdentifierData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LanIdentifierData> for ::windows::core::IUnknown {
-    fn from(value: &LanIdentifierData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LanIdentifierData> for &::windows::core::IUnknown {
-    fn from(value: &LanIdentifierData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LanIdentifierData> for ::windows::core::IInspectable {
-    fn from(value: LanIdentifierData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LanIdentifierData> for ::windows::core::IInspectable {
-    fn from(value: &LanIdentifierData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LanIdentifierData> for &::windows::core::IInspectable {
-    fn from(value: &LanIdentifierData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LanIdentifierData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LanIdentifierData {}
 unsafe impl ::core::marker::Sync for LanIdentifierData {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -2494,36 +2112,7 @@ unsafe impl ::windows::core::Interface for NetworkAdapter {
 impl ::windows::core::RuntimeName for NetworkAdapter {
     const NAME: &'static str = "Windows.Networking.Connectivity.NetworkAdapter";
 }
-impl ::core::convert::From<NetworkAdapter> for ::windows::core::IUnknown {
-    fn from(value: NetworkAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkAdapter> for ::windows::core::IUnknown {
-    fn from(value: &NetworkAdapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkAdapter> for &::windows::core::IUnknown {
-    fn from(value: &NetworkAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkAdapter> for ::windows::core::IInspectable {
-    fn from(value: NetworkAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkAdapter> for ::windows::core::IInspectable {
-    fn from(value: &NetworkAdapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkAdapter> for &::windows::core::IInspectable {
-    fn from(value: &NetworkAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkAdapter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NetworkAdapter {}
 unsafe impl ::core::marker::Sync for NetworkAdapter {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -2665,36 +2254,7 @@ unsafe impl ::windows::core::Interface for NetworkItem {
 impl ::windows::core::RuntimeName for NetworkItem {
     const NAME: &'static str = "Windows.Networking.Connectivity.NetworkItem";
 }
-impl ::core::convert::From<NetworkItem> for ::windows::core::IUnknown {
-    fn from(value: NetworkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkItem> for ::windows::core::IUnknown {
-    fn from(value: &NetworkItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkItem> for &::windows::core::IUnknown {
-    fn from(value: &NetworkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkItem> for ::windows::core::IInspectable {
-    fn from(value: NetworkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkItem> for ::windows::core::IInspectable {
-    fn from(value: &NetworkItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkItem> for &::windows::core::IInspectable {
-    fn from(value: &NetworkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NetworkItem {}
 unsafe impl ::core::marker::Sync for NetworkItem {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -2748,36 +2308,7 @@ unsafe impl ::windows::core::Interface for NetworkSecuritySettings {
 impl ::windows::core::RuntimeName for NetworkSecuritySettings {
     const NAME: &'static str = "Windows.Networking.Connectivity.NetworkSecuritySettings";
 }
-impl ::core::convert::From<NetworkSecuritySettings> for ::windows::core::IUnknown {
-    fn from(value: NetworkSecuritySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkSecuritySettings> for ::windows::core::IUnknown {
-    fn from(value: &NetworkSecuritySettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkSecuritySettings> for &::windows::core::IUnknown {
-    fn from(value: &NetworkSecuritySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkSecuritySettings> for ::windows::core::IInspectable {
-    fn from(value: NetworkSecuritySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkSecuritySettings> for ::windows::core::IInspectable {
-    fn from(value: &NetworkSecuritySettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkSecuritySettings> for &::windows::core::IInspectable {
-    fn from(value: &NetworkSecuritySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkSecuritySettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NetworkSecuritySettings {}
 unsafe impl ::core::marker::Sync for NetworkSecuritySettings {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -2873,36 +2404,7 @@ unsafe impl ::windows::core::Interface for NetworkStateChangeEventDetails {
 impl ::windows::core::RuntimeName for NetworkStateChangeEventDetails {
     const NAME: &'static str = "Windows.Networking.Connectivity.NetworkStateChangeEventDetails";
 }
-impl ::core::convert::From<NetworkStateChangeEventDetails> for ::windows::core::IUnknown {
-    fn from(value: NetworkStateChangeEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkStateChangeEventDetails> for ::windows::core::IUnknown {
-    fn from(value: &NetworkStateChangeEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkStateChangeEventDetails> for &::windows::core::IUnknown {
-    fn from(value: &NetworkStateChangeEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkStateChangeEventDetails> for ::windows::core::IInspectable {
-    fn from(value: NetworkStateChangeEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkStateChangeEventDetails> for ::windows::core::IInspectable {
-    fn from(value: &NetworkStateChangeEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkStateChangeEventDetails> for &::windows::core::IInspectable {
-    fn from(value: &NetworkStateChangeEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkStateChangeEventDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NetworkStateChangeEventDetails {}
 unsafe impl ::core::marker::Sync for NetworkStateChangeEventDetails {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -2965,36 +2467,7 @@ unsafe impl ::windows::core::Interface for NetworkUsage {
 impl ::windows::core::RuntimeName for NetworkUsage {
     const NAME: &'static str = "Windows.Networking.Connectivity.NetworkUsage";
 }
-impl ::core::convert::From<NetworkUsage> for ::windows::core::IUnknown {
-    fn from(value: NetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkUsage> for ::windows::core::IUnknown {
-    fn from(value: &NetworkUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkUsage> for &::windows::core::IUnknown {
-    fn from(value: &NetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkUsage> for ::windows::core::IInspectable {
-    fn from(value: NetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkUsage> for ::windows::core::IInspectable {
-    fn from(value: &NetworkUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkUsage> for &::windows::core::IInspectable {
-    fn from(value: &NetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkUsage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NetworkUsage {}
 unsafe impl ::core::marker::Sync for NetworkUsage {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -3055,36 +2528,7 @@ unsafe impl ::windows::core::Interface for ProviderNetworkUsage {
 impl ::windows::core::RuntimeName for ProviderNetworkUsage {
     const NAME: &'static str = "Windows.Networking.Connectivity.ProviderNetworkUsage";
 }
-impl ::core::convert::From<ProviderNetworkUsage> for ::windows::core::IUnknown {
-    fn from(value: ProviderNetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProviderNetworkUsage> for ::windows::core::IUnknown {
-    fn from(value: &ProviderNetworkUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProviderNetworkUsage> for &::windows::core::IUnknown {
-    fn from(value: &ProviderNetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProviderNetworkUsage> for ::windows::core::IInspectable {
-    fn from(value: ProviderNetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProviderNetworkUsage> for ::windows::core::IInspectable {
-    fn from(value: &ProviderNetworkUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProviderNetworkUsage> for &::windows::core::IInspectable {
-    fn from(value: &ProviderNetworkUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProviderNetworkUsage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProviderNetworkUsage {}
 unsafe impl ::core::marker::Sync for ProviderNetworkUsage {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -3140,36 +2584,7 @@ unsafe impl ::windows::core::Interface for ProxyConfiguration {
 impl ::windows::core::RuntimeName for ProxyConfiguration {
     const NAME: &'static str = "Windows.Networking.Connectivity.ProxyConfiguration";
 }
-impl ::core::convert::From<ProxyConfiguration> for ::windows::core::IUnknown {
-    fn from(value: ProxyConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProxyConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &ProxyConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProxyConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &ProxyConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProxyConfiguration> for ::windows::core::IInspectable {
-    fn from(value: ProxyConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProxyConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &ProxyConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProxyConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &ProxyConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProxyConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProxyConfiguration {}
 unsafe impl ::core::marker::Sync for ProxyConfiguration {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -3241,36 +2656,7 @@ unsafe impl ::windows::core::Interface for RoutePolicy {
 impl ::windows::core::RuntimeName for RoutePolicy {
     const NAME: &'static str = "Windows.Networking.Connectivity.RoutePolicy";
 }
-impl ::core::convert::From<RoutePolicy> for ::windows::core::IUnknown {
-    fn from(value: RoutePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RoutePolicy> for ::windows::core::IUnknown {
-    fn from(value: &RoutePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RoutePolicy> for &::windows::core::IUnknown {
-    fn from(value: &RoutePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RoutePolicy> for ::windows::core::IInspectable {
-    fn from(value: RoutePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RoutePolicy> for ::windows::core::IInspectable {
-    fn from(value: &RoutePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RoutePolicy> for &::windows::core::IInspectable {
-    fn from(value: &RoutePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RoutePolicy, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RoutePolicy {}
 unsafe impl ::core::marker::Sync for RoutePolicy {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -3317,36 +2703,7 @@ unsafe impl ::windows::core::Interface for WlanConnectionProfileDetails {
 impl ::windows::core::RuntimeName for WlanConnectionProfileDetails {
     const NAME: &'static str = "Windows.Networking.Connectivity.WlanConnectionProfileDetails";
 }
-impl ::core::convert::From<WlanConnectionProfileDetails> for ::windows::core::IUnknown {
-    fn from(value: WlanConnectionProfileDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WlanConnectionProfileDetails> for ::windows::core::IUnknown {
-    fn from(value: &WlanConnectionProfileDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WlanConnectionProfileDetails> for &::windows::core::IUnknown {
-    fn from(value: &WlanConnectionProfileDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WlanConnectionProfileDetails> for ::windows::core::IInspectable {
-    fn from(value: WlanConnectionProfileDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WlanConnectionProfileDetails> for ::windows::core::IInspectable {
-    fn from(value: &WlanConnectionProfileDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WlanConnectionProfileDetails> for &::windows::core::IInspectable {
-    fn from(value: &WlanConnectionProfileDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WlanConnectionProfileDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WlanConnectionProfileDetails {}
 unsafe impl ::core::marker::Sync for WlanConnectionProfileDetails {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]
@@ -3430,36 +2787,7 @@ unsafe impl ::windows::core::Interface for WwanConnectionProfileDetails {
 impl ::windows::core::RuntimeName for WwanConnectionProfileDetails {
     const NAME: &'static str = "Windows.Networking.Connectivity.WwanConnectionProfileDetails";
 }
-impl ::core::convert::From<WwanConnectionProfileDetails> for ::windows::core::IUnknown {
-    fn from(value: WwanConnectionProfileDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WwanConnectionProfileDetails> for ::windows::core::IUnknown {
-    fn from(value: &WwanConnectionProfileDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WwanConnectionProfileDetails> for &::windows::core::IUnknown {
-    fn from(value: &WwanConnectionProfileDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WwanConnectionProfileDetails> for ::windows::core::IInspectable {
-    fn from(value: WwanConnectionProfileDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WwanConnectionProfileDetails> for ::windows::core::IInspectable {
-    fn from(value: &WwanConnectionProfileDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WwanConnectionProfileDetails> for &::windows::core::IInspectable {
-    fn from(value: &WwanConnectionProfileDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WwanConnectionProfileDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WwanConnectionProfileDetails {}
 unsafe impl ::core::marker::Sync for WwanConnectionProfileDetails {}
 #[doc = "*Required features: `\"Networking_Connectivity\"`*"]

--- a/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
@@ -2706,36 +2706,7 @@ unsafe impl ::windows::core::Interface for ESim {
 impl ::windows::core::RuntimeName for ESim {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESim";
 }
-impl ::core::convert::From<ESim> for ::windows::core::IUnknown {
-    fn from(value: ESim) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESim> for ::windows::core::IUnknown {
-    fn from(value: &ESim) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESim> for &::windows::core::IUnknown {
-    fn from(value: &ESim) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESim> for ::windows::core::IInspectable {
-    fn from(value: ESim) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESim> for ::windows::core::IInspectable {
-    fn from(value: &ESim) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESim> for &::windows::core::IInspectable {
-    fn from(value: &ESim) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESim, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESim {}
 unsafe impl ::core::marker::Sync for ESim {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -2782,36 +2753,7 @@ unsafe impl ::windows::core::Interface for ESimAddedEventArgs {
 impl ::windows::core::RuntimeName for ESimAddedEventArgs {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimAddedEventArgs";
 }
-impl ::core::convert::From<ESimAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ESimAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ESimAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ESimAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ESimAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ESimAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ESimAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimAddedEventArgs {}
 unsafe impl ::core::marker::Sync for ESimAddedEventArgs {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -2865,36 +2807,7 @@ unsafe impl ::windows::core::Interface for ESimDiscoverEvent {
 impl ::windows::core::RuntimeName for ESimDiscoverEvent {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimDiscoverEvent";
 }
-impl ::core::convert::From<ESimDiscoverEvent> for ::windows::core::IUnknown {
-    fn from(value: ESimDiscoverEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimDiscoverEvent> for ::windows::core::IUnknown {
-    fn from(value: &ESimDiscoverEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimDiscoverEvent> for &::windows::core::IUnknown {
-    fn from(value: &ESimDiscoverEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimDiscoverEvent> for ::windows::core::IInspectable {
-    fn from(value: ESimDiscoverEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimDiscoverEvent> for ::windows::core::IInspectable {
-    fn from(value: &ESimDiscoverEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimDiscoverEvent> for &::windows::core::IInspectable {
-    fn from(value: &ESimDiscoverEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimDiscoverEvent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimDiscoverEvent {}
 unsafe impl ::core::marker::Sync for ESimDiscoverEvent {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -2964,36 +2877,7 @@ unsafe impl ::windows::core::Interface for ESimDiscoverResult {
 impl ::windows::core::RuntimeName for ESimDiscoverResult {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimDiscoverResult";
 }
-impl ::core::convert::From<ESimDiscoverResult> for ::windows::core::IUnknown {
-    fn from(value: ESimDiscoverResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimDiscoverResult> for ::windows::core::IUnknown {
-    fn from(value: &ESimDiscoverResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimDiscoverResult> for &::windows::core::IUnknown {
-    fn from(value: &ESimDiscoverResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimDiscoverResult> for ::windows::core::IInspectable {
-    fn from(value: ESimDiscoverResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimDiscoverResult> for ::windows::core::IInspectable {
-    fn from(value: &ESimDiscoverResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimDiscoverResult> for &::windows::core::IInspectable {
-    fn from(value: &ESimDiscoverResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimDiscoverResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimDiscoverResult {}
 unsafe impl ::core::marker::Sync for ESimDiscoverResult {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -3047,36 +2931,7 @@ unsafe impl ::windows::core::Interface for ESimDownloadProfileMetadataResult {
 impl ::windows::core::RuntimeName for ESimDownloadProfileMetadataResult {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimDownloadProfileMetadataResult";
 }
-impl ::core::convert::From<ESimDownloadProfileMetadataResult> for ::windows::core::IUnknown {
-    fn from(value: ESimDownloadProfileMetadataResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimDownloadProfileMetadataResult> for ::windows::core::IUnknown {
-    fn from(value: &ESimDownloadProfileMetadataResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimDownloadProfileMetadataResult> for &::windows::core::IUnknown {
-    fn from(value: &ESimDownloadProfileMetadataResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimDownloadProfileMetadataResult> for ::windows::core::IInspectable {
-    fn from(value: ESimDownloadProfileMetadataResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimDownloadProfileMetadataResult> for ::windows::core::IInspectable {
-    fn from(value: &ESimDownloadProfileMetadataResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimDownloadProfileMetadataResult> for &::windows::core::IInspectable {
-    fn from(value: &ESimDownloadProfileMetadataResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimDownloadProfileMetadataResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimDownloadProfileMetadataResult {}
 unsafe impl ::core::marker::Sync for ESimDownloadProfileMetadataResult {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -3160,36 +3015,7 @@ unsafe impl ::windows::core::Interface for ESimOperationResult {
 impl ::windows::core::RuntimeName for ESimOperationResult {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimOperationResult";
 }
-impl ::core::convert::From<ESimOperationResult> for ::windows::core::IUnknown {
-    fn from(value: ESimOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimOperationResult> for ::windows::core::IUnknown {
-    fn from(value: &ESimOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimOperationResult> for &::windows::core::IUnknown {
-    fn from(value: &ESimOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimOperationResult> for ::windows::core::IInspectable {
-    fn from(value: ESimOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimOperationResult> for ::windows::core::IInspectable {
-    fn from(value: &ESimOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimOperationResult> for &::windows::core::IInspectable {
-    fn from(value: &ESimOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimOperationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimOperationResult {}
 unsafe impl ::core::marker::Sync for ESimOperationResult {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -3236,36 +3062,7 @@ unsafe impl ::windows::core::Interface for ESimPolicy {
 impl ::windows::core::RuntimeName for ESimPolicy {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimPolicy";
 }
-impl ::core::convert::From<ESimPolicy> for ::windows::core::IUnknown {
-    fn from(value: ESimPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimPolicy> for ::windows::core::IUnknown {
-    fn from(value: &ESimPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimPolicy> for &::windows::core::IUnknown {
-    fn from(value: &ESimPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimPolicy> for ::windows::core::IInspectable {
-    fn from(value: ESimPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimPolicy> for ::windows::core::IInspectable {
-    fn from(value: &ESimPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimPolicy> for &::windows::core::IInspectable {
-    fn from(value: &ESimPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimPolicy, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimPolicy {}
 unsafe impl ::core::marker::Sync for ESimPolicy {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -3390,36 +3187,7 @@ unsafe impl ::windows::core::Interface for ESimProfile {
 impl ::windows::core::RuntimeName for ESimProfile {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimProfile";
 }
-impl ::core::convert::From<ESimProfile> for ::windows::core::IUnknown {
-    fn from(value: ESimProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimProfile> for ::windows::core::IUnknown {
-    fn from(value: &ESimProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimProfile> for &::windows::core::IUnknown {
-    fn from(value: &ESimProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimProfile> for ::windows::core::IInspectable {
-    fn from(value: ESimProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimProfile> for ::windows::core::IInspectable {
-    fn from(value: &ESimProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimProfile> for &::windows::core::IInspectable {
-    fn from(value: &ESimProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimProfile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimProfile {}
 unsafe impl ::core::marker::Sync for ESimProfile {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -3561,36 +3329,7 @@ unsafe impl ::windows::core::Interface for ESimProfileMetadata {
 impl ::windows::core::RuntimeName for ESimProfileMetadata {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimProfileMetadata";
 }
-impl ::core::convert::From<ESimProfileMetadata> for ::windows::core::IUnknown {
-    fn from(value: ESimProfileMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimProfileMetadata> for ::windows::core::IUnknown {
-    fn from(value: &ESimProfileMetadata) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimProfileMetadata> for &::windows::core::IUnknown {
-    fn from(value: &ESimProfileMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimProfileMetadata> for ::windows::core::IInspectable {
-    fn from(value: ESimProfileMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimProfileMetadata> for ::windows::core::IInspectable {
-    fn from(value: &ESimProfileMetadata) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimProfileMetadata> for &::windows::core::IInspectable {
-    fn from(value: &ESimProfileMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimProfileMetadata, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimProfileMetadata {}
 unsafe impl ::core::marker::Sync for ESimProfileMetadata {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -3651,36 +3390,7 @@ unsafe impl ::windows::core::Interface for ESimProfilePolicy {
 impl ::windows::core::RuntimeName for ESimProfilePolicy {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimProfilePolicy";
 }
-impl ::core::convert::From<ESimProfilePolicy> for ::windows::core::IUnknown {
-    fn from(value: ESimProfilePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimProfilePolicy> for ::windows::core::IUnknown {
-    fn from(value: &ESimProfilePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimProfilePolicy> for &::windows::core::IUnknown {
-    fn from(value: &ESimProfilePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimProfilePolicy> for ::windows::core::IInspectable {
-    fn from(value: ESimProfilePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimProfilePolicy> for ::windows::core::IInspectable {
-    fn from(value: &ESimProfilePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimProfilePolicy> for &::windows::core::IInspectable {
-    fn from(value: &ESimProfilePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimProfilePolicy, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimProfilePolicy {}
 unsafe impl ::core::marker::Sync for ESimProfilePolicy {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -3727,36 +3437,7 @@ unsafe impl ::windows::core::Interface for ESimRemovedEventArgs {
 impl ::windows::core::RuntimeName for ESimRemovedEventArgs {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimRemovedEventArgs";
 }
-impl ::core::convert::From<ESimRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ESimRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ESimRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ESimRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ESimRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ESimRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ESimRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimRemovedEventArgs {}
 unsafe impl ::core::marker::Sync for ESimRemovedEventArgs {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -3810,36 +3491,7 @@ unsafe impl ::windows::core::Interface for ESimServiceInfo {
 impl ::windows::core::RuntimeName for ESimServiceInfo {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimServiceInfo";
 }
-impl ::core::convert::From<ESimServiceInfo> for ::windows::core::IUnknown {
-    fn from(value: ESimServiceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimServiceInfo> for ::windows::core::IUnknown {
-    fn from(value: &ESimServiceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimServiceInfo> for &::windows::core::IUnknown {
-    fn from(value: &ESimServiceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimServiceInfo> for ::windows::core::IInspectable {
-    fn from(value: ESimServiceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimServiceInfo> for ::windows::core::IInspectable {
-    fn from(value: &ESimServiceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimServiceInfo> for &::windows::core::IInspectable {
-    fn from(value: &ESimServiceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimServiceInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimServiceInfo {}
 unsafe impl ::core::marker::Sync for ESimServiceInfo {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -3886,36 +3538,7 @@ unsafe impl ::windows::core::Interface for ESimUpdatedEventArgs {
 impl ::windows::core::RuntimeName for ESimUpdatedEventArgs {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimUpdatedEventArgs";
 }
-impl ::core::convert::From<ESimUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ESimUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ESimUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ESimUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ESimUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ESimUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ESimUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for ESimUpdatedEventArgs {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -4045,36 +3668,7 @@ unsafe impl ::windows::core::Interface for ESimWatcher {
 impl ::windows::core::RuntimeName for ESimWatcher {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimWatcher";
 }
-impl ::core::convert::From<ESimWatcher> for ::windows::core::IUnknown {
-    fn from(value: ESimWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimWatcher> for ::windows::core::IUnknown {
-    fn from(value: &ESimWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimWatcher> for &::windows::core::IUnknown {
-    fn from(value: &ESimWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ESimWatcher> for ::windows::core::IInspectable {
-    fn from(value: ESimWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ESimWatcher> for ::windows::core::IInspectable {
-    fn from(value: &ESimWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ESimWatcher> for &::windows::core::IInspectable {
-    fn from(value: &ESimWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ESimWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ESimWatcher {}
 unsafe impl ::core::marker::Sync for ESimWatcher {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -4213,36 +3807,7 @@ unsafe impl ::windows::core::Interface for HotspotAuthenticationContext {
 impl ::windows::core::RuntimeName for HotspotAuthenticationContext {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.HotspotAuthenticationContext";
 }
-impl ::core::convert::From<HotspotAuthenticationContext> for ::windows::core::IUnknown {
-    fn from(value: HotspotAuthenticationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HotspotAuthenticationContext> for ::windows::core::IUnknown {
-    fn from(value: &HotspotAuthenticationContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HotspotAuthenticationContext> for &::windows::core::IUnknown {
-    fn from(value: &HotspotAuthenticationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HotspotAuthenticationContext> for ::windows::core::IInspectable {
-    fn from(value: HotspotAuthenticationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HotspotAuthenticationContext> for ::windows::core::IInspectable {
-    fn from(value: &HotspotAuthenticationContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HotspotAuthenticationContext> for &::windows::core::IInspectable {
-    fn from(value: &HotspotAuthenticationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HotspotAuthenticationContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct HotspotAuthenticationEventDetails(::windows::core::IUnknown);
@@ -4287,36 +3852,7 @@ unsafe impl ::windows::core::Interface for HotspotAuthenticationEventDetails {
 impl ::windows::core::RuntimeName for HotspotAuthenticationEventDetails {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.HotspotAuthenticationEventDetails";
 }
-impl ::core::convert::From<HotspotAuthenticationEventDetails> for ::windows::core::IUnknown {
-    fn from(value: HotspotAuthenticationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HotspotAuthenticationEventDetails> for ::windows::core::IUnknown {
-    fn from(value: &HotspotAuthenticationEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HotspotAuthenticationEventDetails> for &::windows::core::IUnknown {
-    fn from(value: &HotspotAuthenticationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HotspotAuthenticationEventDetails> for ::windows::core::IInspectable {
-    fn from(value: HotspotAuthenticationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HotspotAuthenticationEventDetails> for ::windows::core::IInspectable {
-    fn from(value: &HotspotAuthenticationEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HotspotAuthenticationEventDetails> for &::windows::core::IInspectable {
-    fn from(value: &HotspotAuthenticationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HotspotAuthenticationEventDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct HotspotCredentialsAuthenticationResult(::windows::core::IUnknown);
@@ -4386,36 +3922,7 @@ unsafe impl ::windows::core::Interface for HotspotCredentialsAuthenticationResul
 impl ::windows::core::RuntimeName for HotspotCredentialsAuthenticationResult {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.HotspotCredentialsAuthenticationResult";
 }
-impl ::core::convert::From<HotspotCredentialsAuthenticationResult> for ::windows::core::IUnknown {
-    fn from(value: HotspotCredentialsAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HotspotCredentialsAuthenticationResult> for ::windows::core::IUnknown {
-    fn from(value: &HotspotCredentialsAuthenticationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HotspotCredentialsAuthenticationResult> for &::windows::core::IUnknown {
-    fn from(value: &HotspotCredentialsAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HotspotCredentialsAuthenticationResult> for ::windows::core::IInspectable {
-    fn from(value: HotspotCredentialsAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HotspotCredentialsAuthenticationResult> for ::windows::core::IInspectable {
-    fn from(value: &HotspotCredentialsAuthenticationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HotspotCredentialsAuthenticationResult> for &::windows::core::IInspectable {
-    fn from(value: &HotspotCredentialsAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HotspotCredentialsAuthenticationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 pub struct KnownCSimFilePaths;
 impl KnownCSimFilePaths {
@@ -4693,36 +4200,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandAccount {
 impl ::windows::core::RuntimeName for MobileBroadbandAccount {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandAccount";
 }
-impl ::core::convert::From<MobileBroadbandAccount> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccount> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccount> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandAccount> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccount> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccount> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandAccount, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct MobileBroadbandAccountEventArgs(::windows::core::IUnknown);
@@ -4767,36 +4245,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandAccountEventArgs {
 impl ::windows::core::RuntimeName for MobileBroadbandAccountEventArgs {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandAccountEventArgs";
 }
-impl ::core::convert::From<MobileBroadbandAccountEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandAccountEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandAccountEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandAccountEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandAccountEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandAccountEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandAccountEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandAccountEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandAccountEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct MobileBroadbandAccountUpdatedEventArgs(::windows::core::IUnknown);
@@ -4855,36 +4304,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandAccountUpdatedEventArg
 impl ::windows::core::RuntimeName for MobileBroadbandAccountUpdatedEventArgs {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandAccountUpdatedEventArgs";
 }
-impl ::core::convert::From<MobileBroadbandAccountUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandAccountUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandAccountUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandAccountUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandAccountUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandAccountUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandAccountUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandAccountUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandAccountUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct MobileBroadbandAccountWatcher(::windows::core::IUnknown);
@@ -5019,36 +4439,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandAccountWatcher {
 impl ::windows::core::RuntimeName for MobileBroadbandAccountWatcher {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandAccountWatcher";
 }
-impl ::core::convert::From<MobileBroadbandAccountWatcher> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandAccountWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountWatcher> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandAccountWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountWatcher> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandAccountWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandAccountWatcher> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandAccountWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountWatcher> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandAccountWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAccountWatcher> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandAccountWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandAccountWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct MobileBroadbandAntennaSar(::windows::core::IUnknown);
@@ -5111,36 +4502,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandAntennaSar {
 impl ::windows::core::RuntimeName for MobileBroadbandAntennaSar {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandAntennaSar";
 }
-impl ::core::convert::From<MobileBroadbandAntennaSar> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandAntennaSar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAntennaSar> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandAntennaSar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAntennaSar> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandAntennaSar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandAntennaSar> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandAntennaSar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAntennaSar> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandAntennaSar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandAntennaSar> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandAntennaSar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandAntennaSar, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandAntennaSar {}
 unsafe impl ::core::marker::Sync for MobileBroadbandAntennaSar {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -5252,36 +4614,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandCellCdma {
 impl ::windows::core::RuntimeName for MobileBroadbandCellCdma {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandCellCdma";
 }
-impl ::core::convert::From<MobileBroadbandCellCdma> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandCellCdma) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellCdma> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellCdma) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellCdma> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellCdma) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandCellCdma> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandCellCdma) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellCdma> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellCdma) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellCdma> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellCdma) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandCellCdma, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandCellCdma {}
 unsafe impl ::core::marker::Sync for MobileBroadbandCellCdma {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -5382,36 +4715,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandCellGsm {
 impl ::windows::core::RuntimeName for MobileBroadbandCellGsm {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandCellGsm";
 }
-impl ::core::convert::From<MobileBroadbandCellGsm> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandCellGsm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellGsm> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellGsm) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellGsm> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellGsm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandCellGsm> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandCellGsm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellGsm> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellGsm) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellGsm> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellGsm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandCellGsm, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandCellGsm {}
 unsafe impl ::core::marker::Sync for MobileBroadbandCellGsm {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -5521,36 +4825,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandCellLte {
 impl ::windows::core::RuntimeName for MobileBroadbandCellLte {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandCellLte";
 }
-impl ::core::convert::From<MobileBroadbandCellLte> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandCellLte) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellLte> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellLte) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellLte> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellLte) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandCellLte> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandCellLte) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellLte> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellLte) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellLte> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellLte) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandCellLte, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandCellLte {}
 unsafe impl ::core::marker::Sync for MobileBroadbandCellLte {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -5669,36 +4944,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandCellNR {
 impl ::windows::core::RuntimeName for MobileBroadbandCellNR {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandCellNR";
 }
-impl ::core::convert::From<MobileBroadbandCellNR> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandCellNR) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellNR> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellNR) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellNR> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellNR) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandCellNR> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandCellNR) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellNR> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellNR) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellNR> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellNR) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandCellNR, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandCellNR {}
 unsafe impl ::core::marker::Sync for MobileBroadbandCellNR {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -5808,36 +5054,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandCellTdscdma {
 impl ::windows::core::RuntimeName for MobileBroadbandCellTdscdma {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandCellTdscdma";
 }
-impl ::core::convert::From<MobileBroadbandCellTdscdma> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandCellTdscdma) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellTdscdma> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellTdscdma) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellTdscdma> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellTdscdma) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandCellTdscdma> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandCellTdscdma) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellTdscdma> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellTdscdma) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellTdscdma> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellTdscdma) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandCellTdscdma, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandCellTdscdma {}
 unsafe impl ::core::marker::Sync for MobileBroadbandCellTdscdma {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -5947,36 +5164,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandCellUmts {
 impl ::windows::core::RuntimeName for MobileBroadbandCellUmts {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandCellUmts";
 }
-impl ::core::convert::From<MobileBroadbandCellUmts> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandCellUmts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellUmts> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellUmts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellUmts> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellUmts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandCellUmts> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandCellUmts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellUmts> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellUmts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellUmts> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellUmts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandCellUmts, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandCellUmts {}
 unsafe impl ::core::marker::Sync for MobileBroadbandCellUmts {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -6124,36 +5312,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandCellsInfo {
 impl ::windows::core::RuntimeName for MobileBroadbandCellsInfo {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandCellsInfo";
 }
-impl ::core::convert::From<MobileBroadbandCellsInfo> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandCellsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellsInfo> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellsInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellsInfo> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCellsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandCellsInfo> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandCellsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellsInfo> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellsInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCellsInfo> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCellsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandCellsInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandCellsInfo {}
 unsafe impl ::core::marker::Sync for MobileBroadbandCellsInfo {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -6200,36 +5359,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandCurrentSlotIndexChange
 impl ::windows::core::RuntimeName for MobileBroadbandCurrentSlotIndexChangedEventArgs {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandCurrentSlotIndexChangedEventArgs";
 }
-impl ::core::convert::From<MobileBroadbandCurrentSlotIndexChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandCurrentSlotIndexChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCurrentSlotIndexChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCurrentSlotIndexChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCurrentSlotIndexChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandCurrentSlotIndexChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandCurrentSlotIndexChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandCurrentSlotIndexChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCurrentSlotIndexChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCurrentSlotIndexChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandCurrentSlotIndexChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandCurrentSlotIndexChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandCurrentSlotIndexChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandCurrentSlotIndexChangedEventArgs {}
 unsafe impl ::core::marker::Sync for MobileBroadbandCurrentSlotIndexChangedEventArgs {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -6420,36 +5550,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandDeviceInformation {
 impl ::windows::core::RuntimeName for MobileBroadbandDeviceInformation {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandDeviceInformation";
 }
-impl ::core::convert::From<MobileBroadbandDeviceInformation> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandDeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceInformation> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceInformation> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandDeviceInformation> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandDeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceInformation> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceInformation> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandDeviceInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct MobileBroadbandDeviceService(::windows::core::IUnknown);
@@ -6517,36 +5618,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandDeviceService {
 impl ::windows::core::RuntimeName for MobileBroadbandDeviceService {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandDeviceService";
 }
-impl ::core::convert::From<MobileBroadbandDeviceService> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceService> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceService> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandDeviceService> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceService> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceService> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandDeviceService, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandDeviceService {}
 unsafe impl ::core::marker::Sync for MobileBroadbandDeviceService {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -6602,36 +5674,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandDeviceServiceCommandRe
 impl ::windows::core::RuntimeName for MobileBroadbandDeviceServiceCommandResult {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceCommandResult";
 }
-impl ::core::convert::From<MobileBroadbandDeviceServiceCommandResult> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandDeviceServiceCommandResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceCommandResult> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceCommandResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceCommandResult> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceCommandResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandDeviceServiceCommandResult> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandDeviceServiceCommandResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceCommandResult> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceCommandResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceCommandResult> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceCommandResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandDeviceServiceCommandResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandDeviceServiceCommandResult {}
 unsafe impl ::core::marker::Sync for MobileBroadbandDeviceServiceCommandResult {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -6701,36 +5744,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandDeviceServiceCommandSe
 impl ::windows::core::RuntimeName for MobileBroadbandDeviceServiceCommandSession {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceCommandSession";
 }
-impl ::core::convert::From<MobileBroadbandDeviceServiceCommandSession> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandDeviceServiceCommandSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceCommandSession> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceCommandSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceCommandSession> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceCommandSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandDeviceServiceCommandSession> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandDeviceServiceCommandSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceCommandSession> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceCommandSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceCommandSession> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceCommandSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandDeviceServiceCommandSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandDeviceServiceCommandSession {}
 unsafe impl ::core::marker::Sync for MobileBroadbandDeviceServiceCommandSession {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -6779,36 +5793,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandDeviceServiceDataRecei
 impl ::windows::core::RuntimeName for MobileBroadbandDeviceServiceDataReceivedEventArgs {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceDataReceivedEventArgs";
 }
-impl ::core::convert::From<MobileBroadbandDeviceServiceDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandDeviceServiceDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceDataReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceDataReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandDeviceServiceDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandDeviceServiceDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceDataReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceDataReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceDataReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceDataReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandDeviceServiceDataReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandDeviceServiceDataReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MobileBroadbandDeviceServiceDataReceivedEventArgs {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -6880,36 +5865,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandDeviceServiceDataSessi
 impl ::windows::core::RuntimeName for MobileBroadbandDeviceServiceDataSession {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceDataSession";
 }
-impl ::core::convert::From<MobileBroadbandDeviceServiceDataSession> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandDeviceServiceDataSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceDataSession> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceDataSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceDataSession> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceDataSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandDeviceServiceDataSession> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandDeviceServiceDataSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceDataSession> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceDataSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceDataSession> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceDataSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandDeviceServiceDataSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandDeviceServiceDataSession {}
 unsafe impl ::core::marker::Sync for MobileBroadbandDeviceServiceDataSession {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -6970,36 +5926,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandDeviceServiceInformati
 impl ::windows::core::RuntimeName for MobileBroadbandDeviceServiceInformation {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceInformation";
 }
-impl ::core::convert::From<MobileBroadbandDeviceServiceInformation> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandDeviceServiceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceInformation> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceInformation> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandDeviceServiceInformation> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandDeviceServiceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceInformation> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceInformation> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandDeviceServiceInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandDeviceServiceInformation {}
 unsafe impl ::core::marker::Sync for MobileBroadbandDeviceServiceInformation {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -7062,36 +5989,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandDeviceServiceTriggerDe
 impl ::windows::core::RuntimeName for MobileBroadbandDeviceServiceTriggerDetails {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandDeviceServiceTriggerDetails";
 }
-impl ::core::convert::From<MobileBroadbandDeviceServiceTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandDeviceServiceTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandDeviceServiceTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandDeviceServiceTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandDeviceServiceTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandDeviceServiceTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandDeviceServiceTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandDeviceServiceTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandDeviceServiceTriggerDetails {}
 unsafe impl ::core::marker::Sync for MobileBroadbandDeviceServiceTriggerDetails {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -7279,36 +6177,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandModem {
 impl ::windows::core::RuntimeName for MobileBroadbandModem {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandModem";
 }
-impl ::core::convert::From<MobileBroadbandModem> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandModem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModem> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandModem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModem> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandModem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandModem> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandModem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModem> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandModem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModem> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandModem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandModem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandModem {}
 unsafe impl ::core::marker::Sync for MobileBroadbandModem {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -7376,36 +6245,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandModemConfiguration {
 impl ::windows::core::RuntimeName for MobileBroadbandModemConfiguration {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandModemConfiguration";
 }
-impl ::core::convert::From<MobileBroadbandModemConfiguration> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandModemConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModemConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandModemConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModemConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandModemConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandModemConfiguration> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandModemConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModemConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandModemConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModemConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandModemConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandModemConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct MobileBroadbandModemIsolation(::windows::core::IUnknown);
@@ -7480,36 +6320,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandModemIsolation {
 impl ::windows::core::RuntimeName for MobileBroadbandModemIsolation {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandModemIsolation";
 }
-impl ::core::convert::From<MobileBroadbandModemIsolation> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandModemIsolation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModemIsolation> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandModemIsolation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModemIsolation> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandModemIsolation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandModemIsolation> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandModemIsolation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModemIsolation> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandModemIsolation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandModemIsolation> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandModemIsolation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandModemIsolation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandModemIsolation {}
 unsafe impl ::core::marker::Sync for MobileBroadbandModemIsolation {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -7645,36 +6456,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandNetwork {
 impl ::windows::core::RuntimeName for MobileBroadbandNetwork {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandNetwork";
 }
-impl ::core::convert::From<MobileBroadbandNetwork> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetwork> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandNetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetwork> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandNetwork> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetwork> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandNetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetwork> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandNetwork, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct MobileBroadbandNetworkRegistrationStateChange(::windows::core::IUnknown);
@@ -7726,36 +6508,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandNetworkRegistrationSta
 impl ::windows::core::RuntimeName for MobileBroadbandNetworkRegistrationStateChange {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandNetworkRegistrationStateChange";
 }
-impl ::core::convert::From<MobileBroadbandNetworkRegistrationStateChange> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandNetworkRegistrationStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetworkRegistrationStateChange> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandNetworkRegistrationStateChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetworkRegistrationStateChange> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandNetworkRegistrationStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandNetworkRegistrationStateChange> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandNetworkRegistrationStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetworkRegistrationStateChange> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandNetworkRegistrationStateChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetworkRegistrationStateChange> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandNetworkRegistrationStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandNetworkRegistrationStateChange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandNetworkRegistrationStateChange {}
 unsafe impl ::core::marker::Sync for MobileBroadbandNetworkRegistrationStateChange {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -7804,36 +6557,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandNetworkRegistrationSta
 impl ::windows::core::RuntimeName for MobileBroadbandNetworkRegistrationStateChangeTriggerDetails {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandNetworkRegistrationStateChangeTriggerDetails";
 }
-impl ::core::convert::From<MobileBroadbandNetworkRegistrationStateChangeTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandNetworkRegistrationStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetworkRegistrationStateChangeTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandNetworkRegistrationStateChangeTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetworkRegistrationStateChangeTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandNetworkRegistrationStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandNetworkRegistrationStateChangeTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandNetworkRegistrationStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetworkRegistrationStateChangeTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandNetworkRegistrationStateChangeTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandNetworkRegistrationStateChangeTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandNetworkRegistrationStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandNetworkRegistrationStateChangeTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandNetworkRegistrationStateChangeTriggerDetails {}
 unsafe impl ::core::marker::Sync for MobileBroadbandNetworkRegistrationStateChangeTriggerDetails {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -7896,36 +6620,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandPco {
 impl ::windows::core::RuntimeName for MobileBroadbandPco {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandPco";
 }
-impl ::core::convert::From<MobileBroadbandPco> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandPco) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPco> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPco) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPco> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPco) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandPco> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandPco) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPco> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPco) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPco> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPco) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandPco, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandPco {}
 unsafe impl ::core::marker::Sync for MobileBroadbandPco {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -7972,36 +6667,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandPcoDataChangeTriggerDe
 impl ::windows::core::RuntimeName for MobileBroadbandPcoDataChangeTriggerDetails {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandPcoDataChangeTriggerDetails";
 }
-impl ::core::convert::From<MobileBroadbandPcoDataChangeTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandPcoDataChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPcoDataChangeTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPcoDataChangeTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPcoDataChangeTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPcoDataChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandPcoDataChangeTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandPcoDataChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPcoDataChangeTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPcoDataChangeTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPcoDataChangeTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPcoDataChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandPcoDataChangeTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandPcoDataChangeTriggerDetails {}
 unsafe impl ::core::marker::Sync for MobileBroadbandPcoDataChangeTriggerDetails {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -8135,36 +6801,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandPin {
 impl ::windows::core::RuntimeName for MobileBroadbandPin {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandPin";
 }
-impl ::core::convert::From<MobileBroadbandPin> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPin> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPin> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandPin> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPin> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPin> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandPin, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandPin {}
 unsafe impl ::core::marker::Sync for MobileBroadbandPin {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -8225,36 +6862,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandPinLockStateChange {
 impl ::windows::core::RuntimeName for MobileBroadbandPinLockStateChange {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandPinLockStateChange";
 }
-impl ::core::convert::From<MobileBroadbandPinLockStateChange> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandPinLockStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChange> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPinLockStateChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChange> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPinLockStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandPinLockStateChange> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandPinLockStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChange> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPinLockStateChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChange> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPinLockStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandPinLockStateChange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandPinLockStateChange {}
 unsafe impl ::core::marker::Sync for MobileBroadbandPinLockStateChange {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -8303,36 +6911,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandPinLockStateChangeTrig
 impl ::windows::core::RuntimeName for MobileBroadbandPinLockStateChangeTriggerDetails {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandPinLockStateChangeTriggerDetails";
 }
-impl ::core::convert::From<MobileBroadbandPinLockStateChangeTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandPinLockStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChangeTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPinLockStateChangeTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChangeTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPinLockStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandPinLockStateChangeTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandPinLockStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChangeTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPinLockStateChangeTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinLockStateChangeTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPinLockStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandPinLockStateChangeTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandPinLockStateChangeTriggerDetails {}
 unsafe impl ::core::marker::Sync for MobileBroadbandPinLockStateChangeTriggerDetails {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -8388,36 +6967,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandPinManager {
 impl ::windows::core::RuntimeName for MobileBroadbandPinManager {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandPinManager";
 }
-impl ::core::convert::From<MobileBroadbandPinManager> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandPinManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinManager> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPinManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinManager> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPinManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandPinManager> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandPinManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinManager> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPinManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinManager> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPinManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandPinManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandPinManager {}
 unsafe impl ::core::marker::Sync for MobileBroadbandPinManager {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -8471,36 +7021,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandPinOperationResult {
 impl ::windows::core::RuntimeName for MobileBroadbandPinOperationResult {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandPinOperationResult";
 }
-impl ::core::convert::From<MobileBroadbandPinOperationResult> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandPinOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinOperationResult> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPinOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinOperationResult> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandPinOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandPinOperationResult> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandPinOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinOperationResult> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPinOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandPinOperationResult> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandPinOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandPinOperationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandPinOperationResult {}
 unsafe impl ::core::marker::Sync for MobileBroadbandPinOperationResult {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -8554,36 +7075,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandRadioStateChange {
 impl ::windows::core::RuntimeName for MobileBroadbandRadioStateChange {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandRadioStateChange";
 }
-impl ::core::convert::From<MobileBroadbandRadioStateChange> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandRadioStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChange> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandRadioStateChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChange> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandRadioStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandRadioStateChange> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandRadioStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChange> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandRadioStateChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChange> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandRadioStateChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandRadioStateChange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandRadioStateChange {}
 unsafe impl ::core::marker::Sync for MobileBroadbandRadioStateChange {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -8632,36 +7124,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandRadioStateChangeTrigge
 impl ::windows::core::RuntimeName for MobileBroadbandRadioStateChangeTriggerDetails {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandRadioStateChangeTriggerDetails";
 }
-impl ::core::convert::From<MobileBroadbandRadioStateChangeTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandRadioStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChangeTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandRadioStateChangeTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChangeTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandRadioStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandRadioStateChangeTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandRadioStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChangeTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandRadioStateChangeTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandRadioStateChangeTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandRadioStateChangeTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandRadioStateChangeTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandRadioStateChangeTriggerDetails {}
 unsafe impl ::core::marker::Sync for MobileBroadbandRadioStateChangeTriggerDetails {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -8821,36 +7284,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandSarManager {
 impl ::windows::core::RuntimeName for MobileBroadbandSarManager {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandSarManager";
 }
-impl ::core::convert::From<MobileBroadbandSarManager> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandSarManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSarManager> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandSarManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSarManager> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandSarManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandSarManager> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandSarManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSarManager> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandSarManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSarManager> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandSarManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandSarManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandSarManager {}
 unsafe impl ::core::marker::Sync for MobileBroadbandSarManager {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -8904,36 +7338,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandSlotInfo {
 impl ::windows::core::RuntimeName for MobileBroadbandSlotInfo {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandSlotInfo";
 }
-impl ::core::convert::From<MobileBroadbandSlotInfo> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandSlotInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotInfo> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandSlotInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotInfo> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandSlotInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandSlotInfo> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandSlotInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotInfo> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandSlotInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotInfo> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandSlotInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandSlotInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandSlotInfo {}
 unsafe impl ::core::marker::Sync for MobileBroadbandSlotInfo {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -8980,36 +7385,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandSlotInfoChangedEventAr
 impl ::windows::core::RuntimeName for MobileBroadbandSlotInfoChangedEventArgs {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandSlotInfoChangedEventArgs";
 }
-impl ::core::convert::From<MobileBroadbandSlotInfoChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandSlotInfoChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotInfoChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandSlotInfoChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotInfoChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandSlotInfoChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandSlotInfoChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandSlotInfoChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotInfoChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandSlotInfoChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotInfoChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandSlotInfoChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandSlotInfoChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandSlotInfoChangedEventArgs {}
 unsafe impl ::core::marker::Sync for MobileBroadbandSlotInfoChangedEventArgs {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -9111,36 +7487,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandSlotManager {
 impl ::windows::core::RuntimeName for MobileBroadbandSlotManager {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandSlotManager";
 }
-impl ::core::convert::From<MobileBroadbandSlotManager> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandSlotManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotManager> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandSlotManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotManager> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandSlotManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandSlotManager> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandSlotManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotManager> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandSlotManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandSlotManager> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandSlotManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandSlotManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandSlotManager {}
 unsafe impl ::core::marker::Sync for MobileBroadbandSlotManager {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -9187,36 +7534,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandTransmissionStateChang
 impl ::windows::core::RuntimeName for MobileBroadbandTransmissionStateChangedEventArgs {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandTransmissionStateChangedEventArgs";
 }
-impl ::core::convert::From<MobileBroadbandTransmissionStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandTransmissionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandTransmissionStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandTransmissionStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandTransmissionStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandTransmissionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandTransmissionStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandTransmissionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandTransmissionStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandTransmissionStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandTransmissionStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandTransmissionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandTransmissionStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandTransmissionStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for MobileBroadbandTransmissionStateChangedEventArgs {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -9272,36 +7590,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandUicc {
 impl ::windows::core::RuntimeName for MobileBroadbandUicc {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandUicc";
 }
-impl ::core::convert::From<MobileBroadbandUicc> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandUicc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUicc> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandUicc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUicc> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandUicc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandUicc> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandUicc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUicc> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandUicc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUicc> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandUicc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandUicc, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandUicc {}
 unsafe impl ::core::marker::Sync for MobileBroadbandUicc {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -9383,36 +7672,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandUiccApp {
 impl ::windows::core::RuntimeName for MobileBroadbandUiccApp {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandUiccApp";
 }
-impl ::core::convert::From<MobileBroadbandUiccApp> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandUiccApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccApp> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandUiccApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccApp> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandUiccApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandUiccApp> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandUiccApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccApp> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandUiccApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccApp> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandUiccApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandUiccApp, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandUiccApp {}
 unsafe impl ::core::marker::Sync for MobileBroadbandUiccApp {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -9468,36 +7728,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandUiccAppReadRecordResul
 impl ::windows::core::RuntimeName for MobileBroadbandUiccAppReadRecordResult {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandUiccAppReadRecordResult";
 }
-impl ::core::convert::From<MobileBroadbandUiccAppReadRecordResult> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandUiccAppReadRecordResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppReadRecordResult> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandUiccAppReadRecordResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppReadRecordResult> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandUiccAppReadRecordResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandUiccAppReadRecordResult> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandUiccAppReadRecordResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppReadRecordResult> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandUiccAppReadRecordResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppReadRecordResult> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandUiccAppReadRecordResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandUiccAppReadRecordResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandUiccAppReadRecordResult {}
 unsafe impl ::core::marker::Sync for MobileBroadbandUiccAppReadRecordResult {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -9579,36 +7810,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandUiccAppRecordDetailsRe
 impl ::windows::core::RuntimeName for MobileBroadbandUiccAppRecordDetailsResult {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandUiccAppRecordDetailsResult";
 }
-impl ::core::convert::From<MobileBroadbandUiccAppRecordDetailsResult> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandUiccAppRecordDetailsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppRecordDetailsResult> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandUiccAppRecordDetailsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppRecordDetailsResult> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandUiccAppRecordDetailsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandUiccAppRecordDetailsResult> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandUiccAppRecordDetailsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppRecordDetailsResult> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandUiccAppRecordDetailsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppRecordDetailsResult> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandUiccAppRecordDetailsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandUiccAppRecordDetailsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandUiccAppRecordDetailsResult {}
 unsafe impl ::core::marker::Sync for MobileBroadbandUiccAppRecordDetailsResult {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -9664,36 +7866,7 @@ unsafe impl ::windows::core::Interface for MobileBroadbandUiccAppsResult {
 impl ::windows::core::RuntimeName for MobileBroadbandUiccAppsResult {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandUiccAppsResult";
 }
-impl ::core::convert::From<MobileBroadbandUiccAppsResult> for ::windows::core::IUnknown {
-    fn from(value: MobileBroadbandUiccAppsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppsResult> for ::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandUiccAppsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppsResult> for &::windows::core::IUnknown {
-    fn from(value: &MobileBroadbandUiccAppsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MobileBroadbandUiccAppsResult> for ::windows::core::IInspectable {
-    fn from(value: MobileBroadbandUiccAppsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppsResult> for ::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandUiccAppsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MobileBroadbandUiccAppsResult> for &::windows::core::IInspectable {
-    fn from(value: &MobileBroadbandUiccAppsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MobileBroadbandUiccAppsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MobileBroadbandUiccAppsResult {}
 unsafe impl ::core::marker::Sync for MobileBroadbandUiccAppsResult {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -9740,36 +7913,7 @@ unsafe impl ::windows::core::Interface for NetworkOperatorDataUsageTriggerDetail
 impl ::windows::core::RuntimeName for NetworkOperatorDataUsageTriggerDetails {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.NetworkOperatorDataUsageTriggerDetails";
 }
-impl ::core::convert::From<NetworkOperatorDataUsageTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: NetworkOperatorDataUsageTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorDataUsageTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorDataUsageTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorDataUsageTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorDataUsageTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkOperatorDataUsageTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: NetworkOperatorDataUsageTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorDataUsageTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorDataUsageTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorDataUsageTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorDataUsageTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkOperatorDataUsageTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NetworkOperatorDataUsageTriggerDetails {}
 unsafe impl ::core::marker::Sync for NetworkOperatorDataUsageTriggerDetails {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -9857,36 +8001,7 @@ unsafe impl ::windows::core::Interface for NetworkOperatorNotificationEventDetai
 impl ::windows::core::RuntimeName for NetworkOperatorNotificationEventDetails {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.NetworkOperatorNotificationEventDetails";
 }
-impl ::core::convert::From<NetworkOperatorNotificationEventDetails> for ::windows::core::IUnknown {
-    fn from(value: NetworkOperatorNotificationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorNotificationEventDetails> for ::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorNotificationEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorNotificationEventDetails> for &::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorNotificationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkOperatorNotificationEventDetails> for ::windows::core::IInspectable {
-    fn from(value: NetworkOperatorNotificationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorNotificationEventDetails> for ::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorNotificationEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorNotificationEventDetails> for &::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorNotificationEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkOperatorNotificationEventDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NetworkOperatorNotificationEventDetails {}
 unsafe impl ::core::marker::Sync for NetworkOperatorNotificationEventDetails {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -9982,36 +8097,7 @@ unsafe impl ::windows::core::Interface for NetworkOperatorTetheringAccessPointCo
 impl ::windows::core::RuntimeName for NetworkOperatorTetheringAccessPointConfiguration {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.NetworkOperatorTetheringAccessPointConfiguration";
 }
-impl ::core::convert::From<NetworkOperatorTetheringAccessPointConfiguration> for ::windows::core::IUnknown {
-    fn from(value: NetworkOperatorTetheringAccessPointConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringAccessPointConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorTetheringAccessPointConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringAccessPointConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorTetheringAccessPointConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkOperatorTetheringAccessPointConfiguration> for ::windows::core::IInspectable {
-    fn from(value: NetworkOperatorTetheringAccessPointConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringAccessPointConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorTetheringAccessPointConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringAccessPointConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorTetheringAccessPointConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkOperatorTetheringAccessPointConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NetworkOperatorTetheringAccessPointConfiguration {}
 unsafe impl ::core::marker::Sync for NetworkOperatorTetheringAccessPointConfiguration {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -10067,36 +8153,7 @@ unsafe impl ::windows::core::Interface for NetworkOperatorTetheringClient {
 impl ::windows::core::RuntimeName for NetworkOperatorTetheringClient {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.NetworkOperatorTetheringClient";
 }
-impl ::core::convert::From<NetworkOperatorTetheringClient> for ::windows::core::IUnknown {
-    fn from(value: NetworkOperatorTetheringClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringClient> for ::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorTetheringClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringClient> for &::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorTetheringClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkOperatorTetheringClient> for ::windows::core::IInspectable {
-    fn from(value: NetworkOperatorTetheringClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringClient> for ::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorTetheringClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringClient> for &::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorTetheringClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkOperatorTetheringClient, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NetworkOperatorTetheringClient {}
 unsafe impl ::core::marker::Sync for NetworkOperatorTetheringClient {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -10284,36 +8341,7 @@ unsafe impl ::windows::core::Interface for NetworkOperatorTetheringManager {
 impl ::windows::core::RuntimeName for NetworkOperatorTetheringManager {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.NetworkOperatorTetheringManager";
 }
-impl ::core::convert::From<NetworkOperatorTetheringManager> for ::windows::core::IUnknown {
-    fn from(value: NetworkOperatorTetheringManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringManager> for ::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorTetheringManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringManager> for &::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorTetheringManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkOperatorTetheringManager> for ::windows::core::IInspectable {
-    fn from(value: NetworkOperatorTetheringManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringManager> for ::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorTetheringManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringManager> for &::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorTetheringManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkOperatorTetheringManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct NetworkOperatorTetheringOperationResult(::windows::core::IUnknown);
@@ -10365,36 +8393,7 @@ unsafe impl ::windows::core::Interface for NetworkOperatorTetheringOperationResu
 impl ::windows::core::RuntimeName for NetworkOperatorTetheringOperationResult {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.NetworkOperatorTetheringOperationResult";
 }
-impl ::core::convert::From<NetworkOperatorTetheringOperationResult> for ::windows::core::IUnknown {
-    fn from(value: NetworkOperatorTetheringOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringOperationResult> for ::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorTetheringOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringOperationResult> for &::windows::core::IUnknown {
-    fn from(value: &NetworkOperatorTetheringOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NetworkOperatorTetheringOperationResult> for ::windows::core::IInspectable {
-    fn from(value: NetworkOperatorTetheringOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringOperationResult> for ::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorTetheringOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NetworkOperatorTetheringOperationResult> for &::windows::core::IInspectable {
-    fn from(value: &NetworkOperatorTetheringOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NetworkOperatorTetheringOperationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct ProvisionFromXmlDocumentResults(::windows::core::IUnknown);
@@ -10446,36 +8445,7 @@ unsafe impl ::windows::core::Interface for ProvisionFromXmlDocumentResults {
 impl ::windows::core::RuntimeName for ProvisionFromXmlDocumentResults {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ProvisionFromXmlDocumentResults";
 }
-impl ::core::convert::From<ProvisionFromXmlDocumentResults> for ::windows::core::IUnknown {
-    fn from(value: ProvisionFromXmlDocumentResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProvisionFromXmlDocumentResults> for ::windows::core::IUnknown {
-    fn from(value: &ProvisionFromXmlDocumentResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProvisionFromXmlDocumentResults> for &::windows::core::IUnknown {
-    fn from(value: &ProvisionFromXmlDocumentResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProvisionFromXmlDocumentResults> for ::windows::core::IInspectable {
-    fn from(value: ProvisionFromXmlDocumentResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProvisionFromXmlDocumentResults> for ::windows::core::IInspectable {
-    fn from(value: &ProvisionFromXmlDocumentResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProvisionFromXmlDocumentResults> for &::windows::core::IInspectable {
-    fn from(value: &ProvisionFromXmlDocumentResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProvisionFromXmlDocumentResults, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct ProvisionedProfile(::windows::core::IUnknown);
@@ -10525,36 +8495,7 @@ unsafe impl ::windows::core::Interface for ProvisionedProfile {
 impl ::windows::core::RuntimeName for ProvisionedProfile {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ProvisionedProfile";
 }
-impl ::core::convert::From<ProvisionedProfile> for ::windows::core::IUnknown {
-    fn from(value: ProvisionedProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProvisionedProfile> for ::windows::core::IUnknown {
-    fn from(value: &ProvisionedProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProvisionedProfile> for &::windows::core::IUnknown {
-    fn from(value: &ProvisionedProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProvisionedProfile> for ::windows::core::IInspectable {
-    fn from(value: ProvisionedProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProvisionedProfile> for ::windows::core::IInspectable {
-    fn from(value: &ProvisionedProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProvisionedProfile> for &::windows::core::IInspectable {
-    fn from(value: &ProvisionedProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProvisionedProfile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct ProvisioningAgent(::windows::core::IUnknown);
@@ -10626,36 +8567,7 @@ unsafe impl ::windows::core::Interface for ProvisioningAgent {
 impl ::windows::core::RuntimeName for ProvisioningAgent {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ProvisioningAgent";
 }
-impl ::core::convert::From<ProvisioningAgent> for ::windows::core::IUnknown {
-    fn from(value: ProvisioningAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProvisioningAgent> for ::windows::core::IUnknown {
-    fn from(value: &ProvisioningAgent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProvisioningAgent> for &::windows::core::IUnknown {
-    fn from(value: &ProvisioningAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProvisioningAgent> for ::windows::core::IInspectable {
-    fn from(value: ProvisioningAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProvisioningAgent> for ::windows::core::IInspectable {
-    fn from(value: &ProvisioningAgent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProvisioningAgent> for &::windows::core::IInspectable {
-    fn from(value: &ProvisioningAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProvisioningAgent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct TetheringEntitlementCheckTriggerDetails(::windows::core::IUnknown);
@@ -10708,36 +8620,7 @@ unsafe impl ::windows::core::Interface for TetheringEntitlementCheckTriggerDetai
 impl ::windows::core::RuntimeName for TetheringEntitlementCheckTriggerDetails {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.TetheringEntitlementCheckTriggerDetails";
 }
-impl ::core::convert::From<TetheringEntitlementCheckTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: TetheringEntitlementCheckTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TetheringEntitlementCheckTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &TetheringEntitlementCheckTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TetheringEntitlementCheckTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &TetheringEntitlementCheckTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TetheringEntitlementCheckTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: TetheringEntitlementCheckTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TetheringEntitlementCheckTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &TetheringEntitlementCheckTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TetheringEntitlementCheckTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &TetheringEntitlementCheckTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TetheringEntitlementCheckTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TetheringEntitlementCheckTriggerDetails {}
 unsafe impl ::core::marker::Sync for TetheringEntitlementCheckTriggerDetails {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -10821,36 +8704,7 @@ unsafe impl ::windows::core::Interface for UssdMessage {
 impl ::windows::core::RuntimeName for UssdMessage {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.UssdMessage";
 }
-impl ::core::convert::From<UssdMessage> for ::windows::core::IUnknown {
-    fn from(value: UssdMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UssdMessage> for ::windows::core::IUnknown {
-    fn from(value: &UssdMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UssdMessage> for &::windows::core::IUnknown {
-    fn from(value: &UssdMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UssdMessage> for ::windows::core::IInspectable {
-    fn from(value: UssdMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UssdMessage> for ::windows::core::IInspectable {
-    fn from(value: &UssdMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UssdMessage> for &::windows::core::IInspectable {
-    fn from(value: &UssdMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UssdMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UssdMessage {}
 unsafe impl ::core::marker::Sync for UssdMessage {}
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
@@ -10904,36 +8758,7 @@ unsafe impl ::windows::core::Interface for UssdReply {
 impl ::windows::core::RuntimeName for UssdReply {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.UssdReply";
 }
-impl ::core::convert::From<UssdReply> for ::windows::core::IUnknown {
-    fn from(value: UssdReply) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UssdReply> for ::windows::core::IUnknown {
-    fn from(value: &UssdReply) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UssdReply> for &::windows::core::IUnknown {
-    fn from(value: &UssdReply) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UssdReply> for ::windows::core::IInspectable {
-    fn from(value: UssdReply) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UssdReply> for ::windows::core::IInspectable {
-    fn from(value: &UssdReply) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UssdReply> for &::windows::core::IInspectable {
-    fn from(value: &UssdReply) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UssdReply, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 pub struct UssdSession(::windows::core::IUnknown);
@@ -11001,36 +8826,7 @@ unsafe impl ::windows::core::Interface for UssdSession {
 impl ::windows::core::RuntimeName for UssdSession {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.UssdSession";
 }
-impl ::core::convert::From<UssdSession> for ::windows::core::IUnknown {
-    fn from(value: UssdSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UssdSession> for ::windows::core::IUnknown {
-    fn from(value: &UssdSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UssdSession> for &::windows::core::IUnknown {
-    fn from(value: &UssdSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UssdSession> for ::windows::core::IInspectable {
-    fn from(value: UssdSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UssdSession> for ::windows::core::IInspectable {
-    fn from(value: &UssdSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UssdSession> for &::windows::core::IInspectable {
-    fn from(value: &UssdSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UssdSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Networking_NetworkOperators\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
@@ -355,36 +355,7 @@ unsafe impl ::windows::core::Interface for ConnectionRequestedEventArgs {
 impl ::windows::core::RuntimeName for ConnectionRequestedEventArgs {
     const NAME: &'static str = "Windows.Networking.Proximity.ConnectionRequestedEventArgs";
 }
-impl ::core::convert::From<ConnectionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ConnectionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectionRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ConnectionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ConnectionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ConnectionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ConnectionRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ConnectionRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ConnectionRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for ConnectionRequestedEventArgs {}
 #[doc = "*Required features: `\"Networking_Proximity\"`*"]
@@ -611,36 +582,7 @@ unsafe impl ::windows::core::Interface for PeerInformation {
 impl ::windows::core::RuntimeName for PeerInformation {
     const NAME: &'static str = "Windows.Networking.Proximity.PeerInformation";
 }
-impl ::core::convert::From<PeerInformation> for ::windows::core::IUnknown {
-    fn from(value: PeerInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PeerInformation> for ::windows::core::IUnknown {
-    fn from(value: &PeerInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PeerInformation> for &::windows::core::IUnknown {
-    fn from(value: &PeerInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PeerInformation> for ::windows::core::IInspectable {
-    fn from(value: PeerInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PeerInformation> for ::windows::core::IInspectable {
-    fn from(value: &PeerInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PeerInformation> for &::windows::core::IInspectable {
-    fn from(value: &PeerInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PeerInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PeerInformation {}
 unsafe impl ::core::marker::Sync for PeerInformation {}
 #[doc = "*Required features: `\"Networking_Proximity\"`*"]
@@ -770,36 +712,7 @@ unsafe impl ::windows::core::Interface for PeerWatcher {
 impl ::windows::core::RuntimeName for PeerWatcher {
     const NAME: &'static str = "Windows.Networking.Proximity.PeerWatcher";
 }
-impl ::core::convert::From<PeerWatcher> for ::windows::core::IUnknown {
-    fn from(value: PeerWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PeerWatcher> for ::windows::core::IUnknown {
-    fn from(value: &PeerWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PeerWatcher> for &::windows::core::IUnknown {
-    fn from(value: &PeerWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PeerWatcher> for ::windows::core::IInspectable {
-    fn from(value: PeerWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PeerWatcher> for ::windows::core::IInspectable {
-    fn from(value: &PeerWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PeerWatcher> for &::windows::core::IInspectable {
-    fn from(value: &PeerWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PeerWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PeerWatcher {}
 unsafe impl ::core::marker::Sync for PeerWatcher {}
 #[doc = "*Required features: `\"Networking_Proximity\"`*"]
@@ -986,36 +899,7 @@ unsafe impl ::windows::core::Interface for ProximityDevice {
 impl ::windows::core::RuntimeName for ProximityDevice {
     const NAME: &'static str = "Windows.Networking.Proximity.ProximityDevice";
 }
-impl ::core::convert::From<ProximityDevice> for ::windows::core::IUnknown {
-    fn from(value: ProximityDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximityDevice> for ::windows::core::IUnknown {
-    fn from(value: &ProximityDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximityDevice> for &::windows::core::IUnknown {
-    fn from(value: &ProximityDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProximityDevice> for ::windows::core::IInspectable {
-    fn from(value: ProximityDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximityDevice> for ::windows::core::IInspectable {
-    fn from(value: &ProximityDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximityDevice> for &::windows::core::IInspectable {
-    fn from(value: &ProximityDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProximityDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProximityDevice {}
 unsafe impl ::core::marker::Sync for ProximityDevice {}
 #[doc = "*Required features: `\"Networking_Proximity\"`*"]
@@ -1085,36 +969,7 @@ unsafe impl ::windows::core::Interface for ProximityMessage {
 impl ::windows::core::RuntimeName for ProximityMessage {
     const NAME: &'static str = "Windows.Networking.Proximity.ProximityMessage";
 }
-impl ::core::convert::From<ProximityMessage> for ::windows::core::IUnknown {
-    fn from(value: ProximityMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximityMessage> for ::windows::core::IUnknown {
-    fn from(value: &ProximityMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximityMessage> for &::windows::core::IUnknown {
-    fn from(value: &ProximityMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProximityMessage> for ::windows::core::IInspectable {
-    fn from(value: ProximityMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProximityMessage> for ::windows::core::IInspectable {
-    fn from(value: &ProximityMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProximityMessage> for &::windows::core::IInspectable {
-    fn from(value: &ProximityMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProximityMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProximityMessage {}
 unsafe impl ::core::marker::Sync for ProximityMessage {}
 #[doc = "*Required features: `\"Networking_Proximity\"`*"]
@@ -1177,36 +1032,7 @@ unsafe impl ::windows::core::Interface for TriggeredConnectionStateChangedEventA
 impl ::windows::core::RuntimeName for TriggeredConnectionStateChangedEventArgs {
     const NAME: &'static str = "Windows.Networking.Proximity.TriggeredConnectionStateChangedEventArgs";
 }
-impl ::core::convert::From<TriggeredConnectionStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TriggeredConnectionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TriggeredConnectionStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TriggeredConnectionStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TriggeredConnectionStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TriggeredConnectionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TriggeredConnectionStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TriggeredConnectionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TriggeredConnectionStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TriggeredConnectionStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TriggeredConnectionStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TriggeredConnectionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TriggeredConnectionStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TriggeredConnectionStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for TriggeredConnectionStateChangedEventArgs {}
 #[doc = "*Required features: `\"Networking_Proximity\"`*"]

--- a/crates/libs/windows/src/Windows/Networking/PushNotifications/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/PushNotifications/mod.rs
@@ -327,36 +327,7 @@ unsafe impl ::windows::core::Interface for PushNotificationChannel {
 impl ::windows::core::RuntimeName for PushNotificationChannel {
     const NAME: &'static str = "Windows.Networking.PushNotifications.PushNotificationChannel";
 }
-impl ::core::convert::From<PushNotificationChannel> for ::windows::core::IUnknown {
-    fn from(value: PushNotificationChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PushNotificationChannel> for ::windows::core::IUnknown {
-    fn from(value: &PushNotificationChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PushNotificationChannel> for &::windows::core::IUnknown {
-    fn from(value: &PushNotificationChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PushNotificationChannel> for ::windows::core::IInspectable {
-    fn from(value: PushNotificationChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PushNotificationChannel> for ::windows::core::IInspectable {
-    fn from(value: &PushNotificationChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PushNotificationChannel> for &::windows::core::IInspectable {
-    fn from(value: &PushNotificationChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PushNotificationChannel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PushNotificationChannel {}
 unsafe impl ::core::marker::Sync for PushNotificationChannel {}
 #[doc = "*Required features: `\"Networking_PushNotifications\"`*"]
@@ -536,36 +507,7 @@ unsafe impl ::windows::core::Interface for PushNotificationChannelManagerForUser
 impl ::windows::core::RuntimeName for PushNotificationChannelManagerForUser {
     const NAME: &'static str = "Windows.Networking.PushNotifications.PushNotificationChannelManagerForUser";
 }
-impl ::core::convert::From<PushNotificationChannelManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: PushNotificationChannelManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PushNotificationChannelManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: &PushNotificationChannelManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PushNotificationChannelManagerForUser> for &::windows::core::IUnknown {
-    fn from(value: &PushNotificationChannelManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PushNotificationChannelManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: PushNotificationChannelManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PushNotificationChannelManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: &PushNotificationChannelManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PushNotificationChannelManagerForUser> for &::windows::core::IInspectable {
-    fn from(value: &PushNotificationChannelManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PushNotificationChannelManagerForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PushNotificationChannelManagerForUser {}
 unsafe impl ::core::marker::Sync for PushNotificationChannelManagerForUser {}
 #[doc = "*Required features: `\"Networking_PushNotifications\"`*"]
@@ -604,36 +546,7 @@ unsafe impl ::windows::core::Interface for PushNotificationChannelsRevokedEventA
 impl ::windows::core::RuntimeName for PushNotificationChannelsRevokedEventArgs {
     const NAME: &'static str = "Windows.Networking.PushNotifications.PushNotificationChannelsRevokedEventArgs";
 }
-impl ::core::convert::From<PushNotificationChannelsRevokedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PushNotificationChannelsRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PushNotificationChannelsRevokedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PushNotificationChannelsRevokedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PushNotificationChannelsRevokedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PushNotificationChannelsRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PushNotificationChannelsRevokedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PushNotificationChannelsRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PushNotificationChannelsRevokedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PushNotificationChannelsRevokedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PushNotificationChannelsRevokedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PushNotificationChannelsRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PushNotificationChannelsRevokedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PushNotificationChannelsRevokedEventArgs {}
 unsafe impl ::core::marker::Sync for PushNotificationChannelsRevokedEventArgs {}
 #[doc = "*Required features: `\"Networking_PushNotifications\"`*"]
@@ -725,36 +638,7 @@ unsafe impl ::windows::core::Interface for PushNotificationReceivedEventArgs {
 impl ::windows::core::RuntimeName for PushNotificationReceivedEventArgs {
     const NAME: &'static str = "Windows.Networking.PushNotifications.PushNotificationReceivedEventArgs";
 }
-impl ::core::convert::From<PushNotificationReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PushNotificationReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PushNotificationReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PushNotificationReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PushNotificationReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PushNotificationReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PushNotificationReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PushNotificationReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PushNotificationReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PushNotificationReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PushNotificationReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PushNotificationReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PushNotificationReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PushNotificationReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for PushNotificationReceivedEventArgs {}
 #[doc = "*Required features: `\"Networking_PushNotifications\"`*"]
@@ -826,36 +710,7 @@ unsafe impl ::windows::core::Interface for RawNotification {
 impl ::windows::core::RuntimeName for RawNotification {
     const NAME: &'static str = "Windows.Networking.PushNotifications.RawNotification";
 }
-impl ::core::convert::From<RawNotification> for ::windows::core::IUnknown {
-    fn from(value: RawNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RawNotification> for ::windows::core::IUnknown {
-    fn from(value: &RawNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RawNotification> for &::windows::core::IUnknown {
-    fn from(value: &RawNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RawNotification> for ::windows::core::IInspectable {
-    fn from(value: RawNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RawNotification> for ::windows::core::IInspectable {
-    fn from(value: &RawNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RawNotification> for &::windows::core::IInspectable {
-    fn from(value: &RawNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RawNotification, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RawNotification {}
 unsafe impl ::core::marker::Sync for RawNotification {}
 #[doc = "*Required features: `\"Networking_PushNotifications\"`*"]

--- a/crates/libs/windows/src/Windows/Networking/ServiceDiscovery/Dnssd/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/ServiceDiscovery/Dnssd/mod.rs
@@ -189,36 +189,7 @@ unsafe impl ::windows::core::Interface for DnssdRegistrationResult {
 impl ::windows::core::RuntimeName for DnssdRegistrationResult {
     const NAME: &'static str = "Windows.Networking.ServiceDiscovery.Dnssd.DnssdRegistrationResult";
 }
-impl ::core::convert::From<DnssdRegistrationResult> for ::windows::core::IUnknown {
-    fn from(value: DnssdRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DnssdRegistrationResult> for ::windows::core::IUnknown {
-    fn from(value: &DnssdRegistrationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DnssdRegistrationResult> for &::windows::core::IUnknown {
-    fn from(value: &DnssdRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DnssdRegistrationResult> for ::windows::core::IInspectable {
-    fn from(value: DnssdRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DnssdRegistrationResult> for ::windows::core::IInspectable {
-    fn from(value: &DnssdRegistrationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DnssdRegistrationResult> for &::windows::core::IInspectable {
-    fn from(value: &DnssdRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DnssdRegistrationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<DnssdRegistrationResult> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -400,36 +371,7 @@ unsafe impl ::windows::core::Interface for DnssdServiceInstance {
 impl ::windows::core::RuntimeName for DnssdServiceInstance {
     const NAME: &'static str = "Windows.Networking.ServiceDiscovery.Dnssd.DnssdServiceInstance";
 }
-impl ::core::convert::From<DnssdServiceInstance> for ::windows::core::IUnknown {
-    fn from(value: DnssdServiceInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DnssdServiceInstance> for ::windows::core::IUnknown {
-    fn from(value: &DnssdServiceInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DnssdServiceInstance> for &::windows::core::IUnknown {
-    fn from(value: &DnssdServiceInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DnssdServiceInstance> for ::windows::core::IInspectable {
-    fn from(value: DnssdServiceInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DnssdServiceInstance> for ::windows::core::IInspectable {
-    fn from(value: &DnssdServiceInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DnssdServiceInstance> for &::windows::core::IInspectable {
-    fn from(value: &DnssdServiceInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DnssdServiceInstance, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<DnssdServiceInstance> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -563,41 +505,7 @@ impl ::core::iter::IntoIterator for &DnssdServiceInstanceCollection {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<DnssdServiceInstanceCollection> for ::windows::core::IUnknown {
-    fn from(value: DnssdServiceInstanceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&DnssdServiceInstanceCollection> for ::windows::core::IUnknown {
-    fn from(value: &DnssdServiceInstanceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&DnssdServiceInstanceCollection> for &::windows::core::IUnknown {
-    fn from(value: &DnssdServiceInstanceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<DnssdServiceInstanceCollection> for ::windows::core::IInspectable {
-    fn from(value: DnssdServiceInstanceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&DnssdServiceInstanceCollection> for ::windows::core::IInspectable {
-    fn from(value: &DnssdServiceInstanceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&DnssdServiceInstanceCollection> for &::windows::core::IInspectable {
-    fn from(value: &DnssdServiceInstanceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DnssdServiceInstanceCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<DnssdServiceInstanceCollection> for super::super::super::Foundation::Collections::IIterable<DnssdServiceInstance> {
     type Error = ::windows::core::Error;
@@ -743,36 +651,7 @@ unsafe impl ::windows::core::Interface for DnssdServiceWatcher {
 impl ::windows::core::RuntimeName for DnssdServiceWatcher {
     const NAME: &'static str = "Windows.Networking.ServiceDiscovery.Dnssd.DnssdServiceWatcher";
 }
-impl ::core::convert::From<DnssdServiceWatcher> for ::windows::core::IUnknown {
-    fn from(value: DnssdServiceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DnssdServiceWatcher> for ::windows::core::IUnknown {
-    fn from(value: &DnssdServiceWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DnssdServiceWatcher> for &::windows::core::IUnknown {
-    fn from(value: &DnssdServiceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DnssdServiceWatcher> for ::windows::core::IInspectable {
-    fn from(value: DnssdServiceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DnssdServiceWatcher> for ::windows::core::IInspectable {
-    fn from(value: &DnssdServiceWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DnssdServiceWatcher> for &::windows::core::IInspectable {
-    fn from(value: &DnssdServiceWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DnssdServiceWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DnssdServiceWatcher {}
 unsafe impl ::core::marker::Sync for DnssdServiceWatcher {}
 #[doc = "*Required features: `\"Networking_ServiceDiscovery_Dnssd\"`*"]

--- a/crates/libs/windows/src/Windows/Networking/Sockets/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Sockets/mod.rs
@@ -56,36 +56,7 @@ impl IControlChannelTriggerEventDetails {
         }
     }
 }
-impl ::core::convert::From<IControlChannelTriggerEventDetails> for ::windows::core::IUnknown {
-    fn from(value: IControlChannelTriggerEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IControlChannelTriggerEventDetails> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IControlChannelTriggerEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IControlChannelTriggerEventDetails> for ::windows::core::IUnknown {
-    fn from(value: &IControlChannelTriggerEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IControlChannelTriggerEventDetails> for ::windows::core::IInspectable {
-    fn from(value: IControlChannelTriggerEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IControlChannelTriggerEventDetails> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IControlChannelTriggerEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IControlChannelTriggerEventDetails> for ::windows::core::IInspectable {
-    fn from(value: &IControlChannelTriggerEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IControlChannelTriggerEventDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IControlChannelTriggerEventDetails {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -163,36 +134,7 @@ impl IControlChannelTriggerResetEventDetails {
         }
     }
 }
-impl ::core::convert::From<IControlChannelTriggerResetEventDetails> for ::windows::core::IUnknown {
-    fn from(value: IControlChannelTriggerResetEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IControlChannelTriggerResetEventDetails> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IControlChannelTriggerResetEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IControlChannelTriggerResetEventDetails> for ::windows::core::IUnknown {
-    fn from(value: &IControlChannelTriggerResetEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IControlChannelTriggerResetEventDetails> for ::windows::core::IInspectable {
-    fn from(value: IControlChannelTriggerResetEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IControlChannelTriggerResetEventDetails> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IControlChannelTriggerResetEventDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IControlChannelTriggerResetEventDetails> for ::windows::core::IInspectable {
-    fn from(value: &IControlChannelTriggerResetEventDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IControlChannelTriggerResetEventDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IControlChannelTriggerResetEventDetails {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1363,36 +1305,7 @@ impl IWebSocket {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IWebSocket> for ::windows::core::IUnknown {
-    fn from(value: IWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebSocket> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebSocket> for ::windows::core::IUnknown {
-    fn from(value: &IWebSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebSocket> for ::windows::core::IInspectable {
-    fn from(value: IWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebSocket> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebSocket> for ::windows::core::IInspectable {
-    fn from(value: &IWebSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebSocket, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IWebSocket> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1538,36 +1451,7 @@ impl IWebSocketControl {
         }
     }
 }
-impl ::core::convert::From<IWebSocketControl> for ::windows::core::IUnknown {
-    fn from(value: IWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebSocketControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebSocketControl> for ::windows::core::IUnknown {
-    fn from(value: &IWebSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebSocketControl> for ::windows::core::IInspectable {
-    fn from(value: IWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebSocketControl> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebSocketControl> for ::windows::core::IInspectable {
-    fn from(value: &IWebSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebSocketControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebSocketControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1688,36 +1572,7 @@ impl IWebSocketControl2 {
         }
     }
 }
-impl ::core::convert::From<IWebSocketControl2> for ::windows::core::IUnknown {
-    fn from(value: IWebSocketControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebSocketControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebSocketControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebSocketControl2> for ::windows::core::IUnknown {
-    fn from(value: &IWebSocketControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebSocketControl2> for ::windows::core::IInspectable {
-    fn from(value: IWebSocketControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebSocketControl2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebSocketControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebSocketControl2> for ::windows::core::IInspectable {
-    fn from(value: &IWebSocketControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebSocketControl2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IWebSocketControl2> for IWebSocketControl {
     type Error = ::windows::core::Error;
     fn try_from(value: IWebSocketControl2) -> ::windows::core::Result<Self> {
@@ -1819,36 +1674,7 @@ impl IWebSocketInformation {
         }
     }
 }
-impl ::core::convert::From<IWebSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: IWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebSocketInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: &IWebSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: IWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebSocketInformation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: &IWebSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebSocketInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebSocketInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1946,36 +1772,7 @@ impl IWebSocketInformation2 {
         }
     }
 }
-impl ::core::convert::From<IWebSocketInformation2> for ::windows::core::IUnknown {
-    fn from(value: IWebSocketInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebSocketInformation2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebSocketInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebSocketInformation2> for ::windows::core::IUnknown {
-    fn from(value: &IWebSocketInformation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebSocketInformation2> for ::windows::core::IInspectable {
-    fn from(value: IWebSocketInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebSocketInformation2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebSocketInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebSocketInformation2> for ::windows::core::IInspectable {
-    fn from(value: &IWebSocketInformation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebSocketInformation2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IWebSocketInformation2> for IWebSocketInformation {
     type Error = ::windows::core::Error;
     fn try_from(value: IWebSocketInformation2) -> ::windows::core::Result<Self> {
@@ -2213,36 +2010,7 @@ unsafe impl ::windows::core::Interface for ControlChannelTrigger {
 impl ::windows::core::RuntimeName for ControlChannelTrigger {
     const NAME: &'static str = "Windows.Networking.Sockets.ControlChannelTrigger";
 }
-impl ::core::convert::From<ControlChannelTrigger> for ::windows::core::IUnknown {
-    fn from(value: ControlChannelTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ControlChannelTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ControlChannelTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ControlChannelTrigger> for &::windows::core::IUnknown {
-    fn from(value: &ControlChannelTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ControlChannelTrigger> for ::windows::core::IInspectable {
-    fn from(value: ControlChannelTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ControlChannelTrigger> for ::windows::core::IInspectable {
-    fn from(value: &ControlChannelTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ControlChannelTrigger> for &::windows::core::IInspectable {
-    fn from(value: &ControlChannelTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ControlChannelTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ControlChannelTrigger> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2474,36 +2242,7 @@ unsafe impl ::windows::core::Interface for DatagramSocket {
 impl ::windows::core::RuntimeName for DatagramSocket {
     const NAME: &'static str = "Windows.Networking.Sockets.DatagramSocket";
 }
-impl ::core::convert::From<DatagramSocket> for ::windows::core::IUnknown {
-    fn from(value: DatagramSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DatagramSocket> for ::windows::core::IUnknown {
-    fn from(value: &DatagramSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DatagramSocket> for &::windows::core::IUnknown {
-    fn from(value: &DatagramSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DatagramSocket> for ::windows::core::IInspectable {
-    fn from(value: DatagramSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DatagramSocket> for ::windows::core::IInspectable {
-    fn from(value: &DatagramSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DatagramSocket> for &::windows::core::IInspectable {
-    fn from(value: &DatagramSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DatagramSocket, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<DatagramSocket> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2620,36 +2359,7 @@ unsafe impl ::windows::core::Interface for DatagramSocketControl {
 impl ::windows::core::RuntimeName for DatagramSocketControl {
     const NAME: &'static str = "Windows.Networking.Sockets.DatagramSocketControl";
 }
-impl ::core::convert::From<DatagramSocketControl> for ::windows::core::IUnknown {
-    fn from(value: DatagramSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DatagramSocketControl> for ::windows::core::IUnknown {
-    fn from(value: &DatagramSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DatagramSocketControl> for &::windows::core::IUnknown {
-    fn from(value: &DatagramSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DatagramSocketControl> for ::windows::core::IInspectable {
-    fn from(value: DatagramSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DatagramSocketControl> for ::windows::core::IInspectable {
-    fn from(value: &DatagramSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DatagramSocketControl> for &::windows::core::IInspectable {
-    fn from(value: &DatagramSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DatagramSocketControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DatagramSocketControl {}
 unsafe impl ::core::marker::Sync for DatagramSocketControl {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -2717,36 +2427,7 @@ unsafe impl ::windows::core::Interface for DatagramSocketInformation {
 impl ::windows::core::RuntimeName for DatagramSocketInformation {
     const NAME: &'static str = "Windows.Networking.Sockets.DatagramSocketInformation";
 }
-impl ::core::convert::From<DatagramSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: DatagramSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DatagramSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: &DatagramSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DatagramSocketInformation> for &::windows::core::IUnknown {
-    fn from(value: &DatagramSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DatagramSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: DatagramSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DatagramSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: &DatagramSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DatagramSocketInformation> for &::windows::core::IInspectable {
-    fn from(value: &DatagramSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DatagramSocketInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DatagramSocketInformation {}
 unsafe impl ::core::marker::Sync for DatagramSocketInformation {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -2825,36 +2506,7 @@ unsafe impl ::windows::core::Interface for DatagramSocketMessageReceivedEventArg
 impl ::windows::core::RuntimeName for DatagramSocketMessageReceivedEventArgs {
     const NAME: &'static str = "Windows.Networking.Sockets.DatagramSocketMessageReceivedEventArgs";
 }
-impl ::core::convert::From<DatagramSocketMessageReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DatagramSocketMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DatagramSocketMessageReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DatagramSocketMessageReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DatagramSocketMessageReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DatagramSocketMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DatagramSocketMessageReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DatagramSocketMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DatagramSocketMessageReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DatagramSocketMessageReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DatagramSocketMessageReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DatagramSocketMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DatagramSocketMessageReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DatagramSocketMessageReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for DatagramSocketMessageReceivedEventArgs {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -3018,36 +2670,7 @@ unsafe impl ::windows::core::Interface for MessageWebSocket {
 impl ::windows::core::RuntimeName for MessageWebSocket {
     const NAME: &'static str = "Windows.Networking.Sockets.MessageWebSocket";
 }
-impl ::core::convert::From<MessageWebSocket> for ::windows::core::IUnknown {
-    fn from(value: MessageWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MessageWebSocket> for ::windows::core::IUnknown {
-    fn from(value: &MessageWebSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MessageWebSocket> for &::windows::core::IUnknown {
-    fn from(value: &MessageWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MessageWebSocket> for ::windows::core::IInspectable {
-    fn from(value: MessageWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MessageWebSocket> for ::windows::core::IInspectable {
-    fn from(value: &MessageWebSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MessageWebSocket> for &::windows::core::IInspectable {
-    fn from(value: &MessageWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MessageWebSocket, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<MessageWebSocket> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3259,36 +2882,7 @@ unsafe impl ::windows::core::Interface for MessageWebSocketControl {
 impl ::windows::core::RuntimeName for MessageWebSocketControl {
     const NAME: &'static str = "Windows.Networking.Sockets.MessageWebSocketControl";
 }
-impl ::core::convert::From<MessageWebSocketControl> for ::windows::core::IUnknown {
-    fn from(value: MessageWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MessageWebSocketControl> for ::windows::core::IUnknown {
-    fn from(value: &MessageWebSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MessageWebSocketControl> for &::windows::core::IUnknown {
-    fn from(value: &MessageWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MessageWebSocketControl> for ::windows::core::IInspectable {
-    fn from(value: MessageWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MessageWebSocketControl> for ::windows::core::IInspectable {
-    fn from(value: &MessageWebSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MessageWebSocketControl> for &::windows::core::IInspectable {
-    fn from(value: &MessageWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MessageWebSocketControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MessageWebSocketControl> for IWebSocketControl {
     type Error = ::windows::core::Error;
     fn try_from(value: MessageWebSocketControl) -> ::windows::core::Result<Self> {
@@ -3421,36 +3015,7 @@ unsafe impl ::windows::core::Interface for MessageWebSocketInformation {
 impl ::windows::core::RuntimeName for MessageWebSocketInformation {
     const NAME: &'static str = "Windows.Networking.Sockets.MessageWebSocketInformation";
 }
-impl ::core::convert::From<MessageWebSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: MessageWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MessageWebSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: &MessageWebSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MessageWebSocketInformation> for &::windows::core::IUnknown {
-    fn from(value: &MessageWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MessageWebSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: MessageWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MessageWebSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: &MessageWebSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MessageWebSocketInformation> for &::windows::core::IInspectable {
-    fn from(value: &MessageWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MessageWebSocketInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MessageWebSocketInformation> for IWebSocketInformation {
     type Error = ::windows::core::Error;
     fn try_from(value: MessageWebSocketInformation) -> ::windows::core::Result<Self> {
@@ -3560,36 +3125,7 @@ unsafe impl ::windows::core::Interface for MessageWebSocketMessageReceivedEventA
 impl ::windows::core::RuntimeName for MessageWebSocketMessageReceivedEventArgs {
     const NAME: &'static str = "Windows.Networking.Sockets.MessageWebSocketMessageReceivedEventArgs";
 }
-impl ::core::convert::From<MessageWebSocketMessageReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: MessageWebSocketMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MessageWebSocketMessageReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &MessageWebSocketMessageReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MessageWebSocketMessageReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &MessageWebSocketMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MessageWebSocketMessageReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: MessageWebSocketMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MessageWebSocketMessageReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &MessageWebSocketMessageReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MessageWebSocketMessageReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &MessageWebSocketMessageReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MessageWebSocketMessageReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MessageWebSocketMessageReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MessageWebSocketMessageReceivedEventArgs {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -3692,36 +3228,7 @@ unsafe impl ::windows::core::Interface for ServerMessageWebSocket {
 impl ::windows::core::RuntimeName for ServerMessageWebSocket {
     const NAME: &'static str = "Windows.Networking.Sockets.ServerMessageWebSocket";
 }
-impl ::core::convert::From<ServerMessageWebSocket> for ::windows::core::IUnknown {
-    fn from(value: ServerMessageWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocket> for ::windows::core::IUnknown {
-    fn from(value: &ServerMessageWebSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocket> for &::windows::core::IUnknown {
-    fn from(value: &ServerMessageWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ServerMessageWebSocket> for ::windows::core::IInspectable {
-    fn from(value: ServerMessageWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocket> for ::windows::core::IInspectable {
-    fn from(value: &ServerMessageWebSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocket> for &::windows::core::IInspectable {
-    fn from(value: &ServerMessageWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ServerMessageWebSocket, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ServerMessageWebSocket> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3794,36 +3301,7 @@ unsafe impl ::windows::core::Interface for ServerMessageWebSocketControl {
 impl ::windows::core::RuntimeName for ServerMessageWebSocketControl {
     const NAME: &'static str = "Windows.Networking.Sockets.ServerMessageWebSocketControl";
 }
-impl ::core::convert::From<ServerMessageWebSocketControl> for ::windows::core::IUnknown {
-    fn from(value: ServerMessageWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocketControl> for ::windows::core::IUnknown {
-    fn from(value: &ServerMessageWebSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocketControl> for &::windows::core::IUnknown {
-    fn from(value: &ServerMessageWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ServerMessageWebSocketControl> for ::windows::core::IInspectable {
-    fn from(value: ServerMessageWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocketControl> for ::windows::core::IInspectable {
-    fn from(value: &ServerMessageWebSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocketControl> for &::windows::core::IInspectable {
-    fn from(value: &ServerMessageWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ServerMessageWebSocketControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ServerMessageWebSocketControl {}
 unsafe impl ::core::marker::Sync for ServerMessageWebSocketControl {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -3884,36 +3362,7 @@ unsafe impl ::windows::core::Interface for ServerMessageWebSocketInformation {
 impl ::windows::core::RuntimeName for ServerMessageWebSocketInformation {
     const NAME: &'static str = "Windows.Networking.Sockets.ServerMessageWebSocketInformation";
 }
-impl ::core::convert::From<ServerMessageWebSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: ServerMessageWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: &ServerMessageWebSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocketInformation> for &::windows::core::IUnknown {
-    fn from(value: &ServerMessageWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ServerMessageWebSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: ServerMessageWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: &ServerMessageWebSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServerMessageWebSocketInformation> for &::windows::core::IInspectable {
-    fn from(value: &ServerMessageWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ServerMessageWebSocketInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ServerMessageWebSocketInformation {}
 unsafe impl ::core::marker::Sync for ServerMessageWebSocketInformation {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -4003,36 +3452,7 @@ unsafe impl ::windows::core::Interface for ServerStreamWebSocket {
 impl ::windows::core::RuntimeName for ServerStreamWebSocket {
     const NAME: &'static str = "Windows.Networking.Sockets.ServerStreamWebSocket";
 }
-impl ::core::convert::From<ServerStreamWebSocket> for ::windows::core::IUnknown {
-    fn from(value: ServerStreamWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServerStreamWebSocket> for ::windows::core::IUnknown {
-    fn from(value: &ServerStreamWebSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServerStreamWebSocket> for &::windows::core::IUnknown {
-    fn from(value: &ServerStreamWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ServerStreamWebSocket> for ::windows::core::IInspectable {
-    fn from(value: ServerStreamWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServerStreamWebSocket> for ::windows::core::IInspectable {
-    fn from(value: &ServerStreamWebSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServerStreamWebSocket> for &::windows::core::IInspectable {
-    fn from(value: &ServerStreamWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ServerStreamWebSocket, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ServerStreamWebSocket> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4115,36 +3535,7 @@ unsafe impl ::windows::core::Interface for ServerStreamWebSocketInformation {
 impl ::windows::core::RuntimeName for ServerStreamWebSocketInformation {
     const NAME: &'static str = "Windows.Networking.Sockets.ServerStreamWebSocketInformation";
 }
-impl ::core::convert::From<ServerStreamWebSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: ServerStreamWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServerStreamWebSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: &ServerStreamWebSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServerStreamWebSocketInformation> for &::windows::core::IUnknown {
-    fn from(value: &ServerStreamWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ServerStreamWebSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: ServerStreamWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServerStreamWebSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: &ServerStreamWebSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServerStreamWebSocketInformation> for &::windows::core::IInspectable {
-    fn from(value: &ServerStreamWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ServerStreamWebSocketInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ServerStreamWebSocketInformation {}
 unsafe impl ::core::marker::Sync for ServerStreamWebSocketInformation {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -4210,36 +3601,7 @@ unsafe impl ::windows::core::Interface for SocketActivityContext {
 impl ::windows::core::RuntimeName for SocketActivityContext {
     const NAME: &'static str = "Windows.Networking.Sockets.SocketActivityContext";
 }
-impl ::core::convert::From<SocketActivityContext> for ::windows::core::IUnknown {
-    fn from(value: SocketActivityContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SocketActivityContext> for ::windows::core::IUnknown {
-    fn from(value: &SocketActivityContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SocketActivityContext> for &::windows::core::IUnknown {
-    fn from(value: &SocketActivityContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SocketActivityContext> for ::windows::core::IInspectable {
-    fn from(value: SocketActivityContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SocketActivityContext> for ::windows::core::IInspectable {
-    fn from(value: &SocketActivityContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SocketActivityContext> for &::windows::core::IInspectable {
-    fn from(value: &SocketActivityContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocketActivityContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SocketActivityContext {}
 unsafe impl ::core::marker::Sync for SocketActivityContext {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -4341,36 +3703,7 @@ unsafe impl ::windows::core::Interface for SocketActivityInformation {
 impl ::windows::core::RuntimeName for SocketActivityInformation {
     const NAME: &'static str = "Windows.Networking.Sockets.SocketActivityInformation";
 }
-impl ::core::convert::From<SocketActivityInformation> for ::windows::core::IUnknown {
-    fn from(value: SocketActivityInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SocketActivityInformation> for ::windows::core::IUnknown {
-    fn from(value: &SocketActivityInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SocketActivityInformation> for &::windows::core::IUnknown {
-    fn from(value: &SocketActivityInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SocketActivityInformation> for ::windows::core::IInspectable {
-    fn from(value: SocketActivityInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SocketActivityInformation> for ::windows::core::IInspectable {
-    fn from(value: &SocketActivityInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SocketActivityInformation> for &::windows::core::IInspectable {
-    fn from(value: &SocketActivityInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocketActivityInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SocketActivityInformation {}
 unsafe impl ::core::marker::Sync for SocketActivityInformation {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -4424,36 +3757,7 @@ unsafe impl ::windows::core::Interface for SocketActivityTriggerDetails {
 impl ::windows::core::RuntimeName for SocketActivityTriggerDetails {
     const NAME: &'static str = "Windows.Networking.Sockets.SocketActivityTriggerDetails";
 }
-impl ::core::convert::From<SocketActivityTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: SocketActivityTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SocketActivityTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &SocketActivityTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SocketActivityTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &SocketActivityTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SocketActivityTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: SocketActivityTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SocketActivityTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &SocketActivityTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SocketActivityTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &SocketActivityTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SocketActivityTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SocketActivityTriggerDetails {}
 unsafe impl ::core::marker::Sync for SocketActivityTriggerDetails {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -4662,36 +3966,7 @@ unsafe impl ::windows::core::Interface for StreamSocket {
 impl ::windows::core::RuntimeName for StreamSocket {
     const NAME: &'static str = "Windows.Networking.Sockets.StreamSocket";
 }
-impl ::core::convert::From<StreamSocket> for ::windows::core::IUnknown {
-    fn from(value: StreamSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocket> for ::windows::core::IUnknown {
-    fn from(value: &StreamSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocket> for &::windows::core::IUnknown {
-    fn from(value: &StreamSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StreamSocket> for ::windows::core::IInspectable {
-    fn from(value: StreamSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocket> for ::windows::core::IInspectable {
-    fn from(value: &StreamSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocket> for &::windows::core::IInspectable {
-    fn from(value: &StreamSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StreamSocket, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<StreamSocket> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4854,36 +4129,7 @@ unsafe impl ::windows::core::Interface for StreamSocketControl {
 impl ::windows::core::RuntimeName for StreamSocketControl {
     const NAME: &'static str = "Windows.Networking.Sockets.StreamSocketControl";
 }
-impl ::core::convert::From<StreamSocketControl> for ::windows::core::IUnknown {
-    fn from(value: StreamSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketControl> for ::windows::core::IUnknown {
-    fn from(value: &StreamSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketControl> for &::windows::core::IUnknown {
-    fn from(value: &StreamSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StreamSocketControl> for ::windows::core::IInspectable {
-    fn from(value: StreamSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketControl> for ::windows::core::IInspectable {
-    fn from(value: &StreamSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketControl> for &::windows::core::IInspectable {
-    fn from(value: &StreamSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StreamSocketControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StreamSocketControl {}
 unsafe impl ::core::marker::Sync for StreamSocketControl {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -5029,36 +4275,7 @@ unsafe impl ::windows::core::Interface for StreamSocketInformation {
 impl ::windows::core::RuntimeName for StreamSocketInformation {
     const NAME: &'static str = "Windows.Networking.Sockets.StreamSocketInformation";
 }
-impl ::core::convert::From<StreamSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: StreamSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: &StreamSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketInformation> for &::windows::core::IUnknown {
-    fn from(value: &StreamSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StreamSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: StreamSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: &StreamSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketInformation> for &::windows::core::IInspectable {
-    fn from(value: &StreamSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StreamSocketInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StreamSocketInformation {}
 unsafe impl ::core::marker::Sync for StreamSocketInformation {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -5201,36 +4418,7 @@ unsafe impl ::windows::core::Interface for StreamSocketListener {
 impl ::windows::core::RuntimeName for StreamSocketListener {
     const NAME: &'static str = "Windows.Networking.Sockets.StreamSocketListener";
 }
-impl ::core::convert::From<StreamSocketListener> for ::windows::core::IUnknown {
-    fn from(value: StreamSocketListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketListener> for ::windows::core::IUnknown {
-    fn from(value: &StreamSocketListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketListener> for &::windows::core::IUnknown {
-    fn from(value: &StreamSocketListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StreamSocketListener> for ::windows::core::IInspectable {
-    fn from(value: StreamSocketListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketListener> for ::windows::core::IInspectable {
-    fn from(value: &StreamSocketListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketListener> for &::windows::core::IInspectable {
-    fn from(value: &StreamSocketListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StreamSocketListener, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<StreamSocketListener> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5299,36 +4487,7 @@ unsafe impl ::windows::core::Interface for StreamSocketListenerConnectionReceive
 impl ::windows::core::RuntimeName for StreamSocketListenerConnectionReceivedEventArgs {
     const NAME: &'static str = "Windows.Networking.Sockets.StreamSocketListenerConnectionReceivedEventArgs";
 }
-impl ::core::convert::From<StreamSocketListenerConnectionReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: StreamSocketListenerConnectionReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerConnectionReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &StreamSocketListenerConnectionReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerConnectionReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &StreamSocketListenerConnectionReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StreamSocketListenerConnectionReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: StreamSocketListenerConnectionReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerConnectionReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &StreamSocketListenerConnectionReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerConnectionReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &StreamSocketListenerConnectionReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StreamSocketListenerConnectionReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StreamSocketListenerConnectionReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for StreamSocketListenerConnectionReceivedEventArgs {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -5423,36 +4582,7 @@ unsafe impl ::windows::core::Interface for StreamSocketListenerControl {
 impl ::windows::core::RuntimeName for StreamSocketListenerControl {
     const NAME: &'static str = "Windows.Networking.Sockets.StreamSocketListenerControl";
 }
-impl ::core::convert::From<StreamSocketListenerControl> for ::windows::core::IUnknown {
-    fn from(value: StreamSocketListenerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerControl> for ::windows::core::IUnknown {
-    fn from(value: &StreamSocketListenerControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerControl> for &::windows::core::IUnknown {
-    fn from(value: &StreamSocketListenerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StreamSocketListenerControl> for ::windows::core::IInspectable {
-    fn from(value: StreamSocketListenerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerControl> for ::windows::core::IInspectable {
-    fn from(value: &StreamSocketListenerControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerControl> for &::windows::core::IInspectable {
-    fn from(value: &StreamSocketListenerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StreamSocketListenerControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StreamSocketListenerControl {}
 unsafe impl ::core::marker::Sync for StreamSocketListenerControl {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -5499,36 +4629,7 @@ unsafe impl ::windows::core::Interface for StreamSocketListenerInformation {
 impl ::windows::core::RuntimeName for StreamSocketListenerInformation {
     const NAME: &'static str = "Windows.Networking.Sockets.StreamSocketListenerInformation";
 }
-impl ::core::convert::From<StreamSocketListenerInformation> for ::windows::core::IUnknown {
-    fn from(value: StreamSocketListenerInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerInformation> for ::windows::core::IUnknown {
-    fn from(value: &StreamSocketListenerInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerInformation> for &::windows::core::IUnknown {
-    fn from(value: &StreamSocketListenerInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StreamSocketListenerInformation> for ::windows::core::IInspectable {
-    fn from(value: StreamSocketListenerInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerInformation> for ::windows::core::IInspectable {
-    fn from(value: &StreamSocketListenerInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamSocketListenerInformation> for &::windows::core::IInspectable {
-    fn from(value: &StreamSocketListenerInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StreamSocketListenerInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StreamSocketListenerInformation {}
 unsafe impl ::core::marker::Sync for StreamSocketListenerInformation {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -5660,36 +4761,7 @@ unsafe impl ::windows::core::Interface for StreamWebSocket {
 impl ::windows::core::RuntimeName for StreamWebSocket {
     const NAME: &'static str = "Windows.Networking.Sockets.StreamWebSocket";
 }
-impl ::core::convert::From<StreamWebSocket> for ::windows::core::IUnknown {
-    fn from(value: StreamWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamWebSocket> for ::windows::core::IUnknown {
-    fn from(value: &StreamWebSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamWebSocket> for &::windows::core::IUnknown {
-    fn from(value: &StreamWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StreamWebSocket> for ::windows::core::IInspectable {
-    fn from(value: StreamWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamWebSocket> for ::windows::core::IInspectable {
-    fn from(value: &StreamWebSocket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamWebSocket> for &::windows::core::IInspectable {
-    fn from(value: &StreamWebSocket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StreamWebSocket, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<StreamWebSocket> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -5879,36 +4951,7 @@ unsafe impl ::windows::core::Interface for StreamWebSocketControl {
 impl ::windows::core::RuntimeName for StreamWebSocketControl {
     const NAME: &'static str = "Windows.Networking.Sockets.StreamWebSocketControl";
 }
-impl ::core::convert::From<StreamWebSocketControl> for ::windows::core::IUnknown {
-    fn from(value: StreamWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamWebSocketControl> for ::windows::core::IUnknown {
-    fn from(value: &StreamWebSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamWebSocketControl> for &::windows::core::IUnknown {
-    fn from(value: &StreamWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StreamWebSocketControl> for ::windows::core::IInspectable {
-    fn from(value: StreamWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamWebSocketControl> for ::windows::core::IInspectable {
-    fn from(value: &StreamWebSocketControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamWebSocketControl> for &::windows::core::IInspectable {
-    fn from(value: &StreamWebSocketControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StreamWebSocketControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StreamWebSocketControl> for IWebSocketControl {
     type Error = ::windows::core::Error;
     fn try_from(value: StreamWebSocketControl) -> ::windows::core::Result<Self> {
@@ -6041,36 +5084,7 @@ unsafe impl ::windows::core::Interface for StreamWebSocketInformation {
 impl ::windows::core::RuntimeName for StreamWebSocketInformation {
     const NAME: &'static str = "Windows.Networking.Sockets.StreamWebSocketInformation";
 }
-impl ::core::convert::From<StreamWebSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: StreamWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamWebSocketInformation> for ::windows::core::IUnknown {
-    fn from(value: &StreamWebSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamWebSocketInformation> for &::windows::core::IUnknown {
-    fn from(value: &StreamWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StreamWebSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: StreamWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StreamWebSocketInformation> for ::windows::core::IInspectable {
-    fn from(value: &StreamWebSocketInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StreamWebSocketInformation> for &::windows::core::IInspectable {
-    fn from(value: &StreamWebSocketInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StreamWebSocketInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StreamWebSocketInformation> for IWebSocketInformation {
     type Error = ::windows::core::Error;
     fn try_from(value: StreamWebSocketInformation) -> ::windows::core::Result<Self> {
@@ -6162,36 +5176,7 @@ unsafe impl ::windows::core::Interface for WebSocketClosedEventArgs {
 impl ::windows::core::RuntimeName for WebSocketClosedEventArgs {
     const NAME: &'static str = "Windows.Networking.Sockets.WebSocketClosedEventArgs";
 }
-impl ::core::convert::From<WebSocketClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebSocketClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebSocketClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebSocketClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebSocketClosedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebSocketClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebSocketClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebSocketClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebSocketClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebSocketClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebSocketClosedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebSocketClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebSocketClosedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebSocketClosedEventArgs {}
 unsafe impl ::core::marker::Sync for WebSocketClosedEventArgs {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]
@@ -6279,41 +5264,7 @@ impl ::windows::core::RuntimeName for WebSocketKeepAlive {
     const NAME: &'static str = "Windows.Networking.Sockets.WebSocketKeepAlive";
 }
 #[cfg(feature = "ApplicationModel_Background")]
-impl ::core::convert::From<WebSocketKeepAlive> for ::windows::core::IUnknown {
-    fn from(value: WebSocketKeepAlive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Background")]
-impl ::core::convert::From<&WebSocketKeepAlive> for ::windows::core::IUnknown {
-    fn from(value: &WebSocketKeepAlive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Background")]
-impl ::core::convert::From<&WebSocketKeepAlive> for &::windows::core::IUnknown {
-    fn from(value: &WebSocketKeepAlive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Background")]
-impl ::core::convert::From<WebSocketKeepAlive> for ::windows::core::IInspectable {
-    fn from(value: WebSocketKeepAlive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Background")]
-impl ::core::convert::From<&WebSocketKeepAlive> for ::windows::core::IInspectable {
-    fn from(value: &WebSocketKeepAlive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Background")]
-impl ::core::convert::From<&WebSocketKeepAlive> for &::windows::core::IInspectable {
-    fn from(value: &WebSocketKeepAlive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebSocketKeepAlive, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Background")]
 impl ::core::convert::TryFrom<WebSocketKeepAlive> for super::super::ApplicationModel::Background::IBackgroundTask {
     type Error = ::windows::core::Error;
@@ -6424,36 +5375,7 @@ unsafe impl ::windows::core::Interface for WebSocketServerCustomValidationReques
 impl ::windows::core::RuntimeName for WebSocketServerCustomValidationRequestedEventArgs {
     const NAME: &'static str = "Windows.Networking.Sockets.WebSocketServerCustomValidationRequestedEventArgs";
 }
-impl ::core::convert::From<WebSocketServerCustomValidationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebSocketServerCustomValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebSocketServerCustomValidationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebSocketServerCustomValidationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebSocketServerCustomValidationRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebSocketServerCustomValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebSocketServerCustomValidationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebSocketServerCustomValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebSocketServerCustomValidationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebSocketServerCustomValidationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebSocketServerCustomValidationRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebSocketServerCustomValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebSocketServerCustomValidationRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebSocketServerCustomValidationRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for WebSocketServerCustomValidationRequestedEventArgs {}
 #[doc = "*Required features: `\"Networking_Sockets\"`*"]

--- a/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
@@ -272,36 +272,7 @@ impl IVpnChannelStatics {
         unsafe { (::windows::core::Vtable::vtable(this).ProcessEventAsync)(::windows::core::Vtable::as_raw(this), thirdpartyplugin.into().abi(), event.into().abi()).ok() }
     }
 }
-impl ::core::convert::From<IVpnChannelStatics> for ::windows::core::IUnknown {
-    fn from(value: IVpnChannelStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnChannelStatics> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVpnChannelStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnChannelStatics> for ::windows::core::IUnknown {
-    fn from(value: &IVpnChannelStatics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVpnChannelStatics> for ::windows::core::IInspectable {
-    fn from(value: IVpnChannelStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnChannelStatics> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVpnChannelStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnChannelStatics> for ::windows::core::IInspectable {
-    fn from(value: &IVpnChannelStatics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVpnChannelStatics, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVpnChannelStatics {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -376,36 +347,7 @@ impl IVpnCredential {
         }
     }
 }
-impl ::core::convert::From<IVpnCredential> for ::windows::core::IUnknown {
-    fn from(value: IVpnCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnCredential> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVpnCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnCredential> for ::windows::core::IUnknown {
-    fn from(value: &IVpnCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVpnCredential> for ::windows::core::IInspectable {
-    fn from(value: IVpnCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnCredential> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVpnCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnCredential> for ::windows::core::IInspectable {
-    fn from(value: &IVpnCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVpnCredential, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVpnCredential {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -564,36 +506,7 @@ impl IVpnCustomPrompt {
         }
     }
 }
-impl ::core::convert::From<IVpnCustomPrompt> for ::windows::core::IUnknown {
-    fn from(value: IVpnCustomPrompt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnCustomPrompt> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVpnCustomPrompt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnCustomPrompt> for ::windows::core::IUnknown {
-    fn from(value: &IVpnCustomPrompt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVpnCustomPrompt> for ::windows::core::IInspectable {
-    fn from(value: IVpnCustomPrompt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnCustomPrompt> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVpnCustomPrompt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnCustomPrompt> for ::windows::core::IInspectable {
-    fn from(value: &IVpnCustomPrompt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVpnCustomPrompt, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVpnCustomPrompt {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -689,36 +602,7 @@ impl IVpnCustomPromptElement {
         }
     }
 }
-impl ::core::convert::From<IVpnCustomPromptElement> for ::windows::core::IUnknown {
-    fn from(value: IVpnCustomPromptElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnCustomPromptElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVpnCustomPromptElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnCustomPromptElement> for ::windows::core::IUnknown {
-    fn from(value: &IVpnCustomPromptElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVpnCustomPromptElement> for ::windows::core::IInspectable {
-    fn from(value: IVpnCustomPromptElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnCustomPromptElement> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVpnCustomPromptElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnCustomPromptElement> for ::windows::core::IInspectable {
-    fn from(value: &IVpnCustomPromptElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVpnCustomPromptElement, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVpnCustomPromptElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -919,36 +803,7 @@ impl IVpnDomainNameInfoFactory {
         }
     }
 }
-impl ::core::convert::From<IVpnDomainNameInfoFactory> for ::windows::core::IUnknown {
-    fn from(value: IVpnDomainNameInfoFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnDomainNameInfoFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVpnDomainNameInfoFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnDomainNameInfoFactory> for ::windows::core::IUnknown {
-    fn from(value: &IVpnDomainNameInfoFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVpnDomainNameInfoFactory> for ::windows::core::IInspectable {
-    fn from(value: IVpnDomainNameInfoFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnDomainNameInfoFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVpnDomainNameInfoFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnDomainNameInfoFactory> for ::windows::core::IInspectable {
-    fn from(value: &IVpnDomainNameInfoFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVpnDomainNameInfoFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVpnDomainNameInfoFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1052,36 +907,7 @@ impl IVpnInterfaceIdFactory {
         }
     }
 }
-impl ::core::convert::From<IVpnInterfaceIdFactory> for ::windows::core::IUnknown {
-    fn from(value: IVpnInterfaceIdFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnInterfaceIdFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVpnInterfaceIdFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnInterfaceIdFactory> for ::windows::core::IUnknown {
-    fn from(value: &IVpnInterfaceIdFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVpnInterfaceIdFactory> for ::windows::core::IInspectable {
-    fn from(value: IVpnInterfaceIdFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnInterfaceIdFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVpnInterfaceIdFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnInterfaceIdFactory> for ::windows::core::IInspectable {
-    fn from(value: &IVpnInterfaceIdFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVpnInterfaceIdFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVpnInterfaceIdFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1249,36 +1075,7 @@ impl IVpnNamespaceInfoFactory {
         }
     }
 }
-impl ::core::convert::From<IVpnNamespaceInfoFactory> for ::windows::core::IUnknown {
-    fn from(value: IVpnNamespaceInfoFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnNamespaceInfoFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVpnNamespaceInfoFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnNamespaceInfoFactory> for ::windows::core::IUnknown {
-    fn from(value: &IVpnNamespaceInfoFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVpnNamespaceInfoFactory> for ::windows::core::IInspectable {
-    fn from(value: IVpnNamespaceInfoFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnNamespaceInfoFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVpnNamespaceInfoFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnNamespaceInfoFactory> for ::windows::core::IInspectable {
-    fn from(value: &IVpnNamespaceInfoFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVpnNamespaceInfoFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVpnNamespaceInfoFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1427,36 +1224,7 @@ impl IVpnPacketBufferFactory {
         }
     }
 }
-impl ::core::convert::From<IVpnPacketBufferFactory> for ::windows::core::IUnknown {
-    fn from(value: IVpnPacketBufferFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnPacketBufferFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVpnPacketBufferFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnPacketBufferFactory> for ::windows::core::IUnknown {
-    fn from(value: &IVpnPacketBufferFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVpnPacketBufferFactory> for ::windows::core::IInspectable {
-    fn from(value: IVpnPacketBufferFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnPacketBufferFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVpnPacketBufferFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnPacketBufferFactory> for ::windows::core::IInspectable {
-    fn from(value: &IVpnPacketBufferFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVpnPacketBufferFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVpnPacketBufferFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1580,36 +1348,7 @@ impl IVpnPlugIn {
         unsafe { (::windows::core::Vtable::vtable(this).Decapsulate)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(channel), ::core::mem::transmute_copy(encapbuffer), ::core::mem::transmute_copy(decapsulatedpackets), ::core::mem::transmute_copy(controlpacketstosend)).ok() }
     }
 }
-impl ::core::convert::From<IVpnPlugIn> for ::windows::core::IUnknown {
-    fn from(value: IVpnPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnPlugIn> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVpnPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnPlugIn> for ::windows::core::IUnknown {
-    fn from(value: &IVpnPlugIn) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVpnPlugIn> for ::windows::core::IInspectable {
-    fn from(value: IVpnPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnPlugIn> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVpnPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnPlugIn> for ::windows::core::IInspectable {
-    fn from(value: &IVpnPlugIn) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVpnPlugIn, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVpnPlugIn {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1762,36 +1501,7 @@ impl IVpnProfile {
         unsafe { (::windows::core::Vtable::vtable(this).SetAlwaysOn)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<IVpnProfile> for ::windows::core::IUnknown {
-    fn from(value: IVpnProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnProfile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVpnProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnProfile> for ::windows::core::IUnknown {
-    fn from(value: &IVpnProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVpnProfile> for ::windows::core::IInspectable {
-    fn from(value: IVpnProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnProfile> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVpnProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnProfile> for ::windows::core::IInspectable {
-    fn from(value: &IVpnProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVpnProfile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVpnProfile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1926,36 +1636,7 @@ impl IVpnRouteFactory {
         }
     }
 }
-impl ::core::convert::From<IVpnRouteFactory> for ::windows::core::IUnknown {
-    fn from(value: IVpnRouteFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnRouteFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVpnRouteFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnRouteFactory> for ::windows::core::IUnknown {
-    fn from(value: &IVpnRouteFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVpnRouteFactory> for ::windows::core::IInspectable {
-    fn from(value: IVpnRouteFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVpnRouteFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVpnRouteFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVpnRouteFactory> for ::windows::core::IInspectable {
-    fn from(value: &IVpnRouteFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVpnRouteFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVpnRouteFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2156,36 +1837,7 @@ unsafe impl ::windows::core::Interface for VpnAppId {
 impl ::windows::core::RuntimeName for VpnAppId {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnAppId";
 }
-impl ::core::convert::From<VpnAppId> for ::windows::core::IUnknown {
-    fn from(value: VpnAppId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnAppId> for ::windows::core::IUnknown {
-    fn from(value: &VpnAppId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnAppId> for &::windows::core::IUnknown {
-    fn from(value: &VpnAppId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnAppId> for ::windows::core::IInspectable {
-    fn from(value: VpnAppId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnAppId> for ::windows::core::IInspectable {
-    fn from(value: &VpnAppId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnAppId> for &::windows::core::IInspectable {
-    fn from(value: &VpnAppId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnAppId, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnAppId {}
 unsafe impl ::core::marker::Sync for VpnAppId {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -2545,36 +2197,7 @@ unsafe impl ::windows::core::Interface for VpnChannel {
 impl ::windows::core::RuntimeName for VpnChannel {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnChannel";
 }
-impl ::core::convert::From<VpnChannel> for ::windows::core::IUnknown {
-    fn from(value: VpnChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnChannel> for ::windows::core::IUnknown {
-    fn from(value: &VpnChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnChannel> for &::windows::core::IUnknown {
-    fn from(value: &VpnChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnChannel> for ::windows::core::IInspectable {
-    fn from(value: VpnChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnChannel> for ::windows::core::IInspectable {
-    fn from(value: &VpnChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnChannel> for &::windows::core::IInspectable {
-    fn from(value: &VpnChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnChannel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnChannel {}
 unsafe impl ::core::marker::Sync for VpnChannel {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -2621,36 +2244,7 @@ unsafe impl ::windows::core::Interface for VpnChannelActivityEventArgs {
 impl ::windows::core::RuntimeName for VpnChannelActivityEventArgs {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnChannelActivityEventArgs";
 }
-impl ::core::convert::From<VpnChannelActivityEventArgs> for ::windows::core::IUnknown {
-    fn from(value: VpnChannelActivityEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnChannelActivityEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &VpnChannelActivityEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnChannelActivityEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &VpnChannelActivityEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnChannelActivityEventArgs> for ::windows::core::IInspectable {
-    fn from(value: VpnChannelActivityEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnChannelActivityEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &VpnChannelActivityEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnChannelActivityEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &VpnChannelActivityEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnChannelActivityEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnChannelActivityEventArgs {}
 unsafe impl ::core::marker::Sync for VpnChannelActivityEventArgs {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -2697,36 +2291,7 @@ unsafe impl ::windows::core::Interface for VpnChannelActivityStateChangedArgs {
 impl ::windows::core::RuntimeName for VpnChannelActivityStateChangedArgs {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnChannelActivityStateChangedArgs";
 }
-impl ::core::convert::From<VpnChannelActivityStateChangedArgs> for ::windows::core::IUnknown {
-    fn from(value: VpnChannelActivityStateChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnChannelActivityStateChangedArgs> for ::windows::core::IUnknown {
-    fn from(value: &VpnChannelActivityStateChangedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnChannelActivityStateChangedArgs> for &::windows::core::IUnknown {
-    fn from(value: &VpnChannelActivityStateChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnChannelActivityStateChangedArgs> for ::windows::core::IInspectable {
-    fn from(value: VpnChannelActivityStateChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnChannelActivityStateChangedArgs> for ::windows::core::IInspectable {
-    fn from(value: &VpnChannelActivityStateChangedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnChannelActivityStateChangedArgs> for &::windows::core::IInspectable {
-    fn from(value: &VpnChannelActivityStateChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnChannelActivityStateChangedArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnChannelActivityStateChangedArgs {}
 unsafe impl ::core::marker::Sync for VpnChannelActivityStateChangedArgs {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -2798,36 +2363,7 @@ unsafe impl ::windows::core::Interface for VpnChannelConfiguration {
 impl ::windows::core::RuntimeName for VpnChannelConfiguration {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnChannelConfiguration";
 }
-impl ::core::convert::From<VpnChannelConfiguration> for ::windows::core::IUnknown {
-    fn from(value: VpnChannelConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnChannelConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &VpnChannelConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnChannelConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &VpnChannelConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnChannelConfiguration> for ::windows::core::IInspectable {
-    fn from(value: VpnChannelConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnChannelConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &VpnChannelConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnChannelConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &VpnChannelConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnChannelConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnChannelConfiguration {}
 unsafe impl ::core::marker::Sync for VpnChannelConfiguration {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -2901,36 +2437,7 @@ unsafe impl ::windows::core::Interface for VpnCredential {
 impl ::windows::core::RuntimeName for VpnCredential {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnCredential";
 }
-impl ::core::convert::From<VpnCredential> for ::windows::core::IUnknown {
-    fn from(value: VpnCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCredential> for ::windows::core::IUnknown {
-    fn from(value: &VpnCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCredential> for &::windows::core::IUnknown {
-    fn from(value: &VpnCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnCredential> for ::windows::core::IInspectable {
-    fn from(value: VpnCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCredential> for ::windows::core::IInspectable {
-    fn from(value: &VpnCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCredential> for &::windows::core::IInspectable {
-    fn from(value: &VpnCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnCredential, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnCredential> for IVpnCredential {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnCredential) -> ::windows::core::Result<Self> {
@@ -3047,36 +2554,7 @@ unsafe impl ::windows::core::Interface for VpnCustomCheckBox {
 impl ::windows::core::RuntimeName for VpnCustomCheckBox {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnCustomCheckBox";
 }
-impl ::core::convert::From<VpnCustomCheckBox> for ::windows::core::IUnknown {
-    fn from(value: VpnCustomCheckBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomCheckBox> for ::windows::core::IUnknown {
-    fn from(value: &VpnCustomCheckBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomCheckBox> for &::windows::core::IUnknown {
-    fn from(value: &VpnCustomCheckBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnCustomCheckBox> for ::windows::core::IInspectable {
-    fn from(value: VpnCustomCheckBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomCheckBox> for ::windows::core::IInspectable {
-    fn from(value: &VpnCustomCheckBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomCheckBox> for &::windows::core::IInspectable {
-    fn from(value: &VpnCustomCheckBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnCustomCheckBox, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnCustomCheckBox> for IVpnCustomPrompt {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnCustomCheckBox) -> ::windows::core::Result<Self> {
@@ -3201,36 +2679,7 @@ unsafe impl ::windows::core::Interface for VpnCustomComboBox {
 impl ::windows::core::RuntimeName for VpnCustomComboBox {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnCustomComboBox";
 }
-impl ::core::convert::From<VpnCustomComboBox> for ::windows::core::IUnknown {
-    fn from(value: VpnCustomComboBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomComboBox> for ::windows::core::IUnknown {
-    fn from(value: &VpnCustomComboBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomComboBox> for &::windows::core::IUnknown {
-    fn from(value: &VpnCustomComboBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnCustomComboBox> for ::windows::core::IInspectable {
-    fn from(value: VpnCustomComboBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomComboBox> for ::windows::core::IInspectable {
-    fn from(value: &VpnCustomComboBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomComboBox> for &::windows::core::IInspectable {
-    fn from(value: &VpnCustomComboBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnCustomComboBox, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnCustomComboBox> for IVpnCustomPrompt {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnCustomComboBox) -> ::windows::core::Result<Self> {
@@ -3358,36 +2807,7 @@ unsafe impl ::windows::core::Interface for VpnCustomEditBox {
 impl ::windows::core::RuntimeName for VpnCustomEditBox {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnCustomEditBox";
 }
-impl ::core::convert::From<VpnCustomEditBox> for ::windows::core::IUnknown {
-    fn from(value: VpnCustomEditBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomEditBox> for ::windows::core::IUnknown {
-    fn from(value: &VpnCustomEditBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomEditBox> for &::windows::core::IUnknown {
-    fn from(value: &VpnCustomEditBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnCustomEditBox> for ::windows::core::IInspectable {
-    fn from(value: VpnCustomEditBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomEditBox> for ::windows::core::IInspectable {
-    fn from(value: &VpnCustomEditBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomEditBox> for &::windows::core::IInspectable {
-    fn from(value: &VpnCustomEditBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnCustomEditBox, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnCustomEditBox> for IVpnCustomPrompt {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnCustomEditBox) -> ::windows::core::Result<Self> {
@@ -3486,36 +2906,7 @@ unsafe impl ::windows::core::Interface for VpnCustomErrorBox {
 impl ::windows::core::RuntimeName for VpnCustomErrorBox {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnCustomErrorBox";
 }
-impl ::core::convert::From<VpnCustomErrorBox> for ::windows::core::IUnknown {
-    fn from(value: VpnCustomErrorBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomErrorBox> for ::windows::core::IUnknown {
-    fn from(value: &VpnCustomErrorBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomErrorBox> for &::windows::core::IUnknown {
-    fn from(value: &VpnCustomErrorBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnCustomErrorBox> for ::windows::core::IInspectable {
-    fn from(value: VpnCustomErrorBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomErrorBox> for ::windows::core::IInspectable {
-    fn from(value: &VpnCustomErrorBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomErrorBox> for &::windows::core::IInspectable {
-    fn from(value: &VpnCustomErrorBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnCustomErrorBox, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnCustomErrorBox> for IVpnCustomPrompt {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnCustomErrorBox) -> ::windows::core::Result<Self> {
@@ -3632,36 +3023,7 @@ unsafe impl ::windows::core::Interface for VpnCustomPromptBooleanInput {
 impl ::windows::core::RuntimeName for VpnCustomPromptBooleanInput {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnCustomPromptBooleanInput";
 }
-impl ::core::convert::From<VpnCustomPromptBooleanInput> for ::windows::core::IUnknown {
-    fn from(value: VpnCustomPromptBooleanInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptBooleanInput> for ::windows::core::IUnknown {
-    fn from(value: &VpnCustomPromptBooleanInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptBooleanInput> for &::windows::core::IUnknown {
-    fn from(value: &VpnCustomPromptBooleanInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnCustomPromptBooleanInput> for ::windows::core::IInspectable {
-    fn from(value: VpnCustomPromptBooleanInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptBooleanInput> for ::windows::core::IInspectable {
-    fn from(value: &VpnCustomPromptBooleanInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptBooleanInput> for &::windows::core::IInspectable {
-    fn from(value: &VpnCustomPromptBooleanInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnCustomPromptBooleanInput, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnCustomPromptBooleanInput> for IVpnCustomPromptElement {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnCustomPromptBooleanInput) -> ::windows::core::Result<Self> {
@@ -3776,36 +3138,7 @@ unsafe impl ::windows::core::Interface for VpnCustomPromptOptionSelector {
 impl ::windows::core::RuntimeName for VpnCustomPromptOptionSelector {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnCustomPromptOptionSelector";
 }
-impl ::core::convert::From<VpnCustomPromptOptionSelector> for ::windows::core::IUnknown {
-    fn from(value: VpnCustomPromptOptionSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptOptionSelector> for ::windows::core::IUnknown {
-    fn from(value: &VpnCustomPromptOptionSelector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptOptionSelector> for &::windows::core::IUnknown {
-    fn from(value: &VpnCustomPromptOptionSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnCustomPromptOptionSelector> for ::windows::core::IInspectable {
-    fn from(value: VpnCustomPromptOptionSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptOptionSelector> for ::windows::core::IInspectable {
-    fn from(value: &VpnCustomPromptOptionSelector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptOptionSelector> for &::windows::core::IInspectable {
-    fn from(value: &VpnCustomPromptOptionSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnCustomPromptOptionSelector, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnCustomPromptOptionSelector> for IVpnCustomPromptElement {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnCustomPromptOptionSelector) -> ::windows::core::Result<Self> {
@@ -3915,36 +3248,7 @@ unsafe impl ::windows::core::Interface for VpnCustomPromptText {
 impl ::windows::core::RuntimeName for VpnCustomPromptText {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnCustomPromptText";
 }
-impl ::core::convert::From<VpnCustomPromptText> for ::windows::core::IUnknown {
-    fn from(value: VpnCustomPromptText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptText> for ::windows::core::IUnknown {
-    fn from(value: &VpnCustomPromptText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptText> for &::windows::core::IUnknown {
-    fn from(value: &VpnCustomPromptText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnCustomPromptText> for ::windows::core::IInspectable {
-    fn from(value: VpnCustomPromptText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptText> for ::windows::core::IInspectable {
-    fn from(value: &VpnCustomPromptText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptText> for &::windows::core::IInspectable {
-    fn from(value: &VpnCustomPromptText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnCustomPromptText, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnCustomPromptText> for IVpnCustomPromptElement {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnCustomPromptText) -> ::windows::core::Result<Self> {
@@ -4072,36 +3376,7 @@ unsafe impl ::windows::core::Interface for VpnCustomPromptTextInput {
 impl ::windows::core::RuntimeName for VpnCustomPromptTextInput {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnCustomPromptTextInput";
 }
-impl ::core::convert::From<VpnCustomPromptTextInput> for ::windows::core::IUnknown {
-    fn from(value: VpnCustomPromptTextInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptTextInput> for ::windows::core::IUnknown {
-    fn from(value: &VpnCustomPromptTextInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptTextInput> for &::windows::core::IUnknown {
-    fn from(value: &VpnCustomPromptTextInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnCustomPromptTextInput> for ::windows::core::IInspectable {
-    fn from(value: VpnCustomPromptTextInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptTextInput> for ::windows::core::IInspectable {
-    fn from(value: &VpnCustomPromptTextInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomPromptTextInput> for &::windows::core::IInspectable {
-    fn from(value: &VpnCustomPromptTextInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnCustomPromptTextInput, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnCustomPromptTextInput> for IVpnCustomPromptElement {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnCustomPromptTextInput) -> ::windows::core::Result<Self> {
@@ -4211,36 +3486,7 @@ unsafe impl ::windows::core::Interface for VpnCustomTextBox {
 impl ::windows::core::RuntimeName for VpnCustomTextBox {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnCustomTextBox";
 }
-impl ::core::convert::From<VpnCustomTextBox> for ::windows::core::IUnknown {
-    fn from(value: VpnCustomTextBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomTextBox> for ::windows::core::IUnknown {
-    fn from(value: &VpnCustomTextBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomTextBox> for &::windows::core::IUnknown {
-    fn from(value: &VpnCustomTextBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnCustomTextBox> for ::windows::core::IInspectable {
-    fn from(value: VpnCustomTextBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnCustomTextBox> for ::windows::core::IInspectable {
-    fn from(value: &VpnCustomTextBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnCustomTextBox> for &::windows::core::IInspectable {
-    fn from(value: &VpnCustomTextBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnCustomTextBox, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnCustomTextBox> for IVpnCustomPrompt {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnCustomTextBox) -> ::windows::core::Result<Self> {
@@ -4330,36 +3576,7 @@ unsafe impl ::windows::core::Interface for VpnDomainNameAssignment {
 impl ::windows::core::RuntimeName for VpnDomainNameAssignment {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnDomainNameAssignment";
 }
-impl ::core::convert::From<VpnDomainNameAssignment> for ::windows::core::IUnknown {
-    fn from(value: VpnDomainNameAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnDomainNameAssignment> for ::windows::core::IUnknown {
-    fn from(value: &VpnDomainNameAssignment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnDomainNameAssignment> for &::windows::core::IUnknown {
-    fn from(value: &VpnDomainNameAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnDomainNameAssignment> for ::windows::core::IInspectable {
-    fn from(value: VpnDomainNameAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnDomainNameAssignment> for ::windows::core::IInspectable {
-    fn from(value: &VpnDomainNameAssignment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnDomainNameAssignment> for &::windows::core::IInspectable {
-    fn from(value: &VpnDomainNameAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnDomainNameAssignment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnDomainNameAssignment {}
 unsafe impl ::core::marker::Sync for VpnDomainNameAssignment {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -4467,36 +3684,7 @@ unsafe impl ::windows::core::Interface for VpnDomainNameInfo {
 impl ::windows::core::RuntimeName for VpnDomainNameInfo {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnDomainNameInfo";
 }
-impl ::core::convert::From<VpnDomainNameInfo> for ::windows::core::IUnknown {
-    fn from(value: VpnDomainNameInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnDomainNameInfo> for ::windows::core::IUnknown {
-    fn from(value: &VpnDomainNameInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnDomainNameInfo> for &::windows::core::IUnknown {
-    fn from(value: &VpnDomainNameInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnDomainNameInfo> for ::windows::core::IInspectable {
-    fn from(value: VpnDomainNameInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnDomainNameInfo> for ::windows::core::IInspectable {
-    fn from(value: &VpnDomainNameInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnDomainNameInfo> for &::windows::core::IInspectable {
-    fn from(value: &VpnDomainNameInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnDomainNameInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnDomainNameInfo {}
 unsafe impl ::core::marker::Sync for VpnDomainNameInfo {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -4595,36 +3783,7 @@ unsafe impl ::windows::core::Interface for VpnForegroundActivatedEventArgs {
 impl ::windows::core::RuntimeName for VpnForegroundActivatedEventArgs {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnForegroundActivatedEventArgs";
 }
-impl ::core::convert::From<VpnForegroundActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: VpnForegroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnForegroundActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &VpnForegroundActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnForegroundActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &VpnForegroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnForegroundActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: VpnForegroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnForegroundActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &VpnForegroundActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnForegroundActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &VpnForegroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnForegroundActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<VpnForegroundActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -4714,36 +3873,7 @@ unsafe impl ::windows::core::Interface for VpnForegroundActivationOperation {
 impl ::windows::core::RuntimeName for VpnForegroundActivationOperation {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnForegroundActivationOperation";
 }
-impl ::core::convert::From<VpnForegroundActivationOperation> for ::windows::core::IUnknown {
-    fn from(value: VpnForegroundActivationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnForegroundActivationOperation> for ::windows::core::IUnknown {
-    fn from(value: &VpnForegroundActivationOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnForegroundActivationOperation> for &::windows::core::IUnknown {
-    fn from(value: &VpnForegroundActivationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnForegroundActivationOperation> for ::windows::core::IInspectable {
-    fn from(value: VpnForegroundActivationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnForegroundActivationOperation> for ::windows::core::IInspectable {
-    fn from(value: &VpnForegroundActivationOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnForegroundActivationOperation> for &::windows::core::IInspectable {
-    fn from(value: &VpnForegroundActivationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnForegroundActivationOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnForegroundActivationOperation {}
 unsafe impl ::core::marker::Sync for VpnForegroundActivationOperation {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -4798,36 +3928,7 @@ unsafe impl ::windows::core::Interface for VpnInterfaceId {
 impl ::windows::core::RuntimeName for VpnInterfaceId {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnInterfaceId";
 }
-impl ::core::convert::From<VpnInterfaceId> for ::windows::core::IUnknown {
-    fn from(value: VpnInterfaceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnInterfaceId> for ::windows::core::IUnknown {
-    fn from(value: &VpnInterfaceId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnInterfaceId> for &::windows::core::IUnknown {
-    fn from(value: &VpnInterfaceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnInterfaceId> for ::windows::core::IInspectable {
-    fn from(value: VpnInterfaceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnInterfaceId> for ::windows::core::IInspectable {
-    fn from(value: &VpnInterfaceId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnInterfaceId> for &::windows::core::IInspectable {
-    fn from(value: &VpnInterfaceId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnInterfaceId, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnInterfaceId {}
 unsafe impl ::core::marker::Sync for VpnInterfaceId {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -4979,36 +4080,7 @@ unsafe impl ::windows::core::Interface for VpnManagementAgent {
 impl ::windows::core::RuntimeName for VpnManagementAgent {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnManagementAgent";
 }
-impl ::core::convert::From<VpnManagementAgent> for ::windows::core::IUnknown {
-    fn from(value: VpnManagementAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnManagementAgent> for ::windows::core::IUnknown {
-    fn from(value: &VpnManagementAgent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnManagementAgent> for &::windows::core::IUnknown {
-    fn from(value: &VpnManagementAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnManagementAgent> for ::windows::core::IInspectable {
-    fn from(value: VpnManagementAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnManagementAgent> for ::windows::core::IInspectable {
-    fn from(value: &VpnManagementAgent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnManagementAgent> for &::windows::core::IInspectable {
-    fn from(value: &VpnManagementAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnManagementAgent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnManagementAgent {}
 unsafe impl ::core::marker::Sync for VpnManagementAgent {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -5089,36 +4161,7 @@ unsafe impl ::windows::core::Interface for VpnNamespaceAssignment {
 impl ::windows::core::RuntimeName for VpnNamespaceAssignment {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnNamespaceAssignment";
 }
-impl ::core::convert::From<VpnNamespaceAssignment> for ::windows::core::IUnknown {
-    fn from(value: VpnNamespaceAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnNamespaceAssignment> for ::windows::core::IUnknown {
-    fn from(value: &VpnNamespaceAssignment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnNamespaceAssignment> for &::windows::core::IUnknown {
-    fn from(value: &VpnNamespaceAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnNamespaceAssignment> for ::windows::core::IInspectable {
-    fn from(value: VpnNamespaceAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnNamespaceAssignment> for ::windows::core::IInspectable {
-    fn from(value: &VpnNamespaceAssignment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnNamespaceAssignment> for &::windows::core::IInspectable {
-    fn from(value: &VpnNamespaceAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnNamespaceAssignment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnNamespaceAssignment {}
 unsafe impl ::core::marker::Sync for VpnNamespaceAssignment {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -5226,36 +4269,7 @@ unsafe impl ::windows::core::Interface for VpnNamespaceInfo {
 impl ::windows::core::RuntimeName for VpnNamespaceInfo {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnNamespaceInfo";
 }
-impl ::core::convert::From<VpnNamespaceInfo> for ::windows::core::IUnknown {
-    fn from(value: VpnNamespaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnNamespaceInfo> for ::windows::core::IUnknown {
-    fn from(value: &VpnNamespaceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnNamespaceInfo> for &::windows::core::IUnknown {
-    fn from(value: &VpnNamespaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnNamespaceInfo> for ::windows::core::IInspectable {
-    fn from(value: VpnNamespaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnNamespaceInfo> for ::windows::core::IInspectable {
-    fn from(value: &VpnNamespaceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnNamespaceInfo> for &::windows::core::IInspectable {
-    fn from(value: &VpnNamespaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnNamespaceInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnNamespaceInfo {}
 unsafe impl ::core::marker::Sync for VpnNamespaceInfo {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -5453,36 +4467,7 @@ unsafe impl ::windows::core::Interface for VpnNativeProfile {
 impl ::windows::core::RuntimeName for VpnNativeProfile {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnNativeProfile";
 }
-impl ::core::convert::From<VpnNativeProfile> for ::windows::core::IUnknown {
-    fn from(value: VpnNativeProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnNativeProfile> for ::windows::core::IUnknown {
-    fn from(value: &VpnNativeProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnNativeProfile> for &::windows::core::IUnknown {
-    fn from(value: &VpnNativeProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnNativeProfile> for ::windows::core::IInspectable {
-    fn from(value: VpnNativeProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnNativeProfile> for ::windows::core::IInspectable {
-    fn from(value: &VpnNativeProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnNativeProfile> for &::windows::core::IInspectable {
-    fn from(value: &VpnNativeProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnNativeProfile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnNativeProfile> for IVpnProfile {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnNativeProfile) -> ::windows::core::Result<Self> {
@@ -5604,36 +4589,7 @@ unsafe impl ::windows::core::Interface for VpnPacketBuffer {
 impl ::windows::core::RuntimeName for VpnPacketBuffer {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnPacketBuffer";
 }
-impl ::core::convert::From<VpnPacketBuffer> for ::windows::core::IUnknown {
-    fn from(value: VpnPacketBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnPacketBuffer> for ::windows::core::IUnknown {
-    fn from(value: &VpnPacketBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnPacketBuffer> for &::windows::core::IUnknown {
-    fn from(value: &VpnPacketBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnPacketBuffer> for ::windows::core::IInspectable {
-    fn from(value: VpnPacketBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnPacketBuffer> for ::windows::core::IInspectable {
-    fn from(value: &VpnPacketBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnPacketBuffer> for &::windows::core::IInspectable {
-    fn from(value: &VpnPacketBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnPacketBuffer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnPacketBuffer {}
 unsafe impl ::core::marker::Sync for VpnPacketBuffer {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -5742,36 +4698,7 @@ impl ::core::iter::IntoIterator for &VpnPacketBufferList {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<VpnPacketBufferList> for ::windows::core::IUnknown {
-    fn from(value: VpnPacketBufferList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnPacketBufferList> for ::windows::core::IUnknown {
-    fn from(value: &VpnPacketBufferList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnPacketBufferList> for &::windows::core::IUnknown {
-    fn from(value: &VpnPacketBufferList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnPacketBufferList> for ::windows::core::IInspectable {
-    fn from(value: VpnPacketBufferList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnPacketBufferList> for ::windows::core::IInspectable {
-    fn from(value: &VpnPacketBufferList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnPacketBufferList> for &::windows::core::IInspectable {
-    fn from(value: &VpnPacketBufferList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnPacketBufferList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<VpnPacketBufferList> for super::super::Foundation::Collections::IIterable<VpnPacketBuffer> {
     type Error = ::windows::core::Error;
@@ -5858,36 +4785,7 @@ unsafe impl ::windows::core::Interface for VpnPickedCredential {
 impl ::windows::core::RuntimeName for VpnPickedCredential {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnPickedCredential";
 }
-impl ::core::convert::From<VpnPickedCredential> for ::windows::core::IUnknown {
-    fn from(value: VpnPickedCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnPickedCredential> for ::windows::core::IUnknown {
-    fn from(value: &VpnPickedCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnPickedCredential> for &::windows::core::IUnknown {
-    fn from(value: &VpnPickedCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnPickedCredential> for ::windows::core::IInspectable {
-    fn from(value: VpnPickedCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnPickedCredential> for ::windows::core::IInspectable {
-    fn from(value: &VpnPickedCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnPickedCredential> for &::windows::core::IInspectable {
-    fn from(value: &VpnPickedCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnPickedCredential, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnPickedCredential {}
 unsafe impl ::core::marker::Sync for VpnPickedCredential {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -6052,36 +4950,7 @@ unsafe impl ::windows::core::Interface for VpnPlugInProfile {
 impl ::windows::core::RuntimeName for VpnPlugInProfile {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnPlugInProfile";
 }
-impl ::core::convert::From<VpnPlugInProfile> for ::windows::core::IUnknown {
-    fn from(value: VpnPlugInProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnPlugInProfile> for ::windows::core::IUnknown {
-    fn from(value: &VpnPlugInProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnPlugInProfile> for &::windows::core::IUnknown {
-    fn from(value: &VpnPlugInProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnPlugInProfile> for ::windows::core::IInspectable {
-    fn from(value: VpnPlugInProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnPlugInProfile> for ::windows::core::IInspectable {
-    fn from(value: &VpnPlugInProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnPlugInProfile> for &::windows::core::IInspectable {
-    fn from(value: &VpnPlugInProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnPlugInProfile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VpnPlugInProfile> for IVpnProfile {
     type Error = ::windows::core::Error;
     fn try_from(value: VpnPlugInProfile) -> ::windows::core::Result<Self> {
@@ -6173,36 +5042,7 @@ unsafe impl ::windows::core::Interface for VpnRoute {
 impl ::windows::core::RuntimeName for VpnRoute {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnRoute";
 }
-impl ::core::convert::From<VpnRoute> for ::windows::core::IUnknown {
-    fn from(value: VpnRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnRoute> for ::windows::core::IUnknown {
-    fn from(value: &VpnRoute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnRoute> for &::windows::core::IUnknown {
-    fn from(value: &VpnRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnRoute> for ::windows::core::IInspectable {
-    fn from(value: VpnRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnRoute> for ::windows::core::IInspectable {
-    fn from(value: &VpnRoute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnRoute> for &::windows::core::IInspectable {
-    fn from(value: &VpnRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnRoute, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnRoute {}
 unsafe impl ::core::marker::Sync for VpnRoute {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -6336,36 +5176,7 @@ unsafe impl ::windows::core::Interface for VpnRouteAssignment {
 impl ::windows::core::RuntimeName for VpnRouteAssignment {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnRouteAssignment";
 }
-impl ::core::convert::From<VpnRouteAssignment> for ::windows::core::IUnknown {
-    fn from(value: VpnRouteAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnRouteAssignment> for ::windows::core::IUnknown {
-    fn from(value: &VpnRouteAssignment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnRouteAssignment> for &::windows::core::IUnknown {
-    fn from(value: &VpnRouteAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnRouteAssignment> for ::windows::core::IInspectable {
-    fn from(value: VpnRouteAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnRouteAssignment> for ::windows::core::IInspectable {
-    fn from(value: &VpnRouteAssignment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnRouteAssignment> for &::windows::core::IInspectable {
-    fn from(value: &VpnRouteAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnRouteAssignment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnRouteAssignment {}
 unsafe impl ::core::marker::Sync for VpnRouteAssignment {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -6414,36 +5225,7 @@ unsafe impl ::windows::core::Interface for VpnSystemHealth {
 impl ::windows::core::RuntimeName for VpnSystemHealth {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnSystemHealth";
 }
-impl ::core::convert::From<VpnSystemHealth> for ::windows::core::IUnknown {
-    fn from(value: VpnSystemHealth) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnSystemHealth> for ::windows::core::IUnknown {
-    fn from(value: &VpnSystemHealth) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnSystemHealth> for &::windows::core::IUnknown {
-    fn from(value: &VpnSystemHealth) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnSystemHealth> for ::windows::core::IInspectable {
-    fn from(value: VpnSystemHealth) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnSystemHealth> for ::windows::core::IInspectable {
-    fn from(value: &VpnSystemHealth) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnSystemHealth> for &::windows::core::IInspectable {
-    fn from(value: &VpnSystemHealth) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnSystemHealth, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnSystemHealth {}
 unsafe impl ::core::marker::Sync for VpnSystemHealth {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -6572,36 +5354,7 @@ unsafe impl ::windows::core::Interface for VpnTrafficFilter {
 impl ::windows::core::RuntimeName for VpnTrafficFilter {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnTrafficFilter";
 }
-impl ::core::convert::From<VpnTrafficFilter> for ::windows::core::IUnknown {
-    fn from(value: VpnTrafficFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnTrafficFilter> for ::windows::core::IUnknown {
-    fn from(value: &VpnTrafficFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnTrafficFilter> for &::windows::core::IUnknown {
-    fn from(value: &VpnTrafficFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnTrafficFilter> for ::windows::core::IInspectable {
-    fn from(value: VpnTrafficFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnTrafficFilter> for ::windows::core::IInspectable {
-    fn from(value: &VpnTrafficFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnTrafficFilter> for &::windows::core::IInspectable {
-    fn from(value: &VpnTrafficFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnTrafficFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnTrafficFilter {}
 unsafe impl ::core::marker::Sync for VpnTrafficFilter {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]
@@ -6679,36 +5432,7 @@ unsafe impl ::windows::core::Interface for VpnTrafficFilterAssignment {
 impl ::windows::core::RuntimeName for VpnTrafficFilterAssignment {
     const NAME: &'static str = "Windows.Networking.Vpn.VpnTrafficFilterAssignment";
 }
-impl ::core::convert::From<VpnTrafficFilterAssignment> for ::windows::core::IUnknown {
-    fn from(value: VpnTrafficFilterAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnTrafficFilterAssignment> for ::windows::core::IUnknown {
-    fn from(value: &VpnTrafficFilterAssignment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnTrafficFilterAssignment> for &::windows::core::IUnknown {
-    fn from(value: &VpnTrafficFilterAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VpnTrafficFilterAssignment> for ::windows::core::IInspectable {
-    fn from(value: VpnTrafficFilterAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VpnTrafficFilterAssignment> for ::windows::core::IInspectable {
-    fn from(value: &VpnTrafficFilterAssignment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VpnTrafficFilterAssignment> for &::windows::core::IInspectable {
-    fn from(value: &VpnTrafficFilterAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VpnTrafficFilterAssignment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VpnTrafficFilterAssignment {}
 unsafe impl ::core::marker::Sync for VpnTrafficFilterAssignment {}
 #[doc = "*Required features: `\"Networking_Vpn\"`*"]

--- a/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
@@ -480,36 +480,7 @@ unsafe impl ::windows::core::Interface for XboxLiveDeviceAddress {
 impl ::windows::core::RuntimeName for XboxLiveDeviceAddress {
     const NAME: &'static str = "Windows.Networking.XboxLive.XboxLiveDeviceAddress";
 }
-impl ::core::convert::From<XboxLiveDeviceAddress> for ::windows::core::IUnknown {
-    fn from(value: XboxLiveDeviceAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveDeviceAddress> for ::windows::core::IUnknown {
-    fn from(value: &XboxLiveDeviceAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveDeviceAddress> for &::windows::core::IUnknown {
-    fn from(value: &XboxLiveDeviceAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XboxLiveDeviceAddress> for ::windows::core::IInspectable {
-    fn from(value: XboxLiveDeviceAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveDeviceAddress> for ::windows::core::IInspectable {
-    fn from(value: &XboxLiveDeviceAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveDeviceAddress> for &::windows::core::IInspectable {
-    fn from(value: &XboxLiveDeviceAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XboxLiveDeviceAddress, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XboxLiveDeviceAddress {}
 unsafe impl ::core::marker::Sync for XboxLiveDeviceAddress {}
 #[doc = "*Required features: `\"Networking_XboxLive\"`*"]
@@ -647,36 +618,7 @@ unsafe impl ::windows::core::Interface for XboxLiveEndpointPair {
 impl ::windows::core::RuntimeName for XboxLiveEndpointPair {
     const NAME: &'static str = "Windows.Networking.XboxLive.XboxLiveEndpointPair";
 }
-impl ::core::convert::From<XboxLiveEndpointPair> for ::windows::core::IUnknown {
-    fn from(value: XboxLiveEndpointPair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPair> for ::windows::core::IUnknown {
-    fn from(value: &XboxLiveEndpointPair) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPair> for &::windows::core::IUnknown {
-    fn from(value: &XboxLiveEndpointPair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XboxLiveEndpointPair> for ::windows::core::IInspectable {
-    fn from(value: XboxLiveEndpointPair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPair> for ::windows::core::IInspectable {
-    fn from(value: &XboxLiveEndpointPair) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPair> for &::windows::core::IInspectable {
-    fn from(value: &XboxLiveEndpointPair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XboxLiveEndpointPair, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XboxLiveEndpointPair {}
 unsafe impl ::core::marker::Sync for XboxLiveEndpointPair {}
 #[doc = "*Required features: `\"Networking_XboxLive\"`*"]
@@ -744,36 +686,7 @@ unsafe impl ::windows::core::Interface for XboxLiveEndpointPairCreationResult {
 impl ::windows::core::RuntimeName for XboxLiveEndpointPairCreationResult {
     const NAME: &'static str = "Windows.Networking.XboxLive.XboxLiveEndpointPairCreationResult";
 }
-impl ::core::convert::From<XboxLiveEndpointPairCreationResult> for ::windows::core::IUnknown {
-    fn from(value: XboxLiveEndpointPairCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairCreationResult> for ::windows::core::IUnknown {
-    fn from(value: &XboxLiveEndpointPairCreationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairCreationResult> for &::windows::core::IUnknown {
-    fn from(value: &XboxLiveEndpointPairCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XboxLiveEndpointPairCreationResult> for ::windows::core::IInspectable {
-    fn from(value: XboxLiveEndpointPairCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairCreationResult> for ::windows::core::IInspectable {
-    fn from(value: &XboxLiveEndpointPairCreationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairCreationResult> for &::windows::core::IInspectable {
-    fn from(value: &XboxLiveEndpointPairCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XboxLiveEndpointPairCreationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XboxLiveEndpointPairCreationResult {}
 unsafe impl ::core::marker::Sync for XboxLiveEndpointPairCreationResult {}
 #[doc = "*Required features: `\"Networking_XboxLive\"`*"]
@@ -827,36 +740,7 @@ unsafe impl ::windows::core::Interface for XboxLiveEndpointPairStateChangedEvent
 impl ::windows::core::RuntimeName for XboxLiveEndpointPairStateChangedEventArgs {
     const NAME: &'static str = "Windows.Networking.XboxLive.XboxLiveEndpointPairStateChangedEventArgs";
 }
-impl ::core::convert::From<XboxLiveEndpointPairStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: XboxLiveEndpointPairStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &XboxLiveEndpointPairStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &XboxLiveEndpointPairStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XboxLiveEndpointPairStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: XboxLiveEndpointPairStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &XboxLiveEndpointPairStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &XboxLiveEndpointPairStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XboxLiveEndpointPairStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XboxLiveEndpointPairStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for XboxLiveEndpointPairStateChangedEventArgs {}
 #[doc = "*Required features: `\"Networking_XboxLive\"`*"]
@@ -1017,36 +901,7 @@ unsafe impl ::windows::core::Interface for XboxLiveEndpointPairTemplate {
 impl ::windows::core::RuntimeName for XboxLiveEndpointPairTemplate {
     const NAME: &'static str = "Windows.Networking.XboxLive.XboxLiveEndpointPairTemplate";
 }
-impl ::core::convert::From<XboxLiveEndpointPairTemplate> for ::windows::core::IUnknown {
-    fn from(value: XboxLiveEndpointPairTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairTemplate> for ::windows::core::IUnknown {
-    fn from(value: &XboxLiveEndpointPairTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairTemplate> for &::windows::core::IUnknown {
-    fn from(value: &XboxLiveEndpointPairTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XboxLiveEndpointPairTemplate> for ::windows::core::IInspectable {
-    fn from(value: XboxLiveEndpointPairTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairTemplate> for ::windows::core::IInspectable {
-    fn from(value: &XboxLiveEndpointPairTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveEndpointPairTemplate> for &::windows::core::IInspectable {
-    fn from(value: &XboxLiveEndpointPairTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XboxLiveEndpointPairTemplate, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XboxLiveEndpointPairTemplate {}
 unsafe impl ::core::marker::Sync for XboxLiveEndpointPairTemplate {}
 #[doc = "*Required features: `\"Networking_XboxLive\"`*"]
@@ -1093,36 +948,7 @@ unsafe impl ::windows::core::Interface for XboxLiveInboundEndpointPairCreatedEve
 impl ::windows::core::RuntimeName for XboxLiveInboundEndpointPairCreatedEventArgs {
     const NAME: &'static str = "Windows.Networking.XboxLive.XboxLiveInboundEndpointPairCreatedEventArgs";
 }
-impl ::core::convert::From<XboxLiveInboundEndpointPairCreatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: XboxLiveInboundEndpointPairCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveInboundEndpointPairCreatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &XboxLiveInboundEndpointPairCreatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveInboundEndpointPairCreatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &XboxLiveInboundEndpointPairCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XboxLiveInboundEndpointPairCreatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: XboxLiveInboundEndpointPairCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveInboundEndpointPairCreatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &XboxLiveInboundEndpointPairCreatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveInboundEndpointPairCreatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &XboxLiveInboundEndpointPairCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XboxLiveInboundEndpointPairCreatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XboxLiveInboundEndpointPairCreatedEventArgs {}
 unsafe impl ::core::marker::Sync for XboxLiveInboundEndpointPairCreatedEventArgs {}
 #[doc = "*Required features: `\"Networking_XboxLive\"`*"]
@@ -1347,36 +1173,7 @@ unsafe impl ::windows::core::Interface for XboxLiveQualityOfServiceMeasurement {
 impl ::windows::core::RuntimeName for XboxLiveQualityOfServiceMeasurement {
     const NAME: &'static str = "Windows.Networking.XboxLive.XboxLiveQualityOfServiceMeasurement";
 }
-impl ::core::convert::From<XboxLiveQualityOfServiceMeasurement> for ::windows::core::IUnknown {
-    fn from(value: XboxLiveQualityOfServiceMeasurement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServiceMeasurement> for ::windows::core::IUnknown {
-    fn from(value: &XboxLiveQualityOfServiceMeasurement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServiceMeasurement> for &::windows::core::IUnknown {
-    fn from(value: &XboxLiveQualityOfServiceMeasurement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XboxLiveQualityOfServiceMeasurement> for ::windows::core::IInspectable {
-    fn from(value: XboxLiveQualityOfServiceMeasurement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServiceMeasurement> for ::windows::core::IInspectable {
-    fn from(value: &XboxLiveQualityOfServiceMeasurement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServiceMeasurement> for &::windows::core::IInspectable {
-    fn from(value: &XboxLiveQualityOfServiceMeasurement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XboxLiveQualityOfServiceMeasurement, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XboxLiveQualityOfServiceMeasurement {}
 unsafe impl ::core::marker::Sync for XboxLiveQualityOfServiceMeasurement {}
 #[doc = "*Required features: `\"Networking_XboxLive\"`*"]
@@ -1444,36 +1241,7 @@ unsafe impl ::windows::core::Interface for XboxLiveQualityOfServiceMetricResult 
 impl ::windows::core::RuntimeName for XboxLiveQualityOfServiceMetricResult {
     const NAME: &'static str = "Windows.Networking.XboxLive.XboxLiveQualityOfServiceMetricResult";
 }
-impl ::core::convert::From<XboxLiveQualityOfServiceMetricResult> for ::windows::core::IUnknown {
-    fn from(value: XboxLiveQualityOfServiceMetricResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServiceMetricResult> for ::windows::core::IUnknown {
-    fn from(value: &XboxLiveQualityOfServiceMetricResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServiceMetricResult> for &::windows::core::IUnknown {
-    fn from(value: &XboxLiveQualityOfServiceMetricResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XboxLiveQualityOfServiceMetricResult> for ::windows::core::IInspectable {
-    fn from(value: XboxLiveQualityOfServiceMetricResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServiceMetricResult> for ::windows::core::IInspectable {
-    fn from(value: &XboxLiveQualityOfServiceMetricResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServiceMetricResult> for &::windows::core::IInspectable {
-    fn from(value: &XboxLiveQualityOfServiceMetricResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XboxLiveQualityOfServiceMetricResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XboxLiveQualityOfServiceMetricResult {}
 unsafe impl ::core::marker::Sync for XboxLiveQualityOfServiceMetricResult {}
 #[doc = "*Required features: `\"Networking_XboxLive\"`*"]
@@ -1536,36 +1304,7 @@ unsafe impl ::windows::core::Interface for XboxLiveQualityOfServicePrivatePayloa
 impl ::windows::core::RuntimeName for XboxLiveQualityOfServicePrivatePayloadResult {
     const NAME: &'static str = "Windows.Networking.XboxLive.XboxLiveQualityOfServicePrivatePayloadResult";
 }
-impl ::core::convert::From<XboxLiveQualityOfServicePrivatePayloadResult> for ::windows::core::IUnknown {
-    fn from(value: XboxLiveQualityOfServicePrivatePayloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServicePrivatePayloadResult> for ::windows::core::IUnknown {
-    fn from(value: &XboxLiveQualityOfServicePrivatePayloadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServicePrivatePayloadResult> for &::windows::core::IUnknown {
-    fn from(value: &XboxLiveQualityOfServicePrivatePayloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<XboxLiveQualityOfServicePrivatePayloadResult> for ::windows::core::IInspectable {
-    fn from(value: XboxLiveQualityOfServicePrivatePayloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServicePrivatePayloadResult> for ::windows::core::IInspectable {
-    fn from(value: &XboxLiveQualityOfServicePrivatePayloadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&XboxLiveQualityOfServicePrivatePayloadResult> for &::windows::core::IInspectable {
-    fn from(value: &XboxLiveQualityOfServicePrivatePayloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(XboxLiveQualityOfServicePrivatePayloadResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for XboxLiveQualityOfServicePrivatePayloadResult {}
 unsafe impl ::core::marker::Sync for XboxLiveQualityOfServicePrivatePayloadResult {}
 #[doc = "*Required features: `\"Networking_XboxLive\"`*"]

--- a/crates/libs/windows/src/Windows/Networking/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/mod.rs
@@ -198,36 +198,7 @@ unsafe impl ::windows::core::Interface for EndpointPair {
 impl ::windows::core::RuntimeName for EndpointPair {
     const NAME: &'static str = "Windows.Networking.EndpointPair";
 }
-impl ::core::convert::From<EndpointPair> for ::windows::core::IUnknown {
-    fn from(value: EndpointPair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EndpointPair> for ::windows::core::IUnknown {
-    fn from(value: &EndpointPair) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EndpointPair> for &::windows::core::IUnknown {
-    fn from(value: &EndpointPair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EndpointPair> for ::windows::core::IInspectable {
-    fn from(value: EndpointPair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EndpointPair> for ::windows::core::IInspectable {
-    fn from(value: &EndpointPair) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EndpointPair> for &::windows::core::IInspectable {
-    fn from(value: &EndpointPair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EndpointPair, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EndpointPair {}
 unsafe impl ::core::marker::Sync for EndpointPair {}
 #[doc = "*Required features: `\"Networking\"`*"]
@@ -342,36 +313,7 @@ unsafe impl ::windows::core::Interface for HostName {
 impl ::windows::core::RuntimeName for HostName {
     const NAME: &'static str = "Windows.Networking.HostName";
 }
-impl ::core::convert::From<HostName> for ::windows::core::IUnknown {
-    fn from(value: HostName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HostName> for ::windows::core::IUnknown {
-    fn from(value: &HostName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HostName> for &::windows::core::IUnknown {
-    fn from(value: &HostName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HostName> for ::windows::core::IInspectable {
-    fn from(value: HostName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HostName> for ::windows::core::IInspectable {
-    fn from(value: &HostName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HostName> for &::windows::core::IInspectable {
-    fn from(value: &HostName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HostName, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HostName> for super::Foundation::IStringable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Perception/People/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/People/mod.rs
@@ -220,36 +220,7 @@ unsafe impl ::windows::core::Interface for EyesPose {
 impl ::windows::core::RuntimeName for EyesPose {
     const NAME: &'static str = "Windows.Perception.People.EyesPose";
 }
-impl ::core::convert::From<EyesPose> for ::windows::core::IUnknown {
-    fn from(value: EyesPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EyesPose> for ::windows::core::IUnknown {
-    fn from(value: &EyesPose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EyesPose> for &::windows::core::IUnknown {
-    fn from(value: &EyesPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EyesPose> for ::windows::core::IInspectable {
-    fn from(value: EyesPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EyesPose> for ::windows::core::IInspectable {
-    fn from(value: &EyesPose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EyesPose> for &::windows::core::IInspectable {
-    fn from(value: &EyesPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EyesPose, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EyesPose {}
 unsafe impl ::core::marker::Sync for EyesPose {}
 #[doc = "*Required features: `\"Perception_People\"`*"]
@@ -344,36 +315,7 @@ unsafe impl ::windows::core::Interface for HandMeshObserver {
 impl ::windows::core::RuntimeName for HandMeshObserver {
     const NAME: &'static str = "Windows.Perception.People.HandMeshObserver";
 }
-impl ::core::convert::From<HandMeshObserver> for ::windows::core::IUnknown {
-    fn from(value: HandMeshObserver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HandMeshObserver> for ::windows::core::IUnknown {
-    fn from(value: &HandMeshObserver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HandMeshObserver> for &::windows::core::IUnknown {
-    fn from(value: &HandMeshObserver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HandMeshObserver> for ::windows::core::IInspectable {
-    fn from(value: HandMeshObserver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HandMeshObserver> for ::windows::core::IInspectable {
-    fn from(value: &HandMeshObserver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HandMeshObserver> for &::windows::core::IInspectable {
-    fn from(value: &HandMeshObserver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HandMeshObserver, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HandMeshObserver {}
 unsafe impl ::core::marker::Sync for HandMeshObserver {}
 #[doc = "*Required features: `\"Perception_People\"`*"]
@@ -435,36 +377,7 @@ unsafe impl ::windows::core::Interface for HandMeshVertexState {
 impl ::windows::core::RuntimeName for HandMeshVertexState {
     const NAME: &'static str = "Windows.Perception.People.HandMeshVertexState";
 }
-impl ::core::convert::From<HandMeshVertexState> for ::windows::core::IUnknown {
-    fn from(value: HandMeshVertexState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HandMeshVertexState> for ::windows::core::IUnknown {
-    fn from(value: &HandMeshVertexState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HandMeshVertexState> for &::windows::core::IUnknown {
-    fn from(value: &HandMeshVertexState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HandMeshVertexState> for ::windows::core::IInspectable {
-    fn from(value: HandMeshVertexState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HandMeshVertexState> for ::windows::core::IInspectable {
-    fn from(value: &HandMeshVertexState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HandMeshVertexState> for &::windows::core::IInspectable {
-    fn from(value: &HandMeshVertexState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HandMeshVertexState, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HandMeshVertexState {}
 unsafe impl ::core::marker::Sync for HandMeshVertexState {}
 #[doc = "*Required features: `\"Perception_People\"`*"]
@@ -537,36 +450,7 @@ unsafe impl ::windows::core::Interface for HandPose {
 impl ::windows::core::RuntimeName for HandPose {
     const NAME: &'static str = "Windows.Perception.People.HandPose";
 }
-impl ::core::convert::From<HandPose> for ::windows::core::IUnknown {
-    fn from(value: HandPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HandPose> for ::windows::core::IUnknown {
-    fn from(value: &HandPose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HandPose> for &::windows::core::IUnknown {
-    fn from(value: &HandPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HandPose> for ::windows::core::IInspectable {
-    fn from(value: HandPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HandPose> for ::windows::core::IInspectable {
-    fn from(value: &HandPose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HandPose> for &::windows::core::IInspectable {
-    fn from(value: &HandPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HandPose, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HandPose {}
 unsafe impl ::core::marker::Sync for HandPose {}
 #[doc = "*Required features: `\"Perception_People\"`*"]
@@ -633,36 +517,7 @@ unsafe impl ::windows::core::Interface for HeadPose {
 impl ::windows::core::RuntimeName for HeadPose {
     const NAME: &'static str = "Windows.Perception.People.HeadPose";
 }
-impl ::core::convert::From<HeadPose> for ::windows::core::IUnknown {
-    fn from(value: HeadPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HeadPose> for ::windows::core::IUnknown {
-    fn from(value: &HeadPose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HeadPose> for &::windows::core::IUnknown {
-    fn from(value: &HeadPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HeadPose> for ::windows::core::IInspectable {
-    fn from(value: HeadPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HeadPose> for ::windows::core::IInspectable {
-    fn from(value: &HeadPose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HeadPose> for &::windows::core::IInspectable {
-    fn from(value: &HeadPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HeadPose, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HeadPose {}
 unsafe impl ::core::marker::Sync for HeadPose {}
 #[doc = "*Required features: `\"Perception_People\"`*"]

--- a/crates/libs/windows/src/Windows/Perception/Spatial/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Spatial/Preview/mod.rs
@@ -125,36 +125,7 @@ unsafe impl ::windows::core::Interface for SpatialGraphInteropFrameOfReferencePr
 impl ::windows::core::RuntimeName for SpatialGraphInteropFrameOfReferencePreview {
     const NAME: &'static str = "Windows.Perception.Spatial.Preview.SpatialGraphInteropFrameOfReferencePreview";
 }
-impl ::core::convert::From<SpatialGraphInteropFrameOfReferencePreview> for ::windows::core::IUnknown {
-    fn from(value: SpatialGraphInteropFrameOfReferencePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialGraphInteropFrameOfReferencePreview> for ::windows::core::IUnknown {
-    fn from(value: &SpatialGraphInteropFrameOfReferencePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialGraphInteropFrameOfReferencePreview> for &::windows::core::IUnknown {
-    fn from(value: &SpatialGraphInteropFrameOfReferencePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialGraphInteropFrameOfReferencePreview> for ::windows::core::IInspectable {
-    fn from(value: SpatialGraphInteropFrameOfReferencePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialGraphInteropFrameOfReferencePreview> for ::windows::core::IInspectable {
-    fn from(value: &SpatialGraphInteropFrameOfReferencePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialGraphInteropFrameOfReferencePreview> for &::windows::core::IInspectable {
-    fn from(value: &SpatialGraphInteropFrameOfReferencePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialGraphInteropFrameOfReferencePreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialGraphInteropFrameOfReferencePreview {}
 unsafe impl ::core::marker::Sync for SpatialGraphInteropFrameOfReferencePreview {}
 #[doc = "*Required features: `\"Perception_Spatial_Preview\"`*"]

--- a/crates/libs/windows/src/Windows/Perception/Spatial/Surfaces/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Spatial/Surfaces/mod.rs
@@ -286,36 +286,7 @@ unsafe impl ::windows::core::Interface for SpatialSurfaceInfo {
 impl ::windows::core::RuntimeName for SpatialSurfaceInfo {
     const NAME: &'static str = "Windows.Perception.Spatial.Surfaces.SpatialSurfaceInfo";
 }
-impl ::core::convert::From<SpatialSurfaceInfo> for ::windows::core::IUnknown {
-    fn from(value: SpatialSurfaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceInfo> for ::windows::core::IUnknown {
-    fn from(value: &SpatialSurfaceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceInfo> for &::windows::core::IUnknown {
-    fn from(value: &SpatialSurfaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialSurfaceInfo> for ::windows::core::IInspectable {
-    fn from(value: SpatialSurfaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceInfo> for ::windows::core::IInspectable {
-    fn from(value: &SpatialSurfaceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceInfo> for &::windows::core::IInspectable {
-    fn from(value: &SpatialSurfaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialSurfaceInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialSurfaceInfo {}
 unsafe impl ::core::marker::Sync for SpatialSurfaceInfo {}
 #[doc = "*Required features: `\"Perception_Spatial_Surfaces\"`*"]
@@ -399,36 +370,7 @@ unsafe impl ::windows::core::Interface for SpatialSurfaceMesh {
 impl ::windows::core::RuntimeName for SpatialSurfaceMesh {
     const NAME: &'static str = "Windows.Perception.Spatial.Surfaces.SpatialSurfaceMesh";
 }
-impl ::core::convert::From<SpatialSurfaceMesh> for ::windows::core::IUnknown {
-    fn from(value: SpatialSurfaceMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMesh> for ::windows::core::IUnknown {
-    fn from(value: &SpatialSurfaceMesh) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMesh> for &::windows::core::IUnknown {
-    fn from(value: &SpatialSurfaceMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialSurfaceMesh> for ::windows::core::IInspectable {
-    fn from(value: SpatialSurfaceMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMesh> for ::windows::core::IInspectable {
-    fn from(value: &SpatialSurfaceMesh) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMesh> for &::windows::core::IInspectable {
-    fn from(value: &SpatialSurfaceMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialSurfaceMesh, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialSurfaceMesh {}
 unsafe impl ::core::marker::Sync for SpatialSurfaceMesh {}
 #[doc = "*Required features: `\"Perception_Spatial_Surfaces\"`*"]
@@ -500,36 +442,7 @@ unsafe impl ::windows::core::Interface for SpatialSurfaceMeshBuffer {
 impl ::windows::core::RuntimeName for SpatialSurfaceMeshBuffer {
     const NAME: &'static str = "Windows.Perception.Spatial.Surfaces.SpatialSurfaceMeshBuffer";
 }
-impl ::core::convert::From<SpatialSurfaceMeshBuffer> for ::windows::core::IUnknown {
-    fn from(value: SpatialSurfaceMeshBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMeshBuffer> for ::windows::core::IUnknown {
-    fn from(value: &SpatialSurfaceMeshBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMeshBuffer> for &::windows::core::IUnknown {
-    fn from(value: &SpatialSurfaceMeshBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialSurfaceMeshBuffer> for ::windows::core::IInspectable {
-    fn from(value: SpatialSurfaceMeshBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMeshBuffer> for ::windows::core::IInspectable {
-    fn from(value: &SpatialSurfaceMeshBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMeshBuffer> for &::windows::core::IInspectable {
-    fn from(value: &SpatialSurfaceMeshBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialSurfaceMeshBuffer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialSurfaceMeshBuffer {}
 unsafe impl ::core::marker::Sync for SpatialSurfaceMeshBuffer {}
 #[doc = "*Required features: `\"Perception_Spatial_Surfaces\"`*"]
@@ -661,36 +574,7 @@ unsafe impl ::windows::core::Interface for SpatialSurfaceMeshOptions {
 impl ::windows::core::RuntimeName for SpatialSurfaceMeshOptions {
     const NAME: &'static str = "Windows.Perception.Spatial.Surfaces.SpatialSurfaceMeshOptions";
 }
-impl ::core::convert::From<SpatialSurfaceMeshOptions> for ::windows::core::IUnknown {
-    fn from(value: SpatialSurfaceMeshOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMeshOptions> for ::windows::core::IUnknown {
-    fn from(value: &SpatialSurfaceMeshOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMeshOptions> for &::windows::core::IUnknown {
-    fn from(value: &SpatialSurfaceMeshOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialSurfaceMeshOptions> for ::windows::core::IInspectable {
-    fn from(value: SpatialSurfaceMeshOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMeshOptions> for ::windows::core::IInspectable {
-    fn from(value: &SpatialSurfaceMeshOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceMeshOptions> for &::windows::core::IInspectable {
-    fn from(value: &SpatialSurfaceMeshOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialSurfaceMeshOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialSurfaceMeshOptions {}
 unsafe impl ::core::marker::Sync for SpatialSurfaceMeshOptions {}
 #[doc = "*Required features: `\"Perception_Spatial_Surfaces\"`*"]
@@ -799,36 +683,7 @@ unsafe impl ::windows::core::Interface for SpatialSurfaceObserver {
 impl ::windows::core::RuntimeName for SpatialSurfaceObserver {
     const NAME: &'static str = "Windows.Perception.Spatial.Surfaces.SpatialSurfaceObserver";
 }
-impl ::core::convert::From<SpatialSurfaceObserver> for ::windows::core::IUnknown {
-    fn from(value: SpatialSurfaceObserver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceObserver> for ::windows::core::IUnknown {
-    fn from(value: &SpatialSurfaceObserver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceObserver> for &::windows::core::IUnknown {
-    fn from(value: &SpatialSurfaceObserver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialSurfaceObserver> for ::windows::core::IInspectable {
-    fn from(value: SpatialSurfaceObserver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceObserver> for ::windows::core::IInspectable {
-    fn from(value: &SpatialSurfaceObserver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialSurfaceObserver> for &::windows::core::IInspectable {
-    fn from(value: &SpatialSurfaceObserver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialSurfaceObserver, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialSurfaceObserver {}
 unsafe impl ::core::marker::Sync for SpatialSurfaceObserver {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Perception/Spatial/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Spatial/mod.rs
@@ -795,36 +795,7 @@ unsafe impl ::windows::core::Interface for SpatialAnchor {
 impl ::windows::core::RuntimeName for SpatialAnchor {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialAnchor";
 }
-impl ::core::convert::From<SpatialAnchor> for ::windows::core::IUnknown {
-    fn from(value: SpatialAnchor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAnchor> for ::windows::core::IUnknown {
-    fn from(value: &SpatialAnchor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAnchor> for &::windows::core::IUnknown {
-    fn from(value: &SpatialAnchor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialAnchor> for ::windows::core::IInspectable {
-    fn from(value: SpatialAnchor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAnchor> for ::windows::core::IInspectable {
-    fn from(value: &SpatialAnchor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAnchor> for &::windows::core::IInspectable {
-    fn from(value: &SpatialAnchor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialAnchor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialAnchor {}
 unsafe impl ::core::marker::Sync for SpatialAnchor {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -885,36 +856,7 @@ unsafe impl ::windows::core::Interface for SpatialAnchorExportSufficiency {
 impl ::windows::core::RuntimeName for SpatialAnchorExportSufficiency {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialAnchorExportSufficiency";
 }
-impl ::core::convert::From<SpatialAnchorExportSufficiency> for ::windows::core::IUnknown {
-    fn from(value: SpatialAnchorExportSufficiency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAnchorExportSufficiency> for ::windows::core::IUnknown {
-    fn from(value: &SpatialAnchorExportSufficiency) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAnchorExportSufficiency> for &::windows::core::IUnknown {
-    fn from(value: &SpatialAnchorExportSufficiency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialAnchorExportSufficiency> for ::windows::core::IInspectable {
-    fn from(value: SpatialAnchorExportSufficiency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAnchorExportSufficiency> for ::windows::core::IInspectable {
-    fn from(value: &SpatialAnchorExportSufficiency) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAnchorExportSufficiency> for &::windows::core::IInspectable {
-    fn from(value: &SpatialAnchorExportSufficiency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialAnchorExportSufficiency, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialAnchorExportSufficiency {}
 unsafe impl ::core::marker::Sync for SpatialAnchorExportSufficiency {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -995,36 +937,7 @@ unsafe impl ::windows::core::Interface for SpatialAnchorExporter {
 impl ::windows::core::RuntimeName for SpatialAnchorExporter {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialAnchorExporter";
 }
-impl ::core::convert::From<SpatialAnchorExporter> for ::windows::core::IUnknown {
-    fn from(value: SpatialAnchorExporter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAnchorExporter> for ::windows::core::IUnknown {
-    fn from(value: &SpatialAnchorExporter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAnchorExporter> for &::windows::core::IUnknown {
-    fn from(value: &SpatialAnchorExporter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialAnchorExporter> for ::windows::core::IInspectable {
-    fn from(value: SpatialAnchorExporter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAnchorExporter> for ::windows::core::IInspectable {
-    fn from(value: &SpatialAnchorExporter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAnchorExporter> for &::windows::core::IInspectable {
-    fn from(value: &SpatialAnchorExporter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialAnchorExporter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialAnchorExporter {}
 unsafe impl ::core::marker::Sync for SpatialAnchorExporter {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -1093,36 +1006,7 @@ unsafe impl ::windows::core::Interface for SpatialAnchorRawCoordinateSystemAdjus
 impl ::windows::core::RuntimeName for SpatialAnchorRawCoordinateSystemAdjustedEventArgs {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialAnchorRawCoordinateSystemAdjustedEventArgs";
 }
-impl ::core::convert::From<SpatialAnchorRawCoordinateSystemAdjustedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialAnchorRawCoordinateSystemAdjustedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAnchorRawCoordinateSystemAdjustedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialAnchorRawCoordinateSystemAdjustedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAnchorRawCoordinateSystemAdjustedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialAnchorRawCoordinateSystemAdjustedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialAnchorRawCoordinateSystemAdjustedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialAnchorRawCoordinateSystemAdjustedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAnchorRawCoordinateSystemAdjustedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialAnchorRawCoordinateSystemAdjustedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAnchorRawCoordinateSystemAdjustedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialAnchorRawCoordinateSystemAdjustedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialAnchorRawCoordinateSystemAdjustedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialAnchorRawCoordinateSystemAdjustedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialAnchorRawCoordinateSystemAdjustedEventArgs {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -1186,36 +1070,7 @@ unsafe impl ::windows::core::Interface for SpatialAnchorStore {
 impl ::windows::core::RuntimeName for SpatialAnchorStore {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialAnchorStore";
 }
-impl ::core::convert::From<SpatialAnchorStore> for ::windows::core::IUnknown {
-    fn from(value: SpatialAnchorStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAnchorStore> for ::windows::core::IUnknown {
-    fn from(value: &SpatialAnchorStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAnchorStore> for &::windows::core::IUnknown {
-    fn from(value: &SpatialAnchorStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialAnchorStore> for ::windows::core::IInspectable {
-    fn from(value: SpatialAnchorStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialAnchorStore> for ::windows::core::IInspectable {
-    fn from(value: &SpatialAnchorStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialAnchorStore> for &::windows::core::IInspectable {
-    fn from(value: &SpatialAnchorStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialAnchorStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialAnchorStore {}
 unsafe impl ::core::marker::Sync for SpatialAnchorStore {}
 #[doc = "*Required features: `\"Perception_Spatial\"`, `\"deprecated\"`*"]
@@ -1342,36 +1197,7 @@ unsafe impl ::windows::core::Interface for SpatialBoundingVolume {
 impl ::windows::core::RuntimeName for SpatialBoundingVolume {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialBoundingVolume";
 }
-impl ::core::convert::From<SpatialBoundingVolume> for ::windows::core::IUnknown {
-    fn from(value: SpatialBoundingVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialBoundingVolume> for ::windows::core::IUnknown {
-    fn from(value: &SpatialBoundingVolume) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialBoundingVolume> for &::windows::core::IUnknown {
-    fn from(value: &SpatialBoundingVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialBoundingVolume> for ::windows::core::IInspectable {
-    fn from(value: SpatialBoundingVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialBoundingVolume> for ::windows::core::IInspectable {
-    fn from(value: &SpatialBoundingVolume) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialBoundingVolume> for &::windows::core::IInspectable {
-    fn from(value: &SpatialBoundingVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialBoundingVolume, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialBoundingVolume {}
 unsafe impl ::core::marker::Sync for SpatialBoundingVolume {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -1420,36 +1246,7 @@ unsafe impl ::windows::core::Interface for SpatialCoordinateSystem {
 impl ::windows::core::RuntimeName for SpatialCoordinateSystem {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialCoordinateSystem";
 }
-impl ::core::convert::From<SpatialCoordinateSystem> for ::windows::core::IUnknown {
-    fn from(value: SpatialCoordinateSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialCoordinateSystem> for ::windows::core::IUnknown {
-    fn from(value: &SpatialCoordinateSystem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialCoordinateSystem> for &::windows::core::IUnknown {
-    fn from(value: &SpatialCoordinateSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialCoordinateSystem> for ::windows::core::IInspectable {
-    fn from(value: SpatialCoordinateSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialCoordinateSystem> for ::windows::core::IInspectable {
-    fn from(value: &SpatialCoordinateSystem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialCoordinateSystem> for &::windows::core::IInspectable {
-    fn from(value: &SpatialCoordinateSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialCoordinateSystem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialCoordinateSystem {}
 unsafe impl ::core::marker::Sync for SpatialCoordinateSystem {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -1531,36 +1328,7 @@ unsafe impl ::windows::core::Interface for SpatialEntity {
 impl ::windows::core::RuntimeName for SpatialEntity {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialEntity";
 }
-impl ::core::convert::From<SpatialEntity> for ::windows::core::IUnknown {
-    fn from(value: SpatialEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntity> for ::windows::core::IUnknown {
-    fn from(value: &SpatialEntity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntity> for &::windows::core::IUnknown {
-    fn from(value: &SpatialEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialEntity> for ::windows::core::IInspectable {
-    fn from(value: SpatialEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntity> for ::windows::core::IInspectable {
-    fn from(value: &SpatialEntity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntity> for &::windows::core::IInspectable {
-    fn from(value: &SpatialEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialEntity, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialEntity {}
 unsafe impl ::core::marker::Sync for SpatialEntity {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -1607,36 +1375,7 @@ unsafe impl ::windows::core::Interface for SpatialEntityAddedEventArgs {
 impl ::windows::core::RuntimeName for SpatialEntityAddedEventArgs {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialEntityAddedEventArgs";
 }
-impl ::core::convert::From<SpatialEntityAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialEntityAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntityAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialEntityAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntityAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialEntityAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialEntityAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialEntityAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntityAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialEntityAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntityAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialEntityAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialEntityAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialEntityAddedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialEntityAddedEventArgs {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -1683,36 +1422,7 @@ unsafe impl ::windows::core::Interface for SpatialEntityRemovedEventArgs {
 impl ::windows::core::RuntimeName for SpatialEntityRemovedEventArgs {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialEntityRemovedEventArgs";
 }
-impl ::core::convert::From<SpatialEntityRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialEntityRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntityRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialEntityRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntityRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialEntityRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialEntityRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialEntityRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntityRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialEntityRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntityRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialEntityRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialEntityRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialEntityRemovedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialEntityRemovedEventArgs {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -1796,36 +1506,7 @@ unsafe impl ::windows::core::Interface for SpatialEntityStore {
 impl ::windows::core::RuntimeName for SpatialEntityStore {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialEntityStore";
 }
-impl ::core::convert::From<SpatialEntityStore> for ::windows::core::IUnknown {
-    fn from(value: SpatialEntityStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntityStore> for ::windows::core::IUnknown {
-    fn from(value: &SpatialEntityStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntityStore> for &::windows::core::IUnknown {
-    fn from(value: &SpatialEntityStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialEntityStore> for ::windows::core::IInspectable {
-    fn from(value: SpatialEntityStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntityStore> for ::windows::core::IInspectable {
-    fn from(value: &SpatialEntityStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntityStore> for &::windows::core::IInspectable {
-    fn from(value: &SpatialEntityStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialEntityStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialEntityStore {}
 unsafe impl ::core::marker::Sync for SpatialEntityStore {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -1872,36 +1553,7 @@ unsafe impl ::windows::core::Interface for SpatialEntityUpdatedEventArgs {
 impl ::windows::core::RuntimeName for SpatialEntityUpdatedEventArgs {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialEntityUpdatedEventArgs";
 }
-impl ::core::convert::From<SpatialEntityUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialEntityUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntityUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialEntityUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntityUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialEntityUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialEntityUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialEntityUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntityUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialEntityUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntityUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialEntityUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialEntityUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialEntityUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialEntityUpdatedEventArgs {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -2016,36 +1668,7 @@ unsafe impl ::windows::core::Interface for SpatialEntityWatcher {
 impl ::windows::core::RuntimeName for SpatialEntityWatcher {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialEntityWatcher";
 }
-impl ::core::convert::From<SpatialEntityWatcher> for ::windows::core::IUnknown {
-    fn from(value: SpatialEntityWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntityWatcher> for ::windows::core::IUnknown {
-    fn from(value: &SpatialEntityWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntityWatcher> for &::windows::core::IUnknown {
-    fn from(value: &SpatialEntityWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialEntityWatcher> for ::windows::core::IInspectable {
-    fn from(value: SpatialEntityWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialEntityWatcher> for ::windows::core::IInspectable {
-    fn from(value: &SpatialEntityWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialEntityWatcher> for &::windows::core::IInspectable {
-    fn from(value: &SpatialEntityWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialEntityWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialEntityWatcher {}
 unsafe impl ::core::marker::Sync for SpatialEntityWatcher {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -2157,36 +1780,7 @@ unsafe impl ::windows::core::Interface for SpatialLocation {
 impl ::windows::core::RuntimeName for SpatialLocation {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialLocation";
 }
-impl ::core::convert::From<SpatialLocation> for ::windows::core::IUnknown {
-    fn from(value: SpatialLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialLocation> for ::windows::core::IUnknown {
-    fn from(value: &SpatialLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialLocation> for &::windows::core::IUnknown {
-    fn from(value: &SpatialLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialLocation> for ::windows::core::IInspectable {
-    fn from(value: SpatialLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialLocation> for ::windows::core::IInspectable {
-    fn from(value: &SpatialLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialLocation> for &::windows::core::IInspectable {
-    fn from(value: &SpatialLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialLocation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialLocation {}
 unsafe impl ::core::marker::Sync for SpatialLocation {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -2349,36 +1943,7 @@ unsafe impl ::windows::core::Interface for SpatialLocator {
 impl ::windows::core::RuntimeName for SpatialLocator {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialLocator";
 }
-impl ::core::convert::From<SpatialLocator> for ::windows::core::IUnknown {
-    fn from(value: SpatialLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialLocator> for ::windows::core::IUnknown {
-    fn from(value: &SpatialLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialLocator> for &::windows::core::IUnknown {
-    fn from(value: &SpatialLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialLocator> for ::windows::core::IInspectable {
-    fn from(value: SpatialLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialLocator> for ::windows::core::IInspectable {
-    fn from(value: &SpatialLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialLocator> for &::windows::core::IInspectable {
-    fn from(value: &SpatialLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialLocator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialLocator {}
 unsafe impl ::core::marker::Sync for SpatialLocator {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -2468,36 +2033,7 @@ unsafe impl ::windows::core::Interface for SpatialLocatorAttachedFrameOfReferenc
 impl ::windows::core::RuntimeName for SpatialLocatorAttachedFrameOfReference {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialLocatorAttachedFrameOfReference";
 }
-impl ::core::convert::From<SpatialLocatorAttachedFrameOfReference> for ::windows::core::IUnknown {
-    fn from(value: SpatialLocatorAttachedFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialLocatorAttachedFrameOfReference> for ::windows::core::IUnknown {
-    fn from(value: &SpatialLocatorAttachedFrameOfReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialLocatorAttachedFrameOfReference> for &::windows::core::IUnknown {
-    fn from(value: &SpatialLocatorAttachedFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialLocatorAttachedFrameOfReference> for ::windows::core::IInspectable {
-    fn from(value: SpatialLocatorAttachedFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialLocatorAttachedFrameOfReference> for ::windows::core::IInspectable {
-    fn from(value: &SpatialLocatorAttachedFrameOfReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialLocatorAttachedFrameOfReference> for &::windows::core::IInspectable {
-    fn from(value: &SpatialLocatorAttachedFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialLocatorAttachedFrameOfReference, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialLocatorAttachedFrameOfReference {}
 unsafe impl ::core::marker::Sync for SpatialLocatorAttachedFrameOfReference {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -2548,36 +2084,7 @@ unsafe impl ::windows::core::Interface for SpatialLocatorPositionalTrackingDeact
 impl ::windows::core::RuntimeName for SpatialLocatorPositionalTrackingDeactivatingEventArgs {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialLocatorPositionalTrackingDeactivatingEventArgs";
 }
-impl ::core::convert::From<SpatialLocatorPositionalTrackingDeactivatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialLocatorPositionalTrackingDeactivatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialLocatorPositionalTrackingDeactivatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialLocatorPositionalTrackingDeactivatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialLocatorPositionalTrackingDeactivatingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialLocatorPositionalTrackingDeactivatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialLocatorPositionalTrackingDeactivatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialLocatorPositionalTrackingDeactivatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialLocatorPositionalTrackingDeactivatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialLocatorPositionalTrackingDeactivatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialLocatorPositionalTrackingDeactivatingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialLocatorPositionalTrackingDeactivatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialLocatorPositionalTrackingDeactivatingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialLocatorPositionalTrackingDeactivatingEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialLocatorPositionalTrackingDeactivatingEventArgs {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -2686,36 +2193,7 @@ unsafe impl ::windows::core::Interface for SpatialStageFrameOfReference {
 impl ::windows::core::RuntimeName for SpatialStageFrameOfReference {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialStageFrameOfReference";
 }
-impl ::core::convert::From<SpatialStageFrameOfReference> for ::windows::core::IUnknown {
-    fn from(value: SpatialStageFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialStageFrameOfReference> for ::windows::core::IUnknown {
-    fn from(value: &SpatialStageFrameOfReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialStageFrameOfReference> for &::windows::core::IUnknown {
-    fn from(value: &SpatialStageFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialStageFrameOfReference> for ::windows::core::IInspectable {
-    fn from(value: SpatialStageFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialStageFrameOfReference> for ::windows::core::IInspectable {
-    fn from(value: &SpatialStageFrameOfReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialStageFrameOfReference> for &::windows::core::IInspectable {
-    fn from(value: &SpatialStageFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialStageFrameOfReference, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialStageFrameOfReference {}
 unsafe impl ::core::marker::Sync for SpatialStageFrameOfReference {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]
@@ -2762,36 +2240,7 @@ unsafe impl ::windows::core::Interface for SpatialStationaryFrameOfReference {
 impl ::windows::core::RuntimeName for SpatialStationaryFrameOfReference {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialStationaryFrameOfReference";
 }
-impl ::core::convert::From<SpatialStationaryFrameOfReference> for ::windows::core::IUnknown {
-    fn from(value: SpatialStationaryFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialStationaryFrameOfReference> for ::windows::core::IUnknown {
-    fn from(value: &SpatialStationaryFrameOfReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialStationaryFrameOfReference> for &::windows::core::IUnknown {
-    fn from(value: &SpatialStationaryFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialStationaryFrameOfReference> for ::windows::core::IInspectable {
-    fn from(value: SpatialStationaryFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialStationaryFrameOfReference> for ::windows::core::IInspectable {
-    fn from(value: &SpatialStationaryFrameOfReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialStationaryFrameOfReference> for &::windows::core::IInspectable {
-    fn from(value: &SpatialStationaryFrameOfReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialStationaryFrameOfReference, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialStationaryFrameOfReference {}
 unsafe impl ::core::marker::Sync for SpatialStationaryFrameOfReference {}
 #[doc = "*Required features: `\"Perception_Spatial\"`*"]

--- a/crates/libs/windows/src/Windows/Perception/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/mod.rs
@@ -144,36 +144,7 @@ unsafe impl ::windows::core::Interface for PerceptionTimestamp {
 impl ::windows::core::RuntimeName for PerceptionTimestamp {
     const NAME: &'static str = "Windows.Perception.PerceptionTimestamp";
 }
-impl ::core::convert::From<PerceptionTimestamp> for ::windows::core::IUnknown {
-    fn from(value: PerceptionTimestamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PerceptionTimestamp> for ::windows::core::IUnknown {
-    fn from(value: &PerceptionTimestamp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PerceptionTimestamp> for &::windows::core::IUnknown {
-    fn from(value: &PerceptionTimestamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PerceptionTimestamp> for ::windows::core::IInspectable {
-    fn from(value: PerceptionTimestamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PerceptionTimestamp> for ::windows::core::IInspectable {
-    fn from(value: &PerceptionTimestamp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PerceptionTimestamp> for &::windows::core::IInspectable {
-    fn from(value: &PerceptionTimestamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PerceptionTimestamp, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PerceptionTimestamp {}
 unsafe impl ::core::marker::Sync for PerceptionTimestamp {}
 #[doc = "*Required features: `\"Perception\"`*"]

--- a/crates/libs/windows/src/Windows/Phone/Devices/Notification/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Devices/Notification/mod.rs
@@ -90,36 +90,7 @@ unsafe impl ::windows::core::Interface for VibrationDevice {
 impl ::windows::core::RuntimeName for VibrationDevice {
     const NAME: &'static str = "Windows.Phone.Devices.Notification.VibrationDevice";
 }
-impl ::core::convert::From<VibrationDevice> for ::windows::core::IUnknown {
-    fn from(value: VibrationDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VibrationDevice> for ::windows::core::IUnknown {
-    fn from(value: &VibrationDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VibrationDevice> for &::windows::core::IUnknown {
-    fn from(value: &VibrationDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VibrationDevice> for ::windows::core::IInspectable {
-    fn from(value: VibrationDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VibrationDevice> for ::windows::core::IInspectable {
-    fn from(value: &VibrationDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VibrationDevice> for &::windows::core::IInspectable {
-    fn from(value: &VibrationDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VibrationDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VibrationDevice {}
 unsafe impl ::core::marker::Sync for VibrationDevice {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Phone/Devices/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Devices/Power/mod.rs
@@ -119,36 +119,7 @@ unsafe impl ::windows::core::Interface for Battery {
 impl ::windows::core::RuntimeName for Battery {
     const NAME: &'static str = "Windows.Phone.Devices.Power.Battery";
 }
-impl ::core::convert::From<Battery> for ::windows::core::IUnknown {
-    fn from(value: Battery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Battery> for ::windows::core::IUnknown {
-    fn from(value: &Battery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Battery> for &::windows::core::IUnknown {
-    fn from(value: &Battery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Battery> for ::windows::core::IInspectable {
-    fn from(value: Battery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Battery> for ::windows::core::IInspectable {
-    fn from(value: &Battery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Battery> for &::windows::core::IInspectable {
-    fn from(value: &Battery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Battery, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Battery {}
 unsafe impl ::core::marker::Sync for Battery {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Phone/Management/Deployment/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Management/Deployment/mod.rs
@@ -248,36 +248,7 @@ unsafe impl ::windows::core::Interface for Enterprise {
 impl ::windows::core::RuntimeName for Enterprise {
     const NAME: &'static str = "Windows.Phone.Management.Deployment.Enterprise";
 }
-impl ::core::convert::From<Enterprise> for ::windows::core::IUnknown {
-    fn from(value: Enterprise) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Enterprise> for ::windows::core::IUnknown {
-    fn from(value: &Enterprise) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Enterprise> for &::windows::core::IUnknown {
-    fn from(value: &Enterprise) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Enterprise> for ::windows::core::IInspectable {
-    fn from(value: Enterprise) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Enterprise> for ::windows::core::IInspectable {
-    fn from(value: &Enterprise) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Enterprise> for &::windows::core::IInspectable {
-    fn from(value: &Enterprise) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Enterprise, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Enterprise {}
 unsafe impl ::core::marker::Sync for Enterprise {}
 #[doc = "*Required features: `\"Phone_Management_Deployment\"`*"]
@@ -381,36 +352,7 @@ unsafe impl ::windows::core::Interface for EnterpriseEnrollmentResult {
 impl ::windows::core::RuntimeName for EnterpriseEnrollmentResult {
     const NAME: &'static str = "Windows.Phone.Management.Deployment.EnterpriseEnrollmentResult";
 }
-impl ::core::convert::From<EnterpriseEnrollmentResult> for ::windows::core::IUnknown {
-    fn from(value: EnterpriseEnrollmentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnterpriseEnrollmentResult> for ::windows::core::IUnknown {
-    fn from(value: &EnterpriseEnrollmentResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnterpriseEnrollmentResult> for &::windows::core::IUnknown {
-    fn from(value: &EnterpriseEnrollmentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EnterpriseEnrollmentResult> for ::windows::core::IInspectable {
-    fn from(value: EnterpriseEnrollmentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnterpriseEnrollmentResult> for ::windows::core::IInspectable {
-    fn from(value: &EnterpriseEnrollmentResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnterpriseEnrollmentResult> for &::windows::core::IInspectable {
-    fn from(value: &EnterpriseEnrollmentResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EnterpriseEnrollmentResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Management_Deployment\"`*"]
 pub struct InstallationManager;
 impl InstallationManager {
@@ -556,36 +498,7 @@ unsafe impl ::windows::core::Interface for PackageInstallResult {
 impl ::windows::core::RuntimeName for PackageInstallResult {
     const NAME: &'static str = "Windows.Phone.Management.Deployment.PackageInstallResult";
 }
-impl ::core::convert::From<PackageInstallResult> for ::windows::core::IUnknown {
-    fn from(value: PackageInstallResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageInstallResult> for ::windows::core::IUnknown {
-    fn from(value: &PackageInstallResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageInstallResult> for &::windows::core::IUnknown {
-    fn from(value: &PackageInstallResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PackageInstallResult> for ::windows::core::IInspectable {
-    fn from(value: PackageInstallResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PackageInstallResult> for ::windows::core::IInspectable {
-    fn from(value: &PackageInstallResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PackageInstallResult> for &::windows::core::IInspectable {
-    fn from(value: &PackageInstallResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PackageInstallResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Management_Deployment\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/Phone/Media/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Media/Devices/mod.rs
@@ -119,36 +119,7 @@ unsafe impl ::windows::core::Interface for AudioRoutingManager {
 impl ::windows::core::RuntimeName for AudioRoutingManager {
     const NAME: &'static str = "Windows.Phone.Media.Devices.AudioRoutingManager";
 }
-impl ::core::convert::From<AudioRoutingManager> for ::windows::core::IUnknown {
-    fn from(value: AudioRoutingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioRoutingManager> for ::windows::core::IUnknown {
-    fn from(value: &AudioRoutingManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioRoutingManager> for &::windows::core::IUnknown {
-    fn from(value: &AudioRoutingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AudioRoutingManager> for ::windows::core::IInspectable {
-    fn from(value: AudioRoutingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AudioRoutingManager> for ::windows::core::IInspectable {
-    fn from(value: &AudioRoutingManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AudioRoutingManager> for &::windows::core::IInspectable {
-    fn from(value: &AudioRoutingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AudioRoutingManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AudioRoutingManager {}
 unsafe impl ::core::marker::Sync for AudioRoutingManager {}
 #[doc = "*Required features: `\"Phone_Media_Devices\"`*"]

--- a/crates/libs/windows/src/Windows/Phone/Notification/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Notification/Management/mod.rs
@@ -176,36 +176,7 @@ impl IAccessoryNotificationTriggerDetails {
         unsafe { (::windows::core::Vtable::vtable(this).SetStartedProcessing)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<IAccessoryNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: IAccessoryNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccessoryNotificationTriggerDetails> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccessoryNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccessoryNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &IAccessoryNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAccessoryNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: IAccessoryNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccessoryNotificationTriggerDetails> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAccessoryNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccessoryNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &IAccessoryNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccessoryNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAccessoryNotificationTriggerDetails {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1124,36 +1095,7 @@ unsafe impl ::windows::core::Interface for AlarmNotificationTriggerDetails {
 impl ::windows::core::RuntimeName for AlarmNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.AlarmNotificationTriggerDetails";
 }
-impl ::core::convert::From<AlarmNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: AlarmNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AlarmNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &AlarmNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AlarmNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &AlarmNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AlarmNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: AlarmNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AlarmNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &AlarmNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AlarmNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &AlarmNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AlarmNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AlarmNotificationTriggerDetails> for IAccessoryNotificationTriggerDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: AlarmNotificationTriggerDetails) -> ::windows::core::Result<Self> {
@@ -1224,36 +1166,7 @@ unsafe impl ::windows::core::Interface for AppNotificationInfo {
 impl ::windows::core::RuntimeName for AppNotificationInfo {
     const NAME: &'static str = "Windows.Phone.Notification.Management.AppNotificationInfo";
 }
-impl ::core::convert::From<AppNotificationInfo> for ::windows::core::IUnknown {
-    fn from(value: AppNotificationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppNotificationInfo> for ::windows::core::IUnknown {
-    fn from(value: &AppNotificationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppNotificationInfo> for &::windows::core::IUnknown {
-    fn from(value: &AppNotificationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppNotificationInfo> for ::windows::core::IInspectable {
-    fn from(value: AppNotificationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppNotificationInfo> for ::windows::core::IInspectable {
-    fn from(value: &AppNotificationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppNotificationInfo> for &::windows::core::IInspectable {
-    fn from(value: &AppNotificationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppNotificationInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Notification_Management\"`*"]
 #[repr(transparent)]
 pub struct BinaryId(::windows::core::IUnknown);
@@ -1305,36 +1218,7 @@ unsafe impl ::windows::core::Interface for BinaryId {
 impl ::windows::core::RuntimeName for BinaryId {
     const NAME: &'static str = "Windows.Phone.Notification.Management.BinaryId";
 }
-impl ::core::convert::From<BinaryId> for ::windows::core::IUnknown {
-    fn from(value: BinaryId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BinaryId> for ::windows::core::IUnknown {
-    fn from(value: &BinaryId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BinaryId> for &::windows::core::IUnknown {
-    fn from(value: &BinaryId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BinaryId> for ::windows::core::IInspectable {
-    fn from(value: BinaryId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BinaryId> for ::windows::core::IInspectable {
-    fn from(value: &BinaryId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BinaryId> for &::windows::core::IInspectable {
-    fn from(value: &BinaryId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BinaryId, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Notification_Management\"`*"]
 #[repr(transparent)]
 pub struct CalendarChangedNotificationTriggerDetails(::windows::core::IUnknown);
@@ -1427,36 +1311,7 @@ unsafe impl ::windows::core::Interface for CalendarChangedNotificationTriggerDet
 impl ::windows::core::RuntimeName for CalendarChangedNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.CalendarChangedNotificationTriggerDetails";
 }
-impl ::core::convert::From<CalendarChangedNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: CalendarChangedNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CalendarChangedNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &CalendarChangedNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CalendarChangedNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &CalendarChangedNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CalendarChangedNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: CalendarChangedNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CalendarChangedNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &CalendarChangedNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CalendarChangedNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &CalendarChangedNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CalendarChangedNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CalendarChangedNotificationTriggerDetails> for IAccessoryNotificationTriggerDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: CalendarChangedNotificationTriggerDetails) -> ::windows::core::Result<Self> {
@@ -1624,36 +1479,7 @@ unsafe impl ::windows::core::Interface for CortanaTileNotificationTriggerDetails
 impl ::windows::core::RuntimeName for CortanaTileNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.CortanaTileNotificationTriggerDetails";
 }
-impl ::core::convert::From<CortanaTileNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: CortanaTileNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CortanaTileNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &CortanaTileNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CortanaTileNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &CortanaTileNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CortanaTileNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: CortanaTileNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CortanaTileNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &CortanaTileNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CortanaTileNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &CortanaTileNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CortanaTileNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CortanaTileNotificationTriggerDetails> for IAccessoryNotificationTriggerDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: CortanaTileNotificationTriggerDetails) -> ::windows::core::Result<Self> {
@@ -1724,36 +1550,7 @@ unsafe impl ::windows::core::Interface for EmailAccountInfo {
 impl ::windows::core::RuntimeName for EmailAccountInfo {
     const NAME: &'static str = "Windows.Phone.Notification.Management.EmailAccountInfo";
 }
-impl ::core::convert::From<EmailAccountInfo> for ::windows::core::IUnknown {
-    fn from(value: EmailAccountInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailAccountInfo> for ::windows::core::IUnknown {
-    fn from(value: &EmailAccountInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailAccountInfo> for &::windows::core::IUnknown {
-    fn from(value: &EmailAccountInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailAccountInfo> for ::windows::core::IInspectable {
-    fn from(value: EmailAccountInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailAccountInfo> for ::windows::core::IInspectable {
-    fn from(value: &EmailAccountInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailAccountInfo> for &::windows::core::IInspectable {
-    fn from(value: &EmailAccountInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailAccountInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Notification_Management\"`*"]
 #[repr(transparent)]
 pub struct EmailFolderInfo(::windows::core::IUnknown);
@@ -1805,36 +1602,7 @@ unsafe impl ::windows::core::Interface for EmailFolderInfo {
 impl ::windows::core::RuntimeName for EmailFolderInfo {
     const NAME: &'static str = "Windows.Phone.Notification.Management.EmailFolderInfo";
 }
-impl ::core::convert::From<EmailFolderInfo> for ::windows::core::IUnknown {
-    fn from(value: EmailFolderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailFolderInfo> for ::windows::core::IUnknown {
-    fn from(value: &EmailFolderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailFolderInfo> for &::windows::core::IUnknown {
-    fn from(value: &EmailFolderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailFolderInfo> for ::windows::core::IInspectable {
-    fn from(value: EmailFolderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailFolderInfo> for ::windows::core::IInspectable {
-    fn from(value: &EmailFolderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailFolderInfo> for &::windows::core::IInspectable {
-    fn from(value: &EmailFolderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailFolderInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Notification_Management\"`*"]
 #[repr(transparent)]
 pub struct EmailNotificationTriggerDetails(::windows::core::IUnknown);
@@ -1966,36 +1734,7 @@ unsafe impl ::windows::core::Interface for EmailNotificationTriggerDetails {
 impl ::windows::core::RuntimeName for EmailNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.EmailNotificationTriggerDetails";
 }
-impl ::core::convert::From<EmailNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: EmailNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &EmailNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &EmailNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: EmailNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &EmailNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &EmailNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<EmailNotificationTriggerDetails> for IAccessoryNotificationTriggerDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: EmailNotificationTriggerDetails) -> ::windows::core::Result<Self> {
@@ -2121,36 +1860,7 @@ unsafe impl ::windows::core::Interface for EmailReadNotificationTriggerDetails {
 impl ::windows::core::RuntimeName for EmailReadNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.EmailReadNotificationTriggerDetails";
 }
-impl ::core::convert::From<EmailReadNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: EmailReadNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailReadNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &EmailReadNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailReadNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &EmailReadNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EmailReadNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: EmailReadNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EmailReadNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &EmailReadNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EmailReadNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &EmailReadNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EmailReadNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<EmailReadNotificationTriggerDetails> for IAccessoryNotificationTriggerDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: EmailReadNotificationTriggerDetails) -> ::windows::core::Result<Self> {
@@ -2262,36 +1972,7 @@ unsafe impl ::windows::core::Interface for MediaControlsTriggerDetails {
 impl ::windows::core::RuntimeName for MediaControlsTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.MediaControlsTriggerDetails";
 }
-impl ::core::convert::From<MediaControlsTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: MediaControlsTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaControlsTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &MediaControlsTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaControlsTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &MediaControlsTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaControlsTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: MediaControlsTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaControlsTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &MediaControlsTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaControlsTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &MediaControlsTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaControlsTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MediaControlsTriggerDetails> for IAccessoryNotificationTriggerDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: MediaControlsTriggerDetails) -> ::windows::core::Result<Self> {
@@ -2401,36 +2082,7 @@ unsafe impl ::windows::core::Interface for MediaMetadata {
 impl ::windows::core::RuntimeName for MediaMetadata {
     const NAME: &'static str = "Windows.Phone.Notification.Management.MediaMetadata";
 }
-impl ::core::convert::From<MediaMetadata> for ::windows::core::IUnknown {
-    fn from(value: MediaMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaMetadata> for ::windows::core::IUnknown {
-    fn from(value: &MediaMetadata) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaMetadata> for &::windows::core::IUnknown {
-    fn from(value: &MediaMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MediaMetadata> for ::windows::core::IInspectable {
-    fn from(value: MediaMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MediaMetadata> for ::windows::core::IInspectable {
-    fn from(value: &MediaMetadata) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MediaMetadata> for &::windows::core::IInspectable {
-    fn from(value: &MediaMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MediaMetadata, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Notification_Management\"`*"]
 #[repr(transparent)]
 pub struct PhoneCallDetails(::windows::core::IUnknown);
@@ -2558,36 +2210,7 @@ unsafe impl ::windows::core::Interface for PhoneCallDetails {
 impl ::windows::core::RuntimeName for PhoneCallDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.PhoneCallDetails";
 }
-impl ::core::convert::From<PhoneCallDetails> for ::windows::core::IUnknown {
-    fn from(value: PhoneCallDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallDetails> for ::windows::core::IUnknown {
-    fn from(value: &PhoneCallDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallDetails> for &::windows::core::IUnknown {
-    fn from(value: &PhoneCallDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneCallDetails> for ::windows::core::IInspectable {
-    fn from(value: PhoneCallDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneCallDetails> for ::windows::core::IInspectable {
-    fn from(value: &PhoneCallDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneCallDetails> for &::windows::core::IInspectable {
-    fn from(value: &PhoneCallDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneCallDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Notification_Management\"`*"]
 #[repr(transparent)]
 pub struct PhoneLineDetails(::windows::core::IUnknown);
@@ -2674,36 +2297,7 @@ unsafe impl ::windows::core::Interface for PhoneLineDetails {
 impl ::windows::core::RuntimeName for PhoneLineDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.PhoneLineDetails";
 }
-impl ::core::convert::From<PhoneLineDetails> for ::windows::core::IUnknown {
-    fn from(value: PhoneLineDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineDetails> for ::windows::core::IUnknown {
-    fn from(value: &PhoneLineDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineDetails> for &::windows::core::IUnknown {
-    fn from(value: &PhoneLineDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneLineDetails> for ::windows::core::IInspectable {
-    fn from(value: PhoneLineDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneLineDetails> for ::windows::core::IInspectable {
-    fn from(value: &PhoneLineDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneLineDetails> for &::windows::core::IInspectable {
-    fn from(value: &PhoneLineDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneLineDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Notification_Management\"`*"]
 #[repr(transparent)]
 pub struct PhoneNotificationTriggerDetails(::windows::core::IUnknown);
@@ -2803,36 +2397,7 @@ unsafe impl ::windows::core::Interface for PhoneNotificationTriggerDetails {
 impl ::windows::core::RuntimeName for PhoneNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.PhoneNotificationTriggerDetails";
 }
-impl ::core::convert::From<PhoneNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: PhoneNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &PhoneNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &PhoneNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PhoneNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: PhoneNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PhoneNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &PhoneNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PhoneNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &PhoneNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PhoneNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PhoneNotificationTriggerDetails> for IAccessoryNotificationTriggerDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: PhoneNotificationTriggerDetails) -> ::windows::core::Result<Self> {
@@ -2990,36 +2555,7 @@ unsafe impl ::windows::core::Interface for ReminderNotificationTriggerDetails {
 impl ::windows::core::RuntimeName for ReminderNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.ReminderNotificationTriggerDetails";
 }
-impl ::core::convert::From<ReminderNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: ReminderNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ReminderNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &ReminderNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ReminderNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &ReminderNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ReminderNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: ReminderNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ReminderNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &ReminderNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ReminderNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &ReminderNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ReminderNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ReminderNotificationTriggerDetails> for IAccessoryNotificationTriggerDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: ReminderNotificationTriggerDetails) -> ::windows::core::Result<Self> {
@@ -3097,36 +2633,7 @@ unsafe impl ::windows::core::Interface for SpeedDialEntry {
 impl ::windows::core::RuntimeName for SpeedDialEntry {
     const NAME: &'static str = "Windows.Phone.Notification.Management.SpeedDialEntry";
 }
-impl ::core::convert::From<SpeedDialEntry> for ::windows::core::IUnknown {
-    fn from(value: SpeedDialEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeedDialEntry> for ::windows::core::IUnknown {
-    fn from(value: &SpeedDialEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeedDialEntry> for &::windows::core::IUnknown {
-    fn from(value: &SpeedDialEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpeedDialEntry> for ::windows::core::IInspectable {
-    fn from(value: SpeedDialEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpeedDialEntry> for ::windows::core::IInspectable {
-    fn from(value: &SpeedDialEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpeedDialEntry> for &::windows::core::IInspectable {
-    fn from(value: &SpeedDialEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpeedDialEntry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Notification_Management\"`*"]
 #[repr(transparent)]
 pub struct TextResponse(::windows::core::IUnknown);
@@ -3178,36 +2685,7 @@ unsafe impl ::windows::core::Interface for TextResponse {
 impl ::windows::core::RuntimeName for TextResponse {
     const NAME: &'static str = "Windows.Phone.Notification.Management.TextResponse";
 }
-impl ::core::convert::From<TextResponse> for ::windows::core::IUnknown {
-    fn from(value: TextResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TextResponse> for ::windows::core::IUnknown {
-    fn from(value: &TextResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TextResponse> for &::windows::core::IUnknown {
-    fn from(value: &TextResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TextResponse> for ::windows::core::IInspectable {
-    fn from(value: TextResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TextResponse> for ::windows::core::IInspectable {
-    fn from(value: &TextResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TextResponse> for &::windows::core::IInspectable {
-    fn from(value: &TextResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TextResponse, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Notification_Management\"`*"]
 #[repr(transparent)]
 pub struct ToastNotificationTriggerDetails(::windows::core::IUnknown);
@@ -3328,36 +2806,7 @@ unsafe impl ::windows::core::Interface for ToastNotificationTriggerDetails {
 impl ::windows::core::RuntimeName for ToastNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.ToastNotificationTriggerDetails";
 }
-impl ::core::convert::From<ToastNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: ToastNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &ToastNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &ToastNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: ToastNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &ToastNotificationTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &ToastNotificationTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastNotificationTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ToastNotificationTriggerDetails> for IAccessoryNotificationTriggerDetails {
     type Error = ::windows::core::Error;
     fn try_from(value: ToastNotificationTriggerDetails) -> ::windows::core::Result<Self> {
@@ -3449,36 +2898,7 @@ unsafe impl ::windows::core::Interface for VolumeInfo {
 impl ::windows::core::RuntimeName for VolumeInfo {
     const NAME: &'static str = "Windows.Phone.Notification.Management.VolumeInfo";
 }
-impl ::core::convert::From<VolumeInfo> for ::windows::core::IUnknown {
-    fn from(value: VolumeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VolumeInfo> for ::windows::core::IUnknown {
-    fn from(value: &VolumeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VolumeInfo> for &::windows::core::IUnknown {
-    fn from(value: &VolumeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VolumeInfo> for ::windows::core::IInspectable {
-    fn from(value: VolumeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VolumeInfo> for ::windows::core::IInspectable {
-    fn from(value: &VolumeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VolumeInfo> for &::windows::core::IInspectable {
-    fn from(value: &VolumeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VolumeInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Phone_Notification_Management\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/Phone/PersonalInformation/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/PersonalInformation/mod.rs
@@ -160,36 +160,7 @@ impl IContactInformation {
         }
     }
 }
-impl ::core::convert::From<IContactInformation> for ::windows::core::IUnknown {
-    fn from(value: IContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactInformation> for ::windows::core::IUnknown {
-    fn from(value: &IContactInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactInformation> for ::windows::core::IInspectable {
-    fn from(value: IContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactInformation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactInformation> for ::windows::core::IInspectable {
-    fn from(value: &IContactInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IContactInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -278,36 +249,7 @@ impl IContactInformation2 {
         unsafe { (::windows::core::Vtable::vtable(this).SetDisplayPictureDate)(::windows::core::Vtable::as_raw(this), returnvalue).ok() }
     }
 }
-impl ::core::convert::From<IContactInformation2> for ::windows::core::IUnknown {
-    fn from(value: IContactInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactInformation2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactInformation2> for ::windows::core::IUnknown {
-    fn from(value: &IContactInformation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContactInformation2> for ::windows::core::IInspectable {
-    fn from(value: IContactInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactInformation2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContactInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactInformation2> for ::windows::core::IInspectable {
-    fn from(value: &IContactInformation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactInformation2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IContactInformation2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -694,36 +636,7 @@ unsafe impl ::windows::core::Interface for ContactAddress {
 impl ::windows::core::RuntimeName for ContactAddress {
     const NAME: &'static str = "Windows.Phone.PersonalInformation.ContactAddress";
 }
-impl ::core::convert::From<ContactAddress> for ::windows::core::IUnknown {
-    fn from(value: ContactAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactAddress> for ::windows::core::IUnknown {
-    fn from(value: &ContactAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactAddress> for &::windows::core::IUnknown {
-    fn from(value: &ContactAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactAddress> for ::windows::core::IInspectable {
-    fn from(value: ContactAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactAddress> for ::windows::core::IInspectable {
-    fn from(value: &ContactAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactAddress> for &::windows::core::IInspectable {
-    fn from(value: &ContactAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactAddress, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactAddress {}
 unsafe impl ::core::marker::Sync for ContactAddress {}
 #[doc = "*Required features: `\"Phone_PersonalInformation\"`*"]
@@ -791,36 +704,7 @@ unsafe impl ::windows::core::Interface for ContactChangeRecord {
 impl ::windows::core::RuntimeName for ContactChangeRecord {
     const NAME: &'static str = "Windows.Phone.PersonalInformation.ContactChangeRecord";
 }
-impl ::core::convert::From<ContactChangeRecord> for ::windows::core::IUnknown {
-    fn from(value: ContactChangeRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChangeRecord> for ::windows::core::IUnknown {
-    fn from(value: &ContactChangeRecord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChangeRecord> for &::windows::core::IUnknown {
-    fn from(value: &ContactChangeRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactChangeRecord> for ::windows::core::IInspectable {
-    fn from(value: ContactChangeRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactChangeRecord> for ::windows::core::IInspectable {
-    fn from(value: &ContactChangeRecord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactChangeRecord> for &::windows::core::IInspectable {
-    fn from(value: &ContactChangeRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactChangeRecord, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactChangeRecord {}
 unsafe impl ::core::marker::Sync for ContactChangeRecord {}
 #[doc = "*Required features: `\"Phone_PersonalInformation\"`*"]
@@ -997,36 +881,7 @@ unsafe impl ::windows::core::Interface for ContactInformation {
 impl ::windows::core::RuntimeName for ContactInformation {
     const NAME: &'static str = "Windows.Phone.PersonalInformation.ContactInformation";
 }
-impl ::core::convert::From<ContactInformation> for ::windows::core::IUnknown {
-    fn from(value: ContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactInformation> for ::windows::core::IUnknown {
-    fn from(value: &ContactInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactInformation> for &::windows::core::IUnknown {
-    fn from(value: &ContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactInformation> for ::windows::core::IInspectable {
-    fn from(value: ContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactInformation> for ::windows::core::IInspectable {
-    fn from(value: &ContactInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactInformation> for &::windows::core::IInspectable {
-    fn from(value: &ContactInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContactInformation> for IContactInformation {
     type Error = ::windows::core::Error;
     fn try_from(value: ContactInformation) -> ::windows::core::Result<Self> {
@@ -1112,36 +967,7 @@ unsafe impl ::windows::core::Interface for ContactQueryOptions {
 impl ::windows::core::RuntimeName for ContactQueryOptions {
     const NAME: &'static str = "Windows.Phone.PersonalInformation.ContactQueryOptions";
 }
-impl ::core::convert::From<ContactQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: ContactQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactQueryOptions> for ::windows::core::IUnknown {
-    fn from(value: &ContactQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactQueryOptions> for &::windows::core::IUnknown {
-    fn from(value: &ContactQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: ContactQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactQueryOptions> for ::windows::core::IInspectable {
-    fn from(value: &ContactQueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactQueryOptions> for &::windows::core::IInspectable {
-    fn from(value: &ContactQueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactQueryOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactQueryOptions {}
 unsafe impl ::core::marker::Sync for ContactQueryOptions {}
 #[doc = "*Required features: `\"Phone_PersonalInformation\"`*"]
@@ -1215,36 +1041,7 @@ unsafe impl ::windows::core::Interface for ContactQueryResult {
 impl ::windows::core::RuntimeName for ContactQueryResult {
     const NAME: &'static str = "Windows.Phone.PersonalInformation.ContactQueryResult";
 }
-impl ::core::convert::From<ContactQueryResult> for ::windows::core::IUnknown {
-    fn from(value: ContactQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactQueryResult> for ::windows::core::IUnknown {
-    fn from(value: &ContactQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactQueryResult> for &::windows::core::IUnknown {
-    fn from(value: &ContactQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactQueryResult> for ::windows::core::IInspectable {
-    fn from(value: ContactQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactQueryResult> for ::windows::core::IInspectable {
-    fn from(value: &ContactQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactQueryResult> for &::windows::core::IInspectable {
-    fn from(value: &ContactQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactQueryResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactQueryResult {}
 unsafe impl ::core::marker::Sync for ContactQueryResult {}
 #[doc = "*Required features: `\"Phone_PersonalInformation\"`*"]
@@ -1402,36 +1199,7 @@ unsafe impl ::windows::core::Interface for ContactStore {
 impl ::windows::core::RuntimeName for ContactStore {
     const NAME: &'static str = "Windows.Phone.PersonalInformation.ContactStore";
 }
-impl ::core::convert::From<ContactStore> for ::windows::core::IUnknown {
-    fn from(value: ContactStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactStore> for ::windows::core::IUnknown {
-    fn from(value: &ContactStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactStore> for &::windows::core::IUnknown {
-    fn from(value: &ContactStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContactStore> for ::windows::core::IInspectable {
-    fn from(value: ContactStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContactStore> for ::windows::core::IInspectable {
-    fn from(value: &ContactStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContactStore> for &::windows::core::IInspectable {
-    fn from(value: &ContactStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContactStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContactStore {}
 unsafe impl ::core::marker::Sync for ContactStore {}
 #[doc = "*Required features: `\"Phone_PersonalInformation\"`*"]
@@ -1890,36 +1658,7 @@ unsafe impl ::windows::core::Interface for StoredContact {
 impl ::windows::core::RuntimeName for StoredContact {
     const NAME: &'static str = "Windows.Phone.PersonalInformation.StoredContact";
 }
-impl ::core::convert::From<StoredContact> for ::windows::core::IUnknown {
-    fn from(value: StoredContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoredContact> for ::windows::core::IUnknown {
-    fn from(value: &StoredContact) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoredContact> for &::windows::core::IUnknown {
-    fn from(value: &StoredContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoredContact> for ::windows::core::IInspectable {
-    fn from(value: StoredContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoredContact> for ::windows::core::IInspectable {
-    fn from(value: &StoredContact) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoredContact> for &::windows::core::IInspectable {
-    fn from(value: &StoredContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoredContact, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StoredContact> for IContactInformation {
     type Error = ::windows::core::Error;
     fn try_from(value: StoredContact) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Phone/StartScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/StartScreen/mod.rs
@@ -84,36 +84,7 @@ impl IToastNotificationManagerStatics3 {
         }
     }
 }
-impl ::core::convert::From<IToastNotificationManagerStatics3> for ::windows::core::IUnknown {
-    fn from(value: IToastNotificationManagerStatics3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IToastNotificationManagerStatics3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IToastNotificationManagerStatics3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IToastNotificationManagerStatics3> for ::windows::core::IUnknown {
-    fn from(value: &IToastNotificationManagerStatics3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IToastNotificationManagerStatics3> for ::windows::core::IInspectable {
-    fn from(value: IToastNotificationManagerStatics3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IToastNotificationManagerStatics3> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IToastNotificationManagerStatics3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IToastNotificationManagerStatics3> for ::windows::core::IInspectable {
-    fn from(value: &IToastNotificationManagerStatics3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IToastNotificationManagerStatics3, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IToastNotificationManagerStatics3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -308,35 +279,6 @@ unsafe impl ::windows::core::Interface for DualSimTile {
 impl ::windows::core::RuntimeName for DualSimTile {
     const NAME: &'static str = "Windows.Phone.StartScreen.DualSimTile";
 }
-impl ::core::convert::From<DualSimTile> for ::windows::core::IUnknown {
-    fn from(value: DualSimTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DualSimTile> for ::windows::core::IUnknown {
-    fn from(value: &DualSimTile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DualSimTile> for &::windows::core::IUnknown {
-    fn from(value: &DualSimTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DualSimTile> for ::windows::core::IInspectable {
-    fn from(value: DualSimTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DualSimTile> for ::windows::core::IInspectable {
-    fn from(value: &DualSimTile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DualSimTile> for &::windows::core::IInspectable {
-    fn from(value: &DualSimTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DualSimTile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "implement")]
 ::core::include!("impl.rs");

--- a/crates/libs/windows/src/Windows/Phone/System/UserProfile/GameServices/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/System/UserProfile/GameServices/Core/mod.rs
@@ -204,36 +204,7 @@ unsafe impl ::windows::core::Interface for GameServicePropertyCollection {
 impl ::windows::core::RuntimeName for GameServicePropertyCollection {
     const NAME: &'static str = "Windows.Phone.System.UserProfile.GameServices.Core.GameServicePropertyCollection";
 }
-impl ::core::convert::From<GameServicePropertyCollection> for ::windows::core::IUnknown {
-    fn from(value: GameServicePropertyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameServicePropertyCollection> for ::windows::core::IUnknown {
-    fn from(value: &GameServicePropertyCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameServicePropertyCollection> for &::windows::core::IUnknown {
-    fn from(value: &GameServicePropertyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GameServicePropertyCollection> for ::windows::core::IInspectable {
-    fn from(value: GameServicePropertyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GameServicePropertyCollection> for ::windows::core::IInspectable {
-    fn from(value: &GameServicePropertyCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GameServicePropertyCollection> for &::windows::core::IInspectable {
-    fn from(value: &GameServicePropertyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GameServicePropertyCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GameServicePropertyCollection {}
 unsafe impl ::core::marker::Sync for GameServicePropertyCollection {}
 #[doc = "*Required features: `\"Phone_System_UserProfile_GameServices_Core\"`*"]

--- a/crates/libs/windows/src/Windows/Phone/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/UI/Input/mod.rs
@@ -136,36 +136,7 @@ unsafe impl ::windows::core::Interface for BackPressedEventArgs {
 impl ::windows::core::RuntimeName for BackPressedEventArgs {
     const NAME: &'static str = "Windows.Phone.UI.Input.BackPressedEventArgs";
 }
-impl ::core::convert::From<BackPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BackPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BackPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackPressedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BackPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BackPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BackPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackPressedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BackPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackPressedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackPressedEventArgs {}
 unsafe impl ::core::marker::Sync for BackPressedEventArgs {}
 #[doc = "*Required features: `\"Phone_UI_Input\"`*"]
@@ -204,36 +175,7 @@ unsafe impl ::windows::core::Interface for CameraEventArgs {
 impl ::windows::core::RuntimeName for CameraEventArgs {
     const NAME: &'static str = "Windows.Phone.UI.Input.CameraEventArgs";
 }
-impl ::core::convert::From<CameraEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CameraEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CameraEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CameraEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CameraEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CameraEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CameraEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CameraEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CameraEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CameraEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CameraEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CameraEventArgs {}
 unsafe impl ::core::marker::Sync for CameraEventArgs {}
 #[doc = "*Required features: `\"Phone_UI_Input\"`*"]

--- a/crates/libs/windows/src/Windows/Security/Authentication/Identity/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Identity/Core/mod.rs
@@ -306,36 +306,7 @@ unsafe impl ::windows::core::Interface for MicrosoftAccountMultiFactorAuthentica
 impl ::windows::core::RuntimeName for MicrosoftAccountMultiFactorAuthenticationManager {
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorAuthenticationManager";
 }
-impl ::core::convert::From<MicrosoftAccountMultiFactorAuthenticationManager> for ::windows::core::IUnknown {
-    fn from(value: MicrosoftAccountMultiFactorAuthenticationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorAuthenticationManager> for ::windows::core::IUnknown {
-    fn from(value: &MicrosoftAccountMultiFactorAuthenticationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorAuthenticationManager> for &::windows::core::IUnknown {
-    fn from(value: &MicrosoftAccountMultiFactorAuthenticationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MicrosoftAccountMultiFactorAuthenticationManager> for ::windows::core::IInspectable {
-    fn from(value: MicrosoftAccountMultiFactorAuthenticationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorAuthenticationManager> for ::windows::core::IInspectable {
-    fn from(value: &MicrosoftAccountMultiFactorAuthenticationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorAuthenticationManager> for &::windows::core::IInspectable {
-    fn from(value: &MicrosoftAccountMultiFactorAuthenticationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MicrosoftAccountMultiFactorAuthenticationManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MicrosoftAccountMultiFactorAuthenticationManager {}
 unsafe impl ::core::marker::Sync for MicrosoftAccountMultiFactorAuthenticationManager {}
 #[doc = "*Required features: `\"Security_Authentication_Identity_Core\"`*"]
@@ -391,36 +362,7 @@ unsafe impl ::windows::core::Interface for MicrosoftAccountMultiFactorGetSession
 impl ::windows::core::RuntimeName for MicrosoftAccountMultiFactorGetSessionsResult {
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorGetSessionsResult";
 }
-impl ::core::convert::From<MicrosoftAccountMultiFactorGetSessionsResult> for ::windows::core::IUnknown {
-    fn from(value: MicrosoftAccountMultiFactorGetSessionsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorGetSessionsResult> for ::windows::core::IUnknown {
-    fn from(value: &MicrosoftAccountMultiFactorGetSessionsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorGetSessionsResult> for &::windows::core::IUnknown {
-    fn from(value: &MicrosoftAccountMultiFactorGetSessionsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MicrosoftAccountMultiFactorGetSessionsResult> for ::windows::core::IInspectable {
-    fn from(value: MicrosoftAccountMultiFactorGetSessionsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorGetSessionsResult> for ::windows::core::IInspectable {
-    fn from(value: &MicrosoftAccountMultiFactorGetSessionsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorGetSessionsResult> for &::windows::core::IInspectable {
-    fn from(value: &MicrosoftAccountMultiFactorGetSessionsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MicrosoftAccountMultiFactorGetSessionsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MicrosoftAccountMultiFactorGetSessionsResult {}
 unsafe impl ::core::marker::Sync for MicrosoftAccountMultiFactorGetSessionsResult {}
 #[doc = "*Required features: `\"Security_Authentication_Identity_Core\"`*"]
@@ -492,36 +434,7 @@ unsafe impl ::windows::core::Interface for MicrosoftAccountMultiFactorOneTimeCod
 impl ::windows::core::RuntimeName for MicrosoftAccountMultiFactorOneTimeCodedInfo {
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorOneTimeCodedInfo";
 }
-impl ::core::convert::From<MicrosoftAccountMultiFactorOneTimeCodedInfo> for ::windows::core::IUnknown {
-    fn from(value: MicrosoftAccountMultiFactorOneTimeCodedInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorOneTimeCodedInfo> for ::windows::core::IUnknown {
-    fn from(value: &MicrosoftAccountMultiFactorOneTimeCodedInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorOneTimeCodedInfo> for &::windows::core::IUnknown {
-    fn from(value: &MicrosoftAccountMultiFactorOneTimeCodedInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MicrosoftAccountMultiFactorOneTimeCodedInfo> for ::windows::core::IInspectable {
-    fn from(value: MicrosoftAccountMultiFactorOneTimeCodedInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorOneTimeCodedInfo> for ::windows::core::IInspectable {
-    fn from(value: &MicrosoftAccountMultiFactorOneTimeCodedInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorOneTimeCodedInfo> for &::windows::core::IInspectable {
-    fn from(value: &MicrosoftAccountMultiFactorOneTimeCodedInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MicrosoftAccountMultiFactorOneTimeCodedInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MicrosoftAccountMultiFactorOneTimeCodedInfo {}
 unsafe impl ::core::marker::Sync for MicrosoftAccountMultiFactorOneTimeCodedInfo {}
 #[doc = "*Required features: `\"Security_Authentication_Identity_Core\"`*"]
@@ -614,36 +527,7 @@ unsafe impl ::windows::core::Interface for MicrosoftAccountMultiFactorSessionInf
 impl ::windows::core::RuntimeName for MicrosoftAccountMultiFactorSessionInfo {
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorSessionInfo";
 }
-impl ::core::convert::From<MicrosoftAccountMultiFactorSessionInfo> for ::windows::core::IUnknown {
-    fn from(value: MicrosoftAccountMultiFactorSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorSessionInfo> for ::windows::core::IUnknown {
-    fn from(value: &MicrosoftAccountMultiFactorSessionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorSessionInfo> for &::windows::core::IUnknown {
-    fn from(value: &MicrosoftAccountMultiFactorSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MicrosoftAccountMultiFactorSessionInfo> for ::windows::core::IInspectable {
-    fn from(value: MicrosoftAccountMultiFactorSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorSessionInfo> for ::windows::core::IInspectable {
-    fn from(value: &MicrosoftAccountMultiFactorSessionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorSessionInfo> for &::windows::core::IInspectable {
-    fn from(value: &MicrosoftAccountMultiFactorSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MicrosoftAccountMultiFactorSessionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MicrosoftAccountMultiFactorSessionInfo {}
 unsafe impl ::core::marker::Sync for MicrosoftAccountMultiFactorSessionInfo {}
 #[doc = "*Required features: `\"Security_Authentication_Identity_Core\"`*"]
@@ -708,36 +592,7 @@ unsafe impl ::windows::core::Interface for MicrosoftAccountMultiFactorUnregister
 impl ::windows::core::RuntimeName for MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo {
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Core.MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo";
 }
-impl ::core::convert::From<MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo> for ::windows::core::IUnknown {
-    fn from(value: MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo> for ::windows::core::IUnknown {
-    fn from(value: &MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo> for &::windows::core::IUnknown {
-    fn from(value: &MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo> for ::windows::core::IInspectable {
-    fn from(value: MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo> for ::windows::core::IInspectable {
-    fn from(value: &MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo> for &::windows::core::IInspectable {
-    fn from(value: &MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo {}
 unsafe impl ::core::marker::Sync for MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo {}
 #[doc = "*Required features: `\"Security_Authentication_Identity_Core\"`*"]

--- a/crates/libs/windows/src/Windows/Security/Authentication/Identity/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Identity/Provider/mod.rs
@@ -495,41 +495,7 @@ impl ::windows::core::RuntimeName for SecondaryAuthenticationFactorAuthenticatio
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthentication";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorAuthentication> for ::windows::core::IUnknown {
-    fn from(value: SecondaryAuthenticationFactorAuthentication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthentication> for ::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorAuthentication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthentication> for &::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorAuthentication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorAuthentication> for ::windows::core::IInspectable {
-    fn from(value: SecondaryAuthenticationFactorAuthentication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthentication> for ::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorAuthentication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthentication> for &::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorAuthentication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SecondaryAuthenticationFactorAuthentication, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SecondaryAuthenticationFactorAuthentication {}
 #[cfg(feature = "deprecated")]
@@ -600,41 +566,7 @@ impl ::windows::core::RuntimeName for SecondaryAuthenticationFactorAuthenticatio
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthenticationResult";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorAuthenticationResult> for ::windows::core::IUnknown {
-    fn from(value: SecondaryAuthenticationFactorAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationResult> for ::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationResult> for &::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorAuthenticationResult> for ::windows::core::IInspectable {
-    fn from(value: SecondaryAuthenticationFactorAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationResult> for ::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationResult> for &::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SecondaryAuthenticationFactorAuthenticationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SecondaryAuthenticationFactorAuthenticationResult {}
 #[cfg(feature = "deprecated")]
@@ -696,41 +628,7 @@ impl ::windows::core::RuntimeName for SecondaryAuthenticationFactorAuthenticatio
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SecondaryAuthenticationFactorAuthenticationStageChangedEventArgs {}
 #[cfg(feature = "deprecated")]
@@ -810,41 +708,7 @@ impl ::windows::core::RuntimeName for SecondaryAuthenticationFactorAuthenticatio
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorAuthenticationStageInfo";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorAuthenticationStageInfo> for ::windows::core::IUnknown {
-    fn from(value: SecondaryAuthenticationFactorAuthenticationStageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationStageInfo> for ::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationStageInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationStageInfo> for &::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationStageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorAuthenticationStageInfo> for ::windows::core::IInspectable {
-    fn from(value: SecondaryAuthenticationFactorAuthenticationStageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationStageInfo> for ::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationStageInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorAuthenticationStageInfo> for &::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorAuthenticationStageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SecondaryAuthenticationFactorAuthenticationStageInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SecondaryAuthenticationFactorAuthenticationStageInfo {}
 #[cfg(feature = "deprecated")]
@@ -960,41 +824,7 @@ impl ::windows::core::RuntimeName for SecondaryAuthenticationFactorInfo {
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorInfo";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorInfo> for ::windows::core::IUnknown {
-    fn from(value: SecondaryAuthenticationFactorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorInfo> for ::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorInfo> for &::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorInfo> for ::windows::core::IInspectable {
-    fn from(value: SecondaryAuthenticationFactorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorInfo> for ::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorInfo> for &::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SecondaryAuthenticationFactorInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SecondaryAuthenticationFactorInfo {}
 #[cfg(feature = "deprecated")]
@@ -1159,41 +989,7 @@ impl ::windows::core::RuntimeName for SecondaryAuthenticationFactorRegistration 
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorRegistration";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorRegistration> for ::windows::core::IUnknown {
-    fn from(value: SecondaryAuthenticationFactorRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorRegistration> for ::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorRegistration> for &::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorRegistration> for ::windows::core::IInspectable {
-    fn from(value: SecondaryAuthenticationFactorRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorRegistration> for ::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorRegistration> for &::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SecondaryAuthenticationFactorRegistration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SecondaryAuthenticationFactorRegistration {}
 #[cfg(feature = "deprecated")]
@@ -1264,41 +1060,7 @@ impl ::windows::core::RuntimeName for SecondaryAuthenticationFactorRegistrationR
     const NAME: &'static str = "Windows.Security.Authentication.Identity.Provider.SecondaryAuthenticationFactorRegistrationResult";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorRegistrationResult> for ::windows::core::IUnknown {
-    fn from(value: SecondaryAuthenticationFactorRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorRegistrationResult> for ::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorRegistrationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorRegistrationResult> for &::windows::core::IUnknown {
-    fn from(value: &SecondaryAuthenticationFactorRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SecondaryAuthenticationFactorRegistrationResult> for ::windows::core::IInspectable {
-    fn from(value: SecondaryAuthenticationFactorRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorRegistrationResult> for ::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorRegistrationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SecondaryAuthenticationFactorRegistrationResult> for &::windows::core::IInspectable {
-    fn from(value: &SecondaryAuthenticationFactorRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SecondaryAuthenticationFactorRegistrationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for SecondaryAuthenticationFactorRegistrationResult {}
 #[cfg(feature = "deprecated")]

--- a/crates/libs/windows/src/Windows/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Identity/mod.rs
@@ -126,36 +126,7 @@ unsafe impl ::windows::core::Interface for EnterpriseKeyCredentialRegistrationIn
 impl ::windows::core::RuntimeName for EnterpriseKeyCredentialRegistrationInfo {
     const NAME: &'static str = "Windows.Security.Authentication.Identity.EnterpriseKeyCredentialRegistrationInfo";
 }
-impl ::core::convert::From<EnterpriseKeyCredentialRegistrationInfo> for ::windows::core::IUnknown {
-    fn from(value: EnterpriseKeyCredentialRegistrationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnterpriseKeyCredentialRegistrationInfo> for ::windows::core::IUnknown {
-    fn from(value: &EnterpriseKeyCredentialRegistrationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnterpriseKeyCredentialRegistrationInfo> for &::windows::core::IUnknown {
-    fn from(value: &EnterpriseKeyCredentialRegistrationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EnterpriseKeyCredentialRegistrationInfo> for ::windows::core::IInspectable {
-    fn from(value: EnterpriseKeyCredentialRegistrationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnterpriseKeyCredentialRegistrationInfo> for ::windows::core::IInspectable {
-    fn from(value: &EnterpriseKeyCredentialRegistrationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnterpriseKeyCredentialRegistrationInfo> for &::windows::core::IInspectable {
-    fn from(value: &EnterpriseKeyCredentialRegistrationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EnterpriseKeyCredentialRegistrationInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EnterpriseKeyCredentialRegistrationInfo {}
 unsafe impl ::core::marker::Sync for EnterpriseKeyCredentialRegistrationInfo {}
 #[doc = "*Required features: `\"Security_Authentication_Identity\"`*"]
@@ -215,36 +186,7 @@ unsafe impl ::windows::core::Interface for EnterpriseKeyCredentialRegistrationMa
 impl ::windows::core::RuntimeName for EnterpriseKeyCredentialRegistrationManager {
     const NAME: &'static str = "Windows.Security.Authentication.Identity.EnterpriseKeyCredentialRegistrationManager";
 }
-impl ::core::convert::From<EnterpriseKeyCredentialRegistrationManager> for ::windows::core::IUnknown {
-    fn from(value: EnterpriseKeyCredentialRegistrationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnterpriseKeyCredentialRegistrationManager> for ::windows::core::IUnknown {
-    fn from(value: &EnterpriseKeyCredentialRegistrationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnterpriseKeyCredentialRegistrationManager> for &::windows::core::IUnknown {
-    fn from(value: &EnterpriseKeyCredentialRegistrationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EnterpriseKeyCredentialRegistrationManager> for ::windows::core::IInspectable {
-    fn from(value: EnterpriseKeyCredentialRegistrationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnterpriseKeyCredentialRegistrationManager> for ::windows::core::IInspectable {
-    fn from(value: &EnterpriseKeyCredentialRegistrationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnterpriseKeyCredentialRegistrationManager> for &::windows::core::IInspectable {
-    fn from(value: &EnterpriseKeyCredentialRegistrationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EnterpriseKeyCredentialRegistrationManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EnterpriseKeyCredentialRegistrationManager {}
 unsafe impl ::core::marker::Sync for EnterpriseKeyCredentialRegistrationManager {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
@@ -278,36 +278,7 @@ unsafe impl ::windows::core::Interface for OnlineIdAuthenticator {
 impl ::windows::core::RuntimeName for OnlineIdAuthenticator {
     const NAME: &'static str = "Windows.Security.Authentication.OnlineId.OnlineIdAuthenticator";
 }
-impl ::core::convert::From<OnlineIdAuthenticator> for ::windows::core::IUnknown {
-    fn from(value: OnlineIdAuthenticator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdAuthenticator> for ::windows::core::IUnknown {
-    fn from(value: &OnlineIdAuthenticator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdAuthenticator> for &::windows::core::IUnknown {
-    fn from(value: &OnlineIdAuthenticator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OnlineIdAuthenticator> for ::windows::core::IInspectable {
-    fn from(value: OnlineIdAuthenticator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdAuthenticator> for ::windows::core::IInspectable {
-    fn from(value: &OnlineIdAuthenticator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdAuthenticator> for &::windows::core::IInspectable {
-    fn from(value: &OnlineIdAuthenticator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OnlineIdAuthenticator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OnlineIdAuthenticator {}
 unsafe impl ::core::marker::Sync for OnlineIdAuthenticator {}
 #[doc = "*Required features: `\"Security_Authentication_OnlineId\"`*"]
@@ -368,36 +339,7 @@ unsafe impl ::windows::core::Interface for OnlineIdServiceTicket {
 impl ::windows::core::RuntimeName for OnlineIdServiceTicket {
     const NAME: &'static str = "Windows.Security.Authentication.OnlineId.OnlineIdServiceTicket";
 }
-impl ::core::convert::From<OnlineIdServiceTicket> for ::windows::core::IUnknown {
-    fn from(value: OnlineIdServiceTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdServiceTicket> for ::windows::core::IUnknown {
-    fn from(value: &OnlineIdServiceTicket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdServiceTicket> for &::windows::core::IUnknown {
-    fn from(value: &OnlineIdServiceTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OnlineIdServiceTicket> for ::windows::core::IInspectable {
-    fn from(value: OnlineIdServiceTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdServiceTicket> for ::windows::core::IInspectable {
-    fn from(value: &OnlineIdServiceTicket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdServiceTicket> for &::windows::core::IInspectable {
-    fn from(value: &OnlineIdServiceTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OnlineIdServiceTicket, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OnlineIdServiceTicket {}
 unsafe impl ::core::marker::Sync for OnlineIdServiceTicket {}
 #[doc = "*Required features: `\"Security_Authentication_OnlineId\"`*"]
@@ -468,36 +410,7 @@ unsafe impl ::windows::core::Interface for OnlineIdServiceTicketRequest {
 impl ::windows::core::RuntimeName for OnlineIdServiceTicketRequest {
     const NAME: &'static str = "Windows.Security.Authentication.OnlineId.OnlineIdServiceTicketRequest";
 }
-impl ::core::convert::From<OnlineIdServiceTicketRequest> for ::windows::core::IUnknown {
-    fn from(value: OnlineIdServiceTicketRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdServiceTicketRequest> for ::windows::core::IUnknown {
-    fn from(value: &OnlineIdServiceTicketRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdServiceTicketRequest> for &::windows::core::IUnknown {
-    fn from(value: &OnlineIdServiceTicketRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OnlineIdServiceTicketRequest> for ::windows::core::IInspectable {
-    fn from(value: OnlineIdServiceTicketRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdServiceTicketRequest> for ::windows::core::IInspectable {
-    fn from(value: &OnlineIdServiceTicketRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdServiceTicketRequest> for &::windows::core::IInspectable {
-    fn from(value: &OnlineIdServiceTicketRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OnlineIdServiceTicketRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OnlineIdServiceTicketRequest {}
 unsafe impl ::core::marker::Sync for OnlineIdServiceTicketRequest {}
 #[doc = "*Required features: `\"Security_Authentication_OnlineId\"`*"]
@@ -592,36 +505,7 @@ unsafe impl ::windows::core::Interface for OnlineIdSystemAuthenticatorForUser {
 impl ::windows::core::RuntimeName for OnlineIdSystemAuthenticatorForUser {
     const NAME: &'static str = "Windows.Security.Authentication.OnlineId.OnlineIdSystemAuthenticatorForUser";
 }
-impl ::core::convert::From<OnlineIdSystemAuthenticatorForUser> for ::windows::core::IUnknown {
-    fn from(value: OnlineIdSystemAuthenticatorForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemAuthenticatorForUser> for ::windows::core::IUnknown {
-    fn from(value: &OnlineIdSystemAuthenticatorForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemAuthenticatorForUser> for &::windows::core::IUnknown {
-    fn from(value: &OnlineIdSystemAuthenticatorForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OnlineIdSystemAuthenticatorForUser> for ::windows::core::IInspectable {
-    fn from(value: OnlineIdSystemAuthenticatorForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemAuthenticatorForUser> for ::windows::core::IInspectable {
-    fn from(value: &OnlineIdSystemAuthenticatorForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemAuthenticatorForUser> for &::windows::core::IInspectable {
-    fn from(value: &OnlineIdSystemAuthenticatorForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OnlineIdSystemAuthenticatorForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OnlineIdSystemAuthenticatorForUser {}
 unsafe impl ::core::marker::Sync for OnlineIdSystemAuthenticatorForUser {}
 #[doc = "*Required features: `\"Security_Authentication_OnlineId\"`*"]
@@ -675,36 +559,7 @@ unsafe impl ::windows::core::Interface for OnlineIdSystemIdentity {
 impl ::windows::core::RuntimeName for OnlineIdSystemIdentity {
     const NAME: &'static str = "Windows.Security.Authentication.OnlineId.OnlineIdSystemIdentity";
 }
-impl ::core::convert::From<OnlineIdSystemIdentity> for ::windows::core::IUnknown {
-    fn from(value: OnlineIdSystemIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemIdentity> for ::windows::core::IUnknown {
-    fn from(value: &OnlineIdSystemIdentity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemIdentity> for &::windows::core::IUnknown {
-    fn from(value: &OnlineIdSystemIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OnlineIdSystemIdentity> for ::windows::core::IInspectable {
-    fn from(value: OnlineIdSystemIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemIdentity> for ::windows::core::IInspectable {
-    fn from(value: &OnlineIdSystemIdentity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemIdentity> for &::windows::core::IInspectable {
-    fn from(value: &OnlineIdSystemIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OnlineIdSystemIdentity, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OnlineIdSystemIdentity {}
 unsafe impl ::core::marker::Sync for OnlineIdSystemIdentity {}
 #[doc = "*Required features: `\"Security_Authentication_OnlineId\"`*"]
@@ -765,36 +620,7 @@ unsafe impl ::windows::core::Interface for OnlineIdSystemTicketResult {
 impl ::windows::core::RuntimeName for OnlineIdSystemTicketResult {
     const NAME: &'static str = "Windows.Security.Authentication.OnlineId.OnlineIdSystemTicketResult";
 }
-impl ::core::convert::From<OnlineIdSystemTicketResult> for ::windows::core::IUnknown {
-    fn from(value: OnlineIdSystemTicketResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemTicketResult> for ::windows::core::IUnknown {
-    fn from(value: &OnlineIdSystemTicketResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemTicketResult> for &::windows::core::IUnknown {
-    fn from(value: &OnlineIdSystemTicketResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OnlineIdSystemTicketResult> for ::windows::core::IInspectable {
-    fn from(value: OnlineIdSystemTicketResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemTicketResult> for ::windows::core::IInspectable {
-    fn from(value: &OnlineIdSystemTicketResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OnlineIdSystemTicketResult> for &::windows::core::IInspectable {
-    fn from(value: &OnlineIdSystemTicketResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OnlineIdSystemTicketResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OnlineIdSystemTicketResult {}
 unsafe impl ::core::marker::Sync for OnlineIdSystemTicketResult {}
 #[doc = "*Required features: `\"Security_Authentication_OnlineId\"`, `\"Foundation\"`*"]
@@ -936,41 +762,7 @@ impl ::std::future::Future for SignOutUserOperation {
     }
 }
 #[cfg(feature = "Foundation")]
-impl ::core::convert::From<SignOutUserOperation> for ::windows::core::IUnknown {
-    fn from(value: SignOutUserOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&SignOutUserOperation> for ::windows::core::IUnknown {
-    fn from(value: &SignOutUserOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&SignOutUserOperation> for &::windows::core::IUnknown {
-    fn from(value: &SignOutUserOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<SignOutUserOperation> for ::windows::core::IInspectable {
-    fn from(value: SignOutUserOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&SignOutUserOperation> for ::windows::core::IInspectable {
-    fn from(value: &SignOutUserOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&SignOutUserOperation> for &::windows::core::IInspectable {
-    fn from(value: &SignOutUserOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SignOutUserOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<SignOutUserOperation> for super::super::super::Foundation::IAsyncAction {
     type Error = ::windows::core::Error;
@@ -1161,41 +953,7 @@ impl ::std::future::Future for UserAuthenticationOperation {
     }
 }
 #[cfg(feature = "Foundation")]
-impl ::core::convert::From<UserAuthenticationOperation> for ::windows::core::IUnknown {
-    fn from(value: UserAuthenticationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&UserAuthenticationOperation> for ::windows::core::IUnknown {
-    fn from(value: &UserAuthenticationOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&UserAuthenticationOperation> for &::windows::core::IUnknown {
-    fn from(value: &UserAuthenticationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<UserAuthenticationOperation> for ::windows::core::IInspectable {
-    fn from(value: UserAuthenticationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&UserAuthenticationOperation> for ::windows::core::IInspectable {
-    fn from(value: &UserAuthenticationOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&UserAuthenticationOperation> for &::windows::core::IInspectable {
-    fn from(value: &UserAuthenticationOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserAuthenticationOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<UserAuthenticationOperation> for super::super::super::Foundation::IAsyncInfo {
     type Error = ::windows::core::Error;
@@ -1339,36 +1097,7 @@ unsafe impl ::windows::core::Interface for UserIdentity {
 impl ::windows::core::RuntimeName for UserIdentity {
     const NAME: &'static str = "Windows.Security.Authentication.OnlineId.UserIdentity";
 }
-impl ::core::convert::From<UserIdentity> for ::windows::core::IUnknown {
-    fn from(value: UserIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserIdentity> for ::windows::core::IUnknown {
-    fn from(value: &UserIdentity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserIdentity> for &::windows::core::IUnknown {
-    fn from(value: &UserIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserIdentity> for ::windows::core::IInspectable {
-    fn from(value: UserIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserIdentity> for ::windows::core::IInspectable {
-    fn from(value: &UserIdentity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserIdentity> for &::windows::core::IInspectable {
-    fn from(value: &UserIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserIdentity, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserIdentity {}
 unsafe impl ::core::marker::Sync for UserIdentity {}
 #[doc = "*Required features: `\"Security_Authentication_OnlineId\"`*"]

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Core/mod.rs
@@ -463,36 +463,7 @@ unsafe impl ::windows::core::Interface for FindAllAccountsResult {
 impl ::windows::core::RuntimeName for FindAllAccountsResult {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Core.FindAllAccountsResult";
 }
-impl ::core::convert::From<FindAllAccountsResult> for ::windows::core::IUnknown {
-    fn from(value: FindAllAccountsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FindAllAccountsResult> for ::windows::core::IUnknown {
-    fn from(value: &FindAllAccountsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FindAllAccountsResult> for &::windows::core::IUnknown {
-    fn from(value: &FindAllAccountsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FindAllAccountsResult> for ::windows::core::IInspectable {
-    fn from(value: FindAllAccountsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FindAllAccountsResult> for ::windows::core::IInspectable {
-    fn from(value: &FindAllAccountsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FindAllAccountsResult> for &::windows::core::IInspectable {
-    fn from(value: &FindAllAccountsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FindAllAccountsResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FindAllAccountsResult {}
 unsafe impl ::core::marker::Sync for FindAllAccountsResult {}
 #[doc = "*Required features: `\"Security_Authentication_Web_Core\"`*"]
@@ -541,36 +512,7 @@ unsafe impl ::windows::core::Interface for WebAccountEventArgs {
 impl ::windows::core::RuntimeName for WebAccountEventArgs {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Core.WebAccountEventArgs";
 }
-impl ::core::convert::From<WebAccountEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebAccountEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebAccountEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebAccountEventArgs {}
 unsafe impl ::core::marker::Sync for WebAccountEventArgs {}
 #[doc = "*Required features: `\"Security_Authentication_Web_Core\"`*"]
@@ -670,36 +612,7 @@ unsafe impl ::windows::core::Interface for WebAccountMonitor {
 impl ::windows::core::RuntimeName for WebAccountMonitor {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Core.WebAccountMonitor";
 }
-impl ::core::convert::From<WebAccountMonitor> for ::windows::core::IUnknown {
-    fn from(value: WebAccountMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountMonitor> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountMonitor> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountMonitor> for ::windows::core::IInspectable {
-    fn from(value: WebAccountMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountMonitor> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountMonitor> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountMonitor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebAccountMonitor {}
 unsafe impl ::core::marker::Sync for WebAccountMonitor {}
 #[doc = "*Required features: `\"Security_Authentication_Web_Core\"`*"]
@@ -916,36 +829,7 @@ unsafe impl ::windows::core::Interface for WebProviderError {
 impl ::windows::core::RuntimeName for WebProviderError {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Core.WebProviderError";
 }
-impl ::core::convert::From<WebProviderError> for ::windows::core::IUnknown {
-    fn from(value: WebProviderError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebProviderError> for ::windows::core::IUnknown {
-    fn from(value: &WebProviderError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebProviderError> for &::windows::core::IUnknown {
-    fn from(value: &WebProviderError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebProviderError> for ::windows::core::IInspectable {
-    fn from(value: WebProviderError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebProviderError> for ::windows::core::IInspectable {
-    fn from(value: &WebProviderError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebProviderError> for &::windows::core::IInspectable {
-    fn from(value: &WebProviderError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebProviderError, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebProviderError {}
 unsafe impl ::core::marker::Sync for WebProviderError {}
 #[doc = "*Required features: `\"Security_Authentication_Web_Core\"`*"]
@@ -1081,36 +965,7 @@ unsafe impl ::windows::core::Interface for WebTokenRequest {
 impl ::windows::core::RuntimeName for WebTokenRequest {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Core.WebTokenRequest";
 }
-impl ::core::convert::From<WebTokenRequest> for ::windows::core::IUnknown {
-    fn from(value: WebTokenRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebTokenRequest> for ::windows::core::IUnknown {
-    fn from(value: &WebTokenRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebTokenRequest> for &::windows::core::IUnknown {
-    fn from(value: &WebTokenRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebTokenRequest> for ::windows::core::IInspectable {
-    fn from(value: WebTokenRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebTokenRequest> for ::windows::core::IInspectable {
-    fn from(value: &WebTokenRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebTokenRequest> for &::windows::core::IInspectable {
-    fn from(value: &WebTokenRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebTokenRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebTokenRequest {}
 unsafe impl ::core::marker::Sync for WebTokenRequest {}
 #[doc = "*Required features: `\"Security_Authentication_Web_Core\"`*"]
@@ -1182,36 +1037,7 @@ unsafe impl ::windows::core::Interface for WebTokenRequestResult {
 impl ::windows::core::RuntimeName for WebTokenRequestResult {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Core.WebTokenRequestResult";
 }
-impl ::core::convert::From<WebTokenRequestResult> for ::windows::core::IUnknown {
-    fn from(value: WebTokenRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebTokenRequestResult> for ::windows::core::IUnknown {
-    fn from(value: &WebTokenRequestResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebTokenRequestResult> for &::windows::core::IUnknown {
-    fn from(value: &WebTokenRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebTokenRequestResult> for ::windows::core::IInspectable {
-    fn from(value: WebTokenRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebTokenRequestResult> for ::windows::core::IInspectable {
-    fn from(value: &WebTokenRequestResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebTokenRequestResult> for &::windows::core::IInspectable {
-    fn from(value: &WebTokenRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebTokenRequestResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebTokenRequestResult {}
 unsafe impl ::core::marker::Sync for WebTokenRequestResult {}
 #[doc = "*Required features: `\"Security_Authentication_Web_Core\"`*"]
@@ -1317,36 +1143,7 @@ unsafe impl ::windows::core::Interface for WebTokenResponse {
 impl ::windows::core::RuntimeName for WebTokenResponse {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Core.WebTokenResponse";
 }
-impl ::core::convert::From<WebTokenResponse> for ::windows::core::IUnknown {
-    fn from(value: WebTokenResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebTokenResponse> for ::windows::core::IUnknown {
-    fn from(value: &WebTokenResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebTokenResponse> for &::windows::core::IUnknown {
-    fn from(value: &WebTokenResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebTokenResponse> for ::windows::core::IInspectable {
-    fn from(value: WebTokenResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebTokenResponse> for ::windows::core::IInspectable {
-    fn from(value: &WebTokenResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebTokenResponse> for &::windows::core::IInspectable {
-    fn from(value: &WebTokenResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebTokenResponse, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebTokenResponse {}
 unsafe impl ::core::marker::Sync for WebTokenResponse {}
 #[doc = "*Required features: `\"Security_Authentication_Web_Core\"`*"]

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
@@ -224,36 +224,7 @@ impl IWebAccountProviderBaseReportOperation {
         unsafe { (::windows::core::Vtable::vtable(this).ReportError)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(value)).ok() }
     }
 }
-impl ::core::convert::From<IWebAccountProviderBaseReportOperation> for ::windows::core::IUnknown {
-    fn from(value: IWebAccountProviderBaseReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderBaseReportOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAccountProviderBaseReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderBaseReportOperation> for ::windows::core::IUnknown {
-    fn from(value: &IWebAccountProviderBaseReportOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebAccountProviderBaseReportOperation> for ::windows::core::IInspectable {
-    fn from(value: IWebAccountProviderBaseReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderBaseReportOperation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebAccountProviderBaseReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderBaseReportOperation> for ::windows::core::IInspectable {
-    fn from(value: &IWebAccountProviderBaseReportOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAccountProviderBaseReportOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebAccountProviderBaseReportOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -342,36 +313,7 @@ impl IWebAccountProviderOperation {
         }
     }
 }
-impl ::core::convert::From<IWebAccountProviderOperation> for ::windows::core::IUnknown {
-    fn from(value: IWebAccountProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAccountProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderOperation> for ::windows::core::IUnknown {
-    fn from(value: &IWebAccountProviderOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebAccountProviderOperation> for ::windows::core::IInspectable {
-    fn from(value: IWebAccountProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderOperation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebAccountProviderOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderOperation> for ::windows::core::IInspectable {
-    fn from(value: &IWebAccountProviderOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAccountProviderOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebAccountProviderOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -489,36 +431,7 @@ impl IWebAccountProviderSilentReportOperation {
         unsafe { (::windows::core::Vtable::vtable(this).ReportError)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(value)).ok() }
     }
 }
-impl ::core::convert::From<IWebAccountProviderSilentReportOperation> for ::windows::core::IUnknown {
-    fn from(value: IWebAccountProviderSilentReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderSilentReportOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAccountProviderSilentReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderSilentReportOperation> for ::windows::core::IUnknown {
-    fn from(value: &IWebAccountProviderSilentReportOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebAccountProviderSilentReportOperation> for ::windows::core::IInspectable {
-    fn from(value: IWebAccountProviderSilentReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderSilentReportOperation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebAccountProviderSilentReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderSilentReportOperation> for ::windows::core::IInspectable {
-    fn from(value: &IWebAccountProviderSilentReportOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAccountProviderSilentReportOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IWebAccountProviderSilentReportOperation> for IWebAccountProviderBaseReportOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: IWebAccountProviderSilentReportOperation) -> ::windows::core::Result<Self> {
@@ -589,36 +502,7 @@ impl IWebAccountProviderTokenObjects {
         }
     }
 }
-impl ::core::convert::From<IWebAccountProviderTokenObjects> for ::windows::core::IUnknown {
-    fn from(value: IWebAccountProviderTokenObjects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderTokenObjects> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAccountProviderTokenObjects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderTokenObjects> for ::windows::core::IUnknown {
-    fn from(value: &IWebAccountProviderTokenObjects) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebAccountProviderTokenObjects> for ::windows::core::IInspectable {
-    fn from(value: IWebAccountProviderTokenObjects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderTokenObjects> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebAccountProviderTokenObjects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderTokenObjects> for ::windows::core::IInspectable {
-    fn from(value: &IWebAccountProviderTokenObjects) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAccountProviderTokenObjects, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebAccountProviderTokenObjects {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -675,36 +559,7 @@ impl IWebAccountProviderTokenObjects2 {
         }
     }
 }
-impl ::core::convert::From<IWebAccountProviderTokenObjects2> for ::windows::core::IUnknown {
-    fn from(value: IWebAccountProviderTokenObjects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderTokenObjects2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAccountProviderTokenObjects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderTokenObjects2> for ::windows::core::IUnknown {
-    fn from(value: &IWebAccountProviderTokenObjects2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebAccountProviderTokenObjects2> for ::windows::core::IInspectable {
-    fn from(value: IWebAccountProviderTokenObjects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderTokenObjects2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebAccountProviderTokenObjects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderTokenObjects2> for ::windows::core::IInspectable {
-    fn from(value: &IWebAccountProviderTokenObjects2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAccountProviderTokenObjects2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IWebAccountProviderTokenObjects2> for IWebAccountProviderTokenObjects {
     type Error = ::windows::core::Error;
     fn try_from(value: IWebAccountProviderTokenObjects2) -> ::windows::core::Result<Self> {
@@ -805,36 +660,7 @@ impl IWebAccountProviderTokenOperation {
         }
     }
 }
-impl ::core::convert::From<IWebAccountProviderTokenOperation> for ::windows::core::IUnknown {
-    fn from(value: IWebAccountProviderTokenOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderTokenOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAccountProviderTokenOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderTokenOperation> for ::windows::core::IUnknown {
-    fn from(value: &IWebAccountProviderTokenOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebAccountProviderTokenOperation> for ::windows::core::IInspectable {
-    fn from(value: IWebAccountProviderTokenOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderTokenOperation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebAccountProviderTokenOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderTokenOperation> for ::windows::core::IInspectable {
-    fn from(value: &IWebAccountProviderTokenOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAccountProviderTokenOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IWebAccountProviderTokenOperation> for IWebAccountProviderOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: IWebAccountProviderTokenOperation) -> ::windows::core::Result<Self> {
@@ -920,36 +746,7 @@ impl IWebAccountProviderUIReportOperation {
         unsafe { (::windows::core::Vtable::vtable(this).ReportError)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(value)).ok() }
     }
 }
-impl ::core::convert::From<IWebAccountProviderUIReportOperation> for ::windows::core::IUnknown {
-    fn from(value: IWebAccountProviderUIReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderUIReportOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAccountProviderUIReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderUIReportOperation> for ::windows::core::IUnknown {
-    fn from(value: &IWebAccountProviderUIReportOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebAccountProviderUIReportOperation> for ::windows::core::IInspectable {
-    fn from(value: IWebAccountProviderUIReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccountProviderUIReportOperation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebAccountProviderUIReportOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccountProviderUIReportOperation> for ::windows::core::IInspectable {
-    fn from(value: &IWebAccountProviderUIReportOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAccountProviderUIReportOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IWebAccountProviderUIReportOperation> for IWebAccountProviderBaseReportOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: IWebAccountProviderUIReportOperation) -> ::windows::core::Result<Self> {
@@ -1216,36 +1013,7 @@ unsafe impl ::windows::core::Interface for WebAccountClientView {
 impl ::windows::core::RuntimeName for WebAccountClientView {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebAccountClientView";
 }
-impl ::core::convert::From<WebAccountClientView> for ::windows::core::IUnknown {
-    fn from(value: WebAccountClientView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountClientView> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountClientView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountClientView> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountClientView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountClientView> for ::windows::core::IInspectable {
-    fn from(value: WebAccountClientView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountClientView> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountClientView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountClientView> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountClientView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountClientView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebAccountClientView {}
 unsafe impl ::core::marker::Sync for WebAccountClientView {}
 #[doc = "*Required features: `\"Security_Authentication_Web_Provider\"`*"]
@@ -1561,36 +1329,7 @@ unsafe impl ::windows::core::Interface for WebAccountProviderAddAccountOperation
 impl ::windows::core::RuntimeName for WebAccountProviderAddAccountOperation {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebAccountProviderAddAccountOperation";
 }
-impl ::core::convert::From<WebAccountProviderAddAccountOperation> for ::windows::core::IUnknown {
-    fn from(value: WebAccountProviderAddAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderAddAccountOperation> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderAddAccountOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderAddAccountOperation> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderAddAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountProviderAddAccountOperation> for ::windows::core::IInspectable {
-    fn from(value: WebAccountProviderAddAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderAddAccountOperation> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderAddAccountOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderAddAccountOperation> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderAddAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountProviderAddAccountOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebAccountProviderAddAccountOperation> for IWebAccountProviderOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: WebAccountProviderAddAccountOperation) -> ::windows::core::Result<Self> {
@@ -1675,36 +1414,7 @@ unsafe impl ::windows::core::Interface for WebAccountProviderDeleteAccountOperat
 impl ::windows::core::RuntimeName for WebAccountProviderDeleteAccountOperation {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebAccountProviderDeleteAccountOperation";
 }
-impl ::core::convert::From<WebAccountProviderDeleteAccountOperation> for ::windows::core::IUnknown {
-    fn from(value: WebAccountProviderDeleteAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderDeleteAccountOperation> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderDeleteAccountOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderDeleteAccountOperation> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderDeleteAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountProviderDeleteAccountOperation> for ::windows::core::IInspectable {
-    fn from(value: WebAccountProviderDeleteAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderDeleteAccountOperation> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderDeleteAccountOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderDeleteAccountOperation> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderDeleteAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountProviderDeleteAccountOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebAccountProviderDeleteAccountOperation> for IWebAccountProviderBaseReportOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: WebAccountProviderDeleteAccountOperation) -> ::windows::core::Result<Self> {
@@ -1840,36 +1550,7 @@ unsafe impl ::windows::core::Interface for WebAccountProviderGetTokenSilentOpera
 impl ::windows::core::RuntimeName for WebAccountProviderGetTokenSilentOperation {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebAccountProviderGetTokenSilentOperation";
 }
-impl ::core::convert::From<WebAccountProviderGetTokenSilentOperation> for ::windows::core::IUnknown {
-    fn from(value: WebAccountProviderGetTokenSilentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderGetTokenSilentOperation> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderGetTokenSilentOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderGetTokenSilentOperation> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderGetTokenSilentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountProviderGetTokenSilentOperation> for ::windows::core::IInspectable {
-    fn from(value: WebAccountProviderGetTokenSilentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderGetTokenSilentOperation> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderGetTokenSilentOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderGetTokenSilentOperation> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderGetTokenSilentOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountProviderGetTokenSilentOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebAccountProviderGetTokenSilentOperation> for IWebAccountProviderBaseReportOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: WebAccountProviderGetTokenSilentOperation) -> ::windows::core::Result<Self> {
@@ -2005,36 +1686,7 @@ unsafe impl ::windows::core::Interface for WebAccountProviderManageAccountOperat
 impl ::windows::core::RuntimeName for WebAccountProviderManageAccountOperation {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebAccountProviderManageAccountOperation";
 }
-impl ::core::convert::From<WebAccountProviderManageAccountOperation> for ::windows::core::IUnknown {
-    fn from(value: WebAccountProviderManageAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderManageAccountOperation> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderManageAccountOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderManageAccountOperation> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderManageAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountProviderManageAccountOperation> for ::windows::core::IInspectable {
-    fn from(value: WebAccountProviderManageAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderManageAccountOperation> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderManageAccountOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderManageAccountOperation> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderManageAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountProviderManageAccountOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebAccountProviderManageAccountOperation> for IWebAccountProviderOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: WebAccountProviderManageAccountOperation) -> ::windows::core::Result<Self> {
@@ -2145,36 +1797,7 @@ unsafe impl ::windows::core::Interface for WebAccountProviderRequestTokenOperati
 impl ::windows::core::RuntimeName for WebAccountProviderRequestTokenOperation {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebAccountProviderRequestTokenOperation";
 }
-impl ::core::convert::From<WebAccountProviderRequestTokenOperation> for ::windows::core::IUnknown {
-    fn from(value: WebAccountProviderRequestTokenOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderRequestTokenOperation> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderRequestTokenOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderRequestTokenOperation> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderRequestTokenOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountProviderRequestTokenOperation> for ::windows::core::IInspectable {
-    fn from(value: WebAccountProviderRequestTokenOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderRequestTokenOperation> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderRequestTokenOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderRequestTokenOperation> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderRequestTokenOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountProviderRequestTokenOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebAccountProviderRequestTokenOperation> for IWebAccountProviderBaseReportOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: WebAccountProviderRequestTokenOperation) -> ::windows::core::Result<Self> {
@@ -2349,36 +1972,7 @@ unsafe impl ::windows::core::Interface for WebAccountProviderRetrieveCookiesOper
 impl ::windows::core::RuntimeName for WebAccountProviderRetrieveCookiesOperation {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebAccountProviderRetrieveCookiesOperation";
 }
-impl ::core::convert::From<WebAccountProviderRetrieveCookiesOperation> for ::windows::core::IUnknown {
-    fn from(value: WebAccountProviderRetrieveCookiesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderRetrieveCookiesOperation> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderRetrieveCookiesOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderRetrieveCookiesOperation> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderRetrieveCookiesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountProviderRetrieveCookiesOperation> for ::windows::core::IInspectable {
-    fn from(value: WebAccountProviderRetrieveCookiesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderRetrieveCookiesOperation> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderRetrieveCookiesOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderRetrieveCookiesOperation> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderRetrieveCookiesOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountProviderRetrieveCookiesOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebAccountProviderRetrieveCookiesOperation> for IWebAccountProviderBaseReportOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: WebAccountProviderRetrieveCookiesOperation) -> ::windows::core::Result<Self> {
@@ -2498,36 +2092,7 @@ unsafe impl ::windows::core::Interface for WebAccountProviderSignOutAccountOpera
 impl ::windows::core::RuntimeName for WebAccountProviderSignOutAccountOperation {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebAccountProviderSignOutAccountOperation";
 }
-impl ::core::convert::From<WebAccountProviderSignOutAccountOperation> for ::windows::core::IUnknown {
-    fn from(value: WebAccountProviderSignOutAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderSignOutAccountOperation> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderSignOutAccountOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderSignOutAccountOperation> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderSignOutAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountProviderSignOutAccountOperation> for ::windows::core::IInspectable {
-    fn from(value: WebAccountProviderSignOutAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderSignOutAccountOperation> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderSignOutAccountOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderSignOutAccountOperation> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderSignOutAccountOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountProviderSignOutAccountOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebAccountProviderSignOutAccountOperation> for IWebAccountProviderBaseReportOperation {
     type Error = ::windows::core::Error;
     fn try_from(value: WebAccountProviderSignOutAccountOperation) -> ::windows::core::Result<Self> {
@@ -2621,36 +2186,7 @@ unsafe impl ::windows::core::Interface for WebAccountProviderTriggerDetails {
 impl ::windows::core::RuntimeName for WebAccountProviderTriggerDetails {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebAccountProviderTriggerDetails";
 }
-impl ::core::convert::From<WebAccountProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: WebAccountProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: WebAccountProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountProviderTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebAccountProviderTriggerDetails> for IWebAccountProviderTokenObjects {
     type Error = ::windows::core::Error;
     fn try_from(value: WebAccountProviderTriggerDetails) -> ::windows::core::Result<Self> {
@@ -2803,36 +2339,7 @@ unsafe impl ::windows::core::Interface for WebProviderTokenRequest {
 impl ::windows::core::RuntimeName for WebProviderTokenRequest {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebProviderTokenRequest";
 }
-impl ::core::convert::From<WebProviderTokenRequest> for ::windows::core::IUnknown {
-    fn from(value: WebProviderTokenRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebProviderTokenRequest> for ::windows::core::IUnknown {
-    fn from(value: &WebProviderTokenRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebProviderTokenRequest> for &::windows::core::IUnknown {
-    fn from(value: &WebProviderTokenRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebProviderTokenRequest> for ::windows::core::IInspectable {
-    fn from(value: WebProviderTokenRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebProviderTokenRequest> for ::windows::core::IInspectable {
-    fn from(value: &WebProviderTokenRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebProviderTokenRequest> for &::windows::core::IInspectable {
-    fn from(value: &WebProviderTokenRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebProviderTokenRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebProviderTokenRequest {}
 unsafe impl ::core::marker::Sync for WebProviderTokenRequest {}
 #[doc = "*Required features: `\"Security_Authentication_Web_Provider\"`*"]
@@ -2894,36 +2401,7 @@ unsafe impl ::windows::core::Interface for WebProviderTokenResponse {
 impl ::windows::core::RuntimeName for WebProviderTokenResponse {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebProviderTokenResponse";
 }
-impl ::core::convert::From<WebProviderTokenResponse> for ::windows::core::IUnknown {
-    fn from(value: WebProviderTokenResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebProviderTokenResponse> for ::windows::core::IUnknown {
-    fn from(value: &WebProviderTokenResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebProviderTokenResponse> for &::windows::core::IUnknown {
-    fn from(value: &WebProviderTokenResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebProviderTokenResponse> for ::windows::core::IInspectable {
-    fn from(value: WebProviderTokenResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebProviderTokenResponse> for ::windows::core::IInspectable {
-    fn from(value: &WebProviderTokenResponse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebProviderTokenResponse> for &::windows::core::IInspectable {
-    fn from(value: &WebProviderTokenResponse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebProviderTokenResponse, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebProviderTokenResponse {}
 unsafe impl ::core::marker::Sync for WebProviderTokenResponse {}
 #[doc = "*Required features: `\"Security_Authentication_Web_Provider\"`*"]

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
@@ -209,36 +209,7 @@ unsafe impl ::windows::core::Interface for WebAuthenticationResult {
 impl ::windows::core::RuntimeName for WebAuthenticationResult {
     const NAME: &'static str = "Windows.Security.Authentication.Web.WebAuthenticationResult";
 }
-impl ::core::convert::From<WebAuthenticationResult> for ::windows::core::IUnknown {
-    fn from(value: WebAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAuthenticationResult> for ::windows::core::IUnknown {
-    fn from(value: &WebAuthenticationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAuthenticationResult> for &::windows::core::IUnknown {
-    fn from(value: &WebAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAuthenticationResult> for ::windows::core::IInspectable {
-    fn from(value: WebAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAuthenticationResult> for ::windows::core::IInspectable {
-    fn from(value: &WebAuthenticationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAuthenticationResult> for &::windows::core::IInspectable {
-    fn from(value: &WebAuthenticationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAuthenticationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Security_Authentication_Web\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/Security/Authorization/AppCapabilityAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authorization/AppCapabilityAccess/mod.rs
@@ -198,36 +198,7 @@ unsafe impl ::windows::core::Interface for AppCapability {
 impl ::windows::core::RuntimeName for AppCapability {
     const NAME: &'static str = "Windows.Security.Authorization.AppCapabilityAccess.AppCapability";
 }
-impl ::core::convert::From<AppCapability> for ::windows::core::IUnknown {
-    fn from(value: AppCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCapability> for ::windows::core::IUnknown {
-    fn from(value: &AppCapability) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCapability> for &::windows::core::IUnknown {
-    fn from(value: &AppCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCapability> for ::windows::core::IInspectable {
-    fn from(value: AppCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCapability> for ::windows::core::IInspectable {
-    fn from(value: &AppCapability) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCapability> for &::windows::core::IInspectable {
-    fn from(value: &AppCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCapability, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppCapability {}
 unsafe impl ::core::marker::Sync for AppCapability {}
 #[doc = "*Required features: `\"Security_Authorization_AppCapabilityAccess\"`*"]
@@ -266,36 +237,7 @@ unsafe impl ::windows::core::Interface for AppCapabilityAccessChangedEventArgs {
 impl ::windows::core::RuntimeName for AppCapabilityAccessChangedEventArgs {
     const NAME: &'static str = "Windows.Security.Authorization.AppCapabilityAccess.AppCapabilityAccessChangedEventArgs";
 }
-impl ::core::convert::From<AppCapabilityAccessChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppCapabilityAccessChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCapabilityAccessChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppCapabilityAccessChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCapabilityAccessChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppCapabilityAccessChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppCapabilityAccessChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppCapabilityAccessChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppCapabilityAccessChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppCapabilityAccessChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppCapabilityAccessChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppCapabilityAccessChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppCapabilityAccessChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppCapabilityAccessChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppCapabilityAccessChangedEventArgs {}
 #[doc = "*Required features: `\"Security_Authorization_AppCapabilityAccess\"`*"]

--- a/crates/libs/windows/src/Windows/Security/Credentials/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/UI/mod.rs
@@ -308,36 +308,7 @@ unsafe impl ::windows::core::Interface for CredentialPickerOptions {
 impl ::windows::core::RuntimeName for CredentialPickerOptions {
     const NAME: &'static str = "Windows.Security.Credentials.UI.CredentialPickerOptions";
 }
-impl ::core::convert::From<CredentialPickerOptions> for ::windows::core::IUnknown {
-    fn from(value: CredentialPickerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CredentialPickerOptions> for ::windows::core::IUnknown {
-    fn from(value: &CredentialPickerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CredentialPickerOptions> for &::windows::core::IUnknown {
-    fn from(value: &CredentialPickerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CredentialPickerOptions> for ::windows::core::IInspectable {
-    fn from(value: CredentialPickerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CredentialPickerOptions> for ::windows::core::IInspectable {
-    fn from(value: &CredentialPickerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CredentialPickerOptions> for &::windows::core::IInspectable {
-    fn from(value: &CredentialPickerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CredentialPickerOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Security_Credentials_UI\"`*"]
 #[repr(transparent)]
 pub struct CredentialPickerResults(::windows::core::IUnknown);
@@ -426,36 +397,7 @@ unsafe impl ::windows::core::Interface for CredentialPickerResults {
 impl ::windows::core::RuntimeName for CredentialPickerResults {
     const NAME: &'static str = "Windows.Security.Credentials.UI.CredentialPickerResults";
 }
-impl ::core::convert::From<CredentialPickerResults> for ::windows::core::IUnknown {
-    fn from(value: CredentialPickerResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CredentialPickerResults> for ::windows::core::IUnknown {
-    fn from(value: &CredentialPickerResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CredentialPickerResults> for &::windows::core::IUnknown {
-    fn from(value: &CredentialPickerResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CredentialPickerResults> for ::windows::core::IInspectable {
-    fn from(value: CredentialPickerResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CredentialPickerResults> for ::windows::core::IInspectable {
-    fn from(value: &CredentialPickerResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CredentialPickerResults> for &::windows::core::IInspectable {
-    fn from(value: &CredentialPickerResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CredentialPickerResults, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Security_Credentials_UI\"`*"]
 pub struct UserConsentVerifier;
 impl UserConsentVerifier {

--- a/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
@@ -218,36 +218,7 @@ impl IWebAccount {
         }
     }
 }
-impl ::core::convert::From<IWebAccount> for ::windows::core::IUnknown {
-    fn from(value: IWebAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccount> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccount> for ::windows::core::IUnknown {
-    fn from(value: &IWebAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebAccount> for ::windows::core::IInspectable {
-    fn from(value: IWebAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAccount> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAccount> for ::windows::core::IInspectable {
-    fn from(value: &IWebAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAccount, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebAccount {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -502,36 +473,7 @@ unsafe impl ::windows::core::Interface for KeyCredential {
 impl ::windows::core::RuntimeName for KeyCredential {
     const NAME: &'static str = "Windows.Security.Credentials.KeyCredential";
 }
-impl ::core::convert::From<KeyCredential> for ::windows::core::IUnknown {
-    fn from(value: KeyCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyCredential> for ::windows::core::IUnknown {
-    fn from(value: &KeyCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyCredential> for &::windows::core::IUnknown {
-    fn from(value: &KeyCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<KeyCredential> for ::windows::core::IInspectable {
-    fn from(value: KeyCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyCredential> for ::windows::core::IInspectable {
-    fn from(value: &KeyCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyCredential> for &::windows::core::IInspectable {
-    fn from(value: &KeyCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(KeyCredential, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for KeyCredential {}
 unsafe impl ::core::marker::Sync for KeyCredential {}
 #[doc = "*Required features: `\"Security_Credentials\"`*"]
@@ -596,36 +538,7 @@ unsafe impl ::windows::core::Interface for KeyCredentialAttestationResult {
 impl ::windows::core::RuntimeName for KeyCredentialAttestationResult {
     const NAME: &'static str = "Windows.Security.Credentials.KeyCredentialAttestationResult";
 }
-impl ::core::convert::From<KeyCredentialAttestationResult> for ::windows::core::IUnknown {
-    fn from(value: KeyCredentialAttestationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyCredentialAttestationResult> for ::windows::core::IUnknown {
-    fn from(value: &KeyCredentialAttestationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyCredentialAttestationResult> for &::windows::core::IUnknown {
-    fn from(value: &KeyCredentialAttestationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<KeyCredentialAttestationResult> for ::windows::core::IInspectable {
-    fn from(value: KeyCredentialAttestationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyCredentialAttestationResult> for ::windows::core::IInspectable {
-    fn from(value: &KeyCredentialAttestationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyCredentialAttestationResult> for &::windows::core::IInspectable {
-    fn from(value: &KeyCredentialAttestationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(KeyCredentialAttestationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for KeyCredentialAttestationResult {}
 unsafe impl ::core::marker::Sync for KeyCredentialAttestationResult {}
 #[doc = "*Required features: `\"Security_Credentials\"`*"]
@@ -733,36 +646,7 @@ unsafe impl ::windows::core::Interface for KeyCredentialOperationResult {
 impl ::windows::core::RuntimeName for KeyCredentialOperationResult {
     const NAME: &'static str = "Windows.Security.Credentials.KeyCredentialOperationResult";
 }
-impl ::core::convert::From<KeyCredentialOperationResult> for ::windows::core::IUnknown {
-    fn from(value: KeyCredentialOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyCredentialOperationResult> for ::windows::core::IUnknown {
-    fn from(value: &KeyCredentialOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyCredentialOperationResult> for &::windows::core::IUnknown {
-    fn from(value: &KeyCredentialOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<KeyCredentialOperationResult> for ::windows::core::IInspectable {
-    fn from(value: KeyCredentialOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyCredentialOperationResult> for ::windows::core::IInspectable {
-    fn from(value: &KeyCredentialOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyCredentialOperationResult> for &::windows::core::IInspectable {
-    fn from(value: &KeyCredentialOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(KeyCredentialOperationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for KeyCredentialOperationResult {}
 unsafe impl ::core::marker::Sync for KeyCredentialOperationResult {}
 #[doc = "*Required features: `\"Security_Credentials\"`*"]
@@ -816,36 +700,7 @@ unsafe impl ::windows::core::Interface for KeyCredentialRetrievalResult {
 impl ::windows::core::RuntimeName for KeyCredentialRetrievalResult {
     const NAME: &'static str = "Windows.Security.Credentials.KeyCredentialRetrievalResult";
 }
-impl ::core::convert::From<KeyCredentialRetrievalResult> for ::windows::core::IUnknown {
-    fn from(value: KeyCredentialRetrievalResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyCredentialRetrievalResult> for ::windows::core::IUnknown {
-    fn from(value: &KeyCredentialRetrievalResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyCredentialRetrievalResult> for &::windows::core::IUnknown {
-    fn from(value: &KeyCredentialRetrievalResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<KeyCredentialRetrievalResult> for ::windows::core::IInspectable {
-    fn from(value: KeyCredentialRetrievalResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyCredentialRetrievalResult> for ::windows::core::IInspectable {
-    fn from(value: &KeyCredentialRetrievalResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyCredentialRetrievalResult> for &::windows::core::IInspectable {
-    fn from(value: &KeyCredentialRetrievalResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(KeyCredentialRetrievalResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for KeyCredentialRetrievalResult {}
 unsafe impl ::core::marker::Sync for KeyCredentialRetrievalResult {}
 #[doc = "*Required features: `\"Security_Credentials\"`*"]
@@ -949,36 +804,7 @@ unsafe impl ::windows::core::Interface for PasswordCredential {
 impl ::windows::core::RuntimeName for PasswordCredential {
     const NAME: &'static str = "Windows.Security.Credentials.PasswordCredential";
 }
-impl ::core::convert::From<PasswordCredential> for ::windows::core::IUnknown {
-    fn from(value: PasswordCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PasswordCredential> for ::windows::core::IUnknown {
-    fn from(value: &PasswordCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PasswordCredential> for &::windows::core::IUnknown {
-    fn from(value: &PasswordCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PasswordCredential> for ::windows::core::IInspectable {
-    fn from(value: PasswordCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PasswordCredential> for ::windows::core::IInspectable {
-    fn from(value: &PasswordCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PasswordCredential> for &::windows::core::IInspectable {
-    fn from(value: &PasswordCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PasswordCredential, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PasswordCredential {}
 unsafe impl ::core::marker::Sync for PasswordCredential {}
 #[doc = "*Required features: `\"Security_Credentials\"`, `\"Foundation_Collections\"`*"]
@@ -1136,41 +962,7 @@ impl ::core::iter::IntoIterator for &PasswordCredentialPropertyStore {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PasswordCredentialPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: PasswordCredentialPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PasswordCredentialPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: &PasswordCredentialPropertyStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PasswordCredentialPropertyStore> for &::windows::core::IUnknown {
-    fn from(value: &PasswordCredentialPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<PasswordCredentialPropertyStore> for ::windows::core::IInspectable {
-    fn from(value: PasswordCredentialPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PasswordCredentialPropertyStore> for ::windows::core::IInspectable {
-    fn from(value: &PasswordCredentialPropertyStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&PasswordCredentialPropertyStore> for &::windows::core::IInspectable {
-    fn from(value: &PasswordCredentialPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PasswordCredentialPropertyStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<PasswordCredentialPropertyStore> for super::super::Foundation::Collections::IIterable<super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
@@ -1349,36 +1141,7 @@ unsafe impl ::windows::core::Interface for PasswordVault {
 impl ::windows::core::RuntimeName for PasswordVault {
     const NAME: &'static str = "Windows.Security.Credentials.PasswordVault";
 }
-impl ::core::convert::From<PasswordVault> for ::windows::core::IUnknown {
-    fn from(value: PasswordVault) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PasswordVault> for ::windows::core::IUnknown {
-    fn from(value: &PasswordVault) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PasswordVault> for &::windows::core::IUnknown {
-    fn from(value: &PasswordVault) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PasswordVault> for ::windows::core::IInspectable {
-    fn from(value: PasswordVault) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PasswordVault> for ::windows::core::IInspectable {
-    fn from(value: &PasswordVault) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PasswordVault> for &::windows::core::IInspectable {
-    fn from(value: &PasswordVault) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PasswordVault, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PasswordVault {}
 unsafe impl ::core::marker::Sync for PasswordVault {}
 #[doc = "*Required features: `\"Security_Credentials\"`*"]
@@ -1493,36 +1256,7 @@ unsafe impl ::windows::core::Interface for WebAccount {
 impl ::windows::core::RuntimeName for WebAccount {
     const NAME: &'static str = "Windows.Security.Credentials.WebAccount";
 }
-impl ::core::convert::From<WebAccount> for ::windows::core::IUnknown {
-    fn from(value: WebAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccount> for ::windows::core::IUnknown {
-    fn from(value: &WebAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccount> for &::windows::core::IUnknown {
-    fn from(value: &WebAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccount> for ::windows::core::IInspectable {
-    fn from(value: WebAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccount> for ::windows::core::IInspectable {
-    fn from(value: &WebAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccount> for &::windows::core::IInspectable {
-    fn from(value: &WebAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccount, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebAccount> for IWebAccount {
     type Error = ::windows::core::Error;
     fn try_from(value: WebAccount) -> ::windows::core::Result<Self> {
@@ -1647,36 +1381,7 @@ unsafe impl ::windows::core::Interface for WebAccountProvider {
 impl ::windows::core::RuntimeName for WebAccountProvider {
     const NAME: &'static str = "Windows.Security.Credentials.WebAccountProvider";
 }
-impl ::core::convert::From<WebAccountProvider> for ::windows::core::IUnknown {
-    fn from(value: WebAccountProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProvider> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProvider> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountProvider> for ::windows::core::IInspectable {
-    fn from(value: WebAccountProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProvider> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProvider> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebAccountProvider {}
 unsafe impl ::core::marker::Sync for WebAccountProvider {}
 #[doc = "*Required features: `\"Security_Credentials\"`*"]

--- a/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
@@ -1215,36 +1215,7 @@ unsafe impl ::windows::core::Interface for Certificate {
 impl ::windows::core::RuntimeName for Certificate {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.Certificate";
 }
-impl ::core::convert::From<Certificate> for ::windows::core::IUnknown {
-    fn from(value: Certificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Certificate> for ::windows::core::IUnknown {
-    fn from(value: &Certificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Certificate> for &::windows::core::IUnknown {
-    fn from(value: &Certificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Certificate> for ::windows::core::IInspectable {
-    fn from(value: Certificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Certificate> for ::windows::core::IInspectable {
-    fn from(value: &Certificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Certificate> for &::windows::core::IInspectable {
-    fn from(value: &Certificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Certificate, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Certificate {}
 unsafe impl ::core::marker::Sync for Certificate {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -1307,36 +1278,7 @@ unsafe impl ::windows::core::Interface for CertificateChain {
 impl ::windows::core::RuntimeName for CertificateChain {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CertificateChain";
 }
-impl ::core::convert::From<CertificateChain> for ::windows::core::IUnknown {
-    fn from(value: CertificateChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateChain> for ::windows::core::IUnknown {
-    fn from(value: &CertificateChain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateChain> for &::windows::core::IUnknown {
-    fn from(value: &CertificateChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CertificateChain> for ::windows::core::IInspectable {
-    fn from(value: CertificateChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateChain> for ::windows::core::IInspectable {
-    fn from(value: &CertificateChain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateChain> for &::windows::core::IInspectable {
-    fn from(value: &CertificateChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CertificateChain, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CertificateChain {}
 unsafe impl ::core::marker::Sync for CertificateChain {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -1488,36 +1430,7 @@ unsafe impl ::windows::core::Interface for CertificateExtension {
 impl ::windows::core::RuntimeName for CertificateExtension {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CertificateExtension";
 }
-impl ::core::convert::From<CertificateExtension> for ::windows::core::IUnknown {
-    fn from(value: CertificateExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateExtension> for ::windows::core::IUnknown {
-    fn from(value: &CertificateExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateExtension> for &::windows::core::IUnknown {
-    fn from(value: &CertificateExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CertificateExtension> for ::windows::core::IInspectable {
-    fn from(value: CertificateExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateExtension> for ::windows::core::IInspectable {
-    fn from(value: &CertificateExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateExtension> for &::windows::core::IInspectable {
-    fn from(value: &CertificateExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CertificateExtension, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CertificateExtension {}
 unsafe impl ::core::marker::Sync for CertificateExtension {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -1652,36 +1565,7 @@ unsafe impl ::windows::core::Interface for CertificateKeyUsages {
 impl ::windows::core::RuntimeName for CertificateKeyUsages {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CertificateKeyUsages";
 }
-impl ::core::convert::From<CertificateKeyUsages> for ::windows::core::IUnknown {
-    fn from(value: CertificateKeyUsages) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateKeyUsages> for ::windows::core::IUnknown {
-    fn from(value: &CertificateKeyUsages) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateKeyUsages> for &::windows::core::IUnknown {
-    fn from(value: &CertificateKeyUsages) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CertificateKeyUsages> for ::windows::core::IInspectable {
-    fn from(value: CertificateKeyUsages) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateKeyUsages> for ::windows::core::IInspectable {
-    fn from(value: &CertificateKeyUsages) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateKeyUsages> for &::windows::core::IInspectable {
-    fn from(value: &CertificateKeyUsages) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CertificateKeyUsages, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CertificateKeyUsages {}
 unsafe impl ::core::marker::Sync for CertificateKeyUsages {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -1814,36 +1698,7 @@ unsafe impl ::windows::core::Interface for CertificateQuery {
 impl ::windows::core::RuntimeName for CertificateQuery {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CertificateQuery";
 }
-impl ::core::convert::From<CertificateQuery> for ::windows::core::IUnknown {
-    fn from(value: CertificateQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateQuery> for ::windows::core::IUnknown {
-    fn from(value: &CertificateQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateQuery> for &::windows::core::IUnknown {
-    fn from(value: &CertificateQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CertificateQuery> for ::windows::core::IInspectable {
-    fn from(value: CertificateQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateQuery> for ::windows::core::IInspectable {
-    fn from(value: &CertificateQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateQuery> for &::windows::core::IInspectable {
-    fn from(value: &CertificateQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CertificateQuery, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CertificateQuery {}
 unsafe impl ::core::marker::Sync for CertificateQuery {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -2102,36 +1957,7 @@ unsafe impl ::windows::core::Interface for CertificateRequestProperties {
 impl ::windows::core::RuntimeName for CertificateRequestProperties {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CertificateRequestProperties";
 }
-impl ::core::convert::From<CertificateRequestProperties> for ::windows::core::IUnknown {
-    fn from(value: CertificateRequestProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateRequestProperties> for ::windows::core::IUnknown {
-    fn from(value: &CertificateRequestProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateRequestProperties> for &::windows::core::IUnknown {
-    fn from(value: &CertificateRequestProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CertificateRequestProperties> for ::windows::core::IInspectable {
-    fn from(value: CertificateRequestProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateRequestProperties> for ::windows::core::IInspectable {
-    fn from(value: &CertificateRequestProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateRequestProperties> for &::windows::core::IInspectable {
-    fn from(value: &CertificateRequestProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CertificateRequestProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CertificateRequestProperties {}
 unsafe impl ::core::marker::Sync for CertificateRequestProperties {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -2186,36 +2012,7 @@ unsafe impl ::windows::core::Interface for CertificateStore {
 impl ::windows::core::RuntimeName for CertificateStore {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CertificateStore";
 }
-impl ::core::convert::From<CertificateStore> for ::windows::core::IUnknown {
-    fn from(value: CertificateStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateStore> for ::windows::core::IUnknown {
-    fn from(value: &CertificateStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateStore> for &::windows::core::IUnknown {
-    fn from(value: &CertificateStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CertificateStore> for ::windows::core::IInspectable {
-    fn from(value: CertificateStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CertificateStore> for ::windows::core::IInspectable {
-    fn from(value: &CertificateStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CertificateStore> for &::windows::core::IInspectable {
-    fn from(value: &CertificateStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CertificateStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CertificateStore {}
 unsafe impl ::core::marker::Sync for CertificateStore {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -2396,36 +2193,7 @@ unsafe impl ::windows::core::Interface for ChainBuildingParameters {
 impl ::windows::core::RuntimeName for ChainBuildingParameters {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.ChainBuildingParameters";
 }
-impl ::core::convert::From<ChainBuildingParameters> for ::windows::core::IUnknown {
-    fn from(value: ChainBuildingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChainBuildingParameters> for ::windows::core::IUnknown {
-    fn from(value: &ChainBuildingParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChainBuildingParameters> for &::windows::core::IUnknown {
-    fn from(value: &ChainBuildingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChainBuildingParameters> for ::windows::core::IInspectable {
-    fn from(value: ChainBuildingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChainBuildingParameters> for ::windows::core::IInspectable {
-    fn from(value: &ChainBuildingParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChainBuildingParameters> for &::windows::core::IInspectable {
-    fn from(value: &ChainBuildingParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChainBuildingParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChainBuildingParameters {}
 unsafe impl ::core::marker::Sync for ChainBuildingParameters {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -2498,36 +2266,7 @@ unsafe impl ::windows::core::Interface for ChainValidationParameters {
 impl ::windows::core::RuntimeName for ChainValidationParameters {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.ChainValidationParameters";
 }
-impl ::core::convert::From<ChainValidationParameters> for ::windows::core::IUnknown {
-    fn from(value: ChainValidationParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChainValidationParameters> for ::windows::core::IUnknown {
-    fn from(value: &ChainValidationParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChainValidationParameters> for &::windows::core::IUnknown {
-    fn from(value: &ChainValidationParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ChainValidationParameters> for ::windows::core::IInspectable {
-    fn from(value: ChainValidationParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ChainValidationParameters> for ::windows::core::IInspectable {
-    fn from(value: &ChainValidationParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ChainValidationParameters> for &::windows::core::IInspectable {
-    fn from(value: &ChainValidationParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ChainValidationParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ChainValidationParameters {}
 unsafe impl ::core::marker::Sync for ChainValidationParameters {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -2637,36 +2376,7 @@ unsafe impl ::windows::core::Interface for CmsAttachedSignature {
 impl ::windows::core::RuntimeName for CmsAttachedSignature {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CmsAttachedSignature";
 }
-impl ::core::convert::From<CmsAttachedSignature> for ::windows::core::IUnknown {
-    fn from(value: CmsAttachedSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CmsAttachedSignature> for ::windows::core::IUnknown {
-    fn from(value: &CmsAttachedSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CmsAttachedSignature> for &::windows::core::IUnknown {
-    fn from(value: &CmsAttachedSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CmsAttachedSignature> for ::windows::core::IInspectable {
-    fn from(value: CmsAttachedSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CmsAttachedSignature> for ::windows::core::IInspectable {
-    fn from(value: &CmsAttachedSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CmsAttachedSignature> for &::windows::core::IInspectable {
-    fn from(value: &CmsAttachedSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CmsAttachedSignature, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CmsAttachedSignature {}
 unsafe impl ::core::marker::Sync for CmsAttachedSignature {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -2775,36 +2485,7 @@ unsafe impl ::windows::core::Interface for CmsDetachedSignature {
 impl ::windows::core::RuntimeName for CmsDetachedSignature {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CmsDetachedSignature";
 }
-impl ::core::convert::From<CmsDetachedSignature> for ::windows::core::IUnknown {
-    fn from(value: CmsDetachedSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CmsDetachedSignature> for ::windows::core::IUnknown {
-    fn from(value: &CmsDetachedSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CmsDetachedSignature> for &::windows::core::IUnknown {
-    fn from(value: &CmsDetachedSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CmsDetachedSignature> for ::windows::core::IInspectable {
-    fn from(value: CmsDetachedSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CmsDetachedSignature> for ::windows::core::IInspectable {
-    fn from(value: &CmsDetachedSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CmsDetachedSignature> for &::windows::core::IInspectable {
-    fn from(value: &CmsDetachedSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CmsDetachedSignature, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CmsDetachedSignature {}
 unsafe impl ::core::marker::Sync for CmsDetachedSignature {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -2880,36 +2561,7 @@ unsafe impl ::windows::core::Interface for CmsSignerInfo {
 impl ::windows::core::RuntimeName for CmsSignerInfo {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CmsSignerInfo";
 }
-impl ::core::convert::From<CmsSignerInfo> for ::windows::core::IUnknown {
-    fn from(value: CmsSignerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CmsSignerInfo> for ::windows::core::IUnknown {
-    fn from(value: &CmsSignerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CmsSignerInfo> for &::windows::core::IUnknown {
-    fn from(value: &CmsSignerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CmsSignerInfo> for ::windows::core::IInspectable {
-    fn from(value: CmsSignerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CmsSignerInfo> for ::windows::core::IInspectable {
-    fn from(value: &CmsSignerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CmsSignerInfo> for &::windows::core::IInspectable {
-    fn from(value: &CmsSignerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CmsSignerInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CmsSignerInfo {}
 unsafe impl ::core::marker::Sync for CmsSignerInfo {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -2974,36 +2626,7 @@ unsafe impl ::windows::core::Interface for CmsTimestampInfo {
 impl ::windows::core::RuntimeName for CmsTimestampInfo {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CmsTimestampInfo";
 }
-impl ::core::convert::From<CmsTimestampInfo> for ::windows::core::IUnknown {
-    fn from(value: CmsTimestampInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CmsTimestampInfo> for ::windows::core::IUnknown {
-    fn from(value: &CmsTimestampInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CmsTimestampInfo> for &::windows::core::IUnknown {
-    fn from(value: &CmsTimestampInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CmsTimestampInfo> for ::windows::core::IInspectable {
-    fn from(value: CmsTimestampInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CmsTimestampInfo> for ::windows::core::IInspectable {
-    fn from(value: &CmsTimestampInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CmsTimestampInfo> for &::windows::core::IInspectable {
-    fn from(value: &CmsTimestampInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CmsTimestampInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CmsTimestampInfo {}
 unsafe impl ::core::marker::Sync for CmsTimestampInfo {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -3284,36 +2907,7 @@ unsafe impl ::windows::core::Interface for PfxImportParameters {
 impl ::windows::core::RuntimeName for PfxImportParameters {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.PfxImportParameters";
 }
-impl ::core::convert::From<PfxImportParameters> for ::windows::core::IUnknown {
-    fn from(value: PfxImportParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PfxImportParameters> for ::windows::core::IUnknown {
-    fn from(value: &PfxImportParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PfxImportParameters> for &::windows::core::IUnknown {
-    fn from(value: &PfxImportParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PfxImportParameters> for ::windows::core::IInspectable {
-    fn from(value: PfxImportParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PfxImportParameters> for ::windows::core::IInspectable {
-    fn from(value: &PfxImportParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PfxImportParameters> for &::windows::core::IInspectable {
-    fn from(value: &PfxImportParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PfxImportParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PfxImportParameters {}
 unsafe impl ::core::marker::Sync for PfxImportParameters {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -3505,36 +3099,7 @@ unsafe impl ::windows::core::Interface for SubjectAlternativeNameInfo {
 impl ::windows::core::RuntimeName for SubjectAlternativeNameInfo {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.SubjectAlternativeNameInfo";
 }
-impl ::core::convert::From<SubjectAlternativeNameInfo> for ::windows::core::IUnknown {
-    fn from(value: SubjectAlternativeNameInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SubjectAlternativeNameInfo> for ::windows::core::IUnknown {
-    fn from(value: &SubjectAlternativeNameInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SubjectAlternativeNameInfo> for &::windows::core::IUnknown {
-    fn from(value: &SubjectAlternativeNameInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SubjectAlternativeNameInfo> for ::windows::core::IInspectable {
-    fn from(value: SubjectAlternativeNameInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SubjectAlternativeNameInfo> for ::windows::core::IInspectable {
-    fn from(value: &SubjectAlternativeNameInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SubjectAlternativeNameInfo> for &::windows::core::IInspectable {
-    fn from(value: &SubjectAlternativeNameInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SubjectAlternativeNameInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SubjectAlternativeNameInfo {}
 unsafe impl ::core::marker::Sync for SubjectAlternativeNameInfo {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -3619,36 +3184,7 @@ unsafe impl ::windows::core::Interface for UserCertificateEnrollmentManager {
 impl ::windows::core::RuntimeName for UserCertificateEnrollmentManager {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.UserCertificateEnrollmentManager";
 }
-impl ::core::convert::From<UserCertificateEnrollmentManager> for ::windows::core::IUnknown {
-    fn from(value: UserCertificateEnrollmentManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserCertificateEnrollmentManager> for ::windows::core::IUnknown {
-    fn from(value: &UserCertificateEnrollmentManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserCertificateEnrollmentManager> for &::windows::core::IUnknown {
-    fn from(value: &UserCertificateEnrollmentManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserCertificateEnrollmentManager> for ::windows::core::IInspectable {
-    fn from(value: UserCertificateEnrollmentManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserCertificateEnrollmentManager> for ::windows::core::IInspectable {
-    fn from(value: &UserCertificateEnrollmentManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserCertificateEnrollmentManager> for &::windows::core::IInspectable {
-    fn from(value: &UserCertificateEnrollmentManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserCertificateEnrollmentManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserCertificateEnrollmentManager {}
 unsafe impl ::core::marker::Sync for UserCertificateEnrollmentManager {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]
@@ -3713,36 +3249,7 @@ unsafe impl ::windows::core::Interface for UserCertificateStore {
 impl ::windows::core::RuntimeName for UserCertificateStore {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.UserCertificateStore";
 }
-impl ::core::convert::From<UserCertificateStore> for ::windows::core::IUnknown {
-    fn from(value: UserCertificateStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserCertificateStore> for ::windows::core::IUnknown {
-    fn from(value: &UserCertificateStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserCertificateStore> for &::windows::core::IUnknown {
-    fn from(value: &UserCertificateStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserCertificateStore> for ::windows::core::IInspectable {
-    fn from(value: UserCertificateStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserCertificateStore> for ::windows::core::IInspectable {
-    fn from(value: &UserCertificateStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserCertificateStore> for &::windows::core::IInspectable {
-    fn from(value: &UserCertificateStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserCertificateStore, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserCertificateStore {}
 unsafe impl ::core::marker::Sync for UserCertificateStore {}
 #[doc = "*Required features: `\"Security_Cryptography_Certificates\"`*"]

--- a/crates/libs/windows/src/Windows/Security/Cryptography/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/Core/mod.rs
@@ -975,36 +975,7 @@ unsafe impl ::windows::core::Interface for AsymmetricKeyAlgorithmProvider {
 impl ::windows::core::RuntimeName for AsymmetricKeyAlgorithmProvider {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.AsymmetricKeyAlgorithmProvider";
 }
-impl ::core::convert::From<AsymmetricKeyAlgorithmProvider> for ::windows::core::IUnknown {
-    fn from(value: AsymmetricKeyAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsymmetricKeyAlgorithmProvider> for ::windows::core::IUnknown {
-    fn from(value: &AsymmetricKeyAlgorithmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AsymmetricKeyAlgorithmProvider> for &::windows::core::IUnknown {
-    fn from(value: &AsymmetricKeyAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AsymmetricKeyAlgorithmProvider> for ::windows::core::IInspectable {
-    fn from(value: AsymmetricKeyAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsymmetricKeyAlgorithmProvider> for ::windows::core::IInspectable {
-    fn from(value: &AsymmetricKeyAlgorithmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AsymmetricKeyAlgorithmProvider> for &::windows::core::IInspectable {
-    fn from(value: &AsymmetricKeyAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AsymmetricKeyAlgorithmProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AsymmetricKeyAlgorithmProvider {}
 unsafe impl ::core::marker::Sync for AsymmetricKeyAlgorithmProvider {}
 #[doc = "*Required features: `\"Security_Cryptography_Core\"`*"]
@@ -1240,36 +1211,7 @@ unsafe impl ::windows::core::Interface for CryptographicHash {
 impl ::windows::core::RuntimeName for CryptographicHash {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.CryptographicHash";
 }
-impl ::core::convert::From<CryptographicHash> for ::windows::core::IUnknown {
-    fn from(value: CryptographicHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CryptographicHash> for ::windows::core::IUnknown {
-    fn from(value: &CryptographicHash) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CryptographicHash> for &::windows::core::IUnknown {
-    fn from(value: &CryptographicHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CryptographicHash> for ::windows::core::IInspectable {
-    fn from(value: CryptographicHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CryptographicHash> for ::windows::core::IInspectable {
-    fn from(value: &CryptographicHash) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CryptographicHash> for &::windows::core::IInspectable {
-    fn from(value: &CryptographicHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CryptographicHash, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CryptographicHash {}
 unsafe impl ::core::marker::Sync for CryptographicHash {}
 #[doc = "*Required features: `\"Security_Cryptography_Core\"`*"]
@@ -1352,36 +1294,7 @@ unsafe impl ::windows::core::Interface for CryptographicKey {
 impl ::windows::core::RuntimeName for CryptographicKey {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.CryptographicKey";
 }
-impl ::core::convert::From<CryptographicKey> for ::windows::core::IUnknown {
-    fn from(value: CryptographicKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CryptographicKey> for ::windows::core::IUnknown {
-    fn from(value: &CryptographicKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CryptographicKey> for &::windows::core::IUnknown {
-    fn from(value: &CryptographicKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CryptographicKey> for ::windows::core::IInspectable {
-    fn from(value: CryptographicKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CryptographicKey> for ::windows::core::IInspectable {
-    fn from(value: &CryptographicKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CryptographicKey> for &::windows::core::IInspectable {
-    fn from(value: &CryptographicKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CryptographicKey, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CryptographicKey {}
 unsafe impl ::core::marker::Sync for CryptographicKey {}
 #[doc = "*Required features: `\"Security_Cryptography_Core\"`*"]
@@ -1729,36 +1642,7 @@ unsafe impl ::windows::core::Interface for EncryptedAndAuthenticatedData {
 impl ::windows::core::RuntimeName for EncryptedAndAuthenticatedData {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.EncryptedAndAuthenticatedData";
 }
-impl ::core::convert::From<EncryptedAndAuthenticatedData> for ::windows::core::IUnknown {
-    fn from(value: EncryptedAndAuthenticatedData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EncryptedAndAuthenticatedData> for ::windows::core::IUnknown {
-    fn from(value: &EncryptedAndAuthenticatedData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EncryptedAndAuthenticatedData> for &::windows::core::IUnknown {
-    fn from(value: &EncryptedAndAuthenticatedData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EncryptedAndAuthenticatedData> for ::windows::core::IInspectable {
-    fn from(value: EncryptedAndAuthenticatedData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EncryptedAndAuthenticatedData> for ::windows::core::IInspectable {
-    fn from(value: &EncryptedAndAuthenticatedData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EncryptedAndAuthenticatedData> for &::windows::core::IInspectable {
-    fn from(value: &EncryptedAndAuthenticatedData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EncryptedAndAuthenticatedData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EncryptedAndAuthenticatedData {}
 unsafe impl ::core::marker::Sync for EncryptedAndAuthenticatedData {}
 #[doc = "*Required features: `\"Security_Cryptography_Core\"`*"]
@@ -1885,36 +1769,7 @@ unsafe impl ::windows::core::Interface for HashAlgorithmProvider {
 impl ::windows::core::RuntimeName for HashAlgorithmProvider {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.HashAlgorithmProvider";
 }
-impl ::core::convert::From<HashAlgorithmProvider> for ::windows::core::IUnknown {
-    fn from(value: HashAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HashAlgorithmProvider> for ::windows::core::IUnknown {
-    fn from(value: &HashAlgorithmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HashAlgorithmProvider> for &::windows::core::IUnknown {
-    fn from(value: &HashAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HashAlgorithmProvider> for ::windows::core::IInspectable {
-    fn from(value: HashAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HashAlgorithmProvider> for ::windows::core::IInspectable {
-    fn from(value: &HashAlgorithmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HashAlgorithmProvider> for &::windows::core::IInspectable {
-    fn from(value: &HashAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HashAlgorithmProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HashAlgorithmProvider {}
 unsafe impl ::core::marker::Sync for HashAlgorithmProvider {}
 #[doc = "*Required features: `\"Security_Cryptography_Core\"`*"]
@@ -2122,36 +1977,7 @@ unsafe impl ::windows::core::Interface for KeyDerivationAlgorithmProvider {
 impl ::windows::core::RuntimeName for KeyDerivationAlgorithmProvider {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.KeyDerivationAlgorithmProvider";
 }
-impl ::core::convert::From<KeyDerivationAlgorithmProvider> for ::windows::core::IUnknown {
-    fn from(value: KeyDerivationAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyDerivationAlgorithmProvider> for ::windows::core::IUnknown {
-    fn from(value: &KeyDerivationAlgorithmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyDerivationAlgorithmProvider> for &::windows::core::IUnknown {
-    fn from(value: &KeyDerivationAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<KeyDerivationAlgorithmProvider> for ::windows::core::IInspectable {
-    fn from(value: KeyDerivationAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyDerivationAlgorithmProvider> for ::windows::core::IInspectable {
-    fn from(value: &KeyDerivationAlgorithmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyDerivationAlgorithmProvider> for &::windows::core::IInspectable {
-    fn from(value: &KeyDerivationAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(KeyDerivationAlgorithmProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for KeyDerivationAlgorithmProvider {}
 unsafe impl ::core::marker::Sync for KeyDerivationAlgorithmProvider {}
 #[doc = "*Required features: `\"Security_Cryptography_Core\"`*"]
@@ -2290,36 +2116,7 @@ unsafe impl ::windows::core::Interface for KeyDerivationParameters {
 impl ::windows::core::RuntimeName for KeyDerivationParameters {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.KeyDerivationParameters";
 }
-impl ::core::convert::From<KeyDerivationParameters> for ::windows::core::IUnknown {
-    fn from(value: KeyDerivationParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyDerivationParameters> for ::windows::core::IUnknown {
-    fn from(value: &KeyDerivationParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyDerivationParameters> for &::windows::core::IUnknown {
-    fn from(value: &KeyDerivationParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<KeyDerivationParameters> for ::windows::core::IInspectable {
-    fn from(value: KeyDerivationParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyDerivationParameters> for ::windows::core::IInspectable {
-    fn from(value: &KeyDerivationParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyDerivationParameters> for &::windows::core::IInspectable {
-    fn from(value: &KeyDerivationParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(KeyDerivationParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for KeyDerivationParameters {}
 unsafe impl ::core::marker::Sync for KeyDerivationParameters {}
 #[doc = "*Required features: `\"Security_Cryptography_Core\"`*"]
@@ -2458,36 +2255,7 @@ unsafe impl ::windows::core::Interface for MacAlgorithmProvider {
 impl ::windows::core::RuntimeName for MacAlgorithmProvider {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.MacAlgorithmProvider";
 }
-impl ::core::convert::From<MacAlgorithmProvider> for ::windows::core::IUnknown {
-    fn from(value: MacAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MacAlgorithmProvider> for ::windows::core::IUnknown {
-    fn from(value: &MacAlgorithmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MacAlgorithmProvider> for &::windows::core::IUnknown {
-    fn from(value: &MacAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MacAlgorithmProvider> for ::windows::core::IInspectable {
-    fn from(value: MacAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MacAlgorithmProvider> for ::windows::core::IInspectable {
-    fn from(value: &MacAlgorithmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MacAlgorithmProvider> for &::windows::core::IInspectable {
-    fn from(value: &MacAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MacAlgorithmProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MacAlgorithmProvider {}
 unsafe impl ::core::marker::Sync for MacAlgorithmProvider {}
 #[doc = "*Required features: `\"Security_Cryptography_Core\"`*"]
@@ -2719,36 +2487,7 @@ unsafe impl ::windows::core::Interface for SymmetricKeyAlgorithmProvider {
 impl ::windows::core::RuntimeName for SymmetricKeyAlgorithmProvider {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.SymmetricKeyAlgorithmProvider";
 }
-impl ::core::convert::From<SymmetricKeyAlgorithmProvider> for ::windows::core::IUnknown {
-    fn from(value: SymmetricKeyAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SymmetricKeyAlgorithmProvider> for ::windows::core::IUnknown {
-    fn from(value: &SymmetricKeyAlgorithmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SymmetricKeyAlgorithmProvider> for &::windows::core::IUnknown {
-    fn from(value: &SymmetricKeyAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SymmetricKeyAlgorithmProvider> for ::windows::core::IInspectable {
-    fn from(value: SymmetricKeyAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SymmetricKeyAlgorithmProvider> for ::windows::core::IInspectable {
-    fn from(value: &SymmetricKeyAlgorithmProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SymmetricKeyAlgorithmProvider> for &::windows::core::IInspectable {
-    fn from(value: &SymmetricKeyAlgorithmProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SymmetricKeyAlgorithmProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SymmetricKeyAlgorithmProvider {}
 unsafe impl ::core::marker::Sync for SymmetricKeyAlgorithmProvider {}
 #[doc = "*Required features: `\"Security_Cryptography_Core\"`*"]

--- a/crates/libs/windows/src/Windows/Security/Cryptography/DataProtection/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/DataProtection/mod.rs
@@ -154,36 +154,7 @@ unsafe impl ::windows::core::Interface for DataProtectionProvider {
 impl ::windows::core::RuntimeName for DataProtectionProvider {
     const NAME: &'static str = "Windows.Security.Cryptography.DataProtection.DataProtectionProvider";
 }
-impl ::core::convert::From<DataProtectionProvider> for ::windows::core::IUnknown {
-    fn from(value: DataProtectionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataProtectionProvider> for ::windows::core::IUnknown {
-    fn from(value: &DataProtectionProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataProtectionProvider> for &::windows::core::IUnknown {
-    fn from(value: &DataProtectionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataProtectionProvider> for ::windows::core::IInspectable {
-    fn from(value: DataProtectionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataProtectionProvider> for ::windows::core::IInspectable {
-    fn from(value: &DataProtectionProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataProtectionProvider> for &::windows::core::IInspectable {
-    fn from(value: &DataProtectionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataProtectionProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DataProtectionProvider {}
 unsafe impl ::core::marker::Sync for DataProtectionProvider {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Security/DataProtection/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/DataProtection/mod.rs
@@ -154,36 +154,7 @@ unsafe impl ::windows::core::Interface for UserDataAvailabilityStateChangedEvent
 impl ::windows::core::RuntimeName for UserDataAvailabilityStateChangedEventArgs {
     const NAME: &'static str = "Windows.Security.DataProtection.UserDataAvailabilityStateChangedEventArgs";
 }
-impl ::core::convert::From<UserDataAvailabilityStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserDataAvailabilityStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAvailabilityStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserDataAvailabilityStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAvailabilityStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserDataAvailabilityStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataAvailabilityStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserDataAvailabilityStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataAvailabilityStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserDataAvailabilityStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataAvailabilityStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserDataAvailabilityStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataAvailabilityStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataAvailabilityStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for UserDataAvailabilityStateChangedEventArgs {}
 #[doc = "*Required features: `\"Security_DataProtection\"`*"]
@@ -239,36 +210,7 @@ unsafe impl ::windows::core::Interface for UserDataBufferUnprotectResult {
 impl ::windows::core::RuntimeName for UserDataBufferUnprotectResult {
     const NAME: &'static str = "Windows.Security.DataProtection.UserDataBufferUnprotectResult";
 }
-impl ::core::convert::From<UserDataBufferUnprotectResult> for ::windows::core::IUnknown {
-    fn from(value: UserDataBufferUnprotectResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataBufferUnprotectResult> for ::windows::core::IUnknown {
-    fn from(value: &UserDataBufferUnprotectResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataBufferUnprotectResult> for &::windows::core::IUnknown {
-    fn from(value: &UserDataBufferUnprotectResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataBufferUnprotectResult> for ::windows::core::IInspectable {
-    fn from(value: UserDataBufferUnprotectResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataBufferUnprotectResult> for ::windows::core::IInspectable {
-    fn from(value: &UserDataBufferUnprotectResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataBufferUnprotectResult> for &::windows::core::IInspectable {
-    fn from(value: &UserDataBufferUnprotectResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataBufferUnprotectResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataBufferUnprotectResult {}
 unsafe impl ::core::marker::Sync for UserDataBufferUnprotectResult {}
 #[doc = "*Required features: `\"Security_DataProtection\"`*"]
@@ -401,36 +343,7 @@ unsafe impl ::windows::core::Interface for UserDataProtectionManager {
 impl ::windows::core::RuntimeName for UserDataProtectionManager {
     const NAME: &'static str = "Windows.Security.DataProtection.UserDataProtectionManager";
 }
-impl ::core::convert::From<UserDataProtectionManager> for ::windows::core::IUnknown {
-    fn from(value: UserDataProtectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataProtectionManager> for ::windows::core::IUnknown {
-    fn from(value: &UserDataProtectionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataProtectionManager> for &::windows::core::IUnknown {
-    fn from(value: &UserDataProtectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataProtectionManager> for ::windows::core::IInspectable {
-    fn from(value: UserDataProtectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataProtectionManager> for ::windows::core::IInspectable {
-    fn from(value: &UserDataProtectionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataProtectionManager> for &::windows::core::IInspectable {
-    fn from(value: &UserDataProtectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataProtectionManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataProtectionManager {}
 unsafe impl ::core::marker::Sync for UserDataProtectionManager {}
 #[doc = "*Required features: `\"Security_DataProtection\"`*"]
@@ -477,36 +390,7 @@ unsafe impl ::windows::core::Interface for UserDataStorageItemProtectionInfo {
 impl ::windows::core::RuntimeName for UserDataStorageItemProtectionInfo {
     const NAME: &'static str = "Windows.Security.DataProtection.UserDataStorageItemProtectionInfo";
 }
-impl ::core::convert::From<UserDataStorageItemProtectionInfo> for ::windows::core::IUnknown {
-    fn from(value: UserDataStorageItemProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataStorageItemProtectionInfo> for ::windows::core::IUnknown {
-    fn from(value: &UserDataStorageItemProtectionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataStorageItemProtectionInfo> for &::windows::core::IUnknown {
-    fn from(value: &UserDataStorageItemProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataStorageItemProtectionInfo> for ::windows::core::IInspectable {
-    fn from(value: UserDataStorageItemProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataStorageItemProtectionInfo> for ::windows::core::IInspectable {
-    fn from(value: &UserDataStorageItemProtectionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataStorageItemProtectionInfo> for &::windows::core::IInspectable {
-    fn from(value: &UserDataStorageItemProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataStorageItemProtectionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataStorageItemProtectionInfo {}
 unsafe impl ::core::marker::Sync for UserDataStorageItemProtectionInfo {}
 #[doc = "*Required features: `\"Security_DataProtection\"`*"]

--- a/crates/libs/windows/src/Windows/Security/EnterpriseData/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/EnterpriseData/mod.rs
@@ -686,36 +686,7 @@ unsafe impl ::windows::core::Interface for BufferProtectUnprotectResult {
 impl ::windows::core::RuntimeName for BufferProtectUnprotectResult {
     const NAME: &'static str = "Windows.Security.EnterpriseData.BufferProtectUnprotectResult";
 }
-impl ::core::convert::From<BufferProtectUnprotectResult> for ::windows::core::IUnknown {
-    fn from(value: BufferProtectUnprotectResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BufferProtectUnprotectResult> for ::windows::core::IUnknown {
-    fn from(value: &BufferProtectUnprotectResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BufferProtectUnprotectResult> for &::windows::core::IUnknown {
-    fn from(value: &BufferProtectUnprotectResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BufferProtectUnprotectResult> for ::windows::core::IInspectable {
-    fn from(value: BufferProtectUnprotectResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BufferProtectUnprotectResult> for ::windows::core::IInspectable {
-    fn from(value: &BufferProtectUnprotectResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BufferProtectUnprotectResult> for &::windows::core::IInspectable {
-    fn from(value: &BufferProtectUnprotectResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BufferProtectUnprotectResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BufferProtectUnprotectResult {}
 unsafe impl ::core::marker::Sync for BufferProtectUnprotectResult {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -769,36 +740,7 @@ unsafe impl ::windows::core::Interface for DataProtectionInfo {
 impl ::windows::core::RuntimeName for DataProtectionInfo {
     const NAME: &'static str = "Windows.Security.EnterpriseData.DataProtectionInfo";
 }
-impl ::core::convert::From<DataProtectionInfo> for ::windows::core::IUnknown {
-    fn from(value: DataProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataProtectionInfo> for ::windows::core::IUnknown {
-    fn from(value: &DataProtectionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataProtectionInfo> for &::windows::core::IUnknown {
-    fn from(value: &DataProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataProtectionInfo> for ::windows::core::IInspectable {
-    fn from(value: DataProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataProtectionInfo> for ::windows::core::IInspectable {
-    fn from(value: &DataProtectionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataProtectionInfo> for &::windows::core::IInspectable {
-    fn from(value: &DataProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataProtectionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DataProtectionInfo {}
 unsafe impl ::core::marker::Sync for DataProtectionInfo {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -954,36 +896,7 @@ unsafe impl ::windows::core::Interface for FileProtectionInfo {
 impl ::windows::core::RuntimeName for FileProtectionInfo {
     const NAME: &'static str = "Windows.Security.EnterpriseData.FileProtectionInfo";
 }
-impl ::core::convert::From<FileProtectionInfo> for ::windows::core::IUnknown {
-    fn from(value: FileProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileProtectionInfo> for ::windows::core::IUnknown {
-    fn from(value: &FileProtectionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileProtectionInfo> for &::windows::core::IUnknown {
-    fn from(value: &FileProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileProtectionInfo> for ::windows::core::IInspectable {
-    fn from(value: FileProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileProtectionInfo> for ::windows::core::IInspectable {
-    fn from(value: &FileProtectionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileProtectionInfo> for &::windows::core::IInspectable {
-    fn from(value: &FileProtectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileProtectionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FileProtectionInfo {}
 unsafe impl ::core::marker::Sync for FileProtectionInfo {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -1278,36 +1191,7 @@ unsafe impl ::windows::core::Interface for FileUnprotectOptions {
 impl ::windows::core::RuntimeName for FileUnprotectOptions {
     const NAME: &'static str = "Windows.Security.EnterpriseData.FileUnprotectOptions";
 }
-impl ::core::convert::From<FileUnprotectOptions> for ::windows::core::IUnknown {
-    fn from(value: FileUnprotectOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileUnprotectOptions> for ::windows::core::IUnknown {
-    fn from(value: &FileUnprotectOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileUnprotectOptions> for &::windows::core::IUnknown {
-    fn from(value: &FileUnprotectOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileUnprotectOptions> for ::windows::core::IInspectable {
-    fn from(value: FileUnprotectOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileUnprotectOptions> for ::windows::core::IInspectable {
-    fn from(value: &FileUnprotectOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileUnprotectOptions> for &::windows::core::IInspectable {
-    fn from(value: &FileUnprotectOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileUnprotectOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FileUnprotectOptions {}
 unsafe impl ::core::marker::Sync for FileUnprotectOptions {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -1356,36 +1240,7 @@ unsafe impl ::windows::core::Interface for ProtectedAccessResumedEventArgs {
 impl ::windows::core::RuntimeName for ProtectedAccessResumedEventArgs {
     const NAME: &'static str = "Windows.Security.EnterpriseData.ProtectedAccessResumedEventArgs";
 }
-impl ::core::convert::From<ProtectedAccessResumedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ProtectedAccessResumedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedAccessResumedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ProtectedAccessResumedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedAccessResumedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ProtectedAccessResumedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtectedAccessResumedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ProtectedAccessResumedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedAccessResumedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ProtectedAccessResumedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedAccessResumedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ProtectedAccessResumedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtectedAccessResumedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProtectedAccessResumedEventArgs {}
 unsafe impl ::core::marker::Sync for ProtectedAccessResumedEventArgs {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -1452,36 +1307,7 @@ unsafe impl ::windows::core::Interface for ProtectedAccessSuspendingEventArgs {
 impl ::windows::core::RuntimeName for ProtectedAccessSuspendingEventArgs {
     const NAME: &'static str = "Windows.Security.EnterpriseData.ProtectedAccessSuspendingEventArgs";
 }
-impl ::core::convert::From<ProtectedAccessSuspendingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ProtectedAccessSuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedAccessSuspendingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ProtectedAccessSuspendingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedAccessSuspendingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ProtectedAccessSuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtectedAccessSuspendingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ProtectedAccessSuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedAccessSuspendingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ProtectedAccessSuspendingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedAccessSuspendingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ProtectedAccessSuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtectedAccessSuspendingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProtectedAccessSuspendingEventArgs {}
 unsafe impl ::core::marker::Sync for ProtectedAccessSuspendingEventArgs {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -1537,36 +1363,7 @@ unsafe impl ::windows::core::Interface for ProtectedContainerExportResult {
 impl ::windows::core::RuntimeName for ProtectedContainerExportResult {
     const NAME: &'static str = "Windows.Security.EnterpriseData.ProtectedContainerExportResult";
 }
-impl ::core::convert::From<ProtectedContainerExportResult> for ::windows::core::IUnknown {
-    fn from(value: ProtectedContainerExportResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedContainerExportResult> for ::windows::core::IUnknown {
-    fn from(value: &ProtectedContainerExportResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedContainerExportResult> for &::windows::core::IUnknown {
-    fn from(value: &ProtectedContainerExportResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtectedContainerExportResult> for ::windows::core::IInspectable {
-    fn from(value: ProtectedContainerExportResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedContainerExportResult> for ::windows::core::IInspectable {
-    fn from(value: &ProtectedContainerExportResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedContainerExportResult> for &::windows::core::IInspectable {
-    fn from(value: &ProtectedContainerExportResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtectedContainerExportResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProtectedContainerExportResult {}
 unsafe impl ::core::marker::Sync for ProtectedContainerExportResult {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -1622,36 +1419,7 @@ unsafe impl ::windows::core::Interface for ProtectedContainerImportResult {
 impl ::windows::core::RuntimeName for ProtectedContainerImportResult {
     const NAME: &'static str = "Windows.Security.EnterpriseData.ProtectedContainerImportResult";
 }
-impl ::core::convert::From<ProtectedContainerImportResult> for ::windows::core::IUnknown {
-    fn from(value: ProtectedContainerImportResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedContainerImportResult> for ::windows::core::IUnknown {
-    fn from(value: &ProtectedContainerImportResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedContainerImportResult> for &::windows::core::IUnknown {
-    fn from(value: &ProtectedContainerImportResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtectedContainerImportResult> for ::windows::core::IInspectable {
-    fn from(value: ProtectedContainerImportResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedContainerImportResult> for ::windows::core::IInspectable {
-    fn from(value: &ProtectedContainerImportResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedContainerImportResult> for &::windows::core::IInspectable {
-    fn from(value: &ProtectedContainerImportResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtectedContainerImportResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProtectedContainerImportResult {}
 unsafe impl ::core::marker::Sync for ProtectedContainerImportResult {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -1700,36 +1468,7 @@ unsafe impl ::windows::core::Interface for ProtectedContentRevokedEventArgs {
 impl ::windows::core::RuntimeName for ProtectedContentRevokedEventArgs {
     const NAME: &'static str = "Windows.Security.EnterpriseData.ProtectedContentRevokedEventArgs";
 }
-impl ::core::convert::From<ProtectedContentRevokedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ProtectedContentRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedContentRevokedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ProtectedContentRevokedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedContentRevokedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ProtectedContentRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtectedContentRevokedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ProtectedContentRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedContentRevokedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ProtectedContentRevokedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedContentRevokedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ProtectedContentRevokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtectedContentRevokedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProtectedContentRevokedEventArgs {}
 unsafe impl ::core::marker::Sync for ProtectedContentRevokedEventArgs {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -1794,36 +1533,7 @@ unsafe impl ::windows::core::Interface for ProtectedFileCreateResult {
 impl ::windows::core::RuntimeName for ProtectedFileCreateResult {
     const NAME: &'static str = "Windows.Security.EnterpriseData.ProtectedFileCreateResult";
 }
-impl ::core::convert::From<ProtectedFileCreateResult> for ::windows::core::IUnknown {
-    fn from(value: ProtectedFileCreateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedFileCreateResult> for ::windows::core::IUnknown {
-    fn from(value: &ProtectedFileCreateResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedFileCreateResult> for &::windows::core::IUnknown {
-    fn from(value: &ProtectedFileCreateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtectedFileCreateResult> for ::windows::core::IInspectable {
-    fn from(value: ProtectedFileCreateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectedFileCreateResult> for ::windows::core::IInspectable {
-    fn from(value: &ProtectedFileCreateResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectedFileCreateResult> for &::windows::core::IInspectable {
-    fn from(value: &ProtectedFileCreateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtectedFileCreateResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProtectedFileCreateResult {}
 unsafe impl ::core::marker::Sync for ProtectedFileCreateResult {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -1924,36 +1634,7 @@ unsafe impl ::windows::core::Interface for ProtectionPolicyAuditInfo {
 impl ::windows::core::RuntimeName for ProtectionPolicyAuditInfo {
     const NAME: &'static str = "Windows.Security.EnterpriseData.ProtectionPolicyAuditInfo";
 }
-impl ::core::convert::From<ProtectionPolicyAuditInfo> for ::windows::core::IUnknown {
-    fn from(value: ProtectionPolicyAuditInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectionPolicyAuditInfo> for ::windows::core::IUnknown {
-    fn from(value: &ProtectionPolicyAuditInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectionPolicyAuditInfo> for &::windows::core::IUnknown {
-    fn from(value: &ProtectionPolicyAuditInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtectionPolicyAuditInfo> for ::windows::core::IInspectable {
-    fn from(value: ProtectionPolicyAuditInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectionPolicyAuditInfo> for ::windows::core::IInspectable {
-    fn from(value: &ProtectionPolicyAuditInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectionPolicyAuditInfo> for &::windows::core::IInspectable {
-    fn from(value: &ProtectionPolicyAuditInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtectionPolicyAuditInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProtectionPolicyAuditInfo {}
 unsafe impl ::core::marker::Sync for ProtectionPolicyAuditInfo {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -2326,36 +2007,7 @@ unsafe impl ::windows::core::Interface for ProtectionPolicyManager {
 impl ::windows::core::RuntimeName for ProtectionPolicyManager {
     const NAME: &'static str = "Windows.Security.EnterpriseData.ProtectionPolicyManager";
 }
-impl ::core::convert::From<ProtectionPolicyManager> for ::windows::core::IUnknown {
-    fn from(value: ProtectionPolicyManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectionPolicyManager> for ::windows::core::IUnknown {
-    fn from(value: &ProtectionPolicyManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectionPolicyManager> for &::windows::core::IUnknown {
-    fn from(value: &ProtectionPolicyManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtectionPolicyManager> for ::windows::core::IInspectable {
-    fn from(value: ProtectionPolicyManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtectionPolicyManager> for ::windows::core::IInspectable {
-    fn from(value: &ProtectionPolicyManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtectionPolicyManager> for &::windows::core::IInspectable {
-    fn from(value: &ProtectionPolicyManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtectionPolicyManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProtectionPolicyManager {}
 unsafe impl ::core::marker::Sync for ProtectionPolicyManager {}
 #[doc = "*Required features: `\"Security_EnterpriseData\"`*"]
@@ -2401,36 +2053,7 @@ unsafe impl ::windows::core::Interface for ThreadNetworkContext {
 impl ::windows::core::RuntimeName for ThreadNetworkContext {
     const NAME: &'static str = "Windows.Security.EnterpriseData.ThreadNetworkContext";
 }
-impl ::core::convert::From<ThreadNetworkContext> for ::windows::core::IUnknown {
-    fn from(value: ThreadNetworkContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ThreadNetworkContext> for ::windows::core::IUnknown {
-    fn from(value: &ThreadNetworkContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ThreadNetworkContext> for &::windows::core::IUnknown {
-    fn from(value: &ThreadNetworkContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ThreadNetworkContext> for ::windows::core::IInspectable {
-    fn from(value: ThreadNetworkContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ThreadNetworkContext> for ::windows::core::IInspectable {
-    fn from(value: &ThreadNetworkContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ThreadNetworkContext> for &::windows::core::IInspectable {
-    fn from(value: &ThreadNetworkContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ThreadNetworkContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ThreadNetworkContext> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Security/ExchangeActiveSyncProvisioning/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/ExchangeActiveSyncProvisioning/mod.rs
@@ -219,36 +219,7 @@ unsafe impl ::windows::core::Interface for EasClientDeviceInformation {
 impl ::windows::core::RuntimeName for EasClientDeviceInformation {
     const NAME: &'static str = "Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation";
 }
-impl ::core::convert::From<EasClientDeviceInformation> for ::windows::core::IUnknown {
-    fn from(value: EasClientDeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EasClientDeviceInformation> for ::windows::core::IUnknown {
-    fn from(value: &EasClientDeviceInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EasClientDeviceInformation> for &::windows::core::IUnknown {
-    fn from(value: &EasClientDeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EasClientDeviceInformation> for ::windows::core::IInspectable {
-    fn from(value: EasClientDeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EasClientDeviceInformation> for ::windows::core::IInspectable {
-    fn from(value: &EasClientDeviceInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EasClientDeviceInformation> for &::windows::core::IInspectable {
-    fn from(value: &EasClientDeviceInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EasClientDeviceInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Security_ExchangeActiveSyncProvisioning\"`*"]
 #[repr(transparent)]
 pub struct EasClientSecurityPolicy(::windows::core::IUnknown);
@@ -405,36 +376,7 @@ unsafe impl ::windows::core::Interface for EasClientSecurityPolicy {
 impl ::windows::core::RuntimeName for EasClientSecurityPolicy {
     const NAME: &'static str = "Windows.Security.ExchangeActiveSyncProvisioning.EasClientSecurityPolicy";
 }
-impl ::core::convert::From<EasClientSecurityPolicy> for ::windows::core::IUnknown {
-    fn from(value: EasClientSecurityPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EasClientSecurityPolicy> for ::windows::core::IUnknown {
-    fn from(value: &EasClientSecurityPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EasClientSecurityPolicy> for &::windows::core::IUnknown {
-    fn from(value: &EasClientSecurityPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EasClientSecurityPolicy> for ::windows::core::IInspectable {
-    fn from(value: EasClientSecurityPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EasClientSecurityPolicy> for ::windows::core::IInspectable {
-    fn from(value: &EasClientSecurityPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EasClientSecurityPolicy> for &::windows::core::IInspectable {
-    fn from(value: &EasClientSecurityPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EasClientSecurityPolicy, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Security_ExchangeActiveSyncProvisioning\"`*"]
 #[repr(transparent)]
 pub struct EasComplianceResults(::windows::core::IUnknown);
@@ -542,36 +484,7 @@ unsafe impl ::windows::core::Interface for EasComplianceResults {
 impl ::windows::core::RuntimeName for EasComplianceResults {
     const NAME: &'static str = "Windows.Security.ExchangeActiveSyncProvisioning.EasComplianceResults";
 }
-impl ::core::convert::From<EasComplianceResults> for ::windows::core::IUnknown {
-    fn from(value: EasComplianceResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EasComplianceResults> for ::windows::core::IUnknown {
-    fn from(value: &EasComplianceResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EasComplianceResults> for &::windows::core::IUnknown {
-    fn from(value: &EasComplianceResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EasComplianceResults> for ::windows::core::IInspectable {
-    fn from(value: EasComplianceResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EasComplianceResults> for ::windows::core::IInspectable {
-    fn from(value: &EasComplianceResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EasComplianceResults> for &::windows::core::IInspectable {
-    fn from(value: &EasComplianceResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EasComplianceResults, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Security_ExchangeActiveSyncProvisioning\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
@@ -723,36 +723,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironment {
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironment {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironment";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironment> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironment> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironment> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironment> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironment> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironment> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironment {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironment {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -813,36 +784,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentCreateResul
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentCreateResult {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentCreateResult";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentCreateResult> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentCreateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentCreateResult> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentCreateResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentCreateResult> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentCreateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentCreateResult> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentCreateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentCreateResult> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentCreateResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentCreateResult> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentCreateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentCreateResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentCreateResult {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentCreateResult {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -914,36 +856,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentFile {
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentFile {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentFile";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentFile> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentFile> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentFile> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentFile> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentFile> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentFile> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentFile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentFile {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentFile {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -1030,36 +943,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentLaunchFileR
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentLaunchFileResult {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentLaunchFileResult";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentLaunchFileResult> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentLaunchFileResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentLaunchFileResult> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentLaunchFileResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentLaunchFileResult> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentLaunchFileResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentLaunchFileResult> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentLaunchFileResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentLaunchFileResult> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentLaunchFileResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentLaunchFileResult> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentLaunchFileResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentLaunchFileResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentLaunchFileResult {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentLaunchFileResult {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -1212,36 +1096,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentOptions {
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentOptions {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentOptions";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentOptions> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOptions> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOptions> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentOptions> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOptions> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOptions> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentOptions {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentOptions {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -1345,36 +1200,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentOwnerRegist
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentOwnerRegistrationData {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentOwnerRegistrationData";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentOwnerRegistrationData> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentOwnerRegistrationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOwnerRegistrationData> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentOwnerRegistrationData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOwnerRegistrationData> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentOwnerRegistrationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentOwnerRegistrationData> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentOwnerRegistrationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOwnerRegistrationData> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentOwnerRegistrationData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOwnerRegistrationData> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentOwnerRegistrationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentOwnerRegistrationData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentOwnerRegistrationData {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentOwnerRegistrationData {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -1428,36 +1254,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentOwnerRegist
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentOwnerRegistrationResult {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentOwnerRegistrationResult";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentOwnerRegistrationResult> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentOwnerRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOwnerRegistrationResult> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentOwnerRegistrationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOwnerRegistrationResult> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentOwnerRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentOwnerRegistrationResult> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentOwnerRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOwnerRegistrationResult> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentOwnerRegistrationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentOwnerRegistrationResult> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentOwnerRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentOwnerRegistrationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentOwnerRegistrationResult {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentOwnerRegistrationResult {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -1511,36 +1308,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentPostMessage
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentPostMessageResult {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentPostMessageResult";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentPostMessageResult> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentPostMessageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentPostMessageResult> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentPostMessageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentPostMessageResult> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentPostMessageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentPostMessageResult> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentPostMessageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentPostMessageResult> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentPostMessageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentPostMessageResult> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentPostMessageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentPostMessageResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentPostMessageResult {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentPostMessageResult {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -1611,36 +1379,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentProcess {
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentProcess {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentProcess";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentProcess> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentProcess> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentProcess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentProcess> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentProcess> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentProcess> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentProcess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentProcess> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentProcess, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentProcess {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentProcess {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -1698,36 +1437,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentShareFileRe
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentShareFileRequestOptions {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentShareFileRequestOptions";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentShareFileRequestOptions> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentShareFileRequestOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFileRequestOptions> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentShareFileRequestOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFileRequestOptions> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentShareFileRequestOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentShareFileRequestOptions> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentShareFileRequestOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFileRequestOptions> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentShareFileRequestOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFileRequestOptions> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentShareFileRequestOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentShareFileRequestOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentShareFileRequestOptions {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentShareFileRequestOptions {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -1788,36 +1498,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentShareFileRe
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentShareFileResult {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentShareFileResult";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentShareFileResult> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentShareFileResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFileResult> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentShareFileResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFileResult> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentShareFileResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentShareFileResult> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentShareFileResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFileResult> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentShareFileResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFileResult> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentShareFileResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentShareFileResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentShareFileResult {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentShareFileResult {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -1875,36 +1556,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentShareFolder
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentShareFolderRequestOptions {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentShareFolderRequestOptions";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentShareFolderRequestOptions> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentShareFolderRequestOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFolderRequestOptions> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentShareFolderRequestOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFolderRequestOptions> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentShareFolderRequestOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentShareFolderRequestOptions> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentShareFolderRequestOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFolderRequestOptions> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentShareFolderRequestOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFolderRequestOptions> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentShareFolderRequestOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentShareFolderRequestOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentShareFolderRequestOptions {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentShareFolderRequestOptions {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -1958,36 +1610,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentShareFolder
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentShareFolderResult {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentShareFolderResult";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentShareFolderResult> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentShareFolderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFolderResult> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentShareFolderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFolderResult> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentShareFolderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentShareFolderResult> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentShareFolderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFolderResult> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentShareFolderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentShareFolderResult> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentShareFolderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentShareFolderResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentShareFolderResult {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentShareFolderResult {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -2048,36 +1671,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentStartProces
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentStartProcessResult {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentStartProcessResult";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentStartProcessResult> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentStartProcessResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentStartProcessResult> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentStartProcessResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentStartProcessResult> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentStartProcessResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentStartProcessResult> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentStartProcessResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentStartProcessResult> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentStartProcessResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentStartProcessResult> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentStartProcessResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentStartProcessResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentStartProcessResult {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentStartProcessResult {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -2135,36 +1729,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentTelemetryPa
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentTelemetryParameters {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentTelemetryParameters";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentTelemetryParameters> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentTelemetryParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentTelemetryParameters> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentTelemetryParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentTelemetryParameters> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentTelemetryParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentTelemetryParameters> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentTelemetryParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentTelemetryParameters> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentTelemetryParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentTelemetryParameters> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentTelemetryParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentTelemetryParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentTelemetryParameters {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentTelemetryParameters {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]
@@ -2227,36 +1792,7 @@ unsafe impl ::windows::core::Interface for IsolatedWindowsEnvironmentUserInfo {
 impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentUserInfo {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentUserInfo";
 }
-impl ::core::convert::From<IsolatedWindowsEnvironmentUserInfo> for ::windows::core::IUnknown {
-    fn from(value: IsolatedWindowsEnvironmentUserInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentUserInfo> for ::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentUserInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentUserInfo> for &::windows::core::IUnknown {
-    fn from(value: &IsolatedWindowsEnvironmentUserInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IsolatedWindowsEnvironmentUserInfo> for ::windows::core::IInspectable {
-    fn from(value: IsolatedWindowsEnvironmentUserInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentUserInfo> for ::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentUserInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IsolatedWindowsEnvironmentUserInfo> for &::windows::core::IInspectable {
-    fn from(value: &IsolatedWindowsEnvironmentUserInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IsolatedWindowsEnvironmentUserInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentUserInfo {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentUserInfo {}
 #[doc = "*Required features: `\"Security_Isolation\"`*"]

--- a/crates/libs/windows/src/Windows/Services/Cortana/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Cortana/mod.rs
@@ -370,41 +370,7 @@ impl ::windows::core::RuntimeName for CortanaActionableInsights {
     const NAME: &'static str = "Windows.Services.Cortana.CortanaActionableInsights";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<CortanaActionableInsights> for ::windows::core::IUnknown {
-    fn from(value: CortanaActionableInsights) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaActionableInsights> for ::windows::core::IUnknown {
-    fn from(value: &CortanaActionableInsights) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaActionableInsights> for &::windows::core::IUnknown {
-    fn from(value: &CortanaActionableInsights) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<CortanaActionableInsights> for ::windows::core::IInspectable {
-    fn from(value: CortanaActionableInsights) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaActionableInsights> for ::windows::core::IInspectable {
-    fn from(value: &CortanaActionableInsights) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaActionableInsights> for &::windows::core::IInspectable {
-    fn from(value: &CortanaActionableInsights) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CortanaActionableInsights, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for CortanaActionableInsights {}
 #[cfg(feature = "deprecated")]
@@ -494,41 +460,7 @@ impl ::windows::core::RuntimeName for CortanaActionableInsightsOptions {
     const NAME: &'static str = "Windows.Services.Cortana.CortanaActionableInsightsOptions";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<CortanaActionableInsightsOptions> for ::windows::core::IUnknown {
-    fn from(value: CortanaActionableInsightsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaActionableInsightsOptions> for ::windows::core::IUnknown {
-    fn from(value: &CortanaActionableInsightsOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaActionableInsightsOptions> for &::windows::core::IUnknown {
-    fn from(value: &CortanaActionableInsightsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<CortanaActionableInsightsOptions> for ::windows::core::IInspectable {
-    fn from(value: CortanaActionableInsightsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaActionableInsightsOptions> for ::windows::core::IInspectable {
-    fn from(value: &CortanaActionableInsightsOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaActionableInsightsOptions> for &::windows::core::IInspectable {
-    fn from(value: &CortanaActionableInsightsOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CortanaActionableInsightsOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for CortanaActionableInsightsOptions {}
 #[cfg(feature = "deprecated")]
@@ -643,41 +575,7 @@ impl ::windows::core::RuntimeName for CortanaPermissionsManager {
     const NAME: &'static str = "Windows.Services.Cortana.CortanaPermissionsManager";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<CortanaPermissionsManager> for ::windows::core::IUnknown {
-    fn from(value: CortanaPermissionsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaPermissionsManager> for ::windows::core::IUnknown {
-    fn from(value: &CortanaPermissionsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaPermissionsManager> for &::windows::core::IUnknown {
-    fn from(value: &CortanaPermissionsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<CortanaPermissionsManager> for ::windows::core::IInspectable {
-    fn from(value: CortanaPermissionsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaPermissionsManager> for ::windows::core::IInspectable {
-    fn from(value: &CortanaPermissionsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaPermissionsManager> for &::windows::core::IInspectable {
-    fn from(value: &CortanaPermissionsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CortanaPermissionsManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for CortanaPermissionsManager {}
 #[cfg(feature = "deprecated")]
@@ -776,41 +674,7 @@ impl ::windows::core::RuntimeName for CortanaSettings {
     const NAME: &'static str = "Windows.Services.Cortana.CortanaSettings";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<CortanaSettings> for ::windows::core::IUnknown {
-    fn from(value: CortanaSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaSettings> for ::windows::core::IUnknown {
-    fn from(value: &CortanaSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaSettings> for &::windows::core::IUnknown {
-    fn from(value: &CortanaSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<CortanaSettings> for ::windows::core::IInspectable {
-    fn from(value: CortanaSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaSettings> for ::windows::core::IInspectable {
-    fn from(value: &CortanaSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&CortanaSettings> for &::windows::core::IInspectable {
-    fn from(value: &CortanaSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CortanaSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for CortanaSettings {}
 #[cfg(feature = "deprecated")]

--- a/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
@@ -501,36 +501,7 @@ unsafe impl ::windows::core::Interface for GuidanceAudioNotificationRequestedEve
 impl ::windows::core::RuntimeName for GuidanceAudioNotificationRequestedEventArgs {
     const NAME: &'static str = "Windows.Services.Maps.Guidance.GuidanceAudioNotificationRequestedEventArgs";
 }
-impl ::core::convert::From<GuidanceAudioNotificationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GuidanceAudioNotificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceAudioNotificationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GuidanceAudioNotificationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceAudioNotificationRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GuidanceAudioNotificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GuidanceAudioNotificationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GuidanceAudioNotificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceAudioNotificationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GuidanceAudioNotificationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceAudioNotificationRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GuidanceAudioNotificationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GuidanceAudioNotificationRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GuidanceAudioNotificationRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for GuidanceAudioNotificationRequestedEventArgs {}
 #[doc = "*Required features: `\"Services_Maps_Guidance\"`*"]
@@ -584,36 +555,7 @@ unsafe impl ::windows::core::Interface for GuidanceLaneInfo {
 impl ::windows::core::RuntimeName for GuidanceLaneInfo {
     const NAME: &'static str = "Windows.Services.Maps.Guidance.GuidanceLaneInfo";
 }
-impl ::core::convert::From<GuidanceLaneInfo> for ::windows::core::IUnknown {
-    fn from(value: GuidanceLaneInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceLaneInfo> for ::windows::core::IUnknown {
-    fn from(value: &GuidanceLaneInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceLaneInfo> for &::windows::core::IUnknown {
-    fn from(value: &GuidanceLaneInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GuidanceLaneInfo> for ::windows::core::IInspectable {
-    fn from(value: GuidanceLaneInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceLaneInfo> for ::windows::core::IInspectable {
-    fn from(value: &GuidanceLaneInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceLaneInfo> for &::windows::core::IInspectable {
-    fn from(value: &GuidanceLaneInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GuidanceLaneInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GuidanceLaneInfo {}
 unsafe impl ::core::marker::Sync for GuidanceLaneInfo {}
 #[doc = "*Required features: `\"Services_Maps_Guidance\"`*"]
@@ -739,36 +681,7 @@ unsafe impl ::windows::core::Interface for GuidanceManeuver {
 impl ::windows::core::RuntimeName for GuidanceManeuver {
     const NAME: &'static str = "Windows.Services.Maps.Guidance.GuidanceManeuver";
 }
-impl ::core::convert::From<GuidanceManeuver> for ::windows::core::IUnknown {
-    fn from(value: GuidanceManeuver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceManeuver> for ::windows::core::IUnknown {
-    fn from(value: &GuidanceManeuver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceManeuver> for &::windows::core::IUnknown {
-    fn from(value: &GuidanceManeuver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GuidanceManeuver> for ::windows::core::IInspectable {
-    fn from(value: GuidanceManeuver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceManeuver> for ::windows::core::IInspectable {
-    fn from(value: &GuidanceManeuver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceManeuver> for &::windows::core::IInspectable {
-    fn from(value: &GuidanceManeuver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GuidanceManeuver, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GuidanceManeuver {}
 unsafe impl ::core::marker::Sync for GuidanceManeuver {}
 #[doc = "*Required features: `\"Services_Maps_Guidance\"`*"]
@@ -845,36 +758,7 @@ unsafe impl ::windows::core::Interface for GuidanceMapMatchedCoordinate {
 impl ::windows::core::RuntimeName for GuidanceMapMatchedCoordinate {
     const NAME: &'static str = "Windows.Services.Maps.Guidance.GuidanceMapMatchedCoordinate";
 }
-impl ::core::convert::From<GuidanceMapMatchedCoordinate> for ::windows::core::IUnknown {
-    fn from(value: GuidanceMapMatchedCoordinate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceMapMatchedCoordinate> for ::windows::core::IUnknown {
-    fn from(value: &GuidanceMapMatchedCoordinate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceMapMatchedCoordinate> for &::windows::core::IUnknown {
-    fn from(value: &GuidanceMapMatchedCoordinate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GuidanceMapMatchedCoordinate> for ::windows::core::IInspectable {
-    fn from(value: GuidanceMapMatchedCoordinate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceMapMatchedCoordinate> for ::windows::core::IInspectable {
-    fn from(value: &GuidanceMapMatchedCoordinate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceMapMatchedCoordinate> for &::windows::core::IInspectable {
-    fn from(value: &GuidanceMapMatchedCoordinate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GuidanceMapMatchedCoordinate, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GuidanceMapMatchedCoordinate {}
 unsafe impl ::core::marker::Sync for GuidanceMapMatchedCoordinate {}
 #[doc = "*Required features: `\"Services_Maps_Guidance\"`*"]
@@ -1133,36 +1017,7 @@ unsafe impl ::windows::core::Interface for GuidanceNavigator {
 impl ::windows::core::RuntimeName for GuidanceNavigator {
     const NAME: &'static str = "Windows.Services.Maps.Guidance.GuidanceNavigator";
 }
-impl ::core::convert::From<GuidanceNavigator> for ::windows::core::IUnknown {
-    fn from(value: GuidanceNavigator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceNavigator> for ::windows::core::IUnknown {
-    fn from(value: &GuidanceNavigator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceNavigator> for &::windows::core::IUnknown {
-    fn from(value: &GuidanceNavigator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GuidanceNavigator> for ::windows::core::IInspectable {
-    fn from(value: GuidanceNavigator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceNavigator> for ::windows::core::IInspectable {
-    fn from(value: &GuidanceNavigator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceNavigator> for &::windows::core::IInspectable {
-    fn from(value: &GuidanceNavigator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GuidanceNavigator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GuidanceNavigator {}
 unsafe impl ::core::marker::Sync for GuidanceNavigator {}
 #[doc = "*Required features: `\"Services_Maps_Guidance\"`*"]
@@ -1209,36 +1064,7 @@ unsafe impl ::windows::core::Interface for GuidanceReroutedEventArgs {
 impl ::windows::core::RuntimeName for GuidanceReroutedEventArgs {
     const NAME: &'static str = "Windows.Services.Maps.Guidance.GuidanceReroutedEventArgs";
 }
-impl ::core::convert::From<GuidanceReroutedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GuidanceReroutedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceReroutedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GuidanceReroutedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceReroutedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GuidanceReroutedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GuidanceReroutedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GuidanceReroutedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceReroutedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GuidanceReroutedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceReroutedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GuidanceReroutedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GuidanceReroutedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GuidanceReroutedEventArgs {}
 unsafe impl ::core::marker::Sync for GuidanceReroutedEventArgs {}
 #[doc = "*Required features: `\"Services_Maps_Guidance\"`*"]
@@ -1352,36 +1178,7 @@ unsafe impl ::windows::core::Interface for GuidanceRoadSegment {
 impl ::windows::core::RuntimeName for GuidanceRoadSegment {
     const NAME: &'static str = "Windows.Services.Maps.Guidance.GuidanceRoadSegment";
 }
-impl ::core::convert::From<GuidanceRoadSegment> for ::windows::core::IUnknown {
-    fn from(value: GuidanceRoadSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceRoadSegment> for ::windows::core::IUnknown {
-    fn from(value: &GuidanceRoadSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceRoadSegment> for &::windows::core::IUnknown {
-    fn from(value: &GuidanceRoadSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GuidanceRoadSegment> for ::windows::core::IInspectable {
-    fn from(value: GuidanceRoadSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceRoadSegment> for ::windows::core::IInspectable {
-    fn from(value: &GuidanceRoadSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceRoadSegment> for &::windows::core::IInspectable {
-    fn from(value: &GuidanceRoadSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GuidanceRoadSegment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GuidanceRoadSegment {}
 unsafe impl ::core::marker::Sync for GuidanceRoadSegment {}
 #[doc = "*Required features: `\"Services_Maps_Guidance\"`*"]
@@ -1462,36 +1259,7 @@ unsafe impl ::windows::core::Interface for GuidanceRoadSignpost {
 impl ::windows::core::RuntimeName for GuidanceRoadSignpost {
     const NAME: &'static str = "Windows.Services.Maps.Guidance.GuidanceRoadSignpost";
 }
-impl ::core::convert::From<GuidanceRoadSignpost> for ::windows::core::IUnknown {
-    fn from(value: GuidanceRoadSignpost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceRoadSignpost> for ::windows::core::IUnknown {
-    fn from(value: &GuidanceRoadSignpost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceRoadSignpost> for &::windows::core::IUnknown {
-    fn from(value: &GuidanceRoadSignpost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GuidanceRoadSignpost> for ::windows::core::IInspectable {
-    fn from(value: GuidanceRoadSignpost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceRoadSignpost> for ::windows::core::IInspectable {
-    fn from(value: &GuidanceRoadSignpost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceRoadSignpost> for &::windows::core::IInspectable {
-    fn from(value: &GuidanceRoadSignpost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GuidanceRoadSignpost, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GuidanceRoadSignpost {}
 unsafe impl ::core::marker::Sync for GuidanceRoadSignpost {}
 #[doc = "*Required features: `\"Services_Maps_Guidance\"`*"]
@@ -1607,36 +1375,7 @@ unsafe impl ::windows::core::Interface for GuidanceRoute {
 impl ::windows::core::RuntimeName for GuidanceRoute {
     const NAME: &'static str = "Windows.Services.Maps.Guidance.GuidanceRoute";
 }
-impl ::core::convert::From<GuidanceRoute> for ::windows::core::IUnknown {
-    fn from(value: GuidanceRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceRoute> for ::windows::core::IUnknown {
-    fn from(value: &GuidanceRoute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceRoute> for &::windows::core::IUnknown {
-    fn from(value: &GuidanceRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GuidanceRoute> for ::windows::core::IInspectable {
-    fn from(value: GuidanceRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceRoute> for ::windows::core::IInspectable {
-    fn from(value: &GuidanceRoute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceRoute> for &::windows::core::IInspectable {
-    fn from(value: &GuidanceRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GuidanceRoute, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GuidanceRoute {}
 unsafe impl ::core::marker::Sync for GuidanceRoute {}
 #[doc = "*Required features: `\"Services_Maps_Guidance\"`*"]
@@ -1724,36 +1463,7 @@ unsafe impl ::windows::core::Interface for GuidanceTelemetryCollector {
 impl ::windows::core::RuntimeName for GuidanceTelemetryCollector {
     const NAME: &'static str = "Windows.Services.Maps.Guidance.GuidanceTelemetryCollector";
 }
-impl ::core::convert::From<GuidanceTelemetryCollector> for ::windows::core::IUnknown {
-    fn from(value: GuidanceTelemetryCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceTelemetryCollector> for ::windows::core::IUnknown {
-    fn from(value: &GuidanceTelemetryCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceTelemetryCollector> for &::windows::core::IUnknown {
-    fn from(value: &GuidanceTelemetryCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GuidanceTelemetryCollector> for ::windows::core::IInspectable {
-    fn from(value: GuidanceTelemetryCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceTelemetryCollector> for ::windows::core::IInspectable {
-    fn from(value: &GuidanceTelemetryCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceTelemetryCollector> for &::windows::core::IInspectable {
-    fn from(value: &GuidanceTelemetryCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GuidanceTelemetryCollector, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GuidanceTelemetryCollector {}
 unsafe impl ::core::marker::Sync for GuidanceTelemetryCollector {}
 #[doc = "*Required features: `\"Services_Maps_Guidance\"`*"]
@@ -1897,36 +1607,7 @@ unsafe impl ::windows::core::Interface for GuidanceUpdatedEventArgs {
 impl ::windows::core::RuntimeName for GuidanceUpdatedEventArgs {
     const NAME: &'static str = "Windows.Services.Maps.Guidance.GuidanceUpdatedEventArgs";
 }
-impl ::core::convert::From<GuidanceUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: GuidanceUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &GuidanceUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &GuidanceUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GuidanceUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: GuidanceUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GuidanceUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &GuidanceUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GuidanceUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &GuidanceUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GuidanceUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GuidanceUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for GuidanceUpdatedEventArgs {}
 #[doc = "*Required features: `\"Services_Maps_Guidance\"`*"]

--- a/crates/libs/windows/src/Windows/Services/Maps/LocalSearch/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/LocalSearch/mod.rs
@@ -336,36 +336,7 @@ unsafe impl ::windows::core::Interface for LocalLocation {
 impl ::windows::core::RuntimeName for LocalLocation {
     const NAME: &'static str = "Windows.Services.Maps.LocalSearch.LocalLocation";
 }
-impl ::core::convert::From<LocalLocation> for ::windows::core::IUnknown {
-    fn from(value: LocalLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocalLocation> for ::windows::core::IUnknown {
-    fn from(value: &LocalLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocalLocation> for &::windows::core::IUnknown {
-    fn from(value: &LocalLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LocalLocation> for ::windows::core::IInspectable {
-    fn from(value: LocalLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocalLocation> for ::windows::core::IInspectable {
-    fn from(value: &LocalLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocalLocation> for &::windows::core::IInspectable {
-    fn from(value: &LocalLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LocalLocation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LocalLocation {}
 unsafe impl ::core::marker::Sync for LocalLocation {}
 #[doc = "*Required features: `\"Services_Maps_LocalSearch\"`*"]
@@ -441,36 +412,7 @@ unsafe impl ::windows::core::Interface for LocalLocationFinderResult {
 impl ::windows::core::RuntimeName for LocalLocationFinderResult {
     const NAME: &'static str = "Windows.Services.Maps.LocalSearch.LocalLocationFinderResult";
 }
-impl ::core::convert::From<LocalLocationFinderResult> for ::windows::core::IUnknown {
-    fn from(value: LocalLocationFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocalLocationFinderResult> for ::windows::core::IUnknown {
-    fn from(value: &LocalLocationFinderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocalLocationFinderResult> for &::windows::core::IUnknown {
-    fn from(value: &LocalLocationFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LocalLocationFinderResult> for ::windows::core::IInspectable {
-    fn from(value: LocalLocationFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocalLocationFinderResult> for ::windows::core::IInspectable {
-    fn from(value: &LocalLocationFinderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocalLocationFinderResult> for &::windows::core::IInspectable {
-    fn from(value: &LocalLocationFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LocalLocationFinderResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LocalLocationFinderResult {}
 unsafe impl ::core::marker::Sync for LocalLocationFinderResult {}
 #[doc = "*Required features: `\"Services_Maps_LocalSearch\"`*"]
@@ -537,36 +479,7 @@ unsafe impl ::windows::core::Interface for LocalLocationHoursOfOperationItem {
 impl ::windows::core::RuntimeName for LocalLocationHoursOfOperationItem {
     const NAME: &'static str = "Windows.Services.Maps.LocalSearch.LocalLocationHoursOfOperationItem";
 }
-impl ::core::convert::From<LocalLocationHoursOfOperationItem> for ::windows::core::IUnknown {
-    fn from(value: LocalLocationHoursOfOperationItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocalLocationHoursOfOperationItem> for ::windows::core::IUnknown {
-    fn from(value: &LocalLocationHoursOfOperationItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocalLocationHoursOfOperationItem> for &::windows::core::IUnknown {
-    fn from(value: &LocalLocationHoursOfOperationItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LocalLocationHoursOfOperationItem> for ::windows::core::IInspectable {
-    fn from(value: LocalLocationHoursOfOperationItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocalLocationHoursOfOperationItem> for ::windows::core::IInspectable {
-    fn from(value: &LocalLocationHoursOfOperationItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocalLocationHoursOfOperationItem> for &::windows::core::IInspectable {
-    fn from(value: &LocalLocationHoursOfOperationItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LocalLocationHoursOfOperationItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LocalLocationHoursOfOperationItem {}
 unsafe impl ::core::marker::Sync for LocalLocationHoursOfOperationItem {}
 #[doc = "*Required features: `\"Services_Maps_LocalSearch\"`*"]
@@ -631,36 +544,7 @@ unsafe impl ::windows::core::Interface for LocalLocationRatingInfo {
 impl ::windows::core::RuntimeName for LocalLocationRatingInfo {
     const NAME: &'static str = "Windows.Services.Maps.LocalSearch.LocalLocationRatingInfo";
 }
-impl ::core::convert::From<LocalLocationRatingInfo> for ::windows::core::IUnknown {
-    fn from(value: LocalLocationRatingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocalLocationRatingInfo> for ::windows::core::IUnknown {
-    fn from(value: &LocalLocationRatingInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocalLocationRatingInfo> for &::windows::core::IUnknown {
-    fn from(value: &LocalLocationRatingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LocalLocationRatingInfo> for ::windows::core::IInspectable {
-    fn from(value: LocalLocationRatingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LocalLocationRatingInfo> for ::windows::core::IInspectable {
-    fn from(value: &LocalLocationRatingInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LocalLocationRatingInfo> for &::windows::core::IInspectable {
-    fn from(value: &LocalLocationRatingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LocalLocationRatingInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LocalLocationRatingInfo {}
 unsafe impl ::core::marker::Sync for LocalLocationRatingInfo {}
 #[doc = "*Required features: `\"Services_Maps_LocalSearch\"`*"]

--- a/crates/libs/windows/src/Windows/Services/Maps/OfflineMaps/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/OfflineMaps/mod.rs
@@ -206,36 +206,7 @@ unsafe impl ::windows::core::Interface for OfflineMapPackage {
 impl ::windows::core::RuntimeName for OfflineMapPackage {
     const NAME: &'static str = "Windows.Services.Maps.OfflineMaps.OfflineMapPackage";
 }
-impl ::core::convert::From<OfflineMapPackage> for ::windows::core::IUnknown {
-    fn from(value: OfflineMapPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OfflineMapPackage> for ::windows::core::IUnknown {
-    fn from(value: &OfflineMapPackage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OfflineMapPackage> for &::windows::core::IUnknown {
-    fn from(value: &OfflineMapPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OfflineMapPackage> for ::windows::core::IInspectable {
-    fn from(value: OfflineMapPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OfflineMapPackage> for ::windows::core::IInspectable {
-    fn from(value: &OfflineMapPackage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OfflineMapPackage> for &::windows::core::IInspectable {
-    fn from(value: &OfflineMapPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OfflineMapPackage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OfflineMapPackage {}
 unsafe impl ::core::marker::Sync for OfflineMapPackage {}
 #[doc = "*Required features: `\"Services_Maps_OfflineMaps\"`*"]
@@ -291,36 +262,7 @@ unsafe impl ::windows::core::Interface for OfflineMapPackageQueryResult {
 impl ::windows::core::RuntimeName for OfflineMapPackageQueryResult {
     const NAME: &'static str = "Windows.Services.Maps.OfflineMaps.OfflineMapPackageQueryResult";
 }
-impl ::core::convert::From<OfflineMapPackageQueryResult> for ::windows::core::IUnknown {
-    fn from(value: OfflineMapPackageQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OfflineMapPackageQueryResult> for ::windows::core::IUnknown {
-    fn from(value: &OfflineMapPackageQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OfflineMapPackageQueryResult> for &::windows::core::IUnknown {
-    fn from(value: &OfflineMapPackageQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OfflineMapPackageQueryResult> for ::windows::core::IInspectable {
-    fn from(value: OfflineMapPackageQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OfflineMapPackageQueryResult> for ::windows::core::IInspectable {
-    fn from(value: &OfflineMapPackageQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OfflineMapPackageQueryResult> for &::windows::core::IInspectable {
-    fn from(value: &OfflineMapPackageQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OfflineMapPackageQueryResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OfflineMapPackageQueryResult {}
 unsafe impl ::core::marker::Sync for OfflineMapPackageQueryResult {}
 #[doc = "*Required features: `\"Services_Maps_OfflineMaps\"`*"]
@@ -367,36 +309,7 @@ unsafe impl ::windows::core::Interface for OfflineMapPackageStartDownloadResult 
 impl ::windows::core::RuntimeName for OfflineMapPackageStartDownloadResult {
     const NAME: &'static str = "Windows.Services.Maps.OfflineMaps.OfflineMapPackageStartDownloadResult";
 }
-impl ::core::convert::From<OfflineMapPackageStartDownloadResult> for ::windows::core::IUnknown {
-    fn from(value: OfflineMapPackageStartDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OfflineMapPackageStartDownloadResult> for ::windows::core::IUnknown {
-    fn from(value: &OfflineMapPackageStartDownloadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OfflineMapPackageStartDownloadResult> for &::windows::core::IUnknown {
-    fn from(value: &OfflineMapPackageStartDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OfflineMapPackageStartDownloadResult> for ::windows::core::IInspectable {
-    fn from(value: OfflineMapPackageStartDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OfflineMapPackageStartDownloadResult> for ::windows::core::IInspectable {
-    fn from(value: &OfflineMapPackageStartDownloadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OfflineMapPackageStartDownloadResult> for &::windows::core::IInspectable {
-    fn from(value: &OfflineMapPackageStartDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OfflineMapPackageStartDownloadResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OfflineMapPackageStartDownloadResult {}
 unsafe impl ::core::marker::Sync for OfflineMapPackageStartDownloadResult {}
 #[doc = "*Required features: `\"Services_Maps_OfflineMaps\"`*"]

--- a/crates/libs/windows/src/Windows/Services/Maps/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/mod.rs
@@ -789,36 +789,7 @@ unsafe impl ::windows::core::Interface for EnhancedWaypoint {
 impl ::windows::core::RuntimeName for EnhancedWaypoint {
     const NAME: &'static str = "Windows.Services.Maps.EnhancedWaypoint";
 }
-impl ::core::convert::From<EnhancedWaypoint> for ::windows::core::IUnknown {
-    fn from(value: EnhancedWaypoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnhancedWaypoint> for ::windows::core::IUnknown {
-    fn from(value: &EnhancedWaypoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnhancedWaypoint> for &::windows::core::IUnknown {
-    fn from(value: &EnhancedWaypoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EnhancedWaypoint> for ::windows::core::IInspectable {
-    fn from(value: EnhancedWaypoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EnhancedWaypoint> for ::windows::core::IInspectable {
-    fn from(value: &EnhancedWaypoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EnhancedWaypoint> for &::windows::core::IInspectable {
-    fn from(value: &EnhancedWaypoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EnhancedWaypoint, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for EnhancedWaypoint {}
 unsafe impl ::core::marker::Sync for EnhancedWaypoint {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]
@@ -872,36 +843,7 @@ unsafe impl ::windows::core::Interface for ManeuverWarning {
 impl ::windows::core::RuntimeName for ManeuverWarning {
     const NAME: &'static str = "Windows.Services.Maps.ManeuverWarning";
 }
-impl ::core::convert::From<ManeuverWarning> for ::windows::core::IUnknown {
-    fn from(value: ManeuverWarning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ManeuverWarning> for ::windows::core::IUnknown {
-    fn from(value: &ManeuverWarning) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ManeuverWarning> for &::windows::core::IUnknown {
-    fn from(value: &ManeuverWarning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ManeuverWarning> for ::windows::core::IInspectable {
-    fn from(value: ManeuverWarning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ManeuverWarning> for ::windows::core::IInspectable {
-    fn from(value: &ManeuverWarning) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ManeuverWarning> for &::windows::core::IInspectable {
-    fn from(value: &ManeuverWarning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ManeuverWarning, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ManeuverWarning {}
 unsafe impl ::core::marker::Sync for ManeuverWarning {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]
@@ -1053,36 +995,7 @@ unsafe impl ::windows::core::Interface for MapAddress {
 impl ::windows::core::RuntimeName for MapAddress {
     const NAME: &'static str = "Windows.Services.Maps.MapAddress";
 }
-impl ::core::convert::From<MapAddress> for ::windows::core::IUnknown {
-    fn from(value: MapAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapAddress> for ::windows::core::IUnknown {
-    fn from(value: &MapAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapAddress> for &::windows::core::IUnknown {
-    fn from(value: &MapAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MapAddress> for ::windows::core::IInspectable {
-    fn from(value: MapAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapAddress> for ::windows::core::IInspectable {
-    fn from(value: &MapAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapAddress> for &::windows::core::IInspectable {
-    fn from(value: &MapAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MapAddress, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MapAddress {}
 unsafe impl ::core::marker::Sync for MapAddress {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]
@@ -1152,36 +1065,7 @@ unsafe impl ::windows::core::Interface for MapLocation {
 impl ::windows::core::RuntimeName for MapLocation {
     const NAME: &'static str = "Windows.Services.Maps.MapLocation";
 }
-impl ::core::convert::From<MapLocation> for ::windows::core::IUnknown {
-    fn from(value: MapLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapLocation> for ::windows::core::IUnknown {
-    fn from(value: &MapLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapLocation> for &::windows::core::IUnknown {
-    fn from(value: &MapLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MapLocation> for ::windows::core::IInspectable {
-    fn from(value: MapLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapLocation> for ::windows::core::IInspectable {
-    fn from(value: &MapLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapLocation> for &::windows::core::IInspectable {
-    fn from(value: &MapLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MapLocation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MapLocation {}
 unsafe impl ::core::marker::Sync for MapLocation {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]
@@ -1286,36 +1170,7 @@ unsafe impl ::windows::core::Interface for MapLocationFinderResult {
 impl ::windows::core::RuntimeName for MapLocationFinderResult {
     const NAME: &'static str = "Windows.Services.Maps.MapLocationFinderResult";
 }
-impl ::core::convert::From<MapLocationFinderResult> for ::windows::core::IUnknown {
-    fn from(value: MapLocationFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapLocationFinderResult> for ::windows::core::IUnknown {
-    fn from(value: &MapLocationFinderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapLocationFinderResult> for &::windows::core::IUnknown {
-    fn from(value: &MapLocationFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MapLocationFinderResult> for ::windows::core::IInspectable {
-    fn from(value: MapLocationFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapLocationFinderResult> for ::windows::core::IInspectable {
-    fn from(value: &MapLocationFinderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapLocationFinderResult> for &::windows::core::IInspectable {
-    fn from(value: &MapLocationFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MapLocationFinderResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MapLocationFinderResult {}
 unsafe impl ::core::marker::Sync for MapLocationFinderResult {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]
@@ -1460,36 +1315,7 @@ unsafe impl ::windows::core::Interface for MapRoute {
 impl ::windows::core::RuntimeName for MapRoute {
     const NAME: &'static str = "Windows.Services.Maps.MapRoute";
 }
-impl ::core::convert::From<MapRoute> for ::windows::core::IUnknown {
-    fn from(value: MapRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapRoute> for ::windows::core::IUnknown {
-    fn from(value: &MapRoute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapRoute> for &::windows::core::IUnknown {
-    fn from(value: &MapRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MapRoute> for ::windows::core::IInspectable {
-    fn from(value: MapRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapRoute> for ::windows::core::IInspectable {
-    fn from(value: &MapRoute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapRoute> for &::windows::core::IInspectable {
-    fn from(value: &MapRoute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MapRoute, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MapRoute {}
 unsafe impl ::core::marker::Sync for MapRoute {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]
@@ -1607,36 +1433,7 @@ unsafe impl ::windows::core::Interface for MapRouteDrivingOptions {
 impl ::windows::core::RuntimeName for MapRouteDrivingOptions {
     const NAME: &'static str = "Windows.Services.Maps.MapRouteDrivingOptions";
 }
-impl ::core::convert::From<MapRouteDrivingOptions> for ::windows::core::IUnknown {
-    fn from(value: MapRouteDrivingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapRouteDrivingOptions> for ::windows::core::IUnknown {
-    fn from(value: &MapRouteDrivingOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapRouteDrivingOptions> for &::windows::core::IUnknown {
-    fn from(value: &MapRouteDrivingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MapRouteDrivingOptions> for ::windows::core::IInspectable {
-    fn from(value: MapRouteDrivingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapRouteDrivingOptions> for ::windows::core::IInspectable {
-    fn from(value: &MapRouteDrivingOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapRouteDrivingOptions> for &::windows::core::IInspectable {
-    fn from(value: &MapRouteDrivingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MapRouteDrivingOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MapRouteDrivingOptions {}
 unsafe impl ::core::marker::Sync for MapRouteDrivingOptions {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]
@@ -1853,36 +1650,7 @@ unsafe impl ::windows::core::Interface for MapRouteFinderResult {
 impl ::windows::core::RuntimeName for MapRouteFinderResult {
     const NAME: &'static str = "Windows.Services.Maps.MapRouteFinderResult";
 }
-impl ::core::convert::From<MapRouteFinderResult> for ::windows::core::IUnknown {
-    fn from(value: MapRouteFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapRouteFinderResult> for ::windows::core::IUnknown {
-    fn from(value: &MapRouteFinderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapRouteFinderResult> for &::windows::core::IUnknown {
-    fn from(value: &MapRouteFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MapRouteFinderResult> for ::windows::core::IInspectable {
-    fn from(value: MapRouteFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapRouteFinderResult> for ::windows::core::IInspectable {
-    fn from(value: &MapRouteFinderResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapRouteFinderResult> for &::windows::core::IInspectable {
-    fn from(value: &MapRouteFinderResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MapRouteFinderResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MapRouteFinderResult {}
 unsafe impl ::core::marker::Sync for MapRouteFinderResult {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]
@@ -1981,36 +1749,7 @@ unsafe impl ::windows::core::Interface for MapRouteLeg {
 impl ::windows::core::RuntimeName for MapRouteLeg {
     const NAME: &'static str = "Windows.Services.Maps.MapRouteLeg";
 }
-impl ::core::convert::From<MapRouteLeg> for ::windows::core::IUnknown {
-    fn from(value: MapRouteLeg) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapRouteLeg> for ::windows::core::IUnknown {
-    fn from(value: &MapRouteLeg) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapRouteLeg> for &::windows::core::IUnknown {
-    fn from(value: &MapRouteLeg) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MapRouteLeg> for ::windows::core::IInspectable {
-    fn from(value: MapRouteLeg) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapRouteLeg> for ::windows::core::IInspectable {
-    fn from(value: &MapRouteLeg) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapRouteLeg> for &::windows::core::IInspectable {
-    fn from(value: &MapRouteLeg) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MapRouteLeg, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MapRouteLeg {}
 unsafe impl ::core::marker::Sync for MapRouteLeg {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]
@@ -2124,36 +1863,7 @@ unsafe impl ::windows::core::Interface for MapRouteManeuver {
 impl ::windows::core::RuntimeName for MapRouteManeuver {
     const NAME: &'static str = "Windows.Services.Maps.MapRouteManeuver";
 }
-impl ::core::convert::From<MapRouteManeuver> for ::windows::core::IUnknown {
-    fn from(value: MapRouteManeuver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapRouteManeuver> for ::windows::core::IUnknown {
-    fn from(value: &MapRouteManeuver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapRouteManeuver> for &::windows::core::IUnknown {
-    fn from(value: &MapRouteManeuver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MapRouteManeuver> for ::windows::core::IInspectable {
-    fn from(value: MapRouteManeuver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MapRouteManeuver> for ::windows::core::IInspectable {
-    fn from(value: &MapRouteManeuver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MapRouteManeuver> for &::windows::core::IInspectable {
-    fn from(value: &MapRouteManeuver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MapRouteManeuver, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for MapRouteManeuver {}
 unsafe impl ::core::marker::Sync for MapRouteManeuver {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]
@@ -2356,36 +2066,7 @@ unsafe impl ::windows::core::Interface for PlaceInfo {
 impl ::windows::core::RuntimeName for PlaceInfo {
     const NAME: &'static str = "Windows.Services.Maps.PlaceInfo";
 }
-impl ::core::convert::From<PlaceInfo> for ::windows::core::IUnknown {
-    fn from(value: PlaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaceInfo> for ::windows::core::IUnknown {
-    fn from(value: &PlaceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaceInfo> for &::windows::core::IUnknown {
-    fn from(value: &PlaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlaceInfo> for ::windows::core::IInspectable {
-    fn from(value: PlaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaceInfo> for ::windows::core::IInspectable {
-    fn from(value: &PlaceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaceInfo> for &::windows::core::IInspectable {
-    fn from(value: &PlaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlaceInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PlaceInfo {}
 unsafe impl ::core::marker::Sync for PlaceInfo {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]
@@ -2454,36 +2135,7 @@ unsafe impl ::windows::core::Interface for PlaceInfoCreateOptions {
 impl ::windows::core::RuntimeName for PlaceInfoCreateOptions {
     const NAME: &'static str = "Windows.Services.Maps.PlaceInfoCreateOptions";
 }
-impl ::core::convert::From<PlaceInfoCreateOptions> for ::windows::core::IUnknown {
-    fn from(value: PlaceInfoCreateOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaceInfoCreateOptions> for ::windows::core::IUnknown {
-    fn from(value: &PlaceInfoCreateOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaceInfoCreateOptions> for &::windows::core::IUnknown {
-    fn from(value: &PlaceInfoCreateOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlaceInfoCreateOptions> for ::windows::core::IInspectable {
-    fn from(value: PlaceInfoCreateOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlaceInfoCreateOptions> for ::windows::core::IInspectable {
-    fn from(value: &PlaceInfoCreateOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlaceInfoCreateOptions> for &::windows::core::IInspectable {
-    fn from(value: &PlaceInfoCreateOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlaceInfoCreateOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PlaceInfoCreateOptions {}
 unsafe impl ::core::marker::Sync for PlaceInfoCreateOptions {}
 #[doc = "*Required features: `\"Services_Maps\"`*"]

--- a/crates/libs/windows/src/Windows/Services/Store/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Store/mod.rs
@@ -1058,36 +1058,7 @@ unsafe impl ::windows::core::Interface for StoreAcquireLicenseResult {
 impl ::windows::core::RuntimeName for StoreAcquireLicenseResult {
     const NAME: &'static str = "Windows.Services.Store.StoreAcquireLicenseResult";
 }
-impl ::core::convert::From<StoreAcquireLicenseResult> for ::windows::core::IUnknown {
-    fn from(value: StoreAcquireLicenseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreAcquireLicenseResult> for ::windows::core::IUnknown {
-    fn from(value: &StoreAcquireLicenseResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreAcquireLicenseResult> for &::windows::core::IUnknown {
-    fn from(value: &StoreAcquireLicenseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreAcquireLicenseResult> for ::windows::core::IInspectable {
-    fn from(value: StoreAcquireLicenseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreAcquireLicenseResult> for ::windows::core::IInspectable {
-    fn from(value: &StoreAcquireLicenseResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreAcquireLicenseResult> for &::windows::core::IInspectable {
-    fn from(value: &StoreAcquireLicenseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreAcquireLicenseResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreAcquireLicenseResult {}
 unsafe impl ::core::marker::Sync for StoreAcquireLicenseResult {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -1203,36 +1174,7 @@ unsafe impl ::windows::core::Interface for StoreAppLicense {
 impl ::windows::core::RuntimeName for StoreAppLicense {
     const NAME: &'static str = "Windows.Services.Store.StoreAppLicense";
 }
-impl ::core::convert::From<StoreAppLicense> for ::windows::core::IUnknown {
-    fn from(value: StoreAppLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreAppLicense> for ::windows::core::IUnknown {
-    fn from(value: &StoreAppLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreAppLicense> for &::windows::core::IUnknown {
-    fn from(value: &StoreAppLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreAppLicense> for ::windows::core::IInspectable {
-    fn from(value: StoreAppLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreAppLicense> for ::windows::core::IInspectable {
-    fn from(value: &StoreAppLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreAppLicense> for &::windows::core::IInspectable {
-    fn from(value: &StoreAppLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreAppLicense, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreAppLicense {}
 unsafe impl ::core::marker::Sync for StoreAppLicense {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -1320,36 +1262,7 @@ unsafe impl ::windows::core::Interface for StoreAvailability {
 impl ::windows::core::RuntimeName for StoreAvailability {
     const NAME: &'static str = "Windows.Services.Store.StoreAvailability";
 }
-impl ::core::convert::From<StoreAvailability> for ::windows::core::IUnknown {
-    fn from(value: StoreAvailability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreAvailability> for ::windows::core::IUnknown {
-    fn from(value: &StoreAvailability) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreAvailability> for &::windows::core::IUnknown {
-    fn from(value: &StoreAvailability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreAvailability> for ::windows::core::IInspectable {
-    fn from(value: StoreAvailability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreAvailability> for ::windows::core::IInspectable {
-    fn from(value: &StoreAvailability) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreAvailability> for &::windows::core::IInspectable {
-    fn from(value: &StoreAvailability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreAvailability, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreAvailability {}
 unsafe impl ::core::marker::Sync for StoreAvailability {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -1410,36 +1323,7 @@ unsafe impl ::windows::core::Interface for StoreCanAcquireLicenseResult {
 impl ::windows::core::RuntimeName for StoreCanAcquireLicenseResult {
     const NAME: &'static str = "Windows.Services.Store.StoreCanAcquireLicenseResult";
 }
-impl ::core::convert::From<StoreCanAcquireLicenseResult> for ::windows::core::IUnknown {
-    fn from(value: StoreCanAcquireLicenseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreCanAcquireLicenseResult> for ::windows::core::IUnknown {
-    fn from(value: &StoreCanAcquireLicenseResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreCanAcquireLicenseResult> for &::windows::core::IUnknown {
-    fn from(value: &StoreCanAcquireLicenseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreCanAcquireLicenseResult> for ::windows::core::IInspectable {
-    fn from(value: StoreCanAcquireLicenseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreCanAcquireLicenseResult> for ::windows::core::IInspectable {
-    fn from(value: &StoreCanAcquireLicenseResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreCanAcquireLicenseResult> for &::windows::core::IInspectable {
-    fn from(value: &StoreCanAcquireLicenseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreCanAcquireLicenseResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreCanAcquireLicenseResult {}
 unsafe impl ::core::marker::Sync for StoreCanAcquireLicenseResult {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -1543,36 +1427,7 @@ unsafe impl ::windows::core::Interface for StoreCollectionData {
 impl ::windows::core::RuntimeName for StoreCollectionData {
     const NAME: &'static str = "Windows.Services.Store.StoreCollectionData";
 }
-impl ::core::convert::From<StoreCollectionData> for ::windows::core::IUnknown {
-    fn from(value: StoreCollectionData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreCollectionData> for ::windows::core::IUnknown {
-    fn from(value: &StoreCollectionData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreCollectionData> for &::windows::core::IUnknown {
-    fn from(value: &StoreCollectionData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreCollectionData> for ::windows::core::IInspectable {
-    fn from(value: StoreCollectionData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreCollectionData> for ::windows::core::IInspectable {
-    fn from(value: &StoreCollectionData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreCollectionData> for &::windows::core::IInspectable {
-    fn from(value: &StoreCollectionData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreCollectionData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreCollectionData {}
 unsafe impl ::core::marker::Sync for StoreCollectionData {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -1640,36 +1495,7 @@ unsafe impl ::windows::core::Interface for StoreConsumableResult {
 impl ::windows::core::RuntimeName for StoreConsumableResult {
     const NAME: &'static str = "Windows.Services.Store.StoreConsumableResult";
 }
-impl ::core::convert::From<StoreConsumableResult> for ::windows::core::IUnknown {
-    fn from(value: StoreConsumableResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreConsumableResult> for ::windows::core::IUnknown {
-    fn from(value: &StoreConsumableResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreConsumableResult> for &::windows::core::IUnknown {
-    fn from(value: &StoreConsumableResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreConsumableResult> for ::windows::core::IInspectable {
-    fn from(value: StoreConsumableResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreConsumableResult> for ::windows::core::IInspectable {
-    fn from(value: &StoreConsumableResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreConsumableResult> for &::windows::core::IInspectable {
-    fn from(value: &StoreConsumableResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreConsumableResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreConsumableResult {}
 unsafe impl ::core::marker::Sync for StoreConsumableResult {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -2133,36 +1959,7 @@ unsafe impl ::windows::core::Interface for StoreContext {
 impl ::windows::core::RuntimeName for StoreContext {
     const NAME: &'static str = "Windows.Services.Store.StoreContext";
 }
-impl ::core::convert::From<StoreContext> for ::windows::core::IUnknown {
-    fn from(value: StoreContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreContext> for ::windows::core::IUnknown {
-    fn from(value: &StoreContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreContext> for &::windows::core::IUnknown {
-    fn from(value: &StoreContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreContext> for ::windows::core::IInspectable {
-    fn from(value: StoreContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreContext> for ::windows::core::IInspectable {
-    fn from(value: &StoreContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreContext> for &::windows::core::IInspectable {
-    fn from(value: &StoreContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreContext {}
 unsafe impl ::core::marker::Sync for StoreContext {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -2239,36 +2036,7 @@ unsafe impl ::windows::core::Interface for StoreImage {
 impl ::windows::core::RuntimeName for StoreImage {
     const NAME: &'static str = "Windows.Services.Store.StoreImage";
 }
-impl ::core::convert::From<StoreImage> for ::windows::core::IUnknown {
-    fn from(value: StoreImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreImage> for ::windows::core::IUnknown {
-    fn from(value: &StoreImage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreImage> for &::windows::core::IUnknown {
-    fn from(value: &StoreImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreImage> for ::windows::core::IInspectable {
-    fn from(value: StoreImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreImage> for ::windows::core::IInspectable {
-    fn from(value: &StoreImage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreImage> for &::windows::core::IInspectable {
-    fn from(value: &StoreImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreImage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreImage {}
 unsafe impl ::core::marker::Sync for StoreImage {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -2345,36 +2113,7 @@ unsafe impl ::windows::core::Interface for StoreLicense {
 impl ::windows::core::RuntimeName for StoreLicense {
     const NAME: &'static str = "Windows.Services.Store.StoreLicense";
 }
-impl ::core::convert::From<StoreLicense> for ::windows::core::IUnknown {
-    fn from(value: StoreLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreLicense> for ::windows::core::IUnknown {
-    fn from(value: &StoreLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreLicense> for &::windows::core::IUnknown {
-    fn from(value: &StoreLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreLicense> for ::windows::core::IInspectable {
-    fn from(value: StoreLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreLicense> for ::windows::core::IInspectable {
-    fn from(value: &StoreLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreLicense> for &::windows::core::IInspectable {
-    fn from(value: &StoreLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreLicense, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreLicense {}
 unsafe impl ::core::marker::Sync for StoreLicense {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -2432,36 +2171,7 @@ unsafe impl ::windows::core::Interface for StorePackageInstallOptions {
 impl ::windows::core::RuntimeName for StorePackageInstallOptions {
     const NAME: &'static str = "Windows.Services.Store.StorePackageInstallOptions";
 }
-impl ::core::convert::From<StorePackageInstallOptions> for ::windows::core::IUnknown {
-    fn from(value: StorePackageInstallOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePackageInstallOptions> for ::windows::core::IUnknown {
-    fn from(value: &StorePackageInstallOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePackageInstallOptions> for &::windows::core::IUnknown {
-    fn from(value: &StorePackageInstallOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorePackageInstallOptions> for ::windows::core::IInspectable {
-    fn from(value: StorePackageInstallOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePackageInstallOptions> for ::windows::core::IInspectable {
-    fn from(value: &StorePackageInstallOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePackageInstallOptions> for &::windows::core::IInspectable {
-    fn from(value: &StorePackageInstallOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorePackageInstallOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorePackageInstallOptions {}
 unsafe impl ::core::marker::Sync for StorePackageInstallOptions {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -2542,36 +2252,7 @@ unsafe impl ::windows::core::Interface for StorePackageLicense {
 impl ::windows::core::RuntimeName for StorePackageLicense {
     const NAME: &'static str = "Windows.Services.Store.StorePackageLicense";
 }
-impl ::core::convert::From<StorePackageLicense> for ::windows::core::IUnknown {
-    fn from(value: StorePackageLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePackageLicense> for ::windows::core::IUnknown {
-    fn from(value: &StorePackageLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePackageLicense> for &::windows::core::IUnknown {
-    fn from(value: &StorePackageLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorePackageLicense> for ::windows::core::IInspectable {
-    fn from(value: StorePackageLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePackageLicense> for ::windows::core::IInspectable {
-    fn from(value: &StorePackageLicense) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePackageLicense> for &::windows::core::IInspectable {
-    fn from(value: &StorePackageLicense) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorePackageLicense, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<StorePackageLicense> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2649,36 +2330,7 @@ unsafe impl ::windows::core::Interface for StorePackageUpdate {
 impl ::windows::core::RuntimeName for StorePackageUpdate {
     const NAME: &'static str = "Windows.Services.Store.StorePackageUpdate";
 }
-impl ::core::convert::From<StorePackageUpdate> for ::windows::core::IUnknown {
-    fn from(value: StorePackageUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePackageUpdate> for ::windows::core::IUnknown {
-    fn from(value: &StorePackageUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePackageUpdate> for &::windows::core::IUnknown {
-    fn from(value: &StorePackageUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorePackageUpdate> for ::windows::core::IInspectable {
-    fn from(value: StorePackageUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePackageUpdate> for ::windows::core::IInspectable {
-    fn from(value: &StorePackageUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePackageUpdate> for &::windows::core::IInspectable {
-    fn from(value: &StorePackageUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorePackageUpdate, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorePackageUpdate {}
 unsafe impl ::core::marker::Sync for StorePackageUpdate {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -2743,36 +2395,7 @@ unsafe impl ::windows::core::Interface for StorePackageUpdateResult {
 impl ::windows::core::RuntimeName for StorePackageUpdateResult {
     const NAME: &'static str = "Windows.Services.Store.StorePackageUpdateResult";
 }
-impl ::core::convert::From<StorePackageUpdateResult> for ::windows::core::IUnknown {
-    fn from(value: StorePackageUpdateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePackageUpdateResult> for ::windows::core::IUnknown {
-    fn from(value: &StorePackageUpdateResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePackageUpdateResult> for &::windows::core::IUnknown {
-    fn from(value: &StorePackageUpdateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorePackageUpdateResult> for ::windows::core::IInspectable {
-    fn from(value: StorePackageUpdateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePackageUpdateResult> for ::windows::core::IInspectable {
-    fn from(value: &StorePackageUpdateResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePackageUpdateResult> for &::windows::core::IInspectable {
-    fn from(value: &StorePackageUpdateResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorePackageUpdateResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorePackageUpdateResult {}
 unsafe impl ::core::marker::Sync for StorePackageUpdateResult {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -2856,36 +2479,7 @@ unsafe impl ::windows::core::Interface for StorePrice {
 impl ::windows::core::RuntimeName for StorePrice {
     const NAME: &'static str = "Windows.Services.Store.StorePrice";
 }
-impl ::core::convert::From<StorePrice> for ::windows::core::IUnknown {
-    fn from(value: StorePrice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePrice> for ::windows::core::IUnknown {
-    fn from(value: &StorePrice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePrice> for &::windows::core::IUnknown {
-    fn from(value: &StorePrice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorePrice> for ::windows::core::IInspectable {
-    fn from(value: StorePrice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePrice> for ::windows::core::IInspectable {
-    fn from(value: &StorePrice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePrice> for &::windows::core::IInspectable {
-    fn from(value: &StorePrice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorePrice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorePrice {}
 unsafe impl ::core::marker::Sync for StorePrice {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -3067,36 +2661,7 @@ unsafe impl ::windows::core::Interface for StoreProduct {
 impl ::windows::core::RuntimeName for StoreProduct {
     const NAME: &'static str = "Windows.Services.Store.StoreProduct";
 }
-impl ::core::convert::From<StoreProduct> for ::windows::core::IUnknown {
-    fn from(value: StoreProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreProduct> for ::windows::core::IUnknown {
-    fn from(value: &StoreProduct) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreProduct> for &::windows::core::IUnknown {
-    fn from(value: &StoreProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreProduct> for ::windows::core::IInspectable {
-    fn from(value: StoreProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreProduct> for ::windows::core::IInspectable {
-    fn from(value: &StoreProduct) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreProduct> for &::windows::core::IInspectable {
-    fn from(value: &StoreProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreProduct, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreProduct {}
 unsafe impl ::core::marker::Sync for StoreProduct {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -3152,36 +2717,7 @@ unsafe impl ::windows::core::Interface for StoreProductOptions {
 impl ::windows::core::RuntimeName for StoreProductOptions {
     const NAME: &'static str = "Windows.Services.Store.StoreProductOptions";
 }
-impl ::core::convert::From<StoreProductOptions> for ::windows::core::IUnknown {
-    fn from(value: StoreProductOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreProductOptions> for ::windows::core::IUnknown {
-    fn from(value: &StoreProductOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreProductOptions> for &::windows::core::IUnknown {
-    fn from(value: &StoreProductOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreProductOptions> for ::windows::core::IInspectable {
-    fn from(value: StoreProductOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreProductOptions> for ::windows::core::IInspectable {
-    fn from(value: &StoreProductOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreProductOptions> for &::windows::core::IInspectable {
-    fn from(value: &StoreProductOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreProductOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreProductOptions {}
 unsafe impl ::core::marker::Sync for StoreProductOptions {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -3253,36 +2789,7 @@ unsafe impl ::windows::core::Interface for StoreProductPagedQueryResult {
 impl ::windows::core::RuntimeName for StoreProductPagedQueryResult {
     const NAME: &'static str = "Windows.Services.Store.StoreProductPagedQueryResult";
 }
-impl ::core::convert::From<StoreProductPagedQueryResult> for ::windows::core::IUnknown {
-    fn from(value: StoreProductPagedQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreProductPagedQueryResult> for ::windows::core::IUnknown {
-    fn from(value: &StoreProductPagedQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreProductPagedQueryResult> for &::windows::core::IUnknown {
-    fn from(value: &StoreProductPagedQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreProductPagedQueryResult> for ::windows::core::IInspectable {
-    fn from(value: StoreProductPagedQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreProductPagedQueryResult> for ::windows::core::IInspectable {
-    fn from(value: &StoreProductPagedQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreProductPagedQueryResult> for &::windows::core::IInspectable {
-    fn from(value: &StoreProductPagedQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreProductPagedQueryResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreProductPagedQueryResult {}
 unsafe impl ::core::marker::Sync for StoreProductPagedQueryResult {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -3338,36 +2845,7 @@ unsafe impl ::windows::core::Interface for StoreProductQueryResult {
 impl ::windows::core::RuntimeName for StoreProductQueryResult {
     const NAME: &'static str = "Windows.Services.Store.StoreProductQueryResult";
 }
-impl ::core::convert::From<StoreProductQueryResult> for ::windows::core::IUnknown {
-    fn from(value: StoreProductQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreProductQueryResult> for ::windows::core::IUnknown {
-    fn from(value: &StoreProductQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreProductQueryResult> for &::windows::core::IUnknown {
-    fn from(value: &StoreProductQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreProductQueryResult> for ::windows::core::IInspectable {
-    fn from(value: StoreProductQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreProductQueryResult> for ::windows::core::IInspectable {
-    fn from(value: &StoreProductQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreProductQueryResult> for &::windows::core::IInspectable {
-    fn from(value: &StoreProductQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreProductQueryResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreProductQueryResult {}
 unsafe impl ::core::marker::Sync for StoreProductQueryResult {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -3421,36 +2899,7 @@ unsafe impl ::windows::core::Interface for StoreProductResult {
 impl ::windows::core::RuntimeName for StoreProductResult {
     const NAME: &'static str = "Windows.Services.Store.StoreProductResult";
 }
-impl ::core::convert::From<StoreProductResult> for ::windows::core::IUnknown {
-    fn from(value: StoreProductResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreProductResult> for ::windows::core::IUnknown {
-    fn from(value: &StoreProductResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreProductResult> for &::windows::core::IUnknown {
-    fn from(value: &StoreProductResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreProductResult> for ::windows::core::IInspectable {
-    fn from(value: StoreProductResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreProductResult> for ::windows::core::IInspectable {
-    fn from(value: &StoreProductResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreProductResult> for &::windows::core::IInspectable {
-    fn from(value: &StoreProductResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreProductResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreProductResult {}
 unsafe impl ::core::marker::Sync for StoreProductResult {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -3530,36 +2979,7 @@ unsafe impl ::windows::core::Interface for StorePurchaseProperties {
 impl ::windows::core::RuntimeName for StorePurchaseProperties {
     const NAME: &'static str = "Windows.Services.Store.StorePurchaseProperties";
 }
-impl ::core::convert::From<StorePurchaseProperties> for ::windows::core::IUnknown {
-    fn from(value: StorePurchaseProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePurchaseProperties> for ::windows::core::IUnknown {
-    fn from(value: &StorePurchaseProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePurchaseProperties> for &::windows::core::IUnknown {
-    fn from(value: &StorePurchaseProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorePurchaseProperties> for ::windows::core::IInspectable {
-    fn from(value: StorePurchaseProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePurchaseProperties> for ::windows::core::IInspectable {
-    fn from(value: &StorePurchaseProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePurchaseProperties> for &::windows::core::IInspectable {
-    fn from(value: &StorePurchaseProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorePurchaseProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorePurchaseProperties {}
 unsafe impl ::core::marker::Sync for StorePurchaseProperties {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -3613,36 +3033,7 @@ unsafe impl ::windows::core::Interface for StorePurchaseResult {
 impl ::windows::core::RuntimeName for StorePurchaseResult {
     const NAME: &'static str = "Windows.Services.Store.StorePurchaseResult";
 }
-impl ::core::convert::From<StorePurchaseResult> for ::windows::core::IUnknown {
-    fn from(value: StorePurchaseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePurchaseResult> for ::windows::core::IUnknown {
-    fn from(value: &StorePurchaseResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePurchaseResult> for &::windows::core::IUnknown {
-    fn from(value: &StorePurchaseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorePurchaseResult> for ::windows::core::IInspectable {
-    fn from(value: StorePurchaseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorePurchaseResult> for ::windows::core::IInspectable {
-    fn from(value: &StorePurchaseResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorePurchaseResult> for &::windows::core::IInspectable {
-    fn from(value: &StorePurchaseResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorePurchaseResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorePurchaseResult {}
 unsafe impl ::core::marker::Sync for StorePurchaseResult {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -3767,36 +3158,7 @@ unsafe impl ::windows::core::Interface for StoreQueueItem {
 impl ::windows::core::RuntimeName for StoreQueueItem {
     const NAME: &'static str = "Windows.Services.Store.StoreQueueItem";
 }
-impl ::core::convert::From<StoreQueueItem> for ::windows::core::IUnknown {
-    fn from(value: StoreQueueItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreQueueItem> for ::windows::core::IUnknown {
-    fn from(value: &StoreQueueItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreQueueItem> for &::windows::core::IUnknown {
-    fn from(value: &StoreQueueItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreQueueItem> for ::windows::core::IInspectable {
-    fn from(value: StoreQueueItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreQueueItem> for ::windows::core::IInspectable {
-    fn from(value: &StoreQueueItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreQueueItem> for &::windows::core::IInspectable {
-    fn from(value: &StoreQueueItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreQueueItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreQueueItem {}
 unsafe impl ::core::marker::Sync for StoreQueueItem {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -3843,36 +3205,7 @@ unsafe impl ::windows::core::Interface for StoreQueueItemCompletedEventArgs {
 impl ::windows::core::RuntimeName for StoreQueueItemCompletedEventArgs {
     const NAME: &'static str = "Windows.Services.Store.StoreQueueItemCompletedEventArgs";
 }
-impl ::core::convert::From<StoreQueueItemCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: StoreQueueItemCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreQueueItemCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &StoreQueueItemCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreQueueItemCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &StoreQueueItemCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreQueueItemCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: StoreQueueItemCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreQueueItemCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &StoreQueueItemCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreQueueItemCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &StoreQueueItemCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreQueueItemCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreQueueItemCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for StoreQueueItemCompletedEventArgs {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -3940,36 +3273,7 @@ unsafe impl ::windows::core::Interface for StoreQueueItemStatus {
 impl ::windows::core::RuntimeName for StoreQueueItemStatus {
     const NAME: &'static str = "Windows.Services.Store.StoreQueueItemStatus";
 }
-impl ::core::convert::From<StoreQueueItemStatus> for ::windows::core::IUnknown {
-    fn from(value: StoreQueueItemStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreQueueItemStatus> for ::windows::core::IUnknown {
-    fn from(value: &StoreQueueItemStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreQueueItemStatus> for &::windows::core::IUnknown {
-    fn from(value: &StoreQueueItemStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreQueueItemStatus> for ::windows::core::IInspectable {
-    fn from(value: StoreQueueItemStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreQueueItemStatus> for ::windows::core::IInspectable {
-    fn from(value: &StoreQueueItemStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreQueueItemStatus> for &::windows::core::IInspectable {
-    fn from(value: &StoreQueueItemStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreQueueItemStatus, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreQueueItemStatus {}
 unsafe impl ::core::marker::Sync for StoreQueueItemStatus {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -4037,36 +3341,7 @@ unsafe impl ::windows::core::Interface for StoreRateAndReviewResult {
 impl ::windows::core::RuntimeName for StoreRateAndReviewResult {
     const NAME: &'static str = "Windows.Services.Store.StoreRateAndReviewResult";
 }
-impl ::core::convert::From<StoreRateAndReviewResult> for ::windows::core::IUnknown {
-    fn from(value: StoreRateAndReviewResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreRateAndReviewResult> for ::windows::core::IUnknown {
-    fn from(value: &StoreRateAndReviewResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreRateAndReviewResult> for &::windows::core::IUnknown {
-    fn from(value: &StoreRateAndReviewResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreRateAndReviewResult> for ::windows::core::IInspectable {
-    fn from(value: StoreRateAndReviewResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreRateAndReviewResult> for ::windows::core::IInspectable {
-    fn from(value: &StoreRateAndReviewResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreRateAndReviewResult> for &::windows::core::IInspectable {
-    fn from(value: &StoreRateAndReviewResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreRateAndReviewResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreRateAndReviewResult {}
 unsafe impl ::core::marker::Sync for StoreRateAndReviewResult {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -4149,36 +3424,7 @@ unsafe impl ::windows::core::Interface for StoreSendRequestResult {
 impl ::windows::core::RuntimeName for StoreSendRequestResult {
     const NAME: &'static str = "Windows.Services.Store.StoreSendRequestResult";
 }
-impl ::core::convert::From<StoreSendRequestResult> for ::windows::core::IUnknown {
-    fn from(value: StoreSendRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreSendRequestResult> for ::windows::core::IUnknown {
-    fn from(value: &StoreSendRequestResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreSendRequestResult> for &::windows::core::IUnknown {
-    fn from(value: &StoreSendRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreSendRequestResult> for ::windows::core::IInspectable {
-    fn from(value: StoreSendRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreSendRequestResult> for ::windows::core::IInspectable {
-    fn from(value: &StoreSendRequestResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreSendRequestResult> for &::windows::core::IInspectable {
-    fn from(value: &StoreSendRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreSendRequestResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreSendRequestResult {}
 unsafe impl ::core::marker::Sync for StoreSendRequestResult {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -4365,36 +3611,7 @@ unsafe impl ::windows::core::Interface for StoreSku {
 impl ::windows::core::RuntimeName for StoreSku {
     const NAME: &'static str = "Windows.Services.Store.StoreSku";
 }
-impl ::core::convert::From<StoreSku> for ::windows::core::IUnknown {
-    fn from(value: StoreSku) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreSku> for ::windows::core::IUnknown {
-    fn from(value: &StoreSku) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreSku> for &::windows::core::IUnknown {
-    fn from(value: &StoreSku) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreSku> for ::windows::core::IInspectable {
-    fn from(value: StoreSku) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreSku> for ::windows::core::IInspectable {
-    fn from(value: &StoreSku) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreSku> for &::windows::core::IInspectable {
-    fn from(value: &StoreSku) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreSku, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreSku {}
 unsafe impl ::core::marker::Sync for StoreSku {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -4469,36 +3686,7 @@ unsafe impl ::windows::core::Interface for StoreSubscriptionInfo {
 impl ::windows::core::RuntimeName for StoreSubscriptionInfo {
     const NAME: &'static str = "Windows.Services.Store.StoreSubscriptionInfo";
 }
-impl ::core::convert::From<StoreSubscriptionInfo> for ::windows::core::IUnknown {
-    fn from(value: StoreSubscriptionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreSubscriptionInfo> for ::windows::core::IUnknown {
-    fn from(value: &StoreSubscriptionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreSubscriptionInfo> for &::windows::core::IUnknown {
-    fn from(value: &StoreSubscriptionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreSubscriptionInfo> for ::windows::core::IInspectable {
-    fn from(value: StoreSubscriptionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreSubscriptionInfo> for ::windows::core::IInspectable {
-    fn from(value: &StoreSubscriptionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreSubscriptionInfo> for &::windows::core::IInspectable {
-    fn from(value: &StoreSubscriptionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreSubscriptionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreSubscriptionInfo {}
 unsafe impl ::core::marker::Sync for StoreSubscriptionInfo {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -4552,36 +3740,7 @@ unsafe impl ::windows::core::Interface for StoreUninstallStorePackageResult {
 impl ::windows::core::RuntimeName for StoreUninstallStorePackageResult {
     const NAME: &'static str = "Windows.Services.Store.StoreUninstallStorePackageResult";
 }
-impl ::core::convert::From<StoreUninstallStorePackageResult> for ::windows::core::IUnknown {
-    fn from(value: StoreUninstallStorePackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreUninstallStorePackageResult> for ::windows::core::IUnknown {
-    fn from(value: &StoreUninstallStorePackageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreUninstallStorePackageResult> for &::windows::core::IUnknown {
-    fn from(value: &StoreUninstallStorePackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreUninstallStorePackageResult> for ::windows::core::IInspectable {
-    fn from(value: StoreUninstallStorePackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreUninstallStorePackageResult> for ::windows::core::IInspectable {
-    fn from(value: &StoreUninstallStorePackageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreUninstallStorePackageResult> for &::windows::core::IInspectable {
-    fn from(value: &StoreUninstallStorePackageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreUninstallStorePackageResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreUninstallStorePackageResult {}
 unsafe impl ::core::marker::Sync for StoreUninstallStorePackageResult {}
 #[doc = "*Required features: `\"Services_Store\"`*"]
@@ -4665,36 +3824,7 @@ unsafe impl ::windows::core::Interface for StoreVideo {
 impl ::windows::core::RuntimeName for StoreVideo {
     const NAME: &'static str = "Windows.Services.Store.StoreVideo";
 }
-impl ::core::convert::From<StoreVideo> for ::windows::core::IUnknown {
-    fn from(value: StoreVideo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreVideo> for ::windows::core::IUnknown {
-    fn from(value: &StoreVideo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreVideo> for &::windows::core::IUnknown {
-    fn from(value: &StoreVideo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StoreVideo> for ::windows::core::IInspectable {
-    fn from(value: StoreVideo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StoreVideo> for ::windows::core::IInspectable {
-    fn from(value: &StoreVideo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StoreVideo> for &::windows::core::IInspectable {
-    fn from(value: &StoreVideo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StoreVideo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StoreVideo {}
 unsafe impl ::core::marker::Sync for StoreVideo {}
 #[doc = "*Required features: `\"Services_Store\"`*"]

--- a/crates/libs/windows/src/Windows/Services/TargetedContent/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/TargetedContent/mod.rs
@@ -408,36 +408,7 @@ unsafe impl ::windows::core::Interface for TargetedContentAction {
 impl ::windows::core::RuntimeName for TargetedContentAction {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentAction";
 }
-impl ::core::convert::From<TargetedContentAction> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentAction> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentAction> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentAction> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentAction> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentAction> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentAction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentAction {}
 unsafe impl ::core::marker::Sync for TargetedContentAction {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`*"]
@@ -486,36 +457,7 @@ unsafe impl ::windows::core::Interface for TargetedContentAvailabilityChangedEve
 impl ::windows::core::RuntimeName for TargetedContentAvailabilityChangedEventArgs {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentAvailabilityChangedEventArgs";
 }
-impl ::core::convert::From<TargetedContentAvailabilityChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentAvailabilityChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentAvailabilityChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentAvailabilityChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentAvailabilityChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentAvailabilityChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentAvailabilityChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentAvailabilityChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentAvailabilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentAvailabilityChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentAvailabilityChangedEventArgs {}
 unsafe impl ::core::marker::Sync for TargetedContentAvailabilityChangedEventArgs {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`*"]
@@ -571,36 +513,7 @@ unsafe impl ::windows::core::Interface for TargetedContentChangedEventArgs {
 impl ::windows::core::RuntimeName for TargetedContentChangedEventArgs {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentChangedEventArgs";
 }
-impl ::core::convert::From<TargetedContentChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentChangedEventArgs {}
 unsafe impl ::core::marker::Sync for TargetedContentChangedEventArgs {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`*"]
@@ -689,36 +602,7 @@ unsafe impl ::windows::core::Interface for TargetedContentCollection {
 impl ::windows::core::RuntimeName for TargetedContentCollection {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentCollection";
 }
-impl ::core::convert::From<TargetedContentCollection> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentCollection> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentCollection> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentCollection> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentCollection> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentCollection> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentCollection {}
 unsafe impl ::core::marker::Sync for TargetedContentCollection {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`*"]
@@ -808,36 +692,7 @@ unsafe impl ::windows::core::Interface for TargetedContentContainer {
 impl ::windows::core::RuntimeName for TargetedContentContainer {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentContainer";
 }
-impl ::core::convert::From<TargetedContentContainer> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentContainer> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentContainer> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentContainer> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentContainer> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentContainer> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentContainer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentContainer {}
 unsafe impl ::core::marker::Sync for TargetedContentContainer {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`, `\"Storage_Streams\"`*"]
@@ -897,41 +752,7 @@ impl ::windows::core::RuntimeName for TargetedContentFile {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentFile";
 }
 #[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<TargetedContentFile> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&TargetedContentFile> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&TargetedContentFile> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<TargetedContentFile> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&TargetedContentFile> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&TargetedContentFile> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentFile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Storage_Streams")]
 impl ::core::convert::TryFrom<TargetedContentFile> for super::super::Storage::Streams::IRandomAccessStreamReference {
     type Error = ::windows::core::Error;
@@ -1018,36 +839,7 @@ unsafe impl ::windows::core::Interface for TargetedContentImage {
 impl ::windows::core::RuntimeName for TargetedContentImage {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentImage";
 }
-impl ::core::convert::From<TargetedContentImage> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentImage> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentImage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentImage> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentImage> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentImage> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentImage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentImage> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentImage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Storage_Streams")]
 impl ::core::convert::TryFrom<TargetedContentImage> for super::super::Storage::Streams::IRandomAccessStreamReference {
     type Error = ::windows::core::Error;
@@ -1149,36 +941,7 @@ unsafe impl ::windows::core::Interface for TargetedContentItem {
 impl ::windows::core::RuntimeName for TargetedContentItem {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentItem";
 }
-impl ::core::convert::From<TargetedContentItem> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentItem> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentItem> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentItem> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentItem> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentItem> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentItem {}
 unsafe impl ::core::marker::Sync for TargetedContentItem {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`*"]
@@ -1232,36 +995,7 @@ unsafe impl ::windows::core::Interface for TargetedContentItemState {
 impl ::windows::core::RuntimeName for TargetedContentItemState {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentItemState";
 }
-impl ::core::convert::From<TargetedContentItemState> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentItemState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentItemState> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentItemState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentItemState> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentItemState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentItemState> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentItemState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentItemState> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentItemState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentItemState> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentItemState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentItemState, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentItemState {}
 unsafe impl ::core::marker::Sync for TargetedContentItemState {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`*"]
@@ -1329,36 +1063,7 @@ unsafe impl ::windows::core::Interface for TargetedContentObject {
 impl ::windows::core::RuntimeName for TargetedContentObject {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentObject";
 }
-impl ::core::convert::From<TargetedContentObject> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentObject> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentObject> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentObject> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentObject> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentObject> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentObject, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentObject {}
 unsafe impl ::core::marker::Sync for TargetedContentObject {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`*"]
@@ -1407,36 +1112,7 @@ unsafe impl ::windows::core::Interface for TargetedContentStateChangedEventArgs 
 impl ::windows::core::RuntimeName for TargetedContentStateChangedEventArgs {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentStateChangedEventArgs";
 }
-impl ::core::convert::From<TargetedContentStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for TargetedContentStateChangedEventArgs {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`*"]
@@ -1556,36 +1232,7 @@ unsafe impl ::windows::core::Interface for TargetedContentSubscription {
 impl ::windows::core::RuntimeName for TargetedContentSubscription {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentSubscription";
 }
-impl ::core::convert::From<TargetedContentSubscription> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentSubscription> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentSubscription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentSubscription> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentSubscription> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentSubscription> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentSubscription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentSubscription> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentSubscription, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentSubscription {}
 unsafe impl ::core::marker::Sync for TargetedContentSubscription {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`*"]
@@ -1665,36 +1312,7 @@ unsafe impl ::windows::core::Interface for TargetedContentSubscriptionOptions {
 impl ::windows::core::RuntimeName for TargetedContentSubscriptionOptions {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentSubscriptionOptions";
 }
-impl ::core::convert::From<TargetedContentSubscriptionOptions> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentSubscriptionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentSubscriptionOptions> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentSubscriptionOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentSubscriptionOptions> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentSubscriptionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentSubscriptionOptions> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentSubscriptionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentSubscriptionOptions> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentSubscriptionOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentSubscriptionOptions> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentSubscriptionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentSubscriptionOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentSubscriptionOptions {}
 unsafe impl ::core::marker::Sync for TargetedContentSubscriptionOptions {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`*"]
@@ -1864,36 +1482,7 @@ unsafe impl ::windows::core::Interface for TargetedContentValue {
 impl ::windows::core::RuntimeName for TargetedContentValue {
     const NAME: &'static str = "Windows.Services.TargetedContent.TargetedContentValue";
 }
-impl ::core::convert::From<TargetedContentValue> for ::windows::core::IUnknown {
-    fn from(value: TargetedContentValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentValue> for ::windows::core::IUnknown {
-    fn from(value: &TargetedContentValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentValue> for &::windows::core::IUnknown {
-    fn from(value: &TargetedContentValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetedContentValue> for ::windows::core::IInspectable {
-    fn from(value: TargetedContentValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetedContentValue> for ::windows::core::IInspectable {
-    fn from(value: &TargetedContentValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetedContentValue> for &::windows::core::IInspectable {
-    fn from(value: &TargetedContentValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetedContentValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TargetedContentValue {}
 unsafe impl ::core::marker::Sync for TargetedContentValue {}
 #[doc = "*Required features: `\"Services_TargetedContent\"`*"]

--- a/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
@@ -190,36 +190,7 @@ impl IStorageItemAccessList {
         }
     }
 }
-impl ::core::convert::From<IStorageItemAccessList> for ::windows::core::IUnknown {
-    fn from(value: IStorageItemAccessList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemAccessList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageItemAccessList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemAccessList> for ::windows::core::IUnknown {
-    fn from(value: &IStorageItemAccessList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageItemAccessList> for ::windows::core::IInspectable {
-    fn from(value: IStorageItemAccessList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemAccessList> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageItemAccessList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemAccessList> for ::windows::core::IInspectable {
-    fn from(value: &IStorageItemAccessList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageItemAccessList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageItemAccessList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -441,41 +412,7 @@ impl ::core::iter::IntoIterator for &AccessListEntryView {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<AccessListEntryView> for ::windows::core::IUnknown {
-    fn from(value: AccessListEntryView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&AccessListEntryView> for ::windows::core::IUnknown {
-    fn from(value: &AccessListEntryView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&AccessListEntryView> for &::windows::core::IUnknown {
-    fn from(value: &AccessListEntryView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<AccessListEntryView> for ::windows::core::IInspectable {
-    fn from(value: AccessListEntryView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&AccessListEntryView> for ::windows::core::IInspectable {
-    fn from(value: &AccessListEntryView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&AccessListEntryView> for &::windows::core::IInspectable {
-    fn from(value: &AccessListEntryView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AccessListEntryView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<AccessListEntryView> for super::super::Foundation::Collections::IIterable<AccessListEntry> {
     type Error = ::windows::core::Error;
@@ -564,36 +501,7 @@ unsafe impl ::windows::core::Interface for ItemRemovedEventArgs {
 impl ::windows::core::RuntimeName for ItemRemovedEventArgs {
     const NAME: &'static str = "Windows.Storage.AccessCache.ItemRemovedEventArgs";
 }
-impl ::core::convert::From<ItemRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ItemRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ItemRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ItemRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ItemRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ItemRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ItemRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ItemRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ItemRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ItemRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ItemRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ItemRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ItemRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_AccessCache\"`*"]
 pub struct StorageApplicationPermissions;
 impl StorageApplicationPermissions {
@@ -810,36 +718,7 @@ unsafe impl ::windows::core::Interface for StorageItemAccessList {
 impl ::windows::core::RuntimeName for StorageItemAccessList {
     const NAME: &'static str = "Windows.Storage.AccessCache.StorageItemAccessList";
 }
-impl ::core::convert::From<StorageItemAccessList> for ::windows::core::IUnknown {
-    fn from(value: StorageItemAccessList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageItemAccessList> for ::windows::core::IUnknown {
-    fn from(value: &StorageItemAccessList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageItemAccessList> for &::windows::core::IUnknown {
-    fn from(value: &StorageItemAccessList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageItemAccessList> for ::windows::core::IInspectable {
-    fn from(value: StorageItemAccessList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageItemAccessList> for ::windows::core::IInspectable {
-    fn from(value: &StorageItemAccessList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageItemAccessList> for &::windows::core::IInspectable {
-    fn from(value: &StorageItemAccessList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageItemAccessList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StorageItemAccessList> for IStorageItemAccessList {
     type Error = ::windows::core::Error;
     fn try_from(value: StorageItemAccessList) -> ::windows::core::Result<Self> {
@@ -1064,36 +943,7 @@ unsafe impl ::windows::core::Interface for StorageItemMostRecentlyUsedList {
 impl ::windows::core::RuntimeName for StorageItemMostRecentlyUsedList {
     const NAME: &'static str = "Windows.Storage.AccessCache.StorageItemMostRecentlyUsedList";
 }
-impl ::core::convert::From<StorageItemMostRecentlyUsedList> for ::windows::core::IUnknown {
-    fn from(value: StorageItemMostRecentlyUsedList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageItemMostRecentlyUsedList> for ::windows::core::IUnknown {
-    fn from(value: &StorageItemMostRecentlyUsedList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageItemMostRecentlyUsedList> for &::windows::core::IUnknown {
-    fn from(value: &StorageItemMostRecentlyUsedList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageItemMostRecentlyUsedList> for ::windows::core::IInspectable {
-    fn from(value: StorageItemMostRecentlyUsedList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageItemMostRecentlyUsedList> for ::windows::core::IInspectable {
-    fn from(value: &StorageItemMostRecentlyUsedList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageItemMostRecentlyUsedList> for &::windows::core::IInspectable {
-    fn from(value: &StorageItemMostRecentlyUsedList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageItemMostRecentlyUsedList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StorageItemMostRecentlyUsedList> for IStorageItemAccessList {
     type Error = ::windows::core::Error;
     fn try_from(value: StorageItemMostRecentlyUsedList) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Storage/BulkAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/BulkAccess/mod.rs
@@ -158,36 +158,7 @@ impl IStorageItemInformation {
         unsafe { (::windows::core::Vtable::vtable(this).RemovePropertiesUpdated)(::windows::core::Vtable::as_raw(this), eventcookie).ok() }
     }
 }
-impl ::core::convert::From<IStorageItemInformation> for ::windows::core::IUnknown {
-    fn from(value: IStorageItemInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageItemInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemInformation> for ::windows::core::IUnknown {
-    fn from(value: &IStorageItemInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageItemInformation> for ::windows::core::IInspectable {
-    fn from(value: IStorageItemInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemInformation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageItemInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemInformation> for ::windows::core::IInspectable {
-    fn from(value: &IStorageItemInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageItemInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageItemInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -728,36 +699,7 @@ unsafe impl ::windows::core::Interface for FileInformation {
 impl ::windows::core::RuntimeName for FileInformation {
     const NAME: &'static str = "Windows.Storage.BulkAccess.FileInformation";
 }
-impl ::core::convert::From<FileInformation> for ::windows::core::IUnknown {
-    fn from(value: FileInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileInformation> for ::windows::core::IUnknown {
-    fn from(value: &FileInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileInformation> for &::windows::core::IUnknown {
-    fn from(value: &FileInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileInformation> for ::windows::core::IInspectable {
-    fn from(value: FileInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileInformation> for ::windows::core::IInspectable {
-    fn from(value: &FileInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileInformation> for &::windows::core::IInspectable {
-    fn from(value: &FileInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Storage_Streams")]
 impl ::core::convert::TryFrom<FileInformation> for super::Streams::IInputStreamReference {
     type Error = ::windows::core::Error;
@@ -1119,36 +1061,7 @@ unsafe impl ::windows::core::Interface for FileInformationFactory {
 impl ::windows::core::RuntimeName for FileInformationFactory {
     const NAME: &'static str = "Windows.Storage.BulkAccess.FileInformationFactory";
 }
-impl ::core::convert::From<FileInformationFactory> for ::windows::core::IUnknown {
-    fn from(value: FileInformationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileInformationFactory> for ::windows::core::IUnknown {
-    fn from(value: &FileInformationFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileInformationFactory> for &::windows::core::IUnknown {
-    fn from(value: &FileInformationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileInformationFactory> for ::windows::core::IInspectable {
-    fn from(value: FileInformationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileInformationFactory> for ::windows::core::IInspectable {
-    fn from(value: &FileInformationFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileInformationFactory> for &::windows::core::IInspectable {
-    fn from(value: &FileInformationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileInformationFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FileInformationFactory {}
 unsafe impl ::core::marker::Sync for FileInformationFactory {}
 #[doc = "*Required features: `\"Storage_BulkAccess\"`*"]
@@ -1690,36 +1603,7 @@ unsafe impl ::windows::core::Interface for FolderInformation {
 impl ::windows::core::RuntimeName for FolderInformation {
     const NAME: &'static str = "Windows.Storage.BulkAccess.FolderInformation";
 }
-impl ::core::convert::From<FolderInformation> for ::windows::core::IUnknown {
-    fn from(value: FolderInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FolderInformation> for ::windows::core::IUnknown {
-    fn from(value: &FolderInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FolderInformation> for &::windows::core::IUnknown {
-    fn from(value: &FolderInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FolderInformation> for ::windows::core::IInspectable {
-    fn from(value: FolderInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FolderInformation> for ::windows::core::IInspectable {
-    fn from(value: &FolderInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FolderInformation> for &::windows::core::IInspectable {
-    fn from(value: &FolderInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FolderInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<FolderInformation> for super::IStorageFolder {
     type Error = ::windows::core::Error;
     fn try_from(value: FolderInformation) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Storage/Compression/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Compression/mod.rs
@@ -190,36 +190,7 @@ unsafe impl ::windows::core::Interface for Compressor {
 impl ::windows::core::RuntimeName for Compressor {
     const NAME: &'static str = "Windows.Storage.Compression.Compressor";
 }
-impl ::core::convert::From<Compressor> for ::windows::core::IUnknown {
-    fn from(value: Compressor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Compressor> for ::windows::core::IUnknown {
-    fn from(value: &Compressor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Compressor> for &::windows::core::IUnknown {
-    fn from(value: &Compressor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Compressor> for ::windows::core::IInspectable {
-    fn from(value: Compressor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Compressor> for ::windows::core::IInspectable {
-    fn from(value: &Compressor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Compressor> for &::windows::core::IInspectable {
-    fn from(value: &Compressor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Compressor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<Compressor> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -348,36 +319,7 @@ unsafe impl ::windows::core::Interface for Decompressor {
 impl ::windows::core::RuntimeName for Decompressor {
     const NAME: &'static str = "Windows.Storage.Compression.Decompressor";
 }
-impl ::core::convert::From<Decompressor> for ::windows::core::IUnknown {
-    fn from(value: Decompressor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Decompressor> for ::windows::core::IUnknown {
-    fn from(value: &Decompressor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Decompressor> for &::windows::core::IUnknown {
-    fn from(value: &Decompressor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Decompressor> for ::windows::core::IInspectable {
-    fn from(value: Decompressor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Decompressor> for ::windows::core::IInspectable {
-    fn from(value: &Decompressor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Decompressor> for &::windows::core::IInspectable {
-    fn from(value: &Decompressor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Decompressor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<Decompressor> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
@@ -249,36 +249,7 @@ impl IStorageItemExtraProperties {
         }
     }
 }
-impl ::core::convert::From<IStorageItemExtraProperties> for ::windows::core::IUnknown {
-    fn from(value: IStorageItemExtraProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemExtraProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageItemExtraProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemExtraProperties> for ::windows::core::IUnknown {
-    fn from(value: &IStorageItemExtraProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageItemExtraProperties> for ::windows::core::IInspectable {
-    fn from(value: IStorageItemExtraProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemExtraProperties> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageItemExtraProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemExtraProperties> for ::windows::core::IInspectable {
-    fn from(value: &IStorageItemExtraProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageItemExtraProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageItemExtraProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -496,36 +467,7 @@ unsafe impl ::windows::core::Interface for BasicProperties {
 impl ::windows::core::RuntimeName for BasicProperties {
     const NAME: &'static str = "Windows.Storage.FileProperties.BasicProperties";
 }
-impl ::core::convert::From<BasicProperties> for ::windows::core::IUnknown {
-    fn from(value: BasicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BasicProperties> for ::windows::core::IUnknown {
-    fn from(value: &BasicProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BasicProperties> for &::windows::core::IUnknown {
-    fn from(value: &BasicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BasicProperties> for ::windows::core::IInspectable {
-    fn from(value: BasicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BasicProperties> for ::windows::core::IInspectable {
-    fn from(value: &BasicProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BasicProperties> for &::windows::core::IInspectable {
-    fn from(value: &BasicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BasicProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BasicProperties> for IStorageItemExtraProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: BasicProperties) -> ::windows::core::Result<Self> {
@@ -657,36 +599,7 @@ unsafe impl ::windows::core::Interface for DocumentProperties {
 impl ::windows::core::RuntimeName for DocumentProperties {
     const NAME: &'static str = "Windows.Storage.FileProperties.DocumentProperties";
 }
-impl ::core::convert::From<DocumentProperties> for ::windows::core::IUnknown {
-    fn from(value: DocumentProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DocumentProperties> for ::windows::core::IUnknown {
-    fn from(value: &DocumentProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DocumentProperties> for &::windows::core::IUnknown {
-    fn from(value: &DocumentProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DocumentProperties> for ::windows::core::IInspectable {
-    fn from(value: DocumentProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DocumentProperties> for ::windows::core::IInspectable {
-    fn from(value: &DocumentProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DocumentProperties> for &::windows::core::IInspectable {
-    fn from(value: &DocumentProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DocumentProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DocumentProperties> for IStorageItemExtraProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: DocumentProperties) -> ::windows::core::Result<Self> {
@@ -942,36 +855,7 @@ unsafe impl ::windows::core::Interface for ImageProperties {
 impl ::windows::core::RuntimeName for ImageProperties {
     const NAME: &'static str = "Windows.Storage.FileProperties.ImageProperties";
 }
-impl ::core::convert::From<ImageProperties> for ::windows::core::IUnknown {
-    fn from(value: ImageProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageProperties> for ::windows::core::IUnknown {
-    fn from(value: &ImageProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageProperties> for &::windows::core::IUnknown {
-    fn from(value: &ImageProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImageProperties> for ::windows::core::IInspectable {
-    fn from(value: ImageProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImageProperties> for ::windows::core::IInspectable {
-    fn from(value: &ImageProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImageProperties> for &::windows::core::IInspectable {
-    fn from(value: &ImageProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImageProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ImageProperties> for IStorageItemExtraProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: ImageProperties) -> ::windows::core::Result<Self> {
@@ -1223,36 +1107,7 @@ unsafe impl ::windows::core::Interface for MusicProperties {
 impl ::windows::core::RuntimeName for MusicProperties {
     const NAME: &'static str = "Windows.Storage.FileProperties.MusicProperties";
 }
-impl ::core::convert::From<MusicProperties> for ::windows::core::IUnknown {
-    fn from(value: MusicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MusicProperties> for ::windows::core::IUnknown {
-    fn from(value: &MusicProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MusicProperties> for &::windows::core::IUnknown {
-    fn from(value: &MusicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MusicProperties> for ::windows::core::IInspectable {
-    fn from(value: MusicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MusicProperties> for ::windows::core::IInspectable {
-    fn from(value: &MusicProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MusicProperties> for &::windows::core::IInspectable {
-    fn from(value: &MusicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MusicProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<MusicProperties> for IStorageItemExtraProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: MusicProperties) -> ::windows::core::Result<Self> {
@@ -1380,36 +1235,7 @@ unsafe impl ::windows::core::Interface for StorageItemContentProperties {
 impl ::windows::core::RuntimeName for StorageItemContentProperties {
     const NAME: &'static str = "Windows.Storage.FileProperties.StorageItemContentProperties";
 }
-impl ::core::convert::From<StorageItemContentProperties> for ::windows::core::IUnknown {
-    fn from(value: StorageItemContentProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageItemContentProperties> for ::windows::core::IUnknown {
-    fn from(value: &StorageItemContentProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageItemContentProperties> for &::windows::core::IUnknown {
-    fn from(value: &StorageItemContentProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageItemContentProperties> for ::windows::core::IInspectable {
-    fn from(value: StorageItemContentProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageItemContentProperties> for ::windows::core::IInspectable {
-    fn from(value: &StorageItemContentProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageItemContentProperties> for &::windows::core::IInspectable {
-    fn from(value: &StorageItemContentProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageItemContentProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StorageItemContentProperties> for IStorageItemExtraProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: StorageItemContentProperties) -> ::windows::core::Result<Self> {
@@ -1630,41 +1456,7 @@ impl ::windows::core::RuntimeName for StorageItemThumbnail {
     const NAME: &'static str = "Windows.Storage.FileProperties.StorageItemThumbnail";
 }
 #[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<StorageItemThumbnail> for ::windows::core::IUnknown {
-    fn from(value: StorageItemThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&StorageItemThumbnail> for ::windows::core::IUnknown {
-    fn from(value: &StorageItemThumbnail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&StorageItemThumbnail> for &::windows::core::IUnknown {
-    fn from(value: &StorageItemThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<StorageItemThumbnail> for ::windows::core::IInspectable {
-    fn from(value: StorageItemThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&StorageItemThumbnail> for ::windows::core::IInspectable {
-    fn from(value: &StorageItemThumbnail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&StorageItemThumbnail> for &::windows::core::IInspectable {
-    fn from(value: &StorageItemThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageItemThumbnail, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 impl ::core::convert::TryFrom<StorageItemThumbnail> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2015,36 +1807,7 @@ unsafe impl ::windows::core::Interface for VideoProperties {
 impl ::windows::core::RuntimeName for VideoProperties {
     const NAME: &'static str = "Windows.Storage.FileProperties.VideoProperties";
 }
-impl ::core::convert::From<VideoProperties> for ::windows::core::IUnknown {
-    fn from(value: VideoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoProperties> for ::windows::core::IUnknown {
-    fn from(value: &VideoProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoProperties> for &::windows::core::IUnknown {
-    fn from(value: &VideoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VideoProperties> for ::windows::core::IInspectable {
-    fn from(value: VideoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VideoProperties> for ::windows::core::IInspectable {
-    fn from(value: &VideoProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VideoProperties> for &::windows::core::IInspectable {
-    fn from(value: &VideoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VideoProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VideoProperties> for IStorageItemExtraProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: VideoProperties) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Storage/Pickers/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Pickers/Provider/mod.rs
@@ -332,36 +332,7 @@ unsafe impl ::windows::core::Interface for FileOpenPickerUI {
 impl ::windows::core::RuntimeName for FileOpenPickerUI {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.FileOpenPickerUI";
 }
-impl ::core::convert::From<FileOpenPickerUI> for ::windows::core::IUnknown {
-    fn from(value: FileOpenPickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileOpenPickerUI> for ::windows::core::IUnknown {
-    fn from(value: &FileOpenPickerUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileOpenPickerUI> for &::windows::core::IUnknown {
-    fn from(value: &FileOpenPickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileOpenPickerUI> for ::windows::core::IInspectable {
-    fn from(value: FileOpenPickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileOpenPickerUI> for ::windows::core::IInspectable {
-    fn from(value: &FileOpenPickerUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileOpenPickerUI> for &::windows::core::IInspectable {
-    fn from(value: &FileOpenPickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileOpenPickerUI, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Pickers_Provider\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -419,41 +390,7 @@ impl ::windows::core::RuntimeName for FileRemovedEventArgs {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.FileRemovedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<FileRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: FileRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &FileRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &FileRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<FileRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: FileRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &FileRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&FileRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &FileRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Pickers_Provider\"`*"]
 #[repr(transparent)]
 pub struct FileSavePickerUI(::windows::core::IUnknown);
@@ -562,36 +499,7 @@ unsafe impl ::windows::core::Interface for FileSavePickerUI {
 impl ::windows::core::RuntimeName for FileSavePickerUI {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.FileSavePickerUI";
 }
-impl ::core::convert::From<FileSavePickerUI> for ::windows::core::IUnknown {
-    fn from(value: FileSavePickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileSavePickerUI> for ::windows::core::IUnknown {
-    fn from(value: &FileSavePickerUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileSavePickerUI> for &::windows::core::IUnknown {
-    fn from(value: &FileSavePickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileSavePickerUI> for ::windows::core::IInspectable {
-    fn from(value: FileSavePickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileSavePickerUI> for ::windows::core::IInspectable {
-    fn from(value: &FileSavePickerUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileSavePickerUI> for &::windows::core::IInspectable {
-    fn from(value: &FileSavePickerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileSavePickerUI, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Pickers_Provider\"`*"]
 #[repr(transparent)]
 pub struct PickerClosingDeferral(::windows::core::IUnknown);
@@ -633,36 +541,7 @@ unsafe impl ::windows::core::Interface for PickerClosingDeferral {
 impl ::windows::core::RuntimeName for PickerClosingDeferral {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.PickerClosingDeferral";
 }
-impl ::core::convert::From<PickerClosingDeferral> for ::windows::core::IUnknown {
-    fn from(value: PickerClosingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PickerClosingDeferral> for ::windows::core::IUnknown {
-    fn from(value: &PickerClosingDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PickerClosingDeferral> for &::windows::core::IUnknown {
-    fn from(value: &PickerClosingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PickerClosingDeferral> for ::windows::core::IInspectable {
-    fn from(value: PickerClosingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PickerClosingDeferral> for ::windows::core::IInspectable {
-    fn from(value: &PickerClosingDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PickerClosingDeferral> for &::windows::core::IInspectable {
-    fn from(value: &PickerClosingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PickerClosingDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Pickers_Provider\"`*"]
 #[repr(transparent)]
 pub struct PickerClosingEventArgs(::windows::core::IUnknown);
@@ -714,36 +593,7 @@ unsafe impl ::windows::core::Interface for PickerClosingEventArgs {
 impl ::windows::core::RuntimeName for PickerClosingEventArgs {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.PickerClosingEventArgs";
 }
-impl ::core::convert::From<PickerClosingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PickerClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PickerClosingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PickerClosingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PickerClosingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PickerClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PickerClosingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PickerClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PickerClosingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PickerClosingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PickerClosingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PickerClosingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PickerClosingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Pickers_Provider\"`*"]
 #[repr(transparent)]
 pub struct PickerClosingOperation(::windows::core::IUnknown);
@@ -797,36 +647,7 @@ unsafe impl ::windows::core::Interface for PickerClosingOperation {
 impl ::windows::core::RuntimeName for PickerClosingOperation {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.PickerClosingOperation";
 }
-impl ::core::convert::From<PickerClosingOperation> for ::windows::core::IUnknown {
-    fn from(value: PickerClosingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PickerClosingOperation> for ::windows::core::IUnknown {
-    fn from(value: &PickerClosingOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PickerClosingOperation> for &::windows::core::IUnknown {
-    fn from(value: &PickerClosingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PickerClosingOperation> for ::windows::core::IInspectable {
-    fn from(value: PickerClosingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PickerClosingOperation> for ::windows::core::IInspectable {
-    fn from(value: &PickerClosingOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PickerClosingOperation> for &::windows::core::IInspectable {
-    fn from(value: &PickerClosingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PickerClosingOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Pickers_Provider\"`*"]
 #[repr(transparent)]
 pub struct TargetFileRequest(::windows::core::IUnknown);
@@ -886,36 +707,7 @@ unsafe impl ::windows::core::Interface for TargetFileRequest {
 impl ::windows::core::RuntimeName for TargetFileRequest {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.TargetFileRequest";
 }
-impl ::core::convert::From<TargetFileRequest> for ::windows::core::IUnknown {
-    fn from(value: TargetFileRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetFileRequest> for ::windows::core::IUnknown {
-    fn from(value: &TargetFileRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetFileRequest> for &::windows::core::IUnknown {
-    fn from(value: &TargetFileRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetFileRequest> for ::windows::core::IInspectable {
-    fn from(value: TargetFileRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetFileRequest> for ::windows::core::IInspectable {
-    fn from(value: &TargetFileRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetFileRequest> for &::windows::core::IInspectable {
-    fn from(value: &TargetFileRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetFileRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Pickers_Provider\"`*"]
 #[repr(transparent)]
 pub struct TargetFileRequestDeferral(::windows::core::IUnknown);
@@ -957,36 +749,7 @@ unsafe impl ::windows::core::Interface for TargetFileRequestDeferral {
 impl ::windows::core::RuntimeName for TargetFileRequestDeferral {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.TargetFileRequestDeferral";
 }
-impl ::core::convert::From<TargetFileRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: TargetFileRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetFileRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: &TargetFileRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetFileRequestDeferral> for &::windows::core::IUnknown {
-    fn from(value: &TargetFileRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetFileRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: TargetFileRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetFileRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: &TargetFileRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetFileRequestDeferral> for &::windows::core::IInspectable {
-    fn from(value: &TargetFileRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetFileRequestDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Pickers_Provider\"`*"]
 #[repr(transparent)]
 pub struct TargetFileRequestedEventArgs(::windows::core::IUnknown);
@@ -1031,36 +794,7 @@ unsafe impl ::windows::core::Interface for TargetFileRequestedEventArgs {
 impl ::windows::core::RuntimeName for TargetFileRequestedEventArgs {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.TargetFileRequestedEventArgs";
 }
-impl ::core::convert::From<TargetFileRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TargetFileRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetFileRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TargetFileRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetFileRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TargetFileRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TargetFileRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TargetFileRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TargetFileRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TargetFileRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TargetFileRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TargetFileRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TargetFileRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Pickers_Provider\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/Storage/Pickers/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Pickers/mod.rs
@@ -488,41 +488,7 @@ impl ::core::iter::IntoIterator for &FileExtensionVector {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<FileExtensionVector> for ::windows::core::IUnknown {
-    fn from(value: FileExtensionVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FileExtensionVector> for ::windows::core::IUnknown {
-    fn from(value: &FileExtensionVector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FileExtensionVector> for &::windows::core::IUnknown {
-    fn from(value: &FileExtensionVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<FileExtensionVector> for ::windows::core::IInspectable {
-    fn from(value: FileExtensionVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FileExtensionVector> for ::windows::core::IInspectable {
-    fn from(value: &FileExtensionVector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FileExtensionVector> for &::windows::core::IInspectable {
-    fn from(value: &FileExtensionVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileExtensionVector, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<FileExtensionVector> for super::super::Foundation::Collections::IIterable<::windows::core::HSTRING> {
     type Error = ::windows::core::Error;
@@ -751,36 +717,7 @@ unsafe impl ::windows::core::Interface for FileOpenPicker {
 impl ::windows::core::RuntimeName for FileOpenPicker {
     const NAME: &'static str = "Windows.Storage.Pickers.FileOpenPicker";
 }
-impl ::core::convert::From<FileOpenPicker> for ::windows::core::IUnknown {
-    fn from(value: FileOpenPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileOpenPicker> for ::windows::core::IUnknown {
-    fn from(value: &FileOpenPicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileOpenPicker> for &::windows::core::IUnknown {
-    fn from(value: &FileOpenPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileOpenPicker> for ::windows::core::IInspectable {
-    fn from(value: FileOpenPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileOpenPicker> for ::windows::core::IInspectable {
-    fn from(value: &FileOpenPicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileOpenPicker> for &::windows::core::IInspectable {
-    fn from(value: &FileOpenPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileOpenPicker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FileOpenPicker {}
 unsafe impl ::core::marker::Sync for FileOpenPicker {}
 #[doc = "*Required features: `\"Storage_Pickers\"`, `\"Foundation_Collections\"`*"]
@@ -917,41 +854,7 @@ impl ::core::iter::IntoIterator for &FilePickerFileTypesOrderedMap {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<FilePickerFileTypesOrderedMap> for ::windows::core::IUnknown {
-    fn from(value: FilePickerFileTypesOrderedMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FilePickerFileTypesOrderedMap> for ::windows::core::IUnknown {
-    fn from(value: &FilePickerFileTypesOrderedMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FilePickerFileTypesOrderedMap> for &::windows::core::IUnknown {
-    fn from(value: &FilePickerFileTypesOrderedMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<FilePickerFileTypesOrderedMap> for ::windows::core::IInspectable {
-    fn from(value: FilePickerFileTypesOrderedMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FilePickerFileTypesOrderedMap> for ::windows::core::IInspectable {
-    fn from(value: &FilePickerFileTypesOrderedMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FilePickerFileTypesOrderedMap> for &::windows::core::IInspectable {
-    fn from(value: &FilePickerFileTypesOrderedMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FilePickerFileTypesOrderedMap, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<FilePickerFileTypesOrderedMap> for super::super::Foundation::Collections::IIterable<super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, super::super::Foundation::Collections::IVector<::windows::core::HSTRING>>> {
     type Error = ::windows::core::Error;
@@ -1109,41 +1012,7 @@ impl ::core::iter::IntoIterator for &FilePickerSelectedFilesArray {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<FilePickerSelectedFilesArray> for ::windows::core::IUnknown {
-    fn from(value: FilePickerSelectedFilesArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FilePickerSelectedFilesArray> for ::windows::core::IUnknown {
-    fn from(value: &FilePickerSelectedFilesArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FilePickerSelectedFilesArray> for &::windows::core::IUnknown {
-    fn from(value: &FilePickerSelectedFilesArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<FilePickerSelectedFilesArray> for ::windows::core::IInspectable {
-    fn from(value: FilePickerSelectedFilesArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FilePickerSelectedFilesArray> for ::windows::core::IInspectable {
-    fn from(value: &FilePickerSelectedFilesArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&FilePickerSelectedFilesArray> for &::windows::core::IInspectable {
-    fn from(value: &FilePickerSelectedFilesArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FilePickerSelectedFilesArray, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<FilePickerSelectedFilesArray> for super::super::Foundation::Collections::IIterable<super::StorageFile> {
     type Error = ::windows::core::Error;
@@ -1368,36 +1237,7 @@ unsafe impl ::windows::core::Interface for FileSavePicker {
 impl ::windows::core::RuntimeName for FileSavePicker {
     const NAME: &'static str = "Windows.Storage.Pickers.FileSavePicker";
 }
-impl ::core::convert::From<FileSavePicker> for ::windows::core::IUnknown {
-    fn from(value: FileSavePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileSavePicker> for ::windows::core::IUnknown {
-    fn from(value: &FileSavePicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileSavePicker> for &::windows::core::IUnknown {
-    fn from(value: &FileSavePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileSavePicker> for ::windows::core::IInspectable {
-    fn from(value: FileSavePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileSavePicker> for ::windows::core::IInspectable {
-    fn from(value: &FileSavePicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileSavePicker> for &::windows::core::IInspectable {
-    fn from(value: &FileSavePicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileSavePicker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FileSavePicker {}
 unsafe impl ::core::marker::Sync for FileSavePicker {}
 #[doc = "*Required features: `\"Storage_Pickers\"`*"]
@@ -1543,36 +1383,7 @@ unsafe impl ::windows::core::Interface for FolderPicker {
 impl ::windows::core::RuntimeName for FolderPicker {
     const NAME: &'static str = "Windows.Storage.Pickers.FolderPicker";
 }
-impl ::core::convert::From<FolderPicker> for ::windows::core::IUnknown {
-    fn from(value: FolderPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FolderPicker> for ::windows::core::IUnknown {
-    fn from(value: &FolderPicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FolderPicker> for &::windows::core::IUnknown {
-    fn from(value: &FolderPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FolderPicker> for ::windows::core::IInspectable {
-    fn from(value: FolderPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FolderPicker> for ::windows::core::IInspectable {
-    fn from(value: &FolderPicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FolderPicker> for &::windows::core::IInspectable {
-    fn from(value: &FolderPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FolderPicker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FolderPicker {}
 unsafe impl ::core::marker::Sync for FolderPicker {}
 #[doc = "*Required features: `\"Storage_Pickers\"`*"]

--- a/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
@@ -287,36 +287,7 @@ impl IStorageProviderHandlerFactory {
         }
     }
 }
-impl ::core::convert::From<IStorageProviderHandlerFactory> for ::windows::core::IUnknown {
-    fn from(value: IStorageProviderHandlerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderHandlerFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageProviderHandlerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderHandlerFactory> for ::windows::core::IUnknown {
-    fn from(value: &IStorageProviderHandlerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageProviderHandlerFactory> for ::windows::core::IInspectable {
-    fn from(value: IStorageProviderHandlerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderHandlerFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageProviderHandlerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderHandlerFactory> for ::windows::core::IInspectable {
-    fn from(value: &IStorageProviderHandlerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageProviderHandlerFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageProviderHandlerFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -422,36 +393,7 @@ impl IStorageProviderItemPropertySource {
         }
     }
 }
-impl ::core::convert::From<IStorageProviderItemPropertySource> for ::windows::core::IUnknown {
-    fn from(value: IStorageProviderItemPropertySource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderItemPropertySource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageProviderItemPropertySource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderItemPropertySource> for ::windows::core::IUnknown {
-    fn from(value: &IStorageProviderItemPropertySource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageProviderItemPropertySource> for ::windows::core::IInspectable {
-    fn from(value: IStorageProviderItemPropertySource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderItemPropertySource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageProviderItemPropertySource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderItemPropertySource> for ::windows::core::IInspectable {
-    fn from(value: &IStorageProviderItemPropertySource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageProviderItemPropertySource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageProviderItemPropertySource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -502,36 +444,7 @@ impl IStorageProviderPropertyCapabilities {
         }
     }
 }
-impl ::core::convert::From<IStorageProviderPropertyCapabilities> for ::windows::core::IUnknown {
-    fn from(value: IStorageProviderPropertyCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderPropertyCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageProviderPropertyCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderPropertyCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &IStorageProviderPropertyCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageProviderPropertyCapabilities> for ::windows::core::IInspectable {
-    fn from(value: IStorageProviderPropertyCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderPropertyCapabilities> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageProviderPropertyCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderPropertyCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &IStorageProviderPropertyCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageProviderPropertyCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageProviderPropertyCapabilities {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -633,36 +546,7 @@ impl IStorageProviderStatusSource {
         unsafe { (::windows::core::Vtable::vtable(this).RemoveChanged)(::windows::core::Vtable::as_raw(this), token).ok() }
     }
 }
-impl ::core::convert::From<IStorageProviderStatusSource> for ::windows::core::IUnknown {
-    fn from(value: IStorageProviderStatusSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderStatusSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageProviderStatusSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderStatusSource> for ::windows::core::IUnknown {
-    fn from(value: &IStorageProviderStatusSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageProviderStatusSource> for ::windows::core::IInspectable {
-    fn from(value: IStorageProviderStatusSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderStatusSource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageProviderStatusSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderStatusSource> for ::windows::core::IInspectable {
-    fn from(value: &IStorageProviderStatusSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageProviderStatusSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageProviderStatusSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -850,36 +734,7 @@ impl IStorageProviderUriSource {
         unsafe { (::windows::core::Vtable::vtable(this).GetContentInfoForPath)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(path), ::core::mem::transmute_copy(result)).ok() }
     }
 }
-impl ::core::convert::From<IStorageProviderUriSource> for ::windows::core::IUnknown {
-    fn from(value: IStorageProviderUriSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderUriSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageProviderUriSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderUriSource> for ::windows::core::IUnknown {
-    fn from(value: &IStorageProviderUriSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageProviderUriSource> for ::windows::core::IInspectable {
-    fn from(value: IStorageProviderUriSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderUriSource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageProviderUriSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderUriSource> for ::windows::core::IInspectable {
-    fn from(value: &IStorageProviderUriSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageProviderUriSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageProviderUriSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1041,36 +896,7 @@ unsafe impl ::windows::core::Interface for CachedFileUpdaterUI {
 impl ::windows::core::RuntimeName for CachedFileUpdaterUI {
     const NAME: &'static str = "Windows.Storage.Provider.CachedFileUpdaterUI";
 }
-impl ::core::convert::From<CachedFileUpdaterUI> for ::windows::core::IUnknown {
-    fn from(value: CachedFileUpdaterUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterUI> for ::windows::core::IUnknown {
-    fn from(value: &CachedFileUpdaterUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterUI> for &::windows::core::IUnknown {
-    fn from(value: &CachedFileUpdaterUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CachedFileUpdaterUI> for ::windows::core::IInspectable {
-    fn from(value: CachedFileUpdaterUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterUI> for ::windows::core::IInspectable {
-    fn from(value: &CachedFileUpdaterUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CachedFileUpdaterUI> for &::windows::core::IInspectable {
-    fn from(value: &CachedFileUpdaterUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CachedFileUpdaterUI, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
 #[repr(transparent)]
 pub struct FileUpdateRequest(::windows::core::IUnknown);
@@ -1159,36 +985,7 @@ unsafe impl ::windows::core::Interface for FileUpdateRequest {
 impl ::windows::core::RuntimeName for FileUpdateRequest {
     const NAME: &'static str = "Windows.Storage.Provider.FileUpdateRequest";
 }
-impl ::core::convert::From<FileUpdateRequest> for ::windows::core::IUnknown {
-    fn from(value: FileUpdateRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileUpdateRequest> for ::windows::core::IUnknown {
-    fn from(value: &FileUpdateRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileUpdateRequest> for &::windows::core::IUnknown {
-    fn from(value: &FileUpdateRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileUpdateRequest> for ::windows::core::IInspectable {
-    fn from(value: FileUpdateRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileUpdateRequest> for ::windows::core::IInspectable {
-    fn from(value: &FileUpdateRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileUpdateRequest> for &::windows::core::IInspectable {
-    fn from(value: &FileUpdateRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileUpdateRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
 #[repr(transparent)]
 pub struct FileUpdateRequestDeferral(::windows::core::IUnknown);
@@ -1230,36 +1027,7 @@ unsafe impl ::windows::core::Interface for FileUpdateRequestDeferral {
 impl ::windows::core::RuntimeName for FileUpdateRequestDeferral {
     const NAME: &'static str = "Windows.Storage.Provider.FileUpdateRequestDeferral";
 }
-impl ::core::convert::From<FileUpdateRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: FileUpdateRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileUpdateRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: &FileUpdateRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileUpdateRequestDeferral> for &::windows::core::IUnknown {
-    fn from(value: &FileUpdateRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileUpdateRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: FileUpdateRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileUpdateRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: &FileUpdateRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileUpdateRequestDeferral> for &::windows::core::IInspectable {
-    fn from(value: &FileUpdateRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileUpdateRequestDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
 #[repr(transparent)]
 pub struct FileUpdateRequestedEventArgs(::windows::core::IUnknown);
@@ -1304,36 +1072,7 @@ unsafe impl ::windows::core::Interface for FileUpdateRequestedEventArgs {
 impl ::windows::core::RuntimeName for FileUpdateRequestedEventArgs {
     const NAME: &'static str = "Windows.Storage.Provider.FileUpdateRequestedEventArgs";
 }
-impl ::core::convert::From<FileUpdateRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: FileUpdateRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileUpdateRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &FileUpdateRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileUpdateRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &FileUpdateRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileUpdateRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: FileUpdateRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileUpdateRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &FileUpdateRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileUpdateRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &FileUpdateRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileUpdateRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
 #[repr(transparent)]
 pub struct StorageProviderError(::windows::core::IUnknown);
@@ -1447,36 +1186,7 @@ unsafe impl ::windows::core::Interface for StorageProviderError {
 impl ::windows::core::RuntimeName for StorageProviderError {
     const NAME: &'static str = "Windows.Storage.Provider.StorageProviderError";
 }
-impl ::core::convert::From<StorageProviderError> for ::windows::core::IUnknown {
-    fn from(value: StorageProviderError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderError> for ::windows::core::IUnknown {
-    fn from(value: &StorageProviderError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderError> for &::windows::core::IUnknown {
-    fn from(value: &StorageProviderError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageProviderError> for ::windows::core::IInspectable {
-    fn from(value: StorageProviderError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderError> for ::windows::core::IInspectable {
-    fn from(value: &StorageProviderError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderError> for &::windows::core::IInspectable {
-    fn from(value: &StorageProviderError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageProviderError, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageProviderError {}
 unsafe impl ::core::marker::Sync for StorageProviderError {}
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
@@ -1545,36 +1255,7 @@ unsafe impl ::windows::core::Interface for StorageProviderErrorCommand {
 impl ::windows::core::RuntimeName for StorageProviderErrorCommand {
     const NAME: &'static str = "Windows.Storage.Provider.StorageProviderErrorCommand";
 }
-impl ::core::convert::From<StorageProviderErrorCommand> for ::windows::core::IUnknown {
-    fn from(value: StorageProviderErrorCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderErrorCommand> for ::windows::core::IUnknown {
-    fn from(value: &StorageProviderErrorCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderErrorCommand> for &::windows::core::IUnknown {
-    fn from(value: &StorageProviderErrorCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageProviderErrorCommand> for ::windows::core::IInspectable {
-    fn from(value: StorageProviderErrorCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderErrorCommand> for ::windows::core::IInspectable {
-    fn from(value: &StorageProviderErrorCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderErrorCommand> for &::windows::core::IInspectable {
-    fn from(value: &StorageProviderErrorCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageProviderErrorCommand, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageProviderErrorCommand {}
 unsafe impl ::core::marker::Sync for StorageProviderErrorCommand {}
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
@@ -1639,36 +1320,7 @@ unsafe impl ::windows::core::Interface for StorageProviderFileTypeInfo {
 impl ::windows::core::RuntimeName for StorageProviderFileTypeInfo {
     const NAME: &'static str = "Windows.Storage.Provider.StorageProviderFileTypeInfo";
 }
-impl ::core::convert::From<StorageProviderFileTypeInfo> for ::windows::core::IUnknown {
-    fn from(value: StorageProviderFileTypeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderFileTypeInfo> for ::windows::core::IUnknown {
-    fn from(value: &StorageProviderFileTypeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderFileTypeInfo> for &::windows::core::IUnknown {
-    fn from(value: &StorageProviderFileTypeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageProviderFileTypeInfo> for ::windows::core::IInspectable {
-    fn from(value: StorageProviderFileTypeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderFileTypeInfo> for ::windows::core::IInspectable {
-    fn from(value: &StorageProviderFileTypeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderFileTypeInfo> for &::windows::core::IInspectable {
-    fn from(value: &StorageProviderFileTypeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageProviderFileTypeInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageProviderFileTypeInfo {}
 unsafe impl ::core::marker::Sync for StorageProviderFileTypeInfo {}
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
@@ -1748,36 +1400,7 @@ unsafe impl ::windows::core::Interface for StorageProviderGetContentInfoForPathR
 impl ::windows::core::RuntimeName for StorageProviderGetContentInfoForPathResult {
     const NAME: &'static str = "Windows.Storage.Provider.StorageProviderGetContentInfoForPathResult";
 }
-impl ::core::convert::From<StorageProviderGetContentInfoForPathResult> for ::windows::core::IUnknown {
-    fn from(value: StorageProviderGetContentInfoForPathResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderGetContentInfoForPathResult> for ::windows::core::IUnknown {
-    fn from(value: &StorageProviderGetContentInfoForPathResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderGetContentInfoForPathResult> for &::windows::core::IUnknown {
-    fn from(value: &StorageProviderGetContentInfoForPathResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageProviderGetContentInfoForPathResult> for ::windows::core::IInspectable {
-    fn from(value: StorageProviderGetContentInfoForPathResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderGetContentInfoForPathResult> for ::windows::core::IInspectable {
-    fn from(value: &StorageProviderGetContentInfoForPathResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderGetContentInfoForPathResult> for &::windows::core::IInspectable {
-    fn from(value: &StorageProviderGetContentInfoForPathResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageProviderGetContentInfoForPathResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageProviderGetContentInfoForPathResult {}
 unsafe impl ::core::marker::Sync for StorageProviderGetContentInfoForPathResult {}
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
@@ -1846,36 +1469,7 @@ unsafe impl ::windows::core::Interface for StorageProviderGetPathForContentUriRe
 impl ::windows::core::RuntimeName for StorageProviderGetPathForContentUriResult {
     const NAME: &'static str = "Windows.Storage.Provider.StorageProviderGetPathForContentUriResult";
 }
-impl ::core::convert::From<StorageProviderGetPathForContentUriResult> for ::windows::core::IUnknown {
-    fn from(value: StorageProviderGetPathForContentUriResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderGetPathForContentUriResult> for ::windows::core::IUnknown {
-    fn from(value: &StorageProviderGetPathForContentUriResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderGetPathForContentUriResult> for &::windows::core::IUnknown {
-    fn from(value: &StorageProviderGetPathForContentUriResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageProviderGetPathForContentUriResult> for ::windows::core::IInspectable {
-    fn from(value: StorageProviderGetPathForContentUriResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderGetPathForContentUriResult> for ::windows::core::IInspectable {
-    fn from(value: &StorageProviderGetPathForContentUriResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderGetPathForContentUriResult> for &::windows::core::IInspectable {
-    fn from(value: &StorageProviderGetPathForContentUriResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageProviderGetPathForContentUriResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageProviderGetPathForContentUriResult {}
 unsafe impl ::core::marker::Sync for StorageProviderGetPathForContentUriResult {}
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
@@ -1981,36 +1575,7 @@ unsafe impl ::windows::core::Interface for StorageProviderItemProperty {
 impl ::windows::core::RuntimeName for StorageProviderItemProperty {
     const NAME: &'static str = "Windows.Storage.Provider.StorageProviderItemProperty";
 }
-impl ::core::convert::From<StorageProviderItemProperty> for ::windows::core::IUnknown {
-    fn from(value: StorageProviderItemProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderItemProperty> for ::windows::core::IUnknown {
-    fn from(value: &StorageProviderItemProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderItemProperty> for &::windows::core::IUnknown {
-    fn from(value: &StorageProviderItemProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageProviderItemProperty> for ::windows::core::IInspectable {
-    fn from(value: StorageProviderItemProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderItemProperty> for ::windows::core::IInspectable {
-    fn from(value: &StorageProviderItemProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderItemProperty> for &::windows::core::IInspectable {
-    fn from(value: &StorageProviderItemProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageProviderItemProperty, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageProviderItemProperty {}
 unsafe impl ::core::marker::Sync for StorageProviderItemProperty {}
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
@@ -2079,36 +1644,7 @@ unsafe impl ::windows::core::Interface for StorageProviderItemPropertyDefinition
 impl ::windows::core::RuntimeName for StorageProviderItemPropertyDefinition {
     const NAME: &'static str = "Windows.Storage.Provider.StorageProviderItemPropertyDefinition";
 }
-impl ::core::convert::From<StorageProviderItemPropertyDefinition> for ::windows::core::IUnknown {
-    fn from(value: StorageProviderItemPropertyDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderItemPropertyDefinition> for ::windows::core::IUnknown {
-    fn from(value: &StorageProviderItemPropertyDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderItemPropertyDefinition> for &::windows::core::IUnknown {
-    fn from(value: &StorageProviderItemPropertyDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageProviderItemPropertyDefinition> for ::windows::core::IInspectable {
-    fn from(value: StorageProviderItemPropertyDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderItemPropertyDefinition> for ::windows::core::IInspectable {
-    fn from(value: &StorageProviderItemPropertyDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderItemPropertyDefinition> for &::windows::core::IInspectable {
-    fn from(value: &StorageProviderItemPropertyDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageProviderItemPropertyDefinition, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageProviderItemPropertyDefinition {}
 unsafe impl ::core::marker::Sync for StorageProviderItemPropertyDefinition {}
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
@@ -2194,36 +1730,7 @@ unsafe impl ::windows::core::Interface for StorageProviderStatus {
 impl ::windows::core::RuntimeName for StorageProviderStatus {
     const NAME: &'static str = "Windows.Storage.Provider.StorageProviderStatus";
 }
-impl ::core::convert::From<StorageProviderStatus> for ::windows::core::IUnknown {
-    fn from(value: StorageProviderStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderStatus> for ::windows::core::IUnknown {
-    fn from(value: &StorageProviderStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderStatus> for &::windows::core::IUnknown {
-    fn from(value: &StorageProviderStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageProviderStatus> for ::windows::core::IInspectable {
-    fn from(value: StorageProviderStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderStatus> for ::windows::core::IInspectable {
-    fn from(value: &StorageProviderStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderStatus> for &::windows::core::IInspectable {
-    fn from(value: &StorageProviderStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageProviderStatus, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageProviderStatus {}
 unsafe impl ::core::marker::Sync for StorageProviderStatus {}
 #[doc = "*Required features: `\"Storage_Provider\"`*"]
@@ -2480,36 +1987,7 @@ unsafe impl ::windows::core::Interface for StorageProviderSyncRootInfo {
 impl ::windows::core::RuntimeName for StorageProviderSyncRootInfo {
     const NAME: &'static str = "Windows.Storage.Provider.StorageProviderSyncRootInfo";
 }
-impl ::core::convert::From<StorageProviderSyncRootInfo> for ::windows::core::IUnknown {
-    fn from(value: StorageProviderSyncRootInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderSyncRootInfo> for ::windows::core::IUnknown {
-    fn from(value: &StorageProviderSyncRootInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderSyncRootInfo> for &::windows::core::IUnknown {
-    fn from(value: &StorageProviderSyncRootInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageProviderSyncRootInfo> for ::windows::core::IInspectable {
-    fn from(value: StorageProviderSyncRootInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProviderSyncRootInfo> for ::windows::core::IInspectable {
-    fn from(value: &StorageProviderSyncRootInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProviderSyncRootInfo> for &::windows::core::IInspectable {
-    fn from(value: &StorageProviderSyncRootInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageProviderSyncRootInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageProviderSyncRootInfo {}
 unsafe impl ::core::marker::Sync for StorageProviderSyncRootInfo {}
 #[doc = "*Required features: `\"Storage_Provider\"`*"]

--- a/crates/libs/windows/src/Windows/Storage/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Search/mod.rs
@@ -169,36 +169,7 @@ impl IIndexableContent {
         unsafe { (::windows::core::Vtable::vtable(this).SetStreamContentType)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(value)).ok() }
     }
 }
-impl ::core::convert::From<IIndexableContent> for ::windows::core::IUnknown {
-    fn from(value: IIndexableContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIndexableContent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIndexableContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIndexableContent> for ::windows::core::IUnknown {
-    fn from(value: &IIndexableContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IIndexableContent> for ::windows::core::IInspectable {
-    fn from(value: IIndexableContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIndexableContent> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IIndexableContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIndexableContent> for ::windows::core::IInspectable {
-    fn from(value: &IIndexableContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIndexableContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IIndexableContent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -506,36 +477,7 @@ impl IStorageFolderQueryOperations {
         }
     }
 }
-impl ::core::convert::From<IStorageFolderQueryOperations> for ::windows::core::IUnknown {
-    fn from(value: IStorageFolderQueryOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFolderQueryOperations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageFolderQueryOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFolderQueryOperations> for ::windows::core::IUnknown {
-    fn from(value: &IStorageFolderQueryOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageFolderQueryOperations> for ::windows::core::IInspectable {
-    fn from(value: IStorageFolderQueryOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFolderQueryOperations> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageFolderQueryOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFolderQueryOperations> for ::windows::core::IInspectable {
-    fn from(value: &IStorageFolderQueryOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageFolderQueryOperations, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageFolderQueryOperations {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -758,36 +700,7 @@ impl IStorageQueryResultBase {
         unsafe { (::windows::core::Vtable::vtable(this).ApplyNewQueryOptions)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(newqueryoptions)).ok() }
     }
 }
-impl ::core::convert::From<IStorageQueryResultBase> for ::windows::core::IUnknown {
-    fn from(value: IStorageQueryResultBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageQueryResultBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageQueryResultBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageQueryResultBase> for ::windows::core::IUnknown {
-    fn from(value: &IStorageQueryResultBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageQueryResultBase> for ::windows::core::IInspectable {
-    fn from(value: IStorageQueryResultBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageQueryResultBase> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageQueryResultBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageQueryResultBase> for ::windows::core::IInspectable {
-    fn from(value: &IStorageQueryResultBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageQueryResultBase, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageQueryResultBase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1041,36 +954,7 @@ unsafe impl ::windows::core::Interface for ContentIndexer {
 impl ::windows::core::RuntimeName for ContentIndexer {
     const NAME: &'static str = "Windows.Storage.Search.ContentIndexer";
 }
-impl ::core::convert::From<ContentIndexer> for ::windows::core::IUnknown {
-    fn from(value: ContentIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContentIndexer> for ::windows::core::IUnknown {
-    fn from(value: &ContentIndexer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContentIndexer> for &::windows::core::IUnknown {
-    fn from(value: &ContentIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContentIndexer> for ::windows::core::IInspectable {
-    fn from(value: ContentIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContentIndexer> for ::windows::core::IInspectable {
-    fn from(value: &ContentIndexer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContentIndexer> for &::windows::core::IInspectable {
-    fn from(value: &ContentIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContentIndexer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContentIndexer {}
 unsafe impl ::core::marker::Sync for ContentIndexer {}
 #[doc = "*Required features: `\"Storage_Search\"`*"]
@@ -1162,36 +1046,7 @@ unsafe impl ::windows::core::Interface for ContentIndexerQuery {
 impl ::windows::core::RuntimeName for ContentIndexerQuery {
     const NAME: &'static str = "Windows.Storage.Search.ContentIndexerQuery";
 }
-impl ::core::convert::From<ContentIndexerQuery> for ::windows::core::IUnknown {
-    fn from(value: ContentIndexerQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContentIndexerQuery> for ::windows::core::IUnknown {
-    fn from(value: &ContentIndexerQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContentIndexerQuery> for &::windows::core::IUnknown {
-    fn from(value: &ContentIndexerQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContentIndexerQuery> for ::windows::core::IInspectable {
-    fn from(value: ContentIndexerQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContentIndexerQuery> for ::windows::core::IInspectable {
-    fn from(value: &ContentIndexerQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContentIndexerQuery> for &::windows::core::IInspectable {
-    fn from(value: &ContentIndexerQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContentIndexerQuery, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContentIndexerQuery {}
 unsafe impl ::core::marker::Sync for ContentIndexerQuery {}
 #[doc = "*Required features: `\"Storage_Search\"`*"]
@@ -1288,36 +1143,7 @@ unsafe impl ::windows::core::Interface for IndexableContent {
 impl ::windows::core::RuntimeName for IndexableContent {
     const NAME: &'static str = "Windows.Storage.Search.IndexableContent";
 }
-impl ::core::convert::From<IndexableContent> for ::windows::core::IUnknown {
-    fn from(value: IndexableContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IndexableContent> for ::windows::core::IUnknown {
-    fn from(value: &IndexableContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IndexableContent> for &::windows::core::IUnknown {
-    fn from(value: &IndexableContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IndexableContent> for ::windows::core::IInspectable {
-    fn from(value: IndexableContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IndexableContent> for ::windows::core::IInspectable {
-    fn from(value: &IndexableContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IndexableContent> for &::windows::core::IInspectable {
-    fn from(value: &IndexableContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IndexableContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IndexableContent> for IIndexableContent {
     type Error = ::windows::core::Error;
     fn try_from(value: IndexableContent) -> ::windows::core::Result<Self> {
@@ -1529,36 +1355,7 @@ unsafe impl ::windows::core::Interface for QueryOptions {
 impl ::windows::core::RuntimeName for QueryOptions {
     const NAME: &'static str = "Windows.Storage.Search.QueryOptions";
 }
-impl ::core::convert::From<QueryOptions> for ::windows::core::IUnknown {
-    fn from(value: QueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&QueryOptions> for ::windows::core::IUnknown {
-    fn from(value: &QueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&QueryOptions> for &::windows::core::IUnknown {
-    fn from(value: &QueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<QueryOptions> for ::windows::core::IInspectable {
-    fn from(value: QueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&QueryOptions> for ::windows::core::IInspectable {
-    fn from(value: &QueryOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&QueryOptions> for &::windows::core::IInspectable {
-    fn from(value: &QueryOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(QueryOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for QueryOptions {}
 unsafe impl ::core::marker::Sync for QueryOptions {}
 #[doc = "*Required features: `\"Storage_Search\"`, `\"Foundation_Collections\"`*"]
@@ -1733,41 +1530,7 @@ impl ::core::iter::IntoIterator for &SortEntryVector {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<SortEntryVector> for ::windows::core::IUnknown {
-    fn from(value: SortEntryVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SortEntryVector> for ::windows::core::IUnknown {
-    fn from(value: &SortEntryVector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SortEntryVector> for &::windows::core::IUnknown {
-    fn from(value: &SortEntryVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<SortEntryVector> for ::windows::core::IInspectable {
-    fn from(value: SortEntryVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SortEntryVector> for ::windows::core::IInspectable {
-    fn from(value: &SortEntryVector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SortEntryVector> for &::windows::core::IInspectable {
-    fn from(value: &SortEntryVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SortEntryVector, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<SortEntryVector> for super::super::Foundation::Collections::IIterable<SortEntry> {
     type Error = ::windows::core::Error;
@@ -1945,36 +1708,7 @@ unsafe impl ::windows::core::Interface for StorageFileQueryResult {
 impl ::windows::core::RuntimeName for StorageFileQueryResult {
     const NAME: &'static str = "Windows.Storage.Search.StorageFileQueryResult";
 }
-impl ::core::convert::From<StorageFileQueryResult> for ::windows::core::IUnknown {
-    fn from(value: StorageFileQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageFileQueryResult> for ::windows::core::IUnknown {
-    fn from(value: &StorageFileQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageFileQueryResult> for &::windows::core::IUnknown {
-    fn from(value: &StorageFileQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageFileQueryResult> for ::windows::core::IInspectable {
-    fn from(value: StorageFileQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageFileQueryResult> for ::windows::core::IInspectable {
-    fn from(value: &StorageFileQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageFileQueryResult> for &::windows::core::IInspectable {
-    fn from(value: &StorageFileQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageFileQueryResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StorageFileQueryResult> for IStorageQueryResultBase {
     type Error = ::windows::core::Error;
     fn try_from(value: StorageFileQueryResult) -> ::windows::core::Result<Self> {
@@ -2118,36 +1852,7 @@ unsafe impl ::windows::core::Interface for StorageFolderQueryResult {
 impl ::windows::core::RuntimeName for StorageFolderQueryResult {
     const NAME: &'static str = "Windows.Storage.Search.StorageFolderQueryResult";
 }
-impl ::core::convert::From<StorageFolderQueryResult> for ::windows::core::IUnknown {
-    fn from(value: StorageFolderQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageFolderQueryResult> for ::windows::core::IUnknown {
-    fn from(value: &StorageFolderQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageFolderQueryResult> for &::windows::core::IUnknown {
-    fn from(value: &StorageFolderQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageFolderQueryResult> for ::windows::core::IInspectable {
-    fn from(value: StorageFolderQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageFolderQueryResult> for ::windows::core::IInspectable {
-    fn from(value: &StorageFolderQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageFolderQueryResult> for &::windows::core::IInspectable {
-    fn from(value: &StorageFolderQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageFolderQueryResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StorageFolderQueryResult> for IStorageQueryResultBase {
     type Error = ::windows::core::Error;
     fn try_from(value: StorageFolderQueryResult) -> ::windows::core::Result<Self> {
@@ -2291,36 +1996,7 @@ unsafe impl ::windows::core::Interface for StorageItemQueryResult {
 impl ::windows::core::RuntimeName for StorageItemQueryResult {
     const NAME: &'static str = "Windows.Storage.Search.StorageItemQueryResult";
 }
-impl ::core::convert::From<StorageItemQueryResult> for ::windows::core::IUnknown {
-    fn from(value: StorageItemQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageItemQueryResult> for ::windows::core::IUnknown {
-    fn from(value: &StorageItemQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageItemQueryResult> for &::windows::core::IUnknown {
-    fn from(value: &StorageItemQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageItemQueryResult> for ::windows::core::IInspectable {
-    fn from(value: StorageItemQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageItemQueryResult> for ::windows::core::IInspectable {
-    fn from(value: &StorageItemQueryResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageItemQueryResult> for &::windows::core::IInspectable {
-    fn from(value: &StorageItemQueryResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageItemQueryResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StorageItemQueryResult> for IStorageQueryResultBase {
     type Error = ::windows::core::Error;
     fn try_from(value: StorageItemQueryResult) -> ::windows::core::Result<Self> {
@@ -2391,36 +2067,7 @@ unsafe impl ::windows::core::Interface for StorageLibraryChangeTrackerTriggerDet
 impl ::windows::core::RuntimeName for StorageLibraryChangeTrackerTriggerDetails {
     const NAME: &'static str = "Windows.Storage.Search.StorageLibraryChangeTrackerTriggerDetails";
 }
-impl ::core::convert::From<StorageLibraryChangeTrackerTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: StorageLibraryChangeTrackerTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChangeTrackerTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChangeTrackerTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageLibraryChangeTrackerTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: StorageLibraryChangeTrackerTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChangeTrackerTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChangeTrackerTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageLibraryChangeTrackerTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Search\"`*"]
 #[repr(transparent)]
 pub struct StorageLibraryContentChangedTriggerDetails(::windows::core::IUnknown);
@@ -2474,36 +2121,7 @@ unsafe impl ::windows::core::Interface for StorageLibraryContentChangedTriggerDe
 impl ::windows::core::RuntimeName for StorageLibraryContentChangedTriggerDetails {
     const NAME: &'static str = "Windows.Storage.Search.StorageLibraryContentChangedTriggerDetails";
 }
-impl ::core::convert::From<StorageLibraryContentChangedTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: StorageLibraryContentChangedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryContentChangedTriggerDetails> for ::windows::core::IUnknown {
-    fn from(value: &StorageLibraryContentChangedTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryContentChangedTriggerDetails> for &::windows::core::IUnknown {
-    fn from(value: &StorageLibraryContentChangedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageLibraryContentChangedTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: StorageLibraryContentChangedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryContentChangedTriggerDetails> for ::windows::core::IInspectable {
-    fn from(value: &StorageLibraryContentChangedTriggerDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryContentChangedTriggerDetails> for &::windows::core::IInspectable {
-    fn from(value: &StorageLibraryContentChangedTriggerDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageLibraryContentChangedTriggerDetails, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage_Search\"`*"]
 #[repr(transparent)]
 pub struct ValueAndLanguage(::windows::core::IUnknown);
@@ -2573,36 +2191,7 @@ unsafe impl ::windows::core::Interface for ValueAndLanguage {
 impl ::windows::core::RuntimeName for ValueAndLanguage {
     const NAME: &'static str = "Windows.Storage.Search.ValueAndLanguage";
 }
-impl ::core::convert::From<ValueAndLanguage> for ::windows::core::IUnknown {
-    fn from(value: ValueAndLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ValueAndLanguage> for ::windows::core::IUnknown {
-    fn from(value: &ValueAndLanguage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ValueAndLanguage> for &::windows::core::IUnknown {
-    fn from(value: &ValueAndLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ValueAndLanguage> for ::windows::core::IInspectable {
-    fn from(value: ValueAndLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ValueAndLanguage> for ::windows::core::IInspectable {
-    fn from(value: &ValueAndLanguage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ValueAndLanguage> for &::windows::core::IInspectable {
-    fn from(value: &ValueAndLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ValueAndLanguage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ValueAndLanguage {}
 unsafe impl ::core::marker::Sync for ValueAndLanguage {}
 #[doc = "*Required features: `\"Storage_Search\"`*"]

--- a/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
@@ -21,36 +21,7 @@ impl IBuffer {
         unsafe { (::windows::core::Vtable::vtable(this).SetLength)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<IBuffer> for ::windows::core::IUnknown {
-    fn from(value: IBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBuffer> for ::windows::core::IInspectable {
-    fn from(value: IBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBuffer> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBuffer> for ::windows::core::IInspectable {
-    fn from(value: &IBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBuffer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -137,36 +108,7 @@ impl IContentTypeProvider {
         }
     }
 }
-impl ::core::convert::From<IContentTypeProvider> for ::windows::core::IUnknown {
-    fn from(value: IContentTypeProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContentTypeProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContentTypeProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContentTypeProvider> for ::windows::core::IUnknown {
-    fn from(value: &IContentTypeProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContentTypeProvider> for ::windows::core::IInspectable {
-    fn from(value: IContentTypeProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContentTypeProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContentTypeProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContentTypeProvider> for ::windows::core::IInspectable {
-    fn from(value: &IContentTypeProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContentTypeProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IContentTypeProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -383,36 +325,7 @@ impl IDataReader {
         }
     }
 }
-impl ::core::convert::From<IDataReader> for ::windows::core::IUnknown {
-    fn from(value: IDataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataReader> for ::windows::core::IUnknown {
-    fn from(value: &IDataReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDataReader> for ::windows::core::IInspectable {
-    fn from(value: IDataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataReader> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IDataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataReader> for ::windows::core::IInspectable {
-    fn from(value: &IDataReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IDataReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -668,36 +581,7 @@ impl IDataWriter {
         }
     }
 }
-impl ::core::convert::From<IDataWriter> for ::windows::core::IUnknown {
-    fn from(value: IDataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataWriter> for ::windows::core::IUnknown {
-    fn from(value: &IDataWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDataWriter> for ::windows::core::IInspectable {
-    fn from(value: IDataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataWriter> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IDataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataWriter> for ::windows::core::IInspectable {
-    fn from(value: &IDataWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataWriter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IDataWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -856,36 +740,7 @@ impl IInputStream {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IInputStream> for ::windows::core::IUnknown {
-    fn from(value: IInputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputStream> for ::windows::core::IUnknown {
-    fn from(value: &IInputStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInputStream> for ::windows::core::IInspectable {
-    fn from(value: IInputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputStream> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputStream> for ::windows::core::IInspectable {
-    fn from(value: &IInputStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInputStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IInputStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -960,36 +815,7 @@ impl IInputStreamReference {
         }
     }
 }
-impl ::core::convert::From<IInputStreamReference> for ::windows::core::IUnknown {
-    fn from(value: IInputStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputStreamReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInputStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputStreamReference> for ::windows::core::IUnknown {
-    fn from(value: &IInputStreamReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInputStreamReference> for ::windows::core::IInspectable {
-    fn from(value: IInputStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputStreamReference> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInputStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputStreamReference> for ::windows::core::IInspectable {
-    fn from(value: &IInputStreamReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInputStreamReference, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IInputStreamReference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1061,36 +887,7 @@ impl IOutputStream {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IOutputStream> for ::windows::core::IUnknown {
-    fn from(value: IOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOutputStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOutputStream> for ::windows::core::IUnknown {
-    fn from(value: &IOutputStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOutputStream> for ::windows::core::IInspectable {
-    fn from(value: IOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOutputStream> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOutputStream> for ::windows::core::IInspectable {
-    fn from(value: &IOutputStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOutputStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IOutputStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1185,36 +982,7 @@ impl IPropertySetSerializer {
         unsafe { (::windows::core::Vtable::vtable(this).Deserialize)(::windows::core::Vtable::as_raw(this), propertyset.try_into().map_err(|e| e.into())?.abi(), buffer.try_into().map_err(|e| e.into())?.abi()).ok() }
     }
 }
-impl ::core::convert::From<IPropertySetSerializer> for ::windows::core::IUnknown {
-    fn from(value: IPropertySetSerializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertySetSerializer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertySetSerializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertySetSerializer> for ::windows::core::IUnknown {
-    fn from(value: &IPropertySetSerializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertySetSerializer> for ::windows::core::IInspectable {
-    fn from(value: IPropertySetSerializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertySetSerializer> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPropertySetSerializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertySetSerializer> for ::windows::core::IInspectable {
-    fn from(value: &IPropertySetSerializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertySetSerializer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPropertySetSerializer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1360,36 +1128,7 @@ impl IRandomAccessStream {
         }
     }
 }
-impl ::core::convert::From<IRandomAccessStream> for ::windows::core::IUnknown {
-    fn from(value: IRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRandomAccessStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRandomAccessStream> for ::windows::core::IUnknown {
-    fn from(value: &IRandomAccessStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRandomAccessStream> for ::windows::core::IInspectable {
-    fn from(value: IRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRandomAccessStream> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRandomAccessStream> for ::windows::core::IInspectable {
-    fn from(value: &IRandomAccessStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRandomAccessStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IRandomAccessStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1507,36 +1246,7 @@ impl IRandomAccessStreamReference {
         }
     }
 }
-impl ::core::convert::From<IRandomAccessStreamReference> for ::windows::core::IUnknown {
-    fn from(value: IRandomAccessStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRandomAccessStreamReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRandomAccessStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRandomAccessStreamReference> for ::windows::core::IUnknown {
-    fn from(value: &IRandomAccessStreamReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRandomAccessStreamReference> for ::windows::core::IInspectable {
-    fn from(value: IRandomAccessStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRandomAccessStreamReference> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IRandomAccessStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRandomAccessStreamReference> for ::windows::core::IInspectable {
-    fn from(value: &IRandomAccessStreamReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRandomAccessStreamReference, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IRandomAccessStreamReference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1731,36 +1441,7 @@ impl IRandomAccessStreamWithContentType {
         }
     }
 }
-impl ::core::convert::From<IRandomAccessStreamWithContentType> for ::windows::core::IUnknown {
-    fn from(value: IRandomAccessStreamWithContentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRandomAccessStreamWithContentType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRandomAccessStreamWithContentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRandomAccessStreamWithContentType> for ::windows::core::IUnknown {
-    fn from(value: &IRandomAccessStreamWithContentType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRandomAccessStreamWithContentType> for ::windows::core::IInspectable {
-    fn from(value: IRandomAccessStreamWithContentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRandomAccessStreamWithContentType> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IRandomAccessStreamWithContentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRandomAccessStreamWithContentType> for ::windows::core::IInspectable {
-    fn from(value: &IRandomAccessStreamWithContentType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRandomAccessStreamWithContentType, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IRandomAccessStreamWithContentType> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1988,36 +1669,7 @@ unsafe impl ::windows::core::Interface for Buffer {
 impl ::windows::core::RuntimeName for Buffer {
     const NAME: &'static str = "Windows.Storage.Streams.Buffer";
 }
-impl ::core::convert::From<Buffer> for ::windows::core::IUnknown {
-    fn from(value: Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Buffer> for ::windows::core::IUnknown {
-    fn from(value: &Buffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Buffer> for &::windows::core::IUnknown {
-    fn from(value: &Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Buffer> for ::windows::core::IInspectable {
-    fn from(value: Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Buffer> for ::windows::core::IInspectable {
-    fn from(value: &Buffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Buffer> for &::windows::core::IInspectable {
-    fn from(value: &Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Buffer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Buffer> for IBuffer {
     type Error = ::windows::core::Error;
     fn try_from(value: Buffer) -> ::windows::core::Result<Self> {
@@ -2288,36 +1940,7 @@ unsafe impl ::windows::core::Interface for DataReader {
 impl ::windows::core::RuntimeName for DataReader {
     const NAME: &'static str = "Windows.Storage.Streams.DataReader";
 }
-impl ::core::convert::From<DataReader> for ::windows::core::IUnknown {
-    fn from(value: DataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataReader> for ::windows::core::IUnknown {
-    fn from(value: &DataReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataReader> for &::windows::core::IUnknown {
-    fn from(value: &DataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataReader> for ::windows::core::IInspectable {
-    fn from(value: DataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataReader> for ::windows::core::IInspectable {
-    fn from(value: &DataReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataReader> for &::windows::core::IInspectable {
-    fn from(value: &DataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<DataReader> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2503,41 +2126,7 @@ impl ::std::future::Future for DataReaderLoadOperation {
     }
 }
 #[cfg(feature = "Foundation")]
-impl ::core::convert::From<DataReaderLoadOperation> for ::windows::core::IUnknown {
-    fn from(value: DataReaderLoadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&DataReaderLoadOperation> for ::windows::core::IUnknown {
-    fn from(value: &DataReaderLoadOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&DataReaderLoadOperation> for &::windows::core::IUnknown {
-    fn from(value: &DataReaderLoadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<DataReaderLoadOperation> for ::windows::core::IInspectable {
-    fn from(value: DataReaderLoadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&DataReaderLoadOperation> for ::windows::core::IInspectable {
-    fn from(value: &DataReaderLoadOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&DataReaderLoadOperation> for &::windows::core::IInspectable {
-    fn from(value: &DataReaderLoadOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataReaderLoadOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<DataReaderLoadOperation> for super::super::Foundation::IAsyncInfo {
     type Error = ::windows::core::Error;
@@ -2802,36 +2391,7 @@ unsafe impl ::windows::core::Interface for DataWriter {
 impl ::windows::core::RuntimeName for DataWriter {
     const NAME: &'static str = "Windows.Storage.Streams.DataWriter";
 }
-impl ::core::convert::From<DataWriter> for ::windows::core::IUnknown {
-    fn from(value: DataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataWriter> for ::windows::core::IUnknown {
-    fn from(value: &DataWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataWriter> for &::windows::core::IUnknown {
-    fn from(value: &DataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DataWriter> for ::windows::core::IInspectable {
-    fn from(value: DataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataWriter> for ::windows::core::IInspectable {
-    fn from(value: &DataWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DataWriter> for &::windows::core::IInspectable {
-    fn from(value: &DataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataWriter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<DataWriter> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3017,41 +2577,7 @@ impl ::std::future::Future for DataWriterStoreOperation {
     }
 }
 #[cfg(feature = "Foundation")]
-impl ::core::convert::From<DataWriterStoreOperation> for ::windows::core::IUnknown {
-    fn from(value: DataWriterStoreOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&DataWriterStoreOperation> for ::windows::core::IUnknown {
-    fn from(value: &DataWriterStoreOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&DataWriterStoreOperation> for &::windows::core::IUnknown {
-    fn from(value: &DataWriterStoreOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<DataWriterStoreOperation> for ::windows::core::IInspectable {
-    fn from(value: DataWriterStoreOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&DataWriterStoreOperation> for ::windows::core::IInspectable {
-    fn from(value: &DataWriterStoreOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation")]
-impl ::core::convert::From<&DataWriterStoreOperation> for &::windows::core::IInspectable {
-    fn from(value: &DataWriterStoreOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DataWriterStoreOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<DataWriterStoreOperation> for super::super::Foundation::IAsyncInfo {
     type Error = ::windows::core::Error;
@@ -3156,36 +2682,7 @@ unsafe impl ::windows::core::Interface for FileInputStream {
 impl ::windows::core::RuntimeName for FileInputStream {
     const NAME: &'static str = "Windows.Storage.Streams.FileInputStream";
 }
-impl ::core::convert::From<FileInputStream> for ::windows::core::IUnknown {
-    fn from(value: FileInputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileInputStream> for ::windows::core::IUnknown {
-    fn from(value: &FileInputStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileInputStream> for &::windows::core::IUnknown {
-    fn from(value: &FileInputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileInputStream> for ::windows::core::IInspectable {
-    fn from(value: FileInputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileInputStream> for ::windows::core::IInspectable {
-    fn from(value: &FileInputStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileInputStream> for &::windows::core::IInspectable {
-    fn from(value: &FileInputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileInputStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<FileInputStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3294,36 +2791,7 @@ unsafe impl ::windows::core::Interface for FileOutputStream {
 impl ::windows::core::RuntimeName for FileOutputStream {
     const NAME: &'static str = "Windows.Storage.Streams.FileOutputStream";
 }
-impl ::core::convert::From<FileOutputStream> for ::windows::core::IUnknown {
-    fn from(value: FileOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileOutputStream> for ::windows::core::IUnknown {
-    fn from(value: &FileOutputStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileOutputStream> for &::windows::core::IUnknown {
-    fn from(value: &FileOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileOutputStream> for ::windows::core::IInspectable {
-    fn from(value: FileOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileOutputStream> for ::windows::core::IInspectable {
-    fn from(value: &FileOutputStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileOutputStream> for &::windows::core::IInspectable {
-    fn from(value: &FileOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileOutputStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<FileOutputStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3571,36 +3039,7 @@ unsafe impl ::windows::core::Interface for FileRandomAccessStream {
 impl ::windows::core::RuntimeName for FileRandomAccessStream {
     const NAME: &'static str = "Windows.Storage.Streams.FileRandomAccessStream";
 }
-impl ::core::convert::From<FileRandomAccessStream> for ::windows::core::IUnknown {
-    fn from(value: FileRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileRandomAccessStream> for ::windows::core::IUnknown {
-    fn from(value: &FileRandomAccessStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileRandomAccessStream> for &::windows::core::IUnknown {
-    fn from(value: &FileRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FileRandomAccessStream> for ::windows::core::IInspectable {
-    fn from(value: FileRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FileRandomAccessStream> for ::windows::core::IInspectable {
-    fn from(value: &FileRandomAccessStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FileRandomAccessStream> for &::windows::core::IInspectable {
-    fn from(value: &FileRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FileRandomAccessStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<FileRandomAccessStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3824,36 +3263,7 @@ unsafe impl ::windows::core::Interface for InMemoryRandomAccessStream {
 impl ::windows::core::RuntimeName for InMemoryRandomAccessStream {
     const NAME: &'static str = "Windows.Storage.Streams.InMemoryRandomAccessStream";
 }
-impl ::core::convert::From<InMemoryRandomAccessStream> for ::windows::core::IUnknown {
-    fn from(value: InMemoryRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InMemoryRandomAccessStream> for ::windows::core::IUnknown {
-    fn from(value: &InMemoryRandomAccessStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InMemoryRandomAccessStream> for &::windows::core::IUnknown {
-    fn from(value: &InMemoryRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InMemoryRandomAccessStream> for ::windows::core::IInspectable {
-    fn from(value: InMemoryRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InMemoryRandomAccessStream> for ::windows::core::IInspectable {
-    fn from(value: &InMemoryRandomAccessStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InMemoryRandomAccessStream> for &::windows::core::IInspectable {
-    fn from(value: &InMemoryRandomAccessStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InMemoryRandomAccessStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<InMemoryRandomAccessStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3991,36 +3401,7 @@ unsafe impl ::windows::core::Interface for InputStreamOverStream {
 impl ::windows::core::RuntimeName for InputStreamOverStream {
     const NAME: &'static str = "Windows.Storage.Streams.InputStreamOverStream";
 }
-impl ::core::convert::From<InputStreamOverStream> for ::windows::core::IUnknown {
-    fn from(value: InputStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputStreamOverStream> for ::windows::core::IUnknown {
-    fn from(value: &InputStreamOverStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputStreamOverStream> for &::windows::core::IUnknown {
-    fn from(value: &InputStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InputStreamOverStream> for ::windows::core::IInspectable {
-    fn from(value: InputStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputStreamOverStream> for ::windows::core::IInspectable {
-    fn from(value: &InputStreamOverStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputStreamOverStream> for &::windows::core::IInspectable {
-    fn from(value: &InputStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InputStreamOverStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<InputStreamOverStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4129,36 +3510,7 @@ unsafe impl ::windows::core::Interface for OutputStreamOverStream {
 impl ::windows::core::RuntimeName for OutputStreamOverStream {
     const NAME: &'static str = "Windows.Storage.Streams.OutputStreamOverStream";
 }
-impl ::core::convert::From<OutputStreamOverStream> for ::windows::core::IUnknown {
-    fn from(value: OutputStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OutputStreamOverStream> for ::windows::core::IUnknown {
-    fn from(value: &OutputStreamOverStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OutputStreamOverStream> for &::windows::core::IUnknown {
-    fn from(value: &OutputStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OutputStreamOverStream> for ::windows::core::IInspectable {
-    fn from(value: OutputStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OutputStreamOverStream> for ::windows::core::IInspectable {
-    fn from(value: &OutputStreamOverStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OutputStreamOverStream> for &::windows::core::IInspectable {
-    fn from(value: &OutputStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OutputStreamOverStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<OutputStreamOverStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4391,36 +3743,7 @@ unsafe impl ::windows::core::Interface for RandomAccessStreamOverStream {
 impl ::windows::core::RuntimeName for RandomAccessStreamOverStream {
     const NAME: &'static str = "Windows.Storage.Streams.RandomAccessStreamOverStream";
 }
-impl ::core::convert::From<RandomAccessStreamOverStream> for ::windows::core::IUnknown {
-    fn from(value: RandomAccessStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RandomAccessStreamOverStream> for ::windows::core::IUnknown {
-    fn from(value: &RandomAccessStreamOverStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RandomAccessStreamOverStream> for &::windows::core::IUnknown {
-    fn from(value: &RandomAccessStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RandomAccessStreamOverStream> for ::windows::core::IInspectable {
-    fn from(value: RandomAccessStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RandomAccessStreamOverStream> for ::windows::core::IInspectable {
-    fn from(value: &RandomAccessStreamOverStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RandomAccessStreamOverStream> for &::windows::core::IInspectable {
-    fn from(value: &RandomAccessStreamOverStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RandomAccessStreamOverStream, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<RandomAccessStreamOverStream> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4581,36 +3904,7 @@ unsafe impl ::windows::core::Interface for RandomAccessStreamReference {
 impl ::windows::core::RuntimeName for RandomAccessStreamReference {
     const NAME: &'static str = "Windows.Storage.Streams.RandomAccessStreamReference";
 }
-impl ::core::convert::From<RandomAccessStreamReference> for ::windows::core::IUnknown {
-    fn from(value: RandomAccessStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RandomAccessStreamReference> for ::windows::core::IUnknown {
-    fn from(value: &RandomAccessStreamReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RandomAccessStreamReference> for &::windows::core::IUnknown {
-    fn from(value: &RandomAccessStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RandomAccessStreamReference> for ::windows::core::IInspectable {
-    fn from(value: RandomAccessStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RandomAccessStreamReference> for ::windows::core::IInspectable {
-    fn from(value: &RandomAccessStreamReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RandomAccessStreamReference> for &::windows::core::IInspectable {
-    fn from(value: &RandomAccessStreamReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RandomAccessStreamReference, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RandomAccessStreamReference> for IRandomAccessStreamReference {
     type Error = ::windows::core::Error;
     fn try_from(value: RandomAccessStreamReference) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/mod.rs
@@ -819,36 +819,7 @@ impl IStorageFile {
         }
     }
 }
-impl ::core::convert::From<IStorageFile> for ::windows::core::IUnknown {
-    fn from(value: IStorageFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFile> for ::windows::core::IUnknown {
-    fn from(value: &IStorageFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageFile> for ::windows::core::IInspectable {
-    fn from(value: IStorageFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFile> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFile> for ::windows::core::IInspectable {
-    fn from(value: &IStorageFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageFile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Storage_Streams")]
 impl ::core::convert::TryFrom<IStorageFile> for Streams::IInputStreamReference {
     type Error = ::windows::core::Error;
@@ -1011,36 +982,7 @@ impl IStorageFile2 {
         }
     }
 }
-impl ::core::convert::From<IStorageFile2> for ::windows::core::IUnknown {
-    fn from(value: IStorageFile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFile2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageFile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFile2> for ::windows::core::IUnknown {
-    fn from(value: &IStorageFile2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageFile2> for ::windows::core::IInspectable {
-    fn from(value: IStorageFile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFile2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageFile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFile2> for ::windows::core::IInspectable {
-    fn from(value: &IStorageFile2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageFile2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageFile2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1095,36 +1037,7 @@ impl IStorageFilePropertiesWithAvailability {
         }
     }
 }
-impl ::core::convert::From<IStorageFilePropertiesWithAvailability> for ::windows::core::IUnknown {
-    fn from(value: IStorageFilePropertiesWithAvailability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFilePropertiesWithAvailability> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageFilePropertiesWithAvailability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFilePropertiesWithAvailability> for ::windows::core::IUnknown {
-    fn from(value: &IStorageFilePropertiesWithAvailability) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageFilePropertiesWithAvailability> for ::windows::core::IInspectable {
-    fn from(value: IStorageFilePropertiesWithAvailability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFilePropertiesWithAvailability> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageFilePropertiesWithAvailability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFilePropertiesWithAvailability> for ::windows::core::IInspectable {
-    fn from(value: &IStorageFilePropertiesWithAvailability) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageFilePropertiesWithAvailability, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageFilePropertiesWithAvailability {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1393,36 +1306,7 @@ impl IStorageFolder {
         }
     }
 }
-impl ::core::convert::From<IStorageFolder> for ::windows::core::IUnknown {
-    fn from(value: IStorageFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFolder> for ::windows::core::IUnknown {
-    fn from(value: &IStorageFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageFolder> for ::windows::core::IInspectable {
-    fn from(value: IStorageFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFolder> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFolder> for ::windows::core::IInspectable {
-    fn from(value: &IStorageFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageFolder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IStorageFolder> for IStorageItem {
     type Error = ::windows::core::Error;
     fn try_from(value: IStorageFolder) -> ::windows::core::Result<Self> {
@@ -1530,36 +1414,7 @@ impl IStorageFolder2 {
         }
     }
 }
-impl ::core::convert::From<IStorageFolder2> for ::windows::core::IUnknown {
-    fn from(value: IStorageFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFolder2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFolder2> for ::windows::core::IUnknown {
-    fn from(value: &IStorageFolder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageFolder2> for ::windows::core::IInspectable {
-    fn from(value: IStorageFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFolder2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFolder2> for ::windows::core::IInspectable {
-    fn from(value: &IStorageFolder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageFolder2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageFolder2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1736,36 +1591,7 @@ impl IStorageItem {
         }
     }
 }
-impl ::core::convert::From<IStorageItem> for ::windows::core::IUnknown {
-    fn from(value: IStorageItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItem> for ::windows::core::IUnknown {
-    fn from(value: &IStorageItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageItem> for ::windows::core::IInspectable {
-    fn from(value: IStorageItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItem> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItem> for ::windows::core::IInspectable {
-    fn from(value: &IStorageItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1935,36 +1761,7 @@ impl IStorageItem2 {
         }
     }
 }
-impl ::core::convert::From<IStorageItem2> for ::windows::core::IUnknown {
-    fn from(value: IStorageItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItem2> for ::windows::core::IUnknown {
-    fn from(value: &IStorageItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageItem2> for ::windows::core::IInspectable {
-    fn from(value: IStorageItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItem2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItem2> for ::windows::core::IInspectable {
-    fn from(value: &IStorageItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageItem2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IStorageItem2> for IStorageItem {
     type Error = ::windows::core::Error;
     fn try_from(value: IStorageItem2) -> ::windows::core::Result<Self> {
@@ -2085,36 +1882,7 @@ impl IStorageItemProperties {
         }
     }
 }
-impl ::core::convert::From<IStorageItemProperties> for ::windows::core::IUnknown {
-    fn from(value: IStorageItemProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageItemProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemProperties> for ::windows::core::IUnknown {
-    fn from(value: &IStorageItemProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageItemProperties> for ::windows::core::IInspectable {
-    fn from(value: IStorageItemProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemProperties> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageItemProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemProperties> for ::windows::core::IInspectable {
-    fn from(value: &IStorageItemProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageItemProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStorageItemProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2257,36 +2025,7 @@ impl IStorageItemProperties2 {
         }
     }
 }
-impl ::core::convert::From<IStorageItemProperties2> for ::windows::core::IUnknown {
-    fn from(value: IStorageItemProperties2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemProperties2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageItemProperties2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemProperties2> for ::windows::core::IUnknown {
-    fn from(value: &IStorageItemProperties2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageItemProperties2> for ::windows::core::IInspectable {
-    fn from(value: IStorageItemProperties2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemProperties2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageItemProperties2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemProperties2> for ::windows::core::IInspectable {
-    fn from(value: &IStorageItemProperties2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageItemProperties2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IStorageItemProperties2> for IStorageItemProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: IStorageItemProperties2) -> ::windows::core::Result<Self> {
@@ -2421,36 +2160,7 @@ impl IStorageItemPropertiesWithProvider {
         }
     }
 }
-impl ::core::convert::From<IStorageItemPropertiesWithProvider> for ::windows::core::IUnknown {
-    fn from(value: IStorageItemPropertiesWithProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemPropertiesWithProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageItemPropertiesWithProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemPropertiesWithProvider> for ::windows::core::IUnknown {
-    fn from(value: &IStorageItemPropertiesWithProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStorageItemPropertiesWithProvider> for ::windows::core::IInspectable {
-    fn from(value: IStorageItemPropertiesWithProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemPropertiesWithProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStorageItemPropertiesWithProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemPropertiesWithProvider> for ::windows::core::IInspectable {
-    fn from(value: &IStorageItemPropertiesWithProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageItemPropertiesWithProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<IStorageItemPropertiesWithProvider> for IStorageItemProperties {
     type Error = ::windows::core::Error;
     fn try_from(value: IStorageItemPropertiesWithProvider) -> ::windows::core::Result<Self> {
@@ -2811,36 +2521,7 @@ impl IStreamedFileDataRequest {
         unsafe { (::windows::core::Vtable::vtable(this).FailAndClose)(::windows::core::Vtable::as_raw(this), failuremode).ok() }
     }
 }
-impl ::core::convert::From<IStreamedFileDataRequest> for ::windows::core::IUnknown {
-    fn from(value: IStreamedFileDataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStreamedFileDataRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStreamedFileDataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStreamedFileDataRequest> for ::windows::core::IUnknown {
-    fn from(value: &IStreamedFileDataRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStreamedFileDataRequest> for ::windows::core::IInspectable {
-    fn from(value: IStreamedFileDataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStreamedFileDataRequest> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IStreamedFileDataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStreamedFileDataRequest> for ::windows::core::IInspectable {
-    fn from(value: &IStreamedFileDataRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStreamedFileDataRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IStreamedFileDataRequest {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3246,36 +2927,7 @@ unsafe impl ::windows::core::Interface for AppDataPaths {
 impl ::windows::core::RuntimeName for AppDataPaths {
     const NAME: &'static str = "Windows.Storage.AppDataPaths";
 }
-impl ::core::convert::From<AppDataPaths> for ::windows::core::IUnknown {
-    fn from(value: AppDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppDataPaths> for ::windows::core::IUnknown {
-    fn from(value: &AppDataPaths) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppDataPaths> for &::windows::core::IUnknown {
-    fn from(value: &AppDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppDataPaths> for ::windows::core::IInspectable {
-    fn from(value: AppDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppDataPaths> for ::windows::core::IInspectable {
-    fn from(value: &AppDataPaths) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppDataPaths> for &::windows::core::IInspectable {
-    fn from(value: &AppDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppDataPaths, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppDataPaths {}
 unsafe impl ::core::marker::Sync for AppDataPaths {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -3470,36 +3122,7 @@ unsafe impl ::windows::core::Interface for ApplicationData {
 impl ::windows::core::RuntimeName for ApplicationData {
     const NAME: &'static str = "Windows.Storage.ApplicationData";
 }
-impl ::core::convert::From<ApplicationData> for ::windows::core::IUnknown {
-    fn from(value: ApplicationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationData> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationData> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ApplicationData> for ::windows::core::IInspectable {
-    fn from(value: ApplicationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationData> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationData> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ApplicationData> for super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3679,41 +3302,7 @@ impl ::core::iter::IntoIterator for &ApplicationDataCompositeValue {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ApplicationDataCompositeValue> for ::windows::core::IUnknown {
-    fn from(value: ApplicationDataCompositeValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ApplicationDataCompositeValue> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationDataCompositeValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ApplicationDataCompositeValue> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationDataCompositeValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ApplicationDataCompositeValue> for ::windows::core::IInspectable {
-    fn from(value: ApplicationDataCompositeValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ApplicationDataCompositeValue> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationDataCompositeValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ApplicationDataCompositeValue> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationDataCompositeValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationDataCompositeValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<ApplicationDataCompositeValue> for super::Foundation::Collections::IIterable<super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
@@ -3892,36 +3481,7 @@ unsafe impl ::windows::core::Interface for ApplicationDataContainer {
 impl ::windows::core::RuntimeName for ApplicationDataContainer {
     const NAME: &'static str = "Windows.Storage.ApplicationDataContainer";
 }
-impl ::core::convert::From<ApplicationDataContainer> for ::windows::core::IUnknown {
-    fn from(value: ApplicationDataContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationDataContainer> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationDataContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationDataContainer> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationDataContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ApplicationDataContainer> for ::windows::core::IInspectable {
-    fn from(value: ApplicationDataContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationDataContainer> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationDataContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationDataContainer> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationDataContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationDataContainer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<ApplicationDataContainer> for super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4094,41 +3654,7 @@ impl ::core::iter::IntoIterator for &ApplicationDataContainerSettings {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ApplicationDataContainerSettings> for ::windows::core::IUnknown {
-    fn from(value: ApplicationDataContainerSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ApplicationDataContainerSettings> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationDataContainerSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ApplicationDataContainerSettings> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationDataContainerSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<ApplicationDataContainerSettings> for ::windows::core::IInspectable {
-    fn from(value: ApplicationDataContainerSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ApplicationDataContainerSettings> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationDataContainerSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&ApplicationDataContainerSettings> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationDataContainerSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationDataContainerSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<ApplicationDataContainerSettings> for super::Foundation::Collections::IIterable<super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
@@ -4880,36 +4406,7 @@ unsafe impl ::windows::core::Interface for SetVersionDeferral {
 impl ::windows::core::RuntimeName for SetVersionDeferral {
     const NAME: &'static str = "Windows.Storage.SetVersionDeferral";
 }
-impl ::core::convert::From<SetVersionDeferral> for ::windows::core::IUnknown {
-    fn from(value: SetVersionDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SetVersionDeferral> for ::windows::core::IUnknown {
-    fn from(value: &SetVersionDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SetVersionDeferral> for &::windows::core::IUnknown {
-    fn from(value: &SetVersionDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SetVersionDeferral> for ::windows::core::IInspectable {
-    fn from(value: SetVersionDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SetVersionDeferral> for ::windows::core::IInspectable {
-    fn from(value: &SetVersionDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SetVersionDeferral> for &::windows::core::IInspectable {
-    fn from(value: &SetVersionDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SetVersionDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SetVersionDeferral {}
 unsafe impl ::core::marker::Sync for SetVersionDeferral {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -4970,36 +4467,7 @@ unsafe impl ::windows::core::Interface for SetVersionRequest {
 impl ::windows::core::RuntimeName for SetVersionRequest {
     const NAME: &'static str = "Windows.Storage.SetVersionRequest";
 }
-impl ::core::convert::From<SetVersionRequest> for ::windows::core::IUnknown {
-    fn from(value: SetVersionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SetVersionRequest> for ::windows::core::IUnknown {
-    fn from(value: &SetVersionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SetVersionRequest> for &::windows::core::IUnknown {
-    fn from(value: &SetVersionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SetVersionRequest> for ::windows::core::IInspectable {
-    fn from(value: SetVersionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SetVersionRequest> for ::windows::core::IInspectable {
-    fn from(value: &SetVersionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SetVersionRequest> for &::windows::core::IInspectable {
-    fn from(value: &SetVersionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SetVersionRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SetVersionRequest {}
 unsafe impl ::core::marker::Sync for SetVersionRequest {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -5497,36 +4965,7 @@ unsafe impl ::windows::core::Interface for StorageFile {
 impl ::windows::core::RuntimeName for StorageFile {
     const NAME: &'static str = "Windows.Storage.StorageFile";
 }
-impl ::core::convert::From<StorageFile> for ::windows::core::IUnknown {
-    fn from(value: StorageFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageFile> for ::windows::core::IUnknown {
-    fn from(value: &StorageFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageFile> for &::windows::core::IUnknown {
-    fn from(value: &StorageFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageFile> for ::windows::core::IInspectable {
-    fn from(value: StorageFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageFile> for ::windows::core::IInspectable {
-    fn from(value: &StorageFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageFile> for &::windows::core::IInspectable {
-    fn from(value: &StorageFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageFile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Storage_Streams")]
 impl ::core::convert::TryFrom<StorageFile> for Streams::IInputStreamReference {
     type Error = ::windows::core::Error;
@@ -6238,36 +5677,7 @@ unsafe impl ::windows::core::Interface for StorageFolder {
 impl ::windows::core::RuntimeName for StorageFolder {
     const NAME: &'static str = "Windows.Storage.StorageFolder";
 }
-impl ::core::convert::From<StorageFolder> for ::windows::core::IUnknown {
-    fn from(value: StorageFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageFolder> for ::windows::core::IUnknown {
-    fn from(value: &StorageFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageFolder> for &::windows::core::IUnknown {
-    fn from(value: &StorageFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageFolder> for ::windows::core::IInspectable {
-    fn from(value: StorageFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageFolder> for ::windows::core::IInspectable {
-    fn from(value: &StorageFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageFolder> for &::windows::core::IInspectable {
-    fn from(value: &StorageFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageFolder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StorageFolder> for IStorageFolder {
     type Error = ::windows::core::Error;
     fn try_from(value: StorageFolder) -> ::windows::core::Result<Self> {
@@ -6551,36 +5961,7 @@ unsafe impl ::windows::core::Interface for StorageLibrary {
 impl ::windows::core::RuntimeName for StorageLibrary {
     const NAME: &'static str = "Windows.Storage.StorageLibrary";
 }
-impl ::core::convert::From<StorageLibrary> for ::windows::core::IUnknown {
-    fn from(value: StorageLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibrary> for ::windows::core::IUnknown {
-    fn from(value: &StorageLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibrary> for &::windows::core::IUnknown {
-    fn from(value: &StorageLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageLibrary> for ::windows::core::IInspectable {
-    fn from(value: StorageLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibrary> for ::windows::core::IInspectable {
-    fn from(value: &StorageLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibrary> for &::windows::core::IInspectable {
-    fn from(value: &StorageLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageLibrary, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage\"`*"]
 #[repr(transparent)]
 pub struct StorageLibraryChange(::windows::core::IUnknown);
@@ -6655,36 +6036,7 @@ unsafe impl ::windows::core::Interface for StorageLibraryChange {
 impl ::windows::core::RuntimeName for StorageLibraryChange {
     const NAME: &'static str = "Windows.Storage.StorageLibraryChange";
 }
-impl ::core::convert::From<StorageLibraryChange> for ::windows::core::IUnknown {
-    fn from(value: StorageLibraryChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChange> for ::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChange> for &::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageLibraryChange> for ::windows::core::IInspectable {
-    fn from(value: StorageLibraryChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChange> for ::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChange> for &::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageLibraryChange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageLibraryChange {}
 unsafe impl ::core::marker::Sync for StorageLibraryChange {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -6749,36 +6101,7 @@ unsafe impl ::windows::core::Interface for StorageLibraryChangeReader {
 impl ::windows::core::RuntimeName for StorageLibraryChangeReader {
     const NAME: &'static str = "Windows.Storage.StorageLibraryChangeReader";
 }
-impl ::core::convert::From<StorageLibraryChangeReader> for ::windows::core::IUnknown {
-    fn from(value: StorageLibraryChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeReader> for ::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeReader> for &::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageLibraryChangeReader> for ::windows::core::IInspectable {
-    fn from(value: StorageLibraryChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeReader> for ::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChangeReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeReader> for &::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChangeReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageLibraryChangeReader, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageLibraryChangeReader {}
 unsafe impl ::core::marker::Sync for StorageLibraryChangeReader {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -6841,36 +6164,7 @@ unsafe impl ::windows::core::Interface for StorageLibraryChangeTracker {
 impl ::windows::core::RuntimeName for StorageLibraryChangeTracker {
     const NAME: &'static str = "Windows.Storage.StorageLibraryChangeTracker";
 }
-impl ::core::convert::From<StorageLibraryChangeTracker> for ::windows::core::IUnknown {
-    fn from(value: StorageLibraryChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTracker> for ::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChangeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTracker> for &::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageLibraryChangeTracker> for ::windows::core::IInspectable {
-    fn from(value: StorageLibraryChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTracker> for ::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChangeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTracker> for &::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChangeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageLibraryChangeTracker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageLibraryChangeTracker {}
 unsafe impl ::core::marker::Sync for StorageLibraryChangeTracker {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -6928,36 +6222,7 @@ unsafe impl ::windows::core::Interface for StorageLibraryChangeTrackerOptions {
 impl ::windows::core::RuntimeName for StorageLibraryChangeTrackerOptions {
     const NAME: &'static str = "Windows.Storage.StorageLibraryChangeTrackerOptions";
 }
-impl ::core::convert::From<StorageLibraryChangeTrackerOptions> for ::windows::core::IUnknown {
-    fn from(value: StorageLibraryChangeTrackerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerOptions> for ::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChangeTrackerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerOptions> for &::windows::core::IUnknown {
-    fn from(value: &StorageLibraryChangeTrackerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageLibraryChangeTrackerOptions> for ::windows::core::IInspectable {
-    fn from(value: StorageLibraryChangeTrackerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerOptions> for ::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChangeTrackerOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryChangeTrackerOptions> for &::windows::core::IInspectable {
-    fn from(value: &StorageLibraryChangeTrackerOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageLibraryChangeTrackerOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageLibraryChangeTrackerOptions {}
 unsafe impl ::core::marker::Sync for StorageLibraryChangeTrackerOptions {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -7008,36 +6273,7 @@ unsafe impl ::windows::core::Interface for StorageLibraryLastChangeId {
 impl ::windows::core::RuntimeName for StorageLibraryLastChangeId {
     const NAME: &'static str = "Windows.Storage.StorageLibraryLastChangeId";
 }
-impl ::core::convert::From<StorageLibraryLastChangeId> for ::windows::core::IUnknown {
-    fn from(value: StorageLibraryLastChangeId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryLastChangeId> for ::windows::core::IUnknown {
-    fn from(value: &StorageLibraryLastChangeId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryLastChangeId> for &::windows::core::IUnknown {
-    fn from(value: &StorageLibraryLastChangeId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageLibraryLastChangeId> for ::windows::core::IInspectable {
-    fn from(value: StorageLibraryLastChangeId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageLibraryLastChangeId> for ::windows::core::IInspectable {
-    fn from(value: &StorageLibraryLastChangeId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageLibraryLastChangeId> for &::windows::core::IInspectable {
-    fn from(value: &StorageLibraryLastChangeId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageLibraryLastChangeId, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StorageLibraryLastChangeId {}
 unsafe impl ::core::marker::Sync for StorageLibraryLastChangeId {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -7100,36 +6336,7 @@ unsafe impl ::windows::core::Interface for StorageProvider {
 impl ::windows::core::RuntimeName for StorageProvider {
     const NAME: &'static str = "Windows.Storage.StorageProvider";
 }
-impl ::core::convert::From<StorageProvider> for ::windows::core::IUnknown {
-    fn from(value: StorageProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProvider> for ::windows::core::IUnknown {
-    fn from(value: &StorageProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProvider> for &::windows::core::IUnknown {
-    fn from(value: &StorageProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageProvider> for ::windows::core::IInspectable {
-    fn from(value: StorageProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageProvider> for ::windows::core::IInspectable {
-    fn from(value: &StorageProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageProvider> for &::windows::core::IInspectable {
-    fn from(value: &StorageProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Storage\"`*"]
 #[repr(transparent)]
 pub struct StorageStreamTransaction(::windows::core::IUnknown);
@@ -7191,36 +6398,7 @@ unsafe impl ::windows::core::Interface for StorageStreamTransaction {
 impl ::windows::core::RuntimeName for StorageStreamTransaction {
     const NAME: &'static str = "Windows.Storage.StorageStreamTransaction";
 }
-impl ::core::convert::From<StorageStreamTransaction> for ::windows::core::IUnknown {
-    fn from(value: StorageStreamTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageStreamTransaction> for ::windows::core::IUnknown {
-    fn from(value: &StorageStreamTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageStreamTransaction> for &::windows::core::IUnknown {
-    fn from(value: &StorageStreamTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StorageStreamTransaction> for ::windows::core::IInspectable {
-    fn from(value: StorageStreamTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StorageStreamTransaction> for ::windows::core::IInspectable {
-    fn from(value: &StorageStreamTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StorageStreamTransaction> for &::windows::core::IInspectable {
-    fn from(value: &StorageStreamTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StorageStreamTransaction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<StorageStreamTransaction> for super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -7323,41 +6501,7 @@ impl ::windows::core::RuntimeName for StreamedFileDataRequest {
     const NAME: &'static str = "Windows.Storage.StreamedFileDataRequest";
 }
 #[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<StreamedFileDataRequest> for ::windows::core::IUnknown {
-    fn from(value: StreamedFileDataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&StreamedFileDataRequest> for ::windows::core::IUnknown {
-    fn from(value: &StreamedFileDataRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&StreamedFileDataRequest> for &::windows::core::IUnknown {
-    fn from(value: &StreamedFileDataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<StreamedFileDataRequest> for ::windows::core::IInspectable {
-    fn from(value: StreamedFileDataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&StreamedFileDataRequest> for ::windows::core::IInspectable {
-    fn from(value: &StreamedFileDataRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Storage_Streams")]
-impl ::core::convert::From<&StreamedFileDataRequest> for &::windows::core::IInspectable {
-    fn from(value: &StreamedFileDataRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StreamedFileDataRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 impl ::core::convert::TryFrom<StreamedFileDataRequest> for super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -7468,36 +6612,7 @@ unsafe impl ::windows::core::Interface for SystemAudioProperties {
 impl ::windows::core::RuntimeName for SystemAudioProperties {
     const NAME: &'static str = "Windows.Storage.SystemAudioProperties";
 }
-impl ::core::convert::From<SystemAudioProperties> for ::windows::core::IUnknown {
-    fn from(value: SystemAudioProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemAudioProperties> for ::windows::core::IUnknown {
-    fn from(value: &SystemAudioProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemAudioProperties> for &::windows::core::IUnknown {
-    fn from(value: &SystemAudioProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemAudioProperties> for ::windows::core::IInspectable {
-    fn from(value: SystemAudioProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemAudioProperties> for ::windows::core::IInspectable {
-    fn from(value: &SystemAudioProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemAudioProperties> for &::windows::core::IInspectable {
-    fn from(value: &SystemAudioProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemAudioProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemAudioProperties {}
 unsafe impl ::core::marker::Sync for SystemAudioProperties {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -7660,36 +6775,7 @@ unsafe impl ::windows::core::Interface for SystemDataPaths {
 impl ::windows::core::RuntimeName for SystemDataPaths {
     const NAME: &'static str = "Windows.Storage.SystemDataPaths";
 }
-impl ::core::convert::From<SystemDataPaths> for ::windows::core::IUnknown {
-    fn from(value: SystemDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemDataPaths> for ::windows::core::IUnknown {
-    fn from(value: &SystemDataPaths) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemDataPaths> for &::windows::core::IUnknown {
-    fn from(value: &SystemDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemDataPaths> for ::windows::core::IInspectable {
-    fn from(value: SystemDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemDataPaths> for ::windows::core::IInspectable {
-    fn from(value: &SystemDataPaths) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemDataPaths> for &::windows::core::IInspectable {
-    fn from(value: &SystemDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemDataPaths, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemDataPaths {}
 unsafe impl ::core::marker::Sync for SystemDataPaths {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -7743,36 +6829,7 @@ unsafe impl ::windows::core::Interface for SystemGPSProperties {
 impl ::windows::core::RuntimeName for SystemGPSProperties {
     const NAME: &'static str = "Windows.Storage.SystemGPSProperties";
 }
-impl ::core::convert::From<SystemGPSProperties> for ::windows::core::IUnknown {
-    fn from(value: SystemGPSProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemGPSProperties> for ::windows::core::IUnknown {
-    fn from(value: &SystemGPSProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemGPSProperties> for &::windows::core::IUnknown {
-    fn from(value: &SystemGPSProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemGPSProperties> for ::windows::core::IInspectable {
-    fn from(value: SystemGPSProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemGPSProperties> for ::windows::core::IInspectable {
-    fn from(value: &SystemGPSProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemGPSProperties> for &::windows::core::IInspectable {
-    fn from(value: &SystemGPSProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemGPSProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemGPSProperties {}
 unsafe impl ::core::marker::Sync for SystemGPSProperties {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -7826,36 +6883,7 @@ unsafe impl ::windows::core::Interface for SystemImageProperties {
 impl ::windows::core::RuntimeName for SystemImageProperties {
     const NAME: &'static str = "Windows.Storage.SystemImageProperties";
 }
-impl ::core::convert::From<SystemImageProperties> for ::windows::core::IUnknown {
-    fn from(value: SystemImageProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemImageProperties> for ::windows::core::IUnknown {
-    fn from(value: &SystemImageProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemImageProperties> for &::windows::core::IUnknown {
-    fn from(value: &SystemImageProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemImageProperties> for ::windows::core::IInspectable {
-    fn from(value: SystemImageProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemImageProperties> for ::windows::core::IInspectable {
-    fn from(value: &SystemImageProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemImageProperties> for &::windows::core::IInspectable {
-    fn from(value: &SystemImageProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemImageProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemImageProperties {}
 unsafe impl ::core::marker::Sync for SystemImageProperties {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -7937,36 +6965,7 @@ unsafe impl ::windows::core::Interface for SystemMediaProperties {
 impl ::windows::core::RuntimeName for SystemMediaProperties {
     const NAME: &'static str = "Windows.Storage.SystemMediaProperties";
 }
-impl ::core::convert::From<SystemMediaProperties> for ::windows::core::IUnknown {
-    fn from(value: SystemMediaProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaProperties> for ::windows::core::IUnknown {
-    fn from(value: &SystemMediaProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaProperties> for &::windows::core::IUnknown {
-    fn from(value: &SystemMediaProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemMediaProperties> for ::windows::core::IInspectable {
-    fn from(value: SystemMediaProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMediaProperties> for ::windows::core::IInspectable {
-    fn from(value: &SystemMediaProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMediaProperties> for &::windows::core::IInspectable {
-    fn from(value: &SystemMediaProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemMediaProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemMediaProperties {}
 unsafe impl ::core::marker::Sync for SystemMediaProperties {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -8062,36 +7061,7 @@ unsafe impl ::windows::core::Interface for SystemMusicProperties {
 impl ::windows::core::RuntimeName for SystemMusicProperties {
     const NAME: &'static str = "Windows.Storage.SystemMusicProperties";
 }
-impl ::core::convert::From<SystemMusicProperties> for ::windows::core::IUnknown {
-    fn from(value: SystemMusicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMusicProperties> for ::windows::core::IUnknown {
-    fn from(value: &SystemMusicProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMusicProperties> for &::windows::core::IUnknown {
-    fn from(value: &SystemMusicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemMusicProperties> for ::windows::core::IInspectable {
-    fn from(value: SystemMusicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMusicProperties> for ::windows::core::IInspectable {
-    fn from(value: &SystemMusicProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMusicProperties> for &::windows::core::IInspectable {
-    fn from(value: &SystemMusicProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemMusicProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemMusicProperties {}
 unsafe impl ::core::marker::Sync for SystemMusicProperties {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -8166,36 +7136,7 @@ unsafe impl ::windows::core::Interface for SystemPhotoProperties {
 impl ::windows::core::RuntimeName for SystemPhotoProperties {
     const NAME: &'static str = "Windows.Storage.SystemPhotoProperties";
 }
-impl ::core::convert::From<SystemPhotoProperties> for ::windows::core::IUnknown {
-    fn from(value: SystemPhotoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemPhotoProperties> for ::windows::core::IUnknown {
-    fn from(value: &SystemPhotoProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemPhotoProperties> for &::windows::core::IUnknown {
-    fn from(value: &SystemPhotoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemPhotoProperties> for ::windows::core::IInspectable {
-    fn from(value: SystemPhotoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemPhotoProperties> for ::windows::core::IInspectable {
-    fn from(value: &SystemPhotoProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemPhotoProperties> for &::windows::core::IInspectable {
-    fn from(value: &SystemPhotoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemPhotoProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemPhotoProperties {}
 unsafe impl ::core::marker::Sync for SystemPhotoProperties {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -8360,36 +7301,7 @@ unsafe impl ::windows::core::Interface for SystemVideoProperties {
 impl ::windows::core::RuntimeName for SystemVideoProperties {
     const NAME: &'static str = "Windows.Storage.SystemVideoProperties";
 }
-impl ::core::convert::From<SystemVideoProperties> for ::windows::core::IUnknown {
-    fn from(value: SystemVideoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemVideoProperties> for ::windows::core::IUnknown {
-    fn from(value: &SystemVideoProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemVideoProperties> for &::windows::core::IUnknown {
-    fn from(value: &SystemVideoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemVideoProperties> for ::windows::core::IInspectable {
-    fn from(value: SystemVideoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemVideoProperties> for ::windows::core::IInspectable {
-    fn from(value: &SystemVideoProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemVideoProperties> for &::windows::core::IInspectable {
-    fn from(value: &SystemVideoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemVideoProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemVideoProperties {}
 unsafe impl ::core::marker::Sync for SystemVideoProperties {}
 #[doc = "*Required features: `\"Storage\"`*"]
@@ -8581,36 +7493,7 @@ unsafe impl ::windows::core::Interface for UserDataPaths {
 impl ::windows::core::RuntimeName for UserDataPaths {
     const NAME: &'static str = "Windows.Storage.UserDataPaths";
 }
-impl ::core::convert::From<UserDataPaths> for ::windows::core::IUnknown {
-    fn from(value: UserDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataPaths> for ::windows::core::IUnknown {
-    fn from(value: &UserDataPaths) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataPaths> for &::windows::core::IUnknown {
-    fn from(value: &UserDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDataPaths> for ::windows::core::IInspectable {
-    fn from(value: UserDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDataPaths> for ::windows::core::IInspectable {
-    fn from(value: &UserDataPaths) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDataPaths> for &::windows::core::IInspectable {
-    fn from(value: &UserDataPaths) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDataPaths, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDataPaths {}
 unsafe impl ::core::marker::Sync for UserDataPaths {}
 #[doc = "*Required features: `\"Storage\"`*"]

--- a/crates/libs/windows/src/Windows/System/Diagnostics/DevicePortal/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/DevicePortal/mod.rs
@@ -265,36 +265,7 @@ unsafe impl ::windows::core::Interface for DevicePortalConnection {
 impl ::windows::core::RuntimeName for DevicePortalConnection {
     const NAME: &'static str = "Windows.System.Diagnostics.DevicePortal.DevicePortalConnection";
 }
-impl ::core::convert::From<DevicePortalConnection> for ::windows::core::IUnknown {
-    fn from(value: DevicePortalConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePortalConnection> for ::windows::core::IUnknown {
-    fn from(value: &DevicePortalConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePortalConnection> for &::windows::core::IUnknown {
-    fn from(value: &DevicePortalConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DevicePortalConnection> for ::windows::core::IInspectable {
-    fn from(value: DevicePortalConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePortalConnection> for ::windows::core::IInspectable {
-    fn from(value: &DevicePortalConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePortalConnection> for &::windows::core::IInspectable {
-    fn from(value: &DevicePortalConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DevicePortalConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DevicePortalConnection {}
 unsafe impl ::core::marker::Sync for DevicePortalConnection {}
 #[doc = "*Required features: `\"System_Diagnostics_DevicePortal\"`*"]
@@ -341,36 +312,7 @@ unsafe impl ::windows::core::Interface for DevicePortalConnectionClosedEventArgs
 impl ::windows::core::RuntimeName for DevicePortalConnectionClosedEventArgs {
     const NAME: &'static str = "Windows.System.Diagnostics.DevicePortal.DevicePortalConnectionClosedEventArgs";
 }
-impl ::core::convert::From<DevicePortalConnectionClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DevicePortalConnectionClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePortalConnectionClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DevicePortalConnectionClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePortalConnectionClosedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DevicePortalConnectionClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DevicePortalConnectionClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DevicePortalConnectionClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePortalConnectionClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DevicePortalConnectionClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePortalConnectionClosedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DevicePortalConnectionClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DevicePortalConnectionClosedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DevicePortalConnectionClosedEventArgs {}
 unsafe impl ::core::marker::Sync for DevicePortalConnectionClosedEventArgs {}
 #[doc = "*Required features: `\"System_Diagnostics_DevicePortal\"`*"]
@@ -453,36 +395,7 @@ unsafe impl ::windows::core::Interface for DevicePortalConnectionRequestReceived
 impl ::windows::core::RuntimeName for DevicePortalConnectionRequestReceivedEventArgs {
     const NAME: &'static str = "Windows.System.Diagnostics.DevicePortal.DevicePortalConnectionRequestReceivedEventArgs";
 }
-impl ::core::convert::From<DevicePortalConnectionRequestReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DevicePortalConnectionRequestReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePortalConnectionRequestReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DevicePortalConnectionRequestReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePortalConnectionRequestReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DevicePortalConnectionRequestReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DevicePortalConnectionRequestReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DevicePortalConnectionRequestReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DevicePortalConnectionRequestReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DevicePortalConnectionRequestReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DevicePortalConnectionRequestReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DevicePortalConnectionRequestReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DevicePortalConnectionRequestReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DevicePortalConnectionRequestReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for DevicePortalConnectionRequestReceivedEventArgs {}
 #[doc = "*Required features: `\"System_Diagnostics_DevicePortal\"`*"]

--- a/crates/libs/windows/src/Windows/System/Diagnostics/Telemetry/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/Telemetry/mod.rs
@@ -115,36 +115,7 @@ unsafe impl ::windows::core::Interface for PlatformTelemetryRegistrationResult {
 impl ::windows::core::RuntimeName for PlatformTelemetryRegistrationResult {
     const NAME: &'static str = "Windows.System.Diagnostics.Telemetry.PlatformTelemetryRegistrationResult";
 }
-impl ::core::convert::From<PlatformTelemetryRegistrationResult> for ::windows::core::IUnknown {
-    fn from(value: PlatformTelemetryRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlatformTelemetryRegistrationResult> for ::windows::core::IUnknown {
-    fn from(value: &PlatformTelemetryRegistrationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlatformTelemetryRegistrationResult> for &::windows::core::IUnknown {
-    fn from(value: &PlatformTelemetryRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlatformTelemetryRegistrationResult> for ::windows::core::IInspectable {
-    fn from(value: PlatformTelemetryRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlatformTelemetryRegistrationResult> for ::windows::core::IInspectable {
-    fn from(value: &PlatformTelemetryRegistrationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlatformTelemetryRegistrationResult> for &::windows::core::IInspectable {
-    fn from(value: &PlatformTelemetryRegistrationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlatformTelemetryRegistrationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PlatformTelemetryRegistrationResult {}
 unsafe impl ::core::marker::Sync for PlatformTelemetryRegistrationResult {}
 #[doc = "*Required features: `\"System_Diagnostics_Telemetry\"`*"]
@@ -213,36 +184,7 @@ unsafe impl ::windows::core::Interface for PlatformTelemetryRegistrationSettings
 impl ::windows::core::RuntimeName for PlatformTelemetryRegistrationSettings {
     const NAME: &'static str = "Windows.System.Diagnostics.Telemetry.PlatformTelemetryRegistrationSettings";
 }
-impl ::core::convert::From<PlatformTelemetryRegistrationSettings> for ::windows::core::IUnknown {
-    fn from(value: PlatformTelemetryRegistrationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlatformTelemetryRegistrationSettings> for ::windows::core::IUnknown {
-    fn from(value: &PlatformTelemetryRegistrationSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlatformTelemetryRegistrationSettings> for &::windows::core::IUnknown {
-    fn from(value: &PlatformTelemetryRegistrationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlatformTelemetryRegistrationSettings> for ::windows::core::IInspectable {
-    fn from(value: PlatformTelemetryRegistrationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlatformTelemetryRegistrationSettings> for ::windows::core::IInspectable {
-    fn from(value: &PlatformTelemetryRegistrationSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlatformTelemetryRegistrationSettings> for &::windows::core::IInspectable {
-    fn from(value: &PlatformTelemetryRegistrationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlatformTelemetryRegistrationSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PlatformTelemetryRegistrationSettings {}
 unsafe impl ::core::marker::Sync for PlatformTelemetryRegistrationSettings {}
 #[doc = "*Required features: `\"System_Diagnostics_Telemetry\"`*"]

--- a/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
@@ -214,36 +214,7 @@ unsafe impl ::windows::core::Interface for PlatformDiagnosticTraceInfo {
 impl ::windows::core::RuntimeName for PlatformDiagnosticTraceInfo {
     const NAME: &'static str = "Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticTraceInfo";
 }
-impl ::core::convert::From<PlatformDiagnosticTraceInfo> for ::windows::core::IUnknown {
-    fn from(value: PlatformDiagnosticTraceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlatformDiagnosticTraceInfo> for ::windows::core::IUnknown {
-    fn from(value: &PlatformDiagnosticTraceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlatformDiagnosticTraceInfo> for &::windows::core::IUnknown {
-    fn from(value: &PlatformDiagnosticTraceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlatformDiagnosticTraceInfo> for ::windows::core::IInspectable {
-    fn from(value: PlatformDiagnosticTraceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlatformDiagnosticTraceInfo> for ::windows::core::IInspectable {
-    fn from(value: &PlatformDiagnosticTraceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlatformDiagnosticTraceInfo> for &::windows::core::IInspectable {
-    fn from(value: &PlatformDiagnosticTraceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlatformDiagnosticTraceInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PlatformDiagnosticTraceInfo {}
 unsafe impl ::core::marker::Sync for PlatformDiagnosticTraceInfo {}
 #[doc = "*Required features: `\"System_Diagnostics_TraceReporting\"`*"]
@@ -297,36 +268,7 @@ unsafe impl ::windows::core::Interface for PlatformDiagnosticTraceRuntimeInfo {
 impl ::windows::core::RuntimeName for PlatformDiagnosticTraceRuntimeInfo {
     const NAME: &'static str = "Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticTraceRuntimeInfo";
 }
-impl ::core::convert::From<PlatformDiagnosticTraceRuntimeInfo> for ::windows::core::IUnknown {
-    fn from(value: PlatformDiagnosticTraceRuntimeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlatformDiagnosticTraceRuntimeInfo> for ::windows::core::IUnknown {
-    fn from(value: &PlatformDiagnosticTraceRuntimeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlatformDiagnosticTraceRuntimeInfo> for &::windows::core::IUnknown {
-    fn from(value: &PlatformDiagnosticTraceRuntimeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PlatformDiagnosticTraceRuntimeInfo> for ::windows::core::IInspectable {
-    fn from(value: PlatformDiagnosticTraceRuntimeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PlatformDiagnosticTraceRuntimeInfo> for ::windows::core::IInspectable {
-    fn from(value: &PlatformDiagnosticTraceRuntimeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PlatformDiagnosticTraceRuntimeInfo> for &::windows::core::IInspectable {
-    fn from(value: &PlatformDiagnosticTraceRuntimeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PlatformDiagnosticTraceRuntimeInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PlatformDiagnosticTraceRuntimeInfo {}
 unsafe impl ::core::marker::Sync for PlatformDiagnosticTraceRuntimeInfo {}
 #[doc = "*Required features: `\"System_Diagnostics_TraceReporting\"`*"]

--- a/crates/libs/windows/src/Windows/System/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/mod.rs
@@ -439,36 +439,7 @@ unsafe impl ::windows::core::Interface for DiagnosticActionResult {
 impl ::windows::core::RuntimeName for DiagnosticActionResult {
     const NAME: &'static str = "Windows.System.Diagnostics.DiagnosticActionResult";
 }
-impl ::core::convert::From<DiagnosticActionResult> for ::windows::core::IUnknown {
-    fn from(value: DiagnosticActionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DiagnosticActionResult> for ::windows::core::IUnknown {
-    fn from(value: &DiagnosticActionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DiagnosticActionResult> for &::windows::core::IUnknown {
-    fn from(value: &DiagnosticActionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DiagnosticActionResult> for ::windows::core::IInspectable {
-    fn from(value: DiagnosticActionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DiagnosticActionResult> for ::windows::core::IInspectable {
-    fn from(value: &DiagnosticActionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DiagnosticActionResult> for &::windows::core::IInspectable {
-    fn from(value: &DiagnosticActionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DiagnosticActionResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DiagnosticActionResult {}
 unsafe impl ::core::marker::Sync for DiagnosticActionResult {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -549,36 +520,7 @@ unsafe impl ::windows::core::Interface for DiagnosticInvoker {
 impl ::windows::core::RuntimeName for DiagnosticInvoker {
     const NAME: &'static str = "Windows.System.Diagnostics.DiagnosticInvoker";
 }
-impl ::core::convert::From<DiagnosticInvoker> for ::windows::core::IUnknown {
-    fn from(value: DiagnosticInvoker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DiagnosticInvoker> for ::windows::core::IUnknown {
-    fn from(value: &DiagnosticInvoker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DiagnosticInvoker> for &::windows::core::IUnknown {
-    fn from(value: &DiagnosticInvoker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DiagnosticInvoker> for ::windows::core::IInspectable {
-    fn from(value: DiagnosticInvoker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DiagnosticInvoker> for ::windows::core::IInspectable {
-    fn from(value: &DiagnosticInvoker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DiagnosticInvoker> for &::windows::core::IInspectable {
-    fn from(value: &DiagnosticInvoker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DiagnosticInvoker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DiagnosticInvoker {}
 unsafe impl ::core::marker::Sync for DiagnosticInvoker {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -625,36 +567,7 @@ unsafe impl ::windows::core::Interface for ProcessCpuUsage {
 impl ::windows::core::RuntimeName for ProcessCpuUsage {
     const NAME: &'static str = "Windows.System.Diagnostics.ProcessCpuUsage";
 }
-impl ::core::convert::From<ProcessCpuUsage> for ::windows::core::IUnknown {
-    fn from(value: ProcessCpuUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessCpuUsage> for ::windows::core::IUnknown {
-    fn from(value: &ProcessCpuUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessCpuUsage> for &::windows::core::IUnknown {
-    fn from(value: &ProcessCpuUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessCpuUsage> for ::windows::core::IInspectable {
-    fn from(value: ProcessCpuUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessCpuUsage> for ::windows::core::IInspectable {
-    fn from(value: &ProcessCpuUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessCpuUsage> for &::windows::core::IInspectable {
-    fn from(value: &ProcessCpuUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessCpuUsage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessCpuUsage {}
 unsafe impl ::core::marker::Sync for ProcessCpuUsage {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -712,36 +625,7 @@ unsafe impl ::windows::core::Interface for ProcessCpuUsageReport {
 impl ::windows::core::RuntimeName for ProcessCpuUsageReport {
     const NAME: &'static str = "Windows.System.Diagnostics.ProcessCpuUsageReport";
 }
-impl ::core::convert::From<ProcessCpuUsageReport> for ::windows::core::IUnknown {
-    fn from(value: ProcessCpuUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessCpuUsageReport> for ::windows::core::IUnknown {
-    fn from(value: &ProcessCpuUsageReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessCpuUsageReport> for &::windows::core::IUnknown {
-    fn from(value: &ProcessCpuUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessCpuUsageReport> for ::windows::core::IInspectable {
-    fn from(value: ProcessCpuUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessCpuUsageReport> for ::windows::core::IInspectable {
-    fn from(value: &ProcessCpuUsageReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessCpuUsageReport> for &::windows::core::IInspectable {
-    fn from(value: &ProcessCpuUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessCpuUsageReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessCpuUsageReport {}
 unsafe impl ::core::marker::Sync for ProcessCpuUsageReport {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -878,36 +762,7 @@ unsafe impl ::windows::core::Interface for ProcessDiagnosticInfo {
 impl ::windows::core::RuntimeName for ProcessDiagnosticInfo {
     const NAME: &'static str = "Windows.System.Diagnostics.ProcessDiagnosticInfo";
 }
-impl ::core::convert::From<ProcessDiagnosticInfo> for ::windows::core::IUnknown {
-    fn from(value: ProcessDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessDiagnosticInfo> for ::windows::core::IUnknown {
-    fn from(value: &ProcessDiagnosticInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessDiagnosticInfo> for &::windows::core::IUnknown {
-    fn from(value: &ProcessDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessDiagnosticInfo> for ::windows::core::IInspectable {
-    fn from(value: ProcessDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessDiagnosticInfo> for ::windows::core::IInspectable {
-    fn from(value: &ProcessDiagnosticInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessDiagnosticInfo> for &::windows::core::IInspectable {
-    fn from(value: &ProcessDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessDiagnosticInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessDiagnosticInfo {}
 unsafe impl ::core::marker::Sync for ProcessDiagnosticInfo {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -954,36 +809,7 @@ unsafe impl ::windows::core::Interface for ProcessDiskUsage {
 impl ::windows::core::RuntimeName for ProcessDiskUsage {
     const NAME: &'static str = "Windows.System.Diagnostics.ProcessDiskUsage";
 }
-impl ::core::convert::From<ProcessDiskUsage> for ::windows::core::IUnknown {
-    fn from(value: ProcessDiskUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessDiskUsage> for ::windows::core::IUnknown {
-    fn from(value: &ProcessDiskUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessDiskUsage> for &::windows::core::IUnknown {
-    fn from(value: &ProcessDiskUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessDiskUsage> for ::windows::core::IInspectable {
-    fn from(value: ProcessDiskUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessDiskUsage> for ::windows::core::IInspectable {
-    fn from(value: &ProcessDiskUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessDiskUsage> for &::windows::core::IInspectable {
-    fn from(value: &ProcessDiskUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessDiskUsage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessDiskUsage {}
 unsafe impl ::core::marker::Sync for ProcessDiskUsage {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -1065,36 +891,7 @@ unsafe impl ::windows::core::Interface for ProcessDiskUsageReport {
 impl ::windows::core::RuntimeName for ProcessDiskUsageReport {
     const NAME: &'static str = "Windows.System.Diagnostics.ProcessDiskUsageReport";
 }
-impl ::core::convert::From<ProcessDiskUsageReport> for ::windows::core::IUnknown {
-    fn from(value: ProcessDiskUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessDiskUsageReport> for ::windows::core::IUnknown {
-    fn from(value: &ProcessDiskUsageReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessDiskUsageReport> for &::windows::core::IUnknown {
-    fn from(value: &ProcessDiskUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessDiskUsageReport> for ::windows::core::IInspectable {
-    fn from(value: ProcessDiskUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessDiskUsageReport> for ::windows::core::IInspectable {
-    fn from(value: &ProcessDiskUsageReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessDiskUsageReport> for &::windows::core::IInspectable {
-    fn from(value: &ProcessDiskUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessDiskUsageReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessDiskUsageReport {}
 unsafe impl ::core::marker::Sync for ProcessDiskUsageReport {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -1141,36 +938,7 @@ unsafe impl ::windows::core::Interface for ProcessMemoryUsage {
 impl ::windows::core::RuntimeName for ProcessMemoryUsage {
     const NAME: &'static str = "Windows.System.Diagnostics.ProcessMemoryUsage";
 }
-impl ::core::convert::From<ProcessMemoryUsage> for ::windows::core::IUnknown {
-    fn from(value: ProcessMemoryUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessMemoryUsage> for ::windows::core::IUnknown {
-    fn from(value: &ProcessMemoryUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessMemoryUsage> for &::windows::core::IUnknown {
-    fn from(value: &ProcessMemoryUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessMemoryUsage> for ::windows::core::IInspectable {
-    fn from(value: ProcessMemoryUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessMemoryUsage> for ::windows::core::IInspectable {
-    fn from(value: &ProcessMemoryUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessMemoryUsage> for &::windows::core::IInspectable {
-    fn from(value: &ProcessMemoryUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessMemoryUsage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessMemoryUsage {}
 unsafe impl ::core::marker::Sync for ProcessMemoryUsage {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -1294,36 +1062,7 @@ unsafe impl ::windows::core::Interface for ProcessMemoryUsageReport {
 impl ::windows::core::RuntimeName for ProcessMemoryUsageReport {
     const NAME: &'static str = "Windows.System.Diagnostics.ProcessMemoryUsageReport";
 }
-impl ::core::convert::From<ProcessMemoryUsageReport> for ::windows::core::IUnknown {
-    fn from(value: ProcessMemoryUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessMemoryUsageReport> for ::windows::core::IUnknown {
-    fn from(value: &ProcessMemoryUsageReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessMemoryUsageReport> for &::windows::core::IUnknown {
-    fn from(value: &ProcessMemoryUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessMemoryUsageReport> for ::windows::core::IInspectable {
-    fn from(value: ProcessMemoryUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessMemoryUsageReport> for ::windows::core::IInspectable {
-    fn from(value: &ProcessMemoryUsageReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessMemoryUsageReport> for &::windows::core::IInspectable {
-    fn from(value: &ProcessMemoryUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessMemoryUsageReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessMemoryUsageReport {}
 unsafe impl ::core::marker::Sync for ProcessMemoryUsageReport {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -1370,36 +1109,7 @@ unsafe impl ::windows::core::Interface for SystemCpuUsage {
 impl ::windows::core::RuntimeName for SystemCpuUsage {
     const NAME: &'static str = "Windows.System.Diagnostics.SystemCpuUsage";
 }
-impl ::core::convert::From<SystemCpuUsage> for ::windows::core::IUnknown {
-    fn from(value: SystemCpuUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemCpuUsage> for ::windows::core::IUnknown {
-    fn from(value: &SystemCpuUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemCpuUsage> for &::windows::core::IUnknown {
-    fn from(value: &SystemCpuUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemCpuUsage> for ::windows::core::IInspectable {
-    fn from(value: SystemCpuUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemCpuUsage> for ::windows::core::IInspectable {
-    fn from(value: &SystemCpuUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemCpuUsage> for &::windows::core::IInspectable {
-    fn from(value: &SystemCpuUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemCpuUsage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemCpuUsage {}
 unsafe impl ::core::marker::Sync for SystemCpuUsage {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -1466,36 +1176,7 @@ unsafe impl ::windows::core::Interface for SystemCpuUsageReport {
 impl ::windows::core::RuntimeName for SystemCpuUsageReport {
     const NAME: &'static str = "Windows.System.Diagnostics.SystemCpuUsageReport";
 }
-impl ::core::convert::From<SystemCpuUsageReport> for ::windows::core::IUnknown {
-    fn from(value: SystemCpuUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemCpuUsageReport> for ::windows::core::IUnknown {
-    fn from(value: &SystemCpuUsageReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemCpuUsageReport> for &::windows::core::IUnknown {
-    fn from(value: &SystemCpuUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemCpuUsageReport> for ::windows::core::IInspectable {
-    fn from(value: SystemCpuUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemCpuUsageReport> for ::windows::core::IInspectable {
-    fn from(value: &SystemCpuUsageReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemCpuUsageReport> for &::windows::core::IInspectable {
-    fn from(value: &SystemCpuUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemCpuUsageReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemCpuUsageReport {}
 unsafe impl ::core::marker::Sync for SystemCpuUsageReport {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -1577,36 +1258,7 @@ unsafe impl ::windows::core::Interface for SystemDiagnosticInfo {
 impl ::windows::core::RuntimeName for SystemDiagnosticInfo {
     const NAME: &'static str = "Windows.System.Diagnostics.SystemDiagnosticInfo";
 }
-impl ::core::convert::From<SystemDiagnosticInfo> for ::windows::core::IUnknown {
-    fn from(value: SystemDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemDiagnosticInfo> for ::windows::core::IUnknown {
-    fn from(value: &SystemDiagnosticInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemDiagnosticInfo> for &::windows::core::IUnknown {
-    fn from(value: &SystemDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemDiagnosticInfo> for ::windows::core::IInspectable {
-    fn from(value: SystemDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemDiagnosticInfo> for ::windows::core::IInspectable {
-    fn from(value: &SystemDiagnosticInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemDiagnosticInfo> for &::windows::core::IInspectable {
-    fn from(value: &SystemDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemDiagnosticInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemDiagnosticInfo {}
 unsafe impl ::core::marker::Sync for SystemDiagnosticInfo {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -1653,36 +1305,7 @@ unsafe impl ::windows::core::Interface for SystemMemoryUsage {
 impl ::windows::core::RuntimeName for SystemMemoryUsage {
     const NAME: &'static str = "Windows.System.Diagnostics.SystemMemoryUsage";
 }
-impl ::core::convert::From<SystemMemoryUsage> for ::windows::core::IUnknown {
-    fn from(value: SystemMemoryUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMemoryUsage> for ::windows::core::IUnknown {
-    fn from(value: &SystemMemoryUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMemoryUsage> for &::windows::core::IUnknown {
-    fn from(value: &SystemMemoryUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemMemoryUsage> for ::windows::core::IInspectable {
-    fn from(value: SystemMemoryUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMemoryUsage> for ::windows::core::IInspectable {
-    fn from(value: &SystemMemoryUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMemoryUsage> for &::windows::core::IInspectable {
-    fn from(value: &SystemMemoryUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemMemoryUsage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemMemoryUsage {}
 unsafe impl ::core::marker::Sync for SystemMemoryUsage {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]
@@ -1743,36 +1366,7 @@ unsafe impl ::windows::core::Interface for SystemMemoryUsageReport {
 impl ::windows::core::RuntimeName for SystemMemoryUsageReport {
     const NAME: &'static str = "Windows.System.Diagnostics.SystemMemoryUsageReport";
 }
-impl ::core::convert::From<SystemMemoryUsageReport> for ::windows::core::IUnknown {
-    fn from(value: SystemMemoryUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMemoryUsageReport> for ::windows::core::IUnknown {
-    fn from(value: &SystemMemoryUsageReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMemoryUsageReport> for &::windows::core::IUnknown {
-    fn from(value: &SystemMemoryUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemMemoryUsageReport> for ::windows::core::IInspectable {
-    fn from(value: SystemMemoryUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemMemoryUsageReport> for ::windows::core::IInspectable {
-    fn from(value: &SystemMemoryUsageReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemMemoryUsageReport> for &::windows::core::IInspectable {
-    fn from(value: &SystemMemoryUsageReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemMemoryUsageReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemMemoryUsageReport {}
 unsafe impl ::core::marker::Sync for SystemMemoryUsageReport {}
 #[doc = "*Required features: `\"System_Diagnostics\"`*"]

--- a/crates/libs/windows/src/Windows/System/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Display/mod.rs
@@ -66,35 +66,6 @@ unsafe impl ::windows::core::Interface for DisplayRequest {
 impl ::windows::core::RuntimeName for DisplayRequest {
     const NAME: &'static str = "Windows.System.Display.DisplayRequest";
 }
-impl ::core::convert::From<DisplayRequest> for ::windows::core::IUnknown {
-    fn from(value: DisplayRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayRequest> for ::windows::core::IUnknown {
-    fn from(value: &DisplayRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayRequest> for &::windows::core::IUnknown {
-    fn from(value: &DisplayRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayRequest> for ::windows::core::IInspectable {
-    fn from(value: DisplayRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayRequest> for ::windows::core::IInspectable {
-    fn from(value: &DisplayRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayRequest> for &::windows::core::IInspectable {
-    fn from(value: &DisplayRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "implement")]
 ::core::include!("impl.rs");

--- a/crates/libs/windows/src/Windows/System/Implementation/FileExplorer/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Implementation/FileExplorer/mod.rs
@@ -48,36 +48,7 @@ impl ISysStorageProviderEventSource {
         unsafe { (::windows::core::Vtable::vtable(this).RemoveEventReceived)(::windows::core::Vtable::as_raw(this), token).ok() }
     }
 }
-impl ::core::convert::From<ISysStorageProviderEventSource> for ::windows::core::IUnknown {
-    fn from(value: ISysStorageProviderEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISysStorageProviderEventSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISysStorageProviderEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISysStorageProviderEventSource> for ::windows::core::IUnknown {
-    fn from(value: &ISysStorageProviderEventSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISysStorageProviderEventSource> for ::windows::core::IInspectable {
-    fn from(value: ISysStorageProviderEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISysStorageProviderEventSource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISysStorageProviderEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISysStorageProviderEventSource> for ::windows::core::IInspectable {
-    fn from(value: &ISysStorageProviderEventSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISysStorageProviderEventSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISysStorageProviderEventSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -139,36 +110,7 @@ impl ISysStorageProviderHandlerFactory {
         }
     }
 }
-impl ::core::convert::From<ISysStorageProviderHandlerFactory> for ::windows::core::IUnknown {
-    fn from(value: ISysStorageProviderHandlerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISysStorageProviderHandlerFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISysStorageProviderHandlerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISysStorageProviderHandlerFactory> for ::windows::core::IUnknown {
-    fn from(value: &ISysStorageProviderHandlerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISysStorageProviderHandlerFactory> for ::windows::core::IInspectable {
-    fn from(value: ISysStorageProviderHandlerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISysStorageProviderHandlerFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISysStorageProviderHandlerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISysStorageProviderHandlerFactory> for ::windows::core::IInspectable {
-    fn from(value: &ISysStorageProviderHandlerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISysStorageProviderHandlerFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISysStorageProviderHandlerFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -219,36 +161,7 @@ impl ISysStorageProviderHttpRequestProvider {
         }
     }
 }
-impl ::core::convert::From<ISysStorageProviderHttpRequestProvider> for ::windows::core::IUnknown {
-    fn from(value: ISysStorageProviderHttpRequestProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISysStorageProviderHttpRequestProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISysStorageProviderHttpRequestProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISysStorageProviderHttpRequestProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISysStorageProviderHttpRequestProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISysStorageProviderHttpRequestProvider> for ::windows::core::IInspectable {
-    fn from(value: ISysStorageProviderHttpRequestProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISysStorageProviderHttpRequestProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISysStorageProviderHttpRequestProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISysStorageProviderHttpRequestProvider> for ::windows::core::IInspectable {
-    fn from(value: &ISysStorageProviderHttpRequestProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISysStorageProviderHttpRequestProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISysStorageProviderHttpRequestProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -342,36 +255,7 @@ unsafe impl ::windows::core::Interface for SysStorageProviderEventReceivedEventA
 impl ::windows::core::RuntimeName for SysStorageProviderEventReceivedEventArgs {
     const NAME: &'static str = "Windows.System.Implementation.FileExplorer.SysStorageProviderEventReceivedEventArgs";
 }
-impl ::core::convert::From<SysStorageProviderEventReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SysStorageProviderEventReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SysStorageProviderEventReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SysStorageProviderEventReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SysStorageProviderEventReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SysStorageProviderEventReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SysStorageProviderEventReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SysStorageProviderEventReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SysStorageProviderEventReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SysStorageProviderEventReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SysStorageProviderEventReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SysStorageProviderEventReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SysStorageProviderEventReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SysStorageProviderEventReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for SysStorageProviderEventReceivedEventArgs {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/System/Inventory/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Inventory/mod.rs
@@ -121,36 +121,7 @@ unsafe impl ::windows::core::Interface for InstalledDesktopApp {
 impl ::windows::core::RuntimeName for InstalledDesktopApp {
     const NAME: &'static str = "Windows.System.Inventory.InstalledDesktopApp";
 }
-impl ::core::convert::From<InstalledDesktopApp> for ::windows::core::IUnknown {
-    fn from(value: InstalledDesktopApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InstalledDesktopApp> for ::windows::core::IUnknown {
-    fn from(value: &InstalledDesktopApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InstalledDesktopApp> for &::windows::core::IUnknown {
-    fn from(value: &InstalledDesktopApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InstalledDesktopApp> for ::windows::core::IInspectable {
-    fn from(value: InstalledDesktopApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InstalledDesktopApp> for ::windows::core::IInspectable {
-    fn from(value: &InstalledDesktopApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InstalledDesktopApp> for &::windows::core::IInspectable {
-    fn from(value: &InstalledDesktopApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InstalledDesktopApp, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<InstalledDesktopApp> for super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/System/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Preview/mod.rs
@@ -200,41 +200,7 @@ impl ::windows::core::RuntimeName for TwoPanelHingedDevicePosturePreview {
     const NAME: &'static str = "Windows.System.Preview.TwoPanelHingedDevicePosturePreview";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<TwoPanelHingedDevicePosturePreview> for ::windows::core::IUnknown {
-    fn from(value: TwoPanelHingedDevicePosturePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreview> for ::windows::core::IUnknown {
-    fn from(value: &TwoPanelHingedDevicePosturePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreview> for &::windows::core::IUnknown {
-    fn from(value: &TwoPanelHingedDevicePosturePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<TwoPanelHingedDevicePosturePreview> for ::windows::core::IInspectable {
-    fn from(value: TwoPanelHingedDevicePosturePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreview> for ::windows::core::IInspectable {
-    fn from(value: &TwoPanelHingedDevicePosturePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreview> for &::windows::core::IInspectable {
-    fn from(value: &TwoPanelHingedDevicePosturePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TwoPanelHingedDevicePosturePreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for TwoPanelHingedDevicePosturePreview {}
 #[cfg(feature = "deprecated")]
@@ -341,41 +307,7 @@ impl ::windows::core::RuntimeName for TwoPanelHingedDevicePosturePreviewReading 
     const NAME: &'static str = "Windows.System.Preview.TwoPanelHingedDevicePosturePreviewReading";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<TwoPanelHingedDevicePosturePreviewReading> for ::windows::core::IUnknown {
-    fn from(value: TwoPanelHingedDevicePosturePreviewReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreviewReading> for ::windows::core::IUnknown {
-    fn from(value: &TwoPanelHingedDevicePosturePreviewReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreviewReading> for &::windows::core::IUnknown {
-    fn from(value: &TwoPanelHingedDevicePosturePreviewReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<TwoPanelHingedDevicePosturePreviewReading> for ::windows::core::IInspectable {
-    fn from(value: TwoPanelHingedDevicePosturePreviewReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreviewReading> for ::windows::core::IInspectable {
-    fn from(value: &TwoPanelHingedDevicePosturePreviewReading) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreviewReading> for &::windows::core::IInspectable {
-    fn from(value: &TwoPanelHingedDevicePosturePreviewReading) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TwoPanelHingedDevicePosturePreviewReading, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for TwoPanelHingedDevicePosturePreviewReading {}
 #[cfg(feature = "deprecated")]
@@ -437,41 +369,7 @@ impl ::windows::core::RuntimeName for TwoPanelHingedDevicePosturePreviewReadingC
     const NAME: &'static str = "Windows.System.Preview.TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "deprecated")]
 unsafe impl ::core::marker::Send for TwoPanelHingedDevicePosturePreviewReadingChangedEventArgs {}
 #[cfg(feature = "deprecated")]

--- a/crates/libs/windows/src/Windows/System/Profile/SystemManufacturers/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Profile/SystemManufacturers/mod.rs
@@ -150,36 +150,7 @@ unsafe impl ::windows::core::Interface for OemSupportInfo {
 impl ::windows::core::RuntimeName for OemSupportInfo {
     const NAME: &'static str = "Windows.System.Profile.SystemManufacturers.OemSupportInfo";
 }
-impl ::core::convert::From<OemSupportInfo> for ::windows::core::IUnknown {
-    fn from(value: OemSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OemSupportInfo> for ::windows::core::IUnknown {
-    fn from(value: &OemSupportInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OemSupportInfo> for &::windows::core::IUnknown {
-    fn from(value: &OemSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OemSupportInfo> for ::windows::core::IInspectable {
-    fn from(value: OemSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OemSupportInfo> for ::windows::core::IInspectable {
-    fn from(value: &OemSupportInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OemSupportInfo> for &::windows::core::IInspectable {
-    fn from(value: &OemSupportInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OemSupportInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for OemSupportInfo {}
 unsafe impl ::core::marker::Sync for OemSupportInfo {}
 #[doc = "*Required features: `\"System_Profile_SystemManufacturers\"`*"]
@@ -286,36 +257,7 @@ unsafe impl ::windows::core::Interface for SystemSupportDeviceInfo {
 impl ::windows::core::RuntimeName for SystemSupportDeviceInfo {
     const NAME: &'static str = "Windows.System.Profile.SystemManufacturers.SystemSupportDeviceInfo";
 }
-impl ::core::convert::From<SystemSupportDeviceInfo> for ::windows::core::IUnknown {
-    fn from(value: SystemSupportDeviceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemSupportDeviceInfo> for ::windows::core::IUnknown {
-    fn from(value: &SystemSupportDeviceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemSupportDeviceInfo> for &::windows::core::IUnknown {
-    fn from(value: &SystemSupportDeviceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemSupportDeviceInfo> for ::windows::core::IInspectable {
-    fn from(value: SystemSupportDeviceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemSupportDeviceInfo> for ::windows::core::IInspectable {
-    fn from(value: &SystemSupportDeviceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemSupportDeviceInfo> for &::windows::core::IInspectable {
-    fn from(value: &SystemSupportDeviceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemSupportDeviceInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemSupportDeviceInfo {}
 unsafe impl ::core::marker::Sync for SystemSupportDeviceInfo {}
 #[doc = "*Required features: `\"System_Profile_SystemManufacturers\"`*"]

--- a/crates/libs/windows/src/Windows/System/Profile/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Profile/mod.rs
@@ -450,36 +450,7 @@ unsafe impl ::windows::core::Interface for AnalyticsVersionInfo {
 impl ::windows::core::RuntimeName for AnalyticsVersionInfo {
     const NAME: &'static str = "Windows.System.Profile.AnalyticsVersionInfo";
 }
-impl ::core::convert::From<AnalyticsVersionInfo> for ::windows::core::IUnknown {
-    fn from(value: AnalyticsVersionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AnalyticsVersionInfo> for ::windows::core::IUnknown {
-    fn from(value: &AnalyticsVersionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AnalyticsVersionInfo> for &::windows::core::IUnknown {
-    fn from(value: &AnalyticsVersionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AnalyticsVersionInfo> for ::windows::core::IInspectable {
-    fn from(value: AnalyticsVersionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AnalyticsVersionInfo> for ::windows::core::IInspectable {
-    fn from(value: &AnalyticsVersionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AnalyticsVersionInfo> for &::windows::core::IInspectable {
-    fn from(value: &AnalyticsVersionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AnalyticsVersionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AnalyticsVersionInfo {}
 unsafe impl ::core::marker::Sync for AnalyticsVersionInfo {}
 #[doc = "*Required features: `\"System_Profile\"`*"]
@@ -612,36 +583,7 @@ unsafe impl ::windows::core::Interface for HardwareToken {
 impl ::windows::core::RuntimeName for HardwareToken {
     const NAME: &'static str = "Windows.System.Profile.HardwareToken";
 }
-impl ::core::convert::From<HardwareToken> for ::windows::core::IUnknown {
-    fn from(value: HardwareToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HardwareToken> for ::windows::core::IUnknown {
-    fn from(value: &HardwareToken) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HardwareToken> for &::windows::core::IUnknown {
-    fn from(value: &HardwareToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HardwareToken> for ::windows::core::IInspectable {
-    fn from(value: HardwareToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HardwareToken> for ::windows::core::IInspectable {
-    fn from(value: &HardwareToken) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HardwareToken> for &::windows::core::IInspectable {
-    fn from(value: &HardwareToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HardwareToken, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HardwareToken {}
 unsafe impl ::core::marker::Sync for HardwareToken {}
 #[doc = "*Required features: `\"System_Profile\"`*"]
@@ -957,36 +899,7 @@ unsafe impl ::windows::core::Interface for SystemIdentificationInfo {
 impl ::windows::core::RuntimeName for SystemIdentificationInfo {
     const NAME: &'static str = "Windows.System.Profile.SystemIdentificationInfo";
 }
-impl ::core::convert::From<SystemIdentificationInfo> for ::windows::core::IUnknown {
-    fn from(value: SystemIdentificationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemIdentificationInfo> for ::windows::core::IUnknown {
-    fn from(value: &SystemIdentificationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemIdentificationInfo> for &::windows::core::IUnknown {
-    fn from(value: &SystemIdentificationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemIdentificationInfo> for ::windows::core::IInspectable {
-    fn from(value: SystemIdentificationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemIdentificationInfo> for ::windows::core::IInspectable {
-    fn from(value: &SystemIdentificationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemIdentificationInfo> for &::windows::core::IInspectable {
-    fn from(value: &SystemIdentificationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemIdentificationInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemIdentificationInfo {}
 unsafe impl ::core::marker::Sync for SystemIdentificationInfo {}
 #[doc = "*Required features: `\"System_Profile\"`*"]
@@ -1071,36 +984,7 @@ unsafe impl ::windows::core::Interface for UnsupportedAppRequirement {
 impl ::windows::core::RuntimeName for UnsupportedAppRequirement {
     const NAME: &'static str = "Windows.System.Profile.UnsupportedAppRequirement";
 }
-impl ::core::convert::From<UnsupportedAppRequirement> for ::windows::core::IUnknown {
-    fn from(value: UnsupportedAppRequirement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UnsupportedAppRequirement> for ::windows::core::IUnknown {
-    fn from(value: &UnsupportedAppRequirement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UnsupportedAppRequirement> for &::windows::core::IUnknown {
-    fn from(value: &UnsupportedAppRequirement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UnsupportedAppRequirement> for ::windows::core::IInspectable {
-    fn from(value: UnsupportedAppRequirement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UnsupportedAppRequirement> for ::windows::core::IInspectable {
-    fn from(value: &UnsupportedAppRequirement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UnsupportedAppRequirement> for &::windows::core::IInspectable {
-    fn from(value: &UnsupportedAppRequirement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UnsupportedAppRequirement, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UnsupportedAppRequirement {}
 unsafe impl ::core::marker::Sync for UnsupportedAppRequirement {}
 #[doc = "*Required features: `\"System_Profile\"`*"]

--- a/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
@@ -109,36 +109,7 @@ unsafe impl ::windows::core::Interface for RemoteTextConnection {
 impl ::windows::core::RuntimeName for RemoteTextConnection {
     const NAME: &'static str = "Windows.System.RemoteDesktop.Input.RemoteTextConnection";
 }
-impl ::core::convert::From<RemoteTextConnection> for ::windows::core::IUnknown {
-    fn from(value: RemoteTextConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteTextConnection> for ::windows::core::IUnknown {
-    fn from(value: &RemoteTextConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteTextConnection> for &::windows::core::IUnknown {
-    fn from(value: &RemoteTextConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteTextConnection> for ::windows::core::IInspectable {
-    fn from(value: RemoteTextConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteTextConnection> for ::windows::core::IInspectable {
-    fn from(value: &RemoteTextConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteTextConnection> for &::windows::core::IInspectable {
-    fn from(value: &RemoteTextConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteTextConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<RemoteTextConnection> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/System/RemoteSystems/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteSystems/mod.rs
@@ -412,36 +412,7 @@ pub struct IRemoteSystemEnumerationCompletedEventArgs_Vtbl {
 #[repr(transparent)]
 pub struct IRemoteSystemFilter(::windows::core::IUnknown);
 impl IRemoteSystemFilter {}
-impl ::core::convert::From<IRemoteSystemFilter> for ::windows::core::IUnknown {
-    fn from(value: IRemoteSystemFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRemoteSystemFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteSystemFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRemoteSystemFilter> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteSystemFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRemoteSystemFilter> for ::windows::core::IInspectable {
-    fn from(value: IRemoteSystemFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRemoteSystemFilter> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IRemoteSystemFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRemoteSystemFilter> for ::windows::core::IInspectable {
-    fn from(value: &IRemoteSystemFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteSystemFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IRemoteSystemFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1547,36 +1518,7 @@ unsafe impl ::windows::core::Interface for RemoteSystem {
 impl ::windows::core::RuntimeName for RemoteSystem {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystem";
 }
-impl ::core::convert::From<RemoteSystem> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystem> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystem> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystem> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystem> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystem> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystem {}
 unsafe impl ::core::marker::Sync for RemoteSystem {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -1623,36 +1565,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemAddedEventArgs {
 impl ::windows::core::RuntimeName for RemoteSystemAddedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemAddedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemAddedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemAddedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -1743,36 +1656,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemApp {
 impl ::windows::core::RuntimeName for RemoteSystemApp {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemApp";
 }
-impl ::core::convert::From<RemoteSystemApp> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemApp> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemApp> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemApp> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemApp> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemApp> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemApp, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemApp {}
 unsafe impl ::core::marker::Sync for RemoteSystemApp {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -1854,36 +1738,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemAppRegistration {
 impl ::windows::core::RuntimeName for RemoteSystemAppRegistration {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemAppRegistration";
 }
-impl ::core::convert::From<RemoteSystemAppRegistration> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemAppRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemAppRegistration> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemAppRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemAppRegistration> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemAppRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemAppRegistration> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemAppRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemAppRegistration> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemAppRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemAppRegistration> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemAppRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemAppRegistration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemAppRegistration {}
 unsafe impl ::core::marker::Sync for RemoteSystemAppRegistration {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -1941,36 +1796,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemAuthorizationKindFilter {
 impl ::windows::core::RuntimeName for RemoteSystemAuthorizationKindFilter {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemAuthorizationKindFilter";
 }
-impl ::core::convert::From<RemoteSystemAuthorizationKindFilter> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemAuthorizationKindFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemAuthorizationKindFilter> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemAuthorizationKindFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemAuthorizationKindFilter> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemAuthorizationKindFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemAuthorizationKindFilter> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemAuthorizationKindFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemAuthorizationKindFilter> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemAuthorizationKindFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemAuthorizationKindFilter> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemAuthorizationKindFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemAuthorizationKindFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RemoteSystemAuthorizationKindFilter> for IRemoteSystemFilter {
     type Error = ::windows::core::Error;
     fn try_from(value: RemoteSystemAuthorizationKindFilter) -> ::windows::core::Result<Self> {
@@ -2049,36 +1875,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemConnectionInfo {
 impl ::windows::core::RuntimeName for RemoteSystemConnectionInfo {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemConnectionInfo";
 }
-impl ::core::convert::From<RemoteSystemConnectionInfo> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemConnectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemConnectionInfo> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemConnectionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemConnectionInfo> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemConnectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemConnectionInfo> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemConnectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemConnectionInfo> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemConnectionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemConnectionInfo> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemConnectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemConnectionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemConnectionInfo {}
 unsafe impl ::core::marker::Sync for RemoteSystemConnectionInfo {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -2178,36 +1975,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemConnectionRequest {
 impl ::windows::core::RuntimeName for RemoteSystemConnectionRequest {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemConnectionRequest";
 }
-impl ::core::convert::From<RemoteSystemConnectionRequest> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemConnectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemConnectionRequest> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemConnectionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemConnectionRequest> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemConnectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemConnectionRequest> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemConnectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemConnectionRequest> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemConnectionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemConnectionRequest> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemConnectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemConnectionRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemConnectionRequest {}
 unsafe impl ::core::marker::Sync for RemoteSystemConnectionRequest {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -2265,36 +2033,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemDiscoveryTypeFilter {
 impl ::windows::core::RuntimeName for RemoteSystemDiscoveryTypeFilter {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemDiscoveryTypeFilter";
 }
-impl ::core::convert::From<RemoteSystemDiscoveryTypeFilter> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemDiscoveryTypeFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemDiscoveryTypeFilter> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemDiscoveryTypeFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemDiscoveryTypeFilter> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemDiscoveryTypeFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemDiscoveryTypeFilter> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemDiscoveryTypeFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemDiscoveryTypeFilter> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemDiscoveryTypeFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemDiscoveryTypeFilter> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemDiscoveryTypeFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemDiscoveryTypeFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RemoteSystemDiscoveryTypeFilter> for IRemoteSystemFilter {
     type Error = ::windows::core::Error;
     fn try_from(value: RemoteSystemDiscoveryTypeFilter) -> ::windows::core::Result<Self> {
@@ -2352,36 +2091,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemEnumerationCompletedEvent
 impl ::windows::core::RuntimeName for RemoteSystemEnumerationCompletedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemEnumerationCompletedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemEnumerationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemEnumerationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemEnumerationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemEnumerationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemEnumerationCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemEnumerationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemEnumerationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemEnumerationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemEnumerationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemEnumerationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemEnumerationCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemEnumerationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemEnumerationCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemEnumerationCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemEnumerationCompletedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -2447,36 +2157,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemKindFilter {
 impl ::windows::core::RuntimeName for RemoteSystemKindFilter {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemKindFilter";
 }
-impl ::core::convert::From<RemoteSystemKindFilter> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemKindFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemKindFilter> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemKindFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemKindFilter> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemKindFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemKindFilter> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemKindFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemKindFilter> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemKindFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemKindFilter> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemKindFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemKindFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RemoteSystemKindFilter> for IRemoteSystemFilter {
     type Error = ::windows::core::Error;
     fn try_from(value: RemoteSystemKindFilter) -> ::windows::core::Result<Self> {
@@ -2607,36 +2288,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemRemovedEventArgs {
 impl ::windows::core::RuntimeName for RemoteSystemRemovedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemRemovedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemRemovedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemRemovedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -2745,36 +2397,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSession {
 impl ::windows::core::RuntimeName for RemoteSystemSession {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSession";
 }
-impl ::core::convert::From<RemoteSystemSession> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSession> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSession> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSession> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSession> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSession> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<RemoteSystemSession> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2843,36 +2466,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionAddedEventArgs {
 impl ::windows::core::RuntimeName for RemoteSystemSessionAddedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionAddedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemSessionAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionAddedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionAddedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -2962,36 +2556,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionController {
 impl ::windows::core::RuntimeName for RemoteSystemSessionController {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionController";
 }
-impl ::core::convert::From<RemoteSystemSessionController> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionController> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionController> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionController> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionController> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionController> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionController {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionController {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -3045,36 +2610,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionCreationResult {
 impl ::windows::core::RuntimeName for RemoteSystemSessionCreationResult {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionCreationResult";
 }
-impl ::core::convert::From<RemoteSystemSessionCreationResult> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionCreationResult> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionCreationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionCreationResult> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionCreationResult> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionCreationResult> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionCreationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionCreationResult> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionCreationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionCreationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionCreationResult {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionCreationResult {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -3121,36 +2657,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionDisconnectedEventA
 impl ::windows::core::RuntimeName for RemoteSystemSessionDisconnectedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionDisconnectedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemSessionDisconnectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionDisconnectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionDisconnectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionDisconnectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionDisconnectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionDisconnectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionDisconnectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionDisconnectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionDisconnectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionDisconnectedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionDisconnectedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -3213,36 +2720,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionInfo {
 impl ::windows::core::RuntimeName for RemoteSystemSessionInfo {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionInfo";
 }
-impl ::core::convert::From<RemoteSystemSessionInfo> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInfo> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInfo> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionInfo> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInfo> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInfo> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionInfo {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionInfo {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -3296,36 +2774,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionInvitation {
 impl ::windows::core::RuntimeName for RemoteSystemSessionInvitation {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionInvitation";
 }
-impl ::core::convert::From<RemoteSystemSessionInvitation> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionInvitation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitation> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionInvitation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitation> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionInvitation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionInvitation> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionInvitation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitation> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionInvitation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitation> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionInvitation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionInvitation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionInvitation {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionInvitation {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -3387,36 +2836,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionInvitationListener
 impl ::windows::core::RuntimeName for RemoteSystemSessionInvitationListener {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionInvitationListener";
 }
-impl ::core::convert::From<RemoteSystemSessionInvitationListener> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionInvitationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitationListener> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionInvitationListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitationListener> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionInvitationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionInvitationListener> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionInvitationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitationListener> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionInvitationListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitationListener> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionInvitationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionInvitationListener, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionInvitationListener {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionInvitationListener {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -3463,36 +2883,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionInvitationReceived
 impl ::windows::core::RuntimeName for RemoteSystemSessionInvitationReceivedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionInvitationReceivedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemSessionInvitationReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionInvitationReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitationReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionInvitationReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitationReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionInvitationReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionInvitationReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionInvitationReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitationReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionInvitationReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionInvitationReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionInvitationReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionInvitationReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionInvitationReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionInvitationReceivedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -3543,36 +2934,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionJoinRequest {
 impl ::windows::core::RuntimeName for RemoteSystemSessionJoinRequest {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionJoinRequest";
 }
-impl ::core::convert::From<RemoteSystemSessionJoinRequest> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionJoinRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinRequest> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionJoinRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinRequest> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionJoinRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionJoinRequest> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionJoinRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinRequest> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionJoinRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinRequest> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionJoinRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionJoinRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionJoinRequest {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionJoinRequest {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -3628,36 +2990,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionJoinRequestedEvent
 impl ::windows::core::RuntimeName for RemoteSystemSessionJoinRequestedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionJoinRequestedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemSessionJoinRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionJoinRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionJoinRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionJoinRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionJoinRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionJoinRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionJoinRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionJoinRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionJoinRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionJoinRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionJoinRequestedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -3711,36 +3044,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionJoinResult {
 impl ::windows::core::RuntimeName for RemoteSystemSessionJoinResult {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionJoinResult";
 }
-impl ::core::convert::From<RemoteSystemSessionJoinResult> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionJoinResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinResult> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionJoinResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinResult> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionJoinResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionJoinResult> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionJoinResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinResult> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionJoinResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionJoinResult> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionJoinResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionJoinResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionJoinResult {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionJoinResult {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -3850,36 +3154,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionMessageChannel {
 impl ::windows::core::RuntimeName for RemoteSystemSessionMessageChannel {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionMessageChannel";
 }
-impl ::core::convert::From<RemoteSystemSessionMessageChannel> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionMessageChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionMessageChannel> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionMessageChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionMessageChannel> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionMessageChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionMessageChannel> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionMessageChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionMessageChannel> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionMessageChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionMessageChannel> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionMessageChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionMessageChannel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionMessageChannel {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionMessageChannel {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -3937,36 +3212,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionOptions {
 impl ::windows::core::RuntimeName for RemoteSystemSessionOptions {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionOptions";
 }
-impl ::core::convert::From<RemoteSystemSessionOptions> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionOptions> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionOptions> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionOptions> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionOptions> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionOptions> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionOptions {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionOptions {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -4022,36 +3268,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionParticipant {
 impl ::windows::core::RuntimeName for RemoteSystemSessionParticipant {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionParticipant";
 }
-impl ::core::convert::From<RemoteSystemSessionParticipant> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionParticipant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipant> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionParticipant) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipant> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionParticipant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionParticipant> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionParticipant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipant> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionParticipant) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipant> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionParticipant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionParticipant, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionParticipant {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionParticipant {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -4098,36 +3315,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionParticipantAddedEv
 impl ::windows::core::RuntimeName for RemoteSystemSessionParticipantAddedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionParticipantAddedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemSessionParticipantAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionParticipantAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionParticipantAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionParticipantAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionParticipantAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionParticipantAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionParticipantAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionParticipantAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionParticipantAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionParticipantAddedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionParticipantAddedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -4174,36 +3362,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionParticipantRemoved
 impl ::windows::core::RuntimeName for RemoteSystemSessionParticipantRemovedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionParticipantRemovedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemSessionParticipantRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionParticipantRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionParticipantRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionParticipantRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionParticipantRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionParticipantRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionParticipantRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionParticipantRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionParticipantRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionParticipantRemovedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionParticipantRemovedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -4303,36 +3462,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionParticipantWatcher
 impl ::windows::core::RuntimeName for RemoteSystemSessionParticipantWatcher {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionParticipantWatcher";
 }
-impl ::core::convert::From<RemoteSystemSessionParticipantWatcher> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionParticipantWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantWatcher> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionParticipantWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantWatcher> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionParticipantWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionParticipantWatcher> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionParticipantWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantWatcher> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionParticipantWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionParticipantWatcher> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionParticipantWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionParticipantWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionParticipantWatcher {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionParticipantWatcher {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -4379,36 +3509,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionRemovedEventArgs {
 impl ::windows::core::RuntimeName for RemoteSystemSessionRemovedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionRemovedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemSessionRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionRemovedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionRemovedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -4455,36 +3556,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionUpdatedEventArgs {
 impl ::windows::core::RuntimeName for RemoteSystemSessionUpdatedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionUpdatedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemSessionUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionUpdatedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -4540,36 +3612,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionValueSetReceivedEv
 impl ::windows::core::RuntimeName for RemoteSystemSessionValueSetReceivedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionValueSetReceivedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemSessionValueSetReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionValueSetReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionValueSetReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionValueSetReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionValueSetReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionValueSetReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionValueSetReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionValueSetReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionValueSetReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionValueSetReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionValueSetReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionValueSetReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionValueSetReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionValueSetReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionValueSetReceivedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -4669,36 +3712,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemSessionWatcher {
 impl ::windows::core::RuntimeName for RemoteSystemSessionWatcher {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemSessionWatcher";
 }
-impl ::core::convert::From<RemoteSystemSessionWatcher> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemSessionWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionWatcher> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionWatcher> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemSessionWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemSessionWatcher> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemSessionWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionWatcher> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemSessionWatcher> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemSessionWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemSessionWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemSessionWatcher {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionWatcher {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -4756,36 +3770,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemStatusTypeFilter {
 impl ::windows::core::RuntimeName for RemoteSystemStatusTypeFilter {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemStatusTypeFilter";
 }
-impl ::core::convert::From<RemoteSystemStatusTypeFilter> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemStatusTypeFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemStatusTypeFilter> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemStatusTypeFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemStatusTypeFilter> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemStatusTypeFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemStatusTypeFilter> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemStatusTypeFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemStatusTypeFilter> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemStatusTypeFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemStatusTypeFilter> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemStatusTypeFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemStatusTypeFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RemoteSystemStatusTypeFilter> for IRemoteSystemFilter {
     type Error = ::windows::core::Error;
     fn try_from(value: RemoteSystemStatusTypeFilter) -> ::windows::core::Result<Self> {
@@ -4851,36 +3836,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemUpdatedEventArgs {
 impl ::windows::core::RuntimeName for RemoteSystemUpdatedEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemUpdatedEventArgs";
 }
-impl ::core::convert::From<RemoteSystemUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemUpdatedEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -5010,36 +3966,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemWatcher {
 impl ::windows::core::RuntimeName for RemoteSystemWatcher {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemWatcher";
 }
-impl ::core::convert::From<RemoteSystemWatcher> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemWatcher> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemWatcher> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemWatcher> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemWatcher> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemWatcher> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemWatcher {}
 unsafe impl ::core::marker::Sync for RemoteSystemWatcher {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -5086,36 +4013,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemWatcherErrorOccurredEvent
 impl ::windows::core::RuntimeName for RemoteSystemWatcherErrorOccurredEventArgs {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemWatcherErrorOccurredEventArgs";
 }
-impl ::core::convert::From<RemoteSystemWatcherErrorOccurredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemWatcherErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemWatcherErrorOccurredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemWatcherErrorOccurredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemWatcherErrorOccurredEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemWatcherErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemWatcherErrorOccurredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemWatcherErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemWatcherErrorOccurredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemWatcherErrorOccurredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemWatcherErrorOccurredEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemWatcherErrorOccurredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemWatcherErrorOccurredEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteSystemWatcherErrorOccurredEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemWatcherErrorOccurredEventArgs {}
 #[doc = "*Required features: `\"System_RemoteSystems\"`*"]
@@ -5177,36 +4075,7 @@ unsafe impl ::windows::core::Interface for RemoteSystemWebAccountFilter {
 impl ::windows::core::RuntimeName for RemoteSystemWebAccountFilter {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemWebAccountFilter";
 }
-impl ::core::convert::From<RemoteSystemWebAccountFilter> for ::windows::core::IUnknown {
-    fn from(value: RemoteSystemWebAccountFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemWebAccountFilter> for ::windows::core::IUnknown {
-    fn from(value: &RemoteSystemWebAccountFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemWebAccountFilter> for &::windows::core::IUnknown {
-    fn from(value: &RemoteSystemWebAccountFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteSystemWebAccountFilter> for ::windows::core::IInspectable {
-    fn from(value: RemoteSystemWebAccountFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteSystemWebAccountFilter> for ::windows::core::IInspectable {
-    fn from(value: &RemoteSystemWebAccountFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteSystemWebAccountFilter> for &::windows::core::IInspectable {
-    fn from(value: &RemoteSystemWebAccountFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteSystemWebAccountFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RemoteSystemWebAccountFilter> for IRemoteSystemFilter {
     type Error = ::windows::core::Error;
     fn try_from(value: RemoteSystemWebAccountFilter) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/System/Threading/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/Core/mod.rs
@@ -157,36 +157,7 @@ unsafe impl ::windows::core::Interface for PreallocatedWorkItem {
 impl ::windows::core::RuntimeName for PreallocatedWorkItem {
     const NAME: &'static str = "Windows.System.Threading.Core.PreallocatedWorkItem";
 }
-impl ::core::convert::From<PreallocatedWorkItem> for ::windows::core::IUnknown {
-    fn from(value: PreallocatedWorkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PreallocatedWorkItem> for ::windows::core::IUnknown {
-    fn from(value: &PreallocatedWorkItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PreallocatedWorkItem> for &::windows::core::IUnknown {
-    fn from(value: &PreallocatedWorkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PreallocatedWorkItem> for ::windows::core::IInspectable {
-    fn from(value: PreallocatedWorkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PreallocatedWorkItem> for ::windows::core::IInspectable {
-    fn from(value: &PreallocatedWorkItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PreallocatedWorkItem> for &::windows::core::IInspectable {
-    fn from(value: &PreallocatedWorkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PreallocatedWorkItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PreallocatedWorkItem {}
 unsafe impl ::core::marker::Sync for PreallocatedWorkItem {}
 #[doc = "*Required features: `\"System_Threading_Core\"`*"]
@@ -267,36 +238,7 @@ unsafe impl ::windows::core::Interface for SignalNotifier {
 impl ::windows::core::RuntimeName for SignalNotifier {
     const NAME: &'static str = "Windows.System.Threading.Core.SignalNotifier";
 }
-impl ::core::convert::From<SignalNotifier> for ::windows::core::IUnknown {
-    fn from(value: SignalNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SignalNotifier> for ::windows::core::IUnknown {
-    fn from(value: &SignalNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SignalNotifier> for &::windows::core::IUnknown {
-    fn from(value: &SignalNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SignalNotifier> for ::windows::core::IInspectable {
-    fn from(value: SignalNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SignalNotifier> for ::windows::core::IInspectable {
-    fn from(value: &SignalNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SignalNotifier> for &::windows::core::IInspectable {
-    fn from(value: &SignalNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SignalNotifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SignalNotifier {}
 unsafe impl ::core::marker::Sync for SignalNotifier {}
 #[doc = "*Required features: `\"System_Threading_Core\"`*"]

--- a/crates/libs/windows/src/Windows/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/mod.rs
@@ -211,36 +211,7 @@ unsafe impl ::windows::core::Interface for ThreadPoolTimer {
 impl ::windows::core::RuntimeName for ThreadPoolTimer {
     const NAME: &'static str = "Windows.System.Threading.ThreadPoolTimer";
 }
-impl ::core::convert::From<ThreadPoolTimer> for ::windows::core::IUnknown {
-    fn from(value: ThreadPoolTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ThreadPoolTimer> for ::windows::core::IUnknown {
-    fn from(value: &ThreadPoolTimer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ThreadPoolTimer> for &::windows::core::IUnknown {
-    fn from(value: &ThreadPoolTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ThreadPoolTimer> for ::windows::core::IInspectable {
-    fn from(value: ThreadPoolTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ThreadPoolTimer> for ::windows::core::IInspectable {
-    fn from(value: &ThreadPoolTimer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ThreadPoolTimer> for &::windows::core::IInspectable {
-    fn from(value: &ThreadPoolTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ThreadPoolTimer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ThreadPoolTimer {}
 unsafe impl ::core::marker::Sync for ThreadPoolTimer {}
 #[doc = "*Required features: `\"System_Threading\"`*"]

--- a/crates/libs/windows/src/Windows/System/Update/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Update/mod.rs
@@ -201,36 +201,7 @@ unsafe impl ::windows::core::Interface for SystemUpdateItem {
 impl ::windows::core::RuntimeName for SystemUpdateItem {
     const NAME: &'static str = "Windows.System.Update.SystemUpdateItem";
 }
-impl ::core::convert::From<SystemUpdateItem> for ::windows::core::IUnknown {
-    fn from(value: SystemUpdateItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemUpdateItem> for ::windows::core::IUnknown {
-    fn from(value: &SystemUpdateItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemUpdateItem> for &::windows::core::IUnknown {
-    fn from(value: &SystemUpdateItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemUpdateItem> for ::windows::core::IInspectable {
-    fn from(value: SystemUpdateItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemUpdateItem> for ::windows::core::IInspectable {
-    fn from(value: &SystemUpdateItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemUpdateItem> for &::windows::core::IInspectable {
-    fn from(value: &SystemUpdateItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemUpdateItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemUpdateItem {}
 unsafe impl ::core::marker::Sync for SystemUpdateItem {}
 #[doc = "*Required features: `\"System_Update\"`*"]
@@ -291,36 +262,7 @@ unsafe impl ::windows::core::Interface for SystemUpdateLastErrorInfo {
 impl ::windows::core::RuntimeName for SystemUpdateLastErrorInfo {
     const NAME: &'static str = "Windows.System.Update.SystemUpdateLastErrorInfo";
 }
-impl ::core::convert::From<SystemUpdateLastErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: SystemUpdateLastErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemUpdateLastErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &SystemUpdateLastErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemUpdateLastErrorInfo> for &::windows::core::IUnknown {
-    fn from(value: &SystemUpdateLastErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemUpdateLastErrorInfo> for ::windows::core::IInspectable {
-    fn from(value: SystemUpdateLastErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemUpdateLastErrorInfo> for ::windows::core::IInspectable {
-    fn from(value: &SystemUpdateLastErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemUpdateLastErrorInfo> for &::windows::core::IInspectable {
-    fn from(value: &SystemUpdateLastErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemUpdateLastErrorInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemUpdateLastErrorInfo {}
 unsafe impl ::core::marker::Sync for SystemUpdateLastErrorInfo {}
 #[doc = "*Required features: `\"System_Update\"`*"]

--- a/crates/libs/windows/src/Windows/System/UserProfile/mod.rs
+++ b/crates/libs/windows/src/Windows/System/UserProfile/mod.rs
@@ -488,36 +488,7 @@ unsafe impl ::windows::core::Interface for AdvertisingManagerForUser {
 impl ::windows::core::RuntimeName for AdvertisingManagerForUser {
     const NAME: &'static str = "Windows.System.UserProfile.AdvertisingManagerForUser";
 }
-impl ::core::convert::From<AdvertisingManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: AdvertisingManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvertisingManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: &AdvertisingManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvertisingManagerForUser> for &::windows::core::IUnknown {
-    fn from(value: &AdvertisingManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdvertisingManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: AdvertisingManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdvertisingManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: &AdvertisingManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdvertisingManagerForUser> for &::windows::core::IInspectable {
-    fn from(value: &AdvertisingManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdvertisingManagerForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AdvertisingManagerForUser {}
 unsafe impl ::core::marker::Sync for AdvertisingManagerForUser {}
 #[doc = "*Required features: `\"System_UserProfile\"`*"]
@@ -595,36 +566,7 @@ unsafe impl ::windows::core::Interface for AssignedAccessSettings {
 impl ::windows::core::RuntimeName for AssignedAccessSettings {
     const NAME: &'static str = "Windows.System.UserProfile.AssignedAccessSettings";
 }
-impl ::core::convert::From<AssignedAccessSettings> for ::windows::core::IUnknown {
-    fn from(value: AssignedAccessSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AssignedAccessSettings> for ::windows::core::IUnknown {
-    fn from(value: &AssignedAccessSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AssignedAccessSettings> for &::windows::core::IUnknown {
-    fn from(value: &AssignedAccessSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AssignedAccessSettings> for ::windows::core::IInspectable {
-    fn from(value: AssignedAccessSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AssignedAccessSettings> for ::windows::core::IInspectable {
-    fn from(value: &AssignedAccessSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AssignedAccessSettings> for &::windows::core::IInspectable {
-    fn from(value: &AssignedAccessSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AssignedAccessSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AssignedAccessSettings {}
 unsafe impl ::core::marker::Sync for AssignedAccessSettings {}
 #[doc = "*Required features: `\"System_UserProfile\"`*"]
@@ -695,36 +637,7 @@ unsafe impl ::windows::core::Interface for DiagnosticsSettings {
 impl ::windows::core::RuntimeName for DiagnosticsSettings {
     const NAME: &'static str = "Windows.System.UserProfile.DiagnosticsSettings";
 }
-impl ::core::convert::From<DiagnosticsSettings> for ::windows::core::IUnknown {
-    fn from(value: DiagnosticsSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DiagnosticsSettings> for ::windows::core::IUnknown {
-    fn from(value: &DiagnosticsSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DiagnosticsSettings> for &::windows::core::IUnknown {
-    fn from(value: &DiagnosticsSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DiagnosticsSettings> for ::windows::core::IInspectable {
-    fn from(value: DiagnosticsSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DiagnosticsSettings> for ::windows::core::IInspectable {
-    fn from(value: &DiagnosticsSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DiagnosticsSettings> for &::windows::core::IInspectable {
-    fn from(value: &DiagnosticsSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DiagnosticsSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DiagnosticsSettings {}
 unsafe impl ::core::marker::Sync for DiagnosticsSettings {}
 #[doc = "*Required features: `\"System_UserProfile\"`*"]
@@ -833,36 +746,7 @@ impl ::core::iter::IntoIterator for &FirstSignInSettings {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<FirstSignInSettings> for ::windows::core::IUnknown {
-    fn from(value: FirstSignInSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FirstSignInSettings> for ::windows::core::IUnknown {
-    fn from(value: &FirstSignInSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FirstSignInSettings> for &::windows::core::IUnknown {
-    fn from(value: &FirstSignInSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FirstSignInSettings> for ::windows::core::IInspectable {
-    fn from(value: FirstSignInSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FirstSignInSettings> for ::windows::core::IInspectable {
-    fn from(value: &FirstSignInSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FirstSignInSettings> for &::windows::core::IInspectable {
-    fn from(value: &FirstSignInSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FirstSignInSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<FirstSignInSettings> for super::super::Foundation::Collections::IIterable<super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> {
     type Error = ::windows::core::Error;
@@ -1097,36 +981,7 @@ unsafe impl ::windows::core::Interface for GlobalizationPreferencesForUser {
 impl ::windows::core::RuntimeName for GlobalizationPreferencesForUser {
     const NAME: &'static str = "Windows.System.UserProfile.GlobalizationPreferencesForUser";
 }
-impl ::core::convert::From<GlobalizationPreferencesForUser> for ::windows::core::IUnknown {
-    fn from(value: GlobalizationPreferencesForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalizationPreferencesForUser> for ::windows::core::IUnknown {
-    fn from(value: &GlobalizationPreferencesForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalizationPreferencesForUser> for &::windows::core::IUnknown {
-    fn from(value: &GlobalizationPreferencesForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GlobalizationPreferencesForUser> for ::windows::core::IInspectable {
-    fn from(value: GlobalizationPreferencesForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GlobalizationPreferencesForUser> for ::windows::core::IInspectable {
-    fn from(value: &GlobalizationPreferencesForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GlobalizationPreferencesForUser> for &::windows::core::IInspectable {
-    fn from(value: &GlobalizationPreferencesForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GlobalizationPreferencesForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for GlobalizationPreferencesForUser {}
 unsafe impl ::core::marker::Sync for GlobalizationPreferencesForUser {}
 #[doc = "*Required features: `\"System_UserProfile\"`*"]
@@ -1429,36 +1284,7 @@ unsafe impl ::windows::core::Interface for UserProfilePersonalizationSettings {
 impl ::windows::core::RuntimeName for UserProfilePersonalizationSettings {
     const NAME: &'static str = "Windows.System.UserProfile.UserProfilePersonalizationSettings";
 }
-impl ::core::convert::From<UserProfilePersonalizationSettings> for ::windows::core::IUnknown {
-    fn from(value: UserProfilePersonalizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserProfilePersonalizationSettings> for ::windows::core::IUnknown {
-    fn from(value: &UserProfilePersonalizationSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserProfilePersonalizationSettings> for &::windows::core::IUnknown {
-    fn from(value: &UserProfilePersonalizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserProfilePersonalizationSettings> for ::windows::core::IInspectable {
-    fn from(value: UserProfilePersonalizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserProfilePersonalizationSettings> for ::windows::core::IInspectable {
-    fn from(value: &UserProfilePersonalizationSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserProfilePersonalizationSettings> for &::windows::core::IInspectable {
-    fn from(value: &UserProfilePersonalizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserProfilePersonalizationSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserProfilePersonalizationSettings {}
 unsafe impl ::core::marker::Sync for UserProfilePersonalizationSettings {}
 #[doc = "*Required features: `\"System_UserProfile\"`, `\"deprecated\"`*"]

--- a/crates/libs/windows/src/Windows/System/mod.rs
+++ b/crates/libs/windows/src/Windows/System/mod.rs
@@ -1198,36 +1198,7 @@ impl ILauncherViewOptions {
         unsafe { (::windows::core::Vtable::vtable(this).SetDesiredRemainingView)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<ILauncherViewOptions> for ::windows::core::IUnknown {
-    fn from(value: ILauncherViewOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILauncherViewOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILauncherViewOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILauncherViewOptions> for ::windows::core::IUnknown {
-    fn from(value: &ILauncherViewOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILauncherViewOptions> for ::windows::core::IInspectable {
-    fn from(value: ILauncherViewOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILauncherViewOptions> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ILauncherViewOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILauncherViewOptions> for ::windows::core::IInspectable {
-    fn from(value: &ILauncherViewOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILauncherViewOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ILauncherViewOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1955,36 +1926,7 @@ unsafe impl ::windows::core::Interface for AppActivationResult {
 impl ::windows::core::RuntimeName for AppActivationResult {
     const NAME: &'static str = "Windows.System.AppActivationResult";
 }
-impl ::core::convert::From<AppActivationResult> for ::windows::core::IUnknown {
-    fn from(value: AppActivationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppActivationResult> for ::windows::core::IUnknown {
-    fn from(value: &AppActivationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppActivationResult> for &::windows::core::IUnknown {
-    fn from(value: &AppActivationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppActivationResult> for ::windows::core::IInspectable {
-    fn from(value: AppActivationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppActivationResult> for ::windows::core::IInspectable {
-    fn from(value: &AppActivationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppActivationResult> for &::windows::core::IInspectable {
-    fn from(value: &AppActivationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppActivationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppActivationResult {}
 unsafe impl ::core::marker::Sync for AppActivationResult {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -2114,36 +2056,7 @@ unsafe impl ::windows::core::Interface for AppDiagnosticInfo {
 impl ::windows::core::RuntimeName for AppDiagnosticInfo {
     const NAME: &'static str = "Windows.System.AppDiagnosticInfo";
 }
-impl ::core::convert::From<AppDiagnosticInfo> for ::windows::core::IUnknown {
-    fn from(value: AppDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfo> for ::windows::core::IUnknown {
-    fn from(value: &AppDiagnosticInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfo> for &::windows::core::IUnknown {
-    fn from(value: &AppDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppDiagnosticInfo> for ::windows::core::IInspectable {
-    fn from(value: AppDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfo> for ::windows::core::IInspectable {
-    fn from(value: &AppDiagnosticInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfo> for &::windows::core::IInspectable {
-    fn from(value: &AppDiagnosticInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppDiagnosticInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppDiagnosticInfo {}
 unsafe impl ::core::marker::Sync for AppDiagnosticInfo {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -2258,36 +2171,7 @@ unsafe impl ::windows::core::Interface for AppDiagnosticInfoWatcher {
 impl ::windows::core::RuntimeName for AppDiagnosticInfoWatcher {
     const NAME: &'static str = "Windows.System.AppDiagnosticInfoWatcher";
 }
-impl ::core::convert::From<AppDiagnosticInfoWatcher> for ::windows::core::IUnknown {
-    fn from(value: AppDiagnosticInfoWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfoWatcher> for ::windows::core::IUnknown {
-    fn from(value: &AppDiagnosticInfoWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfoWatcher> for &::windows::core::IUnknown {
-    fn from(value: &AppDiagnosticInfoWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppDiagnosticInfoWatcher> for ::windows::core::IInspectable {
-    fn from(value: AppDiagnosticInfoWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfoWatcher> for ::windows::core::IInspectable {
-    fn from(value: &AppDiagnosticInfoWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfoWatcher> for &::windows::core::IInspectable {
-    fn from(value: &AppDiagnosticInfoWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppDiagnosticInfoWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppDiagnosticInfoWatcher {}
 unsafe impl ::core::marker::Sync for AppDiagnosticInfoWatcher {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -2334,36 +2218,7 @@ unsafe impl ::windows::core::Interface for AppDiagnosticInfoWatcherEventArgs {
 impl ::windows::core::RuntimeName for AppDiagnosticInfoWatcherEventArgs {
     const NAME: &'static str = "Windows.System.AppDiagnosticInfoWatcherEventArgs";
 }
-impl ::core::convert::From<AppDiagnosticInfoWatcherEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppDiagnosticInfoWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfoWatcherEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppDiagnosticInfoWatcherEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfoWatcherEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppDiagnosticInfoWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppDiagnosticInfoWatcherEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppDiagnosticInfoWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfoWatcherEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppDiagnosticInfoWatcherEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppDiagnosticInfoWatcherEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppDiagnosticInfoWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppDiagnosticInfoWatcherEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppDiagnosticInfoWatcherEventArgs {}
 unsafe impl ::core::marker::Sync for AppDiagnosticInfoWatcherEventArgs {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -2410,36 +2265,7 @@ unsafe impl ::windows::core::Interface for AppExecutionStateChangeResult {
 impl ::windows::core::RuntimeName for AppExecutionStateChangeResult {
     const NAME: &'static str = "Windows.System.AppExecutionStateChangeResult";
 }
-impl ::core::convert::From<AppExecutionStateChangeResult> for ::windows::core::IUnknown {
-    fn from(value: AppExecutionStateChangeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExecutionStateChangeResult> for ::windows::core::IUnknown {
-    fn from(value: &AppExecutionStateChangeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExecutionStateChangeResult> for &::windows::core::IUnknown {
-    fn from(value: &AppExecutionStateChangeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppExecutionStateChangeResult> for ::windows::core::IInspectable {
-    fn from(value: AppExecutionStateChangeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppExecutionStateChangeResult> for ::windows::core::IInspectable {
-    fn from(value: &AppExecutionStateChangeResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppExecutionStateChangeResult> for &::windows::core::IInspectable {
-    fn from(value: &AppExecutionStateChangeResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppExecutionStateChangeResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppExecutionStateChangeResult {}
 unsafe impl ::core::marker::Sync for AppExecutionStateChangeResult {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -2514,36 +2340,7 @@ unsafe impl ::windows::core::Interface for AppMemoryReport {
 impl ::windows::core::RuntimeName for AppMemoryReport {
     const NAME: &'static str = "Windows.System.AppMemoryReport";
 }
-impl ::core::convert::From<AppMemoryReport> for ::windows::core::IUnknown {
-    fn from(value: AppMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppMemoryReport> for ::windows::core::IUnknown {
-    fn from(value: &AppMemoryReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppMemoryReport> for &::windows::core::IUnknown {
-    fn from(value: &AppMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppMemoryReport> for ::windows::core::IInspectable {
-    fn from(value: AppMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppMemoryReport> for ::windows::core::IInspectable {
-    fn from(value: &AppMemoryReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppMemoryReport> for &::windows::core::IInspectable {
-    fn from(value: &AppMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppMemoryReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppMemoryReport {}
 unsafe impl ::core::marker::Sync for AppMemoryReport {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -2597,36 +2394,7 @@ unsafe impl ::windows::core::Interface for AppMemoryUsageLimitChangingEventArgs 
 impl ::windows::core::RuntimeName for AppMemoryUsageLimitChangingEventArgs {
     const NAME: &'static str = "Windows.System.AppMemoryUsageLimitChangingEventArgs";
 }
-impl ::core::convert::From<AppMemoryUsageLimitChangingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppMemoryUsageLimitChangingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppMemoryUsageLimitChangingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppMemoryUsageLimitChangingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppMemoryUsageLimitChangingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppMemoryUsageLimitChangingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppMemoryUsageLimitChangingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppMemoryUsageLimitChangingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppMemoryUsageLimitChangingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppMemoryUsageLimitChangingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppMemoryUsageLimitChangingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppMemoryUsageLimitChangingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppMemoryUsageLimitChangingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppMemoryUsageLimitChangingEventArgs {}
 unsafe impl ::core::marker::Sync for AppMemoryUsageLimitChangingEventArgs {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -2694,36 +2462,7 @@ unsafe impl ::windows::core::Interface for AppResourceGroupBackgroundTaskReport 
 impl ::windows::core::RuntimeName for AppResourceGroupBackgroundTaskReport {
     const NAME: &'static str = "Windows.System.AppResourceGroupBackgroundTaskReport";
 }
-impl ::core::convert::From<AppResourceGroupBackgroundTaskReport> for ::windows::core::IUnknown {
-    fn from(value: AppResourceGroupBackgroundTaskReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupBackgroundTaskReport> for ::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupBackgroundTaskReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupBackgroundTaskReport> for &::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupBackgroundTaskReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppResourceGroupBackgroundTaskReport> for ::windows::core::IInspectable {
-    fn from(value: AppResourceGroupBackgroundTaskReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupBackgroundTaskReport> for ::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupBackgroundTaskReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupBackgroundTaskReport> for &::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupBackgroundTaskReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppResourceGroupBackgroundTaskReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppResourceGroupBackgroundTaskReport {}
 unsafe impl ::core::marker::Sync for AppResourceGroupBackgroundTaskReport {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -2836,36 +2575,7 @@ unsafe impl ::windows::core::Interface for AppResourceGroupInfo {
 impl ::windows::core::RuntimeName for AppResourceGroupInfo {
     const NAME: &'static str = "Windows.System.AppResourceGroupInfo";
 }
-impl ::core::convert::From<AppResourceGroupInfo> for ::windows::core::IUnknown {
-    fn from(value: AppResourceGroupInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfo> for ::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfo> for &::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppResourceGroupInfo> for ::windows::core::IInspectable {
-    fn from(value: AppResourceGroupInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfo> for ::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfo> for &::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppResourceGroupInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppResourceGroupInfo {}
 unsafe impl ::core::marker::Sync for AppResourceGroupInfo {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -2995,36 +2705,7 @@ unsafe impl ::windows::core::Interface for AppResourceGroupInfoWatcher {
 impl ::windows::core::RuntimeName for AppResourceGroupInfoWatcher {
     const NAME: &'static str = "Windows.System.AppResourceGroupInfoWatcher";
 }
-impl ::core::convert::From<AppResourceGroupInfoWatcher> for ::windows::core::IUnknown {
-    fn from(value: AppResourceGroupInfoWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcher> for ::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupInfoWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcher> for &::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupInfoWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppResourceGroupInfoWatcher> for ::windows::core::IInspectable {
-    fn from(value: AppResourceGroupInfoWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcher> for ::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupInfoWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcher> for &::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupInfoWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppResourceGroupInfoWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppResourceGroupInfoWatcher {}
 unsafe impl ::core::marker::Sync for AppResourceGroupInfoWatcher {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -3080,36 +2761,7 @@ unsafe impl ::windows::core::Interface for AppResourceGroupInfoWatcherEventArgs 
 impl ::windows::core::RuntimeName for AppResourceGroupInfoWatcherEventArgs {
     const NAME: &'static str = "Windows.System.AppResourceGroupInfoWatcherEventArgs";
 }
-impl ::core::convert::From<AppResourceGroupInfoWatcherEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppResourceGroupInfoWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcherEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupInfoWatcherEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcherEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupInfoWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppResourceGroupInfoWatcherEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppResourceGroupInfoWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcherEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupInfoWatcherEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcherEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupInfoWatcherEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppResourceGroupInfoWatcherEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppResourceGroupInfoWatcherEventArgs {}
 unsafe impl ::core::marker::Sync for AppResourceGroupInfoWatcherEventArgs {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -3165,36 +2817,7 @@ unsafe impl ::windows::core::Interface for AppResourceGroupInfoWatcherExecutionS
 impl ::windows::core::RuntimeName for AppResourceGroupInfoWatcherExecutionStateChangedEventArgs {
     const NAME: &'static str = "Windows.System.AppResourceGroupInfoWatcherExecutionStateChangedEventArgs";
 }
-impl ::core::convert::From<AppResourceGroupInfoWatcherExecutionStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppResourceGroupInfoWatcherExecutionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcherExecutionStateChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupInfoWatcherExecutionStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcherExecutionStateChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupInfoWatcherExecutionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppResourceGroupInfoWatcherExecutionStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppResourceGroupInfoWatcherExecutionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcherExecutionStateChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupInfoWatcherExecutionStateChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupInfoWatcherExecutionStateChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupInfoWatcherExecutionStateChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppResourceGroupInfoWatcherExecutionStateChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppResourceGroupInfoWatcherExecutionStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppResourceGroupInfoWatcherExecutionStateChangedEventArgs {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -3262,36 +2885,7 @@ unsafe impl ::windows::core::Interface for AppResourceGroupMemoryReport {
 impl ::windows::core::RuntimeName for AppResourceGroupMemoryReport {
     const NAME: &'static str = "Windows.System.AppResourceGroupMemoryReport";
 }
-impl ::core::convert::From<AppResourceGroupMemoryReport> for ::windows::core::IUnknown {
-    fn from(value: AppResourceGroupMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupMemoryReport> for ::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupMemoryReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupMemoryReport> for &::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppResourceGroupMemoryReport> for ::windows::core::IInspectable {
-    fn from(value: AppResourceGroupMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupMemoryReport> for ::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupMemoryReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupMemoryReport> for &::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppResourceGroupMemoryReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppResourceGroupMemoryReport {}
 unsafe impl ::core::marker::Sync for AppResourceGroupMemoryReport {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -3345,36 +2939,7 @@ unsafe impl ::windows::core::Interface for AppResourceGroupStateReport {
 impl ::windows::core::RuntimeName for AppResourceGroupStateReport {
     const NAME: &'static str = "Windows.System.AppResourceGroupStateReport";
 }
-impl ::core::convert::From<AppResourceGroupStateReport> for ::windows::core::IUnknown {
-    fn from(value: AppResourceGroupStateReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupStateReport> for ::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupStateReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupStateReport> for &::windows::core::IUnknown {
-    fn from(value: &AppResourceGroupStateReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppResourceGroupStateReport> for ::windows::core::IInspectable {
-    fn from(value: AppResourceGroupStateReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppResourceGroupStateReport> for ::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupStateReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppResourceGroupStateReport> for &::windows::core::IInspectable {
-    fn from(value: &AppResourceGroupStateReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppResourceGroupStateReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppResourceGroupStateReport {}
 unsafe impl ::core::marker::Sync for AppResourceGroupStateReport {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -3454,36 +3019,7 @@ unsafe impl ::windows::core::Interface for AppUriHandlerHost {
 impl ::windows::core::RuntimeName for AppUriHandlerHost {
     const NAME: &'static str = "Windows.System.AppUriHandlerHost";
 }
-impl ::core::convert::From<AppUriHandlerHost> for ::windows::core::IUnknown {
-    fn from(value: AppUriHandlerHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppUriHandlerHost> for ::windows::core::IUnknown {
-    fn from(value: &AppUriHandlerHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppUriHandlerHost> for &::windows::core::IUnknown {
-    fn from(value: &AppUriHandlerHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppUriHandlerHost> for ::windows::core::IInspectable {
-    fn from(value: AppUriHandlerHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppUriHandlerHost> for ::windows::core::IInspectable {
-    fn from(value: &AppUriHandlerHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppUriHandlerHost> for &::windows::core::IInspectable {
-    fn from(value: &AppUriHandlerHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppUriHandlerHost, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppUriHandlerHost {}
 unsafe impl ::core::marker::Sync for AppUriHandlerHost {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -3585,36 +3121,7 @@ unsafe impl ::windows::core::Interface for AppUriHandlerRegistration {
 impl ::windows::core::RuntimeName for AppUriHandlerRegistration {
     const NAME: &'static str = "Windows.System.AppUriHandlerRegistration";
 }
-impl ::core::convert::From<AppUriHandlerRegistration> for ::windows::core::IUnknown {
-    fn from(value: AppUriHandlerRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppUriHandlerRegistration> for ::windows::core::IUnknown {
-    fn from(value: &AppUriHandlerRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppUriHandlerRegistration> for &::windows::core::IUnknown {
-    fn from(value: &AppUriHandlerRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppUriHandlerRegistration> for ::windows::core::IInspectable {
-    fn from(value: AppUriHandlerRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppUriHandlerRegistration> for ::windows::core::IInspectable {
-    fn from(value: &AppUriHandlerRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppUriHandlerRegistration> for &::windows::core::IInspectable {
-    fn from(value: &AppUriHandlerRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppUriHandlerRegistration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppUriHandlerRegistration {}
 unsafe impl ::core::marker::Sync for AppUriHandlerRegistration {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -3709,36 +3216,7 @@ unsafe impl ::windows::core::Interface for AppUriHandlerRegistrationManager {
 impl ::windows::core::RuntimeName for AppUriHandlerRegistrationManager {
     const NAME: &'static str = "Windows.System.AppUriHandlerRegistrationManager";
 }
-impl ::core::convert::From<AppUriHandlerRegistrationManager> for ::windows::core::IUnknown {
-    fn from(value: AppUriHandlerRegistrationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppUriHandlerRegistrationManager> for ::windows::core::IUnknown {
-    fn from(value: &AppUriHandlerRegistrationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppUriHandlerRegistrationManager> for &::windows::core::IUnknown {
-    fn from(value: &AppUriHandlerRegistrationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppUriHandlerRegistrationManager> for ::windows::core::IInspectable {
-    fn from(value: AppUriHandlerRegistrationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppUriHandlerRegistrationManager> for ::windows::core::IInspectable {
-    fn from(value: &AppUriHandlerRegistrationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppUriHandlerRegistrationManager> for &::windows::core::IInspectable {
-    fn from(value: &AppUriHandlerRegistrationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppUriHandlerRegistrationManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppUriHandlerRegistrationManager {}
 unsafe impl ::core::marker::Sync for AppUriHandlerRegistrationManager {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -3864,36 +3342,7 @@ unsafe impl ::windows::core::Interface for DispatcherQueue {
 impl ::windows::core::RuntimeName for DispatcherQueue {
     const NAME: &'static str = "Windows.System.DispatcherQueue";
 }
-impl ::core::convert::From<DispatcherQueue> for ::windows::core::IUnknown {
-    fn from(value: DispatcherQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DispatcherQueue> for ::windows::core::IUnknown {
-    fn from(value: &DispatcherQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DispatcherQueue> for &::windows::core::IUnknown {
-    fn from(value: &DispatcherQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DispatcherQueue> for ::windows::core::IInspectable {
-    fn from(value: DispatcherQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DispatcherQueue> for ::windows::core::IInspectable {
-    fn from(value: &DispatcherQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DispatcherQueue> for &::windows::core::IInspectable {
-    fn from(value: &DispatcherQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DispatcherQueue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DispatcherQueue {}
 unsafe impl ::core::marker::Sync for DispatcherQueue {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -3960,36 +3409,7 @@ unsafe impl ::windows::core::Interface for DispatcherQueueController {
 impl ::windows::core::RuntimeName for DispatcherQueueController {
     const NAME: &'static str = "Windows.System.DispatcherQueueController";
 }
-impl ::core::convert::From<DispatcherQueueController> for ::windows::core::IUnknown {
-    fn from(value: DispatcherQueueController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DispatcherQueueController> for ::windows::core::IUnknown {
-    fn from(value: &DispatcherQueueController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DispatcherQueueController> for &::windows::core::IUnknown {
-    fn from(value: &DispatcherQueueController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DispatcherQueueController> for ::windows::core::IInspectable {
-    fn from(value: DispatcherQueueController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DispatcherQueueController> for ::windows::core::IInspectable {
-    fn from(value: &DispatcherQueueController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DispatcherQueueController> for &::windows::core::IInspectable {
-    fn from(value: &DispatcherQueueController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DispatcherQueueController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DispatcherQueueController {}
 unsafe impl ::core::marker::Sync for DispatcherQueueController {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -4038,36 +3458,7 @@ unsafe impl ::windows::core::Interface for DispatcherQueueShutdownStartingEventA
 impl ::windows::core::RuntimeName for DispatcherQueueShutdownStartingEventArgs {
     const NAME: &'static str = "Windows.System.DispatcherQueueShutdownStartingEventArgs";
 }
-impl ::core::convert::From<DispatcherQueueShutdownStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DispatcherQueueShutdownStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DispatcherQueueShutdownStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DispatcherQueueShutdownStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DispatcherQueueShutdownStartingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DispatcherQueueShutdownStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DispatcherQueueShutdownStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DispatcherQueueShutdownStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DispatcherQueueShutdownStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DispatcherQueueShutdownStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DispatcherQueueShutdownStartingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DispatcherQueueShutdownStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DispatcherQueueShutdownStartingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DispatcherQueueShutdownStartingEventArgs {}
 unsafe impl ::core::marker::Sync for DispatcherQueueShutdownStartingEventArgs {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -4163,36 +3554,7 @@ unsafe impl ::windows::core::Interface for DispatcherQueueTimer {
 impl ::windows::core::RuntimeName for DispatcherQueueTimer {
     const NAME: &'static str = "Windows.System.DispatcherQueueTimer";
 }
-impl ::core::convert::From<DispatcherQueueTimer> for ::windows::core::IUnknown {
-    fn from(value: DispatcherQueueTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DispatcherQueueTimer> for ::windows::core::IUnknown {
-    fn from(value: &DispatcherQueueTimer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DispatcherQueueTimer> for &::windows::core::IUnknown {
-    fn from(value: &DispatcherQueueTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DispatcherQueueTimer> for ::windows::core::IInspectable {
-    fn from(value: DispatcherQueueTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DispatcherQueueTimer> for ::windows::core::IInspectable {
-    fn from(value: &DispatcherQueueTimer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DispatcherQueueTimer> for &::windows::core::IInspectable {
-    fn from(value: &DispatcherQueueTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DispatcherQueueTimer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DispatcherQueueTimer {}
 unsafe impl ::core::marker::Sync for DispatcherQueueTimer {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -4263,36 +3625,7 @@ unsafe impl ::windows::core::Interface for FolderLauncherOptions {
 impl ::windows::core::RuntimeName for FolderLauncherOptions {
     const NAME: &'static str = "Windows.System.FolderLauncherOptions";
 }
-impl ::core::convert::From<FolderLauncherOptions> for ::windows::core::IUnknown {
-    fn from(value: FolderLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FolderLauncherOptions> for ::windows::core::IUnknown {
-    fn from(value: &FolderLauncherOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FolderLauncherOptions> for &::windows::core::IUnknown {
-    fn from(value: &FolderLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FolderLauncherOptions> for ::windows::core::IInspectable {
-    fn from(value: FolderLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FolderLauncherOptions> for ::windows::core::IInspectable {
-    fn from(value: &FolderLauncherOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FolderLauncherOptions> for &::windows::core::IInspectable {
-    fn from(value: &FolderLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FolderLauncherOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<FolderLauncherOptions> for ILauncherViewOptions {
     type Error = ::windows::core::Error;
     fn try_from(value: FolderLauncherOptions) -> ::windows::core::Result<Self> {
@@ -4444,36 +3777,7 @@ unsafe impl ::windows::core::Interface for LaunchUriResult {
 impl ::windows::core::RuntimeName for LaunchUriResult {
     const NAME: &'static str = "Windows.System.LaunchUriResult";
 }
-impl ::core::convert::From<LaunchUriResult> for ::windows::core::IUnknown {
-    fn from(value: LaunchUriResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LaunchUriResult> for ::windows::core::IUnknown {
-    fn from(value: &LaunchUriResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LaunchUriResult> for &::windows::core::IUnknown {
-    fn from(value: &LaunchUriResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LaunchUriResult> for ::windows::core::IInspectable {
-    fn from(value: LaunchUriResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LaunchUriResult> for ::windows::core::IInspectable {
-    fn from(value: &LaunchUriResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LaunchUriResult> for &::windows::core::IInspectable {
-    fn from(value: &LaunchUriResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LaunchUriResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LaunchUriResult {}
 unsafe impl ::core::marker::Sync for LaunchUriResult {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -4932,36 +4236,7 @@ unsafe impl ::windows::core::Interface for LauncherOptions {
 impl ::windows::core::RuntimeName for LauncherOptions {
     const NAME: &'static str = "Windows.System.LauncherOptions";
 }
-impl ::core::convert::From<LauncherOptions> for ::windows::core::IUnknown {
-    fn from(value: LauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LauncherOptions> for ::windows::core::IUnknown {
-    fn from(value: &LauncherOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LauncherOptions> for &::windows::core::IUnknown {
-    fn from(value: &LauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LauncherOptions> for ::windows::core::IInspectable {
-    fn from(value: LauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LauncherOptions> for ::windows::core::IInspectable {
-    fn from(value: &LauncherOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LauncherOptions> for &::windows::core::IInspectable {
-    fn from(value: &LauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LauncherOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LauncherOptions> for ILauncherViewOptions {
     type Error = ::windows::core::Error;
     fn try_from(value: LauncherOptions) -> ::windows::core::Result<Self> {
@@ -5073,36 +4348,7 @@ unsafe impl ::windows::core::Interface for LauncherUIOptions {
 impl ::windows::core::RuntimeName for LauncherUIOptions {
     const NAME: &'static str = "Windows.System.LauncherUIOptions";
 }
-impl ::core::convert::From<LauncherUIOptions> for ::windows::core::IUnknown {
-    fn from(value: LauncherUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LauncherUIOptions> for ::windows::core::IUnknown {
-    fn from(value: &LauncherUIOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LauncherUIOptions> for &::windows::core::IUnknown {
-    fn from(value: &LauncherUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LauncherUIOptions> for ::windows::core::IInspectable {
-    fn from(value: LauncherUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LauncherUIOptions> for ::windows::core::IInspectable {
-    fn from(value: &LauncherUIOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LauncherUIOptions> for &::windows::core::IInspectable {
-    fn from(value: &LauncherUIOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LauncherUIOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for LauncherUIOptions {}
 unsafe impl ::core::marker::Sync for LauncherUIOptions {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -5353,36 +4599,7 @@ unsafe impl ::windows::core::Interface for ProcessLauncherOptions {
 impl ::windows::core::RuntimeName for ProcessLauncherOptions {
     const NAME: &'static str = "Windows.System.ProcessLauncherOptions";
 }
-impl ::core::convert::From<ProcessLauncherOptions> for ::windows::core::IUnknown {
-    fn from(value: ProcessLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessLauncherOptions> for ::windows::core::IUnknown {
-    fn from(value: &ProcessLauncherOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessLauncherOptions> for &::windows::core::IUnknown {
-    fn from(value: &ProcessLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessLauncherOptions> for ::windows::core::IInspectable {
-    fn from(value: ProcessLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessLauncherOptions> for ::windows::core::IInspectable {
-    fn from(value: &ProcessLauncherOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessLauncherOptions> for &::windows::core::IInspectable {
-    fn from(value: &ProcessLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessLauncherOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessLauncherOptions {}
 unsafe impl ::core::marker::Sync for ProcessLauncherOptions {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -5429,36 +4646,7 @@ unsafe impl ::windows::core::Interface for ProcessLauncherResult {
 impl ::windows::core::RuntimeName for ProcessLauncherResult {
     const NAME: &'static str = "Windows.System.ProcessLauncherResult";
 }
-impl ::core::convert::From<ProcessLauncherResult> for ::windows::core::IUnknown {
-    fn from(value: ProcessLauncherResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessLauncherResult> for ::windows::core::IUnknown {
-    fn from(value: &ProcessLauncherResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessLauncherResult> for &::windows::core::IUnknown {
-    fn from(value: &ProcessLauncherResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessLauncherResult> for ::windows::core::IInspectable {
-    fn from(value: ProcessLauncherResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessLauncherResult> for ::windows::core::IInspectable {
-    fn from(value: &ProcessLauncherResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessLauncherResult> for &::windows::core::IInspectable {
-    fn from(value: &ProcessLauncherResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessLauncherResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessLauncherResult {}
 unsafe impl ::core::marker::Sync for ProcessLauncherResult {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -5512,36 +4700,7 @@ unsafe impl ::windows::core::Interface for ProcessMemoryReport {
 impl ::windows::core::RuntimeName for ProcessMemoryReport {
     const NAME: &'static str = "Windows.System.ProcessMemoryReport";
 }
-impl ::core::convert::From<ProcessMemoryReport> for ::windows::core::IUnknown {
-    fn from(value: ProcessMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessMemoryReport> for ::windows::core::IUnknown {
-    fn from(value: &ProcessMemoryReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessMemoryReport> for &::windows::core::IUnknown {
-    fn from(value: &ProcessMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProcessMemoryReport> for ::windows::core::IInspectable {
-    fn from(value: ProcessMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProcessMemoryReport> for ::windows::core::IInspectable {
-    fn from(value: &ProcessMemoryReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProcessMemoryReport> for &::windows::core::IInspectable {
-    fn from(value: &ProcessMemoryReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProcessMemoryReport, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProcessMemoryReport {}
 unsafe impl ::core::marker::Sync for ProcessMemoryReport {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -5587,36 +4746,7 @@ unsafe impl ::windows::core::Interface for ProtocolForResultsOperation {
 impl ::windows::core::RuntimeName for ProtocolForResultsOperation {
     const NAME: &'static str = "Windows.System.ProtocolForResultsOperation";
 }
-impl ::core::convert::From<ProtocolForResultsOperation> for ::windows::core::IUnknown {
-    fn from(value: ProtocolForResultsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtocolForResultsOperation> for ::windows::core::IUnknown {
-    fn from(value: &ProtocolForResultsOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtocolForResultsOperation> for &::windows::core::IUnknown {
-    fn from(value: &ProtocolForResultsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ProtocolForResultsOperation> for ::windows::core::IInspectable {
-    fn from(value: ProtocolForResultsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ProtocolForResultsOperation> for ::windows::core::IInspectable {
-    fn from(value: &ProtocolForResultsOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ProtocolForResultsOperation> for &::windows::core::IInspectable {
-    fn from(value: &ProtocolForResultsOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ProtocolForResultsOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ProtocolForResultsOperation {}
 unsafe impl ::core::marker::Sync for ProtocolForResultsOperation {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -5723,36 +4853,7 @@ unsafe impl ::windows::core::Interface for RemoteLauncherOptions {
 impl ::windows::core::RuntimeName for RemoteLauncherOptions {
     const NAME: &'static str = "Windows.System.RemoteLauncherOptions";
 }
-impl ::core::convert::From<RemoteLauncherOptions> for ::windows::core::IUnknown {
-    fn from(value: RemoteLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteLauncherOptions> for ::windows::core::IUnknown {
-    fn from(value: &RemoteLauncherOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteLauncherOptions> for &::windows::core::IUnknown {
-    fn from(value: &RemoteLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteLauncherOptions> for ::windows::core::IInspectable {
-    fn from(value: RemoteLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteLauncherOptions> for ::windows::core::IInspectable {
-    fn from(value: &RemoteLauncherOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteLauncherOptions> for &::windows::core::IInspectable {
-    fn from(value: &RemoteLauncherOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteLauncherOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteLauncherOptions {}
 unsafe impl ::core::marker::Sync for RemoteLauncherOptions {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -5992,36 +5093,7 @@ unsafe impl ::windows::core::Interface for User {
 impl ::windows::core::RuntimeName for User {
     const NAME: &'static str = "Windows.System.User";
 }
-impl ::core::convert::From<User> for ::windows::core::IUnknown {
-    fn from(value: User) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&User> for ::windows::core::IUnknown {
-    fn from(value: &User) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&User> for &::windows::core::IUnknown {
-    fn from(value: &User) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<User> for ::windows::core::IInspectable {
-    fn from(value: User) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&User> for ::windows::core::IInspectable {
-    fn from(value: &User) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&User> for &::windows::core::IInspectable {
-    fn from(value: &User) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(User, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for User {}
 unsafe impl ::core::marker::Sync for User {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -6065,36 +5137,7 @@ unsafe impl ::windows::core::Interface for UserAuthenticationStatusChangeDeferra
 impl ::windows::core::RuntimeName for UserAuthenticationStatusChangeDeferral {
     const NAME: &'static str = "Windows.System.UserAuthenticationStatusChangeDeferral";
 }
-impl ::core::convert::From<UserAuthenticationStatusChangeDeferral> for ::windows::core::IUnknown {
-    fn from(value: UserAuthenticationStatusChangeDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserAuthenticationStatusChangeDeferral> for ::windows::core::IUnknown {
-    fn from(value: &UserAuthenticationStatusChangeDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserAuthenticationStatusChangeDeferral> for &::windows::core::IUnknown {
-    fn from(value: &UserAuthenticationStatusChangeDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserAuthenticationStatusChangeDeferral> for ::windows::core::IInspectable {
-    fn from(value: UserAuthenticationStatusChangeDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserAuthenticationStatusChangeDeferral> for ::windows::core::IInspectable {
-    fn from(value: &UserAuthenticationStatusChangeDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserAuthenticationStatusChangeDeferral> for &::windows::core::IInspectable {
-    fn from(value: &UserAuthenticationStatusChangeDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserAuthenticationStatusChangeDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserAuthenticationStatusChangeDeferral {}
 unsafe impl ::core::marker::Sync for UserAuthenticationStatusChangeDeferral {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -6162,36 +5205,7 @@ unsafe impl ::windows::core::Interface for UserAuthenticationStatusChangingEvent
 impl ::windows::core::RuntimeName for UserAuthenticationStatusChangingEventArgs {
     const NAME: &'static str = "Windows.System.UserAuthenticationStatusChangingEventArgs";
 }
-impl ::core::convert::From<UserAuthenticationStatusChangingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserAuthenticationStatusChangingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserAuthenticationStatusChangingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserAuthenticationStatusChangingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserAuthenticationStatusChangingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserAuthenticationStatusChangingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserAuthenticationStatusChangingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserAuthenticationStatusChangingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserAuthenticationStatusChangingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserAuthenticationStatusChangingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserAuthenticationStatusChangingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserAuthenticationStatusChangingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserAuthenticationStatusChangingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserAuthenticationStatusChangingEventArgs {}
 unsafe impl ::core::marker::Sync for UserAuthenticationStatusChangingEventArgs {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -6247,36 +5261,7 @@ unsafe impl ::windows::core::Interface for UserChangedEventArgs {
 impl ::windows::core::RuntimeName for UserChangedEventArgs {
     const NAME: &'static str = "Windows.System.UserChangedEventArgs";
 }
-impl ::core::convert::From<UserChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserChangedEventArgs {}
 unsafe impl ::core::marker::Sync for UserChangedEventArgs {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -6368,36 +5353,7 @@ unsafe impl ::windows::core::Interface for UserDeviceAssociationChangedEventArgs
 impl ::windows::core::RuntimeName for UserDeviceAssociationChangedEventArgs {
     const NAME: &'static str = "Windows.System.UserDeviceAssociationChangedEventArgs";
 }
-impl ::core::convert::From<UserDeviceAssociationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserDeviceAssociationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDeviceAssociationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserDeviceAssociationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDeviceAssociationChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserDeviceAssociationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserDeviceAssociationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserDeviceAssociationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserDeviceAssociationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserDeviceAssociationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserDeviceAssociationChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserDeviceAssociationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserDeviceAssociationChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserDeviceAssociationChangedEventArgs {}
 unsafe impl ::core::marker::Sync for UserDeviceAssociationChangedEventArgs {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -6486,36 +5442,7 @@ unsafe impl ::windows::core::Interface for UserPicker {
 impl ::windows::core::RuntimeName for UserPicker {
     const NAME: &'static str = "Windows.System.UserPicker";
 }
-impl ::core::convert::From<UserPicker> for ::windows::core::IUnknown {
-    fn from(value: UserPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserPicker> for ::windows::core::IUnknown {
-    fn from(value: &UserPicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserPicker> for &::windows::core::IUnknown {
-    fn from(value: &UserPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserPicker> for ::windows::core::IInspectable {
-    fn from(value: UserPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserPicker> for ::windows::core::IInspectable {
-    fn from(value: &UserPicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserPicker> for &::windows::core::IInspectable {
-    fn from(value: &UserPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserPicker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserPicker {}
 unsafe impl ::core::marker::Sync for UserPicker {}
 #[doc = "*Required features: `\"System\"`*"]
@@ -6675,36 +5602,7 @@ unsafe impl ::windows::core::Interface for UserWatcher {
 impl ::windows::core::RuntimeName for UserWatcher {
     const NAME: &'static str = "Windows.System.UserWatcher";
 }
-impl ::core::convert::From<UserWatcher> for ::windows::core::IUnknown {
-    fn from(value: UserWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserWatcher> for ::windows::core::IUnknown {
-    fn from(value: &UserWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserWatcher> for &::windows::core::IUnknown {
-    fn from(value: &UserWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserWatcher> for ::windows::core::IInspectable {
-    fn from(value: UserWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserWatcher> for ::windows::core::IInspectable {
-    fn from(value: &UserWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserWatcher> for &::windows::core::IInspectable {
-    fn from(value: &UserWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserWatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserWatcher {}
 unsafe impl ::core::marker::Sync for UserWatcher {}
 #[doc = "*Required features: `\"System\"`*"]

--- a/crates/libs/windows/src/Windows/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Accessibility/mod.rs
@@ -93,36 +93,7 @@ unsafe impl ::windows::core::Interface for ScreenReaderPositionChangedEventArgs 
 impl ::windows::core::RuntimeName for ScreenReaderPositionChangedEventArgs {
     const NAME: &'static str = "Windows.UI.Accessibility.ScreenReaderPositionChangedEventArgs";
 }
-impl ::core::convert::From<ScreenReaderPositionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ScreenReaderPositionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScreenReaderPositionChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ScreenReaderPositionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScreenReaderPositionChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ScreenReaderPositionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ScreenReaderPositionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ScreenReaderPositionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScreenReaderPositionChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ScreenReaderPositionChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScreenReaderPositionChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ScreenReaderPositionChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ScreenReaderPositionChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ScreenReaderPositionChangedEventArgs {}
 unsafe impl ::core::marker::Sync for ScreenReaderPositionChangedEventArgs {}
 #[doc = "*Required features: `\"UI_Accessibility\"`*"]
@@ -191,36 +162,7 @@ unsafe impl ::windows::core::Interface for ScreenReaderService {
 impl ::windows::core::RuntimeName for ScreenReaderService {
     const NAME: &'static str = "Windows.UI.Accessibility.ScreenReaderService";
 }
-impl ::core::convert::From<ScreenReaderService> for ::windows::core::IUnknown {
-    fn from(value: ScreenReaderService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScreenReaderService> for ::windows::core::IUnknown {
-    fn from(value: &ScreenReaderService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScreenReaderService> for &::windows::core::IUnknown {
-    fn from(value: &ScreenReaderService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ScreenReaderService> for ::windows::core::IInspectable {
-    fn from(value: ScreenReaderService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScreenReaderService> for ::windows::core::IInspectable {
-    fn from(value: &ScreenReaderService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScreenReaderService> for &::windows::core::IInspectable {
-    fn from(value: &ScreenReaderService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ScreenReaderService, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ScreenReaderService {}
 unsafe impl ::core::marker::Sync for ScreenReaderService {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
@@ -521,36 +521,7 @@ unsafe impl ::windows::core::Interface for AccountsSettingsPane {
 impl ::windows::core::RuntimeName for AccountsSettingsPane {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.AccountsSettingsPane";
 }
-impl ::core::convert::From<AccountsSettingsPane> for ::windows::core::IUnknown {
-    fn from(value: AccountsSettingsPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPane> for ::windows::core::IUnknown {
-    fn from(value: &AccountsSettingsPane) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPane> for &::windows::core::IUnknown {
-    fn from(value: &AccountsSettingsPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AccountsSettingsPane> for ::windows::core::IInspectable {
-    fn from(value: AccountsSettingsPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPane> for ::windows::core::IInspectable {
-    fn from(value: &AccountsSettingsPane) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPane> for &::windows::core::IInspectable {
-    fn from(value: &AccountsSettingsPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AccountsSettingsPane, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`*"]
 #[repr(transparent)]
 pub struct AccountsSettingsPaneCommandsRequestedEventArgs(::windows::core::IUnknown);
@@ -651,36 +622,7 @@ unsafe impl ::windows::core::Interface for AccountsSettingsPaneCommandsRequested
 impl ::windows::core::RuntimeName for AccountsSettingsPaneCommandsRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.AccountsSettingsPaneCommandsRequestedEventArgs";
 }
-impl ::core::convert::From<AccountsSettingsPaneCommandsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AccountsSettingsPaneCommandsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPaneCommandsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AccountsSettingsPaneCommandsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPaneCommandsRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AccountsSettingsPaneCommandsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AccountsSettingsPaneCommandsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AccountsSettingsPaneCommandsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPaneCommandsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AccountsSettingsPaneCommandsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPaneCommandsRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AccountsSettingsPaneCommandsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AccountsSettingsPaneCommandsRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`*"]
 #[repr(transparent)]
 pub struct AccountsSettingsPaneEventDeferral(::windows::core::IUnknown);
@@ -722,36 +664,7 @@ unsafe impl ::windows::core::Interface for AccountsSettingsPaneEventDeferral {
 impl ::windows::core::RuntimeName for AccountsSettingsPaneEventDeferral {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.AccountsSettingsPaneEventDeferral";
 }
-impl ::core::convert::From<AccountsSettingsPaneEventDeferral> for ::windows::core::IUnknown {
-    fn from(value: AccountsSettingsPaneEventDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPaneEventDeferral> for ::windows::core::IUnknown {
-    fn from(value: &AccountsSettingsPaneEventDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPaneEventDeferral> for &::windows::core::IUnknown {
-    fn from(value: &AccountsSettingsPaneEventDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AccountsSettingsPaneEventDeferral> for ::windows::core::IInspectable {
-    fn from(value: AccountsSettingsPaneEventDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPaneEventDeferral> for ::windows::core::IInspectable {
-    fn from(value: &AccountsSettingsPaneEventDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccountsSettingsPaneEventDeferral> for &::windows::core::IInspectable {
-    fn from(value: &AccountsSettingsPaneEventDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AccountsSettingsPaneEventDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`*"]
 #[repr(transparent)]
 pub struct CredentialCommand(::windows::core::IUnknown);
@@ -826,36 +739,7 @@ unsafe impl ::windows::core::Interface for CredentialCommand {
 impl ::windows::core::RuntimeName for CredentialCommand {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.CredentialCommand";
 }
-impl ::core::convert::From<CredentialCommand> for ::windows::core::IUnknown {
-    fn from(value: CredentialCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CredentialCommand> for ::windows::core::IUnknown {
-    fn from(value: &CredentialCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CredentialCommand> for &::windows::core::IUnknown {
-    fn from(value: &CredentialCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CredentialCommand> for ::windows::core::IInspectable {
-    fn from(value: CredentialCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CredentialCommand> for ::windows::core::IInspectable {
-    fn from(value: &CredentialCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CredentialCommand> for &::windows::core::IInspectable {
-    fn from(value: &CredentialCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CredentialCommand, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`, `\"UI_Popups\"`*"]
 #[cfg(feature = "UI_Popups")]
 #[repr(transparent)]
@@ -981,41 +865,7 @@ impl ::windows::core::RuntimeName for SettingsCommand {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.SettingsCommand";
 }
 #[cfg(feature = "UI_Popups")]
-impl ::core::convert::From<SettingsCommand> for ::windows::core::IUnknown {
-    fn from(value: SettingsCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "UI_Popups")]
-impl ::core::convert::From<&SettingsCommand> for ::windows::core::IUnknown {
-    fn from(value: &SettingsCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "UI_Popups")]
-impl ::core::convert::From<&SettingsCommand> for &::windows::core::IUnknown {
-    fn from(value: &SettingsCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "UI_Popups")]
-impl ::core::convert::From<SettingsCommand> for ::windows::core::IInspectable {
-    fn from(value: SettingsCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "UI_Popups")]
-impl ::core::convert::From<&SettingsCommand> for ::windows::core::IInspectable {
-    fn from(value: &SettingsCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "UI_Popups")]
-impl ::core::convert::From<&SettingsCommand> for &::windows::core::IInspectable {
-    fn from(value: &SettingsCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SettingsCommand, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "UI_Popups")]
 impl ::core::convert::TryFrom<SettingsCommand> for super::Popups::IUICommand {
     type Error = ::windows::core::Error;
@@ -1128,41 +978,7 @@ impl ::windows::core::RuntimeName for SettingsPane {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.SettingsPane";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SettingsPane> for ::windows::core::IUnknown {
-    fn from(value: SettingsPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPane> for ::windows::core::IUnknown {
-    fn from(value: &SettingsPane) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPane> for &::windows::core::IUnknown {
-    fn from(value: &SettingsPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SettingsPane> for ::windows::core::IInspectable {
-    fn from(value: SettingsPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPane> for ::windows::core::IInspectable {
-    fn from(value: &SettingsPane) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPane> for &::windows::core::IInspectable {
-    fn from(value: &SettingsPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SettingsPane, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -1220,41 +1036,7 @@ impl ::windows::core::RuntimeName for SettingsPaneCommandsRequest {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.SettingsPaneCommandsRequest";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SettingsPaneCommandsRequest> for ::windows::core::IUnknown {
-    fn from(value: SettingsPaneCommandsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPaneCommandsRequest> for ::windows::core::IUnknown {
-    fn from(value: &SettingsPaneCommandsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPaneCommandsRequest> for &::windows::core::IUnknown {
-    fn from(value: &SettingsPaneCommandsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SettingsPaneCommandsRequest> for ::windows::core::IInspectable {
-    fn from(value: SettingsPaneCommandsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPaneCommandsRequest> for ::windows::core::IInspectable {
-    fn from(value: &SettingsPaneCommandsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPaneCommandsRequest> for &::windows::core::IInspectable {
-    fn from(value: &SettingsPaneCommandsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SettingsPaneCommandsRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
@@ -1312,41 +1094,7 @@ impl ::windows::core::RuntimeName for SettingsPaneCommandsRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.SettingsPaneCommandsRequestedEventArgs";
 }
 #[cfg(feature = "deprecated")]
-impl ::core::convert::From<SettingsPaneCommandsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SettingsPaneCommandsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPaneCommandsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SettingsPaneCommandsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPaneCommandsRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SettingsPaneCommandsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<SettingsPaneCommandsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SettingsPaneCommandsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPaneCommandsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SettingsPaneCommandsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::convert::From<&SettingsPaneCommandsRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SettingsPaneCommandsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SettingsPaneCommandsRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`*"]
 #[repr(transparent)]
 pub struct WebAccountCommand(::windows::core::IUnknown);
@@ -1420,36 +1168,7 @@ unsafe impl ::windows::core::Interface for WebAccountCommand {
 impl ::windows::core::RuntimeName for WebAccountCommand {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.WebAccountCommand";
 }
-impl ::core::convert::From<WebAccountCommand> for ::windows::core::IUnknown {
-    fn from(value: WebAccountCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountCommand> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountCommand> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountCommand> for ::windows::core::IInspectable {
-    fn from(value: WebAccountCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountCommand> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountCommand> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountCommand, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`*"]
 #[repr(transparent)]
 pub struct WebAccountInvokedArgs(::windows::core::IUnknown);
@@ -1494,36 +1213,7 @@ unsafe impl ::windows::core::Interface for WebAccountInvokedArgs {
 impl ::windows::core::RuntimeName for WebAccountInvokedArgs {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.WebAccountInvokedArgs";
 }
-impl ::core::convert::From<WebAccountInvokedArgs> for ::windows::core::IUnknown {
-    fn from(value: WebAccountInvokedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountInvokedArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountInvokedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountInvokedArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountInvokedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountInvokedArgs> for ::windows::core::IInspectable {
-    fn from(value: WebAccountInvokedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountInvokedArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountInvokedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountInvokedArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountInvokedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountInvokedArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`*"]
 #[repr(transparent)]
 pub struct WebAccountProviderCommand(::windows::core::IUnknown);
@@ -1590,36 +1280,7 @@ unsafe impl ::windows::core::Interface for WebAccountProviderCommand {
 impl ::windows::core::RuntimeName for WebAccountProviderCommand {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.WebAccountProviderCommand";
 }
-impl ::core::convert::From<WebAccountProviderCommand> for ::windows::core::IUnknown {
-    fn from(value: WebAccountProviderCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderCommand> for ::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderCommand> for &::windows::core::IUnknown {
-    fn from(value: &WebAccountProviderCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebAccountProviderCommand> for ::windows::core::IInspectable {
-    fn from(value: WebAccountProviderCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebAccountProviderCommand> for ::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebAccountProviderCommand> for &::windows::core::IInspectable {
-    fn from(value: &WebAccountProviderCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebAccountProviderCommand, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`, `\"deprecated\"`*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/UI/Composition/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Core/mod.rs
@@ -111,36 +111,7 @@ unsafe impl ::windows::core::Interface for CompositorController {
 impl ::windows::core::RuntimeName for CompositorController {
     const NAME: &'static str = "Windows.UI.Composition.Core.CompositorController";
 }
-impl ::core::convert::From<CompositorController> for ::windows::core::IUnknown {
-    fn from(value: CompositorController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositorController> for ::windows::core::IUnknown {
-    fn from(value: &CompositorController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositorController> for &::windows::core::IUnknown {
-    fn from(value: &CompositorController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositorController> for ::windows::core::IInspectable {
-    fn from(value: CompositorController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositorController> for ::windows::core::IInspectable {
-    fn from(value: &CompositorController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositorController> for &::windows::core::IInspectable {
-    fn from(value: &CompositorController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositorController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<CompositorController> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/UI/Composition/Desktop/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Desktop/mod.rs
@@ -169,36 +169,7 @@ unsafe impl ::windows::core::Interface for DesktopWindowTarget {
 impl ::windows::core::RuntimeName for DesktopWindowTarget {
     const NAME: &'static str = "Windows.UI.Composition.Desktop.DesktopWindowTarget";
 }
-impl ::core::convert::From<DesktopWindowTarget> for ::windows::core::IUnknown {
-    fn from(value: DesktopWindowTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DesktopWindowTarget> for ::windows::core::IUnknown {
-    fn from(value: &DesktopWindowTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DesktopWindowTarget> for &::windows::core::IUnknown {
-    fn from(value: &DesktopWindowTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DesktopWindowTarget> for ::windows::core::IInspectable {
-    fn from(value: DesktopWindowTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DesktopWindowTarget> for ::windows::core::IInspectable {
-    fn from(value: &DesktopWindowTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DesktopWindowTarget> for &::windows::core::IInspectable {
-    fn from(value: &DesktopWindowTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DesktopWindowTarget, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DesktopWindowTarget> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: DesktopWindowTarget) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
@@ -111,36 +111,7 @@ unsafe impl ::windows::core::Interface for CompositionDebugHeatMaps {
 impl ::windows::core::RuntimeName for CompositionDebugHeatMaps {
     const NAME: &'static str = "Windows.UI.Composition.Diagnostics.CompositionDebugHeatMaps";
 }
-impl ::core::convert::From<CompositionDebugHeatMaps> for ::windows::core::IUnknown {
-    fn from(value: CompositionDebugHeatMaps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionDebugHeatMaps> for ::windows::core::IUnknown {
-    fn from(value: &CompositionDebugHeatMaps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionDebugHeatMaps> for &::windows::core::IUnknown {
-    fn from(value: &CompositionDebugHeatMaps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionDebugHeatMaps> for ::windows::core::IInspectable {
-    fn from(value: CompositionDebugHeatMaps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionDebugHeatMaps> for ::windows::core::IInspectable {
-    fn from(value: &CompositionDebugHeatMaps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionDebugHeatMaps> for &::windows::core::IInspectable {
-    fn from(value: &CompositionDebugHeatMaps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionDebugHeatMaps, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CompositionDebugHeatMaps {}
 unsafe impl ::core::marker::Sync for CompositionDebugHeatMaps {}
 #[doc = "*Required features: `\"UI_Composition_Diagnostics\"`*"]
@@ -198,36 +169,7 @@ unsafe impl ::windows::core::Interface for CompositionDebugSettings {
 impl ::windows::core::RuntimeName for CompositionDebugSettings {
     const NAME: &'static str = "Windows.UI.Composition.Diagnostics.CompositionDebugSettings";
 }
-impl ::core::convert::From<CompositionDebugSettings> for ::windows::core::IUnknown {
-    fn from(value: CompositionDebugSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionDebugSettings> for ::windows::core::IUnknown {
-    fn from(value: &CompositionDebugSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionDebugSettings> for &::windows::core::IUnknown {
-    fn from(value: &CompositionDebugSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionDebugSettings> for ::windows::core::IInspectable {
-    fn from(value: CompositionDebugSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionDebugSettings> for ::windows::core::IInspectable {
-    fn from(value: &CompositionDebugSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionDebugSettings> for &::windows::core::IInspectable {
-    fn from(value: &CompositionDebugSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionDebugSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CompositionDebugSettings {}
 unsafe impl ::core::marker::Sync for CompositionDebugSettings {}
 #[doc = "*Required features: `\"UI_Composition_Diagnostics\"`*"]

--- a/crates/libs/windows/src/Windows/UI/Composition/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Effects/mod.rs
@@ -177,36 +177,7 @@ unsafe impl ::windows::core::Interface for SceneLightingEffect {
 impl ::windows::core::RuntimeName for SceneLightingEffect {
     const NAME: &'static str = "Windows.UI.Composition.Effects.SceneLightingEffect";
 }
-impl ::core::convert::From<SceneLightingEffect> for ::windows::core::IUnknown {
-    fn from(value: SceneLightingEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneLightingEffect> for ::windows::core::IUnknown {
-    fn from(value: &SceneLightingEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneLightingEffect> for &::windows::core::IUnknown {
-    fn from(value: &SceneLightingEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneLightingEffect> for ::windows::core::IInspectable {
-    fn from(value: SceneLightingEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneLightingEffect> for ::windows::core::IInspectable {
-    fn from(value: &SceneLightingEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneLightingEffect> for &::windows::core::IInspectable {
-    fn from(value: &SceneLightingEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneLightingEffect, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Graphics_Effects")]
 impl ::core::convert::TryFrom<SceneLightingEffect> for super::super::super::Graphics::Effects::IGraphicsEffect {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
@@ -35,36 +35,7 @@ pub struct ICompositionConditionalValueStatics_Vtbl {
 #[repr(transparent)]
 pub struct ICompositionInteractionSource(::windows::core::IUnknown);
 impl ICompositionInteractionSource {}
-impl ::core::convert::From<ICompositionInteractionSource> for ::windows::core::IUnknown {
-    fn from(value: ICompositionInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionInteractionSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositionInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionInteractionSource> for ::windows::core::IUnknown {
-    fn from(value: &ICompositionInteractionSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICompositionInteractionSource> for ::windows::core::IInspectable {
-    fn from(value: ICompositionInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionInteractionSource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICompositionInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionInteractionSource> for ::windows::core::IInspectable {
-    fn from(value: &ICompositionInteractionSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositionInteractionSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICompositionInteractionSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -634,36 +605,7 @@ impl IInteractionTrackerOwner {
         unsafe { (::windows::core::Vtable::vtable(this).ValuesChanged)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(sender), ::core::mem::transmute_copy(args)).ok() }
     }
 }
-impl ::core::convert::From<IInteractionTrackerOwner> for ::windows::core::IUnknown {
-    fn from(value: IInteractionTrackerOwner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInteractionTrackerOwner> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInteractionTrackerOwner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInteractionTrackerOwner> for ::windows::core::IUnknown {
-    fn from(value: &IInteractionTrackerOwner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInteractionTrackerOwner> for ::windows::core::IInspectable {
-    fn from(value: IInteractionTrackerOwner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInteractionTrackerOwner> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInteractionTrackerOwner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInteractionTrackerOwner> for ::windows::core::IInspectable {
-    fn from(value: &IInteractionTrackerOwner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInteractionTrackerOwner, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IInteractionTrackerOwner {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1145,36 +1087,7 @@ unsafe impl ::windows::core::Interface for CompositionConditionalValue {
 impl ::windows::core::RuntimeName for CompositionConditionalValue {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.CompositionConditionalValue";
 }
-impl ::core::convert::From<CompositionConditionalValue> for ::windows::core::IUnknown {
-    fn from(value: CompositionConditionalValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionConditionalValue> for ::windows::core::IUnknown {
-    fn from(value: &CompositionConditionalValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionConditionalValue> for &::windows::core::IUnknown {
-    fn from(value: &CompositionConditionalValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionConditionalValue> for ::windows::core::IInspectable {
-    fn from(value: CompositionConditionalValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionConditionalValue> for ::windows::core::IInspectable {
-    fn from(value: &CompositionConditionalValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionConditionalValue> for &::windows::core::IInspectable {
-    fn from(value: &CompositionConditionalValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionConditionalValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionConditionalValue> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionConditionalValue) -> ::windows::core::Result<Self> {
@@ -1420,36 +1333,7 @@ impl ::core::iter::IntoIterator for &CompositionInteractionSourceCollection {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<CompositionInteractionSourceCollection> for ::windows::core::IUnknown {
-    fn from(value: CompositionInteractionSourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionInteractionSourceCollection> for ::windows::core::IUnknown {
-    fn from(value: &CompositionInteractionSourceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionInteractionSourceCollection> for &::windows::core::IUnknown {
-    fn from(value: &CompositionInteractionSourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionInteractionSourceCollection> for ::windows::core::IInspectable {
-    fn from(value: CompositionInteractionSourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionInteractionSourceCollection> for ::windows::core::IInspectable {
-    fn from(value: &CompositionInteractionSourceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionInteractionSourceCollection> for &::windows::core::IInspectable {
-    fn from(value: &CompositionInteractionSourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionInteractionSourceCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionInteractionSourceCollection> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionInteractionSourceCollection) -> ::windows::core::Result<Self> {
@@ -1698,36 +1582,7 @@ unsafe impl ::windows::core::Interface for InteractionSourceConfiguration {
 impl ::windows::core::RuntimeName for InteractionSourceConfiguration {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionSourceConfiguration";
 }
-impl ::core::convert::From<InteractionSourceConfiguration> for ::windows::core::IUnknown {
-    fn from(value: InteractionSourceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionSourceConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &InteractionSourceConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionSourceConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &InteractionSourceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionSourceConfiguration> for ::windows::core::IInspectable {
-    fn from(value: InteractionSourceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionSourceConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &InteractionSourceConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionSourceConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &InteractionSourceConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionSourceConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InteractionSourceConfiguration> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: InteractionSourceConfiguration) -> ::windows::core::Result<Self> {
@@ -2284,36 +2139,7 @@ unsafe impl ::windows::core::Interface for InteractionTracker {
 impl ::windows::core::RuntimeName for InteractionTracker {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTracker";
 }
-impl ::core::convert::From<InteractionTracker> for ::windows::core::IUnknown {
-    fn from(value: InteractionTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTracker> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTracker> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTracker> for ::windows::core::IInspectable {
-    fn from(value: InteractionTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTracker> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTracker> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTracker, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InteractionTracker> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: InteractionTracker) -> ::windows::core::Result<Self> {
@@ -2423,36 +2249,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerCustomAnimationStat
 impl ::windows::core::RuntimeName for InteractionTrackerCustomAnimationStateEnteredArgs {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerCustomAnimationStateEnteredArgs";
 }
-impl ::core::convert::From<InteractionTrackerCustomAnimationStateEnteredArgs> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerCustomAnimationStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerCustomAnimationStateEnteredArgs> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerCustomAnimationStateEnteredArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerCustomAnimationStateEnteredArgs> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerCustomAnimationStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerCustomAnimationStateEnteredArgs> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerCustomAnimationStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerCustomAnimationStateEnteredArgs> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerCustomAnimationStateEnteredArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerCustomAnimationStateEnteredArgs> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerCustomAnimationStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerCustomAnimationStateEnteredArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InteractionTrackerCustomAnimationStateEnteredArgs {}
 unsafe impl ::core::marker::Sync for InteractionTrackerCustomAnimationStateEnteredArgs {}
 #[doc = "*Required features: `\"UI_Composition_Interactions\"`*"]
@@ -2506,36 +2303,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerIdleStateEnteredArg
 impl ::windows::core::RuntimeName for InteractionTrackerIdleStateEnteredArgs {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerIdleStateEnteredArgs";
 }
-impl ::core::convert::From<InteractionTrackerIdleStateEnteredArgs> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerIdleStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerIdleStateEnteredArgs> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerIdleStateEnteredArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerIdleStateEnteredArgs> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerIdleStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerIdleStateEnteredArgs> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerIdleStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerIdleStateEnteredArgs> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerIdleStateEnteredArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerIdleStateEnteredArgs> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerIdleStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerIdleStateEnteredArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InteractionTrackerIdleStateEnteredArgs {}
 unsafe impl ::core::marker::Sync for InteractionTrackerIdleStateEnteredArgs {}
 #[doc = "*Required features: `\"UI_Composition_Interactions\"`*"]
@@ -2673,36 +2441,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerInertiaModifier {
 impl ::windows::core::RuntimeName for InteractionTrackerInertiaModifier {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerInertiaModifier";
 }
-impl ::core::convert::From<InteractionTrackerInertiaModifier> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerInertiaModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaModifier> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInertiaModifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaModifier> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInertiaModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerInertiaModifier> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerInertiaModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaModifier> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInertiaModifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaModifier> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInertiaModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerInertiaModifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InteractionTrackerInertiaModifier> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: InteractionTrackerInertiaModifier) -> ::windows::core::Result<Self> {
@@ -2929,36 +2668,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerInertiaMotion {
 impl ::windows::core::RuntimeName for InteractionTrackerInertiaMotion {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerInertiaMotion";
 }
-impl ::core::convert::From<InteractionTrackerInertiaMotion> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerInertiaMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaMotion> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInertiaMotion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaMotion> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInertiaMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerInertiaMotion> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerInertiaMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaMotion> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInertiaMotion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaMotion> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInertiaMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerInertiaMotion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InteractionTrackerInertiaMotion> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: InteractionTrackerInertiaMotion) -> ::windows::core::Result<Self> {
@@ -3203,36 +2913,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerInertiaNaturalMotio
 impl ::windows::core::RuntimeName for InteractionTrackerInertiaNaturalMotion {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerInertiaNaturalMotion";
 }
-impl ::core::convert::From<InteractionTrackerInertiaNaturalMotion> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerInertiaNaturalMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaNaturalMotion> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInertiaNaturalMotion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaNaturalMotion> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInertiaNaturalMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerInertiaNaturalMotion> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerInertiaNaturalMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaNaturalMotion> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInertiaNaturalMotion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaNaturalMotion> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInertiaNaturalMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerInertiaNaturalMotion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InteractionTrackerInertiaNaturalMotion> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: InteractionTrackerInertiaNaturalMotion) -> ::windows::core::Result<Self> {
@@ -3474,36 +3155,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerInertiaRestingValue
 impl ::windows::core::RuntimeName for InteractionTrackerInertiaRestingValue {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerInertiaRestingValue";
 }
-impl ::core::convert::From<InteractionTrackerInertiaRestingValue> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerInertiaRestingValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaRestingValue> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInertiaRestingValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaRestingValue> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInertiaRestingValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerInertiaRestingValue> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerInertiaRestingValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaRestingValue> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInertiaRestingValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaRestingValue> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInertiaRestingValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerInertiaRestingValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InteractionTrackerInertiaRestingValue> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: InteractionTrackerInertiaRestingValue) -> ::windows::core::Result<Self> {
@@ -3685,36 +3337,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerInertiaStateEntered
 impl ::windows::core::RuntimeName for InteractionTrackerInertiaStateEnteredArgs {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerInertiaStateEnteredArgs";
 }
-impl ::core::convert::From<InteractionTrackerInertiaStateEnteredArgs> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerInertiaStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaStateEnteredArgs> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInertiaStateEnteredArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaStateEnteredArgs> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInertiaStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerInertiaStateEnteredArgs> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerInertiaStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaStateEnteredArgs> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInertiaStateEnteredArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInertiaStateEnteredArgs> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInertiaStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerInertiaStateEnteredArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InteractionTrackerInertiaStateEnteredArgs {}
 unsafe impl ::core::marker::Sync for InteractionTrackerInertiaStateEnteredArgs {}
 #[doc = "*Required features: `\"UI_Composition_Interactions\"`*"]
@@ -3768,36 +3391,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerInteractingStateEnt
 impl ::windows::core::RuntimeName for InteractionTrackerInteractingStateEnteredArgs {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerInteractingStateEnteredArgs";
 }
-impl ::core::convert::From<InteractionTrackerInteractingStateEnteredArgs> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerInteractingStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInteractingStateEnteredArgs> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInteractingStateEnteredArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInteractingStateEnteredArgs> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerInteractingStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerInteractingStateEnteredArgs> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerInteractingStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInteractingStateEnteredArgs> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInteractingStateEnteredArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerInteractingStateEnteredArgs> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerInteractingStateEnteredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerInteractingStateEnteredArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InteractionTrackerInteractingStateEnteredArgs {}
 unsafe impl ::core::marker::Sync for InteractionTrackerInteractingStateEnteredArgs {}
 #[doc = "*Required features: `\"UI_Composition_Interactions\"`*"]
@@ -3844,36 +3438,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerRequestIgnoredArgs 
 impl ::windows::core::RuntimeName for InteractionTrackerRequestIgnoredArgs {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerRequestIgnoredArgs";
 }
-impl ::core::convert::From<InteractionTrackerRequestIgnoredArgs> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerRequestIgnoredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerRequestIgnoredArgs> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerRequestIgnoredArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerRequestIgnoredArgs> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerRequestIgnoredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerRequestIgnoredArgs> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerRequestIgnoredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerRequestIgnoredArgs> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerRequestIgnoredArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerRequestIgnoredArgs> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerRequestIgnoredArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerRequestIgnoredArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InteractionTrackerRequestIgnoredArgs {}
 unsafe impl ::core::marker::Sync for InteractionTrackerRequestIgnoredArgs {}
 #[doc = "*Required features: `\"UI_Composition_Interactions\"`*"]
@@ -3936,36 +3501,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerValuesChangedArgs {
 impl ::windows::core::RuntimeName for InteractionTrackerValuesChangedArgs {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerValuesChangedArgs";
 }
-impl ::core::convert::From<InteractionTrackerValuesChangedArgs> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerValuesChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerValuesChangedArgs> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerValuesChangedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerValuesChangedArgs> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerValuesChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerValuesChangedArgs> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerValuesChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerValuesChangedArgs> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerValuesChangedArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerValuesChangedArgs> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerValuesChangedArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerValuesChangedArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InteractionTrackerValuesChangedArgs {}
 unsafe impl ::core::marker::Sync for InteractionTrackerValuesChangedArgs {}
 #[doc = "*Required features: `\"UI_Composition_Interactions\"`*"]
@@ -4103,36 +3639,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerVector2InertiaModif
 impl ::windows::core::RuntimeName for InteractionTrackerVector2InertiaModifier {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerVector2InertiaModifier";
 }
-impl ::core::convert::From<InteractionTrackerVector2InertiaModifier> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerVector2InertiaModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerVector2InertiaModifier> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerVector2InertiaModifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerVector2InertiaModifier> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerVector2InertiaModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerVector2InertiaModifier> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerVector2InertiaModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerVector2InertiaModifier> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerVector2InertiaModifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerVector2InertiaModifier> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerVector2InertiaModifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerVector2InertiaModifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InteractionTrackerVector2InertiaModifier> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: InteractionTrackerVector2InertiaModifier) -> ::windows::core::Result<Self> {
@@ -4362,36 +3869,7 @@ unsafe impl ::windows::core::Interface for InteractionTrackerVector2InertiaNatur
 impl ::windows::core::RuntimeName for InteractionTrackerVector2InertiaNaturalMotion {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.InteractionTrackerVector2InertiaNaturalMotion";
 }
-impl ::core::convert::From<InteractionTrackerVector2InertiaNaturalMotion> for ::windows::core::IUnknown {
-    fn from(value: InteractionTrackerVector2InertiaNaturalMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerVector2InertiaNaturalMotion> for ::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerVector2InertiaNaturalMotion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerVector2InertiaNaturalMotion> for &::windows::core::IUnknown {
-    fn from(value: &InteractionTrackerVector2InertiaNaturalMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InteractionTrackerVector2InertiaNaturalMotion> for ::windows::core::IInspectable {
-    fn from(value: InteractionTrackerVector2InertiaNaturalMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InteractionTrackerVector2InertiaNaturalMotion> for ::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerVector2InertiaNaturalMotion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InteractionTrackerVector2InertiaNaturalMotion> for &::windows::core::IInspectable {
-    fn from(value: &InteractionTrackerVector2InertiaNaturalMotion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InteractionTrackerVector2InertiaNaturalMotion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InteractionTrackerVector2InertiaNaturalMotion> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: InteractionTrackerVector2InertiaNaturalMotion) -> ::windows::core::Result<Self> {
@@ -4846,36 +4324,7 @@ unsafe impl ::windows::core::Interface for VisualInteractionSource {
 impl ::windows::core::RuntimeName for VisualInteractionSource {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.VisualInteractionSource";
 }
-impl ::core::convert::From<VisualInteractionSource> for ::windows::core::IUnknown {
-    fn from(value: VisualInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualInteractionSource> for ::windows::core::IUnknown {
-    fn from(value: &VisualInteractionSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualInteractionSource> for &::windows::core::IUnknown {
-    fn from(value: &VisualInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VisualInteractionSource> for ::windows::core::IInspectable {
-    fn from(value: VisualInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualInteractionSource> for ::windows::core::IInspectable {
-    fn from(value: &VisualInteractionSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualInteractionSource> for &::windows::core::IInspectable {
-    fn from(value: &VisualInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VisualInteractionSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VisualInteractionSource> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: VisualInteractionSource) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/UI/Composition/Scenes/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Scenes/mod.rs
@@ -726,36 +726,7 @@ unsafe impl ::windows::core::Interface for SceneBoundingBox {
 impl ::windows::core::RuntimeName for SceneBoundingBox {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneBoundingBox";
 }
-impl ::core::convert::From<SceneBoundingBox> for ::windows::core::IUnknown {
-    fn from(value: SceneBoundingBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneBoundingBox> for ::windows::core::IUnknown {
-    fn from(value: &SceneBoundingBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneBoundingBox> for &::windows::core::IUnknown {
-    fn from(value: &SceneBoundingBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneBoundingBox> for ::windows::core::IInspectable {
-    fn from(value: SceneBoundingBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneBoundingBox> for ::windows::core::IInspectable {
-    fn from(value: &SceneBoundingBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneBoundingBox> for &::windows::core::IInspectable {
-    fn from(value: &SceneBoundingBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneBoundingBox, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneBoundingBox> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneBoundingBox) -> ::windows::core::Result<Self> {
@@ -971,36 +942,7 @@ unsafe impl ::windows::core::Interface for SceneComponent {
 impl ::windows::core::RuntimeName for SceneComponent {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneComponent";
 }
-impl ::core::convert::From<SceneComponent> for ::windows::core::IUnknown {
-    fn from(value: SceneComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneComponent> for ::windows::core::IUnknown {
-    fn from(value: &SceneComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneComponent> for &::windows::core::IUnknown {
-    fn from(value: &SceneComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneComponent> for ::windows::core::IInspectable {
-    fn from(value: SceneComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneComponent> for ::windows::core::IInspectable {
-    fn from(value: &SceneComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneComponent> for &::windows::core::IInspectable {
-    fn from(value: &SceneComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneComponent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneComponent> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneComponent) -> ::windows::core::Result<Self> {
@@ -1344,41 +1286,7 @@ impl ::core::iter::IntoIterator for &SceneComponentCollection {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<SceneComponentCollection> for ::windows::core::IUnknown {
-    fn from(value: SceneComponentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SceneComponentCollection> for ::windows::core::IUnknown {
-    fn from(value: &SceneComponentCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SceneComponentCollection> for &::windows::core::IUnknown {
-    fn from(value: &SceneComponentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<SceneComponentCollection> for ::windows::core::IInspectable {
-    fn from(value: SceneComponentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SceneComponentCollection> for ::windows::core::IInspectable {
-    fn from(value: &SceneComponentCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SceneComponentCollection> for &::windows::core::IInspectable {
-    fn from(value: &SceneComponentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneComponentCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<SceneComponentCollection> for super::IAnimationObject {
     type Error = ::windows::core::Error;
@@ -1642,36 +1550,7 @@ unsafe impl ::windows::core::Interface for SceneMaterial {
 impl ::windows::core::RuntimeName for SceneMaterial {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneMaterial";
 }
-impl ::core::convert::From<SceneMaterial> for ::windows::core::IUnknown {
-    fn from(value: SceneMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMaterial> for ::windows::core::IUnknown {
-    fn from(value: &SceneMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMaterial> for &::windows::core::IUnknown {
-    fn from(value: &SceneMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneMaterial> for ::windows::core::IInspectable {
-    fn from(value: SceneMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMaterial> for ::windows::core::IInspectable {
-    fn from(value: &SceneMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMaterial> for &::windows::core::IInspectable {
-    fn from(value: &SceneMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneMaterial, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneMaterial> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneMaterial) -> ::windows::core::Result<Self> {
@@ -1880,36 +1759,7 @@ unsafe impl ::windows::core::Interface for SceneMaterialInput {
 impl ::windows::core::RuntimeName for SceneMaterialInput {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneMaterialInput";
 }
-impl ::core::convert::From<SceneMaterialInput> for ::windows::core::IUnknown {
-    fn from(value: SceneMaterialInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMaterialInput> for ::windows::core::IUnknown {
-    fn from(value: &SceneMaterialInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMaterialInput> for &::windows::core::IUnknown {
-    fn from(value: &SceneMaterialInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneMaterialInput> for ::windows::core::IInspectable {
-    fn from(value: SceneMaterialInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMaterialInput> for ::windows::core::IInspectable {
-    fn from(value: &SceneMaterialInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMaterialInput> for &::windows::core::IInspectable {
-    fn from(value: &SceneMaterialInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneMaterialInput, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneMaterialInput> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneMaterialInput) -> ::windows::core::Result<Self> {
@@ -2157,36 +2007,7 @@ unsafe impl ::windows::core::Interface for SceneMesh {
 impl ::windows::core::RuntimeName for SceneMesh {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneMesh";
 }
-impl ::core::convert::From<SceneMesh> for ::windows::core::IUnknown {
-    fn from(value: SceneMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMesh> for ::windows::core::IUnknown {
-    fn from(value: &SceneMesh) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMesh> for &::windows::core::IUnknown {
-    fn from(value: &SceneMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneMesh> for ::windows::core::IInspectable {
-    fn from(value: SceneMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMesh> for ::windows::core::IInspectable {
-    fn from(value: &SceneMesh) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMesh> for &::windows::core::IInspectable {
-    fn from(value: &SceneMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneMesh, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneMesh> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneMesh) -> ::windows::core::Result<Self> {
@@ -2477,36 +2298,7 @@ impl ::core::iter::IntoIterator for &SceneMeshMaterialAttributeMap {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<SceneMeshMaterialAttributeMap> for ::windows::core::IUnknown {
-    fn from(value: SceneMeshMaterialAttributeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMeshMaterialAttributeMap> for ::windows::core::IUnknown {
-    fn from(value: &SceneMeshMaterialAttributeMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMeshMaterialAttributeMap> for &::windows::core::IUnknown {
-    fn from(value: &SceneMeshMaterialAttributeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneMeshMaterialAttributeMap> for ::windows::core::IInspectable {
-    fn from(value: SceneMeshMaterialAttributeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMeshMaterialAttributeMap> for ::windows::core::IInspectable {
-    fn from(value: &SceneMeshMaterialAttributeMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMeshMaterialAttributeMap> for &::windows::core::IInspectable {
-    fn from(value: &SceneMeshMaterialAttributeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneMeshMaterialAttributeMap, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneMeshMaterialAttributeMap> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneMeshMaterialAttributeMap) -> ::windows::core::Result<Self> {
@@ -2809,36 +2601,7 @@ unsafe impl ::windows::core::Interface for SceneMeshRendererComponent {
 impl ::windows::core::RuntimeName for SceneMeshRendererComponent {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneMeshRendererComponent";
 }
-impl ::core::convert::From<SceneMeshRendererComponent> for ::windows::core::IUnknown {
-    fn from(value: SceneMeshRendererComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMeshRendererComponent> for ::windows::core::IUnknown {
-    fn from(value: &SceneMeshRendererComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMeshRendererComponent> for &::windows::core::IUnknown {
-    fn from(value: &SceneMeshRendererComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneMeshRendererComponent> for ::windows::core::IInspectable {
-    fn from(value: SceneMeshRendererComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMeshRendererComponent> for ::windows::core::IInspectable {
-    fn from(value: &SceneMeshRendererComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMeshRendererComponent> for &::windows::core::IInspectable {
-    fn from(value: &SceneMeshRendererComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneMeshRendererComponent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneMeshRendererComponent> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneMeshRendererComponent) -> ::windows::core::Result<Self> {
@@ -3265,36 +3028,7 @@ unsafe impl ::windows::core::Interface for SceneMetallicRoughnessMaterial {
 impl ::windows::core::RuntimeName for SceneMetallicRoughnessMaterial {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneMetallicRoughnessMaterial";
 }
-impl ::core::convert::From<SceneMetallicRoughnessMaterial> for ::windows::core::IUnknown {
-    fn from(value: SceneMetallicRoughnessMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMetallicRoughnessMaterial> for ::windows::core::IUnknown {
-    fn from(value: &SceneMetallicRoughnessMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMetallicRoughnessMaterial> for &::windows::core::IUnknown {
-    fn from(value: &SceneMetallicRoughnessMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneMetallicRoughnessMaterial> for ::windows::core::IInspectable {
-    fn from(value: SceneMetallicRoughnessMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneMetallicRoughnessMaterial> for ::windows::core::IInspectable {
-    fn from(value: &SceneMetallicRoughnessMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneMetallicRoughnessMaterial> for &::windows::core::IInspectable {
-    fn from(value: &SceneMetallicRoughnessMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneMetallicRoughnessMaterial, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneMetallicRoughnessMaterial> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneMetallicRoughnessMaterial) -> ::windows::core::Result<Self> {
@@ -3615,36 +3349,7 @@ unsafe impl ::windows::core::Interface for SceneModelTransform {
 impl ::windows::core::RuntimeName for SceneModelTransform {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneModelTransform";
 }
-impl ::core::convert::From<SceneModelTransform> for ::windows::core::IUnknown {
-    fn from(value: SceneModelTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneModelTransform> for ::windows::core::IUnknown {
-    fn from(value: &SceneModelTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneModelTransform> for &::windows::core::IUnknown {
-    fn from(value: &SceneModelTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneModelTransform> for ::windows::core::IInspectable {
-    fn from(value: SceneModelTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneModelTransform> for ::windows::core::IInspectable {
-    fn from(value: &SceneModelTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneModelTransform> for &::windows::core::IInspectable {
-    fn from(value: &SceneModelTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneModelTransform, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneModelTransform> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneModelTransform) -> ::windows::core::Result<Self> {
@@ -3903,36 +3608,7 @@ unsafe impl ::windows::core::Interface for SceneNode {
 impl ::windows::core::RuntimeName for SceneNode {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneNode";
 }
-impl ::core::convert::From<SceneNode> for ::windows::core::IUnknown {
-    fn from(value: SceneNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneNode> for ::windows::core::IUnknown {
-    fn from(value: &SceneNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneNode> for &::windows::core::IUnknown {
-    fn from(value: &SceneNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneNode> for ::windows::core::IInspectable {
-    fn from(value: SceneNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneNode> for ::windows::core::IInspectable {
-    fn from(value: &SceneNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneNode> for &::windows::core::IInspectable {
-    fn from(value: &SceneNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneNode> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneNode) -> ::windows::core::Result<Self> {
@@ -4264,41 +3940,7 @@ impl ::core::iter::IntoIterator for &SceneNodeCollection {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<SceneNodeCollection> for ::windows::core::IUnknown {
-    fn from(value: SceneNodeCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SceneNodeCollection> for ::windows::core::IUnknown {
-    fn from(value: &SceneNodeCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SceneNodeCollection> for &::windows::core::IUnknown {
-    fn from(value: &SceneNodeCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<SceneNodeCollection> for ::windows::core::IInspectable {
-    fn from(value: SceneNodeCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SceneNodeCollection> for ::windows::core::IInspectable {
-    fn from(value: &SceneNodeCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&SceneNodeCollection> for &::windows::core::IInspectable {
-    fn from(value: &SceneNodeCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneNodeCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<SceneNodeCollection> for super::IAnimationObject {
     type Error = ::windows::core::Error;
@@ -4562,36 +4204,7 @@ unsafe impl ::windows::core::Interface for SceneObject {
 impl ::windows::core::RuntimeName for SceneObject {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneObject";
 }
-impl ::core::convert::From<SceneObject> for ::windows::core::IUnknown {
-    fn from(value: SceneObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneObject> for ::windows::core::IUnknown {
-    fn from(value: &SceneObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneObject> for &::windows::core::IUnknown {
-    fn from(value: &SceneObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneObject> for ::windows::core::IInspectable {
-    fn from(value: SceneObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneObject> for ::windows::core::IInspectable {
-    fn from(value: &SceneObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneObject> for &::windows::core::IInspectable {
-    fn from(value: &SceneObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneObject, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneObject> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneObject) -> ::windows::core::Result<Self> {
@@ -4897,36 +4510,7 @@ unsafe impl ::windows::core::Interface for ScenePbrMaterial {
 impl ::windows::core::RuntimeName for ScenePbrMaterial {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.ScenePbrMaterial";
 }
-impl ::core::convert::From<ScenePbrMaterial> for ::windows::core::IUnknown {
-    fn from(value: ScenePbrMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScenePbrMaterial> for ::windows::core::IUnknown {
-    fn from(value: &ScenePbrMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScenePbrMaterial> for &::windows::core::IUnknown {
-    fn from(value: &ScenePbrMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ScenePbrMaterial> for ::windows::core::IInspectable {
-    fn from(value: ScenePbrMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScenePbrMaterial> for ::windows::core::IInspectable {
-    fn from(value: &ScenePbrMaterial) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScenePbrMaterial> for &::windows::core::IInspectable {
-    fn from(value: &ScenePbrMaterial) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ScenePbrMaterial, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ScenePbrMaterial> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: ScenePbrMaterial) -> ::windows::core::Result<Self> {
@@ -5157,36 +4741,7 @@ unsafe impl ::windows::core::Interface for SceneRendererComponent {
 impl ::windows::core::RuntimeName for SceneRendererComponent {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneRendererComponent";
 }
-impl ::core::convert::From<SceneRendererComponent> for ::windows::core::IUnknown {
-    fn from(value: SceneRendererComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneRendererComponent> for ::windows::core::IUnknown {
-    fn from(value: &SceneRendererComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneRendererComponent> for &::windows::core::IUnknown {
-    fn from(value: &SceneRendererComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneRendererComponent> for ::windows::core::IInspectable {
-    fn from(value: SceneRendererComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneRendererComponent> for ::windows::core::IInspectable {
-    fn from(value: &SceneRendererComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneRendererComponent> for &::windows::core::IInspectable {
-    fn from(value: &SceneRendererComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneRendererComponent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneRendererComponent> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneRendererComponent) -> ::windows::core::Result<Self> {
@@ -5469,36 +5024,7 @@ unsafe impl ::windows::core::Interface for SceneSurfaceMaterialInput {
 impl ::windows::core::RuntimeName for SceneSurfaceMaterialInput {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneSurfaceMaterialInput";
 }
-impl ::core::convert::From<SceneSurfaceMaterialInput> for ::windows::core::IUnknown {
-    fn from(value: SceneSurfaceMaterialInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneSurfaceMaterialInput> for ::windows::core::IUnknown {
-    fn from(value: &SceneSurfaceMaterialInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneSurfaceMaterialInput> for &::windows::core::IUnknown {
-    fn from(value: &SceneSurfaceMaterialInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneSurfaceMaterialInput> for ::windows::core::IInspectable {
-    fn from(value: SceneSurfaceMaterialInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneSurfaceMaterialInput> for ::windows::core::IInspectable {
-    fn from(value: &SceneSurfaceMaterialInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneSurfaceMaterialInput> for &::windows::core::IInspectable {
-    fn from(value: &SceneSurfaceMaterialInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneSurfaceMaterialInput, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneSurfaceMaterialInput> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneSurfaceMaterialInput) -> ::windows::core::Result<Self> {
@@ -6035,36 +5561,7 @@ unsafe impl ::windows::core::Interface for SceneVisual {
 impl ::windows::core::RuntimeName for SceneVisual {
     const NAME: &'static str = "Windows.UI.Composition.Scenes.SceneVisual";
 }
-impl ::core::convert::From<SceneVisual> for ::windows::core::IUnknown {
-    fn from(value: SceneVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneVisual> for ::windows::core::IUnknown {
-    fn from(value: &SceneVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneVisual> for &::windows::core::IUnknown {
-    fn from(value: &SceneVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SceneVisual> for ::windows::core::IInspectable {
-    fn from(value: SceneVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SceneVisual> for ::windows::core::IInspectable {
-    fn from(value: &SceneVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SceneVisual> for &::windows::core::IInspectable {
-    fn from(value: &SceneVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SceneVisual, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SceneVisual> for super::IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SceneVisual) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/UI/Composition/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/mod.rs
@@ -89,36 +89,7 @@ impl IAnimationObject {
         unsafe { (::windows::core::Vtable::vtable(this).PopulatePropertyInfo)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(propertyname), ::core::mem::transmute_copy(propertyinfo)).ok() }
     }
 }
-impl ::core::convert::From<IAnimationObject> for ::windows::core::IUnknown {
-    fn from(value: IAnimationObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAnimationObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAnimationObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAnimationObject> for ::windows::core::IUnknown {
-    fn from(value: &IAnimationObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAnimationObject> for ::windows::core::IInspectable {
-    fn from(value: IAnimationObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAnimationObject> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAnimationObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAnimationObject> for ::windows::core::IInspectable {
-    fn from(value: &IAnimationObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAnimationObject, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAnimationObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -418,36 +389,7 @@ pub struct ICompositionAnimation4_Vtbl {
 #[repr(transparent)]
 pub struct ICompositionAnimationBase(::windows::core::IUnknown);
 impl ICompositionAnimationBase {}
-impl ::core::convert::From<ICompositionAnimationBase> for ::windows::core::IUnknown {
-    fn from(value: ICompositionAnimationBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionAnimationBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositionAnimationBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionAnimationBase> for ::windows::core::IUnknown {
-    fn from(value: &ICompositionAnimationBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICompositionAnimationBase> for ::windows::core::IInspectable {
-    fn from(value: ICompositionAnimationBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionAnimationBase> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICompositionAnimationBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionAnimationBase> for ::windows::core::IInspectable {
-    fn from(value: &ICompositionAnimationBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositionAnimationBase, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICompositionAnimationBase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2077,36 +2019,7 @@ impl ICompositionSupportsSystemBackdrop {
         unsafe { (::windows::core::Vtable::vtable(this).SetSystemBackdrop)(::windows::core::Vtable::as_raw(this), value.into().abi()).ok() }
     }
 }
-impl ::core::convert::From<ICompositionSupportsSystemBackdrop> for ::windows::core::IUnknown {
-    fn from(value: ICompositionSupportsSystemBackdrop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionSupportsSystemBackdrop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositionSupportsSystemBackdrop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionSupportsSystemBackdrop> for ::windows::core::IUnknown {
-    fn from(value: &ICompositionSupportsSystemBackdrop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICompositionSupportsSystemBackdrop> for ::windows::core::IInspectable {
-    fn from(value: ICompositionSupportsSystemBackdrop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionSupportsSystemBackdrop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICompositionSupportsSystemBackdrop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionSupportsSystemBackdrop> for ::windows::core::IInspectable {
-    fn from(value: &ICompositionSupportsSystemBackdrop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositionSupportsSystemBackdrop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICompositionSupportsSystemBackdrop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2147,36 +2060,7 @@ pub struct ICompositionSupportsSystemBackdrop_Vtbl {
 #[repr(transparent)]
 pub struct ICompositionSurface(::windows::core::IUnknown);
 impl ICompositionSurface {}
-impl ::core::convert::From<ICompositionSurface> for ::windows::core::IUnknown {
-    fn from(value: ICompositionSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionSurface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositionSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionSurface> for ::windows::core::IUnknown {
-    fn from(value: &ICompositionSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICompositionSurface> for ::windows::core::IInspectable {
-    fn from(value: ICompositionSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionSurface> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICompositionSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionSurface> for ::windows::core::IInspectable {
-    fn from(value: &ICompositionSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositionSurface, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICompositionSurface {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2321,36 +2205,7 @@ impl ICompositionSurfaceFacade {
         }
     }
 }
-impl ::core::convert::From<ICompositionSurfaceFacade> for ::windows::core::IUnknown {
-    fn from(value: ICompositionSurfaceFacade) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionSurfaceFacade> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositionSurfaceFacade) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionSurfaceFacade> for ::windows::core::IUnknown {
-    fn from(value: &ICompositionSurfaceFacade) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICompositionSurfaceFacade> for ::windows::core::IInspectable {
-    fn from(value: ICompositionSurfaceFacade) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionSurfaceFacade> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICompositionSurfaceFacade) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionSurfaceFacade> for ::windows::core::IInspectable {
-    fn from(value: &ICompositionSurfaceFacade) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositionSurfaceFacade, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICompositionSurfaceFacade {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4117,36 +3972,7 @@ pub struct IVisualCollection_Vtbl {
 #[repr(transparent)]
 pub struct IVisualElement(::windows::core::IUnknown);
 impl IVisualElement {}
-impl ::core::convert::From<IVisualElement> for ::windows::core::IUnknown {
-    fn from(value: IVisualElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVisualElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualElement> for ::windows::core::IUnknown {
-    fn from(value: &IVisualElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVisualElement> for ::windows::core::IInspectable {
-    fn from(value: IVisualElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualElement> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVisualElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualElement> for ::windows::core::IInspectable {
-    fn from(value: &IVisualElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVisualElement, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVisualElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4193,36 +4019,7 @@ impl IVisualElement2 {
         }
     }
 }
-impl ::core::convert::From<IVisualElement2> for ::windows::core::IUnknown {
-    fn from(value: IVisualElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualElement2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVisualElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualElement2> for ::windows::core::IUnknown {
-    fn from(value: &IVisualElement2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVisualElement2> for ::windows::core::IInspectable {
-    fn from(value: IVisualElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualElement2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVisualElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualElement2> for ::windows::core::IInspectable {
-    fn from(value: &IVisualElement2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVisualElement2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVisualElement2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4472,36 +4269,7 @@ unsafe impl ::windows::core::Interface for AmbientLight {
 impl ::windows::core::RuntimeName for AmbientLight {
     const NAME: &'static str = "Windows.UI.Composition.AmbientLight";
 }
-impl ::core::convert::From<AmbientLight> for ::windows::core::IUnknown {
-    fn from(value: AmbientLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AmbientLight> for ::windows::core::IUnknown {
-    fn from(value: &AmbientLight) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AmbientLight> for &::windows::core::IUnknown {
-    fn from(value: &AmbientLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AmbientLight> for ::windows::core::IInspectable {
-    fn from(value: AmbientLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AmbientLight> for ::windows::core::IInspectable {
-    fn from(value: &AmbientLight) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AmbientLight> for &::windows::core::IInspectable {
-    fn from(value: &AmbientLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AmbientLight, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AmbientLight> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: AmbientLight) -> ::windows::core::Result<Self> {
@@ -4768,36 +4536,7 @@ unsafe impl ::windows::core::Interface for AnimationController {
 impl ::windows::core::RuntimeName for AnimationController {
     const NAME: &'static str = "Windows.UI.Composition.AnimationController";
 }
-impl ::core::convert::From<AnimationController> for ::windows::core::IUnknown {
-    fn from(value: AnimationController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AnimationController> for ::windows::core::IUnknown {
-    fn from(value: &AnimationController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AnimationController> for &::windows::core::IUnknown {
-    fn from(value: &AnimationController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AnimationController> for ::windows::core::IInspectable {
-    fn from(value: AnimationController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AnimationController> for ::windows::core::IInspectable {
-    fn from(value: &AnimationController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AnimationController> for &::windows::core::IInspectable {
-    fn from(value: &AnimationController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AnimationController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AnimationController> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: AnimationController) -> ::windows::core::Result<Self> {
@@ -5016,36 +4755,7 @@ unsafe impl ::windows::core::Interface for AnimationPropertyInfo {
 impl ::windows::core::RuntimeName for AnimationPropertyInfo {
     const NAME: &'static str = "Windows.UI.Composition.AnimationPropertyInfo";
 }
-impl ::core::convert::From<AnimationPropertyInfo> for ::windows::core::IUnknown {
-    fn from(value: AnimationPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AnimationPropertyInfo> for ::windows::core::IUnknown {
-    fn from(value: &AnimationPropertyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AnimationPropertyInfo> for &::windows::core::IUnknown {
-    fn from(value: &AnimationPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AnimationPropertyInfo> for ::windows::core::IInspectable {
-    fn from(value: AnimationPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AnimationPropertyInfo> for ::windows::core::IInspectable {
-    fn from(value: &AnimationPropertyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AnimationPropertyInfo> for &::windows::core::IInspectable {
-    fn from(value: &AnimationPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AnimationPropertyInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AnimationPropertyInfo> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: AnimationPropertyInfo) -> ::windows::core::Result<Self> {
@@ -5253,36 +4963,7 @@ unsafe impl ::windows::core::Interface for BackEasingFunction {
 impl ::windows::core::RuntimeName for BackEasingFunction {
     const NAME: &'static str = "Windows.UI.Composition.BackEasingFunction";
 }
-impl ::core::convert::From<BackEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: BackEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: &BackEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackEasingFunction> for &::windows::core::IUnknown {
-    fn from(value: &BackEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: BackEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: &BackEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackEasingFunction> for &::windows::core::IInspectable {
-    fn from(value: &BackEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackEasingFunction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BackEasingFunction> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: BackEasingFunction) -> ::windows::core::Result<Self> {
@@ -5689,36 +5370,7 @@ unsafe impl ::windows::core::Interface for BooleanKeyFrameAnimation {
 impl ::windows::core::RuntimeName for BooleanKeyFrameAnimation {
     const NAME: &'static str = "Windows.UI.Composition.BooleanKeyFrameAnimation";
 }
-impl ::core::convert::From<BooleanKeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: BooleanKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BooleanKeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: &BooleanKeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BooleanKeyFrameAnimation> for &::windows::core::IUnknown {
-    fn from(value: &BooleanKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BooleanKeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: BooleanKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BooleanKeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: &BooleanKeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BooleanKeyFrameAnimation> for &::windows::core::IInspectable {
-    fn from(value: &BooleanKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BooleanKeyFrameAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BooleanKeyFrameAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: BooleanKeyFrameAnimation) -> ::windows::core::Result<Self> {
@@ -5982,36 +5634,7 @@ unsafe impl ::windows::core::Interface for BounceEasingFunction {
 impl ::windows::core::RuntimeName for BounceEasingFunction {
     const NAME: &'static str = "Windows.UI.Composition.BounceEasingFunction";
 }
-impl ::core::convert::From<BounceEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: BounceEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BounceEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: &BounceEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BounceEasingFunction> for &::windows::core::IUnknown {
-    fn from(value: &BounceEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BounceEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: BounceEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BounceEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: &BounceEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BounceEasingFunction> for &::windows::core::IInspectable {
-    fn from(value: &BounceEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BounceEasingFunction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BounceEasingFunction> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: BounceEasingFunction) -> ::windows::core::Result<Self> {
@@ -6419,36 +6042,7 @@ unsafe impl ::windows::core::Interface for BounceScalarNaturalMotionAnimation {
 impl ::windows::core::RuntimeName for BounceScalarNaturalMotionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.BounceScalarNaturalMotionAnimation";
 }
-impl ::core::convert::From<BounceScalarNaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: BounceScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BounceScalarNaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &BounceScalarNaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BounceScalarNaturalMotionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &BounceScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BounceScalarNaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: BounceScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BounceScalarNaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &BounceScalarNaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BounceScalarNaturalMotionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &BounceScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BounceScalarNaturalMotionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BounceScalarNaturalMotionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: BounceScalarNaturalMotionAnimation) -> ::windows::core::Result<Self> {
@@ -6909,36 +6503,7 @@ unsafe impl ::windows::core::Interface for BounceVector2NaturalMotionAnimation {
 impl ::windows::core::RuntimeName for BounceVector2NaturalMotionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.BounceVector2NaturalMotionAnimation";
 }
-impl ::core::convert::From<BounceVector2NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: BounceVector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BounceVector2NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &BounceVector2NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BounceVector2NaturalMotionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &BounceVector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BounceVector2NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: BounceVector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BounceVector2NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &BounceVector2NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BounceVector2NaturalMotionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &BounceVector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BounceVector2NaturalMotionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BounceVector2NaturalMotionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: BounceVector2NaturalMotionAnimation) -> ::windows::core::Result<Self> {
@@ -7399,36 +6964,7 @@ unsafe impl ::windows::core::Interface for BounceVector3NaturalMotionAnimation {
 impl ::windows::core::RuntimeName for BounceVector3NaturalMotionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.BounceVector3NaturalMotionAnimation";
 }
-impl ::core::convert::From<BounceVector3NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: BounceVector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BounceVector3NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &BounceVector3NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BounceVector3NaturalMotionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &BounceVector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BounceVector3NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: BounceVector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BounceVector3NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &BounceVector3NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BounceVector3NaturalMotionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &BounceVector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BounceVector3NaturalMotionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<BounceVector3NaturalMotionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: BounceVector3NaturalMotionAnimation) -> ::windows::core::Result<Self> {
@@ -7693,36 +7229,7 @@ unsafe impl ::windows::core::Interface for CircleEasingFunction {
 impl ::windows::core::RuntimeName for CircleEasingFunction {
     const NAME: &'static str = "Windows.UI.Composition.CircleEasingFunction";
 }
-impl ::core::convert::From<CircleEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: CircleEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CircleEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: &CircleEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CircleEasingFunction> for &::windows::core::IUnknown {
-    fn from(value: &CircleEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CircleEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: CircleEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CircleEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: &CircleEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CircleEasingFunction> for &::windows::core::IInspectable {
-    fn from(value: &CircleEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CircleEasingFunction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CircleEasingFunction> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CircleEasingFunction) -> ::windows::core::Result<Self> {
@@ -8147,36 +7654,7 @@ unsafe impl ::windows::core::Interface for ColorKeyFrameAnimation {
 impl ::windows::core::RuntimeName for ColorKeyFrameAnimation {
     const NAME: &'static str = "Windows.UI.Composition.ColorKeyFrameAnimation";
 }
-impl ::core::convert::From<ColorKeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: ColorKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ColorKeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: &ColorKeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ColorKeyFrameAnimation> for &::windows::core::IUnknown {
-    fn from(value: &ColorKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ColorKeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: ColorKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ColorKeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: &ColorKeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ColorKeyFrameAnimation> for &::windows::core::IInspectable {
-    fn from(value: &ColorKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ColorKeyFrameAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ColorKeyFrameAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: ColorKeyFrameAnimation) -> ::windows::core::Result<Self> {
@@ -8510,36 +7988,7 @@ unsafe impl ::windows::core::Interface for CompositionAnimation {
 impl ::windows::core::RuntimeName for CompositionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.CompositionAnimation";
 }
-impl ::core::convert::From<CompositionAnimation> for ::windows::core::IUnknown {
-    fn from(value: CompositionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &CompositionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &CompositionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionAnimation> for ::windows::core::IInspectable {
-    fn from(value: CompositionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &CompositionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &CompositionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionAnimation) -> ::windows::core::Result<Self> {
@@ -8802,36 +8251,7 @@ impl ::core::iter::IntoIterator for &CompositionAnimationGroup {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<CompositionAnimationGroup> for ::windows::core::IUnknown {
-    fn from(value: CompositionAnimationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionAnimationGroup> for ::windows::core::IUnknown {
-    fn from(value: &CompositionAnimationGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionAnimationGroup> for &::windows::core::IUnknown {
-    fn from(value: &CompositionAnimationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionAnimationGroup> for ::windows::core::IInspectable {
-    fn from(value: CompositionAnimationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionAnimationGroup> for ::windows::core::IInspectable {
-    fn from(value: &CompositionAnimationGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionAnimationGroup> for &::windows::core::IInspectable {
-    fn from(value: &CompositionAnimationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionAnimationGroup, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionAnimationGroup> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionAnimationGroup) -> ::windows::core::Result<Self> {
@@ -9066,36 +8486,7 @@ unsafe impl ::windows::core::Interface for CompositionBackdropBrush {
 impl ::windows::core::RuntimeName for CompositionBackdropBrush {
     const NAME: &'static str = "Windows.UI.Composition.CompositionBackdropBrush";
 }
-impl ::core::convert::From<CompositionBackdropBrush> for ::windows::core::IUnknown {
-    fn from(value: CompositionBackdropBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionBackdropBrush> for ::windows::core::IUnknown {
-    fn from(value: &CompositionBackdropBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionBackdropBrush> for &::windows::core::IUnknown {
-    fn from(value: &CompositionBackdropBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionBackdropBrush> for ::windows::core::IInspectable {
-    fn from(value: CompositionBackdropBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionBackdropBrush> for ::windows::core::IInspectable {
-    fn from(value: &CompositionBackdropBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionBackdropBrush> for &::windows::core::IInspectable {
-    fn from(value: &CompositionBackdropBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionBackdropBrush, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionBackdropBrush> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionBackdropBrush) -> ::windows::core::Result<Self> {
@@ -9304,36 +8695,7 @@ unsafe impl ::windows::core::Interface for CompositionBatchCompletedEventArgs {
 impl ::windows::core::RuntimeName for CompositionBatchCompletedEventArgs {
     const NAME: &'static str = "Windows.UI.Composition.CompositionBatchCompletedEventArgs";
 }
-impl ::core::convert::From<CompositionBatchCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CompositionBatchCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionBatchCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CompositionBatchCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionBatchCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CompositionBatchCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionBatchCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CompositionBatchCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionBatchCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CompositionBatchCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionBatchCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CompositionBatchCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionBatchCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionBatchCompletedEventArgs> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionBatchCompletedEventArgs) -> ::windows::core::Result<Self> {
@@ -9527,36 +8889,7 @@ unsafe impl ::windows::core::Interface for CompositionBrush {
 impl ::windows::core::RuntimeName for CompositionBrush {
     const NAME: &'static str = "Windows.UI.Composition.CompositionBrush";
 }
-impl ::core::convert::From<CompositionBrush> for ::windows::core::IUnknown {
-    fn from(value: CompositionBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionBrush> for ::windows::core::IUnknown {
-    fn from(value: &CompositionBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionBrush> for &::windows::core::IUnknown {
-    fn from(value: &CompositionBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionBrush> for ::windows::core::IInspectable {
-    fn from(value: CompositionBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionBrush> for ::windows::core::IInspectable {
-    fn from(value: &CompositionBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionBrush> for &::windows::core::IInspectable {
-    fn from(value: &CompositionBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionBrush, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionBrush> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionBrush) -> ::windows::core::Result<Self> {
@@ -9692,36 +9025,7 @@ unsafe impl ::windows::core::Interface for CompositionCapabilities {
 impl ::windows::core::RuntimeName for CompositionCapabilities {
     const NAME: &'static str = "Windows.UI.Composition.CompositionCapabilities";
 }
-impl ::core::convert::From<CompositionCapabilities> for ::windows::core::IUnknown {
-    fn from(value: CompositionCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &CompositionCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionCapabilities> for &::windows::core::IUnknown {
-    fn from(value: &CompositionCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionCapabilities> for ::windows::core::IInspectable {
-    fn from(value: CompositionCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionCapabilities> for ::windows::core::IInspectable {
-    fn from(value: &CompositionCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionCapabilities> for &::windows::core::IInspectable {
-    fn from(value: &CompositionCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionCapabilities, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CompositionCapabilities {}
 unsafe impl ::core::marker::Sync for CompositionCapabilities {}
 #[doc = "*Required features: `\"UI_Composition\"`*"]
@@ -9956,36 +9260,7 @@ unsafe impl ::windows::core::Interface for CompositionClip {
 impl ::windows::core::RuntimeName for CompositionClip {
     const NAME: &'static str = "Windows.UI.Composition.CompositionClip";
 }
-impl ::core::convert::From<CompositionClip> for ::windows::core::IUnknown {
-    fn from(value: CompositionClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionClip> for ::windows::core::IUnknown {
-    fn from(value: &CompositionClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionClip> for &::windows::core::IUnknown {
-    fn from(value: &CompositionClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionClip> for ::windows::core::IInspectable {
-    fn from(value: CompositionClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionClip> for ::windows::core::IInspectable {
-    fn from(value: &CompositionClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionClip> for &::windows::core::IInspectable {
-    fn from(value: &CompositionClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionClip, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionClip> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionClip) -> ::windows::core::Result<Self> {
@@ -10190,36 +9465,7 @@ unsafe impl ::windows::core::Interface for CompositionColorBrush {
 impl ::windows::core::RuntimeName for CompositionColorBrush {
     const NAME: &'static str = "Windows.UI.Composition.CompositionColorBrush";
 }
-impl ::core::convert::From<CompositionColorBrush> for ::windows::core::IUnknown {
-    fn from(value: CompositionColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionColorBrush> for ::windows::core::IUnknown {
-    fn from(value: &CompositionColorBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionColorBrush> for &::windows::core::IUnknown {
-    fn from(value: &CompositionColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionColorBrush> for ::windows::core::IInspectable {
-    fn from(value: CompositionColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionColorBrush> for ::windows::core::IInspectable {
-    fn from(value: &CompositionColorBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionColorBrush> for &::windows::core::IInspectable {
-    fn from(value: &CompositionColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionColorBrush, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionColorBrush> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionColorBrush) -> ::windows::core::Result<Self> {
@@ -10450,36 +9696,7 @@ unsafe impl ::windows::core::Interface for CompositionColorGradientStop {
 impl ::windows::core::RuntimeName for CompositionColorGradientStop {
     const NAME: &'static str = "Windows.UI.Composition.CompositionColorGradientStop";
 }
-impl ::core::convert::From<CompositionColorGradientStop> for ::windows::core::IUnknown {
-    fn from(value: CompositionColorGradientStop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionColorGradientStop> for ::windows::core::IUnknown {
-    fn from(value: &CompositionColorGradientStop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionColorGradientStop> for &::windows::core::IUnknown {
-    fn from(value: &CompositionColorGradientStop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionColorGradientStop> for ::windows::core::IInspectable {
-    fn from(value: CompositionColorGradientStop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionColorGradientStop> for ::windows::core::IInspectable {
-    fn from(value: &CompositionColorGradientStop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionColorGradientStop> for &::windows::core::IInspectable {
-    fn from(value: &CompositionColorGradientStop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionColorGradientStop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionColorGradientStop> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionColorGradientStop) -> ::windows::core::Result<Self> {
@@ -10687,36 +9904,7 @@ impl ::core::iter::IntoIterator for &CompositionColorGradientStopCollection {
         super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<CompositionColorGradientStopCollection> for ::windows::core::IUnknown {
-    fn from(value: CompositionColorGradientStopCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionColorGradientStopCollection> for ::windows::core::IUnknown {
-    fn from(value: &CompositionColorGradientStopCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionColorGradientStopCollection> for &::windows::core::IUnknown {
-    fn from(value: &CompositionColorGradientStopCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionColorGradientStopCollection> for ::windows::core::IInspectable {
-    fn from(value: CompositionColorGradientStopCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionColorGradientStopCollection> for ::windows::core::IInspectable {
-    fn from(value: &CompositionColorGradientStopCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionColorGradientStopCollection> for &::windows::core::IInspectable {
-    fn from(value: &CompositionColorGradientStopCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionColorGradientStopCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<CompositionColorGradientStopCollection> for super::super::Foundation::Collections::IIterable<CompositionColorGradientStop> {
     type Error = ::windows::core::Error;
@@ -10927,36 +10115,7 @@ unsafe impl ::windows::core::Interface for CompositionCommitBatch {
 impl ::windows::core::RuntimeName for CompositionCommitBatch {
     const NAME: &'static str = "Windows.UI.Composition.CompositionCommitBatch";
 }
-impl ::core::convert::From<CompositionCommitBatch> for ::windows::core::IUnknown {
-    fn from(value: CompositionCommitBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionCommitBatch> for ::windows::core::IUnknown {
-    fn from(value: &CompositionCommitBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionCommitBatch> for &::windows::core::IUnknown {
-    fn from(value: &CompositionCommitBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionCommitBatch> for ::windows::core::IInspectable {
-    fn from(value: CompositionCommitBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionCommitBatch> for ::windows::core::IInspectable {
-    fn from(value: &CompositionCommitBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionCommitBatch> for &::windows::core::IInspectable {
-    fn from(value: &CompositionCommitBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionCommitBatch, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionCommitBatch> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionCommitBatch) -> ::windows::core::Result<Self> {
@@ -11241,36 +10400,7 @@ unsafe impl ::windows::core::Interface for CompositionContainerShape {
 impl ::windows::core::RuntimeName for CompositionContainerShape {
     const NAME: &'static str = "Windows.UI.Composition.CompositionContainerShape";
 }
-impl ::core::convert::From<CompositionContainerShape> for ::windows::core::IUnknown {
-    fn from(value: CompositionContainerShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionContainerShape> for ::windows::core::IUnknown {
-    fn from(value: &CompositionContainerShape) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionContainerShape> for &::windows::core::IUnknown {
-    fn from(value: &CompositionContainerShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionContainerShape> for ::windows::core::IInspectable {
-    fn from(value: CompositionContainerShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionContainerShape> for ::windows::core::IInspectable {
-    fn from(value: &CompositionContainerShape) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionContainerShape> for &::windows::core::IInspectable {
-    fn from(value: &CompositionContainerShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionContainerShape, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionContainerShape> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionContainerShape) -> ::windows::core::Result<Self> {
@@ -11545,36 +10675,7 @@ unsafe impl ::windows::core::Interface for CompositionDrawingSurface {
 impl ::windows::core::RuntimeName for CompositionDrawingSurface {
     const NAME: &'static str = "Windows.UI.Composition.CompositionDrawingSurface";
 }
-impl ::core::convert::From<CompositionDrawingSurface> for ::windows::core::IUnknown {
-    fn from(value: CompositionDrawingSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionDrawingSurface> for ::windows::core::IUnknown {
-    fn from(value: &CompositionDrawingSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionDrawingSurface> for &::windows::core::IUnknown {
-    fn from(value: &CompositionDrawingSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionDrawingSurface> for ::windows::core::IInspectable {
-    fn from(value: CompositionDrawingSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionDrawingSurface> for ::windows::core::IInspectable {
-    fn from(value: &CompositionDrawingSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionDrawingSurface> for &::windows::core::IInspectable {
-    fn from(value: &CompositionDrawingSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionDrawingSurface, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionDrawingSurface> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionDrawingSurface) -> ::windows::core::Result<Self> {
@@ -11860,36 +10961,7 @@ unsafe impl ::windows::core::Interface for CompositionEasingFunction {
 impl ::windows::core::RuntimeName for CompositionEasingFunction {
     const NAME: &'static str = "Windows.UI.Composition.CompositionEasingFunction";
 }
-impl ::core::convert::From<CompositionEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: CompositionEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: &CompositionEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionEasingFunction> for &::windows::core::IUnknown {
-    fn from(value: &CompositionEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: CompositionEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: &CompositionEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionEasingFunction> for &::windows::core::IInspectable {
-    fn from(value: &CompositionEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionEasingFunction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionEasingFunction> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionEasingFunction) -> ::windows::core::Result<Self> {
@@ -12097,36 +11169,7 @@ unsafe impl ::windows::core::Interface for CompositionEffectBrush {
 impl ::windows::core::RuntimeName for CompositionEffectBrush {
     const NAME: &'static str = "Windows.UI.Composition.CompositionEffectBrush";
 }
-impl ::core::convert::From<CompositionEffectBrush> for ::windows::core::IUnknown {
-    fn from(value: CompositionEffectBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionEffectBrush> for ::windows::core::IUnknown {
-    fn from(value: &CompositionEffectBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionEffectBrush> for &::windows::core::IUnknown {
-    fn from(value: &CompositionEffectBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionEffectBrush> for ::windows::core::IInspectable {
-    fn from(value: CompositionEffectBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionEffectBrush> for ::windows::core::IInspectable {
-    fn from(value: &CompositionEffectBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionEffectBrush> for &::windows::core::IInspectable {
-    fn from(value: &CompositionEffectBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionEffectBrush, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionEffectBrush> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionEffectBrush) -> ::windows::core::Result<Self> {
@@ -12356,36 +11399,7 @@ unsafe impl ::windows::core::Interface for CompositionEffectFactory {
 impl ::windows::core::RuntimeName for CompositionEffectFactory {
     const NAME: &'static str = "Windows.UI.Composition.CompositionEffectFactory";
 }
-impl ::core::convert::From<CompositionEffectFactory> for ::windows::core::IUnknown {
-    fn from(value: CompositionEffectFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionEffectFactory> for ::windows::core::IUnknown {
-    fn from(value: &CompositionEffectFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionEffectFactory> for &::windows::core::IUnknown {
-    fn from(value: &CompositionEffectFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionEffectFactory> for ::windows::core::IInspectable {
-    fn from(value: CompositionEffectFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionEffectFactory> for ::windows::core::IInspectable {
-    fn from(value: &CompositionEffectFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionEffectFactory> for &::windows::core::IInspectable {
-    fn from(value: &CompositionEffectFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionEffectFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionEffectFactory> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionEffectFactory) -> ::windows::core::Result<Self> {
@@ -12499,36 +11513,7 @@ unsafe impl ::windows::core::Interface for CompositionEffectSourceParameter {
 impl ::windows::core::RuntimeName for CompositionEffectSourceParameter {
     const NAME: &'static str = "Windows.UI.Composition.CompositionEffectSourceParameter";
 }
-impl ::core::convert::From<CompositionEffectSourceParameter> for ::windows::core::IUnknown {
-    fn from(value: CompositionEffectSourceParameter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionEffectSourceParameter> for ::windows::core::IUnknown {
-    fn from(value: &CompositionEffectSourceParameter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionEffectSourceParameter> for &::windows::core::IUnknown {
-    fn from(value: &CompositionEffectSourceParameter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionEffectSourceParameter> for ::windows::core::IInspectable {
-    fn from(value: CompositionEffectSourceParameter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionEffectSourceParameter> for ::windows::core::IInspectable {
-    fn from(value: &CompositionEffectSourceParameter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionEffectSourceParameter> for &::windows::core::IInspectable {
-    fn from(value: &CompositionEffectSourceParameter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionEffectSourceParameter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Graphics_Effects")]
 impl ::core::convert::TryFrom<CompositionEffectSourceParameter> for super::super::Graphics::Effects::IGraphicsEffectSource {
     type Error = ::windows::core::Error;
@@ -12751,36 +11736,7 @@ unsafe impl ::windows::core::Interface for CompositionEllipseGeometry {
 impl ::windows::core::RuntimeName for CompositionEllipseGeometry {
     const NAME: &'static str = "Windows.UI.Composition.CompositionEllipseGeometry";
 }
-impl ::core::convert::From<CompositionEllipseGeometry> for ::windows::core::IUnknown {
-    fn from(value: CompositionEllipseGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionEllipseGeometry> for ::windows::core::IUnknown {
-    fn from(value: &CompositionEllipseGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionEllipseGeometry> for &::windows::core::IUnknown {
-    fn from(value: &CompositionEllipseGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionEllipseGeometry> for ::windows::core::IInspectable {
-    fn from(value: CompositionEllipseGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionEllipseGeometry> for ::windows::core::IInspectable {
-    fn from(value: &CompositionEllipseGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionEllipseGeometry> for &::windows::core::IInspectable {
-    fn from(value: &CompositionEllipseGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionEllipseGeometry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionEllipseGeometry> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionEllipseGeometry) -> ::windows::core::Result<Self> {
@@ -13111,36 +12067,7 @@ unsafe impl ::windows::core::Interface for CompositionGeometricClip {
 impl ::windows::core::RuntimeName for CompositionGeometricClip {
     const NAME: &'static str = "Windows.UI.Composition.CompositionGeometricClip";
 }
-impl ::core::convert::From<CompositionGeometricClip> for ::windows::core::IUnknown {
-    fn from(value: CompositionGeometricClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionGeometricClip> for ::windows::core::IUnknown {
-    fn from(value: &CompositionGeometricClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionGeometricClip> for &::windows::core::IUnknown {
-    fn from(value: &CompositionGeometricClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionGeometricClip> for ::windows::core::IInspectable {
-    fn from(value: CompositionGeometricClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionGeometricClip> for ::windows::core::IInspectable {
-    fn from(value: &CompositionGeometricClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionGeometricClip> for &::windows::core::IInspectable {
-    fn from(value: &CompositionGeometricClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionGeometricClip, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionGeometricClip> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionGeometricClip) -> ::windows::core::Result<Self> {
@@ -13382,36 +12309,7 @@ unsafe impl ::windows::core::Interface for CompositionGeometry {
 impl ::windows::core::RuntimeName for CompositionGeometry {
     const NAME: &'static str = "Windows.UI.Composition.CompositionGeometry";
 }
-impl ::core::convert::From<CompositionGeometry> for ::windows::core::IUnknown {
-    fn from(value: CompositionGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionGeometry> for ::windows::core::IUnknown {
-    fn from(value: &CompositionGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionGeometry> for &::windows::core::IUnknown {
-    fn from(value: &CompositionGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionGeometry> for ::windows::core::IInspectable {
-    fn from(value: CompositionGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionGeometry> for ::windows::core::IInspectable {
-    fn from(value: &CompositionGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionGeometry> for &::windows::core::IInspectable {
-    fn from(value: &CompositionGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionGeometry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionGeometry> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionGeometry) -> ::windows::core::Result<Self> {
@@ -13742,36 +12640,7 @@ unsafe impl ::windows::core::Interface for CompositionGradientBrush {
 impl ::windows::core::RuntimeName for CompositionGradientBrush {
     const NAME: &'static str = "Windows.UI.Composition.CompositionGradientBrush";
 }
-impl ::core::convert::From<CompositionGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: CompositionGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: &CompositionGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionGradientBrush> for &::windows::core::IUnknown {
-    fn from(value: &CompositionGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionGradientBrush> for ::windows::core::IInspectable {
-    fn from(value: CompositionGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionGradientBrush> for ::windows::core::IInspectable {
-    fn from(value: &CompositionGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionGradientBrush> for &::windows::core::IInspectable {
-    fn from(value: &CompositionGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionGradientBrush, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionGradientBrush> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionGradientBrush) -> ::windows::core::Result<Self> {
@@ -14047,36 +12916,7 @@ unsafe impl ::windows::core::Interface for CompositionGraphicsDevice {
 impl ::windows::core::RuntimeName for CompositionGraphicsDevice {
     const NAME: &'static str = "Windows.UI.Composition.CompositionGraphicsDevice";
 }
-impl ::core::convert::From<CompositionGraphicsDevice> for ::windows::core::IUnknown {
-    fn from(value: CompositionGraphicsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionGraphicsDevice> for ::windows::core::IUnknown {
-    fn from(value: &CompositionGraphicsDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionGraphicsDevice> for &::windows::core::IUnknown {
-    fn from(value: &CompositionGraphicsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionGraphicsDevice> for ::windows::core::IInspectable {
-    fn from(value: CompositionGraphicsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionGraphicsDevice> for ::windows::core::IInspectable {
-    fn from(value: &CompositionGraphicsDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionGraphicsDevice> for &::windows::core::IInspectable {
-    fn from(value: &CompositionGraphicsDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionGraphicsDevice, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionGraphicsDevice> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionGraphicsDevice) -> ::windows::core::Result<Self> {
@@ -14295,36 +13135,7 @@ unsafe impl ::windows::core::Interface for CompositionLight {
 impl ::windows::core::RuntimeName for CompositionLight {
     const NAME: &'static str = "Windows.UI.Composition.CompositionLight";
 }
-impl ::core::convert::From<CompositionLight> for ::windows::core::IUnknown {
-    fn from(value: CompositionLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionLight> for ::windows::core::IUnknown {
-    fn from(value: &CompositionLight) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionLight> for &::windows::core::IUnknown {
-    fn from(value: &CompositionLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionLight> for ::windows::core::IInspectable {
-    fn from(value: CompositionLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionLight> for ::windows::core::IInspectable {
-    fn from(value: &CompositionLight) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionLight> for &::windows::core::IInspectable {
-    fn from(value: &CompositionLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionLight, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionLight> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionLight) -> ::windows::core::Result<Self> {
@@ -14581,36 +13392,7 @@ unsafe impl ::windows::core::Interface for CompositionLineGeometry {
 impl ::windows::core::RuntimeName for CompositionLineGeometry {
     const NAME: &'static str = "Windows.UI.Composition.CompositionLineGeometry";
 }
-impl ::core::convert::From<CompositionLineGeometry> for ::windows::core::IUnknown {
-    fn from(value: CompositionLineGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionLineGeometry> for ::windows::core::IUnknown {
-    fn from(value: &CompositionLineGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionLineGeometry> for &::windows::core::IUnknown {
-    fn from(value: &CompositionLineGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionLineGeometry> for ::windows::core::IInspectable {
-    fn from(value: CompositionLineGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionLineGeometry> for ::windows::core::IInspectable {
-    fn from(value: &CompositionLineGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionLineGeometry> for &::windows::core::IInspectable {
-    fn from(value: &CompositionLineGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionLineGeometry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionLineGeometry> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionLineGeometry) -> ::windows::core::Result<Self> {
@@ -14986,36 +13768,7 @@ unsafe impl ::windows::core::Interface for CompositionLinearGradientBrush {
 impl ::windows::core::RuntimeName for CompositionLinearGradientBrush {
     const NAME: &'static str = "Windows.UI.Composition.CompositionLinearGradientBrush";
 }
-impl ::core::convert::From<CompositionLinearGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: CompositionLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionLinearGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: &CompositionLinearGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionLinearGradientBrush> for &::windows::core::IUnknown {
-    fn from(value: &CompositionLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionLinearGradientBrush> for ::windows::core::IInspectable {
-    fn from(value: CompositionLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionLinearGradientBrush> for ::windows::core::IInspectable {
-    fn from(value: &CompositionLinearGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionLinearGradientBrush> for &::windows::core::IInspectable {
-    fn from(value: &CompositionLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionLinearGradientBrush, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionLinearGradientBrush> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionLinearGradientBrush) -> ::windows::core::Result<Self> {
@@ -15267,36 +14020,7 @@ unsafe impl ::windows::core::Interface for CompositionMaskBrush {
 impl ::windows::core::RuntimeName for CompositionMaskBrush {
     const NAME: &'static str = "Windows.UI.Composition.CompositionMaskBrush";
 }
-impl ::core::convert::From<CompositionMaskBrush> for ::windows::core::IUnknown {
-    fn from(value: CompositionMaskBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionMaskBrush> for ::windows::core::IUnknown {
-    fn from(value: &CompositionMaskBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionMaskBrush> for &::windows::core::IUnknown {
-    fn from(value: &CompositionMaskBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionMaskBrush> for ::windows::core::IInspectable {
-    fn from(value: CompositionMaskBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionMaskBrush> for ::windows::core::IInspectable {
-    fn from(value: &CompositionMaskBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionMaskBrush> for &::windows::core::IInspectable {
-    fn from(value: &CompositionMaskBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionMaskBrush, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionMaskBrush> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionMaskBrush) -> ::windows::core::Result<Self> {
@@ -15546,36 +14270,7 @@ unsafe impl ::windows::core::Interface for CompositionMipmapSurface {
 impl ::windows::core::RuntimeName for CompositionMipmapSurface {
     const NAME: &'static str = "Windows.UI.Composition.CompositionMipmapSurface";
 }
-impl ::core::convert::From<CompositionMipmapSurface> for ::windows::core::IUnknown {
-    fn from(value: CompositionMipmapSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionMipmapSurface> for ::windows::core::IUnknown {
-    fn from(value: &CompositionMipmapSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionMipmapSurface> for &::windows::core::IUnknown {
-    fn from(value: &CompositionMipmapSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionMipmapSurface> for ::windows::core::IInspectable {
-    fn from(value: CompositionMipmapSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionMipmapSurface> for ::windows::core::IInspectable {
-    fn from(value: &CompositionMipmapSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionMipmapSurface> for &::windows::core::IInspectable {
-    fn from(value: &CompositionMipmapSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionMipmapSurface, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionMipmapSurface> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionMipmapSurface) -> ::windows::core::Result<Self> {
@@ -15917,36 +14612,7 @@ unsafe impl ::windows::core::Interface for CompositionNineGridBrush {
 impl ::windows::core::RuntimeName for CompositionNineGridBrush {
     const NAME: &'static str = "Windows.UI.Composition.CompositionNineGridBrush";
 }
-impl ::core::convert::From<CompositionNineGridBrush> for ::windows::core::IUnknown {
-    fn from(value: CompositionNineGridBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionNineGridBrush> for ::windows::core::IUnknown {
-    fn from(value: &CompositionNineGridBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionNineGridBrush> for &::windows::core::IUnknown {
-    fn from(value: &CompositionNineGridBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionNineGridBrush> for ::windows::core::IInspectable {
-    fn from(value: CompositionNineGridBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionNineGridBrush> for ::windows::core::IInspectable {
-    fn from(value: &CompositionNineGridBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionNineGridBrush> for &::windows::core::IInspectable {
-    fn from(value: &CompositionNineGridBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionNineGridBrush, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionNineGridBrush> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionNineGridBrush) -> ::windows::core::Result<Self> {
@@ -16177,36 +14843,7 @@ unsafe impl ::windows::core::Interface for CompositionObject {
 impl ::windows::core::RuntimeName for CompositionObject {
     const NAME: &'static str = "Windows.UI.Composition.CompositionObject";
 }
-impl ::core::convert::From<CompositionObject> for ::windows::core::IUnknown {
-    fn from(value: CompositionObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionObject> for ::windows::core::IUnknown {
-    fn from(value: &CompositionObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionObject> for &::windows::core::IUnknown {
-    fn from(value: &CompositionObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionObject> for ::windows::core::IInspectable {
-    fn from(value: CompositionObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionObject> for ::windows::core::IInspectable {
-    fn from(value: &CompositionObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionObject> for &::windows::core::IInspectable {
-    fn from(value: &CompositionObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionObject, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionObject> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionObject) -> ::windows::core::Result<Self> {
@@ -16304,36 +14941,7 @@ unsafe impl ::windows::core::Interface for CompositionPath {
 impl ::windows::core::RuntimeName for CompositionPath {
     const NAME: &'static str = "Windows.UI.Composition.CompositionPath";
 }
-impl ::core::convert::From<CompositionPath> for ::windows::core::IUnknown {
-    fn from(value: CompositionPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionPath> for ::windows::core::IUnknown {
-    fn from(value: &CompositionPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionPath> for &::windows::core::IUnknown {
-    fn from(value: &CompositionPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionPath> for ::windows::core::IInspectable {
-    fn from(value: CompositionPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionPath> for ::windows::core::IInspectable {
-    fn from(value: &CompositionPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionPath> for &::windows::core::IInspectable {
-    fn from(value: &CompositionPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionPath, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Graphics")]
 impl ::core::convert::TryFrom<CompositionPath> for super::super::Graphics::IGeometrySource2D {
     type Error = ::windows::core::Error;
@@ -16537,36 +15145,7 @@ unsafe impl ::windows::core::Interface for CompositionPathGeometry {
 impl ::windows::core::RuntimeName for CompositionPathGeometry {
     const NAME: &'static str = "Windows.UI.Composition.CompositionPathGeometry";
 }
-impl ::core::convert::From<CompositionPathGeometry> for ::windows::core::IUnknown {
-    fn from(value: CompositionPathGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionPathGeometry> for ::windows::core::IUnknown {
-    fn from(value: &CompositionPathGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionPathGeometry> for &::windows::core::IUnknown {
-    fn from(value: &CompositionPathGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionPathGeometry> for ::windows::core::IInspectable {
-    fn from(value: CompositionPathGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionPathGeometry> for ::windows::core::IInspectable {
-    fn from(value: &CompositionPathGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionPathGeometry> for &::windows::core::IInspectable {
-    fn from(value: &CompositionPathGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionPathGeometry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionPathGeometry> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionPathGeometry) -> ::windows::core::Result<Self> {
@@ -16836,36 +15415,7 @@ unsafe impl ::windows::core::Interface for CompositionProjectedShadow {
 impl ::windows::core::RuntimeName for CompositionProjectedShadow {
     const NAME: &'static str = "Windows.UI.Composition.CompositionProjectedShadow";
 }
-impl ::core::convert::From<CompositionProjectedShadow> for ::windows::core::IUnknown {
-    fn from(value: CompositionProjectedShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadow> for ::windows::core::IUnknown {
-    fn from(value: &CompositionProjectedShadow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadow> for &::windows::core::IUnknown {
-    fn from(value: &CompositionProjectedShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionProjectedShadow> for ::windows::core::IInspectable {
-    fn from(value: CompositionProjectedShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadow> for ::windows::core::IInspectable {
-    fn from(value: &CompositionProjectedShadow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadow> for &::windows::core::IInspectable {
-    fn from(value: &CompositionProjectedShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionProjectedShadow, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionProjectedShadow> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionProjectedShadow) -> ::windows::core::Result<Self> {
@@ -17087,36 +15637,7 @@ unsafe impl ::windows::core::Interface for CompositionProjectedShadowCaster {
 impl ::windows::core::RuntimeName for CompositionProjectedShadowCaster {
     const NAME: &'static str = "Windows.UI.Composition.CompositionProjectedShadowCaster";
 }
-impl ::core::convert::From<CompositionProjectedShadowCaster> for ::windows::core::IUnknown {
-    fn from(value: CompositionProjectedShadowCaster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowCaster> for ::windows::core::IUnknown {
-    fn from(value: &CompositionProjectedShadowCaster) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowCaster> for &::windows::core::IUnknown {
-    fn from(value: &CompositionProjectedShadowCaster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionProjectedShadowCaster> for ::windows::core::IInspectable {
-    fn from(value: CompositionProjectedShadowCaster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowCaster> for ::windows::core::IInspectable {
-    fn from(value: &CompositionProjectedShadowCaster) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowCaster> for &::windows::core::IInspectable {
-    fn from(value: &CompositionProjectedShadowCaster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionProjectedShadowCaster, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionProjectedShadowCaster> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionProjectedShadowCaster) -> ::windows::core::Result<Self> {
@@ -17377,36 +15898,7 @@ impl ::core::iter::IntoIterator for &CompositionProjectedShadowCasterCollection 
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<CompositionProjectedShadowCasterCollection> for ::windows::core::IUnknown {
-    fn from(value: CompositionProjectedShadowCasterCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowCasterCollection> for ::windows::core::IUnknown {
-    fn from(value: &CompositionProjectedShadowCasterCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowCasterCollection> for &::windows::core::IUnknown {
-    fn from(value: &CompositionProjectedShadowCasterCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionProjectedShadowCasterCollection> for ::windows::core::IInspectable {
-    fn from(value: CompositionProjectedShadowCasterCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowCasterCollection> for ::windows::core::IInspectable {
-    fn from(value: &CompositionProjectedShadowCasterCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowCasterCollection> for &::windows::core::IInspectable {
-    fn from(value: &CompositionProjectedShadowCasterCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionProjectedShadowCasterCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionProjectedShadowCasterCollection> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionProjectedShadowCasterCollection) -> ::windows::core::Result<Self> {
@@ -17636,36 +16128,7 @@ unsafe impl ::windows::core::Interface for CompositionProjectedShadowReceiver {
 impl ::windows::core::RuntimeName for CompositionProjectedShadowReceiver {
     const NAME: &'static str = "Windows.UI.Composition.CompositionProjectedShadowReceiver";
 }
-impl ::core::convert::From<CompositionProjectedShadowReceiver> for ::windows::core::IUnknown {
-    fn from(value: CompositionProjectedShadowReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowReceiver> for ::windows::core::IUnknown {
-    fn from(value: &CompositionProjectedShadowReceiver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowReceiver> for &::windows::core::IUnknown {
-    fn from(value: &CompositionProjectedShadowReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionProjectedShadowReceiver> for ::windows::core::IInspectable {
-    fn from(value: CompositionProjectedShadowReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowReceiver> for ::windows::core::IInspectable {
-    fn from(value: &CompositionProjectedShadowReceiver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowReceiver> for &::windows::core::IInspectable {
-    fn from(value: &CompositionProjectedShadowReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionProjectedShadowReceiver, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionProjectedShadowReceiver> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionProjectedShadowReceiver) -> ::windows::core::Result<Self> {
@@ -17903,36 +16366,7 @@ impl ::core::iter::IntoIterator for &CompositionProjectedShadowReceiverUnordered
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<CompositionProjectedShadowReceiverUnorderedCollection> for ::windows::core::IUnknown {
-    fn from(value: CompositionProjectedShadowReceiverUnorderedCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowReceiverUnorderedCollection> for ::windows::core::IUnknown {
-    fn from(value: &CompositionProjectedShadowReceiverUnorderedCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowReceiverUnorderedCollection> for &::windows::core::IUnknown {
-    fn from(value: &CompositionProjectedShadowReceiverUnorderedCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionProjectedShadowReceiverUnorderedCollection> for ::windows::core::IInspectable {
-    fn from(value: CompositionProjectedShadowReceiverUnorderedCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowReceiverUnorderedCollection> for ::windows::core::IInspectable {
-    fn from(value: &CompositionProjectedShadowReceiverUnorderedCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionProjectedShadowReceiverUnorderedCollection> for &::windows::core::IInspectable {
-    fn from(value: &CompositionProjectedShadowReceiverUnorderedCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionProjectedShadowReceiverUnorderedCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionProjectedShadowReceiverUnorderedCollection> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionProjectedShadowReceiverUnorderedCollection) -> ::windows::core::Result<Self> {
@@ -18271,36 +16705,7 @@ unsafe impl ::windows::core::Interface for CompositionPropertySet {
 impl ::windows::core::RuntimeName for CompositionPropertySet {
     const NAME: &'static str = "Windows.UI.Composition.CompositionPropertySet";
 }
-impl ::core::convert::From<CompositionPropertySet> for ::windows::core::IUnknown {
-    fn from(value: CompositionPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionPropertySet> for ::windows::core::IUnknown {
-    fn from(value: &CompositionPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionPropertySet> for &::windows::core::IUnknown {
-    fn from(value: &CompositionPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionPropertySet> for ::windows::core::IInspectable {
-    fn from(value: CompositionPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionPropertySet> for ::windows::core::IInspectable {
-    fn from(value: &CompositionPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionPropertySet> for &::windows::core::IInspectable {
-    fn from(value: &CompositionPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionPropertySet, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionPropertySet> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionPropertySet) -> ::windows::core::Result<Self> {
@@ -18676,36 +17081,7 @@ unsafe impl ::windows::core::Interface for CompositionRadialGradientBrush {
 impl ::windows::core::RuntimeName for CompositionRadialGradientBrush {
     const NAME: &'static str = "Windows.UI.Composition.CompositionRadialGradientBrush";
 }
-impl ::core::convert::From<CompositionRadialGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: CompositionRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionRadialGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: &CompositionRadialGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionRadialGradientBrush> for &::windows::core::IUnknown {
-    fn from(value: &CompositionRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionRadialGradientBrush> for ::windows::core::IInspectable {
-    fn from(value: CompositionRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionRadialGradientBrush> for ::windows::core::IInspectable {
-    fn from(value: &CompositionRadialGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionRadialGradientBrush> for &::windows::core::IInspectable {
-    fn from(value: &CompositionRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionRadialGradientBrush, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionRadialGradientBrush> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionRadialGradientBrush) -> ::windows::core::Result<Self> {
@@ -18992,36 +17368,7 @@ unsafe impl ::windows::core::Interface for CompositionRectangleGeometry {
 impl ::windows::core::RuntimeName for CompositionRectangleGeometry {
     const NAME: &'static str = "Windows.UI.Composition.CompositionRectangleGeometry";
 }
-impl ::core::convert::From<CompositionRectangleGeometry> for ::windows::core::IUnknown {
-    fn from(value: CompositionRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionRectangleGeometry> for ::windows::core::IUnknown {
-    fn from(value: &CompositionRectangleGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionRectangleGeometry> for &::windows::core::IUnknown {
-    fn from(value: &CompositionRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionRectangleGeometry> for ::windows::core::IInspectable {
-    fn from(value: CompositionRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionRectangleGeometry> for ::windows::core::IInspectable {
-    fn from(value: &CompositionRectangleGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionRectangleGeometry> for &::windows::core::IInspectable {
-    fn from(value: &CompositionRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionRectangleGeometry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionRectangleGeometry> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionRectangleGeometry) -> ::windows::core::Result<Self> {
@@ -19308,36 +17655,7 @@ unsafe impl ::windows::core::Interface for CompositionRoundedRectangleGeometry {
 impl ::windows::core::RuntimeName for CompositionRoundedRectangleGeometry {
     const NAME: &'static str = "Windows.UI.Composition.CompositionRoundedRectangleGeometry";
 }
-impl ::core::convert::From<CompositionRoundedRectangleGeometry> for ::windows::core::IUnknown {
-    fn from(value: CompositionRoundedRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionRoundedRectangleGeometry> for ::windows::core::IUnknown {
-    fn from(value: &CompositionRoundedRectangleGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionRoundedRectangleGeometry> for &::windows::core::IUnknown {
-    fn from(value: &CompositionRoundedRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionRoundedRectangleGeometry> for ::windows::core::IInspectable {
-    fn from(value: CompositionRoundedRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionRoundedRectangleGeometry> for ::windows::core::IInspectable {
-    fn from(value: &CompositionRoundedRectangleGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionRoundedRectangleGeometry> for &::windows::core::IInspectable {
-    fn from(value: &CompositionRoundedRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionRoundedRectangleGeometry, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionRoundedRectangleGeometry> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionRoundedRectangleGeometry) -> ::windows::core::Result<Self> {
@@ -19587,36 +17905,7 @@ unsafe impl ::windows::core::Interface for CompositionScopedBatch {
 impl ::windows::core::RuntimeName for CompositionScopedBatch {
     const NAME: &'static str = "Windows.UI.Composition.CompositionScopedBatch";
 }
-impl ::core::convert::From<CompositionScopedBatch> for ::windows::core::IUnknown {
-    fn from(value: CompositionScopedBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionScopedBatch> for ::windows::core::IUnknown {
-    fn from(value: &CompositionScopedBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionScopedBatch> for &::windows::core::IUnknown {
-    fn from(value: &CompositionScopedBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionScopedBatch> for ::windows::core::IInspectable {
-    fn from(value: CompositionScopedBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionScopedBatch> for ::windows::core::IInspectable {
-    fn from(value: &CompositionScopedBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionScopedBatch> for &::windows::core::IInspectable {
-    fn from(value: &CompositionScopedBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionScopedBatch, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionScopedBatch> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionScopedBatch) -> ::windows::core::Result<Self> {
@@ -19810,36 +18099,7 @@ unsafe impl ::windows::core::Interface for CompositionShadow {
 impl ::windows::core::RuntimeName for CompositionShadow {
     const NAME: &'static str = "Windows.UI.Composition.CompositionShadow";
 }
-impl ::core::convert::From<CompositionShadow> for ::windows::core::IUnknown {
-    fn from(value: CompositionShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionShadow> for ::windows::core::IUnknown {
-    fn from(value: &CompositionShadow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionShadow> for &::windows::core::IUnknown {
-    fn from(value: &CompositionShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionShadow> for ::windows::core::IInspectable {
-    fn from(value: CompositionShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionShadow> for ::windows::core::IInspectable {
-    fn from(value: &CompositionShadow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionShadow> for &::windows::core::IInspectable {
-    fn from(value: &CompositionShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionShadow, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionShadow> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionShadow) -> ::windows::core::Result<Self> {
@@ -20115,36 +18375,7 @@ unsafe impl ::windows::core::Interface for CompositionShape {
 impl ::windows::core::RuntimeName for CompositionShape {
     const NAME: &'static str = "Windows.UI.Composition.CompositionShape";
 }
-impl ::core::convert::From<CompositionShape> for ::windows::core::IUnknown {
-    fn from(value: CompositionShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionShape> for ::windows::core::IUnknown {
-    fn from(value: &CompositionShape) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionShape> for &::windows::core::IUnknown {
-    fn from(value: &CompositionShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionShape> for ::windows::core::IInspectable {
-    fn from(value: CompositionShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionShape> for ::windows::core::IInspectable {
-    fn from(value: &CompositionShape) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionShape> for &::windows::core::IInspectable {
-    fn from(value: &CompositionShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionShape, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionShape> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionShape) -> ::windows::core::Result<Self> {
@@ -20473,41 +18704,7 @@ impl ::core::iter::IntoIterator for &CompositionShapeCollection {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<CompositionShapeCollection> for ::windows::core::IUnknown {
-    fn from(value: CompositionShapeCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&CompositionShapeCollection> for ::windows::core::IUnknown {
-    fn from(value: &CompositionShapeCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&CompositionShapeCollection> for &::windows::core::IUnknown {
-    fn from(value: &CompositionShapeCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<CompositionShapeCollection> for ::windows::core::IInspectable {
-    fn from(value: CompositionShapeCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&CompositionShapeCollection> for ::windows::core::IInspectable {
-    fn from(value: &CompositionShapeCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&CompositionShapeCollection> for &::windows::core::IInspectable {
-    fn from(value: &CompositionShapeCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionShapeCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<CompositionShapeCollection> for IAnimationObject {
     type Error = ::windows::core::Error;
@@ -20974,36 +19171,7 @@ unsafe impl ::windows::core::Interface for CompositionSpriteShape {
 impl ::windows::core::RuntimeName for CompositionSpriteShape {
     const NAME: &'static str = "Windows.UI.Composition.CompositionSpriteShape";
 }
-impl ::core::convert::From<CompositionSpriteShape> for ::windows::core::IUnknown {
-    fn from(value: CompositionSpriteShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionSpriteShape> for ::windows::core::IUnknown {
-    fn from(value: &CompositionSpriteShape) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionSpriteShape> for &::windows::core::IUnknown {
-    fn from(value: &CompositionSpriteShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionSpriteShape> for ::windows::core::IInspectable {
-    fn from(value: CompositionSpriteShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionSpriteShape> for ::windows::core::IInspectable {
-    fn from(value: &CompositionSpriteShape) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionSpriteShape> for &::windows::core::IInspectable {
-    fn from(value: &CompositionSpriteShape) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionSpriteShape, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionSpriteShape> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionSpriteShape) -> ::windows::core::Result<Self> {
@@ -21335,41 +19503,7 @@ impl ::core::iter::IntoIterator for &CompositionStrokeDashArray {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<CompositionStrokeDashArray> for ::windows::core::IUnknown {
-    fn from(value: CompositionStrokeDashArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&CompositionStrokeDashArray> for ::windows::core::IUnknown {
-    fn from(value: &CompositionStrokeDashArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&CompositionStrokeDashArray> for &::windows::core::IUnknown {
-    fn from(value: &CompositionStrokeDashArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<CompositionStrokeDashArray> for ::windows::core::IInspectable {
-    fn from(value: CompositionStrokeDashArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&CompositionStrokeDashArray> for ::windows::core::IInspectable {
-    fn from(value: &CompositionStrokeDashArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&CompositionStrokeDashArray> for &::windows::core::IInspectable {
-    fn from(value: &CompositionStrokeDashArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionStrokeDashArray, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<CompositionStrokeDashArray> for IAnimationObject {
     type Error = ::windows::core::Error;
@@ -21782,36 +19916,7 @@ unsafe impl ::windows::core::Interface for CompositionSurfaceBrush {
 impl ::windows::core::RuntimeName for CompositionSurfaceBrush {
     const NAME: &'static str = "Windows.UI.Composition.CompositionSurfaceBrush";
 }
-impl ::core::convert::From<CompositionSurfaceBrush> for ::windows::core::IUnknown {
-    fn from(value: CompositionSurfaceBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionSurfaceBrush> for ::windows::core::IUnknown {
-    fn from(value: &CompositionSurfaceBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionSurfaceBrush> for &::windows::core::IUnknown {
-    fn from(value: &CompositionSurfaceBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionSurfaceBrush> for ::windows::core::IInspectable {
-    fn from(value: CompositionSurfaceBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionSurfaceBrush> for ::windows::core::IInspectable {
-    fn from(value: &CompositionSurfaceBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionSurfaceBrush> for &::windows::core::IInspectable {
-    fn from(value: &CompositionSurfaceBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionSurfaceBrush, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionSurfaceBrush> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionSurfaceBrush) -> ::windows::core::Result<Self> {
@@ -22034,36 +20139,7 @@ unsafe impl ::windows::core::Interface for CompositionTarget {
 impl ::windows::core::RuntimeName for CompositionTarget {
     const NAME: &'static str = "Windows.UI.Composition.CompositionTarget";
 }
-impl ::core::convert::From<CompositionTarget> for ::windows::core::IUnknown {
-    fn from(value: CompositionTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionTarget> for ::windows::core::IUnknown {
-    fn from(value: &CompositionTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionTarget> for &::windows::core::IUnknown {
-    fn from(value: &CompositionTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionTarget> for ::windows::core::IInspectable {
-    fn from(value: CompositionTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionTarget> for ::windows::core::IInspectable {
-    fn from(value: &CompositionTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionTarget> for &::windows::core::IInspectable {
-    fn from(value: &CompositionTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionTarget, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionTarget> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionTarget) -> ::windows::core::Result<Self> {
@@ -22257,36 +20333,7 @@ unsafe impl ::windows::core::Interface for CompositionTransform {
 impl ::windows::core::RuntimeName for CompositionTransform {
     const NAME: &'static str = "Windows.UI.Composition.CompositionTransform";
 }
-impl ::core::convert::From<CompositionTransform> for ::windows::core::IUnknown {
-    fn from(value: CompositionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionTransform> for ::windows::core::IUnknown {
-    fn from(value: &CompositionTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionTransform> for &::windows::core::IUnknown {
-    fn from(value: &CompositionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionTransform> for ::windows::core::IInspectable {
-    fn from(value: CompositionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionTransform> for ::windows::core::IInspectable {
-    fn from(value: &CompositionTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionTransform> for &::windows::core::IInspectable {
-    fn from(value: &CompositionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionTransform, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionTransform> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionTransform) -> ::windows::core::Result<Self> {
@@ -22543,36 +20590,7 @@ unsafe impl ::windows::core::Interface for CompositionViewBox {
 impl ::windows::core::RuntimeName for CompositionViewBox {
     const NAME: &'static str = "Windows.UI.Composition.CompositionViewBox";
 }
-impl ::core::convert::From<CompositionViewBox> for ::windows::core::IUnknown {
-    fn from(value: CompositionViewBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionViewBox> for ::windows::core::IUnknown {
-    fn from(value: &CompositionViewBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionViewBox> for &::windows::core::IUnknown {
-    fn from(value: &CompositionViewBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionViewBox> for ::windows::core::IInspectable {
-    fn from(value: CompositionViewBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionViewBox> for ::windows::core::IInspectable {
-    fn from(value: &CompositionViewBox) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionViewBox> for &::windows::core::IInspectable {
-    fn from(value: &CompositionViewBox) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionViewBox, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionViewBox> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionViewBox) -> ::windows::core::Result<Self> {
@@ -22838,36 +20856,7 @@ unsafe impl ::windows::core::Interface for CompositionVirtualDrawingSurface {
 impl ::windows::core::RuntimeName for CompositionVirtualDrawingSurface {
     const NAME: &'static str = "Windows.UI.Composition.CompositionVirtualDrawingSurface";
 }
-impl ::core::convert::From<CompositionVirtualDrawingSurface> for ::windows::core::IUnknown {
-    fn from(value: CompositionVirtualDrawingSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionVirtualDrawingSurface> for ::windows::core::IUnknown {
-    fn from(value: &CompositionVirtualDrawingSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionVirtualDrawingSurface> for &::windows::core::IUnknown {
-    fn from(value: &CompositionVirtualDrawingSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionVirtualDrawingSurface> for ::windows::core::IInspectable {
-    fn from(value: CompositionVirtualDrawingSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionVirtualDrawingSurface> for ::windows::core::IInspectable {
-    fn from(value: &CompositionVirtualDrawingSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionVirtualDrawingSurface> for &::windows::core::IInspectable {
-    fn from(value: &CompositionVirtualDrawingSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionVirtualDrawingSurface, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionVirtualDrawingSurface> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionVirtualDrawingSurface) -> ::windows::core::Result<Self> {
@@ -23139,36 +21128,7 @@ unsafe impl ::windows::core::Interface for CompositionVisualSurface {
 impl ::windows::core::RuntimeName for CompositionVisualSurface {
     const NAME: &'static str = "Windows.UI.Composition.CompositionVisualSurface";
 }
-impl ::core::convert::From<CompositionVisualSurface> for ::windows::core::IUnknown {
-    fn from(value: CompositionVisualSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionVisualSurface> for ::windows::core::IUnknown {
-    fn from(value: &CompositionVisualSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionVisualSurface> for &::windows::core::IUnknown {
-    fn from(value: &CompositionVisualSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompositionVisualSurface> for ::windows::core::IInspectable {
-    fn from(value: CompositionVisualSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompositionVisualSurface> for ::windows::core::IInspectable {
-    fn from(value: &CompositionVisualSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompositionVisualSurface> for &::windows::core::IInspectable {
-    fn from(value: &CompositionVisualSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompositionVisualSurface, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CompositionVisualSurface> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CompositionVisualSurface) -> ::windows::core::Result<Self> {
@@ -23902,36 +21862,7 @@ unsafe impl ::windows::core::Interface for Compositor {
 impl ::windows::core::RuntimeName for Compositor {
     const NAME: &'static str = "Windows.UI.Composition.Compositor";
 }
-impl ::core::convert::From<Compositor> for ::windows::core::IUnknown {
-    fn from(value: Compositor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Compositor> for ::windows::core::IUnknown {
-    fn from(value: &Compositor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Compositor> for &::windows::core::IUnknown {
-    fn from(value: &Compositor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Compositor> for ::windows::core::IInspectable {
-    fn from(value: Compositor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Compositor> for ::windows::core::IInspectable {
-    fn from(value: &Compositor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Compositor> for &::windows::core::IInspectable {
-    fn from(value: &Compositor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Compositor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<Compositor> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -24382,36 +22313,7 @@ unsafe impl ::windows::core::Interface for ContainerVisual {
 impl ::windows::core::RuntimeName for ContainerVisual {
     const NAME: &'static str = "Windows.UI.Composition.ContainerVisual";
 }
-impl ::core::convert::From<ContainerVisual> for ::windows::core::IUnknown {
-    fn from(value: ContainerVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContainerVisual> for ::windows::core::IUnknown {
-    fn from(value: &ContainerVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContainerVisual> for &::windows::core::IUnknown {
-    fn from(value: &ContainerVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContainerVisual> for ::windows::core::IInspectable {
-    fn from(value: ContainerVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContainerVisual> for ::windows::core::IInspectable {
-    fn from(value: &ContainerVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContainerVisual> for &::windows::core::IInspectable {
-    fn from(value: &ContainerVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContainerVisual, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ContainerVisual> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: ContainerVisual) -> ::windows::core::Result<Self> {
@@ -24638,36 +22540,7 @@ unsafe impl ::windows::core::Interface for CubicBezierEasingFunction {
 impl ::windows::core::RuntimeName for CubicBezierEasingFunction {
     const NAME: &'static str = "Windows.UI.Composition.CubicBezierEasingFunction";
 }
-impl ::core::convert::From<CubicBezierEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: CubicBezierEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CubicBezierEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: &CubicBezierEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CubicBezierEasingFunction> for &::windows::core::IUnknown {
-    fn from(value: &CubicBezierEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CubicBezierEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: CubicBezierEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CubicBezierEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: &CubicBezierEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CubicBezierEasingFunction> for &::windows::core::IInspectable {
-    fn from(value: &CubicBezierEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CubicBezierEasingFunction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CubicBezierEasingFunction> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: CubicBezierEasingFunction) -> ::windows::core::Result<Self> {
@@ -25207,36 +23080,7 @@ unsafe impl ::windows::core::Interface for DelegatedInkTrailVisual {
 impl ::windows::core::RuntimeName for DelegatedInkTrailVisual {
     const NAME: &'static str = "Windows.UI.Composition.DelegatedInkTrailVisual";
 }
-impl ::core::convert::From<DelegatedInkTrailVisual> for ::windows::core::IUnknown {
-    fn from(value: DelegatedInkTrailVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DelegatedInkTrailVisual> for ::windows::core::IUnknown {
-    fn from(value: &DelegatedInkTrailVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DelegatedInkTrailVisual> for &::windows::core::IUnknown {
-    fn from(value: &DelegatedInkTrailVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DelegatedInkTrailVisual> for ::windows::core::IInspectable {
-    fn from(value: DelegatedInkTrailVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DelegatedInkTrailVisual> for ::windows::core::IInspectable {
-    fn from(value: &DelegatedInkTrailVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DelegatedInkTrailVisual> for &::windows::core::IInspectable {
-    fn from(value: &DelegatedInkTrailVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DelegatedInkTrailVisual, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DelegatedInkTrailVisual> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: DelegatedInkTrailVisual) -> ::windows::core::Result<Self> {
@@ -25521,36 +23365,7 @@ unsafe impl ::windows::core::Interface for DistantLight {
 impl ::windows::core::RuntimeName for DistantLight {
     const NAME: &'static str = "Windows.UI.Composition.DistantLight";
 }
-impl ::core::convert::From<DistantLight> for ::windows::core::IUnknown {
-    fn from(value: DistantLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DistantLight> for ::windows::core::IUnknown {
-    fn from(value: &DistantLight) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DistantLight> for &::windows::core::IUnknown {
-    fn from(value: &DistantLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DistantLight> for ::windows::core::IInspectable {
-    fn from(value: DistantLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DistantLight> for ::windows::core::IInspectable {
-    fn from(value: &DistantLight) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DistantLight> for &::windows::core::IInspectable {
-    fn from(value: &DistantLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DistantLight, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DistantLight> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: DistantLight) -> ::windows::core::Result<Self> {
@@ -25832,36 +23647,7 @@ unsafe impl ::windows::core::Interface for DropShadow {
 impl ::windows::core::RuntimeName for DropShadow {
     const NAME: &'static str = "Windows.UI.Composition.DropShadow";
 }
-impl ::core::convert::From<DropShadow> for ::windows::core::IUnknown {
-    fn from(value: DropShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DropShadow> for ::windows::core::IUnknown {
-    fn from(value: &DropShadow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DropShadow> for &::windows::core::IUnknown {
-    fn from(value: &DropShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DropShadow> for ::windows::core::IInspectable {
-    fn from(value: DropShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DropShadow> for ::windows::core::IInspectable {
-    fn from(value: &DropShadow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DropShadow> for &::windows::core::IInspectable {
-    fn from(value: &DropShadow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DropShadow, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<DropShadow> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: DropShadow) -> ::windows::core::Result<Self> {
@@ -26091,36 +23877,7 @@ unsafe impl ::windows::core::Interface for ElasticEasingFunction {
 impl ::windows::core::RuntimeName for ElasticEasingFunction {
     const NAME: &'static str = "Windows.UI.Composition.ElasticEasingFunction";
 }
-impl ::core::convert::From<ElasticEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: ElasticEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ElasticEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: &ElasticEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ElasticEasingFunction> for &::windows::core::IUnknown {
-    fn from(value: &ElasticEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ElasticEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: ElasticEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ElasticEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: &ElasticEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ElasticEasingFunction> for &::windows::core::IInspectable {
-    fn from(value: &ElasticEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ElasticEasingFunction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ElasticEasingFunction> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: ElasticEasingFunction) -> ::windows::core::Result<Self> {
@@ -26343,36 +24100,7 @@ unsafe impl ::windows::core::Interface for ExponentialEasingFunction {
 impl ::windows::core::RuntimeName for ExponentialEasingFunction {
     const NAME: &'static str = "Windows.UI.Composition.ExponentialEasingFunction";
 }
-impl ::core::convert::From<ExponentialEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: ExponentialEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExponentialEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: &ExponentialEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExponentialEasingFunction> for &::windows::core::IUnknown {
-    fn from(value: &ExponentialEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ExponentialEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: ExponentialEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExponentialEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: &ExponentialEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExponentialEasingFunction> for &::windows::core::IInspectable {
-    fn from(value: &ExponentialEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ExponentialEasingFunction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ExponentialEasingFunction> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: ExponentialEasingFunction) -> ::windows::core::Result<Self> {
@@ -26683,36 +24411,7 @@ unsafe impl ::windows::core::Interface for ExpressionAnimation {
 impl ::windows::core::RuntimeName for ExpressionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.ExpressionAnimation";
 }
-impl ::core::convert::From<ExpressionAnimation> for ::windows::core::IUnknown {
-    fn from(value: ExpressionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExpressionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &ExpressionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExpressionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &ExpressionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ExpressionAnimation> for ::windows::core::IInspectable {
-    fn from(value: ExpressionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ExpressionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &ExpressionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ExpressionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &ExpressionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ExpressionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ExpressionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: ExpressionAnimation) -> ::windows::core::Result<Self> {
@@ -27026,36 +24725,7 @@ impl ::core::iter::IntoIterator for &ImplicitAnimationCollection {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<ImplicitAnimationCollection> for ::windows::core::IUnknown {
-    fn from(value: ImplicitAnimationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImplicitAnimationCollection> for ::windows::core::IUnknown {
-    fn from(value: &ImplicitAnimationCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImplicitAnimationCollection> for &::windows::core::IUnknown {
-    fn from(value: &ImplicitAnimationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ImplicitAnimationCollection> for ::windows::core::IInspectable {
-    fn from(value: ImplicitAnimationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ImplicitAnimationCollection> for ::windows::core::IInspectable {
-    fn from(value: &ImplicitAnimationCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ImplicitAnimationCollection> for &::windows::core::IInspectable {
-    fn from(value: &ImplicitAnimationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ImplicitAnimationCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ImplicitAnimationCollection> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: ImplicitAnimationCollection) -> ::windows::core::Result<Self> {
@@ -27386,41 +25056,7 @@ impl ::core::iter::IntoIterator for &InitialValueExpressionCollection {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<InitialValueExpressionCollection> for ::windows::core::IUnknown {
-    fn from(value: InitialValueExpressionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&InitialValueExpressionCollection> for ::windows::core::IUnknown {
-    fn from(value: &InitialValueExpressionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&InitialValueExpressionCollection> for &::windows::core::IUnknown {
-    fn from(value: &InitialValueExpressionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<InitialValueExpressionCollection> for ::windows::core::IInspectable {
-    fn from(value: InitialValueExpressionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&InitialValueExpressionCollection> for ::windows::core::IInspectable {
-    fn from(value: &InitialValueExpressionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&InitialValueExpressionCollection> for &::windows::core::IInspectable {
-    fn from(value: &InitialValueExpressionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InitialValueExpressionCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<InitialValueExpressionCollection> for IAnimationObject {
     type Error = ::windows::core::Error;
@@ -27807,36 +25443,7 @@ unsafe impl ::windows::core::Interface for InsetClip {
 impl ::windows::core::RuntimeName for InsetClip {
     const NAME: &'static str = "Windows.UI.Composition.InsetClip";
 }
-impl ::core::convert::From<InsetClip> for ::windows::core::IUnknown {
-    fn from(value: InsetClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InsetClip> for ::windows::core::IUnknown {
-    fn from(value: &InsetClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InsetClip> for &::windows::core::IUnknown {
-    fn from(value: &InsetClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InsetClip> for ::windows::core::IInspectable {
-    fn from(value: InsetClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InsetClip> for ::windows::core::IInspectable {
-    fn from(value: &InsetClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InsetClip> for &::windows::core::IInspectable {
-    fn from(value: &InsetClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InsetClip, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InsetClip> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: InsetClip) -> ::windows::core::Result<Self> {
@@ -28239,36 +25846,7 @@ unsafe impl ::windows::core::Interface for KeyFrameAnimation {
 impl ::windows::core::RuntimeName for KeyFrameAnimation {
     const NAME: &'static str = "Windows.UI.Composition.KeyFrameAnimation";
 }
-impl ::core::convert::From<KeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: &KeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyFrameAnimation> for &::windows::core::IUnknown {
-    fn from(value: &KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<KeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: &KeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyFrameAnimation> for &::windows::core::IInspectable {
-    fn from(value: &KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(KeyFrameAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<KeyFrameAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: KeyFrameAnimation) -> ::windows::core::Result<Self> {
@@ -28812,36 +26390,7 @@ unsafe impl ::windows::core::Interface for LayerVisual {
 impl ::windows::core::RuntimeName for LayerVisual {
     const NAME: &'static str = "Windows.UI.Composition.LayerVisual";
 }
-impl ::core::convert::From<LayerVisual> for ::windows::core::IUnknown {
-    fn from(value: LayerVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LayerVisual> for ::windows::core::IUnknown {
-    fn from(value: &LayerVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LayerVisual> for &::windows::core::IUnknown {
-    fn from(value: &LayerVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LayerVisual> for ::windows::core::IInspectable {
-    fn from(value: LayerVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LayerVisual> for ::windows::core::IInspectable {
-    fn from(value: &LayerVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LayerVisual> for &::windows::core::IInspectable {
-    fn from(value: &LayerVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LayerVisual, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LayerVisual> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: LayerVisual) -> ::windows::core::Result<Self> {
@@ -29065,36 +26614,7 @@ unsafe impl ::windows::core::Interface for LinearEasingFunction {
 impl ::windows::core::RuntimeName for LinearEasingFunction {
     const NAME: &'static str = "Windows.UI.Composition.LinearEasingFunction";
 }
-impl ::core::convert::From<LinearEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: LinearEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LinearEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: &LinearEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LinearEasingFunction> for &::windows::core::IUnknown {
-    fn from(value: &LinearEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<LinearEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: LinearEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&LinearEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: &LinearEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&LinearEasingFunction> for &::windows::core::IInspectable {
-    fn from(value: &LinearEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LinearEasingFunction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<LinearEasingFunction> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: LinearEasingFunction) -> ::windows::core::Result<Self> {
@@ -29431,36 +26951,7 @@ unsafe impl ::windows::core::Interface for NaturalMotionAnimation {
 impl ::windows::core::RuntimeName for NaturalMotionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.NaturalMotionAnimation";
 }
-impl ::core::convert::From<NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NaturalMotionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NaturalMotionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NaturalMotionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<NaturalMotionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: NaturalMotionAnimation) -> ::windows::core::Result<Self> {
@@ -29893,36 +27384,7 @@ unsafe impl ::windows::core::Interface for PathKeyFrameAnimation {
 impl ::windows::core::RuntimeName for PathKeyFrameAnimation {
     const NAME: &'static str = "Windows.UI.Composition.PathKeyFrameAnimation";
 }
-impl ::core::convert::From<PathKeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: PathKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PathKeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: &PathKeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PathKeyFrameAnimation> for &::windows::core::IUnknown {
-    fn from(value: &PathKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PathKeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: PathKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PathKeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: &PathKeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PathKeyFrameAnimation> for &::windows::core::IInspectable {
-    fn from(value: &PathKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PathKeyFrameAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PathKeyFrameAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: PathKeyFrameAnimation) -> ::windows::core::Result<Self> {
@@ -30296,36 +27758,7 @@ unsafe impl ::windows::core::Interface for PointLight {
 impl ::windows::core::RuntimeName for PointLight {
     const NAME: &'static str = "Windows.UI.Composition.PointLight";
 }
-impl ::core::convert::From<PointLight> for ::windows::core::IUnknown {
-    fn from(value: PointLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointLight> for ::windows::core::IUnknown {
-    fn from(value: &PointLight) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointLight> for &::windows::core::IUnknown {
-    fn from(value: &PointLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PointLight> for ::windows::core::IInspectable {
-    fn from(value: PointLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointLight> for ::windows::core::IInspectable {
-    fn from(value: &PointLight) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointLight> for &::windows::core::IInspectable {
-    fn from(value: &PointLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PointLight, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PointLight> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: PointLight) -> ::windows::core::Result<Self> {
@@ -30548,36 +27981,7 @@ unsafe impl ::windows::core::Interface for PowerEasingFunction {
 impl ::windows::core::RuntimeName for PowerEasingFunction {
     const NAME: &'static str = "Windows.UI.Composition.PowerEasingFunction";
 }
-impl ::core::convert::From<PowerEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: PowerEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PowerEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: &PowerEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PowerEasingFunction> for &::windows::core::IUnknown {
-    fn from(value: &PowerEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PowerEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: PowerEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PowerEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: &PowerEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PowerEasingFunction> for &::windows::core::IInspectable {
-    fn from(value: &PowerEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PowerEasingFunction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PowerEasingFunction> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: PowerEasingFunction) -> ::windows::core::Result<Self> {
@@ -30995,36 +28399,7 @@ unsafe impl ::windows::core::Interface for QuaternionKeyFrameAnimation {
 impl ::windows::core::RuntimeName for QuaternionKeyFrameAnimation {
     const NAME: &'static str = "Windows.UI.Composition.QuaternionKeyFrameAnimation";
 }
-impl ::core::convert::From<QuaternionKeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: QuaternionKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&QuaternionKeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: &QuaternionKeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&QuaternionKeyFrameAnimation> for &::windows::core::IUnknown {
-    fn from(value: &QuaternionKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<QuaternionKeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: QuaternionKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&QuaternionKeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: &QuaternionKeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&QuaternionKeyFrameAnimation> for &::windows::core::IInspectable {
-    fn from(value: &QuaternionKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(QuaternionKeyFrameAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<QuaternionKeyFrameAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: QuaternionKeyFrameAnimation) -> ::windows::core::Result<Self> {
@@ -31468,36 +28843,7 @@ unsafe impl ::windows::core::Interface for RectangleClip {
 impl ::windows::core::RuntimeName for RectangleClip {
     const NAME: &'static str = "Windows.UI.Composition.RectangleClip";
 }
-impl ::core::convert::From<RectangleClip> for ::windows::core::IUnknown {
-    fn from(value: RectangleClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RectangleClip> for ::windows::core::IUnknown {
-    fn from(value: &RectangleClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RectangleClip> for &::windows::core::IUnknown {
-    fn from(value: &RectangleClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RectangleClip> for ::windows::core::IInspectable {
-    fn from(value: RectangleClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RectangleClip> for ::windows::core::IInspectable {
-    fn from(value: &RectangleClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RectangleClip> for &::windows::core::IInspectable {
-    fn from(value: &RectangleClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RectangleClip, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RectangleClip> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: RectangleClip) -> ::windows::core::Result<Self> {
@@ -32011,36 +29357,7 @@ unsafe impl ::windows::core::Interface for RedirectVisual {
 impl ::windows::core::RuntimeName for RedirectVisual {
     const NAME: &'static str = "Windows.UI.Composition.RedirectVisual";
 }
-impl ::core::convert::From<RedirectVisual> for ::windows::core::IUnknown {
-    fn from(value: RedirectVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RedirectVisual> for ::windows::core::IUnknown {
-    fn from(value: &RedirectVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RedirectVisual> for &::windows::core::IUnknown {
-    fn from(value: &RedirectVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RedirectVisual> for ::windows::core::IInspectable {
-    fn from(value: RedirectVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RedirectVisual> for ::windows::core::IInspectable {
-    fn from(value: &RedirectVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RedirectVisual> for &::windows::core::IInspectable {
-    fn from(value: &RedirectVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RedirectVisual, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RedirectVisual> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: RedirectVisual) -> ::windows::core::Result<Self> {
@@ -32271,36 +29588,7 @@ unsafe impl ::windows::core::Interface for RenderingDeviceReplacedEventArgs {
 impl ::windows::core::RuntimeName for RenderingDeviceReplacedEventArgs {
     const NAME: &'static str = "Windows.UI.Composition.RenderingDeviceReplacedEventArgs";
 }
-impl ::core::convert::From<RenderingDeviceReplacedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RenderingDeviceReplacedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RenderingDeviceReplacedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RenderingDeviceReplacedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RenderingDeviceReplacedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RenderingDeviceReplacedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RenderingDeviceReplacedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RenderingDeviceReplacedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RenderingDeviceReplacedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RenderingDeviceReplacedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RenderingDeviceReplacedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RenderingDeviceReplacedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RenderingDeviceReplacedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RenderingDeviceReplacedEventArgs> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: RenderingDeviceReplacedEventArgs) -> ::windows::core::Result<Self> {
@@ -32699,36 +29987,7 @@ unsafe impl ::windows::core::Interface for ScalarKeyFrameAnimation {
 impl ::windows::core::RuntimeName for ScalarKeyFrameAnimation {
     const NAME: &'static str = "Windows.UI.Composition.ScalarKeyFrameAnimation";
 }
-impl ::core::convert::From<ScalarKeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: ScalarKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScalarKeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: &ScalarKeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScalarKeyFrameAnimation> for &::windows::core::IUnknown {
-    fn from(value: &ScalarKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ScalarKeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: ScalarKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScalarKeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: &ScalarKeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScalarKeyFrameAnimation> for &::windows::core::IInspectable {
-    fn from(value: &ScalarKeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ScalarKeyFrameAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ScalarKeyFrameAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: ScalarKeyFrameAnimation) -> ::windows::core::Result<Self> {
@@ -33148,36 +30407,7 @@ unsafe impl ::windows::core::Interface for ScalarNaturalMotionAnimation {
 impl ::windows::core::RuntimeName for ScalarNaturalMotionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.ScalarNaturalMotionAnimation";
 }
-impl ::core::convert::From<ScalarNaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: ScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScalarNaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &ScalarNaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScalarNaturalMotionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &ScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ScalarNaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: ScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScalarNaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &ScalarNaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScalarNaturalMotionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &ScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ScalarNaturalMotionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ScalarNaturalMotionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: ScalarNaturalMotionAnimation) -> ::windows::core::Result<Self> {
@@ -33731,36 +30961,7 @@ unsafe impl ::windows::core::Interface for ShapeVisual {
 impl ::windows::core::RuntimeName for ShapeVisual {
     const NAME: &'static str = "Windows.UI.Composition.ShapeVisual";
 }
-impl ::core::convert::From<ShapeVisual> for ::windows::core::IUnknown {
-    fn from(value: ShapeVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShapeVisual> for ::windows::core::IUnknown {
-    fn from(value: &ShapeVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShapeVisual> for &::windows::core::IUnknown {
-    fn from(value: &ShapeVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShapeVisual> for ::windows::core::IInspectable {
-    fn from(value: ShapeVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShapeVisual> for ::windows::core::IInspectable {
-    fn from(value: &ShapeVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShapeVisual> for &::windows::core::IInspectable {
-    fn from(value: &ShapeVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShapeVisual, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ShapeVisual> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: ShapeVisual) -> ::windows::core::Result<Self> {
@@ -33991,36 +31192,7 @@ unsafe impl ::windows::core::Interface for SineEasingFunction {
 impl ::windows::core::RuntimeName for SineEasingFunction {
     const NAME: &'static str = "Windows.UI.Composition.SineEasingFunction";
 }
-impl ::core::convert::From<SineEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: SineEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SineEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: &SineEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SineEasingFunction> for &::windows::core::IUnknown {
-    fn from(value: &SineEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SineEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: SineEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SineEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: &SineEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SineEasingFunction> for &::windows::core::IInspectable {
-    fn from(value: &SineEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SineEasingFunction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SineEasingFunction> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SineEasingFunction) -> ::windows::core::Result<Self> {
@@ -34441,36 +31613,7 @@ unsafe impl ::windows::core::Interface for SpotLight {
 impl ::windows::core::RuntimeName for SpotLight {
     const NAME: &'static str = "Windows.UI.Composition.SpotLight";
 }
-impl ::core::convert::From<SpotLight> for ::windows::core::IUnknown {
-    fn from(value: SpotLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpotLight> for ::windows::core::IUnknown {
-    fn from(value: &SpotLight) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpotLight> for &::windows::core::IUnknown {
-    fn from(value: &SpotLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpotLight> for ::windows::core::IInspectable {
-    fn from(value: SpotLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpotLight> for ::windows::core::IInspectable {
-    fn from(value: &SpotLight) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpotLight> for &::windows::core::IInspectable {
-    fn from(value: &SpotLight) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpotLight, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SpotLight> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SpotLight) -> ::windows::core::Result<Self> {
@@ -34882,36 +32025,7 @@ unsafe impl ::windows::core::Interface for SpringScalarNaturalMotionAnimation {
 impl ::windows::core::RuntimeName for SpringScalarNaturalMotionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.SpringScalarNaturalMotionAnimation";
 }
-impl ::core::convert::From<SpringScalarNaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: SpringScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpringScalarNaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &SpringScalarNaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpringScalarNaturalMotionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &SpringScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpringScalarNaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: SpringScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpringScalarNaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &SpringScalarNaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpringScalarNaturalMotionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &SpringScalarNaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpringScalarNaturalMotionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SpringScalarNaturalMotionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SpringScalarNaturalMotionAnimation) -> ::windows::core::Result<Self> {
@@ -35376,36 +32490,7 @@ unsafe impl ::windows::core::Interface for SpringVector2NaturalMotionAnimation {
 impl ::windows::core::RuntimeName for SpringVector2NaturalMotionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.SpringVector2NaturalMotionAnimation";
 }
-impl ::core::convert::From<SpringVector2NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: SpringVector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpringVector2NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &SpringVector2NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpringVector2NaturalMotionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &SpringVector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpringVector2NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: SpringVector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpringVector2NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &SpringVector2NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpringVector2NaturalMotionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &SpringVector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpringVector2NaturalMotionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SpringVector2NaturalMotionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SpringVector2NaturalMotionAnimation) -> ::windows::core::Result<Self> {
@@ -35870,36 +32955,7 @@ unsafe impl ::windows::core::Interface for SpringVector3NaturalMotionAnimation {
 impl ::windows::core::RuntimeName for SpringVector3NaturalMotionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.SpringVector3NaturalMotionAnimation";
 }
-impl ::core::convert::From<SpringVector3NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: SpringVector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpringVector3NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &SpringVector3NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpringVector3NaturalMotionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &SpringVector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpringVector3NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: SpringVector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpringVector3NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &SpringVector3NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpringVector3NaturalMotionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &SpringVector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpringVector3NaturalMotionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SpringVector3NaturalMotionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SpringVector3NaturalMotionAnimation) -> ::windows::core::Result<Self> {
@@ -36476,36 +33532,7 @@ unsafe impl ::windows::core::Interface for SpriteVisual {
 impl ::windows::core::RuntimeName for SpriteVisual {
     const NAME: &'static str = "Windows.UI.Composition.SpriteVisual";
 }
-impl ::core::convert::From<SpriteVisual> for ::windows::core::IUnknown {
-    fn from(value: SpriteVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpriteVisual> for ::windows::core::IUnknown {
-    fn from(value: &SpriteVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpriteVisual> for &::windows::core::IUnknown {
-    fn from(value: &SpriteVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpriteVisual> for ::windows::core::IInspectable {
-    fn from(value: SpriteVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpriteVisual> for ::windows::core::IInspectable {
-    fn from(value: &SpriteVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpriteVisual> for &::windows::core::IInspectable {
-    fn from(value: &SpriteVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpriteVisual, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SpriteVisual> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: SpriteVisual) -> ::windows::core::Result<Self> {
@@ -36784,36 +33811,7 @@ unsafe impl ::windows::core::Interface for StepEasingFunction {
 impl ::windows::core::RuntimeName for StepEasingFunction {
     const NAME: &'static str = "Windows.UI.Composition.StepEasingFunction";
 }
-impl ::core::convert::From<StepEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: StepEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StepEasingFunction> for ::windows::core::IUnknown {
-    fn from(value: &StepEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StepEasingFunction> for &::windows::core::IUnknown {
-    fn from(value: &StepEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StepEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: StepEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StepEasingFunction> for ::windows::core::IInspectable {
-    fn from(value: &StepEasingFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StepEasingFunction> for &::windows::core::IInspectable {
-    fn from(value: &StepEasingFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StepEasingFunction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<StepEasingFunction> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: StepEasingFunction) -> ::windows::core::Result<Self> {
@@ -37231,36 +34229,7 @@ unsafe impl ::windows::core::Interface for Vector2KeyFrameAnimation {
 impl ::windows::core::RuntimeName for Vector2KeyFrameAnimation {
     const NAME: &'static str = "Windows.UI.Composition.Vector2KeyFrameAnimation";
 }
-impl ::core::convert::From<Vector2KeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: Vector2KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Vector2KeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: &Vector2KeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Vector2KeyFrameAnimation> for &::windows::core::IUnknown {
-    fn from(value: &Vector2KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Vector2KeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: Vector2KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Vector2KeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: &Vector2KeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Vector2KeyFrameAnimation> for &::windows::core::IInspectable {
-    fn from(value: &Vector2KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Vector2KeyFrameAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Vector2KeyFrameAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: Vector2KeyFrameAnimation) -> ::windows::core::Result<Self> {
@@ -37684,36 +34653,7 @@ unsafe impl ::windows::core::Interface for Vector2NaturalMotionAnimation {
 impl ::windows::core::RuntimeName for Vector2NaturalMotionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.Vector2NaturalMotionAnimation";
 }
-impl ::core::convert::From<Vector2NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: Vector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Vector2NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &Vector2NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Vector2NaturalMotionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &Vector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Vector2NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: Vector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Vector2NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &Vector2NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Vector2NaturalMotionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &Vector2NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Vector2NaturalMotionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Vector2NaturalMotionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: Vector2NaturalMotionAnimation) -> ::windows::core::Result<Self> {
@@ -38165,36 +35105,7 @@ unsafe impl ::windows::core::Interface for Vector3KeyFrameAnimation {
 impl ::windows::core::RuntimeName for Vector3KeyFrameAnimation {
     const NAME: &'static str = "Windows.UI.Composition.Vector3KeyFrameAnimation";
 }
-impl ::core::convert::From<Vector3KeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: Vector3KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Vector3KeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: &Vector3KeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Vector3KeyFrameAnimation> for &::windows::core::IUnknown {
-    fn from(value: &Vector3KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Vector3KeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: Vector3KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Vector3KeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: &Vector3KeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Vector3KeyFrameAnimation> for &::windows::core::IInspectable {
-    fn from(value: &Vector3KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Vector3KeyFrameAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Vector3KeyFrameAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: Vector3KeyFrameAnimation) -> ::windows::core::Result<Self> {
@@ -38618,36 +35529,7 @@ unsafe impl ::windows::core::Interface for Vector3NaturalMotionAnimation {
 impl ::windows::core::RuntimeName for Vector3NaturalMotionAnimation {
     const NAME: &'static str = "Windows.UI.Composition.Vector3NaturalMotionAnimation";
 }
-impl ::core::convert::From<Vector3NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: Vector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Vector3NaturalMotionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &Vector3NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Vector3NaturalMotionAnimation> for &::windows::core::IUnknown {
-    fn from(value: &Vector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Vector3NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: Vector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Vector3NaturalMotionAnimation> for ::windows::core::IInspectable {
-    fn from(value: &Vector3NaturalMotionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Vector3NaturalMotionAnimation> for &::windows::core::IInspectable {
-    fn from(value: &Vector3NaturalMotionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Vector3NaturalMotionAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Vector3NaturalMotionAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: Vector3NaturalMotionAnimation) -> ::windows::core::Result<Self> {
@@ -39099,36 +35981,7 @@ unsafe impl ::windows::core::Interface for Vector4KeyFrameAnimation {
 impl ::windows::core::RuntimeName for Vector4KeyFrameAnimation {
     const NAME: &'static str = "Windows.UI.Composition.Vector4KeyFrameAnimation";
 }
-impl ::core::convert::From<Vector4KeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: Vector4KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Vector4KeyFrameAnimation> for ::windows::core::IUnknown {
-    fn from(value: &Vector4KeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Vector4KeyFrameAnimation> for &::windows::core::IUnknown {
-    fn from(value: &Vector4KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Vector4KeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: Vector4KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Vector4KeyFrameAnimation> for ::windows::core::IInspectable {
-    fn from(value: &Vector4KeyFrameAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Vector4KeyFrameAnimation> for &::windows::core::IInspectable {
-    fn from(value: &Vector4KeyFrameAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Vector4KeyFrameAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Vector4KeyFrameAnimation> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: Vector4KeyFrameAnimation) -> ::windows::core::Result<Self> {
@@ -39655,36 +36508,7 @@ unsafe impl ::windows::core::Interface for Visual {
 impl ::windows::core::RuntimeName for Visual {
     const NAME: &'static str = "Windows.UI.Composition.Visual";
 }
-impl ::core::convert::From<Visual> for ::windows::core::IUnknown {
-    fn from(value: Visual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Visual> for ::windows::core::IUnknown {
-    fn from(value: &Visual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Visual> for &::windows::core::IUnknown {
-    fn from(value: &Visual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Visual> for ::windows::core::IInspectable {
-    fn from(value: Visual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Visual> for ::windows::core::IInspectable {
-    fn from(value: &Visual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Visual> for &::windows::core::IInspectable {
-    fn from(value: &Visual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Visual, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<Visual> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: Visual) -> ::windows::core::Result<Self> {
@@ -39951,36 +36775,7 @@ impl ::core::iter::IntoIterator for &VisualCollection {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<VisualCollection> for ::windows::core::IUnknown {
-    fn from(value: VisualCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualCollection> for ::windows::core::IUnknown {
-    fn from(value: &VisualCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualCollection> for &::windows::core::IUnknown {
-    fn from(value: &VisualCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VisualCollection> for ::windows::core::IInspectable {
-    fn from(value: VisualCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualCollection> for ::windows::core::IInspectable {
-    fn from(value: &VisualCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualCollection> for &::windows::core::IInspectable {
-    fn from(value: &VisualCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VisualCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VisualCollection> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: VisualCollection) -> ::windows::core::Result<Self> {
@@ -40246,36 +37041,7 @@ impl ::core::iter::IntoIterator for &VisualUnorderedCollection {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<VisualUnorderedCollection> for ::windows::core::IUnknown {
-    fn from(value: VisualUnorderedCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualUnorderedCollection> for ::windows::core::IUnknown {
-    fn from(value: &VisualUnorderedCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualUnorderedCollection> for &::windows::core::IUnknown {
-    fn from(value: &VisualUnorderedCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VisualUnorderedCollection> for ::windows::core::IInspectable {
-    fn from(value: VisualUnorderedCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualUnorderedCollection> for ::windows::core::IInspectable {
-    fn from(value: &VisualUnorderedCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualUnorderedCollection> for &::windows::core::IInspectable {
-    fn from(value: &VisualUnorderedCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VisualUnorderedCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VisualUnorderedCollection> for IAnimationObject {
     type Error = ::windows::core::Error;
     fn try_from(value: VisualUnorderedCollection) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/mod.rs
@@ -108,36 +108,7 @@ impl IPropertyAnimation {
         }
     }
 }
-impl ::core::convert::From<IPropertyAnimation> for ::windows::core::IUnknown {
-    fn from(value: IPropertyAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyAnimation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyAnimation> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertyAnimation> for ::windows::core::IInspectable {
-    fn from(value: IPropertyAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyAnimation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPropertyAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyAnimation> for ::windows::core::IInspectable {
-    fn from(value: &IPropertyAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPropertyAnimation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -306,36 +277,7 @@ unsafe impl ::windows::core::Interface for AnimationDescription {
 impl ::windows::core::RuntimeName for AnimationDescription {
     const NAME: &'static str = "Windows.UI.Core.AnimationMetrics.AnimationDescription";
 }
-impl ::core::convert::From<AnimationDescription> for ::windows::core::IUnknown {
-    fn from(value: AnimationDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AnimationDescription> for ::windows::core::IUnknown {
-    fn from(value: &AnimationDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AnimationDescription> for &::windows::core::IUnknown {
-    fn from(value: &AnimationDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AnimationDescription> for ::windows::core::IInspectable {
-    fn from(value: AnimationDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AnimationDescription> for ::windows::core::IInspectable {
-    fn from(value: &AnimationDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AnimationDescription> for &::windows::core::IInspectable {
-    fn from(value: &AnimationDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AnimationDescription, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AnimationDescription {}
 unsafe impl ::core::marker::Sync for AnimationDescription {}
 #[doc = "*Required features: `\"UI_Core_AnimationMetrics\"`*"]
@@ -434,36 +376,7 @@ unsafe impl ::windows::core::Interface for OpacityAnimation {
 impl ::windows::core::RuntimeName for OpacityAnimation {
     const NAME: &'static str = "Windows.UI.Core.AnimationMetrics.OpacityAnimation";
 }
-impl ::core::convert::From<OpacityAnimation> for ::windows::core::IUnknown {
-    fn from(value: OpacityAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OpacityAnimation> for ::windows::core::IUnknown {
-    fn from(value: &OpacityAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OpacityAnimation> for &::windows::core::IUnknown {
-    fn from(value: &OpacityAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<OpacityAnimation> for ::windows::core::IInspectable {
-    fn from(value: OpacityAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OpacityAnimation> for ::windows::core::IInspectable {
-    fn from(value: &OpacityAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&OpacityAnimation> for &::windows::core::IInspectable {
-    fn from(value: &OpacityAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(OpacityAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<OpacityAnimation> for IPropertyAnimation {
     type Error = ::windows::core::Error;
     fn try_from(value: OpacityAnimation) -> ::windows::core::Result<Self> {
@@ -565,36 +478,7 @@ unsafe impl ::windows::core::Interface for PropertyAnimation {
 impl ::windows::core::RuntimeName for PropertyAnimation {
     const NAME: &'static str = "Windows.UI.Core.AnimationMetrics.PropertyAnimation";
 }
-impl ::core::convert::From<PropertyAnimation> for ::windows::core::IUnknown {
-    fn from(value: PropertyAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PropertyAnimation> for ::windows::core::IUnknown {
-    fn from(value: &PropertyAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PropertyAnimation> for &::windows::core::IUnknown {
-    fn from(value: &PropertyAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PropertyAnimation> for ::windows::core::IInspectable {
-    fn from(value: PropertyAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PropertyAnimation> for ::windows::core::IInspectable {
-    fn from(value: &PropertyAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PropertyAnimation> for &::windows::core::IInspectable {
-    fn from(value: &PropertyAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PropertyAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PropertyAnimation> for IPropertyAnimation {
     type Error = ::windows::core::Error;
     fn try_from(value: PropertyAnimation) -> ::windows::core::Result<Self> {
@@ -737,36 +621,7 @@ unsafe impl ::windows::core::Interface for ScaleAnimation {
 impl ::windows::core::RuntimeName for ScaleAnimation {
     const NAME: &'static str = "Windows.UI.Core.AnimationMetrics.ScaleAnimation";
 }
-impl ::core::convert::From<ScaleAnimation> for ::windows::core::IUnknown {
-    fn from(value: ScaleAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScaleAnimation> for ::windows::core::IUnknown {
-    fn from(value: &ScaleAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScaleAnimation> for &::windows::core::IUnknown {
-    fn from(value: &ScaleAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ScaleAnimation> for ::windows::core::IInspectable {
-    fn from(value: ScaleAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScaleAnimation> for ::windows::core::IInspectable {
-    fn from(value: &ScaleAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScaleAnimation> for &::windows::core::IInspectable {
-    fn from(value: &ScaleAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ScaleAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ScaleAnimation> for IPropertyAnimation {
     type Error = ::windows::core::Error;
     fn try_from(value: ScaleAnimation) -> ::windows::core::Result<Self> {
@@ -868,36 +723,7 @@ unsafe impl ::windows::core::Interface for TranslationAnimation {
 impl ::windows::core::RuntimeName for TranslationAnimation {
     const NAME: &'static str = "Windows.UI.Core.AnimationMetrics.TranslationAnimation";
 }
-impl ::core::convert::From<TranslationAnimation> for ::windows::core::IUnknown {
-    fn from(value: TranslationAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TranslationAnimation> for ::windows::core::IUnknown {
-    fn from(value: &TranslationAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TranslationAnimation> for &::windows::core::IUnknown {
-    fn from(value: &TranslationAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TranslationAnimation> for ::windows::core::IInspectable {
-    fn from(value: TranslationAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TranslationAnimation> for ::windows::core::IInspectable {
-    fn from(value: &TranslationAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TranslationAnimation> for &::windows::core::IInspectable {
-    fn from(value: &TranslationAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TranslationAnimation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<TranslationAnimation> for IPropertyAnimation {
     type Error = ::windows::core::Error;
     fn try_from(value: TranslationAnimation) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/UI/Core/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/Preview/mod.rs
@@ -137,36 +137,7 @@ unsafe impl ::windows::core::Interface for CoreAppWindowPreview {
 impl ::windows::core::RuntimeName for CoreAppWindowPreview {
     const NAME: &'static str = "Windows.UI.Core.Preview.CoreAppWindowPreview";
 }
-impl ::core::convert::From<CoreAppWindowPreview> for ::windows::core::IUnknown {
-    fn from(value: CoreAppWindowPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreAppWindowPreview> for ::windows::core::IUnknown {
-    fn from(value: &CoreAppWindowPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreAppWindowPreview> for &::windows::core::IUnknown {
-    fn from(value: &CoreAppWindowPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreAppWindowPreview> for ::windows::core::IInspectable {
-    fn from(value: CoreAppWindowPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreAppWindowPreview> for ::windows::core::IInspectable {
-    fn from(value: &CoreAppWindowPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreAppWindowPreview> for &::windows::core::IInspectable {
-    fn from(value: &CoreAppWindowPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreAppWindowPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreAppWindowPreview {}
 unsafe impl ::core::marker::Sync for CoreAppWindowPreview {}
 #[doc = "*Required features: `\"UI_Core_Preview\"`*"]
@@ -226,36 +197,7 @@ unsafe impl ::windows::core::Interface for SystemNavigationCloseRequestedPreview
 impl ::windows::core::RuntimeName for SystemNavigationCloseRequestedPreviewEventArgs {
     const NAME: &'static str = "Windows.UI.Core.Preview.SystemNavigationCloseRequestedPreviewEventArgs";
 }
-impl ::core::convert::From<SystemNavigationCloseRequestedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SystemNavigationCloseRequestedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemNavigationCloseRequestedPreviewEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SystemNavigationCloseRequestedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemNavigationCloseRequestedPreviewEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SystemNavigationCloseRequestedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemNavigationCloseRequestedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SystemNavigationCloseRequestedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemNavigationCloseRequestedPreviewEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SystemNavigationCloseRequestedPreviewEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemNavigationCloseRequestedPreviewEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SystemNavigationCloseRequestedPreviewEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemNavigationCloseRequestedPreviewEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemNavigationCloseRequestedPreviewEventArgs {}
 unsafe impl ::core::marker::Sync for SystemNavigationCloseRequestedPreviewEventArgs {}
 #[doc = "*Required features: `\"UI_Core_Preview\"`*"]
@@ -321,36 +263,7 @@ unsafe impl ::windows::core::Interface for SystemNavigationManagerPreview {
 impl ::windows::core::RuntimeName for SystemNavigationManagerPreview {
     const NAME: &'static str = "Windows.UI.Core.Preview.SystemNavigationManagerPreview";
 }
-impl ::core::convert::From<SystemNavigationManagerPreview> for ::windows::core::IUnknown {
-    fn from(value: SystemNavigationManagerPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemNavigationManagerPreview> for ::windows::core::IUnknown {
-    fn from(value: &SystemNavigationManagerPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemNavigationManagerPreview> for &::windows::core::IUnknown {
-    fn from(value: &SystemNavigationManagerPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemNavigationManagerPreview> for ::windows::core::IInspectable {
-    fn from(value: SystemNavigationManagerPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemNavigationManagerPreview> for ::windows::core::IInspectable {
-    fn from(value: &SystemNavigationManagerPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemNavigationManagerPreview> for &::windows::core::IInspectable {
-    fn from(value: &SystemNavigationManagerPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemNavigationManagerPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemNavigationManagerPreview {}
 unsafe impl ::core::marker::Sync for SystemNavigationManagerPreview {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/UI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/mod.rs
@@ -135,36 +135,7 @@ impl ICoreAcceleratorKeys {
         unsafe { (::windows::core::Vtable::vtable(this).RemoveAcceleratorKeyActivated)(::windows::core::Vtable::as_raw(this), cookie).ok() }
     }
 }
-impl ::core::convert::From<ICoreAcceleratorKeys> for ::windows::core::IUnknown {
-    fn from(value: ICoreAcceleratorKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreAcceleratorKeys> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreAcceleratorKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreAcceleratorKeys> for ::windows::core::IUnknown {
-    fn from(value: &ICoreAcceleratorKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICoreAcceleratorKeys> for ::windows::core::IInspectable {
-    fn from(value: ICoreAcceleratorKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreAcceleratorKeys> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICoreAcceleratorKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreAcceleratorKeys> for ::windows::core::IInspectable {
-    fn from(value: &ICoreAcceleratorKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreAcceleratorKeys, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICoreAcceleratorKeys {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -437,36 +408,7 @@ impl ICoreInputSourceBase {
         unsafe { (::windows::core::Vtable::vtable(this).RemoveInputEnabled)(::windows::core::Vtable::as_raw(this), cookie).ok() }
     }
 }
-impl ::core::convert::From<ICoreInputSourceBase> for ::windows::core::IUnknown {
-    fn from(value: ICoreInputSourceBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreInputSourceBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreInputSourceBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreInputSourceBase> for ::windows::core::IUnknown {
-    fn from(value: &ICoreInputSourceBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICoreInputSourceBase> for ::windows::core::IInspectable {
-    fn from(value: ICoreInputSourceBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreInputSourceBase> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICoreInputSourceBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreInputSourceBase> for ::windows::core::IInspectable {
-    fn from(value: &ICoreInputSourceBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreInputSourceBase, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICoreInputSourceBase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -714,36 +656,7 @@ impl ICorePointerInputSource {
         unsafe { (::windows::core::Vtable::vtable(this).RemovePointerWheelChanged)(::windows::core::Vtable::as_raw(this), cookie).ok() }
     }
 }
-impl ::core::convert::From<ICorePointerInputSource> for ::windows::core::IUnknown {
-    fn from(value: ICorePointerInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICorePointerInputSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICorePointerInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICorePointerInputSource> for ::windows::core::IUnknown {
-    fn from(value: &ICorePointerInputSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICorePointerInputSource> for ::windows::core::IInspectable {
-    fn from(value: ICorePointerInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICorePointerInputSource> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICorePointerInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICorePointerInputSource> for ::windows::core::IInspectable {
-    fn from(value: &ICorePointerInputSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICorePointerInputSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICorePointerInputSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -997,36 +910,7 @@ impl ICorePointerInputSource2 {
         unsafe { (::windows::core::Vtable::vtable(this).RemovePointerWheelChanged)(::windows::core::Vtable::as_raw(this), cookie).ok() }
     }
 }
-impl ::core::convert::From<ICorePointerInputSource2> for ::windows::core::IUnknown {
-    fn from(value: ICorePointerInputSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICorePointerInputSource2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICorePointerInputSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICorePointerInputSource2> for ::windows::core::IUnknown {
-    fn from(value: &ICorePointerInputSource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICorePointerInputSource2> for ::windows::core::IInspectable {
-    fn from(value: ICorePointerInputSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICorePointerInputSource2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICorePointerInputSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICorePointerInputSource2> for ::windows::core::IInspectable {
-    fn from(value: &ICorePointerInputSource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICorePointerInputSource2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ICorePointerInputSource2> for ICorePointerInputSource {
     type Error = ::windows::core::Error;
     fn try_from(value: ICorePointerInputSource2) -> ::windows::core::Result<Self> {
@@ -1134,36 +1018,7 @@ impl ICorePointerRedirector {
         unsafe { (::windows::core::Vtable::vtable(this).RemovePointerRoutedReleased)(::windows::core::Vtable::as_raw(this), cookie).ok() }
     }
 }
-impl ::core::convert::From<ICorePointerRedirector> for ::windows::core::IUnknown {
-    fn from(value: ICorePointerRedirector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICorePointerRedirector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICorePointerRedirector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICorePointerRedirector> for ::windows::core::IUnknown {
-    fn from(value: &ICorePointerRedirector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICorePointerRedirector> for ::windows::core::IInspectable {
-    fn from(value: ICorePointerRedirector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICorePointerRedirector> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICorePointerRedirector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICorePointerRedirector> for ::windows::core::IInspectable {
-    fn from(value: &ICorePointerRedirector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICorePointerRedirector, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICorePointerRedirector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1619,36 +1474,7 @@ impl ICoreWindow {
         unsafe { (::windows::core::Vtable::vtable(this).RemoveVisibilityChanged)(::windows::core::Vtable::as_raw(this), cookie).ok() }
     }
 }
-impl ::core::convert::From<ICoreWindow> for ::windows::core::IUnknown {
-    fn from(value: ICoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreWindow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreWindow> for ::windows::core::IUnknown {
-    fn from(value: &ICoreWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICoreWindow> for ::windows::core::IInspectable {
-    fn from(value: ICoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreWindow> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreWindow> for ::windows::core::IInspectable {
-    fn from(value: &ICoreWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreWindow, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICoreWindow {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2027,36 +1853,7 @@ impl ICoreWindowEventArgs {
         unsafe { (::windows::core::Vtable::vtable(this).SetHandled)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<ICoreWindowEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ICoreWindowEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreWindowEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreWindowEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreWindowEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ICoreWindowEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICoreWindowEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ICoreWindowEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreWindowEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICoreWindowEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreWindowEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ICoreWindowEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreWindowEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICoreWindowEventArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2285,36 +2082,7 @@ impl IInitializeWithCoreWindow {
         unsafe { (::windows::core::Vtable::vtable(this).Initialize)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(window)).ok() }
     }
 }
-impl ::core::convert::From<IInitializeWithCoreWindow> for ::windows::core::IUnknown {
-    fn from(value: IInitializeWithCoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeWithCoreWindow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitializeWithCoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeWithCoreWindow> for ::windows::core::IUnknown {
-    fn from(value: &IInitializeWithCoreWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInitializeWithCoreWindow> for ::windows::core::IInspectable {
-    fn from(value: IInitializeWithCoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeWithCoreWindow> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInitializeWithCoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeWithCoreWindow> for ::windows::core::IInspectable {
-    fn from(value: &IInitializeWithCoreWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitializeWithCoreWindow, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IInitializeWithCoreWindow {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2642,36 +2410,7 @@ unsafe impl ::windows::core::Interface for AcceleratorKeyEventArgs {
 impl ::windows::core::RuntimeName for AcceleratorKeyEventArgs {
     const NAME: &'static str = "Windows.UI.Core.AcceleratorKeyEventArgs";
 }
-impl ::core::convert::From<AcceleratorKeyEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AcceleratorKeyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AcceleratorKeyEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AcceleratorKeyEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AcceleratorKeyEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AcceleratorKeyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AcceleratorKeyEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AcceleratorKeyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AcceleratorKeyEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AcceleratorKeyEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AcceleratorKeyEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AcceleratorKeyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AcceleratorKeyEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AcceleratorKeyEventArgs> for ICoreWindowEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: AcceleratorKeyEventArgs) -> ::windows::core::Result<Self> {
@@ -2755,36 +2494,7 @@ unsafe impl ::windows::core::Interface for AutomationProviderRequestedEventArgs 
 impl ::windows::core::RuntimeName for AutomationProviderRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.AutomationProviderRequestedEventArgs";
 }
-impl ::core::convert::From<AutomationProviderRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AutomationProviderRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationProviderRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AutomationProviderRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationProviderRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AutomationProviderRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AutomationProviderRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AutomationProviderRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationProviderRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AutomationProviderRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationProviderRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AutomationProviderRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AutomationProviderRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AutomationProviderRequestedEventArgs> for ICoreWindowEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: AutomationProviderRequestedEventArgs) -> ::windows::core::Result<Self> {
@@ -2852,36 +2562,7 @@ unsafe impl ::windows::core::Interface for BackRequestedEventArgs {
 impl ::windows::core::RuntimeName for BackRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.BackRequestedEventArgs";
 }
-impl ::core::convert::From<BackRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BackRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BackRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BackRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BackRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BackRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BackRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BackRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BackRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BackRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BackRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for BackRequestedEventArgs {}
 #[doc = "*Required features: `\"UI_Core\"`*"]
@@ -2946,36 +2627,7 @@ unsafe impl ::windows::core::Interface for CharacterReceivedEventArgs {
 impl ::windows::core::RuntimeName for CharacterReceivedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.CharacterReceivedEventArgs";
 }
-impl ::core::convert::From<CharacterReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CharacterReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CharacterReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CharacterReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CharacterReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CharacterReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CharacterReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CharacterReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CharacterReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CharacterReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CharacterReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CharacterReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CharacterReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CharacterReceivedEventArgs> for ICoreWindowEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: CharacterReceivedEventArgs) -> ::windows::core::Result<Self> {
@@ -3065,36 +2717,7 @@ unsafe impl ::windows::core::Interface for ClosestInteractiveBoundsRequestedEven
 impl ::windows::core::RuntimeName for ClosestInteractiveBoundsRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.ClosestInteractiveBoundsRequestedEventArgs";
 }
-impl ::core::convert::From<ClosestInteractiveBoundsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ClosestInteractiveBoundsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClosestInteractiveBoundsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ClosestInteractiveBoundsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClosestInteractiveBoundsRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ClosestInteractiveBoundsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ClosestInteractiveBoundsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ClosestInteractiveBoundsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ClosestInteractiveBoundsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ClosestInteractiveBoundsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ClosestInteractiveBoundsRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ClosestInteractiveBoundsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ClosestInteractiveBoundsRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Core\"`*"]
 #[repr(transparent)]
 pub struct CoreAcceleratorKeys(::windows::core::IUnknown);
@@ -3147,36 +2770,7 @@ unsafe impl ::windows::core::Interface for CoreAcceleratorKeys {
 impl ::windows::core::RuntimeName for CoreAcceleratorKeys {
     const NAME: &'static str = "Windows.UI.Core.CoreAcceleratorKeys";
 }
-impl ::core::convert::From<CoreAcceleratorKeys> for ::windows::core::IUnknown {
-    fn from(value: CoreAcceleratorKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreAcceleratorKeys> for ::windows::core::IUnknown {
-    fn from(value: &CoreAcceleratorKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreAcceleratorKeys> for &::windows::core::IUnknown {
-    fn from(value: &CoreAcceleratorKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreAcceleratorKeys> for ::windows::core::IInspectable {
-    fn from(value: CoreAcceleratorKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreAcceleratorKeys> for ::windows::core::IInspectable {
-    fn from(value: &CoreAcceleratorKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreAcceleratorKeys> for &::windows::core::IInspectable {
-    fn from(value: &CoreAcceleratorKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreAcceleratorKeys, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CoreAcceleratorKeys> for ICoreAcceleratorKeys {
     type Error = ::windows::core::Error;
     fn try_from(value: CoreAcceleratorKeys) -> ::windows::core::Result<Self> {
@@ -3545,36 +3139,7 @@ unsafe impl ::windows::core::Interface for CoreComponentInputSource {
 impl ::windows::core::RuntimeName for CoreComponentInputSource {
     const NAME: &'static str = "Windows.UI.Core.CoreComponentInputSource";
 }
-impl ::core::convert::From<CoreComponentInputSource> for ::windows::core::IUnknown {
-    fn from(value: CoreComponentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreComponentInputSource> for ::windows::core::IUnknown {
-    fn from(value: &CoreComponentInputSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreComponentInputSource> for &::windows::core::IUnknown {
-    fn from(value: &CoreComponentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreComponentInputSource> for ::windows::core::IInspectable {
-    fn from(value: CoreComponentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreComponentInputSource> for ::windows::core::IInspectable {
-    fn from(value: &CoreComponentInputSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreComponentInputSource> for &::windows::core::IInspectable {
-    fn from(value: &CoreComponentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreComponentInputSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CoreComponentInputSource> for ICoreInputSourceBase {
     type Error = ::windows::core::Error;
     fn try_from(value: CoreComponentInputSource) -> ::windows::core::Result<Self> {
@@ -3696,36 +3261,7 @@ unsafe impl ::windows::core::Interface for CoreCursor {
 impl ::windows::core::RuntimeName for CoreCursor {
     const NAME: &'static str = "Windows.UI.Core.CoreCursor";
 }
-impl ::core::convert::From<CoreCursor> for ::windows::core::IUnknown {
-    fn from(value: CoreCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreCursor> for ::windows::core::IUnknown {
-    fn from(value: &CoreCursor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreCursor> for &::windows::core::IUnknown {
-    fn from(value: &CoreCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreCursor> for ::windows::core::IInspectable {
-    fn from(value: CoreCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreCursor> for ::windows::core::IInspectable {
-    fn from(value: &CoreCursor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreCursor> for &::windows::core::IInspectable {
-    fn from(value: &CoreCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreCursor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreCursor {}
 unsafe impl ::core::marker::Sync for CoreCursor {}
 #[doc = "*Required features: `\"UI_Core\"`*"]
@@ -3856,36 +3392,7 @@ unsafe impl ::windows::core::Interface for CoreDispatcher {
 impl ::windows::core::RuntimeName for CoreDispatcher {
     const NAME: &'static str = "Windows.UI.Core.CoreDispatcher";
 }
-impl ::core::convert::From<CoreDispatcher> for ::windows::core::IUnknown {
-    fn from(value: CoreDispatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDispatcher> for ::windows::core::IUnknown {
-    fn from(value: &CoreDispatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDispatcher> for &::windows::core::IUnknown {
-    fn from(value: &CoreDispatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreDispatcher> for ::windows::core::IInspectable {
-    fn from(value: CoreDispatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreDispatcher> for ::windows::core::IInspectable {
-    fn from(value: &CoreDispatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreDispatcher> for &::windows::core::IInspectable {
-    fn from(value: &CoreDispatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreDispatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CoreDispatcher> for ICoreAcceleratorKeys {
     type Error = ::windows::core::Error;
     fn try_from(value: CoreDispatcher) -> ::windows::core::Result<Self> {
@@ -4171,36 +3678,7 @@ unsafe impl ::windows::core::Interface for CoreIndependentInputSource {
 impl ::windows::core::RuntimeName for CoreIndependentInputSource {
     const NAME: &'static str = "Windows.UI.Core.CoreIndependentInputSource";
 }
-impl ::core::convert::From<CoreIndependentInputSource> for ::windows::core::IUnknown {
-    fn from(value: CoreIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreIndependentInputSource> for ::windows::core::IUnknown {
-    fn from(value: &CoreIndependentInputSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreIndependentInputSource> for &::windows::core::IUnknown {
-    fn from(value: &CoreIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreIndependentInputSource> for ::windows::core::IInspectable {
-    fn from(value: CoreIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreIndependentInputSource> for ::windows::core::IInspectable {
-    fn from(value: &CoreIndependentInputSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreIndependentInputSource> for &::windows::core::IInspectable {
-    fn from(value: &CoreIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreIndependentInputSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CoreIndependentInputSource> for ICoreInputSourceBase {
     type Error = ::windows::core::Error;
     fn try_from(value: CoreIndependentInputSource) -> ::windows::core::Result<Self> {
@@ -4387,36 +3865,7 @@ unsafe impl ::windows::core::Interface for CoreIndependentInputSourceController 
 impl ::windows::core::RuntimeName for CoreIndependentInputSourceController {
     const NAME: &'static str = "Windows.UI.Core.CoreIndependentInputSourceController";
 }
-impl ::core::convert::From<CoreIndependentInputSourceController> for ::windows::core::IUnknown {
-    fn from(value: CoreIndependentInputSourceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreIndependentInputSourceController> for ::windows::core::IUnknown {
-    fn from(value: &CoreIndependentInputSourceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreIndependentInputSourceController> for &::windows::core::IUnknown {
-    fn from(value: &CoreIndependentInputSourceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreIndependentInputSourceController> for ::windows::core::IInspectable {
-    fn from(value: CoreIndependentInputSourceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreIndependentInputSourceController> for ::windows::core::IInspectable {
-    fn from(value: &CoreIndependentInputSourceController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreIndependentInputSourceController> for &::windows::core::IInspectable {
-    fn from(value: &CoreIndependentInputSourceController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreIndependentInputSourceController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<CoreIndependentInputSourceController> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4985,36 +4434,7 @@ unsafe impl ::windows::core::Interface for CoreWindow {
 impl ::windows::core::RuntimeName for CoreWindow {
     const NAME: &'static str = "Windows.UI.Core.CoreWindow";
 }
-impl ::core::convert::From<CoreWindow> for ::windows::core::IUnknown {
-    fn from(value: CoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindow> for ::windows::core::IUnknown {
-    fn from(value: &CoreWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindow> for &::windows::core::IUnknown {
-    fn from(value: &CoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreWindow> for ::windows::core::IInspectable {
-    fn from(value: CoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindow> for ::windows::core::IInspectable {
-    fn from(value: &CoreWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindow> for &::windows::core::IInspectable {
-    fn from(value: &CoreWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreWindow, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CoreWindow> for ICorePointerRedirector {
     type Error = ::windows::core::Error;
     fn try_from(value: CoreWindow) -> ::windows::core::Result<Self> {
@@ -5218,36 +4638,7 @@ unsafe impl ::windows::core::Interface for CoreWindowDialog {
 impl ::windows::core::RuntimeName for CoreWindowDialog {
     const NAME: &'static str = "Windows.UI.Core.CoreWindowDialog";
 }
-impl ::core::convert::From<CoreWindowDialog> for ::windows::core::IUnknown {
-    fn from(value: CoreWindowDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindowDialog> for ::windows::core::IUnknown {
-    fn from(value: &CoreWindowDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindowDialog> for &::windows::core::IUnknown {
-    fn from(value: &CoreWindowDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreWindowDialog> for ::windows::core::IInspectable {
-    fn from(value: CoreWindowDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindowDialog> for ::windows::core::IInspectable {
-    fn from(value: &CoreWindowDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindowDialog> for &::windows::core::IInspectable {
-    fn from(value: &CoreWindowDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreWindowDialog, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Core\"`*"]
 #[repr(transparent)]
 pub struct CoreWindowEventArgs(::windows::core::IUnknown);
@@ -5296,36 +4687,7 @@ unsafe impl ::windows::core::Interface for CoreWindowEventArgs {
 impl ::windows::core::RuntimeName for CoreWindowEventArgs {
     const NAME: &'static str = "Windows.UI.Core.CoreWindowEventArgs";
 }
-impl ::core::convert::From<CoreWindowEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreWindowEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindowEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreWindowEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindowEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreWindowEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreWindowEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreWindowEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindowEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreWindowEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindowEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreWindowEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreWindowEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<CoreWindowEventArgs> for ICoreWindowEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: CoreWindowEventArgs) -> ::windows::core::Result<Self> {
@@ -5502,36 +4864,7 @@ unsafe impl ::windows::core::Interface for CoreWindowFlyout {
 impl ::windows::core::RuntimeName for CoreWindowFlyout {
     const NAME: &'static str = "Windows.UI.Core.CoreWindowFlyout";
 }
-impl ::core::convert::From<CoreWindowFlyout> for ::windows::core::IUnknown {
-    fn from(value: CoreWindowFlyout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindowFlyout> for ::windows::core::IUnknown {
-    fn from(value: &CoreWindowFlyout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindowFlyout> for &::windows::core::IUnknown {
-    fn from(value: &CoreWindowFlyout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreWindowFlyout> for ::windows::core::IInspectable {
-    fn from(value: CoreWindowFlyout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindowFlyout> for ::windows::core::IInspectable {
-    fn from(value: &CoreWindowFlyout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindowFlyout> for &::windows::core::IInspectable {
-    fn from(value: &CoreWindowFlyout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreWindowFlyout, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Core\"`*"]
 #[repr(transparent)]
 pub struct CoreWindowPopupShowingEventArgs(::windows::core::IUnknown);
@@ -5575,36 +4908,7 @@ unsafe impl ::windows::core::Interface for CoreWindowPopupShowingEventArgs {
 impl ::windows::core::RuntimeName for CoreWindowPopupShowingEventArgs {
     const NAME: &'static str = "Windows.UI.Core.CoreWindowPopupShowingEventArgs";
 }
-impl ::core::convert::From<CoreWindowPopupShowingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreWindowPopupShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindowPopupShowingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreWindowPopupShowingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindowPopupShowingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreWindowPopupShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreWindowPopupShowingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreWindowPopupShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindowPopupShowingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreWindowPopupShowingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindowPopupShowingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreWindowPopupShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreWindowPopupShowingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Core\"`*"]
 #[repr(transparent)]
 pub struct CoreWindowResizeManager(::windows::core::IUnknown);
@@ -5668,36 +4972,7 @@ unsafe impl ::windows::core::Interface for CoreWindowResizeManager {
 impl ::windows::core::RuntimeName for CoreWindowResizeManager {
     const NAME: &'static str = "Windows.UI.Core.CoreWindowResizeManager";
 }
-impl ::core::convert::From<CoreWindowResizeManager> for ::windows::core::IUnknown {
-    fn from(value: CoreWindowResizeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindowResizeManager> for ::windows::core::IUnknown {
-    fn from(value: &CoreWindowResizeManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindowResizeManager> for &::windows::core::IUnknown {
-    fn from(value: &CoreWindowResizeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreWindowResizeManager> for ::windows::core::IInspectable {
-    fn from(value: CoreWindowResizeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWindowResizeManager> for ::windows::core::IInspectable {
-    fn from(value: &CoreWindowResizeManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWindowResizeManager> for &::windows::core::IInspectable {
-    fn from(value: &CoreWindowResizeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreWindowResizeManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreWindowResizeManager {}
 unsafe impl ::core::marker::Sync for CoreWindowResizeManager {}
 #[doc = "*Required features: `\"UI_Core\"`*"]
@@ -5744,36 +5019,7 @@ unsafe impl ::windows::core::Interface for IdleDispatchedHandlerArgs {
 impl ::windows::core::RuntimeName for IdleDispatchedHandlerArgs {
     const NAME: &'static str = "Windows.UI.Core.IdleDispatchedHandlerArgs";
 }
-impl ::core::convert::From<IdleDispatchedHandlerArgs> for ::windows::core::IUnknown {
-    fn from(value: IdleDispatchedHandlerArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IdleDispatchedHandlerArgs> for ::windows::core::IUnknown {
-    fn from(value: &IdleDispatchedHandlerArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IdleDispatchedHandlerArgs> for &::windows::core::IUnknown {
-    fn from(value: &IdleDispatchedHandlerArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<IdleDispatchedHandlerArgs> for ::windows::core::IInspectable {
-    fn from(value: IdleDispatchedHandlerArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IdleDispatchedHandlerArgs> for ::windows::core::IInspectable {
-    fn from(value: &IdleDispatchedHandlerArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&IdleDispatchedHandlerArgs> for &::windows::core::IInspectable {
-    fn from(value: &IdleDispatchedHandlerArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(IdleDispatchedHandlerArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Core\"`*"]
 #[repr(transparent)]
 pub struct InputEnabledEventArgs(::windows::core::IUnknown);
@@ -5829,36 +5075,7 @@ unsafe impl ::windows::core::Interface for InputEnabledEventArgs {
 impl ::windows::core::RuntimeName for InputEnabledEventArgs {
     const NAME: &'static str = "Windows.UI.Core.InputEnabledEventArgs";
 }
-impl ::core::convert::From<InputEnabledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: InputEnabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputEnabledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &InputEnabledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputEnabledEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &InputEnabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InputEnabledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: InputEnabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputEnabledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &InputEnabledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputEnabledEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &InputEnabledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InputEnabledEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InputEnabledEventArgs> for ICoreWindowEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: InputEnabledEventArgs) -> ::windows::core::Result<Self> {
@@ -5949,36 +5166,7 @@ unsafe impl ::windows::core::Interface for KeyEventArgs {
 impl ::windows::core::RuntimeName for KeyEventArgs {
     const NAME: &'static str = "Windows.UI.Core.KeyEventArgs";
 }
-impl ::core::convert::From<KeyEventArgs> for ::windows::core::IUnknown {
-    fn from(value: KeyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &KeyEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &KeyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<KeyEventArgs> for ::windows::core::IInspectable {
-    fn from(value: KeyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &KeyEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &KeyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(KeyEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<KeyEventArgs> for ICoreWindowEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: KeyEventArgs) -> ::windows::core::Result<Self> {
@@ -6073,36 +5261,7 @@ unsafe impl ::windows::core::Interface for PointerEventArgs {
 impl ::windows::core::RuntimeName for PointerEventArgs {
     const NAME: &'static str = "Windows.UI.Core.PointerEventArgs";
 }
-impl ::core::convert::From<PointerEventArgs> for ::windows::core::IUnknown {
-    fn from(value: PointerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointerEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &PointerEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointerEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &PointerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PointerEventArgs> for ::windows::core::IInspectable {
-    fn from(value: PointerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointerEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &PointerEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointerEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &PointerEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PointerEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<PointerEventArgs> for ICoreWindowEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: PointerEventArgs) -> ::windows::core::Result<Self> {
@@ -6196,36 +5355,7 @@ unsafe impl ::windows::core::Interface for SystemNavigationManager {
 impl ::windows::core::RuntimeName for SystemNavigationManager {
     const NAME: &'static str = "Windows.UI.Core.SystemNavigationManager";
 }
-impl ::core::convert::From<SystemNavigationManager> for ::windows::core::IUnknown {
-    fn from(value: SystemNavigationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemNavigationManager> for ::windows::core::IUnknown {
-    fn from(value: &SystemNavigationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemNavigationManager> for &::windows::core::IUnknown {
-    fn from(value: &SystemNavigationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemNavigationManager> for ::windows::core::IInspectable {
-    fn from(value: SystemNavigationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemNavigationManager> for ::windows::core::IInspectable {
-    fn from(value: &SystemNavigationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemNavigationManager> for &::windows::core::IInspectable {
-    fn from(value: &SystemNavigationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemNavigationManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemNavigationManager {}
 unsafe impl ::core::marker::Sync for SystemNavigationManager {}
 #[doc = "*Required features: `\"UI_Core\"`*"]
@@ -6327,36 +5457,7 @@ unsafe impl ::windows::core::Interface for TouchHitTestingEventArgs {
 impl ::windows::core::RuntimeName for TouchHitTestingEventArgs {
     const NAME: &'static str = "Windows.UI.Core.TouchHitTestingEventArgs";
 }
-impl ::core::convert::From<TouchHitTestingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TouchHitTestingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TouchHitTestingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TouchHitTestingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TouchHitTestingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TouchHitTestingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TouchHitTestingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TouchHitTestingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TouchHitTestingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TouchHitTestingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TouchHitTestingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TouchHitTestingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TouchHitTestingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<TouchHitTestingEventArgs> for ICoreWindowEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: TouchHitTestingEventArgs) -> ::windows::core::Result<Self> {
@@ -6431,36 +5532,7 @@ unsafe impl ::windows::core::Interface for VisibilityChangedEventArgs {
 impl ::windows::core::RuntimeName for VisibilityChangedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.VisibilityChangedEventArgs";
 }
-impl ::core::convert::From<VisibilityChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: VisibilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisibilityChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &VisibilityChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisibilityChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &VisibilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VisibilityChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: VisibilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisibilityChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &VisibilityChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisibilityChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &VisibilityChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VisibilityChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<VisibilityChangedEventArgs> for ICoreWindowEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: VisibilityChangedEventArgs) -> ::windows::core::Result<Self> {
@@ -6535,36 +5607,7 @@ unsafe impl ::windows::core::Interface for WindowActivatedEventArgs {
 impl ::windows::core::RuntimeName for WindowActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.WindowActivatedEventArgs";
 }
-impl ::core::convert::From<WindowActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WindowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WindowActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WindowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WindowActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WindowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WindowActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WindowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WindowActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WindowActivatedEventArgs> for ICoreWindowEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: WindowActivatedEventArgs) -> ::windows::core::Result<Self> {
@@ -6641,36 +5684,7 @@ unsafe impl ::windows::core::Interface for WindowSizeChangedEventArgs {
 impl ::windows::core::RuntimeName for WindowSizeChangedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.WindowSizeChangedEventArgs";
 }
-impl ::core::convert::From<WindowSizeChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WindowSizeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowSizeChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WindowSizeChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowSizeChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WindowSizeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WindowSizeChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WindowSizeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowSizeChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WindowSizeChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowSizeChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WindowSizeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WindowSizeChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WindowSizeChangedEventArgs> for ICoreWindowEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: WindowSizeChangedEventArgs) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/UI/Input/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Core/mod.rs
@@ -128,36 +128,7 @@ unsafe impl ::windows::core::Interface for RadialControllerIndependentInputSourc
 impl ::windows::core::RuntimeName for RadialControllerIndependentInputSource {
     const NAME: &'static str = "Windows.UI.Input.Core.RadialControllerIndependentInputSource";
 }
-impl ::core::convert::From<RadialControllerIndependentInputSource> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerIndependentInputSource> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerIndependentInputSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerIndependentInputSource> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerIndependentInputSource> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerIndependentInputSource> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerIndependentInputSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerIndependentInputSource> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerIndependentInputSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerIndependentInputSource {}
 unsafe impl ::core::marker::Sync for RadialControllerIndependentInputSource {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/mod.rs
@@ -148,36 +148,7 @@ impl IInkAnalysisNode {
         }
     }
 }
-impl ::core::convert::From<IInkAnalysisNode> for ::windows::core::IUnknown {
-    fn from(value: IInkAnalysisNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkAnalysisNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkAnalysisNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkAnalysisNode> for ::windows::core::IUnknown {
-    fn from(value: &IInkAnalysisNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInkAnalysisNode> for ::windows::core::IInspectable {
-    fn from(value: IInkAnalysisNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkAnalysisNode> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInkAnalysisNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkAnalysisNode> for ::windows::core::IInspectable {
-    fn from(value: &IInkAnalysisNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkAnalysisNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IInkAnalysisNode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -340,36 +311,7 @@ impl IInkAnalyzerFactory {
         }
     }
 }
-impl ::core::convert::From<IInkAnalyzerFactory> for ::windows::core::IUnknown {
-    fn from(value: IInkAnalyzerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkAnalyzerFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkAnalyzerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkAnalyzerFactory> for ::windows::core::IUnknown {
-    fn from(value: &IInkAnalyzerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInkAnalyzerFactory> for ::windows::core::IInspectable {
-    fn from(value: IInkAnalyzerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkAnalyzerFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInkAnalyzerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkAnalyzerFactory> for ::windows::core::IInspectable {
-    fn from(value: &IInkAnalyzerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkAnalyzerFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IInkAnalyzerFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -506,36 +448,7 @@ unsafe impl ::windows::core::Interface for InkAnalysisInkBullet {
 impl ::windows::core::RuntimeName for InkAnalysisInkBullet {
     const NAME: &'static str = "Windows.UI.Input.Inking.Analysis.InkAnalysisInkBullet";
 }
-impl ::core::convert::From<InkAnalysisInkBullet> for ::windows::core::IUnknown {
-    fn from(value: InkAnalysisInkBullet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkBullet> for ::windows::core::IUnknown {
-    fn from(value: &InkAnalysisInkBullet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkBullet> for &::windows::core::IUnknown {
-    fn from(value: &InkAnalysisInkBullet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkAnalysisInkBullet> for ::windows::core::IInspectable {
-    fn from(value: InkAnalysisInkBullet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkBullet> for ::windows::core::IInspectable {
-    fn from(value: &InkAnalysisInkBullet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkBullet> for &::windows::core::IInspectable {
-    fn from(value: &InkAnalysisInkBullet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkAnalysisInkBullet, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkAnalysisInkBullet> for IInkAnalysisNode {
     type Error = ::windows::core::Error;
     fn try_from(value: InkAnalysisInkBullet) -> ::windows::core::Result<Self> {
@@ -676,36 +589,7 @@ unsafe impl ::windows::core::Interface for InkAnalysisInkDrawing {
 impl ::windows::core::RuntimeName for InkAnalysisInkDrawing {
     const NAME: &'static str = "Windows.UI.Input.Inking.Analysis.InkAnalysisInkDrawing";
 }
-impl ::core::convert::From<InkAnalysisInkDrawing> for ::windows::core::IUnknown {
-    fn from(value: InkAnalysisInkDrawing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkDrawing> for ::windows::core::IUnknown {
-    fn from(value: &InkAnalysisInkDrawing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkDrawing> for &::windows::core::IUnknown {
-    fn from(value: &InkAnalysisInkDrawing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkAnalysisInkDrawing> for ::windows::core::IInspectable {
-    fn from(value: InkAnalysisInkDrawing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkDrawing> for ::windows::core::IInspectable {
-    fn from(value: &InkAnalysisInkDrawing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkDrawing> for &::windows::core::IInspectable {
-    fn from(value: &InkAnalysisInkDrawing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkAnalysisInkDrawing, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkAnalysisInkDrawing> for IInkAnalysisNode {
     type Error = ::windows::core::Error;
     fn try_from(value: InkAnalysisInkDrawing) -> ::windows::core::Result<Self> {
@@ -837,36 +721,7 @@ unsafe impl ::windows::core::Interface for InkAnalysisInkWord {
 impl ::windows::core::RuntimeName for InkAnalysisInkWord {
     const NAME: &'static str = "Windows.UI.Input.Inking.Analysis.InkAnalysisInkWord";
 }
-impl ::core::convert::From<InkAnalysisInkWord> for ::windows::core::IUnknown {
-    fn from(value: InkAnalysisInkWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkWord> for ::windows::core::IUnknown {
-    fn from(value: &InkAnalysisInkWord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkWord> for &::windows::core::IUnknown {
-    fn from(value: &InkAnalysisInkWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkAnalysisInkWord> for ::windows::core::IInspectable {
-    fn from(value: InkAnalysisInkWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkWord> for ::windows::core::IInspectable {
-    fn from(value: &InkAnalysisInkWord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisInkWord> for &::windows::core::IInspectable {
-    fn from(value: &InkAnalysisInkWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkAnalysisInkWord, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkAnalysisInkWord> for IInkAnalysisNode {
     type Error = ::windows::core::Error;
     fn try_from(value: InkAnalysisInkWord) -> ::windows::core::Result<Self> {
@@ -996,36 +851,7 @@ unsafe impl ::windows::core::Interface for InkAnalysisLine {
 impl ::windows::core::RuntimeName for InkAnalysisLine {
     const NAME: &'static str = "Windows.UI.Input.Inking.Analysis.InkAnalysisLine";
 }
-impl ::core::convert::From<InkAnalysisLine> for ::windows::core::IUnknown {
-    fn from(value: InkAnalysisLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisLine> for ::windows::core::IUnknown {
-    fn from(value: &InkAnalysisLine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisLine> for &::windows::core::IUnknown {
-    fn from(value: &InkAnalysisLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkAnalysisLine> for ::windows::core::IInspectable {
-    fn from(value: InkAnalysisLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisLine> for ::windows::core::IInspectable {
-    fn from(value: &InkAnalysisLine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisLine> for &::windows::core::IInspectable {
-    fn from(value: &InkAnalysisLine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkAnalysisLine, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkAnalysisLine> for IInkAnalysisNode {
     type Error = ::windows::core::Error;
     fn try_from(value: InkAnalysisLine) -> ::windows::core::Result<Self> {
@@ -1148,36 +974,7 @@ unsafe impl ::windows::core::Interface for InkAnalysisListItem {
 impl ::windows::core::RuntimeName for InkAnalysisListItem {
     const NAME: &'static str = "Windows.UI.Input.Inking.Analysis.InkAnalysisListItem";
 }
-impl ::core::convert::From<InkAnalysisListItem> for ::windows::core::IUnknown {
-    fn from(value: InkAnalysisListItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisListItem> for ::windows::core::IUnknown {
-    fn from(value: &InkAnalysisListItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisListItem> for &::windows::core::IUnknown {
-    fn from(value: &InkAnalysisListItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkAnalysisListItem> for ::windows::core::IInspectable {
-    fn from(value: InkAnalysisListItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisListItem> for ::windows::core::IInspectable {
-    fn from(value: &InkAnalysisListItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisListItem> for &::windows::core::IInspectable {
-    fn from(value: &InkAnalysisListItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkAnalysisListItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkAnalysisListItem> for IInkAnalysisNode {
     type Error = ::windows::core::Error;
     fn try_from(value: InkAnalysisListItem) -> ::windows::core::Result<Self> {
@@ -1293,36 +1090,7 @@ unsafe impl ::windows::core::Interface for InkAnalysisNode {
 impl ::windows::core::RuntimeName for InkAnalysisNode {
     const NAME: &'static str = "Windows.UI.Input.Inking.Analysis.InkAnalysisNode";
 }
-impl ::core::convert::From<InkAnalysisNode> for ::windows::core::IUnknown {
-    fn from(value: InkAnalysisNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisNode> for ::windows::core::IUnknown {
-    fn from(value: &InkAnalysisNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisNode> for &::windows::core::IUnknown {
-    fn from(value: &InkAnalysisNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkAnalysisNode> for ::windows::core::IInspectable {
-    fn from(value: InkAnalysisNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisNode> for ::windows::core::IInspectable {
-    fn from(value: &InkAnalysisNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisNode> for &::windows::core::IInspectable {
-    fn from(value: &InkAnalysisNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkAnalysisNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkAnalysisNode> for IInkAnalysisNode {
     type Error = ::windows::core::Error;
     fn try_from(value: InkAnalysisNode) -> ::windows::core::Result<Self> {
@@ -1445,36 +1213,7 @@ unsafe impl ::windows::core::Interface for InkAnalysisParagraph {
 impl ::windows::core::RuntimeName for InkAnalysisParagraph {
     const NAME: &'static str = "Windows.UI.Input.Inking.Analysis.InkAnalysisParagraph";
 }
-impl ::core::convert::From<InkAnalysisParagraph> for ::windows::core::IUnknown {
-    fn from(value: InkAnalysisParagraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisParagraph> for ::windows::core::IUnknown {
-    fn from(value: &InkAnalysisParagraph) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisParagraph> for &::windows::core::IUnknown {
-    fn from(value: &InkAnalysisParagraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkAnalysisParagraph> for ::windows::core::IInspectable {
-    fn from(value: InkAnalysisParagraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisParagraph> for ::windows::core::IInspectable {
-    fn from(value: &InkAnalysisParagraph) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisParagraph> for &::windows::core::IInspectable {
-    fn from(value: &InkAnalysisParagraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkAnalysisParagraph, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkAnalysisParagraph> for IInkAnalysisNode {
     type Error = ::windows::core::Error;
     fn try_from(value: InkAnalysisParagraph) -> ::windows::core::Result<Self> {
@@ -1540,36 +1279,7 @@ unsafe impl ::windows::core::Interface for InkAnalysisResult {
 impl ::windows::core::RuntimeName for InkAnalysisResult {
     const NAME: &'static str = "Windows.UI.Input.Inking.Analysis.InkAnalysisResult";
 }
-impl ::core::convert::From<InkAnalysisResult> for ::windows::core::IUnknown {
-    fn from(value: InkAnalysisResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisResult> for ::windows::core::IUnknown {
-    fn from(value: &InkAnalysisResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisResult> for &::windows::core::IUnknown {
-    fn from(value: &InkAnalysisResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkAnalysisResult> for ::windows::core::IInspectable {
-    fn from(value: InkAnalysisResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisResult> for ::windows::core::IInspectable {
-    fn from(value: &InkAnalysisResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisResult> for &::windows::core::IInspectable {
-    fn from(value: &InkAnalysisResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkAnalysisResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkAnalysisResult {}
 unsafe impl ::core::marker::Sync for InkAnalysisResult {}
 #[doc = "*Required features: `\"UI_Input_Inking_Analysis\"`*"]
@@ -1682,36 +1392,7 @@ unsafe impl ::windows::core::Interface for InkAnalysisRoot {
 impl ::windows::core::RuntimeName for InkAnalysisRoot {
     const NAME: &'static str = "Windows.UI.Input.Inking.Analysis.InkAnalysisRoot";
 }
-impl ::core::convert::From<InkAnalysisRoot> for ::windows::core::IUnknown {
-    fn from(value: InkAnalysisRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisRoot> for ::windows::core::IUnknown {
-    fn from(value: &InkAnalysisRoot) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisRoot> for &::windows::core::IUnknown {
-    fn from(value: &InkAnalysisRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkAnalysisRoot> for ::windows::core::IInspectable {
-    fn from(value: InkAnalysisRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisRoot> for ::windows::core::IInspectable {
-    fn from(value: &InkAnalysisRoot) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisRoot> for &::windows::core::IInspectable {
-    fn from(value: &InkAnalysisRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkAnalysisRoot, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkAnalysisRoot> for IInkAnalysisNode {
     type Error = ::windows::core::Error;
     fn try_from(value: InkAnalysisRoot) -> ::windows::core::Result<Self> {
@@ -1834,36 +1515,7 @@ unsafe impl ::windows::core::Interface for InkAnalysisWritingRegion {
 impl ::windows::core::RuntimeName for InkAnalysisWritingRegion {
     const NAME: &'static str = "Windows.UI.Input.Inking.Analysis.InkAnalysisWritingRegion";
 }
-impl ::core::convert::From<InkAnalysisWritingRegion> for ::windows::core::IUnknown {
-    fn from(value: InkAnalysisWritingRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisWritingRegion> for ::windows::core::IUnknown {
-    fn from(value: &InkAnalysisWritingRegion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisWritingRegion> for &::windows::core::IUnknown {
-    fn from(value: &InkAnalysisWritingRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkAnalysisWritingRegion> for ::windows::core::IInspectable {
-    fn from(value: InkAnalysisWritingRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalysisWritingRegion> for ::windows::core::IInspectable {
-    fn from(value: &InkAnalysisWritingRegion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalysisWritingRegion> for &::windows::core::IInspectable {
-    fn from(value: &InkAnalysisWritingRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkAnalysisWritingRegion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkAnalysisWritingRegion> for IInkAnalysisNode {
     type Error = ::windows::core::Error;
     fn try_from(value: InkAnalysisWritingRegion) -> ::windows::core::Result<Self> {
@@ -1992,36 +1644,7 @@ unsafe impl ::windows::core::Interface for InkAnalyzer {
 impl ::windows::core::RuntimeName for InkAnalyzer {
     const NAME: &'static str = "Windows.UI.Input.Inking.Analysis.InkAnalyzer";
 }
-impl ::core::convert::From<InkAnalyzer> for ::windows::core::IUnknown {
-    fn from(value: InkAnalyzer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalyzer> for ::windows::core::IUnknown {
-    fn from(value: &InkAnalyzer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalyzer> for &::windows::core::IUnknown {
-    fn from(value: &InkAnalyzer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkAnalyzer> for ::windows::core::IInspectable {
-    fn from(value: InkAnalyzer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkAnalyzer> for ::windows::core::IInspectable {
-    fn from(value: &InkAnalyzer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkAnalyzer> for &::windows::core::IInspectable {
-    fn from(value: &InkAnalyzer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkAnalyzer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkAnalyzer {}
 unsafe impl ::core::marker::Sync for InkAnalyzer {}
 #[doc = "*Required features: `\"UI_Input_Inking_Analysis\"`*"]

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Core/mod.rs
@@ -361,36 +361,7 @@ unsafe impl ::windows::core::Interface for CoreIncrementalInkStroke {
 impl ::windows::core::RuntimeName for CoreIncrementalInkStroke {
     const NAME: &'static str = "Windows.UI.Input.Inking.Core.CoreIncrementalInkStroke";
 }
-impl ::core::convert::From<CoreIncrementalInkStroke> for ::windows::core::IUnknown {
-    fn from(value: CoreIncrementalInkStroke) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreIncrementalInkStroke> for ::windows::core::IUnknown {
-    fn from(value: &CoreIncrementalInkStroke) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreIncrementalInkStroke> for &::windows::core::IUnknown {
-    fn from(value: &CoreIncrementalInkStroke) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreIncrementalInkStroke> for ::windows::core::IInspectable {
-    fn from(value: CoreIncrementalInkStroke) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreIncrementalInkStroke> for ::windows::core::IInspectable {
-    fn from(value: &CoreIncrementalInkStroke) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreIncrementalInkStroke> for &::windows::core::IInspectable {
-    fn from(value: &CoreIncrementalInkStroke) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreIncrementalInkStroke, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreIncrementalInkStroke {}
 unsafe impl ::core::marker::Sync for CoreIncrementalInkStroke {}
 #[doc = "*Required features: `\"UI_Input_Inking_Core\"`*"]
@@ -568,36 +539,7 @@ unsafe impl ::windows::core::Interface for CoreInkIndependentInputSource {
 impl ::windows::core::RuntimeName for CoreInkIndependentInputSource {
     const NAME: &'static str = "Windows.UI.Input.Inking.Core.CoreInkIndependentInputSource";
 }
-impl ::core::convert::From<CoreInkIndependentInputSource> for ::windows::core::IUnknown {
-    fn from(value: CoreInkIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInkIndependentInputSource> for ::windows::core::IUnknown {
-    fn from(value: &CoreInkIndependentInputSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInkIndependentInputSource> for &::windows::core::IUnknown {
-    fn from(value: &CoreInkIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreInkIndependentInputSource> for ::windows::core::IInspectable {
-    fn from(value: CoreInkIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInkIndependentInputSource> for ::windows::core::IInspectable {
-    fn from(value: &CoreInkIndependentInputSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInkIndependentInputSource> for &::windows::core::IInspectable {
-    fn from(value: &CoreInkIndependentInputSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreInkIndependentInputSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreInkIndependentInputSource {}
 unsafe impl ::core::marker::Sync for CoreInkIndependentInputSource {}
 #[doc = "*Required features: `\"UI_Input_Inking_Core\"`*"]
@@ -669,36 +611,7 @@ unsafe impl ::windows::core::Interface for CoreInkPresenterHost {
 impl ::windows::core::RuntimeName for CoreInkPresenterHost {
     const NAME: &'static str = "Windows.UI.Input.Inking.Core.CoreInkPresenterHost";
 }
-impl ::core::convert::From<CoreInkPresenterHost> for ::windows::core::IUnknown {
-    fn from(value: CoreInkPresenterHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInkPresenterHost> for ::windows::core::IUnknown {
-    fn from(value: &CoreInkPresenterHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInkPresenterHost> for &::windows::core::IUnknown {
-    fn from(value: &CoreInkPresenterHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreInkPresenterHost> for ::windows::core::IInspectable {
-    fn from(value: CoreInkPresenterHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInkPresenterHost> for ::windows::core::IInspectable {
-    fn from(value: &CoreInkPresenterHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInkPresenterHost> for &::windows::core::IInspectable {
-    fn from(value: &CoreInkPresenterHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreInkPresenterHost, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreInkPresenterHost {}
 unsafe impl ::core::marker::Sync for CoreInkPresenterHost {}
 #[doc = "*Required features: `\"UI_Input_Inking_Core\"`*"]
@@ -765,36 +678,7 @@ unsafe impl ::windows::core::Interface for CoreWetStrokeUpdateEventArgs {
 impl ::windows::core::RuntimeName for CoreWetStrokeUpdateEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Inking.Core.CoreWetStrokeUpdateEventArgs";
 }
-impl ::core::convert::From<CoreWetStrokeUpdateEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreWetStrokeUpdateEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWetStrokeUpdateEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreWetStrokeUpdateEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWetStrokeUpdateEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreWetStrokeUpdateEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreWetStrokeUpdateEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreWetStrokeUpdateEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWetStrokeUpdateEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreWetStrokeUpdateEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWetStrokeUpdateEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreWetStrokeUpdateEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreWetStrokeUpdateEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreWetStrokeUpdateEventArgs {}
 unsafe impl ::core::marker::Sync for CoreWetStrokeUpdateEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Inking_Core\"`*"]
@@ -927,36 +811,7 @@ unsafe impl ::windows::core::Interface for CoreWetStrokeUpdateSource {
 impl ::windows::core::RuntimeName for CoreWetStrokeUpdateSource {
     const NAME: &'static str = "Windows.UI.Input.Inking.Core.CoreWetStrokeUpdateSource";
 }
-impl ::core::convert::From<CoreWetStrokeUpdateSource> for ::windows::core::IUnknown {
-    fn from(value: CoreWetStrokeUpdateSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWetStrokeUpdateSource> for ::windows::core::IUnknown {
-    fn from(value: &CoreWetStrokeUpdateSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWetStrokeUpdateSource> for &::windows::core::IUnknown {
-    fn from(value: &CoreWetStrokeUpdateSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreWetStrokeUpdateSource> for ::windows::core::IInspectable {
-    fn from(value: CoreWetStrokeUpdateSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreWetStrokeUpdateSource> for ::windows::core::IInspectable {
-    fn from(value: &CoreWetStrokeUpdateSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreWetStrokeUpdateSource> for &::windows::core::IInspectable {
-    fn from(value: &CoreWetStrokeUpdateSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreWetStrokeUpdateSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreWetStrokeUpdateSource {}
 unsafe impl ::core::marker::Sync for CoreWetStrokeUpdateSource {}
 #[doc = "*Required features: `\"UI_Input_Inking_Core\"`*"]

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Preview/mod.rs
@@ -105,36 +105,7 @@ unsafe impl ::windows::core::Interface for PalmRejectionDelayZonePreview {
 impl ::windows::core::RuntimeName for PalmRejectionDelayZonePreview {
     const NAME: &'static str = "Windows.UI.Input.Inking.Preview.PalmRejectionDelayZonePreview";
 }
-impl ::core::convert::From<PalmRejectionDelayZonePreview> for ::windows::core::IUnknown {
-    fn from(value: PalmRejectionDelayZonePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PalmRejectionDelayZonePreview> for ::windows::core::IUnknown {
-    fn from(value: &PalmRejectionDelayZonePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PalmRejectionDelayZonePreview> for &::windows::core::IUnknown {
-    fn from(value: &PalmRejectionDelayZonePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PalmRejectionDelayZonePreview> for ::windows::core::IInspectable {
-    fn from(value: PalmRejectionDelayZonePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PalmRejectionDelayZonePreview> for ::windows::core::IInspectable {
-    fn from(value: &PalmRejectionDelayZonePreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PalmRejectionDelayZonePreview> for &::windows::core::IInspectable {
-    fn from(value: &PalmRejectionDelayZonePreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PalmRejectionDelayZonePreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<PalmRejectionDelayZonePreview> for super::super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/mod.rs
@@ -305,36 +305,7 @@ impl IInkPointFactory {
         }
     }
 }
-impl ::core::convert::From<IInkPointFactory> for ::windows::core::IUnknown {
-    fn from(value: IInkPointFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkPointFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkPointFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkPointFactory> for ::windows::core::IUnknown {
-    fn from(value: &IInkPointFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInkPointFactory> for ::windows::core::IInspectable {
-    fn from(value: IInkPointFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkPointFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInkPointFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkPointFactory> for ::windows::core::IInspectable {
-    fn from(value: &IInkPointFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkPointFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IInkPointFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -562,36 +533,7 @@ impl IInkPresenterRulerFactory {
         }
     }
 }
-impl ::core::convert::From<IInkPresenterRulerFactory> for ::windows::core::IUnknown {
-    fn from(value: IInkPresenterRulerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkPresenterRulerFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkPresenterRulerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkPresenterRulerFactory> for ::windows::core::IUnknown {
-    fn from(value: &IInkPresenterRulerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInkPresenterRulerFactory> for ::windows::core::IInspectable {
-    fn from(value: IInkPresenterRulerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkPresenterRulerFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInkPresenterRulerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkPresenterRulerFactory> for ::windows::core::IInspectable {
-    fn from(value: &IInkPresenterRulerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkPresenterRulerFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IInkPresenterRulerFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -687,36 +629,7 @@ impl IInkPresenterStencil {
         unsafe { (::windows::core::Vtable::vtable(this).SetTransform)(::windows::core::Vtable::as_raw(this), value).ok() }
     }
 }
-impl ::core::convert::From<IInkPresenterStencil> for ::windows::core::IUnknown {
-    fn from(value: IInkPresenterStencil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkPresenterStencil> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkPresenterStencil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkPresenterStencil> for ::windows::core::IUnknown {
-    fn from(value: &IInkPresenterStencil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInkPresenterStencil> for ::windows::core::IInspectable {
-    fn from(value: IInkPresenterStencil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkPresenterStencil> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInkPresenterStencil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkPresenterStencil> for ::windows::core::IInspectable {
-    fn from(value: &IInkPresenterStencil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkPresenterStencil, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IInkPresenterStencil {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -834,36 +747,7 @@ impl IInkRecognizerContainer {
         }
     }
 }
-impl ::core::convert::From<IInkRecognizerContainer> for ::windows::core::IUnknown {
-    fn from(value: IInkRecognizerContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkRecognizerContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRecognizerContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkRecognizerContainer> for ::windows::core::IUnknown {
-    fn from(value: &IInkRecognizerContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInkRecognizerContainer> for ::windows::core::IInspectable {
-    fn from(value: IInkRecognizerContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkRecognizerContainer> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInkRecognizerContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkRecognizerContainer> for ::windows::core::IInspectable {
-    fn from(value: &IInkRecognizerContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRecognizerContainer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IInkRecognizerContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1197,36 +1081,7 @@ impl IInkStrokeContainer {
         }
     }
 }
-impl ::core::convert::From<IInkStrokeContainer> for ::windows::core::IUnknown {
-    fn from(value: IInkStrokeContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkStrokeContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkStrokeContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkStrokeContainer> for ::windows::core::IUnknown {
-    fn from(value: &IInkStrokeContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInkStrokeContainer> for ::windows::core::IInspectable {
-    fn from(value: IInkStrokeContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkStrokeContainer> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInkStrokeContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkStrokeContainer> for ::windows::core::IInspectable {
-    fn from(value: &IInkStrokeContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkStrokeContainer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IInkStrokeContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1771,36 +1626,7 @@ unsafe impl ::windows::core::Interface for InkDrawingAttributes {
 impl ::windows::core::RuntimeName for InkDrawingAttributes {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkDrawingAttributes";
 }
-impl ::core::convert::From<InkDrawingAttributes> for ::windows::core::IUnknown {
-    fn from(value: InkDrawingAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkDrawingAttributes> for ::windows::core::IUnknown {
-    fn from(value: &InkDrawingAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkDrawingAttributes> for &::windows::core::IUnknown {
-    fn from(value: &InkDrawingAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkDrawingAttributes> for ::windows::core::IInspectable {
-    fn from(value: InkDrawingAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkDrawingAttributes> for ::windows::core::IInspectable {
-    fn from(value: &InkDrawingAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkDrawingAttributes> for &::windows::core::IInspectable {
-    fn from(value: &InkDrawingAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkDrawingAttributes, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkDrawingAttributes {}
 unsafe impl ::core::marker::Sync for InkDrawingAttributes {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -1851,36 +1677,7 @@ unsafe impl ::windows::core::Interface for InkDrawingAttributesPencilProperties 
 impl ::windows::core::RuntimeName for InkDrawingAttributesPencilProperties {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkDrawingAttributesPencilProperties";
 }
-impl ::core::convert::From<InkDrawingAttributesPencilProperties> for ::windows::core::IUnknown {
-    fn from(value: InkDrawingAttributesPencilProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkDrawingAttributesPencilProperties> for ::windows::core::IUnknown {
-    fn from(value: &InkDrawingAttributesPencilProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkDrawingAttributesPencilProperties> for &::windows::core::IUnknown {
-    fn from(value: &InkDrawingAttributesPencilProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkDrawingAttributesPencilProperties> for ::windows::core::IInspectable {
-    fn from(value: InkDrawingAttributesPencilProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkDrawingAttributesPencilProperties> for ::windows::core::IInspectable {
-    fn from(value: &InkDrawingAttributesPencilProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkDrawingAttributesPencilProperties> for &::windows::core::IInspectable {
-    fn from(value: &InkDrawingAttributesPencilProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkDrawingAttributesPencilProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkDrawingAttributesPencilProperties {}
 unsafe impl ::core::marker::Sync for InkDrawingAttributesPencilProperties {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -1953,36 +1750,7 @@ unsafe impl ::windows::core::Interface for InkInputConfiguration {
 impl ::windows::core::RuntimeName for InkInputConfiguration {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkInputConfiguration";
 }
-impl ::core::convert::From<InkInputConfiguration> for ::windows::core::IUnknown {
-    fn from(value: InkInputConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkInputConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &InkInputConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkInputConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &InkInputConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkInputConfiguration> for ::windows::core::IInspectable {
-    fn from(value: InkInputConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkInputConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &InkInputConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkInputConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &InkInputConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkInputConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkInputConfiguration {}
 unsafe impl ::core::marker::Sync for InkInputConfiguration {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -2044,36 +1812,7 @@ unsafe impl ::windows::core::Interface for InkInputProcessingConfiguration {
 impl ::windows::core::RuntimeName for InkInputProcessingConfiguration {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkInputProcessingConfiguration";
 }
-impl ::core::convert::From<InkInputProcessingConfiguration> for ::windows::core::IUnknown {
-    fn from(value: InkInputProcessingConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkInputProcessingConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &InkInputProcessingConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkInputProcessingConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &InkInputProcessingConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkInputProcessingConfiguration> for ::windows::core::IInspectable {
-    fn from(value: InkInputProcessingConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkInputProcessingConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &InkInputProcessingConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkInputProcessingConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &InkInputProcessingConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkInputProcessingConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkInputProcessingConfiguration {}
 unsafe impl ::core::marker::Sync for InkInputProcessingConfiguration {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -2313,36 +2052,7 @@ unsafe impl ::windows::core::Interface for InkManager {
 impl ::windows::core::RuntimeName for InkManager {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkManager";
 }
-impl ::core::convert::From<InkManager> for ::windows::core::IUnknown {
-    fn from(value: InkManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkManager> for ::windows::core::IUnknown {
-    fn from(value: &InkManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkManager> for &::windows::core::IUnknown {
-    fn from(value: &InkManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkManager> for ::windows::core::IInspectable {
-    fn from(value: InkManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkManager> for ::windows::core::IInspectable {
-    fn from(value: &InkManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkManager> for &::windows::core::IInspectable {
-    fn from(value: &InkManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkManager> for IInkRecognizerContainer {
     type Error = ::windows::core::Error;
     fn try_from(value: InkManager) -> ::windows::core::Result<Self> {
@@ -2455,36 +2165,7 @@ unsafe impl ::windows::core::Interface for InkModelerAttributes {
 impl ::windows::core::RuntimeName for InkModelerAttributes {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkModelerAttributes";
 }
-impl ::core::convert::From<InkModelerAttributes> for ::windows::core::IUnknown {
-    fn from(value: InkModelerAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkModelerAttributes> for ::windows::core::IUnknown {
-    fn from(value: &InkModelerAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkModelerAttributes> for &::windows::core::IUnknown {
-    fn from(value: &InkModelerAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkModelerAttributes> for ::windows::core::IInspectable {
-    fn from(value: InkModelerAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkModelerAttributes> for ::windows::core::IInspectable {
-    fn from(value: &InkModelerAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkModelerAttributes> for &::windows::core::IInspectable {
-    fn from(value: &InkModelerAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkModelerAttributes, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkModelerAttributes {}
 unsafe impl ::core::marker::Sync for InkModelerAttributes {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -2587,36 +2268,7 @@ unsafe impl ::windows::core::Interface for InkPoint {
 impl ::windows::core::RuntimeName for InkPoint {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkPoint";
 }
-impl ::core::convert::From<InkPoint> for ::windows::core::IUnknown {
-    fn from(value: InkPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkPoint> for ::windows::core::IUnknown {
-    fn from(value: &InkPoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkPoint> for &::windows::core::IUnknown {
-    fn from(value: &InkPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkPoint> for ::windows::core::IInspectable {
-    fn from(value: InkPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkPoint> for ::windows::core::IInspectable {
-    fn from(value: &InkPoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkPoint> for &::windows::core::IInspectable {
-    fn from(value: &InkPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkPoint, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkPoint {}
 unsafe impl ::core::marker::Sync for InkPoint {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -2784,36 +2436,7 @@ unsafe impl ::windows::core::Interface for InkPresenter {
 impl ::windows::core::RuntimeName for InkPresenter {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkPresenter";
 }
-impl ::core::convert::From<InkPresenter> for ::windows::core::IUnknown {
-    fn from(value: InkPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkPresenter> for ::windows::core::IUnknown {
-    fn from(value: &InkPresenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkPresenter> for &::windows::core::IUnknown {
-    fn from(value: &InkPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkPresenter> for ::windows::core::IInspectable {
-    fn from(value: InkPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkPresenter> for ::windows::core::IInspectable {
-    fn from(value: &InkPresenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkPresenter> for &::windows::core::IInspectable {
-    fn from(value: &InkPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkPresenter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkPresenter {}
 unsafe impl ::core::marker::Sync for InkPresenter {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -2996,36 +2619,7 @@ unsafe impl ::windows::core::Interface for InkPresenterProtractor {
 impl ::windows::core::RuntimeName for InkPresenterProtractor {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkPresenterProtractor";
 }
-impl ::core::convert::From<InkPresenterProtractor> for ::windows::core::IUnknown {
-    fn from(value: InkPresenterProtractor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkPresenterProtractor> for ::windows::core::IUnknown {
-    fn from(value: &InkPresenterProtractor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkPresenterProtractor> for &::windows::core::IUnknown {
-    fn from(value: &InkPresenterProtractor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkPresenterProtractor> for ::windows::core::IInspectable {
-    fn from(value: InkPresenterProtractor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkPresenterProtractor> for ::windows::core::IInspectable {
-    fn from(value: &InkPresenterProtractor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkPresenterProtractor> for &::windows::core::IInspectable {
-    fn from(value: &InkPresenterProtractor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkPresenterProtractor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkPresenterProtractor> for IInkPresenterStencil {
     type Error = ::windows::core::Error;
     fn try_from(value: InkPresenterProtractor) -> ::windows::core::Result<Self> {
@@ -3194,36 +2788,7 @@ unsafe impl ::windows::core::Interface for InkPresenterRuler {
 impl ::windows::core::RuntimeName for InkPresenterRuler {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkPresenterRuler";
 }
-impl ::core::convert::From<InkPresenterRuler> for ::windows::core::IUnknown {
-    fn from(value: InkPresenterRuler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkPresenterRuler> for ::windows::core::IUnknown {
-    fn from(value: &InkPresenterRuler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkPresenterRuler> for &::windows::core::IUnknown {
-    fn from(value: &InkPresenterRuler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkPresenterRuler> for ::windows::core::IInspectable {
-    fn from(value: InkPresenterRuler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkPresenterRuler> for ::windows::core::IInspectable {
-    fn from(value: &InkPresenterRuler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkPresenterRuler> for &::windows::core::IInspectable {
-    fn from(value: &InkPresenterRuler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkPresenterRuler, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkPresenterRuler> for IInkPresenterStencil {
     type Error = ::windows::core::Error;
     fn try_from(value: InkPresenterRuler) -> ::windows::core::Result<Self> {
@@ -3309,36 +2874,7 @@ unsafe impl ::windows::core::Interface for InkRecognitionResult {
 impl ::windows::core::RuntimeName for InkRecognitionResult {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkRecognitionResult";
 }
-impl ::core::convert::From<InkRecognitionResult> for ::windows::core::IUnknown {
-    fn from(value: InkRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkRecognitionResult> for ::windows::core::IUnknown {
-    fn from(value: &InkRecognitionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkRecognitionResult> for &::windows::core::IUnknown {
-    fn from(value: &InkRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkRecognitionResult> for ::windows::core::IInspectable {
-    fn from(value: InkRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkRecognitionResult> for ::windows::core::IInspectable {
-    fn from(value: &InkRecognitionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkRecognitionResult> for &::windows::core::IInspectable {
-    fn from(value: &InkRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkRecognitionResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkRecognitionResult {}
 unsafe impl ::core::marker::Sync for InkRecognitionResult {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -3385,36 +2921,7 @@ unsafe impl ::windows::core::Interface for InkRecognizer {
 impl ::windows::core::RuntimeName for InkRecognizer {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkRecognizer";
 }
-impl ::core::convert::From<InkRecognizer> for ::windows::core::IUnknown {
-    fn from(value: InkRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkRecognizer> for ::windows::core::IUnknown {
-    fn from(value: &InkRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkRecognizer> for &::windows::core::IUnknown {
-    fn from(value: &InkRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkRecognizer> for ::windows::core::IInspectable {
-    fn from(value: InkRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkRecognizer> for ::windows::core::IInspectable {
-    fn from(value: &InkRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkRecognizer> for &::windows::core::IInspectable {
-    fn from(value: &InkRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkRecognizer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
 #[repr(transparent)]
 pub struct InkRecognizerContainer(::windows::core::IUnknown);
@@ -3481,36 +2988,7 @@ unsafe impl ::windows::core::Interface for InkRecognizerContainer {
 impl ::windows::core::RuntimeName for InkRecognizerContainer {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkRecognizerContainer";
 }
-impl ::core::convert::From<InkRecognizerContainer> for ::windows::core::IUnknown {
-    fn from(value: InkRecognizerContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkRecognizerContainer> for ::windows::core::IUnknown {
-    fn from(value: &InkRecognizerContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkRecognizerContainer> for &::windows::core::IUnknown {
-    fn from(value: &InkRecognizerContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkRecognizerContainer> for ::windows::core::IInspectable {
-    fn from(value: InkRecognizerContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkRecognizerContainer> for ::windows::core::IInspectable {
-    fn from(value: &InkRecognizerContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkRecognizerContainer> for &::windows::core::IInspectable {
-    fn from(value: &InkRecognizerContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkRecognizerContainer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkRecognizerContainer> for IInkRecognizerContainer {
     type Error = ::windows::core::Error;
     fn try_from(value: InkRecognizerContainer) -> ::windows::core::Result<Self> {
@@ -3697,36 +3175,7 @@ unsafe impl ::windows::core::Interface for InkStroke {
 impl ::windows::core::RuntimeName for InkStroke {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkStroke";
 }
-impl ::core::convert::From<InkStroke> for ::windows::core::IUnknown {
-    fn from(value: InkStroke) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStroke> for ::windows::core::IUnknown {
-    fn from(value: &InkStroke) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStroke> for &::windows::core::IUnknown {
-    fn from(value: &InkStroke) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkStroke> for ::windows::core::IInspectable {
-    fn from(value: InkStroke) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStroke> for ::windows::core::IInspectable {
-    fn from(value: &InkStroke) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStroke> for &::windows::core::IInspectable {
-    fn from(value: &InkStroke) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkStroke, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkStroke {}
 unsafe impl ::core::marker::Sync for InkStroke {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -3838,36 +3287,7 @@ unsafe impl ::windows::core::Interface for InkStrokeBuilder {
 impl ::windows::core::RuntimeName for InkStrokeBuilder {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkStrokeBuilder";
 }
-impl ::core::convert::From<InkStrokeBuilder> for ::windows::core::IUnknown {
-    fn from(value: InkStrokeBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokeBuilder> for ::windows::core::IUnknown {
-    fn from(value: &InkStrokeBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokeBuilder> for &::windows::core::IUnknown {
-    fn from(value: &InkStrokeBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkStrokeBuilder> for ::windows::core::IInspectable {
-    fn from(value: InkStrokeBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokeBuilder> for ::windows::core::IInspectable {
-    fn from(value: &InkStrokeBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokeBuilder> for &::windows::core::IInspectable {
-    fn from(value: &InkStrokeBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkStrokeBuilder, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
 #[repr(transparent)]
 pub struct InkStrokeContainer(::windows::core::IUnknown);
@@ -4073,36 +3493,7 @@ unsafe impl ::windows::core::Interface for InkStrokeContainer {
 impl ::windows::core::RuntimeName for InkStrokeContainer {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkStrokeContainer";
 }
-impl ::core::convert::From<InkStrokeContainer> for ::windows::core::IUnknown {
-    fn from(value: InkStrokeContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokeContainer> for ::windows::core::IUnknown {
-    fn from(value: &InkStrokeContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokeContainer> for &::windows::core::IUnknown {
-    fn from(value: &InkStrokeContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkStrokeContainer> for ::windows::core::IInspectable {
-    fn from(value: InkStrokeContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokeContainer> for ::windows::core::IInspectable {
-    fn from(value: &InkStrokeContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokeContainer> for &::windows::core::IInspectable {
-    fn from(value: &InkStrokeContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkStrokeContainer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<InkStrokeContainer> for IInkStrokeContainer {
     type Error = ::windows::core::Error;
     fn try_from(value: InkStrokeContainer) -> ::windows::core::Result<Self> {
@@ -4226,36 +3617,7 @@ unsafe impl ::windows::core::Interface for InkStrokeInput {
 impl ::windows::core::RuntimeName for InkStrokeInput {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkStrokeInput";
 }
-impl ::core::convert::From<InkStrokeInput> for ::windows::core::IUnknown {
-    fn from(value: InkStrokeInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokeInput> for ::windows::core::IUnknown {
-    fn from(value: &InkStrokeInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokeInput> for &::windows::core::IUnknown {
-    fn from(value: &InkStrokeInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkStrokeInput> for ::windows::core::IInspectable {
-    fn from(value: InkStrokeInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokeInput> for ::windows::core::IInspectable {
-    fn from(value: &InkStrokeInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokeInput> for &::windows::core::IInspectable {
-    fn from(value: &InkStrokeInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkStrokeInput, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkStrokeInput {}
 unsafe impl ::core::marker::Sync for InkStrokeInput {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -4350,36 +3712,7 @@ unsafe impl ::windows::core::Interface for InkStrokeRenderingSegment {
 impl ::windows::core::RuntimeName for InkStrokeRenderingSegment {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkStrokeRenderingSegment";
 }
-impl ::core::convert::From<InkStrokeRenderingSegment> for ::windows::core::IUnknown {
-    fn from(value: InkStrokeRenderingSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokeRenderingSegment> for ::windows::core::IUnknown {
-    fn from(value: &InkStrokeRenderingSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokeRenderingSegment> for &::windows::core::IUnknown {
-    fn from(value: &InkStrokeRenderingSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkStrokeRenderingSegment> for ::windows::core::IInspectable {
-    fn from(value: InkStrokeRenderingSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokeRenderingSegment> for ::windows::core::IInspectable {
-    fn from(value: &InkStrokeRenderingSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokeRenderingSegment> for &::windows::core::IInspectable {
-    fn from(value: &InkStrokeRenderingSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkStrokeRenderingSegment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkStrokeRenderingSegment {}
 unsafe impl ::core::marker::Sync for InkStrokeRenderingSegment {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -4428,36 +3761,7 @@ unsafe impl ::windows::core::Interface for InkStrokesCollectedEventArgs {
 impl ::windows::core::RuntimeName for InkStrokesCollectedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkStrokesCollectedEventArgs";
 }
-impl ::core::convert::From<InkStrokesCollectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: InkStrokesCollectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokesCollectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &InkStrokesCollectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokesCollectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &InkStrokesCollectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkStrokesCollectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: InkStrokesCollectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokesCollectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &InkStrokesCollectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokesCollectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &InkStrokesCollectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkStrokesCollectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
 #[repr(transparent)]
 pub struct InkStrokesErasedEventArgs(::windows::core::IUnknown);
@@ -4504,36 +3808,7 @@ unsafe impl ::windows::core::Interface for InkStrokesErasedEventArgs {
 impl ::windows::core::RuntimeName for InkStrokesErasedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkStrokesErasedEventArgs";
 }
-impl ::core::convert::From<InkStrokesErasedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: InkStrokesErasedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokesErasedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &InkStrokesErasedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokesErasedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &InkStrokesErasedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkStrokesErasedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: InkStrokesErasedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkStrokesErasedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &InkStrokesErasedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkStrokesErasedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &InkStrokesErasedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkStrokesErasedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
 #[repr(transparent)]
 pub struct InkSynchronizer(::windows::core::IUnknown);
@@ -4584,36 +3859,7 @@ unsafe impl ::windows::core::Interface for InkSynchronizer {
 impl ::windows::core::RuntimeName for InkSynchronizer {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkSynchronizer";
 }
-impl ::core::convert::From<InkSynchronizer> for ::windows::core::IUnknown {
-    fn from(value: InkSynchronizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkSynchronizer> for ::windows::core::IUnknown {
-    fn from(value: &InkSynchronizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkSynchronizer> for &::windows::core::IUnknown {
-    fn from(value: &InkSynchronizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkSynchronizer> for ::windows::core::IInspectable {
-    fn from(value: InkSynchronizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkSynchronizer> for ::windows::core::IInspectable {
-    fn from(value: &InkSynchronizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkSynchronizer> for &::windows::core::IInspectable {
-    fn from(value: &InkSynchronizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkSynchronizer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
 #[repr(transparent)]
 pub struct InkUnprocessedInput(::windows::core::IUnknown);
@@ -4763,36 +4009,7 @@ unsafe impl ::windows::core::Interface for InkUnprocessedInput {
 impl ::windows::core::RuntimeName for InkUnprocessedInput {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkUnprocessedInput";
 }
-impl ::core::convert::From<InkUnprocessedInput> for ::windows::core::IUnknown {
-    fn from(value: InkUnprocessedInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkUnprocessedInput> for ::windows::core::IUnknown {
-    fn from(value: &InkUnprocessedInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkUnprocessedInput> for &::windows::core::IUnknown {
-    fn from(value: &InkUnprocessedInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InkUnprocessedInput> for ::windows::core::IInspectable {
-    fn from(value: InkUnprocessedInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InkUnprocessedInput> for ::windows::core::IInspectable {
-    fn from(value: &InkUnprocessedInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InkUnprocessedInput> for &::windows::core::IInspectable {
-    fn from(value: &InkUnprocessedInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InkUnprocessedInput, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InkUnprocessedInput {}
 unsafe impl ::core::marker::Sync for InkUnprocessedInput {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]
@@ -4889,36 +4106,7 @@ unsafe impl ::windows::core::Interface for PenAndInkSettings {
 impl ::windows::core::RuntimeName for PenAndInkSettings {
     const NAME: &'static str = "Windows.UI.Input.Inking.PenAndInkSettings";
 }
-impl ::core::convert::From<PenAndInkSettings> for ::windows::core::IUnknown {
-    fn from(value: PenAndInkSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenAndInkSettings> for ::windows::core::IUnknown {
-    fn from(value: &PenAndInkSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenAndInkSettings> for &::windows::core::IUnknown {
-    fn from(value: &PenAndInkSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PenAndInkSettings> for ::windows::core::IInspectable {
-    fn from(value: PenAndInkSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PenAndInkSettings> for ::windows::core::IInspectable {
-    fn from(value: &PenAndInkSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PenAndInkSettings> for &::windows::core::IInspectable {
-    fn from(value: &PenAndInkSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PenAndInkSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PenAndInkSettings {}
 unsafe impl ::core::marker::Sync for PenAndInkSettings {}
 #[doc = "*Required features: `\"UI_Input_Inking\"`*"]

--- a/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
@@ -363,36 +363,7 @@ unsafe impl ::windows::core::Interface for InjectedInputGamepadInfo {
 impl ::windows::core::RuntimeName for InjectedInputGamepadInfo {
     const NAME: &'static str = "Windows.UI.Input.Preview.Injection.InjectedInputGamepadInfo";
 }
-impl ::core::convert::From<InjectedInputGamepadInfo> for ::windows::core::IUnknown {
-    fn from(value: InjectedInputGamepadInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InjectedInputGamepadInfo> for ::windows::core::IUnknown {
-    fn from(value: &InjectedInputGamepadInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InjectedInputGamepadInfo> for &::windows::core::IUnknown {
-    fn from(value: &InjectedInputGamepadInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InjectedInputGamepadInfo> for ::windows::core::IInspectable {
-    fn from(value: InjectedInputGamepadInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InjectedInputGamepadInfo> for ::windows::core::IInspectable {
-    fn from(value: &InjectedInputGamepadInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InjectedInputGamepadInfo> for &::windows::core::IInspectable {
-    fn from(value: &InjectedInputGamepadInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InjectedInputGamepadInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input_Preview_Injection\"`*"]
 #[repr(transparent)]
 pub struct InjectedInputKeyboardInfo(::windows::core::IUnknown);
@@ -470,36 +441,7 @@ unsafe impl ::windows::core::Interface for InjectedInputKeyboardInfo {
 impl ::windows::core::RuntimeName for InjectedInputKeyboardInfo {
     const NAME: &'static str = "Windows.UI.Input.Preview.Injection.InjectedInputKeyboardInfo";
 }
-impl ::core::convert::From<InjectedInputKeyboardInfo> for ::windows::core::IUnknown {
-    fn from(value: InjectedInputKeyboardInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InjectedInputKeyboardInfo> for ::windows::core::IUnknown {
-    fn from(value: &InjectedInputKeyboardInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InjectedInputKeyboardInfo> for &::windows::core::IUnknown {
-    fn from(value: &InjectedInputKeyboardInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InjectedInputKeyboardInfo> for ::windows::core::IInspectable {
-    fn from(value: InjectedInputKeyboardInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InjectedInputKeyboardInfo> for ::windows::core::IInspectable {
-    fn from(value: &InjectedInputKeyboardInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InjectedInputKeyboardInfo> for &::windows::core::IInspectable {
-    fn from(value: &InjectedInputKeyboardInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InjectedInputKeyboardInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input_Preview_Injection\"`*"]
 #[repr(transparent)]
 pub struct InjectedInputMouseInfo(::windows::core::IUnknown);
@@ -599,36 +541,7 @@ unsafe impl ::windows::core::Interface for InjectedInputMouseInfo {
 impl ::windows::core::RuntimeName for InjectedInputMouseInfo {
     const NAME: &'static str = "Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo";
 }
-impl ::core::convert::From<InjectedInputMouseInfo> for ::windows::core::IUnknown {
-    fn from(value: InjectedInputMouseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InjectedInputMouseInfo> for ::windows::core::IUnknown {
-    fn from(value: &InjectedInputMouseInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InjectedInputMouseInfo> for &::windows::core::IUnknown {
-    fn from(value: &InjectedInputMouseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InjectedInputMouseInfo> for ::windows::core::IInspectable {
-    fn from(value: InjectedInputMouseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InjectedInputMouseInfo> for ::windows::core::IInspectable {
-    fn from(value: &InjectedInputMouseInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InjectedInputMouseInfo> for &::windows::core::IInspectable {
-    fn from(value: &InjectedInputMouseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InjectedInputMouseInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input_Preview_Injection\"`*"]
 #[repr(transparent)]
 pub struct InjectedInputPenInfo(::windows::core::IUnknown);
@@ -750,36 +663,7 @@ unsafe impl ::windows::core::Interface for InjectedInputPenInfo {
 impl ::windows::core::RuntimeName for InjectedInputPenInfo {
     const NAME: &'static str = "Windows.UI.Input.Preview.Injection.InjectedInputPenInfo";
 }
-impl ::core::convert::From<InjectedInputPenInfo> for ::windows::core::IUnknown {
-    fn from(value: InjectedInputPenInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InjectedInputPenInfo> for ::windows::core::IUnknown {
-    fn from(value: &InjectedInputPenInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InjectedInputPenInfo> for &::windows::core::IUnknown {
-    fn from(value: &InjectedInputPenInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InjectedInputPenInfo> for ::windows::core::IInspectable {
-    fn from(value: InjectedInputPenInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InjectedInputPenInfo> for ::windows::core::IInspectable {
-    fn from(value: &InjectedInputPenInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InjectedInputPenInfo> for &::windows::core::IInspectable {
-    fn from(value: &InjectedInputPenInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InjectedInputPenInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input_Preview_Injection\"`*"]
 #[repr(transparent)]
 pub struct InjectedInputTouchInfo(::windows::core::IUnknown);
@@ -879,36 +763,7 @@ unsafe impl ::windows::core::Interface for InjectedInputTouchInfo {
 impl ::windows::core::RuntimeName for InjectedInputTouchInfo {
     const NAME: &'static str = "Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo";
 }
-impl ::core::convert::From<InjectedInputTouchInfo> for ::windows::core::IUnknown {
-    fn from(value: InjectedInputTouchInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InjectedInputTouchInfo> for ::windows::core::IUnknown {
-    fn from(value: &InjectedInputTouchInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InjectedInputTouchInfo> for &::windows::core::IUnknown {
-    fn from(value: &InjectedInputTouchInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InjectedInputTouchInfo> for ::windows::core::IInspectable {
-    fn from(value: InjectedInputTouchInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InjectedInputTouchInfo> for ::windows::core::IInspectable {
-    fn from(value: &InjectedInputTouchInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InjectedInputTouchInfo> for &::windows::core::IInspectable {
-    fn from(value: &InjectedInputTouchInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InjectedInputTouchInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input_Preview_Injection\"`*"]
 #[repr(transparent)]
 pub struct InputInjector(::windows::core::IUnknown);
@@ -1034,36 +889,7 @@ unsafe impl ::windows::core::Interface for InputInjector {
 impl ::windows::core::RuntimeName for InputInjector {
     const NAME: &'static str = "Windows.UI.Input.Preview.Injection.InputInjector";
 }
-impl ::core::convert::From<InputInjector> for ::windows::core::IUnknown {
-    fn from(value: InputInjector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputInjector> for ::windows::core::IUnknown {
-    fn from(value: &InputInjector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputInjector> for &::windows::core::IUnknown {
-    fn from(value: &InputInjector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InputInjector> for ::windows::core::IInspectable {
-    fn from(value: InputInjector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputInjector> for ::windows::core::IInspectable {
-    fn from(value: &InputInjector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputInjector> for &::windows::core::IInspectable {
-    fn from(value: &InputInjector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InputInjector, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input_Preview_Injection\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
@@ -1287,36 +1287,7 @@ unsafe impl ::windows::core::Interface for SpatialGestureRecognizer {
 impl ::windows::core::RuntimeName for SpatialGestureRecognizer {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialGestureRecognizer";
 }
-impl ::core::convert::From<SpatialGestureRecognizer> for ::windows::core::IUnknown {
-    fn from(value: SpatialGestureRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialGestureRecognizer> for ::windows::core::IUnknown {
-    fn from(value: &SpatialGestureRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialGestureRecognizer> for &::windows::core::IUnknown {
-    fn from(value: &SpatialGestureRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialGestureRecognizer> for ::windows::core::IInspectable {
-    fn from(value: SpatialGestureRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialGestureRecognizer> for ::windows::core::IInspectable {
-    fn from(value: &SpatialGestureRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialGestureRecognizer> for &::windows::core::IInspectable {
-    fn from(value: &SpatialGestureRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialGestureRecognizer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialGestureRecognizer {}
 unsafe impl ::core::marker::Sync for SpatialGestureRecognizer {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -1363,36 +1334,7 @@ unsafe impl ::windows::core::Interface for SpatialHoldCanceledEventArgs {
 impl ::windows::core::RuntimeName for SpatialHoldCanceledEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialHoldCanceledEventArgs";
 }
-impl ::core::convert::From<SpatialHoldCanceledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialHoldCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialHoldCanceledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialHoldCanceledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialHoldCanceledEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialHoldCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialHoldCanceledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialHoldCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialHoldCanceledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialHoldCanceledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialHoldCanceledEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialHoldCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialHoldCanceledEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialHoldCanceledEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialHoldCanceledEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -1439,36 +1381,7 @@ unsafe impl ::windows::core::Interface for SpatialHoldCompletedEventArgs {
 impl ::windows::core::RuntimeName for SpatialHoldCompletedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialHoldCompletedEventArgs";
 }
-impl ::core::convert::From<SpatialHoldCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialHoldCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialHoldCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialHoldCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialHoldCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialHoldCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialHoldCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialHoldCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialHoldCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialHoldCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialHoldCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialHoldCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialHoldCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialHoldCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialHoldCompletedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -1524,36 +1437,7 @@ unsafe impl ::windows::core::Interface for SpatialHoldStartedEventArgs {
 impl ::windows::core::RuntimeName for SpatialHoldStartedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialHoldStartedEventArgs";
 }
-impl ::core::convert::From<SpatialHoldStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialHoldStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialHoldStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialHoldStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialHoldStartedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialHoldStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialHoldStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialHoldStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialHoldStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialHoldStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialHoldStartedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialHoldStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialHoldStartedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialHoldStartedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialHoldStartedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -1600,36 +1484,7 @@ unsafe impl ::windows::core::Interface for SpatialInteraction {
 impl ::windows::core::RuntimeName for SpatialInteraction {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialInteraction";
 }
-impl ::core::convert::From<SpatialInteraction> for ::windows::core::IUnknown {
-    fn from(value: SpatialInteraction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteraction> for ::windows::core::IUnknown {
-    fn from(value: &SpatialInteraction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteraction> for &::windows::core::IUnknown {
-    fn from(value: &SpatialInteraction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialInteraction> for ::windows::core::IInspectable {
-    fn from(value: SpatialInteraction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteraction> for ::windows::core::IInspectable {
-    fn from(value: &SpatialInteraction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteraction> for &::windows::core::IInspectable {
-    fn from(value: &SpatialInteraction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialInteraction, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialInteraction {}
 unsafe impl ::core::marker::Sync for SpatialInteraction {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -1731,36 +1586,7 @@ unsafe impl ::windows::core::Interface for SpatialInteractionController {
 impl ::windows::core::RuntimeName for SpatialInteractionController {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialInteractionController";
 }
-impl ::core::convert::From<SpatialInteractionController> for ::windows::core::IUnknown {
-    fn from(value: SpatialInteractionController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionController> for ::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionController> for &::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialInteractionController> for ::windows::core::IInspectable {
-    fn from(value: SpatialInteractionController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionController> for ::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionController> for &::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialInteractionController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialInteractionController {}
 unsafe impl ::core::marker::Sync for SpatialInteractionController {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -1849,36 +1675,7 @@ unsafe impl ::windows::core::Interface for SpatialInteractionControllerPropertie
 impl ::windows::core::RuntimeName for SpatialInteractionControllerProperties {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialInteractionControllerProperties";
 }
-impl ::core::convert::From<SpatialInteractionControllerProperties> for ::windows::core::IUnknown {
-    fn from(value: SpatialInteractionControllerProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionControllerProperties> for ::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionControllerProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionControllerProperties> for &::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionControllerProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialInteractionControllerProperties> for ::windows::core::IInspectable {
-    fn from(value: SpatialInteractionControllerProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionControllerProperties> for ::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionControllerProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionControllerProperties> for &::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionControllerProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialInteractionControllerProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialInteractionControllerProperties {}
 unsafe impl ::core::marker::Sync for SpatialInteractionControllerProperties {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -1948,36 +1745,7 @@ unsafe impl ::windows::core::Interface for SpatialInteractionDetectedEventArgs {
 impl ::windows::core::RuntimeName for SpatialInteractionDetectedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialInteractionDetectedEventArgs";
 }
-impl ::core::convert::From<SpatialInteractionDetectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialInteractionDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionDetectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionDetectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionDetectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialInteractionDetectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialInteractionDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionDetectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionDetectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionDetectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialInteractionDetectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialInteractionDetectedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialInteractionDetectedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -2138,36 +1906,7 @@ unsafe impl ::windows::core::Interface for SpatialInteractionManager {
 impl ::windows::core::RuntimeName for SpatialInteractionManager {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialInteractionManager";
 }
-impl ::core::convert::From<SpatialInteractionManager> for ::windows::core::IUnknown {
-    fn from(value: SpatialInteractionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionManager> for ::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionManager> for &::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialInteractionManager> for ::windows::core::IInspectable {
-    fn from(value: SpatialInteractionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionManager> for ::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionManager> for &::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialInteractionManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialInteractionManager {}
 unsafe impl ::core::marker::Sync for SpatialInteractionManager {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -2283,36 +2022,7 @@ unsafe impl ::windows::core::Interface for SpatialInteractionSource {
 impl ::windows::core::RuntimeName for SpatialInteractionSource {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialInteractionSource";
 }
-impl ::core::convert::From<SpatialInteractionSource> for ::windows::core::IUnknown {
-    fn from(value: SpatialInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSource> for ::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSource> for &::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialInteractionSource> for ::windows::core::IInspectable {
-    fn from(value: SpatialInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSource> for ::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSource> for &::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialInteractionSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialInteractionSource {}
 unsafe impl ::core::marker::Sync for SpatialInteractionSource {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -2366,36 +2076,7 @@ unsafe impl ::windows::core::Interface for SpatialInteractionSourceEventArgs {
 impl ::windows::core::RuntimeName for SpatialInteractionSourceEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialInteractionSourceEventArgs";
 }
-impl ::core::convert::From<SpatialInteractionSourceEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialInteractionSourceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionSourceEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionSourceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialInteractionSourceEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialInteractionSourceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionSourceEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionSourceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialInteractionSourceEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialInteractionSourceEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialInteractionSourceEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -2485,36 +2166,7 @@ unsafe impl ::windows::core::Interface for SpatialInteractionSourceLocation {
 impl ::windows::core::RuntimeName for SpatialInteractionSourceLocation {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialInteractionSourceLocation";
 }
-impl ::core::convert::From<SpatialInteractionSourceLocation> for ::windows::core::IUnknown {
-    fn from(value: SpatialInteractionSourceLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceLocation> for ::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionSourceLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceLocation> for &::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionSourceLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialInteractionSourceLocation> for ::windows::core::IInspectable {
-    fn from(value: SpatialInteractionSourceLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceLocation> for ::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionSourceLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceLocation> for &::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionSourceLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialInteractionSourceLocation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialInteractionSourceLocation {}
 unsafe impl ::core::marker::Sync for SpatialInteractionSourceLocation {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -2579,36 +2231,7 @@ unsafe impl ::windows::core::Interface for SpatialInteractionSourceProperties {
 impl ::windows::core::RuntimeName for SpatialInteractionSourceProperties {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialInteractionSourceProperties";
 }
-impl ::core::convert::From<SpatialInteractionSourceProperties> for ::windows::core::IUnknown {
-    fn from(value: SpatialInteractionSourceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceProperties> for ::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionSourceProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceProperties> for &::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionSourceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialInteractionSourceProperties> for ::windows::core::IInspectable {
-    fn from(value: SpatialInteractionSourceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceProperties> for ::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionSourceProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceProperties> for &::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionSourceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialInteractionSourceProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialInteractionSourceProperties {}
 unsafe impl ::core::marker::Sync for SpatialInteractionSourceProperties {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -2731,36 +2354,7 @@ unsafe impl ::windows::core::Interface for SpatialInteractionSourceState {
 impl ::windows::core::RuntimeName for SpatialInteractionSourceState {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialInteractionSourceState";
 }
-impl ::core::convert::From<SpatialInteractionSourceState> for ::windows::core::IUnknown {
-    fn from(value: SpatialInteractionSourceState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceState> for ::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionSourceState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceState> for &::windows::core::IUnknown {
-    fn from(value: &SpatialInteractionSourceState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialInteractionSourceState> for ::windows::core::IInspectable {
-    fn from(value: SpatialInteractionSourceState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceState> for ::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionSourceState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialInteractionSourceState> for &::windows::core::IInspectable {
-    fn from(value: &SpatialInteractionSourceState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialInteractionSourceState, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialInteractionSourceState {}
 unsafe impl ::core::marker::Sync for SpatialInteractionSourceState {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -2807,36 +2401,7 @@ unsafe impl ::windows::core::Interface for SpatialManipulationCanceledEventArgs 
 impl ::windows::core::RuntimeName for SpatialManipulationCanceledEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialManipulationCanceledEventArgs";
 }
-impl ::core::convert::From<SpatialManipulationCanceledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialManipulationCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialManipulationCanceledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialManipulationCanceledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialManipulationCanceledEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialManipulationCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialManipulationCanceledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialManipulationCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialManipulationCanceledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialManipulationCanceledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialManipulationCanceledEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialManipulationCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialManipulationCanceledEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialManipulationCanceledEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialManipulationCanceledEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -2892,36 +2457,7 @@ unsafe impl ::windows::core::Interface for SpatialManipulationCompletedEventArgs
 impl ::windows::core::RuntimeName for SpatialManipulationCompletedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialManipulationCompletedEventArgs";
 }
-impl ::core::convert::From<SpatialManipulationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialManipulationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialManipulationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialManipulationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialManipulationCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialManipulationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialManipulationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialManipulationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialManipulationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialManipulationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialManipulationCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialManipulationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialManipulationCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialManipulationCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialManipulationCompletedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -2970,36 +2506,7 @@ unsafe impl ::windows::core::Interface for SpatialManipulationDelta {
 impl ::windows::core::RuntimeName for SpatialManipulationDelta {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialManipulationDelta";
 }
-impl ::core::convert::From<SpatialManipulationDelta> for ::windows::core::IUnknown {
-    fn from(value: SpatialManipulationDelta) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialManipulationDelta> for ::windows::core::IUnknown {
-    fn from(value: &SpatialManipulationDelta) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialManipulationDelta> for &::windows::core::IUnknown {
-    fn from(value: &SpatialManipulationDelta) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialManipulationDelta> for ::windows::core::IInspectable {
-    fn from(value: SpatialManipulationDelta) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialManipulationDelta> for ::windows::core::IInspectable {
-    fn from(value: &SpatialManipulationDelta) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialManipulationDelta> for &::windows::core::IInspectable {
-    fn from(value: &SpatialManipulationDelta) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialManipulationDelta, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialManipulationDelta {}
 unsafe impl ::core::marker::Sync for SpatialManipulationDelta {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -3055,36 +2562,7 @@ unsafe impl ::windows::core::Interface for SpatialManipulationStartedEventArgs {
 impl ::windows::core::RuntimeName for SpatialManipulationStartedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialManipulationStartedEventArgs";
 }
-impl ::core::convert::From<SpatialManipulationStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialManipulationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialManipulationStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialManipulationStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialManipulationStartedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialManipulationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialManipulationStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialManipulationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialManipulationStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialManipulationStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialManipulationStartedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialManipulationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialManipulationStartedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialManipulationStartedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialManipulationStartedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -3140,36 +2618,7 @@ unsafe impl ::windows::core::Interface for SpatialManipulationUpdatedEventArgs {
 impl ::windows::core::RuntimeName for SpatialManipulationUpdatedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialManipulationUpdatedEventArgs";
 }
-impl ::core::convert::From<SpatialManipulationUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialManipulationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialManipulationUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialManipulationUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialManipulationUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialManipulationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialManipulationUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialManipulationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialManipulationUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialManipulationUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialManipulationUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialManipulationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialManipulationUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialManipulationUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialManipulationUpdatedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -3216,36 +2665,7 @@ unsafe impl ::windows::core::Interface for SpatialNavigationCanceledEventArgs {
 impl ::windows::core::RuntimeName for SpatialNavigationCanceledEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialNavigationCanceledEventArgs";
 }
-impl ::core::convert::From<SpatialNavigationCanceledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialNavigationCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialNavigationCanceledEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialNavigationCanceledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialNavigationCanceledEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialNavigationCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialNavigationCanceledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialNavigationCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialNavigationCanceledEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialNavigationCanceledEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialNavigationCanceledEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialNavigationCanceledEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialNavigationCanceledEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialNavigationCanceledEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialNavigationCanceledEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -3301,36 +2721,7 @@ unsafe impl ::windows::core::Interface for SpatialNavigationCompletedEventArgs {
 impl ::windows::core::RuntimeName for SpatialNavigationCompletedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialNavigationCompletedEventArgs";
 }
-impl ::core::convert::From<SpatialNavigationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialNavigationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialNavigationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialNavigationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialNavigationCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialNavigationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialNavigationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialNavigationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialNavigationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialNavigationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialNavigationCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialNavigationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialNavigationCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialNavigationCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialNavigationCompletedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -3407,36 +2798,7 @@ unsafe impl ::windows::core::Interface for SpatialNavigationStartedEventArgs {
 impl ::windows::core::RuntimeName for SpatialNavigationStartedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialNavigationStartedEventArgs";
 }
-impl ::core::convert::From<SpatialNavigationStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialNavigationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialNavigationStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialNavigationStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialNavigationStartedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialNavigationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialNavigationStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialNavigationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialNavigationStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialNavigationStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialNavigationStartedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialNavigationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialNavigationStartedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialNavigationStartedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialNavigationStartedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -3492,36 +2854,7 @@ unsafe impl ::windows::core::Interface for SpatialNavigationUpdatedEventArgs {
 impl ::windows::core::RuntimeName for SpatialNavigationUpdatedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialNavigationUpdatedEventArgs";
 }
-impl ::core::convert::From<SpatialNavigationUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialNavigationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialNavigationUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialNavigationUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialNavigationUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialNavigationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialNavigationUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialNavigationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialNavigationUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialNavigationUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialNavigationUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialNavigationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialNavigationUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialNavigationUpdatedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialNavigationUpdatedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -3604,36 +2937,7 @@ unsafe impl ::windows::core::Interface for SpatialPointerInteractionSourcePose {
 impl ::windows::core::RuntimeName for SpatialPointerInteractionSourcePose {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialPointerInteractionSourcePose";
 }
-impl ::core::convert::From<SpatialPointerInteractionSourcePose> for ::windows::core::IUnknown {
-    fn from(value: SpatialPointerInteractionSourcePose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialPointerInteractionSourcePose> for ::windows::core::IUnknown {
-    fn from(value: &SpatialPointerInteractionSourcePose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialPointerInteractionSourcePose> for &::windows::core::IUnknown {
-    fn from(value: &SpatialPointerInteractionSourcePose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialPointerInteractionSourcePose> for ::windows::core::IInspectable {
-    fn from(value: SpatialPointerInteractionSourcePose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialPointerInteractionSourcePose> for ::windows::core::IInspectable {
-    fn from(value: &SpatialPointerInteractionSourcePose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialPointerInteractionSourcePose> for &::windows::core::IInspectable {
-    fn from(value: &SpatialPointerInteractionSourcePose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialPointerInteractionSourcePose, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialPointerInteractionSourcePose {}
 unsafe impl ::core::marker::Sync for SpatialPointerInteractionSourcePose {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -3727,36 +3031,7 @@ unsafe impl ::windows::core::Interface for SpatialPointerPose {
 impl ::windows::core::RuntimeName for SpatialPointerPose {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialPointerPose";
 }
-impl ::core::convert::From<SpatialPointerPose> for ::windows::core::IUnknown {
-    fn from(value: SpatialPointerPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialPointerPose> for ::windows::core::IUnknown {
-    fn from(value: &SpatialPointerPose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialPointerPose> for &::windows::core::IUnknown {
-    fn from(value: &SpatialPointerPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialPointerPose> for ::windows::core::IInspectable {
-    fn from(value: SpatialPointerPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialPointerPose> for ::windows::core::IInspectable {
-    fn from(value: &SpatialPointerPose) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialPointerPose> for &::windows::core::IInspectable {
-    fn from(value: &SpatialPointerPose) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialPointerPose, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialPointerPose {}
 unsafe impl ::core::marker::Sync for SpatialPointerPose {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -3803,36 +3078,7 @@ unsafe impl ::windows::core::Interface for SpatialRecognitionEndedEventArgs {
 impl ::windows::core::RuntimeName for SpatialRecognitionEndedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialRecognitionEndedEventArgs";
 }
-impl ::core::convert::From<SpatialRecognitionEndedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialRecognitionEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialRecognitionEndedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialRecognitionEndedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialRecognitionEndedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialRecognitionEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialRecognitionEndedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialRecognitionEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialRecognitionEndedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialRecognitionEndedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialRecognitionEndedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialRecognitionEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialRecognitionEndedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialRecognitionEndedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialRecognitionEndedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -3895,36 +3141,7 @@ unsafe impl ::windows::core::Interface for SpatialRecognitionStartedEventArgs {
 impl ::windows::core::RuntimeName for SpatialRecognitionStartedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialRecognitionStartedEventArgs";
 }
-impl ::core::convert::From<SpatialRecognitionStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialRecognitionStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialRecognitionStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialRecognitionStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialRecognitionStartedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialRecognitionStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialRecognitionStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialRecognitionStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialRecognitionStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialRecognitionStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialRecognitionStartedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialRecognitionStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialRecognitionStartedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialRecognitionStartedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialRecognitionStartedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]
@@ -3987,36 +3204,7 @@ unsafe impl ::windows::core::Interface for SpatialTappedEventArgs {
 impl ::windows::core::RuntimeName for SpatialTappedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Spatial.SpatialTappedEventArgs";
 }
-impl ::core::convert::From<SpatialTappedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SpatialTappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialTappedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SpatialTappedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialTappedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SpatialTappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SpatialTappedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SpatialTappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SpatialTappedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SpatialTappedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SpatialTappedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SpatialTappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SpatialTappedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SpatialTappedEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialTappedEventArgs {}
 #[doc = "*Required features: `\"UI_Input_Spatial\"`*"]

--- a/crates/libs/windows/src/Windows/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/mod.rs
@@ -840,36 +840,7 @@ impl IPointerPointTransform {
         }
     }
 }
-impl ::core::convert::From<IPointerPointTransform> for ::windows::core::IUnknown {
-    fn from(value: IPointerPointTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPointerPointTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPointerPointTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPointerPointTransform> for ::windows::core::IUnknown {
-    fn from(value: &IPointerPointTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPointerPointTransform> for ::windows::core::IInspectable {
-    fn from(value: IPointerPointTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPointerPointTransform> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPointerPointTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPointerPointTransform> for ::windows::core::IInspectable {
-    fn from(value: &IPointerPointTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPointerPointTransform, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPointerPointTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1735,36 +1706,7 @@ unsafe impl ::windows::core::Interface for AttachableInputObject {
 impl ::windows::core::RuntimeName for AttachableInputObject {
     const NAME: &'static str = "Windows.UI.Input.AttachableInputObject";
 }
-impl ::core::convert::From<AttachableInputObject> for ::windows::core::IUnknown {
-    fn from(value: AttachableInputObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AttachableInputObject> for ::windows::core::IUnknown {
-    fn from(value: &AttachableInputObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AttachableInputObject> for &::windows::core::IUnknown {
-    fn from(value: &AttachableInputObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AttachableInputObject> for ::windows::core::IInspectable {
-    fn from(value: AttachableInputObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AttachableInputObject> for ::windows::core::IInspectable {
-    fn from(value: &AttachableInputObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AttachableInputObject> for &::windows::core::IInspectable {
-    fn from(value: &AttachableInputObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AttachableInputObject, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<AttachableInputObject> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1858,36 +1800,7 @@ unsafe impl ::windows::core::Interface for CrossSlidingEventArgs {
 impl ::windows::core::RuntimeName for CrossSlidingEventArgs {
     const NAME: &'static str = "Windows.UI.Input.CrossSlidingEventArgs";
 }
-impl ::core::convert::From<CrossSlidingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CrossSlidingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CrossSlidingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CrossSlidingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CrossSlidingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CrossSlidingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CrossSlidingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CrossSlidingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CrossSlidingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CrossSlidingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CrossSlidingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CrossSlidingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CrossSlidingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct DraggingEventArgs(::windows::core::IUnknown);
@@ -1957,36 +1870,7 @@ unsafe impl ::windows::core::Interface for DraggingEventArgs {
 impl ::windows::core::RuntimeName for DraggingEventArgs {
     const NAME: &'static str = "Windows.UI.Input.DraggingEventArgs";
 }
-impl ::core::convert::From<DraggingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: DraggingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DraggingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &DraggingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DraggingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &DraggingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DraggingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: DraggingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DraggingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &DraggingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DraggingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &DraggingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DraggingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct EdgeGesture(::windows::core::IUnknown);
@@ -2080,36 +1964,7 @@ unsafe impl ::windows::core::Interface for EdgeGesture {
 impl ::windows::core::RuntimeName for EdgeGesture {
     const NAME: &'static str = "Windows.UI.Input.EdgeGesture";
 }
-impl ::core::convert::From<EdgeGesture> for ::windows::core::IUnknown {
-    fn from(value: EdgeGesture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EdgeGesture> for ::windows::core::IUnknown {
-    fn from(value: &EdgeGesture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EdgeGesture> for &::windows::core::IUnknown {
-    fn from(value: &EdgeGesture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EdgeGesture> for ::windows::core::IInspectable {
-    fn from(value: EdgeGesture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EdgeGesture> for ::windows::core::IInspectable {
-    fn from(value: &EdgeGesture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EdgeGesture> for &::windows::core::IInspectable {
-    fn from(value: &EdgeGesture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EdgeGesture, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct EdgeGestureEventArgs(::windows::core::IUnknown);
@@ -2154,36 +2009,7 @@ unsafe impl ::windows::core::Interface for EdgeGestureEventArgs {
 impl ::windows::core::RuntimeName for EdgeGestureEventArgs {
     const NAME: &'static str = "Windows.UI.Input.EdgeGestureEventArgs";
 }
-impl ::core::convert::From<EdgeGestureEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EdgeGestureEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EdgeGestureEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EdgeGestureEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EdgeGestureEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EdgeGestureEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<EdgeGestureEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EdgeGestureEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&EdgeGestureEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EdgeGestureEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&EdgeGestureEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EdgeGestureEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EdgeGestureEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct GestureRecognizer(::windows::core::IUnknown);
@@ -2682,36 +2508,7 @@ unsafe impl ::windows::core::Interface for GestureRecognizer {
 impl ::windows::core::RuntimeName for GestureRecognizer {
     const NAME: &'static str = "Windows.UI.Input.GestureRecognizer";
 }
-impl ::core::convert::From<GestureRecognizer> for ::windows::core::IUnknown {
-    fn from(value: GestureRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GestureRecognizer> for ::windows::core::IUnknown {
-    fn from(value: &GestureRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GestureRecognizer> for &::windows::core::IUnknown {
-    fn from(value: &GestureRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<GestureRecognizer> for ::windows::core::IInspectable {
-    fn from(value: GestureRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&GestureRecognizer> for ::windows::core::IInspectable {
-    fn from(value: &GestureRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&GestureRecognizer> for &::windows::core::IInspectable {
-    fn from(value: &GestureRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(GestureRecognizer, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct HoldingEventArgs(::windows::core::IUnknown);
@@ -2788,36 +2585,7 @@ unsafe impl ::windows::core::Interface for HoldingEventArgs {
 impl ::windows::core::RuntimeName for HoldingEventArgs {
     const NAME: &'static str = "Windows.UI.Input.HoldingEventArgs";
 }
-impl ::core::convert::From<HoldingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: HoldingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HoldingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &HoldingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HoldingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &HoldingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HoldingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: HoldingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HoldingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &HoldingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HoldingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &HoldingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HoldingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct InputActivationListener(::windows::core::IUnknown);
@@ -2883,36 +2651,7 @@ unsafe impl ::windows::core::Interface for InputActivationListener {
 impl ::windows::core::RuntimeName for InputActivationListener {
     const NAME: &'static str = "Windows.UI.Input.InputActivationListener";
 }
-impl ::core::convert::From<InputActivationListener> for ::windows::core::IUnknown {
-    fn from(value: InputActivationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputActivationListener> for ::windows::core::IUnknown {
-    fn from(value: &InputActivationListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputActivationListener> for &::windows::core::IUnknown {
-    fn from(value: &InputActivationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InputActivationListener> for ::windows::core::IInspectable {
-    fn from(value: InputActivationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputActivationListener> for ::windows::core::IInspectable {
-    fn from(value: &InputActivationListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputActivationListener> for &::windows::core::IInspectable {
-    fn from(value: &InputActivationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InputActivationListener, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<InputActivationListener> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2996,36 +2735,7 @@ unsafe impl ::windows::core::Interface for InputActivationListenerActivationChan
 impl ::windows::core::RuntimeName for InputActivationListenerActivationChangedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.InputActivationListenerActivationChangedEventArgs";
 }
-impl ::core::convert::From<InputActivationListenerActivationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: InputActivationListenerActivationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputActivationListenerActivationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &InputActivationListenerActivationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputActivationListenerActivationChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &InputActivationListenerActivationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InputActivationListenerActivationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: InputActivationListenerActivationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputActivationListenerActivationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &InputActivationListenerActivationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputActivationListenerActivationChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &InputActivationListenerActivationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InputActivationListenerActivationChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for InputActivationListenerActivationChangedEventArgs {}
 unsafe impl ::core::marker::Sync for InputActivationListenerActivationChangedEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -3117,36 +2827,7 @@ unsafe impl ::windows::core::Interface for KeyboardDeliveryInterceptor {
 impl ::windows::core::RuntimeName for KeyboardDeliveryInterceptor {
     const NAME: &'static str = "Windows.UI.Input.KeyboardDeliveryInterceptor";
 }
-impl ::core::convert::From<KeyboardDeliveryInterceptor> for ::windows::core::IUnknown {
-    fn from(value: KeyboardDeliveryInterceptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyboardDeliveryInterceptor> for ::windows::core::IUnknown {
-    fn from(value: &KeyboardDeliveryInterceptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyboardDeliveryInterceptor> for &::windows::core::IUnknown {
-    fn from(value: &KeyboardDeliveryInterceptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<KeyboardDeliveryInterceptor> for ::windows::core::IInspectable {
-    fn from(value: KeyboardDeliveryInterceptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&KeyboardDeliveryInterceptor> for ::windows::core::IInspectable {
-    fn from(value: &KeyboardDeliveryInterceptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&KeyboardDeliveryInterceptor> for &::windows::core::IInspectable {
-    fn from(value: &KeyboardDeliveryInterceptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(KeyboardDeliveryInterceptor, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for KeyboardDeliveryInterceptor {}
 unsafe impl ::core::marker::Sync for KeyboardDeliveryInterceptor {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -3236,36 +2917,7 @@ unsafe impl ::windows::core::Interface for ManipulationCompletedEventArgs {
 impl ::windows::core::RuntimeName for ManipulationCompletedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.ManipulationCompletedEventArgs";
 }
-impl ::core::convert::From<ManipulationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ManipulationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ManipulationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ManipulationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ManipulationCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ManipulationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ManipulationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ManipulationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ManipulationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ManipulationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ManipulationCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ManipulationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ManipulationCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct ManipulationInertiaStartingEventArgs(::windows::core::IUnknown);
@@ -3355,36 +3007,7 @@ unsafe impl ::windows::core::Interface for ManipulationInertiaStartingEventArgs 
 impl ::windows::core::RuntimeName for ManipulationInertiaStartingEventArgs {
     const NAME: &'static str = "Windows.UI.Input.ManipulationInertiaStartingEventArgs";
 }
-impl ::core::convert::From<ManipulationInertiaStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ManipulationInertiaStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ManipulationInertiaStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ManipulationInertiaStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ManipulationInertiaStartingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ManipulationInertiaStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ManipulationInertiaStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ManipulationInertiaStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ManipulationInertiaStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ManipulationInertiaStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ManipulationInertiaStartingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ManipulationInertiaStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ManipulationInertiaStartingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct ManipulationStartedEventArgs(::windows::core::IUnknown);
@@ -3456,36 +3079,7 @@ unsafe impl ::windows::core::Interface for ManipulationStartedEventArgs {
 impl ::windows::core::RuntimeName for ManipulationStartedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.ManipulationStartedEventArgs";
 }
-impl ::core::convert::From<ManipulationStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ManipulationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ManipulationStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ManipulationStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ManipulationStartedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ManipulationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ManipulationStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ManipulationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ManipulationStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ManipulationStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ManipulationStartedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ManipulationStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ManipulationStartedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct ManipulationUpdatedEventArgs(::windows::core::IUnknown);
@@ -3582,36 +3176,7 @@ unsafe impl ::windows::core::Interface for ManipulationUpdatedEventArgs {
 impl ::windows::core::RuntimeName for ManipulationUpdatedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.ManipulationUpdatedEventArgs";
 }
-impl ::core::convert::From<ManipulationUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ManipulationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ManipulationUpdatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ManipulationUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ManipulationUpdatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ManipulationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ManipulationUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ManipulationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ManipulationUpdatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ManipulationUpdatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ManipulationUpdatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ManipulationUpdatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ManipulationUpdatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct MouseWheelParameters(::windows::core::IUnknown);
@@ -3701,36 +3266,7 @@ unsafe impl ::windows::core::Interface for MouseWheelParameters {
 impl ::windows::core::RuntimeName for MouseWheelParameters {
     const NAME: &'static str = "Windows.UI.Input.MouseWheelParameters";
 }
-impl ::core::convert::From<MouseWheelParameters> for ::windows::core::IUnknown {
-    fn from(value: MouseWheelParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MouseWheelParameters> for ::windows::core::IUnknown {
-    fn from(value: &MouseWheelParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MouseWheelParameters> for &::windows::core::IUnknown {
-    fn from(value: &MouseWheelParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MouseWheelParameters> for ::windows::core::IInspectable {
-    fn from(value: MouseWheelParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MouseWheelParameters> for ::windows::core::IInspectable {
-    fn from(value: &MouseWheelParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MouseWheelParameters> for &::windows::core::IInspectable {
-    fn from(value: &MouseWheelParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MouseWheelParameters, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct PointerPoint(::windows::core::IUnknown);
@@ -3871,36 +3407,7 @@ unsafe impl ::windows::core::Interface for PointerPoint {
 impl ::windows::core::RuntimeName for PointerPoint {
     const NAME: &'static str = "Windows.UI.Input.PointerPoint";
 }
-impl ::core::convert::From<PointerPoint> for ::windows::core::IUnknown {
-    fn from(value: PointerPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointerPoint> for ::windows::core::IUnknown {
-    fn from(value: &PointerPoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointerPoint> for &::windows::core::IUnknown {
-    fn from(value: &PointerPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PointerPoint> for ::windows::core::IInspectable {
-    fn from(value: PointerPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointerPoint> for ::windows::core::IInspectable {
-    fn from(value: &PointerPoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointerPoint> for &::windows::core::IInspectable {
-    fn from(value: &PointerPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PointerPoint, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct PointerPointProperties(::windows::core::IUnknown);
@@ -4119,36 +3626,7 @@ unsafe impl ::windows::core::Interface for PointerPointProperties {
 impl ::windows::core::RuntimeName for PointerPointProperties {
     const NAME: &'static str = "Windows.UI.Input.PointerPointProperties";
 }
-impl ::core::convert::From<PointerPointProperties> for ::windows::core::IUnknown {
-    fn from(value: PointerPointProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointerPointProperties> for ::windows::core::IUnknown {
-    fn from(value: &PointerPointProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointerPointProperties> for &::windows::core::IUnknown {
-    fn from(value: &PointerPointProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PointerPointProperties> for ::windows::core::IInspectable {
-    fn from(value: PointerPointProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointerPointProperties> for ::windows::core::IInspectable {
-    fn from(value: &PointerPointProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointerPointProperties> for &::windows::core::IInspectable {
-    fn from(value: &PointerPointProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PointerPointProperties, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct PointerVisualizationSettings(::windows::core::IUnknown);
@@ -4219,36 +3697,7 @@ unsafe impl ::windows::core::Interface for PointerVisualizationSettings {
 impl ::windows::core::RuntimeName for PointerVisualizationSettings {
     const NAME: &'static str = "Windows.UI.Input.PointerVisualizationSettings";
 }
-impl ::core::convert::From<PointerVisualizationSettings> for ::windows::core::IUnknown {
-    fn from(value: PointerVisualizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointerVisualizationSettings> for ::windows::core::IUnknown {
-    fn from(value: &PointerVisualizationSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointerVisualizationSettings> for &::windows::core::IUnknown {
-    fn from(value: &PointerVisualizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PointerVisualizationSettings> for ::windows::core::IInspectable {
-    fn from(value: PointerVisualizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PointerVisualizationSettings> for ::windows::core::IInspectable {
-    fn from(value: &PointerVisualizationSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PointerVisualizationSettings> for &::windows::core::IInspectable {
-    fn from(value: &PointerVisualizationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PointerVisualizationSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for PointerVisualizationSettings {}
 unsafe impl ::core::marker::Sync for PointerVisualizationSettings {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -4484,36 +3933,7 @@ unsafe impl ::windows::core::Interface for RadialController {
 impl ::windows::core::RuntimeName for RadialController {
     const NAME: &'static str = "Windows.UI.Input.RadialController";
 }
-impl ::core::convert::From<RadialController> for ::windows::core::IUnknown {
-    fn from(value: RadialController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialController> for ::windows::core::IUnknown {
-    fn from(value: &RadialController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialController> for &::windows::core::IUnknown {
-    fn from(value: &RadialController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialController> for ::windows::core::IInspectable {
-    fn from(value: RadialController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialController> for ::windows::core::IInspectable {
-    fn from(value: &RadialController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialController> for &::windows::core::IInspectable {
-    fn from(value: &RadialController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialController {}
 unsafe impl ::core::marker::Sync for RadialController {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -4569,36 +3989,7 @@ unsafe impl ::windows::core::Interface for RadialControllerButtonClickedEventArg
 impl ::windows::core::RuntimeName for RadialControllerButtonClickedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerButtonClickedEventArgs";
 }
-impl ::core::convert::From<RadialControllerButtonClickedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonClickedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerButtonClickedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonClickedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerButtonClickedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonClickedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerButtonClickedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonClickedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerButtonClickedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerButtonClickedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerButtonClickedEventArgs {}
 unsafe impl ::core::marker::Sync for RadialControllerButtonClickedEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -4654,36 +4045,7 @@ unsafe impl ::windows::core::Interface for RadialControllerButtonHoldingEventArg
 impl ::windows::core::RuntimeName for RadialControllerButtonHoldingEventArgs {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerButtonHoldingEventArgs";
 }
-impl ::core::convert::From<RadialControllerButtonHoldingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerButtonHoldingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonHoldingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerButtonHoldingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonHoldingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerButtonHoldingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerButtonHoldingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerButtonHoldingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonHoldingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerButtonHoldingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonHoldingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerButtonHoldingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerButtonHoldingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerButtonHoldingEventArgs {}
 unsafe impl ::core::marker::Sync for RadialControllerButtonHoldingEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -4739,36 +4101,7 @@ unsafe impl ::windows::core::Interface for RadialControllerButtonPressedEventArg
 impl ::windows::core::RuntimeName for RadialControllerButtonPressedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerButtonPressedEventArgs";
 }
-impl ::core::convert::From<RadialControllerButtonPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerButtonPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerButtonPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonPressedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerButtonPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerButtonPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerButtonPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerButtonPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonPressedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerButtonPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerButtonPressedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerButtonPressedEventArgs {}
 unsafe impl ::core::marker::Sync for RadialControllerButtonPressedEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -4824,36 +4157,7 @@ unsafe impl ::windows::core::Interface for RadialControllerButtonReleasedEventAr
 impl ::windows::core::RuntimeName for RadialControllerButtonReleasedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerButtonReleasedEventArgs";
 }
-impl ::core::convert::From<RadialControllerButtonReleasedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerButtonReleasedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonReleasedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerButtonReleasedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonReleasedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerButtonReleasedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerButtonReleasedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerButtonReleasedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonReleasedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerButtonReleasedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerButtonReleasedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerButtonReleasedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerButtonReleasedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerButtonReleasedEventArgs {}
 unsafe impl ::core::marker::Sync for RadialControllerButtonReleasedEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -4970,36 +4274,7 @@ unsafe impl ::windows::core::Interface for RadialControllerConfiguration {
 impl ::windows::core::RuntimeName for RadialControllerConfiguration {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerConfiguration";
 }
-impl ::core::convert::From<RadialControllerConfiguration> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerConfiguration> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerConfiguration {}
 unsafe impl ::core::marker::Sync for RadialControllerConfiguration {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -5062,36 +4337,7 @@ unsafe impl ::windows::core::Interface for RadialControllerControlAcquiredEventA
 impl ::windows::core::RuntimeName for RadialControllerControlAcquiredEventArgs {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerControlAcquiredEventArgs";
 }
-impl ::core::convert::From<RadialControllerControlAcquiredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerControlAcquiredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerControlAcquiredEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerControlAcquiredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerControlAcquiredEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerControlAcquiredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerControlAcquiredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerControlAcquiredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerControlAcquiredEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerControlAcquiredEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerControlAcquiredEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerControlAcquiredEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerControlAcquiredEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerControlAcquiredEventArgs {}
 unsafe impl ::core::marker::Sync for RadialControllerControlAcquiredEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -5169,36 +4415,7 @@ unsafe impl ::windows::core::Interface for RadialControllerMenu {
 impl ::windows::core::RuntimeName for RadialControllerMenu {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerMenu";
 }
-impl ::core::convert::From<RadialControllerMenu> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerMenu> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerMenu> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerMenu> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerMenu> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerMenu> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerMenu, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerMenu {}
 unsafe impl ::core::marker::Sync for RadialControllerMenu {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -5312,36 +4529,7 @@ unsafe impl ::windows::core::Interface for RadialControllerMenuItem {
 impl ::windows::core::RuntimeName for RadialControllerMenuItem {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerMenuItem";
 }
-impl ::core::convert::From<RadialControllerMenuItem> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerMenuItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerMenuItem> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerMenuItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerMenuItem> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerMenuItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerMenuItem> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerMenuItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerMenuItem> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerMenuItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerMenuItem> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerMenuItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerMenuItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerMenuItem {}
 unsafe impl ::core::marker::Sync for RadialControllerMenuItem {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -5411,36 +4599,7 @@ unsafe impl ::windows::core::Interface for RadialControllerRotationChangedEventA
 impl ::windows::core::RuntimeName for RadialControllerRotationChangedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerRotationChangedEventArgs";
 }
-impl ::core::convert::From<RadialControllerRotationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerRotationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerRotationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerRotationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerRotationChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerRotationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerRotationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerRotationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerRotationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerRotationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerRotationChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerRotationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerRotationChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerRotationChangedEventArgs {}
 unsafe impl ::core::marker::Sync for RadialControllerRotationChangedEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -5498,36 +4657,7 @@ unsafe impl ::windows::core::Interface for RadialControllerScreenContact {
 impl ::windows::core::RuntimeName for RadialControllerScreenContact {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerScreenContact";
 }
-impl ::core::convert::From<RadialControllerScreenContact> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerScreenContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContact> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerScreenContact) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContact> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerScreenContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerScreenContact> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerScreenContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContact> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerScreenContact) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContact> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerScreenContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerScreenContact, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerScreenContact {}
 unsafe impl ::core::marker::Sync for RadialControllerScreenContact {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -5590,36 +4720,7 @@ unsafe impl ::windows::core::Interface for RadialControllerScreenContactContinue
 impl ::windows::core::RuntimeName for RadialControllerScreenContactContinuedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerScreenContactContinuedEventArgs";
 }
-impl ::core::convert::From<RadialControllerScreenContactContinuedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerScreenContactContinuedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactContinuedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerScreenContactContinuedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactContinuedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerScreenContactContinuedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerScreenContactContinuedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerScreenContactContinuedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactContinuedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerScreenContactContinuedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactContinuedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerScreenContactContinuedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerScreenContactContinuedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerScreenContactContinuedEventArgs {}
 unsafe impl ::core::marker::Sync for RadialControllerScreenContactContinuedEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -5675,36 +4776,7 @@ unsafe impl ::windows::core::Interface for RadialControllerScreenContactEndedEve
 impl ::windows::core::RuntimeName for RadialControllerScreenContactEndedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerScreenContactEndedEventArgs";
 }
-impl ::core::convert::From<RadialControllerScreenContactEndedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerScreenContactEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactEndedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerScreenContactEndedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactEndedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerScreenContactEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerScreenContactEndedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerScreenContactEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactEndedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerScreenContactEndedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactEndedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerScreenContactEndedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerScreenContactEndedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerScreenContactEndedEventArgs {}
 unsafe impl ::core::marker::Sync for RadialControllerScreenContactEndedEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -5767,36 +4839,7 @@ unsafe impl ::windows::core::Interface for RadialControllerScreenContactStartedE
 impl ::windows::core::RuntimeName for RadialControllerScreenContactStartedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.RadialControllerScreenContactStartedEventArgs";
 }
-impl ::core::convert::From<RadialControllerScreenContactStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RadialControllerScreenContactStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RadialControllerScreenContactStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactStartedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RadialControllerScreenContactStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RadialControllerScreenContactStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RadialControllerScreenContactStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RadialControllerScreenContactStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RadialControllerScreenContactStartedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RadialControllerScreenContactStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RadialControllerScreenContactStartedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RadialControllerScreenContactStartedEventArgs {}
 unsafe impl ::core::marker::Sync for RadialControllerScreenContactStartedEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -5861,36 +4904,7 @@ unsafe impl ::windows::core::Interface for RightTappedEventArgs {
 impl ::windows::core::RuntimeName for RightTappedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.RightTappedEventArgs";
 }
-impl ::core::convert::From<RightTappedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RightTappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RightTappedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RightTappedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RightTappedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RightTappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RightTappedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RightTappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RightTappedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RightTappedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RightTappedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RightTappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RightTappedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 pub struct SystemButtonEventController(::windows::core::IUnknown);
@@ -6007,36 +5021,7 @@ unsafe impl ::windows::core::Interface for SystemButtonEventController {
 impl ::windows::core::RuntimeName for SystemButtonEventController {
     const NAME: &'static str = "Windows.UI.Input.SystemButtonEventController";
 }
-impl ::core::convert::From<SystemButtonEventController> for ::windows::core::IUnknown {
-    fn from(value: SystemButtonEventController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemButtonEventController> for ::windows::core::IUnknown {
-    fn from(value: &SystemButtonEventController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemButtonEventController> for &::windows::core::IUnknown {
-    fn from(value: &SystemButtonEventController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemButtonEventController> for ::windows::core::IInspectable {
-    fn from(value: SystemButtonEventController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemButtonEventController> for ::windows::core::IInspectable {
-    fn from(value: &SystemButtonEventController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemButtonEventController> for &::windows::core::IInspectable {
-    fn from(value: &SystemButtonEventController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemButtonEventController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<SystemButtonEventController> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -6131,36 +5116,7 @@ unsafe impl ::windows::core::Interface for SystemFunctionButtonEventArgs {
 impl ::windows::core::RuntimeName for SystemFunctionButtonEventArgs {
     const NAME: &'static str = "Windows.UI.Input.SystemFunctionButtonEventArgs";
 }
-impl ::core::convert::From<SystemFunctionButtonEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SystemFunctionButtonEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemFunctionButtonEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SystemFunctionButtonEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemFunctionButtonEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SystemFunctionButtonEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemFunctionButtonEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SystemFunctionButtonEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemFunctionButtonEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SystemFunctionButtonEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemFunctionButtonEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SystemFunctionButtonEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemFunctionButtonEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemFunctionButtonEventArgs {}
 unsafe impl ::core::marker::Sync for SystemFunctionButtonEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -6225,36 +5181,7 @@ unsafe impl ::windows::core::Interface for SystemFunctionLockChangedEventArgs {
 impl ::windows::core::RuntimeName for SystemFunctionLockChangedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.SystemFunctionLockChangedEventArgs";
 }
-impl ::core::convert::From<SystemFunctionLockChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SystemFunctionLockChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemFunctionLockChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SystemFunctionLockChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemFunctionLockChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SystemFunctionLockChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemFunctionLockChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SystemFunctionLockChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemFunctionLockChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SystemFunctionLockChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemFunctionLockChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SystemFunctionLockChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemFunctionLockChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemFunctionLockChangedEventArgs {}
 unsafe impl ::core::marker::Sync for SystemFunctionLockChangedEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -6319,36 +5246,7 @@ unsafe impl ::windows::core::Interface for SystemFunctionLockIndicatorChangedEve
 impl ::windows::core::RuntimeName for SystemFunctionLockIndicatorChangedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.SystemFunctionLockIndicatorChangedEventArgs";
 }
-impl ::core::convert::From<SystemFunctionLockIndicatorChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SystemFunctionLockIndicatorChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemFunctionLockIndicatorChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SystemFunctionLockIndicatorChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemFunctionLockIndicatorChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SystemFunctionLockIndicatorChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SystemFunctionLockIndicatorChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SystemFunctionLockIndicatorChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SystemFunctionLockIndicatorChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SystemFunctionLockIndicatorChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SystemFunctionLockIndicatorChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SystemFunctionLockIndicatorChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SystemFunctionLockIndicatorChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SystemFunctionLockIndicatorChangedEventArgs {}
 unsafe impl ::core::marker::Sync for SystemFunctionLockIndicatorChangedEventArgs {}
 #[doc = "*Required features: `\"UI_Input\"`*"]
@@ -6420,36 +5318,7 @@ unsafe impl ::windows::core::Interface for TappedEventArgs {
 impl ::windows::core::RuntimeName for TappedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.TappedEventArgs";
 }
-impl ::core::convert::From<TappedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: TappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TappedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &TappedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TappedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &TappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TappedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: TappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TappedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &TappedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TappedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &TappedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TappedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Input\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/UI/Notifications/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/Management/mod.rs
@@ -150,36 +150,7 @@ unsafe impl ::windows::core::Interface for UserNotificationListener {
 impl ::windows::core::RuntimeName for UserNotificationListener {
     const NAME: &'static str = "Windows.UI.Notifications.Management.UserNotificationListener";
 }
-impl ::core::convert::From<UserNotificationListener> for ::windows::core::IUnknown {
-    fn from(value: UserNotificationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserNotificationListener> for ::windows::core::IUnknown {
-    fn from(value: &UserNotificationListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserNotificationListener> for &::windows::core::IUnknown {
-    fn from(value: &UserNotificationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserNotificationListener> for ::windows::core::IInspectable {
-    fn from(value: UserNotificationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserNotificationListener> for ::windows::core::IInspectable {
-    fn from(value: &UserNotificationListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserNotificationListener> for &::windows::core::IInspectable {
-    fn from(value: &UserNotificationListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserNotificationListener, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserNotificationListener {}
 unsafe impl ::core::marker::Sync for UserNotificationListener {}
 #[doc = "*Required features: `\"UI_Notifications_Management\"`*"]

--- a/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
@@ -21,36 +21,7 @@ impl IAdaptiveNotificationContent {
         }
     }
 }
-impl ::core::convert::From<IAdaptiveNotificationContent> for ::windows::core::IUnknown {
-    fn from(value: IAdaptiveNotificationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdaptiveNotificationContent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAdaptiveNotificationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdaptiveNotificationContent> for ::windows::core::IUnknown {
-    fn from(value: &IAdaptiveNotificationContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAdaptiveNotificationContent> for ::windows::core::IInspectable {
-    fn from(value: IAdaptiveNotificationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdaptiveNotificationContent> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAdaptiveNotificationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdaptiveNotificationContent> for ::windows::core::IInspectable {
-    fn from(value: &IAdaptiveNotificationContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAdaptiveNotificationContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAdaptiveNotificationContent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1548,36 +1519,7 @@ unsafe impl ::windows::core::Interface for AdaptiveNotificationText {
 impl ::windows::core::RuntimeName for AdaptiveNotificationText {
     const NAME: &'static str = "Windows.UI.Notifications.AdaptiveNotificationText";
 }
-impl ::core::convert::From<AdaptiveNotificationText> for ::windows::core::IUnknown {
-    fn from(value: AdaptiveNotificationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveNotificationText> for ::windows::core::IUnknown {
-    fn from(value: &AdaptiveNotificationText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveNotificationText> for &::windows::core::IUnknown {
-    fn from(value: &AdaptiveNotificationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AdaptiveNotificationText> for ::windows::core::IInspectable {
-    fn from(value: AdaptiveNotificationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AdaptiveNotificationText> for ::windows::core::IInspectable {
-    fn from(value: &AdaptiveNotificationText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AdaptiveNotificationText> for &::windows::core::IInspectable {
-    fn from(value: &AdaptiveNotificationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AdaptiveNotificationText, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<AdaptiveNotificationText> for IAdaptiveNotificationContent {
     type Error = ::windows::core::Error;
     fn try_from(value: AdaptiveNotificationText) -> ::windows::core::Result<Self> {
@@ -1677,36 +1619,7 @@ unsafe impl ::windows::core::Interface for BadgeNotification {
 impl ::windows::core::RuntimeName for BadgeNotification {
     const NAME: &'static str = "Windows.UI.Notifications.BadgeNotification";
 }
-impl ::core::convert::From<BadgeNotification> for ::windows::core::IUnknown {
-    fn from(value: BadgeNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BadgeNotification> for ::windows::core::IUnknown {
-    fn from(value: &BadgeNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BadgeNotification> for &::windows::core::IUnknown {
-    fn from(value: &BadgeNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BadgeNotification> for ::windows::core::IInspectable {
-    fn from(value: BadgeNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BadgeNotification> for ::windows::core::IInspectable {
-    fn from(value: &BadgeNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BadgeNotification> for &::windows::core::IInspectable {
-    fn from(value: &BadgeNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BadgeNotification, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BadgeNotification {}
 unsafe impl ::core::marker::Sync for BadgeNotification {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -1827,36 +1740,7 @@ unsafe impl ::windows::core::Interface for BadgeUpdateManagerForUser {
 impl ::windows::core::RuntimeName for BadgeUpdateManagerForUser {
     const NAME: &'static str = "Windows.UI.Notifications.BadgeUpdateManagerForUser";
 }
-impl ::core::convert::From<BadgeUpdateManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: BadgeUpdateManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BadgeUpdateManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: &BadgeUpdateManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BadgeUpdateManagerForUser> for &::windows::core::IUnknown {
-    fn from(value: &BadgeUpdateManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BadgeUpdateManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: BadgeUpdateManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BadgeUpdateManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: &BadgeUpdateManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BadgeUpdateManagerForUser> for &::windows::core::IInspectable {
-    fn from(value: &BadgeUpdateManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BadgeUpdateManagerForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BadgeUpdateManagerForUser {}
 unsafe impl ::core::marker::Sync for BadgeUpdateManagerForUser {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -1920,36 +1804,7 @@ unsafe impl ::windows::core::Interface for BadgeUpdater {
 impl ::windows::core::RuntimeName for BadgeUpdater {
     const NAME: &'static str = "Windows.UI.Notifications.BadgeUpdater";
 }
-impl ::core::convert::From<BadgeUpdater> for ::windows::core::IUnknown {
-    fn from(value: BadgeUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BadgeUpdater> for ::windows::core::IUnknown {
-    fn from(value: &BadgeUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BadgeUpdater> for &::windows::core::IUnknown {
-    fn from(value: &BadgeUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<BadgeUpdater> for ::windows::core::IInspectable {
-    fn from(value: BadgeUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&BadgeUpdater> for ::windows::core::IInspectable {
-    fn from(value: &BadgeUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&BadgeUpdater> for &::windows::core::IInspectable {
-    fn from(value: &BadgeUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BadgeUpdater, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for BadgeUpdater {}
 unsafe impl ::core::marker::Sync for BadgeUpdater {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -2218,36 +2073,7 @@ unsafe impl ::windows::core::Interface for Notification {
 impl ::windows::core::RuntimeName for Notification {
     const NAME: &'static str = "Windows.UI.Notifications.Notification";
 }
-impl ::core::convert::From<Notification> for ::windows::core::IUnknown {
-    fn from(value: Notification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Notification> for ::windows::core::IUnknown {
-    fn from(value: &Notification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Notification> for &::windows::core::IUnknown {
-    fn from(value: &Notification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Notification> for ::windows::core::IInspectable {
-    fn from(value: Notification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Notification> for ::windows::core::IInspectable {
-    fn from(value: &Notification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Notification> for &::windows::core::IInspectable {
-    fn from(value: &Notification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Notification, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Notification {}
 unsafe impl ::core::marker::Sync for Notification {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -2327,36 +2153,7 @@ unsafe impl ::windows::core::Interface for NotificationBinding {
 impl ::windows::core::RuntimeName for NotificationBinding {
     const NAME: &'static str = "Windows.UI.Notifications.NotificationBinding";
 }
-impl ::core::convert::From<NotificationBinding> for ::windows::core::IUnknown {
-    fn from(value: NotificationBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotificationBinding> for ::windows::core::IUnknown {
-    fn from(value: &NotificationBinding) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotificationBinding> for &::windows::core::IUnknown {
-    fn from(value: &NotificationBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NotificationBinding> for ::windows::core::IInspectable {
-    fn from(value: NotificationBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotificationBinding> for ::windows::core::IInspectable {
-    fn from(value: &NotificationBinding) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotificationBinding> for &::windows::core::IInspectable {
-    fn from(value: &NotificationBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NotificationBinding, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NotificationBinding {}
 unsafe impl ::core::marker::Sync for NotificationBinding {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -2452,36 +2249,7 @@ unsafe impl ::windows::core::Interface for NotificationData {
 impl ::windows::core::RuntimeName for NotificationData {
     const NAME: &'static str = "Windows.UI.Notifications.NotificationData";
 }
-impl ::core::convert::From<NotificationData> for ::windows::core::IUnknown {
-    fn from(value: NotificationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotificationData> for ::windows::core::IUnknown {
-    fn from(value: &NotificationData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotificationData> for &::windows::core::IUnknown {
-    fn from(value: &NotificationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NotificationData> for ::windows::core::IInspectable {
-    fn from(value: NotificationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotificationData> for ::windows::core::IInspectable {
-    fn from(value: &NotificationData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotificationData> for &::windows::core::IInspectable {
-    fn from(value: &NotificationData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NotificationData, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NotificationData {}
 unsafe impl ::core::marker::Sync for NotificationData {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -2548,36 +2316,7 @@ unsafe impl ::windows::core::Interface for NotificationVisual {
 impl ::windows::core::RuntimeName for NotificationVisual {
     const NAME: &'static str = "Windows.UI.Notifications.NotificationVisual";
 }
-impl ::core::convert::From<NotificationVisual> for ::windows::core::IUnknown {
-    fn from(value: NotificationVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotificationVisual> for ::windows::core::IUnknown {
-    fn from(value: &NotificationVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotificationVisual> for &::windows::core::IUnknown {
-    fn from(value: &NotificationVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NotificationVisual> for ::windows::core::IInspectable {
-    fn from(value: NotificationVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NotificationVisual> for ::windows::core::IInspectable {
-    fn from(value: &NotificationVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NotificationVisual> for &::windows::core::IInspectable {
-    fn from(value: &NotificationVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NotificationVisual, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for NotificationVisual {}
 unsafe impl ::core::marker::Sync for NotificationVisual {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -2689,36 +2428,7 @@ unsafe impl ::windows::core::Interface for ScheduledTileNotification {
 impl ::windows::core::RuntimeName for ScheduledTileNotification {
     const NAME: &'static str = "Windows.UI.Notifications.ScheduledTileNotification";
 }
-impl ::core::convert::From<ScheduledTileNotification> for ::windows::core::IUnknown {
-    fn from(value: ScheduledTileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScheduledTileNotification> for ::windows::core::IUnknown {
-    fn from(value: &ScheduledTileNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScheduledTileNotification> for &::windows::core::IUnknown {
-    fn from(value: &ScheduledTileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ScheduledTileNotification> for ::windows::core::IInspectable {
-    fn from(value: ScheduledTileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScheduledTileNotification> for ::windows::core::IInspectable {
-    fn from(value: &ScheduledTileNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScheduledTileNotification> for &::windows::core::IInspectable {
-    fn from(value: &ScheduledTileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ScheduledTileNotification, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ScheduledTileNotification {}
 unsafe impl ::core::marker::Sync for ScheduledTileNotification {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -2898,36 +2608,7 @@ unsafe impl ::windows::core::Interface for ScheduledToastNotification {
 impl ::windows::core::RuntimeName for ScheduledToastNotification {
     const NAME: &'static str = "Windows.UI.Notifications.ScheduledToastNotification";
 }
-impl ::core::convert::From<ScheduledToastNotification> for ::windows::core::IUnknown {
-    fn from(value: ScheduledToastNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScheduledToastNotification> for ::windows::core::IUnknown {
-    fn from(value: &ScheduledToastNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScheduledToastNotification> for &::windows::core::IUnknown {
-    fn from(value: &ScheduledToastNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ScheduledToastNotification> for ::windows::core::IInspectable {
-    fn from(value: ScheduledToastNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScheduledToastNotification> for ::windows::core::IInspectable {
-    fn from(value: &ScheduledToastNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScheduledToastNotification> for &::windows::core::IInspectable {
-    fn from(value: &ScheduledToastNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ScheduledToastNotification, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ScheduledToastNotification {}
 unsafe impl ::core::marker::Sync for ScheduledToastNotification {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -2994,36 +2675,7 @@ unsafe impl ::windows::core::Interface for ScheduledToastNotificationShowingEven
 impl ::windows::core::RuntimeName for ScheduledToastNotificationShowingEventArgs {
     const NAME: &'static str = "Windows.UI.Notifications.ScheduledToastNotificationShowingEventArgs";
 }
-impl ::core::convert::From<ScheduledToastNotificationShowingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ScheduledToastNotificationShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScheduledToastNotificationShowingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ScheduledToastNotificationShowingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScheduledToastNotificationShowingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ScheduledToastNotificationShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ScheduledToastNotificationShowingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ScheduledToastNotificationShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ScheduledToastNotificationShowingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ScheduledToastNotificationShowingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ScheduledToastNotificationShowingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ScheduledToastNotificationShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ScheduledToastNotificationShowingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ScheduledToastNotificationShowingEventArgs {}
 unsafe impl ::core::marker::Sync for ScheduledToastNotificationShowingEventArgs {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -3070,36 +2722,7 @@ unsafe impl ::windows::core::Interface for ShownTileNotification {
 impl ::windows::core::RuntimeName for ShownTileNotification {
     const NAME: &'static str = "Windows.UI.Notifications.ShownTileNotification";
 }
-impl ::core::convert::From<ShownTileNotification> for ::windows::core::IUnknown {
-    fn from(value: ShownTileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShownTileNotification> for ::windows::core::IUnknown {
-    fn from(value: &ShownTileNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShownTileNotification> for &::windows::core::IUnknown {
-    fn from(value: &ShownTileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShownTileNotification> for ::windows::core::IInspectable {
-    fn from(value: ShownTileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShownTileNotification> for ::windows::core::IInspectable {
-    fn from(value: &ShownTileNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShownTileNotification> for &::windows::core::IInspectable {
-    fn from(value: &ShownTileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShownTileNotification, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ShownTileNotification {}
 unsafe impl ::core::marker::Sync for ShownTileNotification {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -3180,36 +2803,7 @@ unsafe impl ::windows::core::Interface for TileFlyoutNotification {
 impl ::windows::core::RuntimeName for TileFlyoutNotification {
     const NAME: &'static str = "Windows.UI.Notifications.TileFlyoutNotification";
 }
-impl ::core::convert::From<TileFlyoutNotification> for ::windows::core::IUnknown {
-    fn from(value: TileFlyoutNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileFlyoutNotification> for ::windows::core::IUnknown {
-    fn from(value: &TileFlyoutNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileFlyoutNotification> for &::windows::core::IUnknown {
-    fn from(value: &TileFlyoutNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TileFlyoutNotification> for ::windows::core::IInspectable {
-    fn from(value: TileFlyoutNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileFlyoutNotification> for ::windows::core::IInspectable {
-    fn from(value: &TileFlyoutNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileFlyoutNotification> for &::windows::core::IInspectable {
-    fn from(value: &TileFlyoutNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TileFlyoutNotification, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TileFlyoutNotification {}
 unsafe impl ::core::marker::Sync for TileFlyoutNotification {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -3318,36 +2912,7 @@ unsafe impl ::windows::core::Interface for TileFlyoutUpdater {
 impl ::windows::core::RuntimeName for TileFlyoutUpdater {
     const NAME: &'static str = "Windows.UI.Notifications.TileFlyoutUpdater";
 }
-impl ::core::convert::From<TileFlyoutUpdater> for ::windows::core::IUnknown {
-    fn from(value: TileFlyoutUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileFlyoutUpdater> for ::windows::core::IUnknown {
-    fn from(value: &TileFlyoutUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileFlyoutUpdater> for &::windows::core::IUnknown {
-    fn from(value: &TileFlyoutUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TileFlyoutUpdater> for ::windows::core::IInspectable {
-    fn from(value: TileFlyoutUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileFlyoutUpdater> for ::windows::core::IInspectable {
-    fn from(value: &TileFlyoutUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileFlyoutUpdater> for &::windows::core::IInspectable {
-    fn from(value: &TileFlyoutUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TileFlyoutUpdater, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
 #[repr(transparent)]
 pub struct TileNotification(::windows::core::IUnknown);
@@ -3437,36 +3002,7 @@ unsafe impl ::windows::core::Interface for TileNotification {
 impl ::windows::core::RuntimeName for TileNotification {
     const NAME: &'static str = "Windows.UI.Notifications.TileNotification";
 }
-impl ::core::convert::From<TileNotification> for ::windows::core::IUnknown {
-    fn from(value: TileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileNotification> for ::windows::core::IUnknown {
-    fn from(value: &TileNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileNotification> for &::windows::core::IUnknown {
-    fn from(value: &TileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TileNotification> for ::windows::core::IInspectable {
-    fn from(value: TileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileNotification> for ::windows::core::IInspectable {
-    fn from(value: &TileNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileNotification> for &::windows::core::IInspectable {
-    fn from(value: &TileNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TileNotification, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TileNotification {}
 unsafe impl ::core::marker::Sync for TileNotification {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -3587,36 +3123,7 @@ unsafe impl ::windows::core::Interface for TileUpdateManagerForUser {
 impl ::windows::core::RuntimeName for TileUpdateManagerForUser {
     const NAME: &'static str = "Windows.UI.Notifications.TileUpdateManagerForUser";
 }
-impl ::core::convert::From<TileUpdateManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: TileUpdateManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileUpdateManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: &TileUpdateManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileUpdateManagerForUser> for &::windows::core::IUnknown {
-    fn from(value: &TileUpdateManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TileUpdateManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: TileUpdateManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileUpdateManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: &TileUpdateManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileUpdateManagerForUser> for &::windows::core::IInspectable {
-    fn from(value: &TileUpdateManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TileUpdateManagerForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TileUpdateManagerForUser {}
 unsafe impl ::core::marker::Sync for TileUpdateManagerForUser {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -3740,36 +3247,7 @@ unsafe impl ::windows::core::Interface for TileUpdater {
 impl ::windows::core::RuntimeName for TileUpdater {
     const NAME: &'static str = "Windows.UI.Notifications.TileUpdater";
 }
-impl ::core::convert::From<TileUpdater> for ::windows::core::IUnknown {
-    fn from(value: TileUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileUpdater> for ::windows::core::IUnknown {
-    fn from(value: &TileUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileUpdater> for &::windows::core::IUnknown {
-    fn from(value: &TileUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TileUpdater> for ::windows::core::IInspectable {
-    fn from(value: TileUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileUpdater> for ::windows::core::IInspectable {
-    fn from(value: &TileUpdater) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileUpdater> for &::windows::core::IInspectable {
-    fn from(value: &TileUpdater) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TileUpdater, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TileUpdater {}
 unsafe impl ::core::marker::Sync for TileUpdater {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -3825,36 +3303,7 @@ unsafe impl ::windows::core::Interface for ToastActivatedEventArgs {
 impl ::windows::core::RuntimeName for ToastActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.Notifications.ToastActivatedEventArgs";
 }
-impl ::core::convert::From<ToastActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ToastActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ToastActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ToastActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ToastActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ToastActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ToastActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
 #[repr(transparent)]
 pub struct ToastCollection(::windows::core::IUnknown);
@@ -3949,36 +3398,7 @@ unsafe impl ::windows::core::Interface for ToastCollection {
 impl ::windows::core::RuntimeName for ToastCollection {
     const NAME: &'static str = "Windows.UI.Notifications.ToastCollection";
 }
-impl ::core::convert::From<ToastCollection> for ::windows::core::IUnknown {
-    fn from(value: ToastCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastCollection> for ::windows::core::IUnknown {
-    fn from(value: &ToastCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastCollection> for &::windows::core::IUnknown {
-    fn from(value: &ToastCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastCollection> for ::windows::core::IInspectable {
-    fn from(value: ToastCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastCollection> for ::windows::core::IInspectable {
-    fn from(value: &ToastCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastCollection> for &::windows::core::IInspectable {
-    fn from(value: &ToastCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ToastCollection {}
 unsafe impl ::core::marker::Sync for ToastCollection {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -4079,36 +3499,7 @@ unsafe impl ::windows::core::Interface for ToastCollectionManager {
 impl ::windows::core::RuntimeName for ToastCollectionManager {
     const NAME: &'static str = "Windows.UI.Notifications.ToastCollectionManager";
 }
-impl ::core::convert::From<ToastCollectionManager> for ::windows::core::IUnknown {
-    fn from(value: ToastCollectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastCollectionManager> for ::windows::core::IUnknown {
-    fn from(value: &ToastCollectionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastCollectionManager> for &::windows::core::IUnknown {
-    fn from(value: &ToastCollectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastCollectionManager> for ::windows::core::IInspectable {
-    fn from(value: ToastCollectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastCollectionManager> for ::windows::core::IInspectable {
-    fn from(value: &ToastCollectionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastCollectionManager> for &::windows::core::IInspectable {
-    fn from(value: &ToastCollectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastCollectionManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ToastCollectionManager {}
 unsafe impl ::core::marker::Sync for ToastCollectionManager {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -4155,36 +3546,7 @@ unsafe impl ::windows::core::Interface for ToastDismissedEventArgs {
 impl ::windows::core::RuntimeName for ToastDismissedEventArgs {
     const NAME: &'static str = "Windows.UI.Notifications.ToastDismissedEventArgs";
 }
-impl ::core::convert::From<ToastDismissedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ToastDismissedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastDismissedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ToastDismissedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastDismissedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ToastDismissedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastDismissedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ToastDismissedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastDismissedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ToastDismissedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastDismissedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ToastDismissedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastDismissedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ToastDismissedEventArgs {}
 unsafe impl ::core::marker::Sync for ToastDismissedEventArgs {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -4231,36 +3593,7 @@ unsafe impl ::windows::core::Interface for ToastFailedEventArgs {
 impl ::windows::core::RuntimeName for ToastFailedEventArgs {
     const NAME: &'static str = "Windows.UI.Notifications.ToastFailedEventArgs";
 }
-impl ::core::convert::From<ToastFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ToastFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastFailedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ToastFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastFailedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ToastFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ToastFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastFailedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ToastFailedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastFailedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ToastFailedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastFailedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ToastFailedEventArgs {}
 unsafe impl ::core::marker::Sync for ToastFailedEventArgs {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -4474,36 +3807,7 @@ unsafe impl ::windows::core::Interface for ToastNotification {
 impl ::windows::core::RuntimeName for ToastNotification {
     const NAME: &'static str = "Windows.UI.Notifications.ToastNotification";
 }
-impl ::core::convert::From<ToastNotification> for ::windows::core::IUnknown {
-    fn from(value: ToastNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotification> for ::windows::core::IUnknown {
-    fn from(value: &ToastNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotification> for &::windows::core::IUnknown {
-    fn from(value: &ToastNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastNotification> for ::windows::core::IInspectable {
-    fn from(value: ToastNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotification> for ::windows::core::IInspectable {
-    fn from(value: &ToastNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotification> for &::windows::core::IInspectable {
-    fn from(value: &ToastNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastNotification, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ToastNotification {}
 unsafe impl ::core::marker::Sync for ToastNotification {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -4559,36 +3863,7 @@ unsafe impl ::windows::core::Interface for ToastNotificationActionTriggerDetail 
 impl ::windows::core::RuntimeName for ToastNotificationActionTriggerDetail {
     const NAME: &'static str = "Windows.UI.Notifications.ToastNotificationActionTriggerDetail";
 }
-impl ::core::convert::From<ToastNotificationActionTriggerDetail> for ::windows::core::IUnknown {
-    fn from(value: ToastNotificationActionTriggerDetail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationActionTriggerDetail> for ::windows::core::IUnknown {
-    fn from(value: &ToastNotificationActionTriggerDetail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationActionTriggerDetail> for &::windows::core::IUnknown {
-    fn from(value: &ToastNotificationActionTriggerDetail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastNotificationActionTriggerDetail> for ::windows::core::IInspectable {
-    fn from(value: ToastNotificationActionTriggerDetail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationActionTriggerDetail> for ::windows::core::IInspectable {
-    fn from(value: &ToastNotificationActionTriggerDetail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationActionTriggerDetail> for &::windows::core::IInspectable {
-    fn from(value: &ToastNotificationActionTriggerDetail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastNotificationActionTriggerDetail, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
 #[repr(transparent)]
 pub struct ToastNotificationHistory(::windows::core::IUnknown);
@@ -4672,36 +3947,7 @@ unsafe impl ::windows::core::Interface for ToastNotificationHistory {
 impl ::windows::core::RuntimeName for ToastNotificationHistory {
     const NAME: &'static str = "Windows.UI.Notifications.ToastNotificationHistory";
 }
-impl ::core::convert::From<ToastNotificationHistory> for ::windows::core::IUnknown {
-    fn from(value: ToastNotificationHistory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistory> for ::windows::core::IUnknown {
-    fn from(value: &ToastNotificationHistory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistory> for &::windows::core::IUnknown {
-    fn from(value: &ToastNotificationHistory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastNotificationHistory> for ::windows::core::IInspectable {
-    fn from(value: ToastNotificationHistory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistory> for ::windows::core::IInspectable {
-    fn from(value: &ToastNotificationHistory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistory> for &::windows::core::IInspectable {
-    fn from(value: &ToastNotificationHistory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastNotificationHistory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
 #[repr(transparent)]
 pub struct ToastNotificationHistoryChangedTriggerDetail(::windows::core::IUnknown);
@@ -4753,36 +3999,7 @@ unsafe impl ::windows::core::Interface for ToastNotificationHistoryChangedTrigge
 impl ::windows::core::RuntimeName for ToastNotificationHistoryChangedTriggerDetail {
     const NAME: &'static str = "Windows.UI.Notifications.ToastNotificationHistoryChangedTriggerDetail";
 }
-impl ::core::convert::From<ToastNotificationHistoryChangedTriggerDetail> for ::windows::core::IUnknown {
-    fn from(value: ToastNotificationHistoryChangedTriggerDetail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistoryChangedTriggerDetail> for ::windows::core::IUnknown {
-    fn from(value: &ToastNotificationHistoryChangedTriggerDetail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistoryChangedTriggerDetail> for &::windows::core::IUnknown {
-    fn from(value: &ToastNotificationHistoryChangedTriggerDetail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastNotificationHistoryChangedTriggerDetail> for ::windows::core::IInspectable {
-    fn from(value: ToastNotificationHistoryChangedTriggerDetail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistoryChangedTriggerDetail> for ::windows::core::IInspectable {
-    fn from(value: &ToastNotificationHistoryChangedTriggerDetail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationHistoryChangedTriggerDetail> for &::windows::core::IInspectable {
-    fn from(value: &ToastNotificationHistoryChangedTriggerDetail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastNotificationHistoryChangedTriggerDetail, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
 pub struct ToastNotificationManager;
 impl ToastNotificationManager {
@@ -4952,36 +4169,7 @@ unsafe impl ::windows::core::Interface for ToastNotificationManagerForUser {
 impl ::windows::core::RuntimeName for ToastNotificationManagerForUser {
     const NAME: &'static str = "Windows.UI.Notifications.ToastNotificationManagerForUser";
 }
-impl ::core::convert::From<ToastNotificationManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: ToastNotificationManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationManagerForUser> for ::windows::core::IUnknown {
-    fn from(value: &ToastNotificationManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationManagerForUser> for &::windows::core::IUnknown {
-    fn from(value: &ToastNotificationManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastNotificationManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: ToastNotificationManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotificationManagerForUser> for ::windows::core::IInspectable {
-    fn from(value: &ToastNotificationManagerForUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotificationManagerForUser> for &::windows::core::IInspectable {
-    fn from(value: &ToastNotificationManagerForUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastNotificationManagerForUser, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ToastNotificationManagerForUser {}
 unsafe impl ::core::marker::Sync for ToastNotificationManagerForUser {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -5082,36 +4270,7 @@ unsafe impl ::windows::core::Interface for ToastNotifier {
 impl ::windows::core::RuntimeName for ToastNotifier {
     const NAME: &'static str = "Windows.UI.Notifications.ToastNotifier";
 }
-impl ::core::convert::From<ToastNotifier> for ::windows::core::IUnknown {
-    fn from(value: ToastNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotifier> for ::windows::core::IUnknown {
-    fn from(value: &ToastNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotifier> for &::windows::core::IUnknown {
-    fn from(value: &ToastNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ToastNotifier> for ::windows::core::IInspectable {
-    fn from(value: ToastNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ToastNotifier> for ::windows::core::IInspectable {
-    fn from(value: &ToastNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ToastNotifier> for &::windows::core::IInspectable {
-    fn from(value: &ToastNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ToastNotifier, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ToastNotifier {}
 unsafe impl ::core::marker::Sync for ToastNotifier {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -5183,36 +4342,7 @@ unsafe impl ::windows::core::Interface for UserNotification {
 impl ::windows::core::RuntimeName for UserNotification {
     const NAME: &'static str = "Windows.UI.Notifications.UserNotification";
 }
-impl ::core::convert::From<UserNotification> for ::windows::core::IUnknown {
-    fn from(value: UserNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserNotification> for ::windows::core::IUnknown {
-    fn from(value: &UserNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserNotification> for &::windows::core::IUnknown {
-    fn from(value: &UserNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserNotification> for ::windows::core::IInspectable {
-    fn from(value: UserNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserNotification> for ::windows::core::IInspectable {
-    fn from(value: &UserNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserNotification> for &::windows::core::IInspectable {
-    fn from(value: &UserNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserNotification, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserNotification {}
 unsafe impl ::core::marker::Sync for UserNotification {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]
@@ -5266,36 +4396,7 @@ unsafe impl ::windows::core::Interface for UserNotificationChangedEventArgs {
 impl ::windows::core::RuntimeName for UserNotificationChangedEventArgs {
     const NAME: &'static str = "Windows.UI.Notifications.UserNotificationChangedEventArgs";
 }
-impl ::core::convert::From<UserNotificationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UserNotificationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserNotificationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UserNotificationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserNotificationChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UserNotificationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UserNotificationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UserNotificationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UserNotificationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UserNotificationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UserNotificationChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UserNotificationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UserNotificationChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UserNotificationChangedEventArgs {}
 unsafe impl ::core::marker::Sync for UserNotificationChangedEventArgs {}
 #[doc = "*Required features: `\"UI_Notifications\"`*"]

--- a/crates/libs/windows/src/Windows/UI/Popups/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Popups/mod.rs
@@ -117,36 +117,7 @@ impl IUICommand {
         unsafe { (::windows::core::Vtable::vtable(this).SetId)(::windows::core::Vtable::as_raw(this), value.into().abi()).ok() }
     }
 }
-impl ::core::convert::From<IUICommand> for ::windows::core::IUnknown {
-    fn from(value: IUICommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUICommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUICommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUICommand> for ::windows::core::IUnknown {
-    fn from(value: &IUICommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUICommand> for ::windows::core::IInspectable {
-    fn from(value: IUICommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUICommand> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IUICommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUICommand> for ::windows::core::IInspectable {
-    fn from(value: &IUICommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUICommand, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IUICommand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -331,36 +302,7 @@ unsafe impl ::windows::core::Interface for MessageDialog {
 impl ::windows::core::RuntimeName for MessageDialog {
     const NAME: &'static str = "Windows.UI.Popups.MessageDialog";
 }
-impl ::core::convert::From<MessageDialog> for ::windows::core::IUnknown {
-    fn from(value: MessageDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MessageDialog> for ::windows::core::IUnknown {
-    fn from(value: &MessageDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MessageDialog> for &::windows::core::IUnknown {
-    fn from(value: &MessageDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<MessageDialog> for ::windows::core::IInspectable {
-    fn from(value: MessageDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MessageDialog> for ::windows::core::IInspectable {
-    fn from(value: &MessageDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&MessageDialog> for &::windows::core::IInspectable {
-    fn from(value: &MessageDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(MessageDialog, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Popups\"`*"]
 #[repr(transparent)]
 pub struct PopupMenu(::windows::core::IUnknown);
@@ -441,36 +383,7 @@ unsafe impl ::windows::core::Interface for PopupMenu {
 impl ::windows::core::RuntimeName for PopupMenu {
     const NAME: &'static str = "Windows.UI.Popups.PopupMenu";
 }
-impl ::core::convert::From<PopupMenu> for ::windows::core::IUnknown {
-    fn from(value: PopupMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PopupMenu> for ::windows::core::IUnknown {
-    fn from(value: &PopupMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PopupMenu> for &::windows::core::IUnknown {
-    fn from(value: &PopupMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<PopupMenu> for ::windows::core::IInspectable {
-    fn from(value: PopupMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&PopupMenu> for ::windows::core::IInspectable {
-    fn from(value: &PopupMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&PopupMenu> for &::windows::core::IInspectable {
-    fn from(value: &PopupMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(PopupMenu, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_Popups\"`*"]
 #[repr(transparent)]
 pub struct UICommand(::windows::core::IUnknown);
@@ -577,36 +490,7 @@ unsafe impl ::windows::core::Interface for UICommand {
 impl ::windows::core::RuntimeName for UICommand {
     const NAME: &'static str = "Windows.UI.Popups.UICommand";
 }
-impl ::core::convert::From<UICommand> for ::windows::core::IUnknown {
-    fn from(value: UICommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UICommand> for ::windows::core::IUnknown {
-    fn from(value: &UICommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UICommand> for &::windows::core::IUnknown {
-    fn from(value: &UICommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UICommand> for ::windows::core::IInspectable {
-    fn from(value: UICommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UICommand> for ::windows::core::IInspectable {
-    fn from(value: &UICommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UICommand> for &::windows::core::IInspectable {
-    fn from(value: &UICommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UICommand, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<UICommand> for IUICommand {
     type Error = ::windows::core::Error;
     fn try_from(value: UICommand) -> ::windows::core::Result<Self> {
@@ -708,36 +592,7 @@ unsafe impl ::windows::core::Interface for UICommandSeparator {
 impl ::windows::core::RuntimeName for UICommandSeparator {
     const NAME: &'static str = "Windows.UI.Popups.UICommandSeparator";
 }
-impl ::core::convert::From<UICommandSeparator> for ::windows::core::IUnknown {
-    fn from(value: UICommandSeparator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UICommandSeparator> for ::windows::core::IUnknown {
-    fn from(value: &UICommandSeparator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UICommandSeparator> for &::windows::core::IUnknown {
-    fn from(value: &UICommandSeparator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UICommandSeparator> for ::windows::core::IInspectable {
-    fn from(value: UICommandSeparator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UICommandSeparator> for ::windows::core::IInspectable {
-    fn from(value: &UICommandSeparator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UICommandSeparator> for &::windows::core::IInspectable {
-    fn from(value: &UICommandSeparator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UICommandSeparator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<UICommandSeparator> for IUICommand {
     type Error = ::windows::core::Error;
     fn try_from(value: UICommandSeparator) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Shell/mod.rs
@@ -10,36 +10,7 @@ impl IAdaptiveCard {
         }
     }
 }
-impl ::core::convert::From<IAdaptiveCard> for ::windows::core::IUnknown {
-    fn from(value: IAdaptiveCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdaptiveCard> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAdaptiveCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdaptiveCard> for ::windows::core::IUnknown {
-    fn from(value: &IAdaptiveCard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAdaptiveCard> for ::windows::core::IInspectable {
-    fn from(value: IAdaptiveCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdaptiveCard> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAdaptiveCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdaptiveCard> for ::windows::core::IInspectable {
-    fn from(value: &IAdaptiveCard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAdaptiveCard, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAdaptiveCard {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -87,36 +58,7 @@ impl IAdaptiveCardBuilderStatics {
         }
     }
 }
-impl ::core::convert::From<IAdaptiveCardBuilderStatics> for ::windows::core::IUnknown {
-    fn from(value: IAdaptiveCardBuilderStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdaptiveCardBuilderStatics> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAdaptiveCardBuilderStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdaptiveCardBuilderStatics> for ::windows::core::IUnknown {
-    fn from(value: &IAdaptiveCardBuilderStatics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAdaptiveCardBuilderStatics> for ::windows::core::IInspectable {
-    fn from(value: IAdaptiveCardBuilderStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdaptiveCardBuilderStatics> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAdaptiveCardBuilderStatics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdaptiveCardBuilderStatics> for ::windows::core::IInspectable {
-    fn from(value: &IAdaptiveCardBuilderStatics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAdaptiveCardBuilderStatics, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAdaptiveCardBuilderStatics {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -394,36 +336,7 @@ unsafe impl ::windows::core::Interface for SecurityAppManager {
 impl ::windows::core::RuntimeName for SecurityAppManager {
     const NAME: &'static str = "Windows.UI.Shell.SecurityAppManager";
 }
-impl ::core::convert::From<SecurityAppManager> for ::windows::core::IUnknown {
-    fn from(value: SecurityAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SecurityAppManager> for ::windows::core::IUnknown {
-    fn from(value: &SecurityAppManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SecurityAppManager> for &::windows::core::IUnknown {
-    fn from(value: &SecurityAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SecurityAppManager> for ::windows::core::IInspectable {
-    fn from(value: SecurityAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SecurityAppManager> for ::windows::core::IInspectable {
-    fn from(value: &SecurityAppManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SecurityAppManager> for &::windows::core::IInspectable {
-    fn from(value: &SecurityAppManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SecurityAppManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SecurityAppManager {}
 unsafe impl ::core::marker::Sync for SecurityAppManager {}
 #[doc = "*Required features: `\"UI_Shell\"`*"]
@@ -481,36 +394,7 @@ unsafe impl ::windows::core::Interface for ShareWindowCommandEventArgs {
 impl ::windows::core::RuntimeName for ShareWindowCommandEventArgs {
     const NAME: &'static str = "Windows.UI.Shell.ShareWindowCommandEventArgs";
 }
-impl ::core::convert::From<ShareWindowCommandEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ShareWindowCommandEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareWindowCommandEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ShareWindowCommandEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareWindowCommandEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ShareWindowCommandEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShareWindowCommandEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ShareWindowCommandEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareWindowCommandEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ShareWindowCommandEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareWindowCommandEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ShareWindowCommandEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShareWindowCommandEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ShareWindowCommandEventArgs {}
 unsafe impl ::core::marker::Sync for ShareWindowCommandEventArgs {}
 #[doc = "*Required features: `\"UI_Shell\"`*"]
@@ -603,36 +487,7 @@ unsafe impl ::windows::core::Interface for ShareWindowCommandSource {
 impl ::windows::core::RuntimeName for ShareWindowCommandSource {
     const NAME: &'static str = "Windows.UI.Shell.ShareWindowCommandSource";
 }
-impl ::core::convert::From<ShareWindowCommandSource> for ::windows::core::IUnknown {
-    fn from(value: ShareWindowCommandSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareWindowCommandSource> for ::windows::core::IUnknown {
-    fn from(value: &ShareWindowCommandSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareWindowCommandSource> for &::windows::core::IUnknown {
-    fn from(value: &ShareWindowCommandSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ShareWindowCommandSource> for ::windows::core::IInspectable {
-    fn from(value: ShareWindowCommandSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ShareWindowCommandSource> for ::windows::core::IInspectable {
-    fn from(value: &ShareWindowCommandSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ShareWindowCommandSource> for &::windows::core::IInspectable {
-    fn from(value: &ShareWindowCommandSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ShareWindowCommandSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ShareWindowCommandSource {}
 unsafe impl ::core::marker::Sync for ShareWindowCommandSource {}
 #[doc = "*Required features: `\"UI_Shell\"`*"]
@@ -760,36 +615,7 @@ unsafe impl ::windows::core::Interface for TaskbarManager {
 impl ::windows::core::RuntimeName for TaskbarManager {
     const NAME: &'static str = "Windows.UI.Shell.TaskbarManager";
 }
-impl ::core::convert::From<TaskbarManager> for ::windows::core::IUnknown {
-    fn from(value: TaskbarManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TaskbarManager> for ::windows::core::IUnknown {
-    fn from(value: &TaskbarManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TaskbarManager> for &::windows::core::IUnknown {
-    fn from(value: &TaskbarManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TaskbarManager> for ::windows::core::IInspectable {
-    fn from(value: TaskbarManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TaskbarManager> for ::windows::core::IInspectable {
-    fn from(value: &TaskbarManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TaskbarManager> for &::windows::core::IInspectable {
-    fn from(value: &TaskbarManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TaskbarManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TaskbarManager {}
 unsafe impl ::core::marker::Sync for TaskbarManager {}
 #[doc = "*Required features: `\"UI_Shell\"`*"]

--- a/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
@@ -684,36 +684,7 @@ unsafe impl ::windows::core::Interface for JumpList {
 impl ::windows::core::RuntimeName for JumpList {
     const NAME: &'static str = "Windows.UI.StartScreen.JumpList";
 }
-impl ::core::convert::From<JumpList> for ::windows::core::IUnknown {
-    fn from(value: JumpList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JumpList> for ::windows::core::IUnknown {
-    fn from(value: &JumpList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JumpList> for &::windows::core::IUnknown {
-    fn from(value: &JumpList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<JumpList> for ::windows::core::IInspectable {
-    fn from(value: JumpList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JumpList> for ::windows::core::IInspectable {
-    fn from(value: &JumpList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JumpList> for &::windows::core::IInspectable {
-    fn from(value: &JumpList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(JumpList, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for JumpList {}
 unsafe impl ::core::marker::Sync for JumpList {}
 #[doc = "*Required features: `\"UI_StartScreen\"`*"]
@@ -839,36 +810,7 @@ unsafe impl ::windows::core::Interface for JumpListItem {
 impl ::windows::core::RuntimeName for JumpListItem {
     const NAME: &'static str = "Windows.UI.StartScreen.JumpListItem";
 }
-impl ::core::convert::From<JumpListItem> for ::windows::core::IUnknown {
-    fn from(value: JumpListItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JumpListItem> for ::windows::core::IUnknown {
-    fn from(value: &JumpListItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JumpListItem> for &::windows::core::IUnknown {
-    fn from(value: &JumpListItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<JumpListItem> for ::windows::core::IInspectable {
-    fn from(value: JumpListItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&JumpListItem> for ::windows::core::IInspectable {
-    fn from(value: &JumpListItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&JumpListItem> for &::windows::core::IInspectable {
-    fn from(value: &JumpListItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(JumpListItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for JumpListItem {}
 unsafe impl ::core::marker::Sync for JumpListItem {}
 #[doc = "*Required features: `\"UI_StartScreen\"`*"]
@@ -1279,36 +1221,7 @@ unsafe impl ::windows::core::Interface for SecondaryTile {
 impl ::windows::core::RuntimeName for SecondaryTile {
     const NAME: &'static str = "Windows.UI.StartScreen.SecondaryTile";
 }
-impl ::core::convert::From<SecondaryTile> for ::windows::core::IUnknown {
-    fn from(value: SecondaryTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SecondaryTile> for ::windows::core::IUnknown {
-    fn from(value: &SecondaryTile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SecondaryTile> for &::windows::core::IUnknown {
-    fn from(value: &SecondaryTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SecondaryTile> for ::windows::core::IInspectable {
-    fn from(value: SecondaryTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SecondaryTile> for ::windows::core::IInspectable {
-    fn from(value: &SecondaryTile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SecondaryTile> for &::windows::core::IInspectable {
-    fn from(value: &SecondaryTile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SecondaryTile, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SecondaryTile {}
 unsafe impl ::core::marker::Sync for SecondaryTile {}
 #[doc = "*Required features: `\"UI_StartScreen\"`*"]
@@ -1515,36 +1428,7 @@ unsafe impl ::windows::core::Interface for SecondaryTileVisualElements {
 impl ::windows::core::RuntimeName for SecondaryTileVisualElements {
     const NAME: &'static str = "Windows.UI.StartScreen.SecondaryTileVisualElements";
 }
-impl ::core::convert::From<SecondaryTileVisualElements> for ::windows::core::IUnknown {
-    fn from(value: SecondaryTileVisualElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SecondaryTileVisualElements> for ::windows::core::IUnknown {
-    fn from(value: &SecondaryTileVisualElements) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SecondaryTileVisualElements> for &::windows::core::IUnknown {
-    fn from(value: &SecondaryTileVisualElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SecondaryTileVisualElements> for ::windows::core::IInspectable {
-    fn from(value: SecondaryTileVisualElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SecondaryTileVisualElements> for ::windows::core::IInspectable {
-    fn from(value: &SecondaryTileVisualElements) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SecondaryTileVisualElements> for &::windows::core::IInspectable {
-    fn from(value: &SecondaryTileVisualElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SecondaryTileVisualElements, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SecondaryTileVisualElements {}
 unsafe impl ::core::marker::Sync for SecondaryTileVisualElements {}
 #[doc = "*Required features: `\"UI_StartScreen\"`*"]
@@ -1657,36 +1541,7 @@ unsafe impl ::windows::core::Interface for StartScreenManager {
 impl ::windows::core::RuntimeName for StartScreenManager {
     const NAME: &'static str = "Windows.UI.StartScreen.StartScreenManager";
 }
-impl ::core::convert::From<StartScreenManager> for ::windows::core::IUnknown {
-    fn from(value: StartScreenManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StartScreenManager> for ::windows::core::IUnknown {
-    fn from(value: &StartScreenManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StartScreenManager> for &::windows::core::IUnknown {
-    fn from(value: &StartScreenManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StartScreenManager> for ::windows::core::IInspectable {
-    fn from(value: StartScreenManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StartScreenManager> for ::windows::core::IInspectable {
-    fn from(value: &StartScreenManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StartScreenManager> for &::windows::core::IInspectable {
-    fn from(value: &StartScreenManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StartScreenManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StartScreenManager {}
 unsafe impl ::core::marker::Sync for StartScreenManager {}
 #[doc = "*Required features: `\"UI_StartScreen\"`*"]
@@ -1771,36 +1626,7 @@ unsafe impl ::windows::core::Interface for TileMixedRealityModel {
 impl ::windows::core::RuntimeName for TileMixedRealityModel {
     const NAME: &'static str = "Windows.UI.StartScreen.TileMixedRealityModel";
 }
-impl ::core::convert::From<TileMixedRealityModel> for ::windows::core::IUnknown {
-    fn from(value: TileMixedRealityModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileMixedRealityModel> for ::windows::core::IUnknown {
-    fn from(value: &TileMixedRealityModel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileMixedRealityModel> for &::windows::core::IUnknown {
-    fn from(value: &TileMixedRealityModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<TileMixedRealityModel> for ::windows::core::IInspectable {
-    fn from(value: TileMixedRealityModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&TileMixedRealityModel> for ::windows::core::IInspectable {
-    fn from(value: &TileMixedRealityModel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&TileMixedRealityModel> for &::windows::core::IInspectable {
-    fn from(value: &TileMixedRealityModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(TileMixedRealityModel, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for TileMixedRealityModel {}
 unsafe impl ::core::marker::Sync for TileMixedRealityModel {}
 #[doc = "*Required features: `\"UI_StartScreen\"`*"]
@@ -1872,36 +1698,7 @@ unsafe impl ::windows::core::Interface for VisualElementsRequest {
 impl ::windows::core::RuntimeName for VisualElementsRequest {
     const NAME: &'static str = "Windows.UI.StartScreen.VisualElementsRequest";
 }
-impl ::core::convert::From<VisualElementsRequest> for ::windows::core::IUnknown {
-    fn from(value: VisualElementsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualElementsRequest> for ::windows::core::IUnknown {
-    fn from(value: &VisualElementsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualElementsRequest> for &::windows::core::IUnknown {
-    fn from(value: &VisualElementsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VisualElementsRequest> for ::windows::core::IInspectable {
-    fn from(value: VisualElementsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualElementsRequest> for ::windows::core::IInspectable {
-    fn from(value: &VisualElementsRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualElementsRequest> for &::windows::core::IInspectable {
-    fn from(value: &VisualElementsRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VisualElementsRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VisualElementsRequest {}
 unsafe impl ::core::marker::Sync for VisualElementsRequest {}
 #[doc = "*Required features: `\"UI_StartScreen\"`*"]
@@ -1945,36 +1742,7 @@ unsafe impl ::windows::core::Interface for VisualElementsRequestDeferral {
 impl ::windows::core::RuntimeName for VisualElementsRequestDeferral {
     const NAME: &'static str = "Windows.UI.StartScreen.VisualElementsRequestDeferral";
 }
-impl ::core::convert::From<VisualElementsRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: VisualElementsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualElementsRequestDeferral> for ::windows::core::IUnknown {
-    fn from(value: &VisualElementsRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualElementsRequestDeferral> for &::windows::core::IUnknown {
-    fn from(value: &VisualElementsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VisualElementsRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: VisualElementsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualElementsRequestDeferral> for ::windows::core::IInspectable {
-    fn from(value: &VisualElementsRequestDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualElementsRequestDeferral> for &::windows::core::IInspectable {
-    fn from(value: &VisualElementsRequestDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VisualElementsRequestDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VisualElementsRequestDeferral {}
 unsafe impl ::core::marker::Sync for VisualElementsRequestDeferral {}
 #[doc = "*Required features: `\"UI_StartScreen\"`*"]
@@ -2021,36 +1789,7 @@ unsafe impl ::windows::core::Interface for VisualElementsRequestedEventArgs {
 impl ::windows::core::RuntimeName for VisualElementsRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.StartScreen.VisualElementsRequestedEventArgs";
 }
-impl ::core::convert::From<VisualElementsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: VisualElementsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualElementsRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &VisualElementsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualElementsRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &VisualElementsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<VisualElementsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: VisualElementsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&VisualElementsRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &VisualElementsRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&VisualElementsRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &VisualElementsRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(VisualElementsRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for VisualElementsRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for VisualElementsRequestedEventArgs {}
 #[doc = "*Required features: `\"UI_StartScreen\"`*"]

--- a/crates/libs/windows/src/Windows/UI/Text/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/Core/mod.rs
@@ -539,36 +539,7 @@ unsafe impl ::windows::core::Interface for CoreTextCompositionCompletedEventArgs
 impl ::windows::core::RuntimeName for CoreTextCompositionCompletedEventArgs {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextCompositionCompletedEventArgs";
 }
-impl ::core::convert::From<CoreTextCompositionCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreTextCompositionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextCompositionCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextCompositionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextCompositionCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreTextCompositionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextCompositionCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextCompositionCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextCompositionCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextCompositionCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for CoreTextCompositionCompletedEventArgs {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -622,36 +593,7 @@ unsafe impl ::windows::core::Interface for CoreTextCompositionSegment {
 impl ::windows::core::RuntimeName for CoreTextCompositionSegment {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextCompositionSegment";
 }
-impl ::core::convert::From<CoreTextCompositionSegment> for ::windows::core::IUnknown {
-    fn from(value: CoreTextCompositionSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionSegment> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextCompositionSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionSegment> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextCompositionSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextCompositionSegment> for ::windows::core::IInspectable {
-    fn from(value: CoreTextCompositionSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionSegment> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextCompositionSegment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionSegment> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextCompositionSegment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextCompositionSegment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextCompositionSegment {}
 unsafe impl ::core::marker::Sync for CoreTextCompositionSegment {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -707,36 +649,7 @@ unsafe impl ::windows::core::Interface for CoreTextCompositionStartedEventArgs {
 impl ::windows::core::RuntimeName for CoreTextCompositionStartedEventArgs {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextCompositionStartedEventArgs";
 }
-impl ::core::convert::From<CoreTextCompositionStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreTextCompositionStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionStartedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextCompositionStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionStartedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextCompositionStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextCompositionStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreTextCompositionStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionStartedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextCompositionStartedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextCompositionStartedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextCompositionStartedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextCompositionStartedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextCompositionStartedEventArgs {}
 unsafe impl ::core::marker::Sync for CoreTextCompositionStartedEventArgs {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -990,36 +903,7 @@ unsafe impl ::windows::core::Interface for CoreTextEditContext {
 impl ::windows::core::RuntimeName for CoreTextEditContext {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextEditContext";
 }
-impl ::core::convert::From<CoreTextEditContext> for ::windows::core::IUnknown {
-    fn from(value: CoreTextEditContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextEditContext> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextEditContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextEditContext> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextEditContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextEditContext> for ::windows::core::IInspectable {
-    fn from(value: CoreTextEditContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextEditContext> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextEditContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextEditContext> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextEditContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextEditContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextEditContext {}
 unsafe impl ::core::marker::Sync for CoreTextEditContext {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -1136,36 +1020,7 @@ unsafe impl ::windows::core::Interface for CoreTextFormatUpdatingEventArgs {
 impl ::windows::core::RuntimeName for CoreTextFormatUpdatingEventArgs {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextFormatUpdatingEventArgs";
 }
-impl ::core::convert::From<CoreTextFormatUpdatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreTextFormatUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextFormatUpdatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextFormatUpdatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextFormatUpdatingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextFormatUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextFormatUpdatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreTextFormatUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextFormatUpdatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextFormatUpdatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextFormatUpdatingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextFormatUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextFormatUpdatingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextFormatUpdatingEventArgs {}
 unsafe impl ::core::marker::Sync for CoreTextFormatUpdatingEventArgs {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -1235,36 +1090,7 @@ unsafe impl ::windows::core::Interface for CoreTextLayoutBounds {
 impl ::windows::core::RuntimeName for CoreTextLayoutBounds {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextLayoutBounds";
 }
-impl ::core::convert::From<CoreTextLayoutBounds> for ::windows::core::IUnknown {
-    fn from(value: CoreTextLayoutBounds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutBounds> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextLayoutBounds) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutBounds> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextLayoutBounds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextLayoutBounds> for ::windows::core::IInspectable {
-    fn from(value: CoreTextLayoutBounds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutBounds> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextLayoutBounds) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutBounds> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextLayoutBounds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextLayoutBounds, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextLayoutBounds {}
 unsafe impl ::core::marker::Sync for CoreTextLayoutBounds {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -1341,36 +1167,7 @@ unsafe impl ::windows::core::Interface for CoreTextLayoutRequest {
 impl ::windows::core::RuntimeName for CoreTextLayoutRequest {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextLayoutRequest";
 }
-impl ::core::convert::From<CoreTextLayoutRequest> for ::windows::core::IUnknown {
-    fn from(value: CoreTextLayoutRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutRequest> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextLayoutRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutRequest> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextLayoutRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextLayoutRequest> for ::windows::core::IInspectable {
-    fn from(value: CoreTextLayoutRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutRequest> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextLayoutRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutRequest> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextLayoutRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextLayoutRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextLayoutRequest {}
 unsafe impl ::core::marker::Sync for CoreTextLayoutRequest {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -1417,36 +1214,7 @@ unsafe impl ::windows::core::Interface for CoreTextLayoutRequestedEventArgs {
 impl ::windows::core::RuntimeName for CoreTextLayoutRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextLayoutRequestedEventArgs";
 }
-impl ::core::convert::From<CoreTextLayoutRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreTextLayoutRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextLayoutRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextLayoutRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextLayoutRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreTextLayoutRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextLayoutRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextLayoutRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextLayoutRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextLayoutRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextLayoutRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for CoreTextLayoutRequestedEventArgs {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -1513,36 +1281,7 @@ unsafe impl ::windows::core::Interface for CoreTextSelectionRequest {
 impl ::windows::core::RuntimeName for CoreTextSelectionRequest {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextSelectionRequest";
 }
-impl ::core::convert::From<CoreTextSelectionRequest> for ::windows::core::IUnknown {
-    fn from(value: CoreTextSelectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionRequest> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextSelectionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionRequest> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextSelectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextSelectionRequest> for ::windows::core::IInspectable {
-    fn from(value: CoreTextSelectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionRequest> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextSelectionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionRequest> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextSelectionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextSelectionRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextSelectionRequest {}
 unsafe impl ::core::marker::Sync for CoreTextSelectionRequest {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -1589,36 +1328,7 @@ unsafe impl ::windows::core::Interface for CoreTextSelectionRequestedEventArgs {
 impl ::windows::core::RuntimeName for CoreTextSelectionRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextSelectionRequestedEventArgs";
 }
-impl ::core::convert::From<CoreTextSelectionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreTextSelectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextSelectionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextSelectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextSelectionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreTextSelectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextSelectionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextSelectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextSelectionRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextSelectionRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for CoreTextSelectionRequestedEventArgs {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -1692,36 +1402,7 @@ unsafe impl ::windows::core::Interface for CoreTextSelectionUpdatingEventArgs {
 impl ::windows::core::RuntimeName for CoreTextSelectionUpdatingEventArgs {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextSelectionUpdatingEventArgs";
 }
-impl ::core::convert::From<CoreTextSelectionUpdatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreTextSelectionUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionUpdatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextSelectionUpdatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionUpdatingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextSelectionUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextSelectionUpdatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreTextSelectionUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionUpdatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextSelectionUpdatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextSelectionUpdatingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextSelectionUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextSelectionUpdatingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextSelectionUpdatingEventArgs {}
 unsafe impl ::core::marker::Sync for CoreTextSelectionUpdatingEventArgs {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -1821,36 +1502,7 @@ unsafe impl ::windows::core::Interface for CoreTextServicesManager {
 impl ::windows::core::RuntimeName for CoreTextServicesManager {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextServicesManager";
 }
-impl ::core::convert::From<CoreTextServicesManager> for ::windows::core::IUnknown {
-    fn from(value: CoreTextServicesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextServicesManager> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextServicesManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextServicesManager> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextServicesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextServicesManager> for ::windows::core::IInspectable {
-    fn from(value: CoreTextServicesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextServicesManager> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextServicesManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextServicesManager> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextServicesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextServicesManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextServicesManager {}
 unsafe impl ::core::marker::Sync for CoreTextServicesManager {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -1924,36 +1576,7 @@ unsafe impl ::windows::core::Interface for CoreTextTextRequest {
 impl ::windows::core::RuntimeName for CoreTextTextRequest {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextTextRequest";
 }
-impl ::core::convert::From<CoreTextTextRequest> for ::windows::core::IUnknown {
-    fn from(value: CoreTextTextRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextTextRequest> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextTextRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextTextRequest> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextTextRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextTextRequest> for ::windows::core::IInspectable {
-    fn from(value: CoreTextTextRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextTextRequest> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextTextRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextTextRequest> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextTextRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextTextRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextTextRequest {}
 unsafe impl ::core::marker::Sync for CoreTextTextRequest {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -2000,36 +1623,7 @@ unsafe impl ::windows::core::Interface for CoreTextTextRequestedEventArgs {
 impl ::windows::core::RuntimeName for CoreTextTextRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextTextRequestedEventArgs";
 }
-impl ::core::convert::From<CoreTextTextRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreTextTextRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextTextRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextTextRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextTextRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextTextRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextTextRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreTextTextRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextTextRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextTextRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextTextRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextTextRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextTextRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextTextRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for CoreTextTextRequestedEventArgs {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]
@@ -2126,36 +1720,7 @@ unsafe impl ::windows::core::Interface for CoreTextTextUpdatingEventArgs {
 impl ::windows::core::RuntimeName for CoreTextTextUpdatingEventArgs {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextTextUpdatingEventArgs";
 }
-impl ::core::convert::From<CoreTextTextUpdatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreTextTextUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextTextUpdatingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreTextTextUpdatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextTextUpdatingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreTextTextUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreTextTextUpdatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreTextTextUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreTextTextUpdatingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreTextTextUpdatingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreTextTextUpdatingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreTextTextUpdatingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreTextTextUpdatingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreTextTextUpdatingEventArgs {}
 unsafe impl ::core::marker::Sync for CoreTextTextUpdatingEventArgs {}
 #[doc = "*Required features: `\"UI_Text_Core\"`*"]

--- a/crates/libs/windows/src/Windows/UI/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/mod.rs
@@ -376,36 +376,7 @@ impl ITextCharacterFormat {
         }
     }
 }
-impl ::core::convert::From<ITextCharacterFormat> for ::windows::core::IUnknown {
-    fn from(value: ITextCharacterFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextCharacterFormat> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextCharacterFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextCharacterFormat> for ::windows::core::IUnknown {
-    fn from(value: &ITextCharacterFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextCharacterFormat> for ::windows::core::IInspectable {
-    fn from(value: ITextCharacterFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextCharacterFormat> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ITextCharacterFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextCharacterFormat> for ::windows::core::IInspectable {
-    fn from(value: &ITextCharacterFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextCharacterFormat, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ITextCharacterFormat {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -689,36 +660,7 @@ impl ITextDocument {
         unsafe { (::windows::core::Vtable::vtable(this).Undo)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<ITextDocument> for ::windows::core::IUnknown {
-    fn from(value: ITextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextDocument> for ::windows::core::IUnknown {
-    fn from(value: &ITextDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextDocument> for ::windows::core::IInspectable {
-    fn from(value: ITextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextDocument> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ITextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextDocument> for ::windows::core::IInspectable {
-    fn from(value: &ITextDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextDocument, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ITextDocument {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1116,36 +1058,7 @@ impl ITextParagraphFormat {
         unsafe { (::windows::core::Vtable::vtable(this).SetLineSpacing)(::windows::core::Vtable::as_raw(this), rule, spacing).ok() }
     }
 }
-impl ::core::convert::From<ITextParagraphFormat> for ::windows::core::IUnknown {
-    fn from(value: ITextParagraphFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextParagraphFormat> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextParagraphFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextParagraphFormat> for ::windows::core::IUnknown {
-    fn from(value: &ITextParagraphFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextParagraphFormat> for ::windows::core::IInspectable {
-    fn from(value: ITextParagraphFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextParagraphFormat> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ITextParagraphFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextParagraphFormat> for ::windows::core::IInspectable {
-    fn from(value: &ITextParagraphFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextParagraphFormat, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ITextParagraphFormat {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1564,36 +1477,7 @@ impl ITextRange {
         }
     }
 }
-impl ::core::convert::From<ITextRange> for ::windows::core::IUnknown {
-    fn from(value: ITextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextRange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextRange> for ::windows::core::IUnknown {
-    fn from(value: &ITextRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextRange> for ::windows::core::IInspectable {
-    fn from(value: ITextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextRange> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ITextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextRange> for ::windows::core::IInspectable {
-    fn from(value: &ITextRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextRange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ITextRange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2098,36 +1982,7 @@ impl ITextSelection {
         }
     }
 }
-impl ::core::convert::From<ITextSelection> for ::windows::core::IUnknown {
-    fn from(value: ITextSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextSelection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextSelection> for ::windows::core::IUnknown {
-    fn from(value: &ITextSelection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextSelection> for ::windows::core::IInspectable {
-    fn from(value: ITextSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextSelection> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ITextSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextSelection> for ::windows::core::IInspectable {
-    fn from(value: &ITextSelection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextSelection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ITextSelection> for ITextRange {
     type Error = ::windows::core::Error;
     fn try_from(value: ITextSelection) -> ::windows::core::Result<Self> {
@@ -2294,36 +2149,7 @@ unsafe impl ::windows::core::Interface for ContentLinkInfo {
 impl ::windows::core::RuntimeName for ContentLinkInfo {
     const NAME: &'static str = "Windows.UI.Text.ContentLinkInfo";
 }
-impl ::core::convert::From<ContentLinkInfo> for ::windows::core::IUnknown {
-    fn from(value: ContentLinkInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContentLinkInfo> for ::windows::core::IUnknown {
-    fn from(value: &ContentLinkInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContentLinkInfo> for &::windows::core::IUnknown {
-    fn from(value: &ContentLinkInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ContentLinkInfo> for ::windows::core::IInspectable {
-    fn from(value: ContentLinkInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ContentLinkInfo> for ::windows::core::IInspectable {
-    fn from(value: &ContentLinkInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ContentLinkInfo> for &::windows::core::IInspectable {
-    fn from(value: &ContentLinkInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ContentLinkInfo, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ContentLinkInfo {}
 unsafe impl ::core::marker::Sync for ContentLinkInfo {}
 #[doc = "*Required features: `\"UI_Text\"`*"]
@@ -2434,36 +2260,7 @@ unsafe impl ::windows::core::Interface for FontWeights {
 impl ::windows::core::RuntimeName for FontWeights {
     const NAME: &'static str = "Windows.UI.Text.FontWeights";
 }
-impl ::core::convert::From<FontWeights> for ::windows::core::IUnknown {
-    fn from(value: FontWeights) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FontWeights> for ::windows::core::IUnknown {
-    fn from(value: &FontWeights) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FontWeights> for &::windows::core::IUnknown {
-    fn from(value: &FontWeights) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FontWeights> for ::windows::core::IInspectable {
-    fn from(value: FontWeights) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FontWeights> for ::windows::core::IInspectable {
-    fn from(value: &FontWeights) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FontWeights> for &::windows::core::IInspectable {
-    fn from(value: &FontWeights) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FontWeights, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for FontWeights {}
 unsafe impl ::core::marker::Sync for FontWeights {}
 #[doc = "*Required features: `\"UI_Text\"`*"]
@@ -2713,36 +2510,7 @@ unsafe impl ::windows::core::Interface for RichEditTextDocument {
 impl ::windows::core::RuntimeName for RichEditTextDocument {
     const NAME: &'static str = "Windows.UI.Text.RichEditTextDocument";
 }
-impl ::core::convert::From<RichEditTextDocument> for ::windows::core::IUnknown {
-    fn from(value: RichEditTextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RichEditTextDocument> for ::windows::core::IUnknown {
-    fn from(value: &RichEditTextDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RichEditTextDocument> for &::windows::core::IUnknown {
-    fn from(value: &RichEditTextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RichEditTextDocument> for ::windows::core::IInspectable {
-    fn from(value: RichEditTextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RichEditTextDocument> for ::windows::core::IInspectable {
-    fn from(value: &RichEditTextDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RichEditTextDocument> for &::windows::core::IInspectable {
-    fn from(value: &RichEditTextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RichEditTextDocument, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RichEditTextDocument> for ITextDocument {
     type Error = ::windows::core::Error;
     fn try_from(value: RichEditTextDocument) -> ::windows::core::Result<Self> {
@@ -3143,36 +2911,7 @@ unsafe impl ::windows::core::Interface for RichEditTextRange {
 impl ::windows::core::RuntimeName for RichEditTextRange {
     const NAME: &'static str = "Windows.UI.Text.RichEditTextRange";
 }
-impl ::core::convert::From<RichEditTextRange> for ::windows::core::IUnknown {
-    fn from(value: RichEditTextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RichEditTextRange> for ::windows::core::IUnknown {
-    fn from(value: &RichEditTextRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RichEditTextRange> for &::windows::core::IUnknown {
-    fn from(value: &RichEditTextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RichEditTextRange> for ::windows::core::IInspectable {
-    fn from(value: RichEditTextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RichEditTextRange> for ::windows::core::IInspectable {
-    fn from(value: &RichEditTextRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RichEditTextRange> for &::windows::core::IInspectable {
-    fn from(value: &RichEditTextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RichEditTextRange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<RichEditTextRange> for ITextRange {
     type Error = ::windows::core::Error;
     fn try_from(value: RichEditTextRange) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/UI/UIAutomation/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/UIAutomation/Core/mod.rs
@@ -29,36 +29,7 @@ impl ICoreAutomationConnectionBoundObjectProvider {
         }
     }
 }
-impl ::core::convert::From<ICoreAutomationConnectionBoundObjectProvider> for ::windows::core::IUnknown {
-    fn from(value: ICoreAutomationConnectionBoundObjectProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreAutomationConnectionBoundObjectProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreAutomationConnectionBoundObjectProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreAutomationConnectionBoundObjectProvider> for ::windows::core::IUnknown {
-    fn from(value: &ICoreAutomationConnectionBoundObjectProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICoreAutomationConnectionBoundObjectProvider> for ::windows::core::IInspectable {
-    fn from(value: ICoreAutomationConnectionBoundObjectProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreAutomationConnectionBoundObjectProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICoreAutomationConnectionBoundObjectProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreAutomationConnectionBoundObjectProvider> for ::windows::core::IInspectable {
-    fn from(value: &ICoreAutomationConnectionBoundObjectProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreAutomationConnectionBoundObjectProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICoreAutomationConnectionBoundObjectProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -177,36 +148,7 @@ impl ICoreAutomationRemoteOperationExtensionProvider {
         }
     }
 }
-impl ::core::convert::From<ICoreAutomationRemoteOperationExtensionProvider> for ::windows::core::IUnknown {
-    fn from(value: ICoreAutomationRemoteOperationExtensionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreAutomationRemoteOperationExtensionProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreAutomationRemoteOperationExtensionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreAutomationRemoteOperationExtensionProvider> for ::windows::core::IUnknown {
-    fn from(value: &ICoreAutomationRemoteOperationExtensionProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICoreAutomationRemoteOperationExtensionProvider> for ::windows::core::IInspectable {
-    fn from(value: ICoreAutomationRemoteOperationExtensionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreAutomationRemoteOperationExtensionProvider> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICoreAutomationRemoteOperationExtensionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreAutomationRemoteOperationExtensionProvider> for ::windows::core::IInspectable {
-    fn from(value: &ICoreAutomationRemoteOperationExtensionProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreAutomationRemoteOperationExtensionProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICoreAutomationRemoteOperationExtensionProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -433,36 +375,7 @@ unsafe impl ::windows::core::Interface for AutomationRemoteOperationResult {
 impl ::windows::core::RuntimeName for AutomationRemoteOperationResult {
     const NAME: &'static str = "Windows.UI.UIAutomation.Core.AutomationRemoteOperationResult";
 }
-impl ::core::convert::From<AutomationRemoteOperationResult> for ::windows::core::IUnknown {
-    fn from(value: AutomationRemoteOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationRemoteOperationResult> for ::windows::core::IUnknown {
-    fn from(value: &AutomationRemoteOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationRemoteOperationResult> for &::windows::core::IUnknown {
-    fn from(value: &AutomationRemoteOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AutomationRemoteOperationResult> for ::windows::core::IInspectable {
-    fn from(value: AutomationRemoteOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationRemoteOperationResult> for ::windows::core::IInspectable {
-    fn from(value: &AutomationRemoteOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationRemoteOperationResult> for &::windows::core::IInspectable {
-    fn from(value: &AutomationRemoteOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AutomationRemoteOperationResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AutomationRemoteOperationResult {}
 unsafe impl ::core::marker::Sync for AutomationRemoteOperationResult {}
 #[doc = "*Required features: `\"UI_UIAutomation_Core\"`*"]
@@ -560,36 +473,7 @@ unsafe impl ::windows::core::Interface for CoreAutomationRemoteOperation {
 impl ::windows::core::RuntimeName for CoreAutomationRemoteOperation {
     const NAME: &'static str = "Windows.UI.UIAutomation.Core.CoreAutomationRemoteOperation";
 }
-impl ::core::convert::From<CoreAutomationRemoteOperation> for ::windows::core::IUnknown {
-    fn from(value: CoreAutomationRemoteOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreAutomationRemoteOperation> for ::windows::core::IUnknown {
-    fn from(value: &CoreAutomationRemoteOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreAutomationRemoteOperation> for &::windows::core::IUnknown {
-    fn from(value: &CoreAutomationRemoteOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreAutomationRemoteOperation> for ::windows::core::IInspectable {
-    fn from(value: CoreAutomationRemoteOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreAutomationRemoteOperation> for ::windows::core::IInspectable {
-    fn from(value: &CoreAutomationRemoteOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreAutomationRemoteOperation> for &::windows::core::IInspectable {
-    fn from(value: &CoreAutomationRemoteOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreAutomationRemoteOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreAutomationRemoteOperation {}
 unsafe impl ::core::marker::Sync for CoreAutomationRemoteOperation {}
 #[doc = "*Required features: `\"UI_UIAutomation_Core\"`*"]
@@ -650,36 +534,7 @@ unsafe impl ::windows::core::Interface for CoreAutomationRemoteOperationContext 
 impl ::windows::core::RuntimeName for CoreAutomationRemoteOperationContext {
     const NAME: &'static str = "Windows.UI.UIAutomation.Core.CoreAutomationRemoteOperationContext";
 }
-impl ::core::convert::From<CoreAutomationRemoteOperationContext> for ::windows::core::IUnknown {
-    fn from(value: CoreAutomationRemoteOperationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreAutomationRemoteOperationContext> for ::windows::core::IUnknown {
-    fn from(value: &CoreAutomationRemoteOperationContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreAutomationRemoteOperationContext> for &::windows::core::IUnknown {
-    fn from(value: &CoreAutomationRemoteOperationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreAutomationRemoteOperationContext> for ::windows::core::IInspectable {
-    fn from(value: CoreAutomationRemoteOperationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreAutomationRemoteOperationContext> for ::windows::core::IInspectable {
-    fn from(value: &CoreAutomationRemoteOperationContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreAutomationRemoteOperationContext> for &::windows::core::IInspectable {
-    fn from(value: &CoreAutomationRemoteOperationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreAutomationRemoteOperationContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreAutomationRemoteOperationContext {}
 unsafe impl ::core::marker::Sync for CoreAutomationRemoteOperationContext {}
 #[doc = "*Required features: `\"UI_UIAutomation_Core\"`*"]
@@ -793,36 +648,7 @@ unsafe impl ::windows::core::Interface for RemoteAutomationClientSession {
 impl ::windows::core::RuntimeName for RemoteAutomationClientSession {
     const NAME: &'static str = "Windows.UI.UIAutomation.Core.RemoteAutomationClientSession";
 }
-impl ::core::convert::From<RemoteAutomationClientSession> for ::windows::core::IUnknown {
-    fn from(value: RemoteAutomationClientSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteAutomationClientSession> for ::windows::core::IUnknown {
-    fn from(value: &RemoteAutomationClientSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteAutomationClientSession> for &::windows::core::IUnknown {
-    fn from(value: &RemoteAutomationClientSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteAutomationClientSession> for ::windows::core::IInspectable {
-    fn from(value: RemoteAutomationClientSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteAutomationClientSession> for ::windows::core::IInspectable {
-    fn from(value: &RemoteAutomationClientSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteAutomationClientSession> for &::windows::core::IInspectable {
-    fn from(value: &RemoteAutomationClientSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteAutomationClientSession, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteAutomationClientSession {}
 unsafe impl ::core::marker::Sync for RemoteAutomationClientSession {}
 #[doc = "*Required features: `\"UI_UIAutomation_Core\"`*"]
@@ -876,36 +702,7 @@ unsafe impl ::windows::core::Interface for RemoteAutomationConnectionRequestedEv
 impl ::windows::core::RuntimeName for RemoteAutomationConnectionRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.UIAutomation.Core.RemoteAutomationConnectionRequestedEventArgs";
 }
-impl ::core::convert::From<RemoteAutomationConnectionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteAutomationConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteAutomationConnectionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteAutomationConnectionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteAutomationConnectionRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteAutomationConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteAutomationConnectionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteAutomationConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteAutomationConnectionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteAutomationConnectionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteAutomationConnectionRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteAutomationConnectionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteAutomationConnectionRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteAutomationConnectionRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteAutomationConnectionRequestedEventArgs {}
 #[doc = "*Required features: `\"UI_UIAutomation_Core\"`*"]
@@ -952,36 +749,7 @@ unsafe impl ::windows::core::Interface for RemoteAutomationDisconnectedEventArgs
 impl ::windows::core::RuntimeName for RemoteAutomationDisconnectedEventArgs {
     const NAME: &'static str = "Windows.UI.UIAutomation.Core.RemoteAutomationDisconnectedEventArgs";
 }
-impl ::core::convert::From<RemoteAutomationDisconnectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: RemoteAutomationDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteAutomationDisconnectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &RemoteAutomationDisconnectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteAutomationDisconnectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &RemoteAutomationDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteAutomationDisconnectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: RemoteAutomationDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteAutomationDisconnectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &RemoteAutomationDisconnectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteAutomationDisconnectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &RemoteAutomationDisconnectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteAutomationDisconnectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteAutomationDisconnectedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteAutomationDisconnectedEventArgs {}
 #[doc = "*Required features: `\"UI_UIAutomation_Core\"`*"]
@@ -1052,36 +820,7 @@ unsafe impl ::windows::core::Interface for RemoteAutomationWindow {
 impl ::windows::core::RuntimeName for RemoteAutomationWindow {
     const NAME: &'static str = "Windows.UI.UIAutomation.Core.RemoteAutomationWindow";
 }
-impl ::core::convert::From<RemoteAutomationWindow> for ::windows::core::IUnknown {
-    fn from(value: RemoteAutomationWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteAutomationWindow> for ::windows::core::IUnknown {
-    fn from(value: &RemoteAutomationWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteAutomationWindow> for &::windows::core::IUnknown {
-    fn from(value: &RemoteAutomationWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<RemoteAutomationWindow> for ::windows::core::IInspectable {
-    fn from(value: RemoteAutomationWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&RemoteAutomationWindow> for ::windows::core::IInspectable {
-    fn from(value: &RemoteAutomationWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&RemoteAutomationWindow> for &::windows::core::IInspectable {
-    fn from(value: &RemoteAutomationWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(RemoteAutomationWindow, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for RemoteAutomationWindow {}
 unsafe impl ::core::marker::Sync for RemoteAutomationWindow {}
 #[doc = "*Required features: `\"UI_UIAutomation_Core\"`*"]

--- a/crates/libs/windows/src/Windows/UI/UIAutomation/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/UIAutomation/mod.rs
@@ -121,36 +121,7 @@ unsafe impl ::windows::core::Interface for AutomationConnection {
 impl ::windows::core::RuntimeName for AutomationConnection {
     const NAME: &'static str = "Windows.UI.UIAutomation.AutomationConnection";
 }
-impl ::core::convert::From<AutomationConnection> for ::windows::core::IUnknown {
-    fn from(value: AutomationConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationConnection> for ::windows::core::IUnknown {
-    fn from(value: &AutomationConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationConnection> for &::windows::core::IUnknown {
-    fn from(value: &AutomationConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AutomationConnection> for ::windows::core::IInspectable {
-    fn from(value: AutomationConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationConnection> for ::windows::core::IInspectable {
-    fn from(value: &AutomationConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationConnection> for &::windows::core::IInspectable {
-    fn from(value: &AutomationConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AutomationConnection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AutomationConnection {}
 unsafe impl ::core::marker::Sync for AutomationConnection {}
 #[doc = "*Required features: `\"UI_UIAutomation\"`*"]
@@ -197,36 +168,7 @@ unsafe impl ::windows::core::Interface for AutomationConnectionBoundObject {
 impl ::windows::core::RuntimeName for AutomationConnectionBoundObject {
     const NAME: &'static str = "Windows.UI.UIAutomation.AutomationConnectionBoundObject";
 }
-impl ::core::convert::From<AutomationConnectionBoundObject> for ::windows::core::IUnknown {
-    fn from(value: AutomationConnectionBoundObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationConnectionBoundObject> for ::windows::core::IUnknown {
-    fn from(value: &AutomationConnectionBoundObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationConnectionBoundObject> for &::windows::core::IUnknown {
-    fn from(value: &AutomationConnectionBoundObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AutomationConnectionBoundObject> for ::windows::core::IInspectable {
-    fn from(value: AutomationConnectionBoundObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationConnectionBoundObject> for ::windows::core::IInspectable {
-    fn from(value: &AutomationConnectionBoundObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationConnectionBoundObject> for &::windows::core::IInspectable {
-    fn from(value: &AutomationConnectionBoundObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AutomationConnectionBoundObject, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AutomationConnectionBoundObject {}
 unsafe impl ::core::marker::Sync for AutomationConnectionBoundObject {}
 #[doc = "*Required features: `\"UI_UIAutomation\"`*"]
@@ -287,36 +229,7 @@ unsafe impl ::windows::core::Interface for AutomationElement {
 impl ::windows::core::RuntimeName for AutomationElement {
     const NAME: &'static str = "Windows.UI.UIAutomation.AutomationElement";
 }
-impl ::core::convert::From<AutomationElement> for ::windows::core::IUnknown {
-    fn from(value: AutomationElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationElement> for ::windows::core::IUnknown {
-    fn from(value: &AutomationElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationElement> for &::windows::core::IUnknown {
-    fn from(value: &AutomationElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AutomationElement> for ::windows::core::IInspectable {
-    fn from(value: AutomationElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationElement> for ::windows::core::IInspectable {
-    fn from(value: &AutomationElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationElement> for &::windows::core::IInspectable {
-    fn from(value: &AutomationElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AutomationElement, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AutomationElement {}
 unsafe impl ::core::marker::Sync for AutomationElement {}
 #[doc = "*Required features: `\"UI_UIAutomation\"`*"]
@@ -355,36 +268,7 @@ unsafe impl ::windows::core::Interface for AutomationTextRange {
 impl ::windows::core::RuntimeName for AutomationTextRange {
     const NAME: &'static str = "Windows.UI.UIAutomation.AutomationTextRange";
 }
-impl ::core::convert::From<AutomationTextRange> for ::windows::core::IUnknown {
-    fn from(value: AutomationTextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationTextRange> for ::windows::core::IUnknown {
-    fn from(value: &AutomationTextRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationTextRange> for &::windows::core::IUnknown {
-    fn from(value: &AutomationTextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AutomationTextRange> for ::windows::core::IInspectable {
-    fn from(value: AutomationTextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AutomationTextRange> for ::windows::core::IInspectable {
-    fn from(value: &AutomationTextRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AutomationTextRange> for &::windows::core::IInspectable {
-    fn from(value: &AutomationTextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AutomationTextRange, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AutomationTextRange {}
 unsafe impl ::core::marker::Sync for AutomationTextRange {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/UI/ViewManagement/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ViewManagement/Core/mod.rs
@@ -493,36 +493,7 @@ unsafe impl ::windows::core::Interface for CoreFrameworkInputView {
 impl ::windows::core::RuntimeName for CoreFrameworkInputView {
     const NAME: &'static str = "Windows.UI.ViewManagement.Core.CoreFrameworkInputView";
 }
-impl ::core::convert::From<CoreFrameworkInputView> for ::windows::core::IUnknown {
-    fn from(value: CoreFrameworkInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputView> for ::windows::core::IUnknown {
-    fn from(value: &CoreFrameworkInputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputView> for &::windows::core::IUnknown {
-    fn from(value: &CoreFrameworkInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreFrameworkInputView> for ::windows::core::IInspectable {
-    fn from(value: CoreFrameworkInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputView> for ::windows::core::IInspectable {
-    fn from(value: &CoreFrameworkInputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputView> for &::windows::core::IInspectable {
-    fn from(value: &CoreFrameworkInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreFrameworkInputView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreFrameworkInputView {}
 unsafe impl ::core::marker::Sync for CoreFrameworkInputView {}
 #[doc = "*Required features: `\"UI_ViewManagement_Core\"`*"]
@@ -587,36 +558,7 @@ unsafe impl ::windows::core::Interface for CoreFrameworkInputViewAnimationStarti
 impl ::windows::core::RuntimeName for CoreFrameworkInputViewAnimationStartingEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.Core.CoreFrameworkInputViewAnimationStartingEventArgs";
 }
-impl ::core::convert::From<CoreFrameworkInputViewAnimationStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreFrameworkInputViewAnimationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputViewAnimationStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreFrameworkInputViewAnimationStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputViewAnimationStartingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreFrameworkInputViewAnimationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreFrameworkInputViewAnimationStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreFrameworkInputViewAnimationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputViewAnimationStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreFrameworkInputViewAnimationStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputViewAnimationStartingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreFrameworkInputViewAnimationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreFrameworkInputViewAnimationStartingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreFrameworkInputViewAnimationStartingEventArgs {}
 unsafe impl ::core::marker::Sync for CoreFrameworkInputViewAnimationStartingEventArgs {}
 #[doc = "*Required features: `\"UI_ViewManagement_Core\"`*"]
@@ -672,36 +614,7 @@ unsafe impl ::windows::core::Interface for CoreFrameworkInputViewOcclusionsChang
 impl ::windows::core::RuntimeName for CoreFrameworkInputViewOcclusionsChangedEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.Core.CoreFrameworkInputViewOcclusionsChangedEventArgs";
 }
-impl ::core::convert::From<CoreFrameworkInputViewOcclusionsChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreFrameworkInputViewOcclusionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputViewOcclusionsChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreFrameworkInputViewOcclusionsChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputViewOcclusionsChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreFrameworkInputViewOcclusionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreFrameworkInputViewOcclusionsChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreFrameworkInputViewOcclusionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputViewOcclusionsChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreFrameworkInputViewOcclusionsChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreFrameworkInputViewOcclusionsChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreFrameworkInputViewOcclusionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreFrameworkInputViewOcclusionsChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreFrameworkInputViewOcclusionsChangedEventArgs {}
 unsafe impl ::core::marker::Sync for CoreFrameworkInputViewOcclusionsChangedEventArgs {}
 #[doc = "*Required features: `\"UI_ViewManagement_Core\"`*"]
@@ -928,36 +841,7 @@ unsafe impl ::windows::core::Interface for CoreInputView {
 impl ::windows::core::RuntimeName for CoreInputView {
     const NAME: &'static str = "Windows.UI.ViewManagement.Core.CoreInputView";
 }
-impl ::core::convert::From<CoreInputView> for ::windows::core::IUnknown {
-    fn from(value: CoreInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputView> for ::windows::core::IUnknown {
-    fn from(value: &CoreInputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputView> for &::windows::core::IUnknown {
-    fn from(value: &CoreInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreInputView> for ::windows::core::IInspectable {
-    fn from(value: CoreInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputView> for ::windows::core::IInspectable {
-    fn from(value: &CoreInputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputView> for &::windows::core::IInspectable {
-    fn from(value: &CoreInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreInputView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreInputView {}
 unsafe impl ::core::marker::Sync for CoreInputView {}
 #[doc = "*Required features: `\"UI_ViewManagement_Core\"`*"]
@@ -1026,36 +910,7 @@ unsafe impl ::windows::core::Interface for CoreInputViewAnimationStartingEventAr
 impl ::windows::core::RuntimeName for CoreInputViewAnimationStartingEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.Core.CoreInputViewAnimationStartingEventArgs";
 }
-impl ::core::convert::From<CoreInputViewAnimationStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreInputViewAnimationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewAnimationStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreInputViewAnimationStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewAnimationStartingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreInputViewAnimationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreInputViewAnimationStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreInputViewAnimationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewAnimationStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreInputViewAnimationStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewAnimationStartingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreInputViewAnimationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreInputViewAnimationStartingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreInputViewAnimationStartingEventArgs {}
 unsafe impl ::core::marker::Sync for CoreInputViewAnimationStartingEventArgs {}
 #[doc = "*Required features: `\"UI_ViewManagement_Core\"`*"]
@@ -1102,36 +957,7 @@ unsafe impl ::windows::core::Interface for CoreInputViewHidingEventArgs {
 impl ::windows::core::RuntimeName for CoreInputViewHidingEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.Core.CoreInputViewHidingEventArgs";
 }
-impl ::core::convert::From<CoreInputViewHidingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreInputViewHidingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewHidingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreInputViewHidingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewHidingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreInputViewHidingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreInputViewHidingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreInputViewHidingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewHidingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreInputViewHidingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewHidingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreInputViewHidingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreInputViewHidingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreInputViewHidingEventArgs {}
 unsafe impl ::core::marker::Sync for CoreInputViewHidingEventArgs {}
 #[doc = "*Required features: `\"UI_ViewManagement_Core\"`*"]
@@ -1187,36 +1013,7 @@ unsafe impl ::windows::core::Interface for CoreInputViewOcclusion {
 impl ::windows::core::RuntimeName for CoreInputViewOcclusion {
     const NAME: &'static str = "Windows.UI.ViewManagement.Core.CoreInputViewOcclusion";
 }
-impl ::core::convert::From<CoreInputViewOcclusion> for ::windows::core::IUnknown {
-    fn from(value: CoreInputViewOcclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewOcclusion> for ::windows::core::IUnknown {
-    fn from(value: &CoreInputViewOcclusion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewOcclusion> for &::windows::core::IUnknown {
-    fn from(value: &CoreInputViewOcclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreInputViewOcclusion> for ::windows::core::IInspectable {
-    fn from(value: CoreInputViewOcclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewOcclusion> for ::windows::core::IInspectable {
-    fn from(value: &CoreInputViewOcclusion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewOcclusion> for &::windows::core::IInspectable {
-    fn from(value: &CoreInputViewOcclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreInputViewOcclusion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreInputViewOcclusion {}
 unsafe impl ::core::marker::Sync for CoreInputViewOcclusion {}
 #[doc = "*Required features: `\"UI_ViewManagement_Core\"`*"]
@@ -1276,36 +1073,7 @@ unsafe impl ::windows::core::Interface for CoreInputViewOcclusionsChangedEventAr
 impl ::windows::core::RuntimeName for CoreInputViewOcclusionsChangedEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.Core.CoreInputViewOcclusionsChangedEventArgs";
 }
-impl ::core::convert::From<CoreInputViewOcclusionsChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreInputViewOcclusionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewOcclusionsChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreInputViewOcclusionsChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewOcclusionsChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreInputViewOcclusionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreInputViewOcclusionsChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreInputViewOcclusionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewOcclusionsChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreInputViewOcclusionsChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewOcclusionsChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreInputViewOcclusionsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreInputViewOcclusionsChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreInputViewOcclusionsChangedEventArgs {}
 unsafe impl ::core::marker::Sync for CoreInputViewOcclusionsChangedEventArgs {}
 #[doc = "*Required features: `\"UI_ViewManagement_Core\"`*"]
@@ -1352,36 +1120,7 @@ unsafe impl ::windows::core::Interface for CoreInputViewShowingEventArgs {
 impl ::windows::core::RuntimeName for CoreInputViewShowingEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.Core.CoreInputViewShowingEventArgs";
 }
-impl ::core::convert::From<CoreInputViewShowingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreInputViewShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewShowingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreInputViewShowingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewShowingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreInputViewShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreInputViewShowingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreInputViewShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewShowingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreInputViewShowingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewShowingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreInputViewShowingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreInputViewShowingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreInputViewShowingEventArgs {}
 unsafe impl ::core::marker::Sync for CoreInputViewShowingEventArgs {}
 #[doc = "*Required features: `\"UI_ViewManagement_Core\"`*"]
@@ -1459,36 +1198,7 @@ unsafe impl ::windows::core::Interface for CoreInputViewTransferringXYFocusEvent
 impl ::windows::core::RuntimeName for CoreInputViewTransferringXYFocusEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.Core.CoreInputViewTransferringXYFocusEventArgs";
 }
-impl ::core::convert::From<CoreInputViewTransferringXYFocusEventArgs> for ::windows::core::IUnknown {
-    fn from(value: CoreInputViewTransferringXYFocusEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewTransferringXYFocusEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &CoreInputViewTransferringXYFocusEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewTransferringXYFocusEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &CoreInputViewTransferringXYFocusEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CoreInputViewTransferringXYFocusEventArgs> for ::windows::core::IInspectable {
-    fn from(value: CoreInputViewTransferringXYFocusEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CoreInputViewTransferringXYFocusEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &CoreInputViewTransferringXYFocusEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CoreInputViewTransferringXYFocusEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &CoreInputViewTransferringXYFocusEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CoreInputViewTransferringXYFocusEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for CoreInputViewTransferringXYFocusEventArgs {}
 unsafe impl ::core::marker::Sync for CoreInputViewTransferringXYFocusEventArgs {}
 #[doc = "*Required features: `\"UI_ViewManagement_Core\"`*"]
@@ -1561,36 +1271,7 @@ unsafe impl ::windows::core::Interface for UISettingsController {
 impl ::windows::core::RuntimeName for UISettingsController {
     const NAME: &'static str = "Windows.UI.ViewManagement.Core.UISettingsController";
 }
-impl ::core::convert::From<UISettingsController> for ::windows::core::IUnknown {
-    fn from(value: UISettingsController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UISettingsController> for ::windows::core::IUnknown {
-    fn from(value: &UISettingsController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UISettingsController> for &::windows::core::IUnknown {
-    fn from(value: &UISettingsController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UISettingsController> for ::windows::core::IInspectable {
-    fn from(value: UISettingsController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UISettingsController> for ::windows::core::IInspectable {
-    fn from(value: &UISettingsController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UISettingsController> for &::windows::core::IInspectable {
-    fn from(value: &UISettingsController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UISettingsController, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UISettingsController {}
 unsafe impl ::core::marker::Sync for UISettingsController {}
 #[doc = "*Required features: `\"UI_ViewManagement_Core\"`*"]

--- a/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
@@ -1263,36 +1263,7 @@ unsafe impl ::windows::core::Interface for AccessibilitySettings {
 impl ::windows::core::RuntimeName for AccessibilitySettings {
     const NAME: &'static str = "Windows.UI.ViewManagement.AccessibilitySettings";
 }
-impl ::core::convert::From<AccessibilitySettings> for ::windows::core::IUnknown {
-    fn from(value: AccessibilitySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccessibilitySettings> for ::windows::core::IUnknown {
-    fn from(value: &AccessibilitySettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccessibilitySettings> for &::windows::core::IUnknown {
-    fn from(value: &AccessibilitySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AccessibilitySettings> for ::windows::core::IInspectable {
-    fn from(value: AccessibilitySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AccessibilitySettings> for ::windows::core::IInspectable {
-    fn from(value: &AccessibilitySettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AccessibilitySettings> for &::windows::core::IInspectable {
-    fn from(value: &AccessibilitySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AccessibilitySettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AccessibilitySettings {}
 unsafe impl ::core::marker::Sync for AccessibilitySettings {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -1357,36 +1328,7 @@ unsafe impl ::windows::core::Interface for ActivationViewSwitcher {
 impl ::windows::core::RuntimeName for ActivationViewSwitcher {
     const NAME: &'static str = "Windows.UI.ViewManagement.ActivationViewSwitcher";
 }
-impl ::core::convert::From<ActivationViewSwitcher> for ::windows::core::IUnknown {
-    fn from(value: ActivationViewSwitcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivationViewSwitcher> for ::windows::core::IUnknown {
-    fn from(value: &ActivationViewSwitcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivationViewSwitcher> for &::windows::core::IUnknown {
-    fn from(value: &ActivationViewSwitcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivationViewSwitcher> for ::windows::core::IInspectable {
-    fn from(value: ActivationViewSwitcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivationViewSwitcher> for ::windows::core::IInspectable {
-    fn from(value: &ActivationViewSwitcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivationViewSwitcher> for &::windows::core::IInspectable {
-    fn from(value: &ActivationViewSwitcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivationViewSwitcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ActivationViewSwitcher {}
 unsafe impl ::core::marker::Sync for ActivationViewSwitcher {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -1803,36 +1745,7 @@ unsafe impl ::windows::core::Interface for ApplicationView {
 impl ::windows::core::RuntimeName for ApplicationView {
     const NAME: &'static str = "Windows.UI.ViewManagement.ApplicationView";
 }
-impl ::core::convert::From<ApplicationView> for ::windows::core::IUnknown {
-    fn from(value: ApplicationView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationView> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationView> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ApplicationView> for ::windows::core::IInspectable {
-    fn from(value: ApplicationView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationView> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationView> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ApplicationView {}
 unsafe impl ::core::marker::Sync for ApplicationView {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -1886,36 +1799,7 @@ unsafe impl ::windows::core::Interface for ApplicationViewConsolidatedEventArgs 
 impl ::windows::core::RuntimeName for ApplicationViewConsolidatedEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.ApplicationViewConsolidatedEventArgs";
 }
-impl ::core::convert::From<ApplicationViewConsolidatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: ApplicationViewConsolidatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationViewConsolidatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationViewConsolidatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationViewConsolidatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationViewConsolidatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ApplicationViewConsolidatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: ApplicationViewConsolidatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationViewConsolidatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationViewConsolidatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationViewConsolidatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationViewConsolidatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationViewConsolidatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ApplicationViewConsolidatedEventArgs {}
 unsafe impl ::core::marker::Sync for ApplicationViewConsolidatedEventArgs {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -1972,36 +1856,7 @@ unsafe impl ::windows::core::Interface for ApplicationViewScaling {
 impl ::windows::core::RuntimeName for ApplicationViewScaling {
     const NAME: &'static str = "Windows.UI.ViewManagement.ApplicationViewScaling";
 }
-impl ::core::convert::From<ApplicationViewScaling> for ::windows::core::IUnknown {
-    fn from(value: ApplicationViewScaling) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationViewScaling> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationViewScaling) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationViewScaling> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationViewScaling) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ApplicationViewScaling> for ::windows::core::IInspectable {
-    fn from(value: ApplicationViewScaling) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationViewScaling> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationViewScaling) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationViewScaling> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationViewScaling) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationViewScaling, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
 pub struct ApplicationViewSwitcher;
 impl ApplicationViewSwitcher {
@@ -2367,36 +2222,7 @@ unsafe impl ::windows::core::Interface for ApplicationViewTitleBar {
 impl ::windows::core::RuntimeName for ApplicationViewTitleBar {
     const NAME: &'static str = "Windows.UI.ViewManagement.ApplicationViewTitleBar";
 }
-impl ::core::convert::From<ApplicationViewTitleBar> for ::windows::core::IUnknown {
-    fn from(value: ApplicationViewTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationViewTitleBar> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationViewTitleBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationViewTitleBar> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationViewTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ApplicationViewTitleBar> for ::windows::core::IInspectable {
-    fn from(value: ApplicationViewTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationViewTitleBar> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationViewTitleBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationViewTitleBar> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationViewTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationViewTitleBar, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ApplicationViewTitleBar {}
 unsafe impl ::core::marker::Sync for ApplicationViewTitleBar {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -2465,36 +2291,7 @@ unsafe impl ::windows::core::Interface for ApplicationViewTransferContext {
 impl ::windows::core::RuntimeName for ApplicationViewTransferContext {
     const NAME: &'static str = "Windows.UI.ViewManagement.ApplicationViewTransferContext";
 }
-impl ::core::convert::From<ApplicationViewTransferContext> for ::windows::core::IUnknown {
-    fn from(value: ApplicationViewTransferContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationViewTransferContext> for ::windows::core::IUnknown {
-    fn from(value: &ApplicationViewTransferContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationViewTransferContext> for &::windows::core::IUnknown {
-    fn from(value: &ApplicationViewTransferContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ApplicationViewTransferContext> for ::windows::core::IInspectable {
-    fn from(value: ApplicationViewTransferContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ApplicationViewTransferContext> for ::windows::core::IInspectable {
-    fn from(value: &ApplicationViewTransferContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ApplicationViewTransferContext> for &::windows::core::IInspectable {
-    fn from(value: &ApplicationViewTransferContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ApplicationViewTransferContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
 #[repr(transparent)]
 pub struct InputPane(::windows::core::IUnknown);
@@ -2618,36 +2415,7 @@ unsafe impl ::windows::core::Interface for InputPane {
 impl ::windows::core::RuntimeName for InputPane {
     const NAME: &'static str = "Windows.UI.ViewManagement.InputPane";
 }
-impl ::core::convert::From<InputPane> for ::windows::core::IUnknown {
-    fn from(value: InputPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputPane> for ::windows::core::IUnknown {
-    fn from(value: &InputPane) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputPane> for &::windows::core::IUnknown {
-    fn from(value: &InputPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InputPane> for ::windows::core::IInspectable {
-    fn from(value: InputPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputPane> for ::windows::core::IInspectable {
-    fn from(value: &InputPane) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputPane> for &::windows::core::IInspectable {
-    fn from(value: &InputPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InputPane, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
 #[repr(transparent)]
 pub struct InputPaneVisibilityEventArgs(::windows::core::IUnknown);
@@ -2705,36 +2473,7 @@ unsafe impl ::windows::core::Interface for InputPaneVisibilityEventArgs {
 impl ::windows::core::RuntimeName for InputPaneVisibilityEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.InputPaneVisibilityEventArgs";
 }
-impl ::core::convert::From<InputPaneVisibilityEventArgs> for ::windows::core::IUnknown {
-    fn from(value: InputPaneVisibilityEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputPaneVisibilityEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &InputPaneVisibilityEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputPaneVisibilityEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &InputPaneVisibilityEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<InputPaneVisibilityEventArgs> for ::windows::core::IInspectable {
-    fn from(value: InputPaneVisibilityEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&InputPaneVisibilityEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &InputPaneVisibilityEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&InputPaneVisibilityEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &InputPaneVisibilityEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(InputPaneVisibilityEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
 pub struct ProjectionManager;
 impl ProjectionManager {
@@ -2986,36 +2725,7 @@ unsafe impl ::windows::core::Interface for StatusBar {
 impl ::windows::core::RuntimeName for StatusBar {
     const NAME: &'static str = "Windows.UI.ViewManagement.StatusBar";
 }
-impl ::core::convert::From<StatusBar> for ::windows::core::IUnknown {
-    fn from(value: StatusBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StatusBar> for ::windows::core::IUnknown {
-    fn from(value: &StatusBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StatusBar> for &::windows::core::IUnknown {
-    fn from(value: &StatusBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StatusBar> for ::windows::core::IInspectable {
-    fn from(value: StatusBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StatusBar> for ::windows::core::IInspectable {
-    fn from(value: &StatusBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StatusBar> for &::windows::core::IInspectable {
-    fn from(value: &StatusBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StatusBar, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StatusBar {}
 unsafe impl ::core::marker::Sync for StatusBar {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -3103,36 +2813,7 @@ unsafe impl ::windows::core::Interface for StatusBarProgressIndicator {
 impl ::windows::core::RuntimeName for StatusBarProgressIndicator {
     const NAME: &'static str = "Windows.UI.ViewManagement.StatusBarProgressIndicator";
 }
-impl ::core::convert::From<StatusBarProgressIndicator> for ::windows::core::IUnknown {
-    fn from(value: StatusBarProgressIndicator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StatusBarProgressIndicator> for ::windows::core::IUnknown {
-    fn from(value: &StatusBarProgressIndicator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StatusBarProgressIndicator> for &::windows::core::IUnknown {
-    fn from(value: &StatusBarProgressIndicator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<StatusBarProgressIndicator> for ::windows::core::IInspectable {
-    fn from(value: StatusBarProgressIndicator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&StatusBarProgressIndicator> for ::windows::core::IInspectable {
-    fn from(value: &StatusBarProgressIndicator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&StatusBarProgressIndicator> for &::windows::core::IInspectable {
-    fn from(value: &StatusBarProgressIndicator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(StatusBarProgressIndicator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for StatusBarProgressIndicator {}
 unsafe impl ::core::marker::Sync for StatusBarProgressIndicator {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -3396,36 +3077,7 @@ unsafe impl ::windows::core::Interface for UISettings {
 impl ::windows::core::RuntimeName for UISettings {
     const NAME: &'static str = "Windows.UI.ViewManagement.UISettings";
 }
-impl ::core::convert::From<UISettings> for ::windows::core::IUnknown {
-    fn from(value: UISettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UISettings> for ::windows::core::IUnknown {
-    fn from(value: &UISettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UISettings> for &::windows::core::IUnknown {
-    fn from(value: &UISettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UISettings> for ::windows::core::IInspectable {
-    fn from(value: UISettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UISettings> for ::windows::core::IInspectable {
-    fn from(value: &UISettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UISettings> for &::windows::core::IInspectable {
-    fn from(value: &UISettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UISettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UISettings {}
 unsafe impl ::core::marker::Sync for UISettings {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -3464,36 +3116,7 @@ unsafe impl ::windows::core::Interface for UISettingsAnimationsEnabledChangedEve
 impl ::windows::core::RuntimeName for UISettingsAnimationsEnabledChangedEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.UISettingsAnimationsEnabledChangedEventArgs";
 }
-impl ::core::convert::From<UISettingsAnimationsEnabledChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UISettingsAnimationsEnabledChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UISettingsAnimationsEnabledChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UISettingsAnimationsEnabledChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UISettingsAnimationsEnabledChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UISettingsAnimationsEnabledChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UISettingsAnimationsEnabledChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UISettingsAnimationsEnabledChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UISettingsAnimationsEnabledChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UISettingsAnimationsEnabledChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UISettingsAnimationsEnabledChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UISettingsAnimationsEnabledChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UISettingsAnimationsEnabledChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UISettingsAnimationsEnabledChangedEventArgs {}
 unsafe impl ::core::marker::Sync for UISettingsAnimationsEnabledChangedEventArgs {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -3532,36 +3155,7 @@ unsafe impl ::windows::core::Interface for UISettingsAutoHideScrollBarsChangedEv
 impl ::windows::core::RuntimeName for UISettingsAutoHideScrollBarsChangedEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.UISettingsAutoHideScrollBarsChangedEventArgs";
 }
-impl ::core::convert::From<UISettingsAutoHideScrollBarsChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UISettingsAutoHideScrollBarsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UISettingsAutoHideScrollBarsChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UISettingsAutoHideScrollBarsChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UISettingsAutoHideScrollBarsChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UISettingsAutoHideScrollBarsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UISettingsAutoHideScrollBarsChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UISettingsAutoHideScrollBarsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UISettingsAutoHideScrollBarsChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UISettingsAutoHideScrollBarsChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UISettingsAutoHideScrollBarsChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UISettingsAutoHideScrollBarsChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UISettingsAutoHideScrollBarsChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UISettingsAutoHideScrollBarsChangedEventArgs {}
 unsafe impl ::core::marker::Sync for UISettingsAutoHideScrollBarsChangedEventArgs {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -3600,36 +3194,7 @@ unsafe impl ::windows::core::Interface for UISettingsMessageDurationChangedEvent
 impl ::windows::core::RuntimeName for UISettingsMessageDurationChangedEventArgs {
     const NAME: &'static str = "Windows.UI.ViewManagement.UISettingsMessageDurationChangedEventArgs";
 }
-impl ::core::convert::From<UISettingsMessageDurationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: UISettingsMessageDurationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UISettingsMessageDurationChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &UISettingsMessageDurationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UISettingsMessageDurationChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &UISettingsMessageDurationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UISettingsMessageDurationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: UISettingsMessageDurationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UISettingsMessageDurationChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &UISettingsMessageDurationChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UISettingsMessageDurationChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &UISettingsMessageDurationChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UISettingsMessageDurationChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UISettingsMessageDurationChangedEventArgs {}
 unsafe impl ::core::marker::Sync for UISettingsMessageDurationChangedEventArgs {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -3687,36 +3252,7 @@ unsafe impl ::windows::core::Interface for UIViewSettings {
 impl ::windows::core::RuntimeName for UIViewSettings {
     const NAME: &'static str = "Windows.UI.ViewManagement.UIViewSettings";
 }
-impl ::core::convert::From<UIViewSettings> for ::windows::core::IUnknown {
-    fn from(value: UIViewSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UIViewSettings> for ::windows::core::IUnknown {
-    fn from(value: &UIViewSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UIViewSettings> for &::windows::core::IUnknown {
-    fn from(value: &UIViewSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UIViewSettings> for ::windows::core::IInspectable {
-    fn from(value: UIViewSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UIViewSettings> for ::windows::core::IInspectable {
-    fn from(value: &UIViewSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UIViewSettings> for &::windows::core::IInspectable {
-    fn from(value: &UIViewSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UIViewSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UIViewSettings {}
 unsafe impl ::core::marker::Sync for UIViewSettings {}
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
@@ -3793,36 +3329,7 @@ unsafe impl ::windows::core::Interface for ViewModePreferences {
 impl ::windows::core::RuntimeName for ViewModePreferences {
     const NAME: &'static str = "Windows.UI.ViewManagement.ViewModePreferences";
 }
-impl ::core::convert::From<ViewModePreferences> for ::windows::core::IUnknown {
-    fn from(value: ViewModePreferences) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ViewModePreferences> for ::windows::core::IUnknown {
-    fn from(value: &ViewModePreferences) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ViewModePreferences> for &::windows::core::IUnknown {
-    fn from(value: &ViewModePreferences) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ViewModePreferences> for ::windows::core::IInspectable {
-    fn from(value: ViewModePreferences) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ViewModePreferences> for ::windows::core::IInspectable {
-    fn from(value: &ViewModePreferences) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ViewModePreferences> for &::windows::core::IInspectable {
-    fn from(value: &ViewModePreferences) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ViewModePreferences, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_ViewManagement\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/UI/WebUI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/Core/mod.rs
@@ -128,36 +128,7 @@ pub struct IWebUICommandBarConfirmationButton_Vtbl {
 #[repr(transparent)]
 pub struct IWebUICommandBarElement(::windows::core::IUnknown);
 impl IWebUICommandBarElement {}
-impl ::core::convert::From<IWebUICommandBarElement> for ::windows::core::IUnknown {
-    fn from(value: IWebUICommandBarElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebUICommandBarElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebUICommandBarElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebUICommandBarElement> for ::windows::core::IUnknown {
-    fn from(value: &IWebUICommandBarElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebUICommandBarElement> for ::windows::core::IInspectable {
-    fn from(value: IWebUICommandBarElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebUICommandBarElement> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebUICommandBarElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebUICommandBarElement> for ::windows::core::IInspectable {
-    fn from(value: &IWebUICommandBarElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebUICommandBarElement, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebUICommandBarElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -196,36 +167,7 @@ pub struct IWebUICommandBarElement_Vtbl {
 #[repr(transparent)]
 pub struct IWebUICommandBarIcon(::windows::core::IUnknown);
 impl IWebUICommandBarIcon {}
-impl ::core::convert::From<IWebUICommandBarIcon> for ::windows::core::IUnknown {
-    fn from(value: IWebUICommandBarIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebUICommandBarIcon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebUICommandBarIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebUICommandBarIcon> for ::windows::core::IUnknown {
-    fn from(value: &IWebUICommandBarIcon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebUICommandBarIcon> for ::windows::core::IInspectable {
-    fn from(value: IWebUICommandBarIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebUICommandBarIcon> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebUICommandBarIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebUICommandBarIcon> for ::windows::core::IInspectable {
-    fn from(value: &IWebUICommandBarIcon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebUICommandBarIcon, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebUICommandBarIcon {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -557,36 +499,7 @@ unsafe impl ::windows::core::Interface for WebUICommandBar {
 impl ::windows::core::RuntimeName for WebUICommandBar {
     const NAME: &'static str = "Windows.UI.WebUI.Core.WebUICommandBar";
 }
-impl ::core::convert::From<WebUICommandBar> for ::windows::core::IUnknown {
-    fn from(value: WebUICommandBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBar> for ::windows::core::IUnknown {
-    fn from(value: &WebUICommandBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBar> for &::windows::core::IUnknown {
-    fn from(value: &WebUICommandBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUICommandBar> for ::windows::core::IInspectable {
-    fn from(value: WebUICommandBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBar> for ::windows::core::IInspectable {
-    fn from(value: &WebUICommandBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBar> for &::windows::core::IInspectable {
-    fn from(value: &WebUICommandBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUICommandBar, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebUICommandBar {}
 unsafe impl ::core::marker::Sync for WebUICommandBar {}
 #[doc = "*Required features: `\"UI_WebUI_Core\"`*"]
@@ -661,36 +574,7 @@ unsafe impl ::windows::core::Interface for WebUICommandBarBitmapIcon {
 impl ::windows::core::RuntimeName for WebUICommandBarBitmapIcon {
     const NAME: &'static str = "Windows.UI.WebUI.Core.WebUICommandBarBitmapIcon";
 }
-impl ::core::convert::From<WebUICommandBarBitmapIcon> for ::windows::core::IUnknown {
-    fn from(value: WebUICommandBarBitmapIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarBitmapIcon> for ::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarBitmapIcon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarBitmapIcon> for &::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarBitmapIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUICommandBarBitmapIcon> for ::windows::core::IInspectable {
-    fn from(value: WebUICommandBarBitmapIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarBitmapIcon> for ::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarBitmapIcon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarBitmapIcon> for &::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarBitmapIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUICommandBarBitmapIcon, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebUICommandBarBitmapIcon> for IWebUICommandBarIcon {
     type Error = ::windows::core::Error;
     fn try_from(value: WebUICommandBarBitmapIcon) -> ::windows::core::Result<Self> {
@@ -782,36 +666,7 @@ unsafe impl ::windows::core::Interface for WebUICommandBarConfirmationButton {
 impl ::windows::core::RuntimeName for WebUICommandBarConfirmationButton {
     const NAME: &'static str = "Windows.UI.WebUI.Core.WebUICommandBarConfirmationButton";
 }
-impl ::core::convert::From<WebUICommandBarConfirmationButton> for ::windows::core::IUnknown {
-    fn from(value: WebUICommandBarConfirmationButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarConfirmationButton> for ::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarConfirmationButton) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarConfirmationButton> for &::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarConfirmationButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUICommandBarConfirmationButton> for ::windows::core::IInspectable {
-    fn from(value: WebUICommandBarConfirmationButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarConfirmationButton> for ::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarConfirmationButton) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarConfirmationButton> for &::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarConfirmationButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUICommandBarConfirmationButton, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebUICommandBarConfirmationButton> for IWebUICommandBarElement {
     type Error = ::windows::core::Error;
     fn try_from(value: WebUICommandBarConfirmationButton) -> ::windows::core::Result<Self> {
@@ -951,36 +806,7 @@ unsafe impl ::windows::core::Interface for WebUICommandBarIconButton {
 impl ::windows::core::RuntimeName for WebUICommandBarIconButton {
     const NAME: &'static str = "Windows.UI.WebUI.Core.WebUICommandBarIconButton";
 }
-impl ::core::convert::From<WebUICommandBarIconButton> for ::windows::core::IUnknown {
-    fn from(value: WebUICommandBarIconButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarIconButton> for ::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarIconButton) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarIconButton> for &::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarIconButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUICommandBarIconButton> for ::windows::core::IInspectable {
-    fn from(value: WebUICommandBarIconButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarIconButton> for ::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarIconButton) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarIconButton> for &::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarIconButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUICommandBarIconButton, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebUICommandBarIconButton> for IWebUICommandBarElement {
     type Error = ::windows::core::Error;
     fn try_from(value: WebUICommandBarIconButton) -> ::windows::core::Result<Self> {
@@ -1046,36 +872,7 @@ unsafe impl ::windows::core::Interface for WebUICommandBarItemInvokedEventArgs {
 impl ::windows::core::RuntimeName for WebUICommandBarItemInvokedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.Core.WebUICommandBarItemInvokedEventArgs";
 }
-impl ::core::convert::From<WebUICommandBarItemInvokedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUICommandBarItemInvokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarItemInvokedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarItemInvokedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarItemInvokedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarItemInvokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUICommandBarItemInvokedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUICommandBarItemInvokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarItemInvokedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarItemInvokedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarItemInvokedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarItemInvokedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUICommandBarItemInvokedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebUICommandBarItemInvokedEventArgs {}
 unsafe impl ::core::marker::Sync for WebUICommandBarItemInvokedEventArgs {}
 #[doc = "*Required features: `\"UI_WebUI_Core\"`*"]
@@ -1124,36 +921,7 @@ unsafe impl ::windows::core::Interface for WebUICommandBarSizeChangedEventArgs {
 impl ::windows::core::RuntimeName for WebUICommandBarSizeChangedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.Core.WebUICommandBarSizeChangedEventArgs";
 }
-impl ::core::convert::From<WebUICommandBarSizeChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUICommandBarSizeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarSizeChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarSizeChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarSizeChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarSizeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUICommandBarSizeChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUICommandBarSizeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarSizeChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarSizeChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarSizeChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarSizeChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUICommandBarSizeChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WebUICommandBarSizeChangedEventArgs {}
 unsafe impl ::core::marker::Sync for WebUICommandBarSizeChangedEventArgs {}
 #[doc = "*Required features: `\"UI_WebUI_Core\"`*"]
@@ -1222,36 +990,7 @@ unsafe impl ::windows::core::Interface for WebUICommandBarSymbolIcon {
 impl ::windows::core::RuntimeName for WebUICommandBarSymbolIcon {
     const NAME: &'static str = "Windows.UI.WebUI.Core.WebUICommandBarSymbolIcon";
 }
-impl ::core::convert::From<WebUICommandBarSymbolIcon> for ::windows::core::IUnknown {
-    fn from(value: WebUICommandBarSymbolIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarSymbolIcon> for ::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarSymbolIcon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarSymbolIcon> for &::windows::core::IUnknown {
-    fn from(value: &WebUICommandBarSymbolIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUICommandBarSymbolIcon> for ::windows::core::IInspectable {
-    fn from(value: WebUICommandBarSymbolIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUICommandBarSymbolIcon> for ::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarSymbolIcon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUICommandBarSymbolIcon> for &::windows::core::IInspectable {
-    fn from(value: &WebUICommandBarSymbolIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUICommandBarSymbolIcon, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebUICommandBarSymbolIcon> for IWebUICommandBarIcon {
     type Error = ::windows::core::Error;
     fn try_from(value: WebUICommandBarSymbolIcon) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
@@ -27,36 +27,7 @@ impl IActivatedEventArgsDeferral {
         }
     }
 }
-impl ::core::convert::From<IActivatedEventArgsDeferral> for ::windows::core::IUnknown {
-    fn from(value: IActivatedEventArgsDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActivatedEventArgsDeferral> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActivatedEventArgsDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActivatedEventArgsDeferral> for ::windows::core::IUnknown {
-    fn from(value: &IActivatedEventArgsDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActivatedEventArgsDeferral> for ::windows::core::IInspectable {
-    fn from(value: IActivatedEventArgsDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActivatedEventArgsDeferral> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IActivatedEventArgsDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActivatedEventArgsDeferral> for ::windows::core::IInspectable {
-    fn from(value: &IActivatedEventArgsDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActivatedEventArgsDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IActivatedEventArgsDeferral {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -308,36 +279,7 @@ impl IWebUIBackgroundTaskInstance {
         unsafe { (::windows::core::Vtable::vtable(this).SetSucceeded)(::windows::core::Vtable::as_raw(this), succeeded).ok() }
     }
 }
-impl ::core::convert::From<IWebUIBackgroundTaskInstance> for ::windows::core::IUnknown {
-    fn from(value: IWebUIBackgroundTaskInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebUIBackgroundTaskInstance> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebUIBackgroundTaskInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebUIBackgroundTaskInstance> for ::windows::core::IUnknown {
-    fn from(value: &IWebUIBackgroundTaskInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebUIBackgroundTaskInstance> for ::windows::core::IInspectable {
-    fn from(value: IWebUIBackgroundTaskInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebUIBackgroundTaskInstance> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebUIBackgroundTaskInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebUIBackgroundTaskInstance> for ::windows::core::IInspectable {
-    fn from(value: &IWebUIBackgroundTaskInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebUIBackgroundTaskInstance, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebUIBackgroundTaskInstance {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -416,36 +358,7 @@ impl IWebUINavigatedEventArgs {
         }
     }
 }
-impl ::core::convert::From<IWebUINavigatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IWebUINavigatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebUINavigatedEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebUINavigatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebUINavigatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IWebUINavigatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebUINavigatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: IWebUINavigatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebUINavigatedEventArgs> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebUINavigatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebUINavigatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &IWebUINavigatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebUINavigatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebUINavigatedEventArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -592,36 +505,7 @@ unsafe impl ::windows::core::Interface for ActivatedDeferral {
 impl ::windows::core::RuntimeName for ActivatedDeferral {
     const NAME: &'static str = "Windows.UI.WebUI.ActivatedDeferral";
 }
-impl ::core::convert::From<ActivatedDeferral> for ::windows::core::IUnknown {
-    fn from(value: ActivatedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivatedDeferral> for ::windows::core::IUnknown {
-    fn from(value: &ActivatedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivatedDeferral> for &::windows::core::IUnknown {
-    fn from(value: &ActivatedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivatedDeferral> for ::windows::core::IInspectable {
-    fn from(value: ActivatedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivatedDeferral> for ::windows::core::IInspectable {
-    fn from(value: &ActivatedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivatedDeferral> for &::windows::core::IInspectable {
-    fn from(value: &ActivatedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivatedDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_WebUI\"`*"]
 #[repr(transparent)]
 pub struct ActivatedOperation(::windows::core::IUnknown);
@@ -666,36 +550,7 @@ unsafe impl ::windows::core::Interface for ActivatedOperation {
 impl ::windows::core::RuntimeName for ActivatedOperation {
     const NAME: &'static str = "Windows.UI.WebUI.ActivatedOperation";
 }
-impl ::core::convert::From<ActivatedOperation> for ::windows::core::IUnknown {
-    fn from(value: ActivatedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivatedOperation> for ::windows::core::IUnknown {
-    fn from(value: &ActivatedOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivatedOperation> for &::windows::core::IUnknown {
-    fn from(value: &ActivatedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ActivatedOperation> for ::windows::core::IInspectable {
-    fn from(value: ActivatedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ActivatedOperation> for ::windows::core::IInspectable {
-    fn from(value: &ActivatedOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ActivatedOperation> for &::windows::core::IInspectable {
-    fn from(value: &ActivatedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ActivatedOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_WebUI\"`, `\"ApplicationModel_Activation\"`*"]
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
@@ -753,41 +608,7 @@ impl ::windows::core::RuntimeName for BackgroundActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.BackgroundActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<BackgroundActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: BackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&BackgroundActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &BackgroundActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&BackgroundActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &BackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<BackgroundActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: BackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&BackgroundActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &BackgroundActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&BackgroundActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &BackgroundActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(BackgroundActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<BackgroundActivatedEventArgs> for super::super::ApplicationModel::Activation::IBackgroundActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -871,41 +692,7 @@ impl ::windows::core::RuntimeName for EnteredBackgroundEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.EnteredBackgroundEventArgs";
 }
 #[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<EnteredBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: EnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&EnteredBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &EnteredBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&EnteredBackgroundEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &EnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<EnteredBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: EnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&EnteredBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &EnteredBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&EnteredBackgroundEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &EnteredBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(EnteredBackgroundEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel")]
 impl ::core::convert::TryFrom<EnteredBackgroundEventArgs> for super::super::ApplicationModel::IEnteredBackgroundEventArgs {
     type Error = ::windows::core::Error;
@@ -1077,36 +864,7 @@ unsafe impl ::windows::core::Interface for HtmlPrintDocumentSource {
 impl ::windows::core::RuntimeName for HtmlPrintDocumentSource {
     const NAME: &'static str = "Windows.UI.WebUI.HtmlPrintDocumentSource";
 }
-impl ::core::convert::From<HtmlPrintDocumentSource> for ::windows::core::IUnknown {
-    fn from(value: HtmlPrintDocumentSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HtmlPrintDocumentSource> for ::windows::core::IUnknown {
-    fn from(value: &HtmlPrintDocumentSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HtmlPrintDocumentSource> for &::windows::core::IUnknown {
-    fn from(value: &HtmlPrintDocumentSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HtmlPrintDocumentSource> for ::windows::core::IInspectable {
-    fn from(value: HtmlPrintDocumentSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HtmlPrintDocumentSource> for ::windows::core::IInspectable {
-    fn from(value: &HtmlPrintDocumentSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HtmlPrintDocumentSource> for &::windows::core::IInspectable {
-    fn from(value: &HtmlPrintDocumentSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HtmlPrintDocumentSource, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HtmlPrintDocumentSource> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1210,41 +968,7 @@ impl ::windows::core::RuntimeName for LeavingBackgroundEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.LeavingBackgroundEventArgs";
 }
 #[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<LeavingBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: LeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&LeavingBackgroundEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &LeavingBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&LeavingBackgroundEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &LeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<LeavingBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: LeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&LeavingBackgroundEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &LeavingBackgroundEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&LeavingBackgroundEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &LeavingBackgroundEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(LeavingBackgroundEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel")]
 impl ::core::convert::TryFrom<LeavingBackgroundEventArgs> for super::super::ApplicationModel::ILeavingBackgroundEventArgs {
     type Error = ::windows::core::Error;
@@ -1340,36 +1064,7 @@ unsafe impl ::windows::core::Interface for NewWebUIViewCreatedEventArgs {
 impl ::windows::core::RuntimeName for NewWebUIViewCreatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.NewWebUIViewCreatedEventArgs";
 }
-impl ::core::convert::From<NewWebUIViewCreatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: NewWebUIViewCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NewWebUIViewCreatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &NewWebUIViewCreatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NewWebUIViewCreatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &NewWebUIViewCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<NewWebUIViewCreatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: NewWebUIViewCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&NewWebUIViewCreatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &NewWebUIViewCreatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&NewWebUIViewCreatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &NewWebUIViewCreatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(NewWebUIViewCreatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_WebUI\"`, `\"ApplicationModel\"`*"]
 #[cfg(feature = "ApplicationModel")]
 #[repr(transparent)]
@@ -1424,41 +1119,7 @@ impl ::windows::core::RuntimeName for SuspendingDeferral {
     const NAME: &'static str = "Windows.UI.WebUI.SuspendingDeferral";
 }
 #[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<SuspendingDeferral> for ::windows::core::IUnknown {
-    fn from(value: SuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingDeferral> for ::windows::core::IUnknown {
-    fn from(value: &SuspendingDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingDeferral> for &::windows::core::IUnknown {
-    fn from(value: &SuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<SuspendingDeferral> for ::windows::core::IInspectable {
-    fn from(value: SuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingDeferral> for ::windows::core::IInspectable {
-    fn from(value: &SuspendingDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingDeferral> for &::windows::core::IInspectable {
-    fn from(value: &SuspendingDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SuspendingDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel")]
 impl ::core::convert::TryFrom<SuspendingDeferral> for super::super::ApplicationModel::ISuspendingDeferral {
     type Error = ::windows::core::Error;
@@ -1538,41 +1199,7 @@ impl ::windows::core::RuntimeName for SuspendingEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.SuspendingEventArgs";
 }
 #[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<SuspendingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: SuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &SuspendingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &SuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<SuspendingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: SuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &SuspendingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &SuspendingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SuspendingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel")]
 impl ::core::convert::TryFrom<SuspendingEventArgs> for super::super::ApplicationModel::ISuspendingEventArgs {
     type Error = ::windows::core::Error;
@@ -1661,41 +1288,7 @@ impl ::windows::core::RuntimeName for SuspendingOperation {
     const NAME: &'static str = "Windows.UI.WebUI.SuspendingOperation";
 }
 #[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<SuspendingOperation> for ::windows::core::IUnknown {
-    fn from(value: SuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingOperation> for ::windows::core::IUnknown {
-    fn from(value: &SuspendingOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingOperation> for &::windows::core::IUnknown {
-    fn from(value: &SuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<SuspendingOperation> for ::windows::core::IInspectable {
-    fn from(value: SuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingOperation> for ::windows::core::IInspectable {
-    fn from(value: &SuspendingOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel")]
-impl ::core::convert::From<&SuspendingOperation> for &::windows::core::IInspectable {
-    fn from(value: &SuspendingOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SuspendingOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel")]
 impl ::core::convert::TryFrom<SuspendingOperation> for super::super::ApplicationModel::ISuspendingOperation {
     type Error = ::windows::core::Error;
@@ -1977,41 +1570,7 @@ impl ::windows::core::RuntimeName for WebUIAppointmentsProviderAddAppointmentAct
     const NAME: &'static str = "Windows.UI.WebUI.WebUIAppointmentsProviderAddAppointmentActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIAppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderAddAppointmentActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIAppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderAddAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderAddAppointmentActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIAppointmentsProviderAddAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIAppointmentsProviderAddAppointmentActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIAppointmentsProviderAddAppointmentActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -2231,41 +1790,7 @@ impl ::windows::core::RuntimeName for WebUIAppointmentsProviderRemoveAppointment
     const NAME: &'static str = "Windows.UI.WebUI.WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -2485,41 +2010,7 @@ impl ::windows::core::RuntimeName for WebUIAppointmentsProviderReplaceAppointmen
     const NAME: &'static str = "Windows.UI.WebUI.WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -2757,41 +2248,7 @@ impl ::windows::core::RuntimeName for WebUIAppointmentsProviderShowAppointmentDe
     const NAME: &'static str = "Windows.UI.WebUI.WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -3020,41 +2477,7 @@ impl ::windows::core::RuntimeName for WebUIAppointmentsProviderShowTimeFrameActi
     const NAME: &'static str = "Windows.UI.WebUI.WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -3306,36 +2729,7 @@ unsafe impl ::windows::core::Interface for WebUIBackgroundTaskInstanceRuntimeCla
 impl ::windows::core::RuntimeName for WebUIBackgroundTaskInstanceRuntimeClass {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIBackgroundTaskInstanceRuntimeClass";
 }
-impl ::core::convert::From<WebUIBackgroundTaskInstanceRuntimeClass> for ::windows::core::IUnknown {
-    fn from(value: WebUIBackgroundTaskInstanceRuntimeClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUIBackgroundTaskInstanceRuntimeClass> for ::windows::core::IUnknown {
-    fn from(value: &WebUIBackgroundTaskInstanceRuntimeClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUIBackgroundTaskInstanceRuntimeClass> for &::windows::core::IUnknown {
-    fn from(value: &WebUIBackgroundTaskInstanceRuntimeClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUIBackgroundTaskInstanceRuntimeClass> for ::windows::core::IInspectable {
-    fn from(value: WebUIBackgroundTaskInstanceRuntimeClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUIBackgroundTaskInstanceRuntimeClass> for ::windows::core::IInspectable {
-    fn from(value: &WebUIBackgroundTaskInstanceRuntimeClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUIBackgroundTaskInstanceRuntimeClass> for &::windows::core::IInspectable {
-    fn from(value: &WebUIBackgroundTaskInstanceRuntimeClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIBackgroundTaskInstanceRuntimeClass, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Background")]
 impl ::core::convert::TryFrom<WebUIBackgroundTaskInstanceRuntimeClass> for super::super::ApplicationModel::Background::IBackgroundTaskInstance {
     type Error = ::windows::core::Error;
@@ -3477,41 +2871,7 @@ impl ::windows::core::RuntimeName for WebUIBarcodeScannerPreviewActivatedEventAr
     const NAME: &'static str = "Windows.UI.WebUI.WebUIBarcodeScannerPreviewActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIBarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIBarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIBarcodeScannerPreviewActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIBarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIBarcodeScannerPreviewActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIBarcodeScannerPreviewActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIBarcodeScannerPreviewActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIBarcodeScannerPreviewActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIBarcodeScannerPreviewActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -3704,41 +3064,7 @@ impl ::windows::core::RuntimeName for WebUICachedFileUpdaterActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUICachedFileUpdaterActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUICachedFileUpdaterActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUICachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICachedFileUpdaterActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUICachedFileUpdaterActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICachedFileUpdaterActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUICachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUICachedFileUpdaterActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUICachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICachedFileUpdaterActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUICachedFileUpdaterActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICachedFileUpdaterActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUICachedFileUpdaterActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUICachedFileUpdaterActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUICachedFileUpdaterActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -3927,41 +3253,7 @@ impl ::windows::core::RuntimeName for WebUICameraSettingsActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUICameraSettingsActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUICameraSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUICameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICameraSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUICameraSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICameraSettingsActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUICameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUICameraSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUICameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICameraSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUICameraSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICameraSettingsActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUICameraSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUICameraSettingsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUICameraSettingsActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -4128,41 +3420,7 @@ impl ::windows::core::RuntimeName for WebUICommandLineActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUICommandLineActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUICommandLineActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUICommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICommandLineActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUICommandLineActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICommandLineActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUICommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUICommandLineActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUICommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICommandLineActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUICommandLineActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUICommandLineActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUICommandLineActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUICommandLineActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUICommandLineActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -4373,41 +3631,7 @@ impl ::windows::core::RuntimeName for WebUIContactCallActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIContactCallActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIContactCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactCallActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIContactCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactCallActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIContactCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIContactCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIContactCallActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -4605,41 +3829,7 @@ impl ::windows::core::RuntimeName for WebUIContactMapActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIContactMapActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactMapActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactMapActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIContactMapActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactMapActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactMapActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactMapActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIContactMapActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactMapActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIContactMapActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIContactMapActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIContactMapActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -4846,41 +4036,7 @@ impl ::windows::core::RuntimeName for WebUIContactMessageActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIContactMessageActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactMessageActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactMessageActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIContactMessageActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactMessageActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactMessageActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactMessageActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIContactMessageActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactMessageActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIContactMessageActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIContactMessageActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIContactMessageActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -5078,41 +4234,7 @@ impl ::windows::core::RuntimeName for WebUIContactPanelActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIContactPanelActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactPanelActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPanelActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIContactPanelActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPanelActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactPanelActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPanelActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIContactPanelActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPanelActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIContactPanelActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIContactPanelActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIContactPanelActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -5296,41 +4418,7 @@ impl ::windows::core::RuntimeName for WebUIContactPickerActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIContactPickerActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIContactPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPickerActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIContactPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPickerActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIContactPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIContactPickerActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIContactPickerActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -5515,41 +4603,7 @@ impl ::windows::core::RuntimeName for WebUIContactPostActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIContactPostActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactPostActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPostActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIContactPostActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPostActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactPostActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPostActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIContactPostActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactPostActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIContactPostActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIContactPostActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIContactPostActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -5756,41 +4810,7 @@ impl ::windows::core::RuntimeName for WebUIContactVideoCallActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIContactVideoCallActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactVideoCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactVideoCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIContactVideoCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactVideoCallActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIContactVideoCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactVideoCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIContactVideoCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIContactVideoCallActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIContactVideoCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIContactVideoCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIContactVideoCallActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -5997,41 +5017,7 @@ impl ::windows::core::RuntimeName for WebUIDeviceActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIDeviceActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIDeviceActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIDeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDeviceActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIDeviceActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDeviceActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIDeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIDeviceActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIDeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDeviceActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIDeviceActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDeviceActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIDeviceActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIDeviceActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIDeviceActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -6242,41 +5228,7 @@ impl ::windows::core::RuntimeName for WebUIDevicePairingActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIDevicePairingActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIDevicePairingActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIDevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDevicePairingActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIDevicePairingActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDevicePairingActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIDevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIDevicePairingActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIDevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDevicePairingActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIDevicePairingActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDevicePairingActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIDevicePairingActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIDevicePairingActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIDevicePairingActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -6492,41 +5444,7 @@ impl ::windows::core::RuntimeName for WebUIDialReceiverActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIDialReceiverActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIDialReceiverActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIDialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDialReceiverActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIDialReceiverActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDialReceiverActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIDialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIDialReceiverActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIDialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDialReceiverActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIDialReceiverActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIDialReceiverActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIDialReceiverActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIDialReceiverActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIDialReceiverActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -6786,41 +5704,7 @@ impl ::windows::core::RuntimeName for WebUIFileActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIFileActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIFileActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIFileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIFileActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIFileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIFileActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIFileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIFileActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIFileActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIFileActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIFileActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -7062,41 +5946,7 @@ impl ::windows::core::RuntimeName for WebUIFileOpenPickerActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIFileOpenPickerActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIFileOpenPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIFileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileOpenPickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIFileOpenPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileOpenPickerActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIFileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIFileOpenPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIFileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileOpenPickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIFileOpenPickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileOpenPickerActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIFileOpenPickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIFileOpenPickerActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIFileOpenPickerActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -7316,41 +6166,7 @@ impl ::windows::core::RuntimeName for WebUIFileOpenPickerContinuationEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIFileOpenPickerContinuationEventArgs";
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<WebUIFileOpenPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIFileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFileOpenPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIFileOpenPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFileOpenPickerContinuationEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIFileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<WebUIFileOpenPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIFileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFileOpenPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIFileOpenPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFileOpenPickerContinuationEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIFileOpenPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIFileOpenPickerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<WebUIFileOpenPickerContinuationEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -7579,41 +6395,7 @@ impl ::windows::core::RuntimeName for WebUIFileSavePickerActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIFileSavePickerActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIFileSavePickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIFileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileSavePickerActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIFileSavePickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileSavePickerActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIFileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIFileSavePickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIFileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileSavePickerActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIFileSavePickerActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIFileSavePickerActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIFileSavePickerActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIFileSavePickerActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIFileSavePickerActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -7833,41 +6615,7 @@ impl ::windows::core::RuntimeName for WebUIFileSavePickerContinuationEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIFileSavePickerContinuationEventArgs";
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<WebUIFileSavePickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIFileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFileSavePickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIFileSavePickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFileSavePickerContinuationEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIFileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<WebUIFileSavePickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIFileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFileSavePickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIFileSavePickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFileSavePickerContinuationEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIFileSavePickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIFileSavePickerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<WebUIFileSavePickerContinuationEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -8087,41 +6835,7 @@ impl ::windows::core::RuntimeName for WebUIFolderPickerContinuationEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIFolderPickerContinuationEventArgs";
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<WebUIFolderPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIFolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFolderPickerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIFolderPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFolderPickerContinuationEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIFolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<WebUIFolderPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIFolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFolderPickerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIFolderPickerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
-impl ::core::convert::From<&WebUIFolderPickerContinuationEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIFolderPickerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIFolderPickerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 impl ::core::convert::TryFrom<WebUIFolderPickerContinuationEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -8368,41 +7082,7 @@ impl ::windows::core::RuntimeName for WebUILaunchActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUILaunchActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUILaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUILaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUILaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILaunchActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUILaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUILaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUILaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUILaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILaunchActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUILaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUILaunchActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUILaunchActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -8666,41 +7346,7 @@ impl ::windows::core::RuntimeName for WebUILockScreenActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUILockScreenActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUILockScreenActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUILockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUILockScreenActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUILockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUILockScreenActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUILockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUILockScreenActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUILockScreenActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUILockScreenActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUILockScreenActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -8929,41 +7575,7 @@ impl ::windows::core::RuntimeName for WebUILockScreenCallActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUILockScreenCallActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUILockScreenCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUILockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUILockScreenCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenCallActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUILockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUILockScreenCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUILockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUILockScreenCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenCallActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUILockScreenCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUILockScreenCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUILockScreenCallActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -9156,41 +7768,7 @@ impl ::windows::core::RuntimeName for WebUILockScreenComponentActivatedEventArgs
     const NAME: &'static str = "Windows.UI.WebUI.WebUILockScreenComponentActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUILockScreenComponentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUILockScreenComponentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenComponentActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUILockScreenComponentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenComponentActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUILockScreenComponentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUILockScreenComponentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUILockScreenComponentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenComponentActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUILockScreenComponentActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUILockScreenComponentActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUILockScreenComponentActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUILockScreenComponentActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUILockScreenComponentActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -9276,36 +7854,7 @@ unsafe impl ::windows::core::Interface for WebUINavigatedDeferral {
 impl ::windows::core::RuntimeName for WebUINavigatedDeferral {
     const NAME: &'static str = "Windows.UI.WebUI.WebUINavigatedDeferral";
 }
-impl ::core::convert::From<WebUINavigatedDeferral> for ::windows::core::IUnknown {
-    fn from(value: WebUINavigatedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUINavigatedDeferral> for ::windows::core::IUnknown {
-    fn from(value: &WebUINavigatedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUINavigatedDeferral> for &::windows::core::IUnknown {
-    fn from(value: &WebUINavigatedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUINavigatedDeferral> for ::windows::core::IInspectable {
-    fn from(value: WebUINavigatedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUINavigatedDeferral> for ::windows::core::IInspectable {
-    fn from(value: &WebUINavigatedDeferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUINavigatedDeferral> for &::windows::core::IInspectable {
-    fn from(value: &WebUINavigatedDeferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUINavigatedDeferral, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_WebUI\"`*"]
 #[repr(transparent)]
 pub struct WebUINavigatedEventArgs(::windows::core::IUnknown);
@@ -9350,36 +7899,7 @@ unsafe impl ::windows::core::Interface for WebUINavigatedEventArgs {
 impl ::windows::core::RuntimeName for WebUINavigatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUINavigatedEventArgs";
 }
-impl ::core::convert::From<WebUINavigatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUINavigatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUINavigatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUINavigatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUINavigatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUINavigatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUINavigatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUINavigatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUINavigatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUINavigatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUINavigatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUINavigatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUINavigatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebUINavigatedEventArgs> for IWebUINavigatedEventArgs {
     type Error = ::windows::core::Error;
     fn try_from(value: WebUINavigatedEventArgs) -> ::windows::core::Result<Self> {
@@ -9443,36 +7963,7 @@ unsafe impl ::windows::core::Interface for WebUINavigatedOperation {
 impl ::windows::core::RuntimeName for WebUINavigatedOperation {
     const NAME: &'static str = "Windows.UI.WebUI.WebUINavigatedOperation";
 }
-impl ::core::convert::From<WebUINavigatedOperation> for ::windows::core::IUnknown {
-    fn from(value: WebUINavigatedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUINavigatedOperation> for ::windows::core::IUnknown {
-    fn from(value: &WebUINavigatedOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUINavigatedOperation> for &::windows::core::IUnknown {
-    fn from(value: &WebUINavigatedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUINavigatedOperation> for ::windows::core::IInspectable {
-    fn from(value: WebUINavigatedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUINavigatedOperation> for ::windows::core::IInspectable {
-    fn from(value: &WebUINavigatedOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUINavigatedOperation> for &::windows::core::IInspectable {
-    fn from(value: &WebUINavigatedOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUINavigatedOperation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"UI_WebUI\"`, `\"ApplicationModel_Activation\"`*"]
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
@@ -9573,41 +8064,7 @@ impl ::windows::core::RuntimeName for WebUIPhoneCallActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIPhoneCallActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIPhoneCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIPhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPhoneCallActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIPhoneCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPhoneCallActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIPhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIPhoneCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIPhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPhoneCallActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIPhoneCallActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPhoneCallActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIPhoneCallActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIPhoneCallActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIPhoneCallActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -9791,41 +8248,7 @@ impl ::windows::core::RuntimeName for WebUIPrint3DWorkflowActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIPrint3DWorkflowActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIPrint3DWorkflowActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIPrint3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrint3DWorkflowActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIPrint3DWorkflowActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrint3DWorkflowActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIPrint3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIPrint3DWorkflowActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIPrint3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrint3DWorkflowActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIPrint3DWorkflowActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrint3DWorkflowActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIPrint3DWorkflowActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIPrint3DWorkflowActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIPrint3DWorkflowActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -9983,41 +8406,7 @@ impl ::windows::core::RuntimeName for WebUIPrintTaskSettingsActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIPrintTaskSettingsActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIPrintTaskSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIPrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrintTaskSettingsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIPrintTaskSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrintTaskSettingsActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIPrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIPrintTaskSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIPrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrintTaskSettingsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIPrintTaskSettingsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrintTaskSettingsActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIPrintTaskSettingsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIPrintTaskSettingsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIPrintTaskSettingsActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -10166,41 +8555,7 @@ impl ::windows::core::RuntimeName for WebUIPrintWorkflowForegroundTaskActivatedE
     const NAME: &'static str = "Windows.UI.WebUI.WebUIPrintWorkflowForegroundTaskActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIPrintWorkflowForegroundTaskActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIPrintWorkflowForegroundTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrintWorkflowForegroundTaskActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIPrintWorkflowForegroundTaskActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrintWorkflowForegroundTaskActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIPrintWorkflowForegroundTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIPrintWorkflowForegroundTaskActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIPrintWorkflowForegroundTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrintWorkflowForegroundTaskActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIPrintWorkflowForegroundTaskActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIPrintWorkflowForegroundTaskActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIPrintWorkflowForegroundTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIPrintWorkflowForegroundTaskActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIPrintWorkflowForegroundTaskActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -10372,41 +8727,7 @@ impl ::windows::core::RuntimeName for WebUIProtocolActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIProtocolActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIProtocolActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIProtocolActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIProtocolActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIProtocolActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIProtocolActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIProtocolActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIProtocolActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIProtocolActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIProtocolActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIProtocolActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIProtocolActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -10675,41 +8996,7 @@ impl ::windows::core::RuntimeName for WebUIProtocolForResultsActivatedEventArgs 
     const NAME: &'static str = "Windows.UI.WebUI.WebUIProtocolForResultsActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIProtocolForResultsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIProtocolForResultsActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIProtocolForResultsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIProtocolForResultsActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIProtocolForResultsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIProtocolForResultsActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIProtocolForResultsActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIProtocolForResultsActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIProtocolForResultsActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIProtocolForResultsActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIProtocolForResultsActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -10964,41 +9251,7 @@ impl ::windows::core::RuntimeName for WebUIRestrictedLaunchActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIRestrictedLaunchActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIRestrictedLaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIRestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIRestrictedLaunchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIRestrictedLaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIRestrictedLaunchActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIRestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIRestrictedLaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIRestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIRestrictedLaunchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIRestrictedLaunchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIRestrictedLaunchActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIRestrictedLaunchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIRestrictedLaunchActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIRestrictedLaunchActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -11205,41 +9458,7 @@ impl ::windows::core::RuntimeName for WebUISearchActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUISearchActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUISearchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUISearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUISearchActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUISearchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUISearchActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUISearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUISearchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUISearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUISearchActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUISearchActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUISearchActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUISearchActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUISearchActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUISearchActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -11450,41 +9669,7 @@ impl ::windows::core::RuntimeName for WebUIShareTargetActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIShareTargetActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIShareTargetActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIShareTargetActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIShareTargetActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIShareTargetActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIShareTargetActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIShareTargetActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIShareTargetActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIShareTargetActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIShareTargetActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIShareTargetActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIShareTargetActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -11673,41 +9858,7 @@ impl ::windows::core::RuntimeName for WebUIStartupTaskActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIStartupTaskActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIStartupTaskActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIStartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIStartupTaskActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIStartupTaskActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIStartupTaskActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIStartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIStartupTaskActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIStartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIStartupTaskActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIStartupTaskActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIStartupTaskActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIStartupTaskActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIStartupTaskActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIStartupTaskActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -11909,41 +10060,7 @@ impl ::windows::core::RuntimeName for WebUIToastNotificationActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIToastNotificationActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIToastNotificationActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIToastNotificationActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIToastNotificationActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIToastNotificationActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIToastNotificationActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIToastNotificationActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIToastNotificationActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIToastNotificationActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIToastNotificationActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIToastNotificationActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIToastNotificationActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -12123,41 +10240,7 @@ impl ::windows::core::RuntimeName for WebUIUserDataAccountProviderActivatedEvent
     const NAME: &'static str = "Windows.UI.WebUI.WebUIUserDataAccountProviderActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIUserDataAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIUserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIUserDataAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIUserDataAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIUserDataAccountProviderActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIUserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIUserDataAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIUserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIUserDataAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIUserDataAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIUserDataAccountProviderActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIUserDataAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIUserDataAccountProviderActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIUserDataAccountProviderActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -12777,36 +10860,7 @@ unsafe impl ::windows::core::Interface for WebUIView {
 impl ::windows::core::RuntimeName for WebUIView {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIView";
 }
-impl ::core::convert::From<WebUIView> for ::windows::core::IUnknown {
-    fn from(value: WebUIView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUIView> for ::windows::core::IUnknown {
-    fn from(value: &WebUIView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUIView> for &::windows::core::IUnknown {
-    fn from(value: &WebUIView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebUIView> for ::windows::core::IInspectable {
-    fn from(value: WebUIView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebUIView> for ::windows::core::IInspectable {
-    fn from(value: &WebUIView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebUIView> for &::windows::core::IInspectable {
-    fn from(value: &WebUIView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIView, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Web_UI")]
 impl ::core::convert::TryFrom<WebUIView> for super::super::Web::UI::IWebViewControl {
     type Error = ::windows::core::Error;
@@ -12951,41 +11005,7 @@ impl ::windows::core::RuntimeName for WebUIVoiceCommandActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIVoiceCommandActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIVoiceCommandActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIVoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIVoiceCommandActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIVoiceCommandActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIVoiceCommandActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIVoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIVoiceCommandActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIVoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIVoiceCommandActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIVoiceCommandActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIVoiceCommandActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIVoiceCommandActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIVoiceCommandActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIVoiceCommandActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -13183,41 +11203,7 @@ impl ::windows::core::RuntimeName for WebUIWalletActionActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIWalletActionActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIWalletActionActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIWalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWalletActionActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIWalletActionActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWalletActionActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIWalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIWalletActionActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIWalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWalletActionActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIWalletActionActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWalletActionActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIWalletActionActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIWalletActionActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIWalletActionActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -13384,41 +11370,7 @@ impl ::windows::core::RuntimeName for WebUIWebAccountProviderActivatedEventArgs 
     const NAME: &'static str = "Windows.UI.WebUI.WebUIWebAccountProviderActivatedEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIWebAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIWebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWebAccountProviderActivatedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIWebAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWebAccountProviderActivatedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIWebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIWebAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIWebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWebAccountProviderActivatedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIWebAccountProviderActivatedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWebAccountProviderActivatedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIWebAccountProviderActivatedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIWebAccountProviderActivatedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIWebAccountProviderActivatedEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;
@@ -13607,41 +11559,7 @@ impl ::windows::core::RuntimeName for WebUIWebAuthenticationBrokerContinuationEv
     const NAME: &'static str = "Windows.UI.WebUI.WebUIWebAuthenticationBrokerContinuationEventArgs";
 }
 #[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIWebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebUIWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebUIWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWebAuthenticationBrokerContinuationEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebUIWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<WebUIWebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebUIWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWebAuthenticationBrokerContinuationEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebUIWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "ApplicationModel_Activation")]
-impl ::core::convert::From<&WebUIWebAuthenticationBrokerContinuationEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebUIWebAuthenticationBrokerContinuationEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebUIWebAuthenticationBrokerContinuationEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
 impl ::core::convert::TryFrom<WebUIWebAuthenticationBrokerContinuationEventArgs> for super::super::ApplicationModel::Activation::IActivatedEventArgs {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/UI/WindowManagement/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WindowManagement/Preview/mod.rs
@@ -77,36 +77,7 @@ unsafe impl ::windows::core::Interface for WindowManagementPreview {
 impl ::windows::core::RuntimeName for WindowManagementPreview {
     const NAME: &'static str = "Windows.UI.WindowManagement.Preview.WindowManagementPreview";
 }
-impl ::core::convert::From<WindowManagementPreview> for ::windows::core::IUnknown {
-    fn from(value: WindowManagementPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowManagementPreview> for ::windows::core::IUnknown {
-    fn from(value: &WindowManagementPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowManagementPreview> for &::windows::core::IUnknown {
-    fn from(value: &WindowManagementPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WindowManagementPreview> for ::windows::core::IInspectable {
-    fn from(value: WindowManagementPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowManagementPreview> for ::windows::core::IInspectable {
-    fn from(value: &WindowManagementPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowManagementPreview> for &::windows::core::IInspectable {
-    fn from(value: &WindowManagementPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WindowManagementPreview, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WindowManagementPreview {}
 unsafe impl ::core::marker::Sync for WindowManagementPreview {}
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/UI/WindowManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WindowManagement/mod.rs
@@ -857,36 +857,7 @@ unsafe impl ::windows::core::Interface for AppWindow {
 impl ::windows::core::RuntimeName for AppWindow {
     const NAME: &'static str = "Windows.UI.WindowManagement.AppWindow";
 }
-impl ::core::convert::From<AppWindow> for ::windows::core::IUnknown {
-    fn from(value: AppWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindow> for ::windows::core::IUnknown {
-    fn from(value: &AppWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindow> for &::windows::core::IUnknown {
-    fn from(value: &AppWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppWindow> for ::windows::core::IInspectable {
-    fn from(value: AppWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindow> for ::windows::core::IInspectable {
-    fn from(value: &AppWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindow> for &::windows::core::IInspectable {
-    fn from(value: &AppWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppWindow, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppWindow {}
 unsafe impl ::core::marker::Sync for AppWindow {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -982,36 +953,7 @@ unsafe impl ::windows::core::Interface for AppWindowChangedEventArgs {
 impl ::windows::core::RuntimeName for AppWindowChangedEventArgs {
     const NAME: &'static str = "Windows.UI.WindowManagement.AppWindowChangedEventArgs";
 }
-impl ::core::convert::From<AppWindowChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppWindowChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppWindowChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppWindowChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppWindowChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppWindowChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppWindowChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppWindowChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppWindowChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppWindowChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppWindowChangedEventArgs {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -1071,36 +1013,7 @@ unsafe impl ::windows::core::Interface for AppWindowCloseRequestedEventArgs {
 impl ::windows::core::RuntimeName for AppWindowCloseRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.WindowManagement.AppWindowCloseRequestedEventArgs";
 }
-impl ::core::convert::From<AppWindowCloseRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppWindowCloseRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowCloseRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppWindowCloseRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowCloseRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppWindowCloseRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppWindowCloseRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppWindowCloseRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowCloseRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppWindowCloseRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowCloseRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppWindowCloseRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppWindowCloseRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppWindowCloseRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for AppWindowCloseRequestedEventArgs {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -1147,36 +1060,7 @@ unsafe impl ::windows::core::Interface for AppWindowClosedEventArgs {
 impl ::windows::core::RuntimeName for AppWindowClosedEventArgs {
     const NAME: &'static str = "Windows.UI.WindowManagement.AppWindowClosedEventArgs";
 }
-impl ::core::convert::From<AppWindowClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: AppWindowClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowClosedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &AppWindowClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowClosedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &AppWindowClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppWindowClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: AppWindowClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowClosedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &AppWindowClosedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowClosedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &AppWindowClosedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppWindowClosedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppWindowClosedEventArgs {}
 unsafe impl ::core::marker::Sync for AppWindowClosedEventArgs {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -1236,36 +1120,7 @@ unsafe impl ::windows::core::Interface for AppWindowFrame {
 impl ::windows::core::RuntimeName for AppWindowFrame {
     const NAME: &'static str = "Windows.UI.WindowManagement.AppWindowFrame";
 }
-impl ::core::convert::From<AppWindowFrame> for ::windows::core::IUnknown {
-    fn from(value: AppWindowFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowFrame> for ::windows::core::IUnknown {
-    fn from(value: &AppWindowFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowFrame> for &::windows::core::IUnknown {
-    fn from(value: &AppWindowFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppWindowFrame> for ::windows::core::IInspectable {
-    fn from(value: AppWindowFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowFrame> for ::windows::core::IInspectable {
-    fn from(value: &AppWindowFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowFrame> for &::windows::core::IInspectable {
-    fn from(value: &AppWindowFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppWindowFrame, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppWindowFrame {}
 unsafe impl ::core::marker::Sync for AppWindowFrame {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -1330,36 +1185,7 @@ unsafe impl ::windows::core::Interface for AppWindowPlacement {
 impl ::windows::core::RuntimeName for AppWindowPlacement {
     const NAME: &'static str = "Windows.UI.WindowManagement.AppWindowPlacement";
 }
-impl ::core::convert::From<AppWindowPlacement> for ::windows::core::IUnknown {
-    fn from(value: AppWindowPlacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowPlacement> for ::windows::core::IUnknown {
-    fn from(value: &AppWindowPlacement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowPlacement> for &::windows::core::IUnknown {
-    fn from(value: &AppWindowPlacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppWindowPlacement> for ::windows::core::IInspectable {
-    fn from(value: AppWindowPlacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowPlacement> for ::windows::core::IInspectable {
-    fn from(value: &AppWindowPlacement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowPlacement> for &::windows::core::IInspectable {
-    fn from(value: &AppWindowPlacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppWindowPlacement, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppWindowPlacement {}
 unsafe impl ::core::marker::Sync for AppWindowPlacement {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -1406,36 +1232,7 @@ unsafe impl ::windows::core::Interface for AppWindowPresentationConfiguration {
 impl ::windows::core::RuntimeName for AppWindowPresentationConfiguration {
     const NAME: &'static str = "Windows.UI.WindowManagement.AppWindowPresentationConfiguration";
 }
-impl ::core::convert::From<AppWindowPresentationConfiguration> for ::windows::core::IUnknown {
-    fn from(value: AppWindowPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowPresentationConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &AppWindowPresentationConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowPresentationConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &AppWindowPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppWindowPresentationConfiguration> for ::windows::core::IInspectable {
-    fn from(value: AppWindowPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowPresentationConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &AppWindowPresentationConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowPresentationConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &AppWindowPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppWindowPresentationConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppWindowPresentationConfiguration {}
 unsafe impl ::core::marker::Sync for AppWindowPresentationConfiguration {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -1506,36 +1303,7 @@ unsafe impl ::windows::core::Interface for AppWindowPresenter {
 impl ::windows::core::RuntimeName for AppWindowPresenter {
     const NAME: &'static str = "Windows.UI.WindowManagement.AppWindowPresenter";
 }
-impl ::core::convert::From<AppWindowPresenter> for ::windows::core::IUnknown {
-    fn from(value: AppWindowPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowPresenter> for ::windows::core::IUnknown {
-    fn from(value: &AppWindowPresenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowPresenter> for &::windows::core::IUnknown {
-    fn from(value: &AppWindowPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppWindowPresenter> for ::windows::core::IInspectable {
-    fn from(value: AppWindowPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowPresenter> for ::windows::core::IInspectable {
-    fn from(value: &AppWindowPresenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowPresenter> for &::windows::core::IInspectable {
-    fn from(value: &AppWindowPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppWindowPresenter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppWindowPresenter {}
 unsafe impl ::core::marker::Sync for AppWindowPresenter {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -1841,36 +1609,7 @@ unsafe impl ::windows::core::Interface for AppWindowTitleBar {
 impl ::windows::core::RuntimeName for AppWindowTitleBar {
     const NAME: &'static str = "Windows.UI.WindowManagement.AppWindowTitleBar";
 }
-impl ::core::convert::From<AppWindowTitleBar> for ::windows::core::IUnknown {
-    fn from(value: AppWindowTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowTitleBar> for ::windows::core::IUnknown {
-    fn from(value: &AppWindowTitleBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowTitleBar> for &::windows::core::IUnknown {
-    fn from(value: &AppWindowTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppWindowTitleBar> for ::windows::core::IInspectable {
-    fn from(value: AppWindowTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowTitleBar> for ::windows::core::IInspectable {
-    fn from(value: &AppWindowTitleBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowTitleBar> for &::windows::core::IInspectable {
-    fn from(value: &AppWindowTitleBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppWindowTitleBar, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppWindowTitleBar {}
 unsafe impl ::core::marker::Sync for AppWindowTitleBar {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -1919,36 +1658,7 @@ unsafe impl ::windows::core::Interface for AppWindowTitleBarOcclusion {
 impl ::windows::core::RuntimeName for AppWindowTitleBarOcclusion {
     const NAME: &'static str = "Windows.UI.WindowManagement.AppWindowTitleBarOcclusion";
 }
-impl ::core::convert::From<AppWindowTitleBarOcclusion> for ::windows::core::IUnknown {
-    fn from(value: AppWindowTitleBarOcclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowTitleBarOcclusion> for ::windows::core::IUnknown {
-    fn from(value: &AppWindowTitleBarOcclusion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowTitleBarOcclusion> for &::windows::core::IUnknown {
-    fn from(value: &AppWindowTitleBarOcclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AppWindowTitleBarOcclusion> for ::windows::core::IInspectable {
-    fn from(value: AppWindowTitleBarOcclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AppWindowTitleBarOcclusion> for ::windows::core::IInspectable {
-    fn from(value: &AppWindowTitleBarOcclusion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AppWindowTitleBarOcclusion> for &::windows::core::IInspectable {
-    fn from(value: &AppWindowTitleBarOcclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AppWindowTitleBarOcclusion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for AppWindowTitleBarOcclusion {}
 unsafe impl ::core::marker::Sync for AppWindowTitleBarOcclusion {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -2002,36 +1712,7 @@ unsafe impl ::windows::core::Interface for CompactOverlayPresentationConfigurati
 impl ::windows::core::RuntimeName for CompactOverlayPresentationConfiguration {
     const NAME: &'static str = "Windows.UI.WindowManagement.CompactOverlayPresentationConfiguration";
 }
-impl ::core::convert::From<CompactOverlayPresentationConfiguration> for ::windows::core::IUnknown {
-    fn from(value: CompactOverlayPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompactOverlayPresentationConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &CompactOverlayPresentationConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompactOverlayPresentationConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &CompactOverlayPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<CompactOverlayPresentationConfiguration> for ::windows::core::IInspectable {
-    fn from(value: CompactOverlayPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&CompactOverlayPresentationConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &CompactOverlayPresentationConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&CompactOverlayPresentationConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &CompactOverlayPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(CompactOverlayPresentationConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::From<CompactOverlayPresentationConfiguration> for AppWindowPresentationConfiguration {
     fn from(value: CompactOverlayPresentationConfiguration) -> Self {
         ::core::convert::From::from(&value)
@@ -2100,36 +1781,7 @@ unsafe impl ::windows::core::Interface for DefaultPresentationConfiguration {
 impl ::windows::core::RuntimeName for DefaultPresentationConfiguration {
     const NAME: &'static str = "Windows.UI.WindowManagement.DefaultPresentationConfiguration";
 }
-impl ::core::convert::From<DefaultPresentationConfiguration> for ::windows::core::IUnknown {
-    fn from(value: DefaultPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DefaultPresentationConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &DefaultPresentationConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DefaultPresentationConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &DefaultPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DefaultPresentationConfiguration> for ::windows::core::IInspectable {
-    fn from(value: DefaultPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DefaultPresentationConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &DefaultPresentationConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DefaultPresentationConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &DefaultPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DefaultPresentationConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::From<DefaultPresentationConfiguration> for AppWindowPresentationConfiguration {
     fn from(value: DefaultPresentationConfiguration) -> Self {
         ::core::convert::From::from(&value)
@@ -2238,36 +1890,7 @@ unsafe impl ::windows::core::Interface for DisplayRegion {
 impl ::windows::core::RuntimeName for DisplayRegion {
     const NAME: &'static str = "Windows.UI.WindowManagement.DisplayRegion";
 }
-impl ::core::convert::From<DisplayRegion> for ::windows::core::IUnknown {
-    fn from(value: DisplayRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayRegion> for ::windows::core::IUnknown {
-    fn from(value: &DisplayRegion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayRegion> for &::windows::core::IUnknown {
-    fn from(value: &DisplayRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<DisplayRegion> for ::windows::core::IInspectable {
-    fn from(value: DisplayRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DisplayRegion> for ::windows::core::IInspectable {
-    fn from(value: &DisplayRegion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&DisplayRegion> for &::windows::core::IInspectable {
-    fn from(value: &DisplayRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(DisplayRegion, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for DisplayRegion {}
 unsafe impl ::core::marker::Sync for DisplayRegion {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -2332,36 +1955,7 @@ unsafe impl ::windows::core::Interface for FullScreenPresentationConfiguration {
 impl ::windows::core::RuntimeName for FullScreenPresentationConfiguration {
     const NAME: &'static str = "Windows.UI.WindowManagement.FullScreenPresentationConfiguration";
 }
-impl ::core::convert::From<FullScreenPresentationConfiguration> for ::windows::core::IUnknown {
-    fn from(value: FullScreenPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FullScreenPresentationConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &FullScreenPresentationConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FullScreenPresentationConfiguration> for &::windows::core::IUnknown {
-    fn from(value: &FullScreenPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<FullScreenPresentationConfiguration> for ::windows::core::IInspectable {
-    fn from(value: FullScreenPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&FullScreenPresentationConfiguration> for ::windows::core::IInspectable {
-    fn from(value: &FullScreenPresentationConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&FullScreenPresentationConfiguration> for &::windows::core::IInspectable {
-    fn from(value: &FullScreenPresentationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(FullScreenPresentationConfiguration, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::From<FullScreenPresentationConfiguration> for AppWindowPresentationConfiguration {
     fn from(value: FullScreenPresentationConfiguration) -> Self {
         ::core::convert::From::from(&value)
@@ -2495,36 +2089,7 @@ unsafe impl ::windows::core::Interface for WindowingEnvironment {
 impl ::windows::core::RuntimeName for WindowingEnvironment {
     const NAME: &'static str = "Windows.UI.WindowManagement.WindowingEnvironment";
 }
-impl ::core::convert::From<WindowingEnvironment> for ::windows::core::IUnknown {
-    fn from(value: WindowingEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowingEnvironment> for ::windows::core::IUnknown {
-    fn from(value: &WindowingEnvironment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowingEnvironment> for &::windows::core::IUnknown {
-    fn from(value: &WindowingEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WindowingEnvironment> for ::windows::core::IInspectable {
-    fn from(value: WindowingEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowingEnvironment> for ::windows::core::IInspectable {
-    fn from(value: &WindowingEnvironment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowingEnvironment> for &::windows::core::IInspectable {
-    fn from(value: &WindowingEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WindowingEnvironment, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WindowingEnvironment {}
 unsafe impl ::core::marker::Sync for WindowingEnvironment {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -2571,36 +2136,7 @@ unsafe impl ::windows::core::Interface for WindowingEnvironmentAddedEventArgs {
 impl ::windows::core::RuntimeName for WindowingEnvironmentAddedEventArgs {
     const NAME: &'static str = "Windows.UI.WindowManagement.WindowingEnvironmentAddedEventArgs";
 }
-impl ::core::convert::From<WindowingEnvironmentAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WindowingEnvironmentAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentAddedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WindowingEnvironmentAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentAddedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WindowingEnvironmentAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WindowingEnvironmentAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WindowingEnvironmentAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentAddedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WindowingEnvironmentAddedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentAddedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WindowingEnvironmentAddedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WindowingEnvironmentAddedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WindowingEnvironmentAddedEventArgs {}
 unsafe impl ::core::marker::Sync for WindowingEnvironmentAddedEventArgs {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -2639,36 +2175,7 @@ unsafe impl ::windows::core::Interface for WindowingEnvironmentChangedEventArgs 
 impl ::windows::core::RuntimeName for WindowingEnvironmentChangedEventArgs {
     const NAME: &'static str = "Windows.UI.WindowManagement.WindowingEnvironmentChangedEventArgs";
 }
-impl ::core::convert::From<WindowingEnvironmentChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WindowingEnvironmentChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentChangedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WindowingEnvironmentChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentChangedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WindowingEnvironmentChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WindowingEnvironmentChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WindowingEnvironmentChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentChangedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WindowingEnvironmentChangedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentChangedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WindowingEnvironmentChangedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WindowingEnvironmentChangedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WindowingEnvironmentChangedEventArgs {}
 unsafe impl ::core::marker::Sync for WindowingEnvironmentChangedEventArgs {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]
@@ -2715,36 +2222,7 @@ unsafe impl ::windows::core::Interface for WindowingEnvironmentRemovedEventArgs 
 impl ::windows::core::RuntimeName for WindowingEnvironmentRemovedEventArgs {
     const NAME: &'static str = "Windows.UI.WindowManagement.WindowingEnvironmentRemovedEventArgs";
 }
-impl ::core::convert::From<WindowingEnvironmentRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WindowingEnvironmentRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentRemovedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WindowingEnvironmentRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentRemovedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WindowingEnvironmentRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WindowingEnvironmentRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WindowingEnvironmentRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentRemovedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WindowingEnvironmentRemovedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WindowingEnvironmentRemovedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WindowingEnvironmentRemovedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WindowingEnvironmentRemovedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for WindowingEnvironmentRemovedEventArgs {}
 unsafe impl ::core::marker::Sync for WindowingEnvironmentRemovedEventArgs {}
 #[doc = "*Required features: `\"UI_WindowManagement\"`*"]

--- a/crates/libs/windows/src/Windows/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/mod.rs
@@ -327,36 +327,7 @@ unsafe impl ::windows::core::Interface for ColorHelper {
 impl ::windows::core::RuntimeName for ColorHelper {
     const NAME: &'static str = "Windows.UI.ColorHelper";
 }
-impl ::core::convert::From<ColorHelper> for ::windows::core::IUnknown {
-    fn from(value: ColorHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ColorHelper> for ::windows::core::IUnknown {
-    fn from(value: &ColorHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ColorHelper> for &::windows::core::IUnknown {
-    fn from(value: &ColorHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ColorHelper> for ::windows::core::IInspectable {
-    fn from(value: ColorHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ColorHelper> for ::windows::core::IInspectable {
-    fn from(value: &ColorHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ColorHelper> for &::windows::core::IInspectable {
-    fn from(value: &ColorHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ColorHelper, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for ColorHelper {}
 unsafe impl ::core::marker::Sync for ColorHelper {}
 #[doc = "*Required features: `\"UI\"`*"]
@@ -1247,36 +1218,7 @@ unsafe impl ::windows::core::Interface for Colors {
 impl ::windows::core::RuntimeName for Colors {
     const NAME: &'static str = "Windows.UI.Colors";
 }
-impl ::core::convert::From<Colors> for ::windows::core::IUnknown {
-    fn from(value: Colors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Colors> for ::windows::core::IUnknown {
-    fn from(value: &Colors) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Colors> for &::windows::core::IUnknown {
-    fn from(value: &Colors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Colors> for ::windows::core::IInspectable {
-    fn from(value: Colors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Colors> for ::windows::core::IInspectable {
-    fn from(value: &Colors) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Colors> for &::windows::core::IInspectable {
-    fn from(value: &Colors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Colors, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Colors {}
 unsafe impl ::core::marker::Sync for Colors {}
 #[doc = "*Required features: `\"UI\"`*"]
@@ -1323,36 +1265,7 @@ unsafe impl ::windows::core::Interface for UIContentRoot {
 impl ::windows::core::RuntimeName for UIContentRoot {
     const NAME: &'static str = "Windows.UI.UIContentRoot";
 }
-impl ::core::convert::From<UIContentRoot> for ::windows::core::IUnknown {
-    fn from(value: UIContentRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UIContentRoot> for ::windows::core::IUnknown {
-    fn from(value: &UIContentRoot) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UIContentRoot> for &::windows::core::IUnknown {
-    fn from(value: &UIContentRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UIContentRoot> for ::windows::core::IInspectable {
-    fn from(value: UIContentRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UIContentRoot> for ::windows::core::IInspectable {
-    fn from(value: &UIContentRoot) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UIContentRoot> for &::windows::core::IInspectable {
-    fn from(value: &UIContentRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UIContentRoot, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UIContentRoot {}
 unsafe impl ::core::marker::Sync for UIContentRoot {}
 #[doc = "*Required features: `\"UI\"`*"]
@@ -1391,36 +1304,7 @@ unsafe impl ::windows::core::Interface for UIContext {
 impl ::windows::core::RuntimeName for UIContext {
     const NAME: &'static str = "Windows.UI.UIContext";
 }
-impl ::core::convert::From<UIContext> for ::windows::core::IUnknown {
-    fn from(value: UIContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UIContext> for ::windows::core::IUnknown {
-    fn from(value: &UIContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UIContext> for &::windows::core::IUnknown {
-    fn from(value: &UIContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<UIContext> for ::windows::core::IInspectable {
-    fn from(value: UIContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&UIContext> for ::windows::core::IInspectable {
-    fn from(value: &UIContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&UIContext> for &::windows::core::IInspectable {
-    fn from(value: &UIContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(UIContext, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for UIContext {}
 unsafe impl ::core::marker::Sync for UIContext {}
 #[repr(C)]

--- a/crates/libs/windows/src/Windows/Web/AtomPub/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/AtomPub/mod.rs
@@ -390,36 +390,7 @@ unsafe impl ::windows::core::Interface for AtomPubClient {
 impl ::windows::core::RuntimeName for AtomPubClient {
     const NAME: &'static str = "Windows.Web.AtomPub.AtomPubClient";
 }
-impl ::core::convert::From<AtomPubClient> for ::windows::core::IUnknown {
-    fn from(value: AtomPubClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AtomPubClient> for ::windows::core::IUnknown {
-    fn from(value: &AtomPubClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AtomPubClient> for &::windows::core::IUnknown {
-    fn from(value: &AtomPubClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<AtomPubClient> for ::windows::core::IInspectable {
-    fn from(value: AtomPubClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AtomPubClient> for ::windows::core::IInspectable {
-    fn from(value: &AtomPubClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&AtomPubClient> for &::windows::core::IInspectable {
-    fn from(value: &AtomPubClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(AtomPubClient, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Web_Syndication")]
 impl ::core::convert::TryFrom<AtomPubClient> for super::Syndication::ISyndicationClient {
     type Error = ::windows::core::Error;
@@ -619,36 +590,7 @@ unsafe impl ::windows::core::Interface for ResourceCollection {
 impl ::windows::core::RuntimeName for ResourceCollection {
     const NAME: &'static str = "Windows.Web.AtomPub.ResourceCollection";
 }
-impl ::core::convert::From<ResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: ResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: &ResourceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceCollection> for &::windows::core::IUnknown {
-    fn from(value: &ResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ResourceCollection> for ::windows::core::IInspectable {
-    fn from(value: ResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ResourceCollection> for ::windows::core::IInspectable {
-    fn from(value: &ResourceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ResourceCollection> for &::windows::core::IInspectable {
-    fn from(value: &ResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ResourceCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Web_Syndication")]
 impl ::core::convert::TryFrom<ResourceCollection> for super::Syndication::ISyndicationNode {
     type Error = ::windows::core::Error;
@@ -821,36 +763,7 @@ unsafe impl ::windows::core::Interface for ServiceDocument {
 impl ::windows::core::RuntimeName for ServiceDocument {
     const NAME: &'static str = "Windows.Web.AtomPub.ServiceDocument";
 }
-impl ::core::convert::From<ServiceDocument> for ::windows::core::IUnknown {
-    fn from(value: ServiceDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServiceDocument> for ::windows::core::IUnknown {
-    fn from(value: &ServiceDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServiceDocument> for &::windows::core::IUnknown {
-    fn from(value: &ServiceDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<ServiceDocument> for ::windows::core::IInspectable {
-    fn from(value: ServiceDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ServiceDocument> for ::windows::core::IInspectable {
-    fn from(value: &ServiceDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&ServiceDocument> for &::windows::core::IInspectable {
-    fn from(value: &ServiceDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(ServiceDocument, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Web_Syndication")]
 impl ::core::convert::TryFrom<ServiceDocument> for super::Syndication::ISyndicationNode {
     type Error = ::windows::core::Error;
@@ -1032,36 +945,7 @@ unsafe impl ::windows::core::Interface for Workspace {
 impl ::windows::core::RuntimeName for Workspace {
     const NAME: &'static str = "Windows.Web.AtomPub.Workspace";
 }
-impl ::core::convert::From<Workspace> for ::windows::core::IUnknown {
-    fn from(value: Workspace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Workspace> for ::windows::core::IUnknown {
-    fn from(value: &Workspace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Workspace> for &::windows::core::IUnknown {
-    fn from(value: &Workspace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Workspace> for ::windows::core::IInspectable {
-    fn from(value: Workspace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Workspace> for ::windows::core::IInspectable {
-    fn from(value: &Workspace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Workspace> for &::windows::core::IInspectable {
-    fn from(value: &Workspace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Workspace, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Web_Syndication")]
 impl ::core::convert::TryFrom<Workspace> for super::Syndication::ISyndicationNode {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Web/Http/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Diagnostics/mod.rs
@@ -303,36 +303,7 @@ unsafe impl ::windows::core::Interface for HttpDiagnosticProvider {
 impl ::windows::core::RuntimeName for HttpDiagnosticProvider {
     const NAME: &'static str = "Windows.Web.Http.Diagnostics.HttpDiagnosticProvider";
 }
-impl ::core::convert::From<HttpDiagnosticProvider> for ::windows::core::IUnknown {
-    fn from(value: HttpDiagnosticProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProvider> for ::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProvider> for &::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpDiagnosticProvider> for ::windows::core::IInspectable {
-    fn from(value: HttpDiagnosticProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProvider> for ::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProvider> for &::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpDiagnosticProvider, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HttpDiagnosticProvider {}
 unsafe impl ::core::marker::Sync for HttpDiagnosticProvider {}
 #[doc = "*Required features: `\"Web_Http_Diagnostics\"`*"]
@@ -425,36 +396,7 @@ unsafe impl ::windows::core::Interface for HttpDiagnosticProviderRequestResponse
 impl ::windows::core::RuntimeName for HttpDiagnosticProviderRequestResponseCompletedEventArgs {
     const NAME: &'static str = "Windows.Web.Http.Diagnostics.HttpDiagnosticProviderRequestResponseCompletedEventArgs";
 }
-impl ::core::convert::From<HttpDiagnosticProviderRequestResponseCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: HttpDiagnosticProviderRequestResponseCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestResponseCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticProviderRequestResponseCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestResponseCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticProviderRequestResponseCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpDiagnosticProviderRequestResponseCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: HttpDiagnosticProviderRequestResponseCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestResponseCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticProviderRequestResponseCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestResponseCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticProviderRequestResponseCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpDiagnosticProviderRequestResponseCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HttpDiagnosticProviderRequestResponseCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for HttpDiagnosticProviderRequestResponseCompletedEventArgs {}
 #[doc = "*Required features: `\"Web_Http_Diagnostics\"`*"]
@@ -575,36 +517,7 @@ unsafe impl ::windows::core::Interface for HttpDiagnosticProviderRequestResponse
 impl ::windows::core::RuntimeName for HttpDiagnosticProviderRequestResponseTimestamps {
     const NAME: &'static str = "Windows.Web.Http.Diagnostics.HttpDiagnosticProviderRequestResponseTimestamps";
 }
-impl ::core::convert::From<HttpDiagnosticProviderRequestResponseTimestamps> for ::windows::core::IUnknown {
-    fn from(value: HttpDiagnosticProviderRequestResponseTimestamps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestResponseTimestamps> for ::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticProviderRequestResponseTimestamps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestResponseTimestamps> for &::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticProviderRequestResponseTimestamps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpDiagnosticProviderRequestResponseTimestamps> for ::windows::core::IInspectable {
-    fn from(value: HttpDiagnosticProviderRequestResponseTimestamps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestResponseTimestamps> for ::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticProviderRequestResponseTimestamps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestResponseTimestamps> for &::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticProviderRequestResponseTimestamps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpDiagnosticProviderRequestResponseTimestamps, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HttpDiagnosticProviderRequestResponseTimestamps {}
 unsafe impl ::core::marker::Sync for HttpDiagnosticProviderRequestResponseTimestamps {}
 #[doc = "*Required features: `\"Web_Http_Diagnostics\"`*"]
@@ -697,36 +610,7 @@ unsafe impl ::windows::core::Interface for HttpDiagnosticProviderRequestSentEven
 impl ::windows::core::RuntimeName for HttpDiagnosticProviderRequestSentEventArgs {
     const NAME: &'static str = "Windows.Web.Http.Diagnostics.HttpDiagnosticProviderRequestSentEventArgs";
 }
-impl ::core::convert::From<HttpDiagnosticProviderRequestSentEventArgs> for ::windows::core::IUnknown {
-    fn from(value: HttpDiagnosticProviderRequestSentEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestSentEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticProviderRequestSentEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestSentEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticProviderRequestSentEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpDiagnosticProviderRequestSentEventArgs> for ::windows::core::IInspectable {
-    fn from(value: HttpDiagnosticProviderRequestSentEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestSentEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticProviderRequestSentEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderRequestSentEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticProviderRequestSentEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpDiagnosticProviderRequestSentEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HttpDiagnosticProviderRequestSentEventArgs {}
 unsafe impl ::core::marker::Sync for HttpDiagnosticProviderRequestSentEventArgs {}
 #[doc = "*Required features: `\"Web_Http_Diagnostics\"`*"]
@@ -789,36 +673,7 @@ unsafe impl ::windows::core::Interface for HttpDiagnosticProviderResponseReceive
 impl ::windows::core::RuntimeName for HttpDiagnosticProviderResponseReceivedEventArgs {
     const NAME: &'static str = "Windows.Web.Http.Diagnostics.HttpDiagnosticProviderResponseReceivedEventArgs";
 }
-impl ::core::convert::From<HttpDiagnosticProviderResponseReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: HttpDiagnosticProviderResponseReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderResponseReceivedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticProviderResponseReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderResponseReceivedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticProviderResponseReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpDiagnosticProviderResponseReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: HttpDiagnosticProviderResponseReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderResponseReceivedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticProviderResponseReceivedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticProviderResponseReceivedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticProviderResponseReceivedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpDiagnosticProviderResponseReceivedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HttpDiagnosticProviderResponseReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for HttpDiagnosticProviderResponseReceivedEventArgs {}
 #[doc = "*Required features: `\"Web_Http_Diagnostics\"`*"]
@@ -881,36 +736,7 @@ unsafe impl ::windows::core::Interface for HttpDiagnosticSourceLocation {
 impl ::windows::core::RuntimeName for HttpDiagnosticSourceLocation {
     const NAME: &'static str = "Windows.Web.Http.Diagnostics.HttpDiagnosticSourceLocation";
 }
-impl ::core::convert::From<HttpDiagnosticSourceLocation> for ::windows::core::IUnknown {
-    fn from(value: HttpDiagnosticSourceLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticSourceLocation> for ::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticSourceLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticSourceLocation> for &::windows::core::IUnknown {
-    fn from(value: &HttpDiagnosticSourceLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpDiagnosticSourceLocation> for ::windows::core::IInspectable {
-    fn from(value: HttpDiagnosticSourceLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticSourceLocation> for ::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticSourceLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDiagnosticSourceLocation> for &::windows::core::IInspectable {
-    fn from(value: &HttpDiagnosticSourceLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpDiagnosticSourceLocation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HttpDiagnosticSourceLocation {}
 unsafe impl ::core::marker::Sync for HttpDiagnosticSourceLocation {}
 #[doc = "*Required features: `\"Web_Http_Diagnostics\"`*"]

--- a/crates/libs/windows/src/Windows/Web/Http/Filters/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Filters/mod.rs
@@ -181,36 +181,7 @@ impl IHttpFilter {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IHttpFilter> for ::windows::core::IUnknown {
-    fn from(value: IHttpFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHttpFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpFilter> for ::windows::core::IUnknown {
-    fn from(value: &IHttpFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHttpFilter> for ::windows::core::IInspectable {
-    fn from(value: IHttpFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpFilter> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IHttpFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpFilter> for ::windows::core::IInspectable {
-    fn from(value: &IHttpFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHttpFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IHttpFilter> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -552,36 +523,7 @@ unsafe impl ::windows::core::Interface for HttpBaseProtocolFilter {
 impl ::windows::core::RuntimeName for HttpBaseProtocolFilter {
     const NAME: &'static str = "Windows.Web.Http.Filters.HttpBaseProtocolFilter";
 }
-impl ::core::convert::From<HttpBaseProtocolFilter> for ::windows::core::IUnknown {
-    fn from(value: HttpBaseProtocolFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpBaseProtocolFilter> for ::windows::core::IUnknown {
-    fn from(value: &HttpBaseProtocolFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpBaseProtocolFilter> for &::windows::core::IUnknown {
-    fn from(value: &HttpBaseProtocolFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpBaseProtocolFilter> for ::windows::core::IInspectable {
-    fn from(value: HttpBaseProtocolFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpBaseProtocolFilter> for ::windows::core::IInspectable {
-    fn from(value: &HttpBaseProtocolFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpBaseProtocolFilter> for &::windows::core::IInspectable {
-    fn from(value: &HttpBaseProtocolFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpBaseProtocolFilter, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpBaseProtocolFilter> for super::super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -684,36 +626,7 @@ unsafe impl ::windows::core::Interface for HttpCacheControl {
 impl ::windows::core::RuntimeName for HttpCacheControl {
     const NAME: &'static str = "Windows.Web.Http.Filters.HttpCacheControl";
 }
-impl ::core::convert::From<HttpCacheControl> for ::windows::core::IUnknown {
-    fn from(value: HttpCacheControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCacheControl> for ::windows::core::IUnknown {
-    fn from(value: &HttpCacheControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCacheControl> for &::windows::core::IUnknown {
-    fn from(value: &HttpCacheControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpCacheControl> for ::windows::core::IInspectable {
-    fn from(value: HttpCacheControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCacheControl> for ::windows::core::IInspectable {
-    fn from(value: &HttpCacheControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCacheControl> for &::windows::core::IInspectable {
-    fn from(value: &HttpCacheControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpCacheControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HttpCacheControl {}
 unsafe impl ::core::marker::Sync for HttpCacheControl {}
 #[doc = "*Required features: `\"Web_Http_Filters\"`*"]
@@ -809,36 +722,7 @@ unsafe impl ::windows::core::Interface for HttpServerCustomValidationRequestedEv
 impl ::windows::core::RuntimeName for HttpServerCustomValidationRequestedEventArgs {
     const NAME: &'static str = "Windows.Web.Http.Filters.HttpServerCustomValidationRequestedEventArgs";
 }
-impl ::core::convert::From<HttpServerCustomValidationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: HttpServerCustomValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpServerCustomValidationRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &HttpServerCustomValidationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpServerCustomValidationRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &HttpServerCustomValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpServerCustomValidationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: HttpServerCustomValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpServerCustomValidationRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &HttpServerCustomValidationRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpServerCustomValidationRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &HttpServerCustomValidationRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpServerCustomValidationRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HttpServerCustomValidationRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for HttpServerCustomValidationRequestedEventArgs {}
 #[doc = "*Required features: `\"Web_Http_Filters\"`*"]

--- a/crates/libs/windows/src/Windows/Web/Http/Headers/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Headers/mod.rs
@@ -1548,36 +1548,7 @@ impl ::core::iter::IntoIterator for &HttpCacheDirectiveHeaderValueCollection {
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpCacheDirectiveHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpCacheDirectiveHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCacheDirectiveHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpCacheDirectiveHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCacheDirectiveHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpCacheDirectiveHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpCacheDirectiveHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpCacheDirectiveHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCacheDirectiveHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpCacheDirectiveHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCacheDirectiveHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpCacheDirectiveHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpCacheDirectiveHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpCacheDirectiveHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<HttpNameValueHeaderValue> {
     type Error = ::windows::core::Error;
@@ -1749,36 +1720,7 @@ unsafe impl ::windows::core::Interface for HttpChallengeHeaderValue {
 impl ::windows::core::RuntimeName for HttpChallengeHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpChallengeHeaderValue";
 }
-impl ::core::convert::From<HttpChallengeHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpChallengeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpChallengeHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpChallengeHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpChallengeHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpChallengeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpChallengeHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpChallengeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpChallengeHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpChallengeHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpChallengeHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpChallengeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpChallengeHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpChallengeHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -1972,36 +1914,7 @@ impl ::core::iter::IntoIterator for &HttpChallengeHeaderValueCollection {
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpChallengeHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpChallengeHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpChallengeHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpChallengeHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpChallengeHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpChallengeHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpChallengeHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpChallengeHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpChallengeHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpChallengeHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpChallengeHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpChallengeHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpChallengeHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpChallengeHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<HttpChallengeHeaderValue> {
     type Error = ::windows::core::Error;
@@ -2151,36 +2064,7 @@ unsafe impl ::windows::core::Interface for HttpConnectionOptionHeaderValue {
 impl ::windows::core::RuntimeName for HttpConnectionOptionHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpConnectionOptionHeaderValue";
 }
-impl ::core::convert::From<HttpConnectionOptionHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpConnectionOptionHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpConnectionOptionHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpConnectionOptionHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpConnectionOptionHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpConnectionOptionHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpConnectionOptionHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpConnectionOptionHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpConnectionOptionHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpConnectionOptionHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpConnectionOptionHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpConnectionOptionHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpConnectionOptionHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpConnectionOptionHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -2374,36 +2258,7 @@ impl ::core::iter::IntoIterator for &HttpConnectionOptionHeaderValueCollection {
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpConnectionOptionHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpConnectionOptionHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpConnectionOptionHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpConnectionOptionHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpConnectionOptionHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpConnectionOptionHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpConnectionOptionHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpConnectionOptionHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpConnectionOptionHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpConnectionOptionHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpConnectionOptionHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpConnectionOptionHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpConnectionOptionHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpConnectionOptionHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<HttpConnectionOptionHeaderValue> {
     type Error = ::windows::core::Error;
@@ -2553,36 +2408,7 @@ unsafe impl ::windows::core::Interface for HttpContentCodingHeaderValue {
 impl ::windows::core::RuntimeName for HttpContentCodingHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpContentCodingHeaderValue";
 }
-impl ::core::convert::From<HttpContentCodingHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpContentCodingHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentCodingHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpContentCodingHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentCodingHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpContentCodingHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpContentCodingHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpContentCodingHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentCodingHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpContentCodingHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentCodingHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpContentCodingHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpContentCodingHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpContentCodingHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -2776,36 +2602,7 @@ impl ::core::iter::IntoIterator for &HttpContentCodingHeaderValueCollection {
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpContentCodingHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpContentCodingHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentCodingHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpContentCodingHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentCodingHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpContentCodingHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpContentCodingHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpContentCodingHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentCodingHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpContentCodingHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentCodingHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpContentCodingHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpContentCodingHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpContentCodingHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<HttpContentCodingHeaderValue> {
     type Error = ::windows::core::Error;
@@ -2970,36 +2767,7 @@ unsafe impl ::windows::core::Interface for HttpContentCodingWithQualityHeaderVal
 impl ::windows::core::RuntimeName for HttpContentCodingWithQualityHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpContentCodingWithQualityHeaderValue";
 }
-impl ::core::convert::From<HttpContentCodingWithQualityHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpContentCodingWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentCodingWithQualityHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpContentCodingWithQualityHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentCodingWithQualityHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpContentCodingWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpContentCodingWithQualityHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpContentCodingWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentCodingWithQualityHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpContentCodingWithQualityHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentCodingWithQualityHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpContentCodingWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpContentCodingWithQualityHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpContentCodingWithQualityHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -3193,36 +2961,7 @@ impl ::core::iter::IntoIterator for &HttpContentCodingWithQualityHeaderValueColl
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpContentCodingWithQualityHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpContentCodingWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentCodingWithQualityHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpContentCodingWithQualityHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentCodingWithQualityHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpContentCodingWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpContentCodingWithQualityHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpContentCodingWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentCodingWithQualityHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpContentCodingWithQualityHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentCodingWithQualityHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpContentCodingWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpContentCodingWithQualityHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpContentCodingWithQualityHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<HttpContentCodingWithQualityHeaderValue> {
     type Error = ::windows::core::Error;
@@ -3437,36 +3176,7 @@ unsafe impl ::windows::core::Interface for HttpContentDispositionHeaderValue {
 impl ::windows::core::RuntimeName for HttpContentDispositionHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpContentDispositionHeaderValue";
 }
-impl ::core::convert::From<HttpContentDispositionHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpContentDispositionHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentDispositionHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpContentDispositionHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentDispositionHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpContentDispositionHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpContentDispositionHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpContentDispositionHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentDispositionHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpContentDispositionHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentDispositionHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpContentDispositionHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpContentDispositionHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpContentDispositionHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -3775,36 +3485,7 @@ impl ::core::iter::IntoIterator for &HttpContentHeaderCollection {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<HttpContentHeaderCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpContentHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentHeaderCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpContentHeaderCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentHeaderCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpContentHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpContentHeaderCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpContentHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentHeaderCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpContentHeaderCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentHeaderCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpContentHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpContentHeaderCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpContentHeaderCollection> for super::super::super::Foundation::Collections::IIterable<super::super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::HSTRING>> {
     type Error = ::windows::core::Error;
@@ -3997,36 +3678,7 @@ unsafe impl ::windows::core::Interface for HttpContentRangeHeaderValue {
 impl ::windows::core::RuntimeName for HttpContentRangeHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpContentRangeHeaderValue";
 }
-impl ::core::convert::From<HttpContentRangeHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpContentRangeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentRangeHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpContentRangeHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentRangeHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpContentRangeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpContentRangeHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpContentRangeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpContentRangeHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpContentRangeHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpContentRangeHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpContentRangeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpContentRangeHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpContentRangeHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -4149,36 +3801,7 @@ unsafe impl ::windows::core::Interface for HttpCookiePairHeaderValue {
 impl ::windows::core::RuntimeName for HttpCookiePairHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpCookiePairHeaderValue";
 }
-impl ::core::convert::From<HttpCookiePairHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpCookiePairHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCookiePairHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpCookiePairHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCookiePairHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpCookiePairHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpCookiePairHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpCookiePairHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCookiePairHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpCookiePairHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCookiePairHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpCookiePairHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpCookiePairHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpCookiePairHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -4372,36 +3995,7 @@ impl ::core::iter::IntoIterator for &HttpCookiePairHeaderValueCollection {
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpCookiePairHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpCookiePairHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCookiePairHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpCookiePairHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCookiePairHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpCookiePairHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpCookiePairHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpCookiePairHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCookiePairHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpCookiePairHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCookiePairHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpCookiePairHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpCookiePairHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpCookiePairHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<HttpCookiePairHeaderValue> {
     type Error = ::windows::core::Error;
@@ -4573,36 +4167,7 @@ unsafe impl ::windows::core::Interface for HttpCredentialsHeaderValue {
 impl ::windows::core::RuntimeName for HttpCredentialsHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpCredentialsHeaderValue";
 }
-impl ::core::convert::From<HttpCredentialsHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpCredentialsHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCredentialsHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpCredentialsHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCredentialsHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpCredentialsHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpCredentialsHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpCredentialsHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCredentialsHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpCredentialsHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCredentialsHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpCredentialsHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpCredentialsHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpCredentialsHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -4708,36 +4273,7 @@ unsafe impl ::windows::core::Interface for HttpDateOrDeltaHeaderValue {
 impl ::windows::core::RuntimeName for HttpDateOrDeltaHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpDateOrDeltaHeaderValue";
 }
-impl ::core::convert::From<HttpDateOrDeltaHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpDateOrDeltaHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDateOrDeltaHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpDateOrDeltaHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDateOrDeltaHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpDateOrDeltaHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpDateOrDeltaHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpDateOrDeltaHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpDateOrDeltaHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpDateOrDeltaHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpDateOrDeltaHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpDateOrDeltaHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpDateOrDeltaHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpDateOrDeltaHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -4869,36 +4405,7 @@ unsafe impl ::windows::core::Interface for HttpExpectationHeaderValue {
 impl ::windows::core::RuntimeName for HttpExpectationHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpExpectationHeaderValue";
 }
-impl ::core::convert::From<HttpExpectationHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpExpectationHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpExpectationHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpExpectationHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpExpectationHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpExpectationHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpExpectationHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpExpectationHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpExpectationHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpExpectationHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpExpectationHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpExpectationHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpExpectationHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpExpectationHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -5092,36 +4599,7 @@ impl ::core::iter::IntoIterator for &HttpExpectationHeaderValueCollection {
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpExpectationHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpExpectationHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpExpectationHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpExpectationHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpExpectationHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpExpectationHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpExpectationHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpExpectationHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpExpectationHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpExpectationHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpExpectationHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpExpectationHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpExpectationHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpExpectationHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<HttpExpectationHeaderValue> {
     type Error = ::windows::core::Error;
@@ -5359,36 +4837,7 @@ impl ::core::iter::IntoIterator for &HttpLanguageHeaderValueCollection {
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpLanguageHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpLanguageHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpLanguageHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpLanguageHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpLanguageHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpLanguageHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpLanguageHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpLanguageHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpLanguageHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpLanguageHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpLanguageHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpLanguageHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpLanguageHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(all(feature = "Foundation_Collections", feature = "Globalization"))]
 impl ::core::convert::TryFrom<HttpLanguageHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<super::super::super::Globalization::Language> {
     type Error = ::windows::core::Error;
@@ -5553,36 +5002,7 @@ unsafe impl ::windows::core::Interface for HttpLanguageRangeWithQualityHeaderVal
 impl ::windows::core::RuntimeName for HttpLanguageRangeWithQualityHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpLanguageRangeWithQualityHeaderValue";
 }
-impl ::core::convert::From<HttpLanguageRangeWithQualityHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpLanguageRangeWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpLanguageRangeWithQualityHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpLanguageRangeWithQualityHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpLanguageRangeWithQualityHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpLanguageRangeWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpLanguageRangeWithQualityHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpLanguageRangeWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpLanguageRangeWithQualityHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpLanguageRangeWithQualityHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpLanguageRangeWithQualityHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpLanguageRangeWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpLanguageRangeWithQualityHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpLanguageRangeWithQualityHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -5776,36 +5196,7 @@ impl ::core::iter::IntoIterator for &HttpLanguageRangeWithQualityHeaderValueColl
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpLanguageRangeWithQualityHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpLanguageRangeWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpLanguageRangeWithQualityHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpLanguageRangeWithQualityHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpLanguageRangeWithQualityHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpLanguageRangeWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpLanguageRangeWithQualityHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpLanguageRangeWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpLanguageRangeWithQualityHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpLanguageRangeWithQualityHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpLanguageRangeWithQualityHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpLanguageRangeWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpLanguageRangeWithQualityHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpLanguageRangeWithQualityHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<HttpLanguageRangeWithQualityHeaderValue> {
     type Error = ::windows::core::Error;
@@ -5979,36 +5370,7 @@ unsafe impl ::windows::core::Interface for HttpMediaTypeHeaderValue {
 impl ::windows::core::RuntimeName for HttpMediaTypeHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpMediaTypeHeaderValue";
 }
-impl ::core::convert::From<HttpMediaTypeHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpMediaTypeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpMediaTypeHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpMediaTypeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpMediaTypeHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpMediaTypeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpMediaTypeHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpMediaTypeHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpMediaTypeHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpMediaTypeHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -6163,36 +5525,7 @@ unsafe impl ::windows::core::Interface for HttpMediaTypeWithQualityHeaderValue {
 impl ::windows::core::RuntimeName for HttpMediaTypeWithQualityHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpMediaTypeWithQualityHeaderValue";
 }
-impl ::core::convert::From<HttpMediaTypeWithQualityHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpMediaTypeWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeWithQualityHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpMediaTypeWithQualityHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeWithQualityHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpMediaTypeWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpMediaTypeWithQualityHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpMediaTypeWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeWithQualityHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpMediaTypeWithQualityHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeWithQualityHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpMediaTypeWithQualityHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpMediaTypeWithQualityHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpMediaTypeWithQualityHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -6386,36 +5719,7 @@ impl ::core::iter::IntoIterator for &HttpMediaTypeWithQualityHeaderValueCollecti
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpMediaTypeWithQualityHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpMediaTypeWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeWithQualityHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpMediaTypeWithQualityHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeWithQualityHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpMediaTypeWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpMediaTypeWithQualityHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpMediaTypeWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeWithQualityHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpMediaTypeWithQualityHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMediaTypeWithQualityHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpMediaTypeWithQualityHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpMediaTypeWithQualityHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpMediaTypeWithQualityHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<HttpMediaTypeWithQualityHeaderValue> {
     type Error = ::windows::core::Error;
@@ -6653,36 +5957,7 @@ impl ::core::iter::IntoIterator for &HttpMethodHeaderValueCollection {
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpMethodHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpMethodHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMethodHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpMethodHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMethodHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpMethodHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpMethodHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpMethodHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMethodHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpMethodHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMethodHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpMethodHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpMethodHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpMethodHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<super::HttpMethod> {
     type Error = ::windows::core::Error;
@@ -6849,36 +6124,7 @@ unsafe impl ::windows::core::Interface for HttpNameValueHeaderValue {
 impl ::windows::core::RuntimeName for HttpNameValueHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpNameValueHeaderValue";
 }
-impl ::core::convert::From<HttpNameValueHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpNameValueHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpNameValueHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpNameValueHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpNameValueHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpNameValueHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpNameValueHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpNameValueHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpNameValueHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpNameValueHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpNameValueHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpNameValueHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpNameValueHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpNameValueHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -6997,36 +6243,7 @@ unsafe impl ::windows::core::Interface for HttpProductHeaderValue {
 impl ::windows::core::RuntimeName for HttpProductHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpProductHeaderValue";
 }
-impl ::core::convert::From<HttpProductHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpProductHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpProductHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpProductHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpProductHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpProductHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpProductHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpProductHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpProductHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpProductHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpProductHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpProductHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpProductHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpProductHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -7145,36 +6362,7 @@ unsafe impl ::windows::core::Interface for HttpProductInfoHeaderValue {
 impl ::windows::core::RuntimeName for HttpProductInfoHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpProductInfoHeaderValue";
 }
-impl ::core::convert::From<HttpProductInfoHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpProductInfoHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpProductInfoHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpProductInfoHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpProductInfoHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpProductInfoHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpProductInfoHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpProductInfoHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpProductInfoHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpProductInfoHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpProductInfoHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpProductInfoHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpProductInfoHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpProductInfoHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -7368,36 +6556,7 @@ impl ::core::iter::IntoIterator for &HttpProductInfoHeaderValueCollection {
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpProductInfoHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpProductInfoHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpProductInfoHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpProductInfoHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpProductInfoHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpProductInfoHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpProductInfoHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpProductInfoHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpProductInfoHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpProductInfoHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpProductInfoHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpProductInfoHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpProductInfoHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpProductInfoHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<HttpProductInfoHeaderValue> {
     type Error = ::windows::core::Error;
@@ -7807,36 +6966,7 @@ impl ::core::iter::IntoIterator for &HttpRequestHeaderCollection {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<HttpRequestHeaderCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpRequestHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpRequestHeaderCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpRequestHeaderCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpRequestHeaderCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpRequestHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpRequestHeaderCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpRequestHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpRequestHeaderCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpRequestHeaderCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpRequestHeaderCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpRequestHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpRequestHeaderCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpRequestHeaderCollection> for super::super::super::Foundation::Collections::IIterable<super::super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::HSTRING>> {
     type Error = ::windows::core::Error;
@@ -8150,36 +7280,7 @@ impl ::core::iter::IntoIterator for &HttpResponseHeaderCollection {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<HttpResponseHeaderCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpResponseHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpResponseHeaderCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpResponseHeaderCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpResponseHeaderCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpResponseHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpResponseHeaderCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpResponseHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpResponseHeaderCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpResponseHeaderCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpResponseHeaderCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpResponseHeaderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpResponseHeaderCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpResponseHeaderCollection> for super::super::super::Foundation::Collections::IIterable<super::super::super::Foundation::Collections::IKeyValuePair<::windows::core::HSTRING, ::windows::core::HSTRING>> {
     type Error = ::windows::core::Error;
@@ -8338,36 +7439,7 @@ unsafe impl ::windows::core::Interface for HttpTransferCodingHeaderValue {
 impl ::windows::core::RuntimeName for HttpTransferCodingHeaderValue {
     const NAME: &'static str = "Windows.Web.Http.Headers.HttpTransferCodingHeaderValue";
 }
-impl ::core::convert::From<HttpTransferCodingHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: HttpTransferCodingHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpTransferCodingHeaderValue> for ::windows::core::IUnknown {
-    fn from(value: &HttpTransferCodingHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpTransferCodingHeaderValue> for &::windows::core::IUnknown {
-    fn from(value: &HttpTransferCodingHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpTransferCodingHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: HttpTransferCodingHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpTransferCodingHeaderValue> for ::windows::core::IInspectable {
-    fn from(value: &HttpTransferCodingHeaderValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpTransferCodingHeaderValue> for &::windows::core::IInspectable {
-    fn from(value: &HttpTransferCodingHeaderValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpTransferCodingHeaderValue, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpTransferCodingHeaderValue> for super::super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -8561,36 +7633,7 @@ impl ::core::iter::IntoIterator for &HttpTransferCodingHeaderValueCollection {
         super::super::super::Foundation::Collections::VectorIterator::new(::core::convert::TryInto::try_into(self).ok())
     }
 }
-impl ::core::convert::From<HttpTransferCodingHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpTransferCodingHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpTransferCodingHeaderValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpTransferCodingHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpTransferCodingHeaderValueCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpTransferCodingHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpTransferCodingHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpTransferCodingHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpTransferCodingHeaderValueCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpTransferCodingHeaderValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpTransferCodingHeaderValueCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpTransferCodingHeaderValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpTransferCodingHeaderValueCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpTransferCodingHeaderValueCollection> for super::super::super::Foundation::Collections::IIterable<HttpTransferCodingHeaderValue> {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Web/Http/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/mod.rs
@@ -232,36 +232,7 @@ impl IHttpContent {
         unsafe { (::windows::core::Vtable::vtable(this).Close)(::windows::core::Vtable::as_raw(this)).ok() }
     }
 }
-impl ::core::convert::From<IHttpContent> for ::windows::core::IUnknown {
-    fn from(value: IHttpContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpContent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHttpContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpContent> for ::windows::core::IUnknown {
-    fn from(value: &IHttpContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHttpContent> for ::windows::core::IInspectable {
-    fn from(value: IHttpContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpContent> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IHttpContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpContent> for ::windows::core::IInspectable {
-    fn from(value: &IHttpContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHttpContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<IHttpContent> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -940,36 +911,7 @@ unsafe impl ::windows::core::Interface for HttpBufferContent {
 impl ::windows::core::RuntimeName for HttpBufferContent {
     const NAME: &'static str = "Windows.Web.Http.HttpBufferContent";
 }
-impl ::core::convert::From<HttpBufferContent> for ::windows::core::IUnknown {
-    fn from(value: HttpBufferContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpBufferContent> for ::windows::core::IUnknown {
-    fn from(value: &HttpBufferContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpBufferContent> for &::windows::core::IUnknown {
-    fn from(value: &HttpBufferContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpBufferContent> for ::windows::core::IInspectable {
-    fn from(value: HttpBufferContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpBufferContent> for ::windows::core::IInspectable {
-    fn from(value: &HttpBufferContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpBufferContent> for &::windows::core::IInspectable {
-    fn from(value: &HttpBufferContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpBufferContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpBufferContent> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1316,36 +1258,7 @@ unsafe impl ::windows::core::Interface for HttpClient {
 impl ::windows::core::RuntimeName for HttpClient {
     const NAME: &'static str = "Windows.Web.Http.HttpClient";
 }
-impl ::core::convert::From<HttpClient> for ::windows::core::IUnknown {
-    fn from(value: HttpClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpClient> for ::windows::core::IUnknown {
-    fn from(value: &HttpClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpClient> for &::windows::core::IUnknown {
-    fn from(value: &HttpClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpClient> for ::windows::core::IInspectable {
-    fn from(value: HttpClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpClient> for ::windows::core::IInspectable {
-    fn from(value: &HttpClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpClient> for &::windows::core::IInspectable {
-    fn from(value: &HttpClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpClient, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpClient> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -1522,36 +1435,7 @@ unsafe impl ::windows::core::Interface for HttpCookie {
 impl ::windows::core::RuntimeName for HttpCookie {
     const NAME: &'static str = "Windows.Web.Http.HttpCookie";
 }
-impl ::core::convert::From<HttpCookie> for ::windows::core::IUnknown {
-    fn from(value: HttpCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCookie> for ::windows::core::IUnknown {
-    fn from(value: &HttpCookie) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCookie> for &::windows::core::IUnknown {
-    fn from(value: &HttpCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpCookie> for ::windows::core::IInspectable {
-    fn from(value: HttpCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCookie> for ::windows::core::IInspectable {
-    fn from(value: &HttpCookie) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCookie> for &::windows::core::IInspectable {
-    fn from(value: &HttpCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpCookie, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpCookie> for super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -1685,41 +1569,7 @@ impl ::core::iter::IntoIterator for &HttpCookieCollection {
     }
 }
 #[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<HttpCookieCollection> for ::windows::core::IUnknown {
-    fn from(value: HttpCookieCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&HttpCookieCollection> for ::windows::core::IUnknown {
-    fn from(value: &HttpCookieCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&HttpCookieCollection> for &::windows::core::IUnknown {
-    fn from(value: &HttpCookieCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<HttpCookieCollection> for ::windows::core::IInspectable {
-    fn from(value: HttpCookieCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&HttpCookieCollection> for ::windows::core::IInspectable {
-    fn from(value: &HttpCookieCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Foundation_Collections")]
-impl ::core::convert::From<&HttpCookieCollection> for &::windows::core::IInspectable {
-    fn from(value: &HttpCookieCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpCookieCollection, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
 impl ::core::convert::TryFrom<HttpCookieCollection> for super::super::Foundation::Collections::IIterable<HttpCookie> {
     type Error = ::windows::core::Error;
@@ -1832,36 +1682,7 @@ unsafe impl ::windows::core::Interface for HttpCookieManager {
 impl ::windows::core::RuntimeName for HttpCookieManager {
     const NAME: &'static str = "Windows.Web.Http.HttpCookieManager";
 }
-impl ::core::convert::From<HttpCookieManager> for ::windows::core::IUnknown {
-    fn from(value: HttpCookieManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCookieManager> for ::windows::core::IUnknown {
-    fn from(value: &HttpCookieManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCookieManager> for &::windows::core::IUnknown {
-    fn from(value: &HttpCookieManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpCookieManager> for ::windows::core::IInspectable {
-    fn from(value: HttpCookieManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpCookieManager> for ::windows::core::IInspectable {
-    fn from(value: &HttpCookieManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpCookieManager> for &::windows::core::IInspectable {
-    fn from(value: &HttpCookieManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpCookieManager, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for HttpCookieManager {}
 unsafe impl ::core::marker::Sync for HttpCookieManager {}
 #[doc = "*Required features: `\"Web_Http\"`*"]
@@ -1998,36 +1819,7 @@ unsafe impl ::windows::core::Interface for HttpFormUrlEncodedContent {
 impl ::windows::core::RuntimeName for HttpFormUrlEncodedContent {
     const NAME: &'static str = "Windows.Web.Http.HttpFormUrlEncodedContent";
 }
-impl ::core::convert::From<HttpFormUrlEncodedContent> for ::windows::core::IUnknown {
-    fn from(value: HttpFormUrlEncodedContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpFormUrlEncodedContent> for ::windows::core::IUnknown {
-    fn from(value: &HttpFormUrlEncodedContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpFormUrlEncodedContent> for &::windows::core::IUnknown {
-    fn from(value: &HttpFormUrlEncodedContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpFormUrlEncodedContent> for ::windows::core::IInspectable {
-    fn from(value: HttpFormUrlEncodedContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpFormUrlEncodedContent> for ::windows::core::IInspectable {
-    fn from(value: &HttpFormUrlEncodedContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpFormUrlEncodedContent> for &::windows::core::IInspectable {
-    fn from(value: &HttpFormUrlEncodedContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpFormUrlEncodedContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpFormUrlEncodedContent> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2182,36 +1974,7 @@ unsafe impl ::windows::core::Interface for HttpGetBufferResult {
 impl ::windows::core::RuntimeName for HttpGetBufferResult {
     const NAME: &'static str = "Windows.Web.Http.HttpGetBufferResult";
 }
-impl ::core::convert::From<HttpGetBufferResult> for ::windows::core::IUnknown {
-    fn from(value: HttpGetBufferResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpGetBufferResult> for ::windows::core::IUnknown {
-    fn from(value: &HttpGetBufferResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpGetBufferResult> for &::windows::core::IUnknown {
-    fn from(value: &HttpGetBufferResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpGetBufferResult> for ::windows::core::IInspectable {
-    fn from(value: HttpGetBufferResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpGetBufferResult> for ::windows::core::IInspectable {
-    fn from(value: &HttpGetBufferResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpGetBufferResult> for &::windows::core::IInspectable {
-    fn from(value: &HttpGetBufferResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpGetBufferResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpGetBufferResult> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2347,36 +2110,7 @@ unsafe impl ::windows::core::Interface for HttpGetInputStreamResult {
 impl ::windows::core::RuntimeName for HttpGetInputStreamResult {
     const NAME: &'static str = "Windows.Web.Http.HttpGetInputStreamResult";
 }
-impl ::core::convert::From<HttpGetInputStreamResult> for ::windows::core::IUnknown {
-    fn from(value: HttpGetInputStreamResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpGetInputStreamResult> for ::windows::core::IUnknown {
-    fn from(value: &HttpGetInputStreamResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpGetInputStreamResult> for &::windows::core::IUnknown {
-    fn from(value: &HttpGetInputStreamResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpGetInputStreamResult> for ::windows::core::IInspectable {
-    fn from(value: HttpGetInputStreamResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpGetInputStreamResult> for ::windows::core::IInspectable {
-    fn from(value: &HttpGetInputStreamResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpGetInputStreamResult> for &::windows::core::IInspectable {
-    fn from(value: &HttpGetInputStreamResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpGetInputStreamResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpGetInputStreamResult> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2510,36 +2244,7 @@ unsafe impl ::windows::core::Interface for HttpGetStringResult {
 impl ::windows::core::RuntimeName for HttpGetStringResult {
     const NAME: &'static str = "Windows.Web.Http.HttpGetStringResult";
 }
-impl ::core::convert::From<HttpGetStringResult> for ::windows::core::IUnknown {
-    fn from(value: HttpGetStringResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpGetStringResult> for ::windows::core::IUnknown {
-    fn from(value: &HttpGetStringResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpGetStringResult> for &::windows::core::IUnknown {
-    fn from(value: &HttpGetStringResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpGetStringResult> for ::windows::core::IInspectable {
-    fn from(value: HttpGetStringResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpGetStringResult> for ::windows::core::IInspectable {
-    fn from(value: &HttpGetStringResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpGetStringResult> for &::windows::core::IInspectable {
-    fn from(value: &HttpGetStringResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpGetStringResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpGetStringResult> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -2697,36 +2402,7 @@ unsafe impl ::windows::core::Interface for HttpMethod {
 impl ::windows::core::RuntimeName for HttpMethod {
     const NAME: &'static str = "Windows.Web.Http.HttpMethod";
 }
-impl ::core::convert::From<HttpMethod> for ::windows::core::IUnknown {
-    fn from(value: HttpMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMethod> for ::windows::core::IUnknown {
-    fn from(value: &HttpMethod) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMethod> for &::windows::core::IUnknown {
-    fn from(value: &HttpMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpMethod> for ::windows::core::IInspectable {
-    fn from(value: HttpMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMethod> for ::windows::core::IInspectable {
-    fn from(value: &HttpMethod) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMethod> for &::windows::core::IInspectable {
-    fn from(value: &HttpMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpMethod, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpMethod> for super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;
@@ -2925,36 +2601,7 @@ impl ::core::iter::IntoIterator for &HttpMultipartContent {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<HttpMultipartContent> for ::windows::core::IUnknown {
-    fn from(value: HttpMultipartContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMultipartContent> for ::windows::core::IUnknown {
-    fn from(value: &HttpMultipartContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMultipartContent> for &::windows::core::IUnknown {
-    fn from(value: &HttpMultipartContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpMultipartContent> for ::windows::core::IInspectable {
-    fn from(value: HttpMultipartContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMultipartContent> for ::windows::core::IInspectable {
-    fn from(value: &HttpMultipartContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMultipartContent> for &::windows::core::IInspectable {
-    fn from(value: &HttpMultipartContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpMultipartContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpMultipartContent> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3226,36 +2873,7 @@ impl ::core::iter::IntoIterator for &HttpMultipartFormDataContent {
         self.First().unwrap()
     }
 }
-impl ::core::convert::From<HttpMultipartFormDataContent> for ::windows::core::IUnknown {
-    fn from(value: HttpMultipartFormDataContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMultipartFormDataContent> for ::windows::core::IUnknown {
-    fn from(value: &HttpMultipartFormDataContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMultipartFormDataContent> for &::windows::core::IUnknown {
-    fn from(value: &HttpMultipartFormDataContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpMultipartFormDataContent> for ::windows::core::IInspectable {
-    fn from(value: HttpMultipartFormDataContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpMultipartFormDataContent> for ::windows::core::IInspectable {
-    fn from(value: &HttpMultipartFormDataContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpMultipartFormDataContent> for &::windows::core::IInspectable {
-    fn from(value: &HttpMultipartFormDataContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpMultipartFormDataContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpMultipartFormDataContent> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3481,36 +3099,7 @@ unsafe impl ::windows::core::Interface for HttpRequestMessage {
 impl ::windows::core::RuntimeName for HttpRequestMessage {
     const NAME: &'static str = "Windows.Web.Http.HttpRequestMessage";
 }
-impl ::core::convert::From<HttpRequestMessage> for ::windows::core::IUnknown {
-    fn from(value: HttpRequestMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpRequestMessage> for ::windows::core::IUnknown {
-    fn from(value: &HttpRequestMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpRequestMessage> for &::windows::core::IUnknown {
-    fn from(value: &HttpRequestMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpRequestMessage> for ::windows::core::IInspectable {
-    fn from(value: HttpRequestMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpRequestMessage> for ::windows::core::IInspectable {
-    fn from(value: &HttpRequestMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpRequestMessage> for &::windows::core::IInspectable {
-    fn from(value: &HttpRequestMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpRequestMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpRequestMessage> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3637,36 +3226,7 @@ unsafe impl ::windows::core::Interface for HttpRequestResult {
 impl ::windows::core::RuntimeName for HttpRequestResult {
     const NAME: &'static str = "Windows.Web.Http.HttpRequestResult";
 }
-impl ::core::convert::From<HttpRequestResult> for ::windows::core::IUnknown {
-    fn from(value: HttpRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpRequestResult> for ::windows::core::IUnknown {
-    fn from(value: &HttpRequestResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpRequestResult> for &::windows::core::IUnknown {
-    fn from(value: &HttpRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpRequestResult> for ::windows::core::IInspectable {
-    fn from(value: HttpRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpRequestResult> for ::windows::core::IInspectable {
-    fn from(value: &HttpRequestResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpRequestResult> for &::windows::core::IInspectable {
-    fn from(value: &HttpRequestResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpRequestResult, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpRequestResult> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -3876,36 +3436,7 @@ unsafe impl ::windows::core::Interface for HttpResponseMessage {
 impl ::windows::core::RuntimeName for HttpResponseMessage {
     const NAME: &'static str = "Windows.Web.Http.HttpResponseMessage";
 }
-impl ::core::convert::From<HttpResponseMessage> for ::windows::core::IUnknown {
-    fn from(value: HttpResponseMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpResponseMessage> for ::windows::core::IUnknown {
-    fn from(value: &HttpResponseMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpResponseMessage> for &::windows::core::IUnknown {
-    fn from(value: &HttpResponseMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpResponseMessage> for ::windows::core::IInspectable {
-    fn from(value: HttpResponseMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpResponseMessage> for ::windows::core::IInspectable {
-    fn from(value: &HttpResponseMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpResponseMessage> for &::windows::core::IInspectable {
-    fn from(value: &HttpResponseMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpResponseMessage, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpResponseMessage> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4086,36 +3617,7 @@ unsafe impl ::windows::core::Interface for HttpStreamContent {
 impl ::windows::core::RuntimeName for HttpStreamContent {
     const NAME: &'static str = "Windows.Web.Http.HttpStreamContent";
 }
-impl ::core::convert::From<HttpStreamContent> for ::windows::core::IUnknown {
-    fn from(value: HttpStreamContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpStreamContent> for ::windows::core::IUnknown {
-    fn from(value: &HttpStreamContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpStreamContent> for &::windows::core::IUnknown {
-    fn from(value: &HttpStreamContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpStreamContent> for ::windows::core::IInspectable {
-    fn from(value: HttpStreamContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpStreamContent> for ::windows::core::IInspectable {
-    fn from(value: &HttpStreamContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpStreamContent> for &::windows::core::IInspectable {
-    fn from(value: &HttpStreamContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpStreamContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpStreamContent> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4325,36 +3827,7 @@ unsafe impl ::windows::core::Interface for HttpStringContent {
 impl ::windows::core::RuntimeName for HttpStringContent {
     const NAME: &'static str = "Windows.Web.Http.HttpStringContent";
 }
-impl ::core::convert::From<HttpStringContent> for ::windows::core::IUnknown {
-    fn from(value: HttpStringContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpStringContent> for ::windows::core::IUnknown {
-    fn from(value: &HttpStringContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpStringContent> for &::windows::core::IUnknown {
-    fn from(value: &HttpStringContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpStringContent> for ::windows::core::IInspectable {
-    fn from(value: HttpStringContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpStringContent> for ::windows::core::IInspectable {
-    fn from(value: &HttpStringContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpStringContent> for &::windows::core::IInspectable {
-    fn from(value: &HttpStringContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpStringContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpStringContent> for super::super::Foundation::IClosable {
     type Error = ::windows::core::Error;
@@ -4502,36 +3975,7 @@ unsafe impl ::windows::core::Interface for HttpTransportInformation {
 impl ::windows::core::RuntimeName for HttpTransportInformation {
     const NAME: &'static str = "Windows.Web.Http.HttpTransportInformation";
 }
-impl ::core::convert::From<HttpTransportInformation> for ::windows::core::IUnknown {
-    fn from(value: HttpTransportInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpTransportInformation> for ::windows::core::IUnknown {
-    fn from(value: &HttpTransportInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpTransportInformation> for &::windows::core::IUnknown {
-    fn from(value: &HttpTransportInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<HttpTransportInformation> for ::windows::core::IInspectable {
-    fn from(value: HttpTransportInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&HttpTransportInformation> for ::windows::core::IInspectable {
-    fn from(value: &HttpTransportInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&HttpTransportInformation> for &::windows::core::IInspectable {
-    fn from(value: &HttpTransportInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(HttpTransportInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[cfg(feature = "Foundation")]
 impl ::core::convert::TryFrom<HttpTransportInformation> for super::super::Foundation::IStringable {
     type Error = ::windows::core::Error;

--- a/crates/libs/windows/src/Windows/Web/Syndication/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Syndication/mod.rs
@@ -150,36 +150,7 @@ impl ISyndicationClient {
         }
     }
 }
-impl ::core::convert::From<ISyndicationClient> for ::windows::core::IUnknown {
-    fn from(value: ISyndicationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyndicationClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyndicationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyndicationClient> for ::windows::core::IUnknown {
-    fn from(value: &ISyndicationClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyndicationClient> for ::windows::core::IInspectable {
-    fn from(value: ISyndicationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyndicationClient> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISyndicationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyndicationClient> for ::windows::core::IInspectable {
-    fn from(value: &ISyndicationClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyndicationClient, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISyndicationClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -711,36 +682,7 @@ impl ISyndicationNode {
         }
     }
 }
-impl ::core::convert::From<ISyndicationNode> for ::windows::core::IUnknown {
-    fn from(value: ISyndicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyndicationNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyndicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyndicationNode> for ::windows::core::IUnknown {
-    fn from(value: &ISyndicationNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyndicationNode> for ::windows::core::IInspectable {
-    fn from(value: ISyndicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyndicationNode> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISyndicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyndicationNode> for ::windows::core::IInspectable {
-    fn from(value: &ISyndicationNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyndicationNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISyndicationNode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -991,36 +933,7 @@ impl ISyndicationText {
         }
     }
 }
-impl ::core::convert::From<ISyndicationText> for ::windows::core::IUnknown {
-    fn from(value: ISyndicationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyndicationText> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyndicationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyndicationText> for ::windows::core::IUnknown {
-    fn from(value: &ISyndicationText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyndicationText> for ::windows::core::IInspectable {
-    fn from(value: ISyndicationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyndicationText> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISyndicationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyndicationText> for ::windows::core::IInspectable {
-    fn from(value: &ISyndicationText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyndicationText, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<ISyndicationText> for ISyndicationNode {
     type Error = ::windows::core::Error;
     fn try_from(value: ISyndicationText) -> ::windows::core::Result<Self> {
@@ -1190,36 +1103,7 @@ unsafe impl ::windows::core::Interface for SyndicationAttribute {
 impl ::windows::core::RuntimeName for SyndicationAttribute {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationAttribute";
 }
-impl ::core::convert::From<SyndicationAttribute> for ::windows::core::IUnknown {
-    fn from(value: SyndicationAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationAttribute> for ::windows::core::IUnknown {
-    fn from(value: &SyndicationAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationAttribute> for &::windows::core::IUnknown {
-    fn from(value: &SyndicationAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SyndicationAttribute> for ::windows::core::IInspectable {
-    fn from(value: SyndicationAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationAttribute> for ::windows::core::IInspectable {
-    fn from(value: &SyndicationAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationAttribute> for &::windows::core::IInspectable {
-    fn from(value: &SyndicationAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SyndicationAttribute, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for SyndicationAttribute {}
 unsafe impl ::core::marker::Sync for SyndicationAttribute {}
 #[doc = "*Required features: `\"Web_Syndication\"`*"]
@@ -1402,36 +1286,7 @@ unsafe impl ::windows::core::Interface for SyndicationCategory {
 impl ::windows::core::RuntimeName for SyndicationCategory {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationCategory";
 }
-impl ::core::convert::From<SyndicationCategory> for ::windows::core::IUnknown {
-    fn from(value: SyndicationCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationCategory> for ::windows::core::IUnknown {
-    fn from(value: &SyndicationCategory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationCategory> for &::windows::core::IUnknown {
-    fn from(value: &SyndicationCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SyndicationCategory> for ::windows::core::IInspectable {
-    fn from(value: SyndicationCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationCategory> for ::windows::core::IInspectable {
-    fn from(value: &SyndicationCategory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationCategory> for &::windows::core::IInspectable {
-    fn from(value: &SyndicationCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SyndicationCategory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SyndicationCategory> for ISyndicationNode {
     type Error = ::windows::core::Error;
     fn try_from(value: SyndicationCategory) -> ::windows::core::Result<Self> {
@@ -1586,36 +1441,7 @@ unsafe impl ::windows::core::Interface for SyndicationClient {
 impl ::windows::core::RuntimeName for SyndicationClient {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationClient";
 }
-impl ::core::convert::From<SyndicationClient> for ::windows::core::IUnknown {
-    fn from(value: SyndicationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationClient> for ::windows::core::IUnknown {
-    fn from(value: &SyndicationClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationClient> for &::windows::core::IUnknown {
-    fn from(value: &SyndicationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SyndicationClient> for ::windows::core::IInspectable {
-    fn from(value: SyndicationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationClient> for ::windows::core::IInspectable {
-    fn from(value: &SyndicationClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationClient> for &::windows::core::IInspectable {
-    fn from(value: &SyndicationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SyndicationClient, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SyndicationClient> for ISyndicationClient {
     type Error = ::windows::core::Error;
     fn try_from(value: SyndicationClient) -> ::windows::core::Result<Self> {
@@ -1838,36 +1664,7 @@ unsafe impl ::windows::core::Interface for SyndicationContent {
 impl ::windows::core::RuntimeName for SyndicationContent {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationContent";
 }
-impl ::core::convert::From<SyndicationContent> for ::windows::core::IUnknown {
-    fn from(value: SyndicationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationContent> for ::windows::core::IUnknown {
-    fn from(value: &SyndicationContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationContent> for &::windows::core::IUnknown {
-    fn from(value: &SyndicationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SyndicationContent> for ::windows::core::IInspectable {
-    fn from(value: SyndicationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationContent> for ::windows::core::IInspectable {
-    fn from(value: &SyndicationContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationContent> for &::windows::core::IInspectable {
-    fn from(value: &SyndicationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SyndicationContent, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SyndicationContent> for ISyndicationNode {
     type Error = ::windows::core::Error;
     fn try_from(value: SyndicationContent) -> ::windows::core::Result<Self> {
@@ -2279,36 +2076,7 @@ unsafe impl ::windows::core::Interface for SyndicationFeed {
 impl ::windows::core::RuntimeName for SyndicationFeed {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationFeed";
 }
-impl ::core::convert::From<SyndicationFeed> for ::windows::core::IUnknown {
-    fn from(value: SyndicationFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationFeed> for ::windows::core::IUnknown {
-    fn from(value: &SyndicationFeed) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationFeed> for &::windows::core::IUnknown {
-    fn from(value: &SyndicationFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SyndicationFeed> for ::windows::core::IInspectable {
-    fn from(value: SyndicationFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationFeed> for ::windows::core::IInspectable {
-    fn from(value: &SyndicationFeed) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationFeed> for &::windows::core::IInspectable {
-    fn from(value: &SyndicationFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SyndicationFeed, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SyndicationFeed> for ISyndicationNode {
     type Error = ::windows::core::Error;
     fn try_from(value: SyndicationFeed) -> ::windows::core::Result<Self> {
@@ -2508,36 +2276,7 @@ unsafe impl ::windows::core::Interface for SyndicationGenerator {
 impl ::windows::core::RuntimeName for SyndicationGenerator {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationGenerator";
 }
-impl ::core::convert::From<SyndicationGenerator> for ::windows::core::IUnknown {
-    fn from(value: SyndicationGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationGenerator> for ::windows::core::IUnknown {
-    fn from(value: &SyndicationGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationGenerator> for &::windows::core::IUnknown {
-    fn from(value: &SyndicationGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SyndicationGenerator> for ::windows::core::IInspectable {
-    fn from(value: SyndicationGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationGenerator> for ::windows::core::IInspectable {
-    fn from(value: &SyndicationGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationGenerator> for &::windows::core::IInspectable {
-    fn from(value: &SyndicationGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SyndicationGenerator, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SyndicationGenerator> for ISyndicationNode {
     type Error = ::windows::core::Error;
     fn try_from(value: SyndicationGenerator) -> ::windows::core::Result<Self> {
@@ -2905,36 +2644,7 @@ unsafe impl ::windows::core::Interface for SyndicationItem {
 impl ::windows::core::RuntimeName for SyndicationItem {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationItem";
 }
-impl ::core::convert::From<SyndicationItem> for ::windows::core::IUnknown {
-    fn from(value: SyndicationItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationItem> for ::windows::core::IUnknown {
-    fn from(value: &SyndicationItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationItem> for &::windows::core::IUnknown {
-    fn from(value: &SyndicationItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SyndicationItem> for ::windows::core::IInspectable {
-    fn from(value: SyndicationItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationItem> for ::windows::core::IInspectable {
-    fn from(value: &SyndicationItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationItem> for &::windows::core::IInspectable {
-    fn from(value: &SyndicationItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SyndicationItem, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SyndicationItem> for ISyndicationNode {
     type Error = ::windows::core::Error;
     fn try_from(value: SyndicationItem) -> ::windows::core::Result<Self> {
@@ -3177,36 +2887,7 @@ unsafe impl ::windows::core::Interface for SyndicationLink {
 impl ::windows::core::RuntimeName for SyndicationLink {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationLink";
 }
-impl ::core::convert::From<SyndicationLink> for ::windows::core::IUnknown {
-    fn from(value: SyndicationLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationLink> for ::windows::core::IUnknown {
-    fn from(value: &SyndicationLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationLink> for &::windows::core::IUnknown {
-    fn from(value: &SyndicationLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SyndicationLink> for ::windows::core::IInspectable {
-    fn from(value: SyndicationLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationLink> for ::windows::core::IInspectable {
-    fn from(value: &SyndicationLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationLink> for &::windows::core::IInspectable {
-    fn from(value: &SyndicationLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SyndicationLink, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SyndicationLink> for ISyndicationNode {
     type Error = ::windows::core::Error;
     fn try_from(value: SyndicationLink) -> ::windows::core::Result<Self> {
@@ -3369,36 +3050,7 @@ unsafe impl ::windows::core::Interface for SyndicationNode {
 impl ::windows::core::RuntimeName for SyndicationNode {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationNode";
 }
-impl ::core::convert::From<SyndicationNode> for ::windows::core::IUnknown {
-    fn from(value: SyndicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationNode> for ::windows::core::IUnknown {
-    fn from(value: &SyndicationNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationNode> for &::windows::core::IUnknown {
-    fn from(value: &SyndicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SyndicationNode> for ::windows::core::IInspectable {
-    fn from(value: SyndicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationNode> for ::windows::core::IInspectable {
-    fn from(value: &SyndicationNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationNode> for &::windows::core::IInspectable {
-    fn from(value: &SyndicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SyndicationNode, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SyndicationNode> for ISyndicationNode {
     type Error = ::windows::core::Error;
     fn try_from(value: SyndicationNode) -> ::windows::core::Result<Self> {
@@ -3606,36 +3258,7 @@ unsafe impl ::windows::core::Interface for SyndicationPerson {
 impl ::windows::core::RuntimeName for SyndicationPerson {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationPerson";
 }
-impl ::core::convert::From<SyndicationPerson> for ::windows::core::IUnknown {
-    fn from(value: SyndicationPerson) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationPerson> for ::windows::core::IUnknown {
-    fn from(value: &SyndicationPerson) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationPerson> for &::windows::core::IUnknown {
-    fn from(value: &SyndicationPerson) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SyndicationPerson> for ::windows::core::IInspectable {
-    fn from(value: SyndicationPerson) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationPerson> for ::windows::core::IInspectable {
-    fn from(value: &SyndicationPerson) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationPerson> for &::windows::core::IInspectable {
-    fn from(value: &SyndicationPerson) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SyndicationPerson, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SyndicationPerson> for ISyndicationNode {
     type Error = ::windows::core::Error;
     fn try_from(value: SyndicationPerson) -> ::windows::core::Result<Self> {
@@ -3841,36 +3464,7 @@ unsafe impl ::windows::core::Interface for SyndicationText {
 impl ::windows::core::RuntimeName for SyndicationText {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationText";
 }
-impl ::core::convert::From<SyndicationText> for ::windows::core::IUnknown {
-    fn from(value: SyndicationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationText> for ::windows::core::IUnknown {
-    fn from(value: &SyndicationText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationText> for &::windows::core::IUnknown {
-    fn from(value: &SyndicationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<SyndicationText> for ::windows::core::IInspectable {
-    fn from(value: SyndicationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&SyndicationText> for ::windows::core::IInspectable {
-    fn from(value: &SyndicationText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&SyndicationText> for &::windows::core::IInspectable {
-    fn from(value: &SyndicationText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(SyndicationText, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<SyndicationText> for ISyndicationNode {
     type Error = ::windows::core::Error;
     fn try_from(value: SyndicationText) -> ::windows::core::Result<Self> {

--- a/crates/libs/windows/src/Windows/Web/UI/Interop/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/UI/Interop/mod.rs
@@ -756,36 +756,7 @@ unsafe impl ::windows::core::Interface for WebViewControl {
 impl ::windows::core::RuntimeName for WebViewControl {
     const NAME: &'static str = "Windows.Web.UI.Interop.WebViewControl";
 }
-impl ::core::convert::From<WebViewControl> for ::windows::core::IUnknown {
-    fn from(value: WebViewControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControl> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControl> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControl> for ::windows::core::IInspectable {
-    fn from(value: WebViewControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControl> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControl> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::convert::TryFrom<WebViewControl> for super::IWebViewControl {
     type Error = ::windows::core::Error;
     fn try_from(value: WebViewControl) -> ::windows::core::Result<Self> {
@@ -906,36 +877,7 @@ unsafe impl ::windows::core::Interface for WebViewControlAcceleratorKeyPressedEv
 impl ::windows::core::RuntimeName for WebViewControlAcceleratorKeyPressedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.Interop.WebViewControlAcceleratorKeyPressedEventArgs";
 }
-impl ::core::convert::From<WebViewControlAcceleratorKeyPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlAcceleratorKeyPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlAcceleratorKeyPressedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlAcceleratorKeyPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlAcceleratorKeyPressedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlAcceleratorKeyPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlAcceleratorKeyPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlAcceleratorKeyPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlAcceleratorKeyPressedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlAcceleratorKeyPressedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlAcceleratorKeyPressedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlAcceleratorKeyPressedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlAcceleratorKeyPressedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI_Interop\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlMoveFocusRequestedEventArgs(::windows::core::IUnknown);
@@ -980,36 +922,7 @@ unsafe impl ::windows::core::Interface for WebViewControlMoveFocusRequestedEvent
 impl ::windows::core::RuntimeName for WebViewControlMoveFocusRequestedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.Interop.WebViewControlMoveFocusRequestedEventArgs";
 }
-impl ::core::convert::From<WebViewControlMoveFocusRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlMoveFocusRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlMoveFocusRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlMoveFocusRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlMoveFocusRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlMoveFocusRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlMoveFocusRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlMoveFocusRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlMoveFocusRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlMoveFocusRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlMoveFocusRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlMoveFocusRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlMoveFocusRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI_Interop\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlProcess(::windows::core::IUnknown);
@@ -1123,36 +1036,7 @@ unsafe impl ::windows::core::Interface for WebViewControlProcess {
 impl ::windows::core::RuntimeName for WebViewControlProcess {
     const NAME: &'static str = "Windows.Web.UI.Interop.WebViewControlProcess";
 }
-impl ::core::convert::From<WebViewControlProcess> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlProcess> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlProcess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlProcess> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlProcess> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlProcess> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlProcess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlProcess> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlProcess, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI_Interop\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlProcessOptions(::windows::core::IUnknown);
@@ -1219,36 +1103,7 @@ unsafe impl ::windows::core::Interface for WebViewControlProcessOptions {
 impl ::windows::core::RuntimeName for WebViewControlProcessOptions {
     const NAME: &'static str = "Windows.Web.UI.Interop.WebViewControlProcessOptions";
 }
-impl ::core::convert::From<WebViewControlProcessOptions> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlProcessOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlProcessOptions> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlProcessOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlProcessOptions> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlProcessOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlProcessOptions> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlProcessOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlProcessOptions> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlProcessOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlProcessOptions> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlProcessOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlProcessOptions, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI_Interop\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/Web/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/UI/mod.rs
@@ -424,36 +424,7 @@ impl IWebViewControl {
         unsafe { (::windows::core::Vtable::vtable(this).RemoveWebResourceRequested)(::windows::core::Vtable::as_raw(this), token).ok() }
     }
 }
-impl ::core::convert::From<IWebViewControl> for ::windows::core::IUnknown {
-    fn from(value: IWebViewControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebViewControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebViewControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebViewControl> for ::windows::core::IUnknown {
-    fn from(value: &IWebViewControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebViewControl> for ::windows::core::IInspectable {
-    fn from(value: IWebViewControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebViewControl> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebViewControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebViewControl> for ::windows::core::IInspectable {
-    fn from(value: &IWebViewControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebViewControl, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebViewControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -692,36 +663,7 @@ impl IWebViewControl2 {
         unsafe { (::windows::core::Vtable::vtable(this).AddInitializeScript)(::windows::core::Vtable::as_raw(this), ::core::mem::transmute_copy(script)).ok() }
     }
 }
-impl ::core::convert::From<IWebViewControl2> for ::windows::core::IUnknown {
-    fn from(value: IWebViewControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebViewControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebViewControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebViewControl2> for ::windows::core::IUnknown {
-    fn from(value: &IWebViewControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebViewControl2> for ::windows::core::IInspectable {
-    fn from(value: IWebViewControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebViewControl2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebViewControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebViewControl2> for ::windows::core::IInspectable {
-    fn from(value: &IWebViewControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebViewControl2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebViewControl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1116,36 +1058,7 @@ unsafe impl ::windows::core::Interface for WebViewControlContentLoadingEventArgs
 impl ::windows::core::RuntimeName for WebViewControlContentLoadingEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlContentLoadingEventArgs";
 }
-impl ::core::convert::From<WebViewControlContentLoadingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlContentLoadingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlContentLoadingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlContentLoadingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlContentLoadingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlContentLoadingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlContentLoadingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlContentLoadingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlContentLoadingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlContentLoadingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlContentLoadingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlContentLoadingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlContentLoadingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlDOMContentLoadedEventArgs(::windows::core::IUnknown);
@@ -1192,36 +1105,7 @@ unsafe impl ::windows::core::Interface for WebViewControlDOMContentLoadedEventAr
 impl ::windows::core::RuntimeName for WebViewControlDOMContentLoadedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlDOMContentLoadedEventArgs";
 }
-impl ::core::convert::From<WebViewControlDOMContentLoadedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlDOMContentLoadedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlDOMContentLoadedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlDOMContentLoadedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlDOMContentLoadedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlDOMContentLoadedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlDOMContentLoadedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlDOMContentLoadedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlDOMContentLoadedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlDOMContentLoadedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlDOMContentLoadedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlDOMContentLoadedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlDOMContentLoadedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlDeferredPermissionRequest(::windows::core::IUnknown);
@@ -1290,36 +1174,7 @@ unsafe impl ::windows::core::Interface for WebViewControlDeferredPermissionReque
 impl ::windows::core::RuntimeName for WebViewControlDeferredPermissionRequest {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlDeferredPermissionRequest";
 }
-impl ::core::convert::From<WebViewControlDeferredPermissionRequest> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlDeferredPermissionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlDeferredPermissionRequest> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlDeferredPermissionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlDeferredPermissionRequest> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlDeferredPermissionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlDeferredPermissionRequest> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlDeferredPermissionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlDeferredPermissionRequest> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlDeferredPermissionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlDeferredPermissionRequest> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlDeferredPermissionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlDeferredPermissionRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlLongRunningScriptDetectedEventArgs(::windows::core::IUnknown);
@@ -1377,36 +1232,7 @@ unsafe impl ::windows::core::Interface for WebViewControlLongRunningScriptDetect
 impl ::windows::core::RuntimeName for WebViewControlLongRunningScriptDetectedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlLongRunningScriptDetectedEventArgs";
 }
-impl ::core::convert::From<WebViewControlLongRunningScriptDetectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlLongRunningScriptDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlLongRunningScriptDetectedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlLongRunningScriptDetectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlLongRunningScriptDetectedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlLongRunningScriptDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlLongRunningScriptDetectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlLongRunningScriptDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlLongRunningScriptDetectedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlLongRunningScriptDetectedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlLongRunningScriptDetectedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlLongRunningScriptDetectedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlLongRunningScriptDetectedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlNavigationCompletedEventArgs(::windows::core::IUnknown);
@@ -1467,36 +1293,7 @@ unsafe impl ::windows::core::Interface for WebViewControlNavigationCompletedEven
 impl ::windows::core::RuntimeName for WebViewControlNavigationCompletedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlNavigationCompletedEventArgs";
 }
-impl ::core::convert::From<WebViewControlNavigationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlNavigationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlNavigationCompletedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlNavigationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlNavigationCompletedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlNavigationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlNavigationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlNavigationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlNavigationCompletedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlNavigationCompletedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlNavigationCompletedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlNavigationCompletedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlNavigationCompletedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlNavigationStartingEventArgs(::windows::core::IUnknown);
@@ -1554,36 +1351,7 @@ unsafe impl ::windows::core::Interface for WebViewControlNavigationStartingEvent
 impl ::windows::core::RuntimeName for WebViewControlNavigationStartingEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlNavigationStartingEventArgs";
 }
-impl ::core::convert::From<WebViewControlNavigationStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlNavigationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlNavigationStartingEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlNavigationStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlNavigationStartingEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlNavigationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlNavigationStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlNavigationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlNavigationStartingEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlNavigationStartingEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlNavigationStartingEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlNavigationStartingEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlNavigationStartingEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlNewWindowRequestedEventArgs(::windows::core::IUnknown);
@@ -1674,36 +1442,7 @@ unsafe impl ::windows::core::Interface for WebViewControlNewWindowRequestedEvent
 impl ::windows::core::RuntimeName for WebViewControlNewWindowRequestedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlNewWindowRequestedEventArgs";
 }
-impl ::core::convert::From<WebViewControlNewWindowRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlNewWindowRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlNewWindowRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlNewWindowRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlNewWindowRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlNewWindowRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlNewWindowRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlNewWindowRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlNewWindowRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlNewWindowRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlNewWindowRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlNewWindowRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlNewWindowRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlPermissionRequest(::windows::core::IUnknown);
@@ -1783,36 +1522,7 @@ unsafe impl ::windows::core::Interface for WebViewControlPermissionRequest {
 impl ::windows::core::RuntimeName for WebViewControlPermissionRequest {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlPermissionRequest";
 }
-impl ::core::convert::From<WebViewControlPermissionRequest> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlPermissionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlPermissionRequest> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlPermissionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlPermissionRequest> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlPermissionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlPermissionRequest> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlPermissionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlPermissionRequest> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlPermissionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlPermissionRequest> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlPermissionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlPermissionRequest, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlPermissionRequestedEventArgs(::windows::core::IUnknown);
@@ -1857,36 +1567,7 @@ unsafe impl ::windows::core::Interface for WebViewControlPermissionRequestedEven
 impl ::windows::core::RuntimeName for WebViewControlPermissionRequestedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlPermissionRequestedEventArgs";
 }
-impl ::core::convert::From<WebViewControlPermissionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlPermissionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlPermissionRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlPermissionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlPermissionRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlPermissionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlPermissionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlPermissionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlPermissionRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlPermissionRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlPermissionRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlPermissionRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlPermissionRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlScriptNotifyEventArgs(::windows::core::IUnknown);
@@ -1940,36 +1621,7 @@ unsafe impl ::windows::core::Interface for WebViewControlScriptNotifyEventArgs {
 impl ::windows::core::RuntimeName for WebViewControlScriptNotifyEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlScriptNotifyEventArgs";
 }
-impl ::core::convert::From<WebViewControlScriptNotifyEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlScriptNotifyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlScriptNotifyEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlScriptNotifyEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlScriptNotifyEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlScriptNotifyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlScriptNotifyEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlScriptNotifyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlScriptNotifyEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlScriptNotifyEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlScriptNotifyEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlScriptNotifyEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlScriptNotifyEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlSettings(::windows::core::IUnknown);
@@ -2040,36 +1692,7 @@ unsafe impl ::windows::core::Interface for WebViewControlSettings {
 impl ::windows::core::RuntimeName for WebViewControlSettings {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlSettings";
 }
-impl ::core::convert::From<WebViewControlSettings> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlSettings> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlSettings> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlSettings> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlSettings> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlSettings> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlSettings, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlUnsupportedUriSchemeIdentifiedEventArgs(::windows::core::IUnknown);
@@ -2127,36 +1750,7 @@ unsafe impl ::windows::core::Interface for WebViewControlUnsupportedUriSchemeIde
 impl ::windows::core::RuntimeName for WebViewControlUnsupportedUriSchemeIdentifiedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlUnsupportedUriSchemeIdentifiedEventArgs";
 }
-impl ::core::convert::From<WebViewControlUnsupportedUriSchemeIdentifiedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlUnsupportedUriSchemeIdentifiedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlUnsupportedUriSchemeIdentifiedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlUnsupportedUriSchemeIdentifiedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlUnsupportedUriSchemeIdentifiedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlUnsupportedUriSchemeIdentifiedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlUnsupportedUriSchemeIdentifiedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlUnsupportedUriSchemeIdentifiedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlUnsupportedUriSchemeIdentifiedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlUnsupportedUriSchemeIdentifiedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlUnsupportedUriSchemeIdentifiedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlUnsupportedUriSchemeIdentifiedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlUnsupportedUriSchemeIdentifiedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlUnviewableContentIdentifiedEventArgs(::windows::core::IUnknown);
@@ -2219,36 +1813,7 @@ unsafe impl ::windows::core::Interface for WebViewControlUnviewableContentIdenti
 impl ::windows::core::RuntimeName for WebViewControlUnviewableContentIdentifiedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlUnviewableContentIdentifiedEventArgs";
 }
-impl ::core::convert::From<WebViewControlUnviewableContentIdentifiedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlUnviewableContentIdentifiedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlUnviewableContentIdentifiedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlUnviewableContentIdentifiedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlUnviewableContentIdentifiedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlUnviewableContentIdentifiedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlUnviewableContentIdentifiedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlUnviewableContentIdentifiedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlUnviewableContentIdentifiedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlUnviewableContentIdentifiedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlUnviewableContentIdentifiedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlUnviewableContentIdentifiedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlUnviewableContentIdentifiedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 pub struct WebViewControlWebResourceRequestedEventArgs(::windows::core::IUnknown);
@@ -2319,36 +1884,7 @@ unsafe impl ::windows::core::Interface for WebViewControlWebResourceRequestedEve
 impl ::windows::core::RuntimeName for WebViewControlWebResourceRequestedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlWebResourceRequestedEventArgs";
 }
-impl ::core::convert::From<WebViewControlWebResourceRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: WebViewControlWebResourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlWebResourceRequestedEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &WebViewControlWebResourceRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlWebResourceRequestedEventArgs> for &::windows::core::IUnknown {
-    fn from(value: &WebViewControlWebResourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<WebViewControlWebResourceRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: WebViewControlWebResourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&WebViewControlWebResourceRequestedEventArgs> for ::windows::core::IInspectable {
-    fn from(value: &WebViewControlWebResourceRequestedEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&WebViewControlWebResourceRequestedEventArgs> for &::windows::core::IInspectable {
-    fn from(value: &WebViewControlWebResourceRequestedEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(WebViewControlWebResourceRequestedEventArgs, ::windows::core::IUnknown, ::windows::core::IInspectable);
 #[doc = "*Required features: `\"Web_UI\"`*"]
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]

--- a/crates/libs/windows/src/Windows/Web/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/mod.rs
@@ -20,36 +20,7 @@ impl IUriToStreamResolver {
         }
     }
 }
-impl ::core::convert::From<IUriToStreamResolver> for ::windows::core::IUnknown {
-    fn from(value: IUriToStreamResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUriToStreamResolver> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUriToStreamResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUriToStreamResolver> for ::windows::core::IUnknown {
-    fn from(value: &IUriToStreamResolver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUriToStreamResolver> for ::windows::core::IInspectable {
-    fn from(value: IUriToStreamResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUriToStreamResolver> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IUriToStreamResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUriToStreamResolver> for ::windows::core::IInspectable {
-    fn from(value: &IUriToStreamResolver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUriToStreamResolver, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IUriToStreamResolver {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
@@ -73,51 +73,7 @@ impl IDMLBindingTable {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(desc.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IDMLBindingTable> for ::windows::core::IUnknown {
-    fn from(value: IDMLBindingTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLBindingTable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLBindingTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLBindingTable> for ::windows::core::IUnknown {
-    fn from(value: &IDMLBindingTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLBindingTable> for IDMLObject {
-    fn from(value: IDMLBindingTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLBindingTable> for &'a IDMLObject {
-    fn from(value: &'a IDMLBindingTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLBindingTable> for IDMLObject {
-    fn from(value: &IDMLBindingTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLBindingTable> for IDMLDeviceChild {
-    fn from(value: IDMLBindingTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLBindingTable> for &'a IDMLDeviceChild {
-    fn from(value: &'a IDMLBindingTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLBindingTable> for IDMLDeviceChild {
-    fn from(value: &IDMLBindingTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLBindingTable, ::windows::core::IUnknown, IDMLObject, IDMLDeviceChild);
 impl ::core::clone::Clone for IDMLBindingTable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -193,51 +149,7 @@ impl IDMLCommandRecorder {
         (::windows::core::Vtable::vtable(self).RecordDispatch)(::windows::core::Vtable::as_raw(self), commandlist.into().abi(), dispatchable.into().abi(), bindings.into().abi())
     }
 }
-impl ::core::convert::From<IDMLCommandRecorder> for ::windows::core::IUnknown {
-    fn from(value: IDMLCommandRecorder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLCommandRecorder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLCommandRecorder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLCommandRecorder> for ::windows::core::IUnknown {
-    fn from(value: &IDMLCommandRecorder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLCommandRecorder> for IDMLObject {
-    fn from(value: IDMLCommandRecorder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLCommandRecorder> for &'a IDMLObject {
-    fn from(value: &'a IDMLCommandRecorder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLCommandRecorder> for IDMLObject {
-    fn from(value: &IDMLCommandRecorder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLCommandRecorder> for IDMLDeviceChild {
-    fn from(value: IDMLCommandRecorder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLCommandRecorder> for &'a IDMLDeviceChild {
-    fn from(value: &'a IDMLCommandRecorder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLCommandRecorder> for IDMLDeviceChild {
-    fn from(value: &IDMLCommandRecorder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLCommandRecorder, ::windows::core::IUnknown, IDMLObject, IDMLDeviceChild);
 impl ::core::clone::Clone for IDMLCommandRecorder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -304,81 +216,7 @@ impl IDMLCompiledOperator {
         result__
     }
 }
-impl ::core::convert::From<IDMLCompiledOperator> for ::windows::core::IUnknown {
-    fn from(value: IDMLCompiledOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLCompiledOperator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLCompiledOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLCompiledOperator> for ::windows::core::IUnknown {
-    fn from(value: &IDMLCompiledOperator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLCompiledOperator> for IDMLObject {
-    fn from(value: IDMLCompiledOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLCompiledOperator> for &'a IDMLObject {
-    fn from(value: &'a IDMLCompiledOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLCompiledOperator> for IDMLObject {
-    fn from(value: &IDMLCompiledOperator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLCompiledOperator> for IDMLDeviceChild {
-    fn from(value: IDMLCompiledOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLCompiledOperator> for &'a IDMLDeviceChild {
-    fn from(value: &'a IDMLCompiledOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLCompiledOperator> for IDMLDeviceChild {
-    fn from(value: &IDMLCompiledOperator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLCompiledOperator> for IDMLPageable {
-    fn from(value: IDMLCompiledOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLCompiledOperator> for &'a IDMLPageable {
-    fn from(value: &'a IDMLCompiledOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLCompiledOperator> for IDMLPageable {
-    fn from(value: &IDMLCompiledOperator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLCompiledOperator> for IDMLDispatchable {
-    fn from(value: IDMLCompiledOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLCompiledOperator> for &'a IDMLDispatchable {
-    fn from(value: &'a IDMLCompiledOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLCompiledOperator> for IDMLDispatchable {
-    fn from(value: &IDMLCompiledOperator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLCompiledOperator, ::windows::core::IUnknown, IDMLObject, IDMLDeviceChild, IDMLPageable, IDMLDispatchable);
 impl ::core::clone::Clone for IDMLCompiledOperator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -419,21 +257,7 @@ impl IDMLDebugDevice {
         (::windows::core::Vtable::vtable(self).SetMuteDebugOutput)(::windows::core::Vtable::as_raw(self), mute.into())
     }
 }
-impl ::core::convert::From<IDMLDebugDevice> for ::windows::core::IUnknown {
-    fn from(value: IDMLDebugDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDebugDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLDebugDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDebugDevice> for ::windows::core::IUnknown {
-    fn from(value: &IDMLDebugDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLDebugDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDMLDebugDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -543,36 +367,7 @@ impl IDMLDevice {
         (::windows::core::Vtable::vtable(self).GetParentDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDMLDevice> for ::windows::core::IUnknown {
-    fn from(value: IDMLDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDevice> for ::windows::core::IUnknown {
-    fn from(value: &IDMLDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLDevice> for IDMLObject {
-    fn from(value: IDMLDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDevice> for &'a IDMLObject {
-    fn from(value: &'a IDMLDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDevice> for IDMLObject {
-    fn from(value: &IDMLDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLDevice, ::windows::core::IUnknown, IDMLObject);
 impl ::core::clone::Clone for IDMLDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -697,51 +492,7 @@ impl IDMLDevice1 {
         (::windows::core::Vtable::vtable(self).CompileGraph)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(desc), flags, &<T as ::windows::core::Interface>::IID, result__ as *mut _ as *mut _).ok()
     }
 }
-impl ::core::convert::From<IDMLDevice1> for ::windows::core::IUnknown {
-    fn from(value: IDMLDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDevice1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDevice1> for ::windows::core::IUnknown {
-    fn from(value: &IDMLDevice1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLDevice1> for IDMLObject {
-    fn from(value: IDMLDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDevice1> for &'a IDMLObject {
-    fn from(value: &'a IDMLDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDevice1> for IDMLObject {
-    fn from(value: &IDMLDevice1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLDevice1> for IDMLDevice {
-    fn from(value: IDMLDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDevice1> for &'a IDMLDevice {
-    fn from(value: &'a IDMLDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDevice1> for IDMLDevice {
-    fn from(value: &IDMLDevice1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLDevice1, ::windows::core::IUnknown, IDMLObject, IDMLDevice);
 impl ::core::clone::Clone for IDMLDevice1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -800,36 +551,7 @@ impl IDMLDeviceChild {
         (::windows::core::Vtable::vtable(self).GetDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDMLDeviceChild> for ::windows::core::IUnknown {
-    fn from(value: IDMLDeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDeviceChild> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLDeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDeviceChild> for ::windows::core::IUnknown {
-    fn from(value: &IDMLDeviceChild) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLDeviceChild> for IDMLObject {
-    fn from(value: IDMLDeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDeviceChild> for &'a IDMLObject {
-    fn from(value: &'a IDMLDeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDeviceChild> for IDMLObject {
-    fn from(value: &IDMLDeviceChild) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLDeviceChild, ::windows::core::IUnknown, IDMLObject);
 impl ::core::clone::Clone for IDMLDeviceChild {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -893,66 +615,7 @@ impl IDMLDispatchable {
         result__
     }
 }
-impl ::core::convert::From<IDMLDispatchable> for ::windows::core::IUnknown {
-    fn from(value: IDMLDispatchable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDispatchable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLDispatchable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDispatchable> for ::windows::core::IUnknown {
-    fn from(value: &IDMLDispatchable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLDispatchable> for IDMLObject {
-    fn from(value: IDMLDispatchable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDispatchable> for &'a IDMLObject {
-    fn from(value: &'a IDMLDispatchable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDispatchable> for IDMLObject {
-    fn from(value: &IDMLDispatchable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLDispatchable> for IDMLDeviceChild {
-    fn from(value: IDMLDispatchable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDispatchable> for &'a IDMLDeviceChild {
-    fn from(value: &'a IDMLDispatchable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDispatchable> for IDMLDeviceChild {
-    fn from(value: &IDMLDispatchable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLDispatchable> for IDMLPageable {
-    fn from(value: IDMLDispatchable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLDispatchable> for &'a IDMLPageable {
-    fn from(value: &'a IDMLDispatchable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLDispatchable> for IDMLPageable {
-    fn from(value: &IDMLDispatchable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLDispatchable, ::windows::core::IUnknown, IDMLObject, IDMLDeviceChild, IDMLPageable);
 impl ::core::clone::Clone for IDMLDispatchable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1004,21 +667,7 @@ impl IDMLObject {
         (::windows::core::Vtable::vtable(self).SetName)(::windows::core::Vtable::as_raw(self), name.into()).ok()
     }
 }
-impl ::core::convert::From<IDMLObject> for ::windows::core::IUnknown {
-    fn from(value: IDMLObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLObject> for ::windows::core::IUnknown {
-    fn from(value: &IDMLObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDMLObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1080,51 +729,7 @@ impl IDMLOperator {
         (::windows::core::Vtable::vtable(self).base__.GetDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDMLOperator> for ::windows::core::IUnknown {
-    fn from(value: IDMLOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLOperator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLOperator> for ::windows::core::IUnknown {
-    fn from(value: &IDMLOperator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLOperator> for IDMLObject {
-    fn from(value: IDMLOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLOperator> for &'a IDMLObject {
-    fn from(value: &'a IDMLOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLOperator> for IDMLObject {
-    fn from(value: &IDMLOperator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLOperator> for IDMLDeviceChild {
-    fn from(value: IDMLOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLOperator> for &'a IDMLDeviceChild {
-    fn from(value: &'a IDMLOperator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLOperator> for IDMLDeviceChild {
-    fn from(value: &IDMLOperator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLOperator, ::windows::core::IUnknown, IDMLObject, IDMLDeviceChild);
 impl ::core::clone::Clone for IDMLOperator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1190,81 +795,7 @@ impl IDMLOperatorInitializer {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self), operators.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(operators.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr()))).ok()
     }
 }
-impl ::core::convert::From<IDMLOperatorInitializer> for ::windows::core::IUnknown {
-    fn from(value: IDMLOperatorInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLOperatorInitializer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLOperatorInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLOperatorInitializer> for ::windows::core::IUnknown {
-    fn from(value: &IDMLOperatorInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLOperatorInitializer> for IDMLObject {
-    fn from(value: IDMLOperatorInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLOperatorInitializer> for &'a IDMLObject {
-    fn from(value: &'a IDMLOperatorInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLOperatorInitializer> for IDMLObject {
-    fn from(value: &IDMLOperatorInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLOperatorInitializer> for IDMLDeviceChild {
-    fn from(value: IDMLOperatorInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLOperatorInitializer> for &'a IDMLDeviceChild {
-    fn from(value: &'a IDMLOperatorInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLOperatorInitializer> for IDMLDeviceChild {
-    fn from(value: &IDMLOperatorInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLOperatorInitializer> for IDMLPageable {
-    fn from(value: IDMLOperatorInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLOperatorInitializer> for &'a IDMLPageable {
-    fn from(value: &'a IDMLOperatorInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLOperatorInitializer> for IDMLPageable {
-    fn from(value: &IDMLOperatorInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLOperatorInitializer> for IDMLDispatchable {
-    fn from(value: IDMLOperatorInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLOperatorInitializer> for &'a IDMLDispatchable {
-    fn from(value: &'a IDMLOperatorInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLOperatorInitializer> for IDMLDispatchable {
-    fn from(value: &IDMLOperatorInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLOperatorInitializer, ::windows::core::IUnknown, IDMLObject, IDMLDeviceChild, IDMLPageable, IDMLDispatchable);
 impl ::core::clone::Clone for IDMLOperatorInitializer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1323,51 +854,7 @@ impl IDMLPageable {
         (::windows::core::Vtable::vtable(self).base__.GetDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDMLPageable> for ::windows::core::IUnknown {
-    fn from(value: IDMLPageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLPageable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMLPageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLPageable> for ::windows::core::IUnknown {
-    fn from(value: &IDMLPageable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLPageable> for IDMLObject {
-    fn from(value: IDMLPageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLPageable> for &'a IDMLObject {
-    fn from(value: &'a IDMLPageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLPageable> for IDMLObject {
-    fn from(value: &IDMLPageable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDMLPageable> for IDMLDeviceChild {
-    fn from(value: IDMLPageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMLPageable> for &'a IDMLDeviceChild {
-    fn from(value: &'a IDMLPageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMLPageable> for IDMLDeviceChild {
-    fn from(value: &IDMLPageable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMLPageable, ::windows::core::IUnknown, IDMLObject, IDMLDeviceChild);
 impl ::core::clone::Clone for IDMLPageable {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
@@ -49,21 +49,7 @@ impl IMLOperatorAttributes {
         (::windows::core::Vtable::vtable(self).GetStringAttributeElement)(::windows::core::Vtable::as_raw(self), name.into(), elementindex, attributeelement.len() as _, ::core::mem::transmute(attributeelement.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IMLOperatorAttributes> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorAttributes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorAttributes> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorAttributes, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLOperatorAttributes {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -106,21 +92,7 @@ impl IMLOperatorKernel {
         (::windows::core::Vtable::vtable(self).Compute)(::windows::core::Vtable::as_raw(self), context.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMLOperatorKernel> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorKernel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorKernel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorKernel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorKernel> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorKernel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorKernel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLOperatorKernel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -173,21 +145,7 @@ impl IMLOperatorKernelContext {
         (::windows::core::Vtable::vtable(self).GetExecutionInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(executionobject.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<IMLOperatorKernelContext> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorKernelContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorKernelContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorKernelContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorKernelContext> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorKernelContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorKernelContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLOperatorKernelContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -281,36 +239,7 @@ impl IMLOperatorKernelCreationContext {
         (::windows::core::Vtable::vtable(self).GetExecutionInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(executionobject.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<IMLOperatorKernelCreationContext> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorKernelCreationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorKernelCreationContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorKernelCreationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorKernelCreationContext> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorKernelCreationContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMLOperatorKernelCreationContext> for IMLOperatorAttributes {
-    fn from(value: IMLOperatorKernelCreationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorKernelCreationContext> for &'a IMLOperatorAttributes {
-    fn from(value: &'a IMLOperatorKernelCreationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorKernelCreationContext> for IMLOperatorAttributes {
-    fn from(value: &IMLOperatorKernelCreationContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorKernelCreationContext, ::windows::core::IUnknown, IMLOperatorAttributes);
 impl ::core::clone::Clone for IMLOperatorKernelCreationContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -359,21 +288,7 @@ impl IMLOperatorKernelFactory {
         (::windows::core::Vtable::vtable(self).CreateKernel)(::windows::core::Vtable::as_raw(self), context.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMLOperatorKernel>(result__)
     }
 }
-impl ::core::convert::From<IMLOperatorKernelFactory> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorKernelFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorKernelFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorKernelFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorKernelFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorKernelFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorKernelFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLOperatorKernelFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -421,21 +336,7 @@ impl IMLOperatorRegistry {
         (::windows::core::Vtable::vtable(self).RegisterOperatorKernel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(operatorkernel), operatorkernelfactory.into().abi(), shapeinferrer.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMLOperatorRegistry> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorRegistry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorRegistry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorRegistry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorRegistry> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorRegistry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorRegistry, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLOperatorRegistry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -522,36 +423,7 @@ impl IMLOperatorShapeInferenceContext {
         (::windows::core::Vtable::vtable(self).SetOutputTensorShape)(::windows::core::Vtable::as_raw(self), outputindex, dimensioncount, ::core::mem::transmute(dimensions)).ok()
     }
 }
-impl ::core::convert::From<IMLOperatorShapeInferenceContext> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorShapeInferenceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorShapeInferenceContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorShapeInferenceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorShapeInferenceContext> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorShapeInferenceContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMLOperatorShapeInferenceContext> for IMLOperatorAttributes {
-    fn from(value: IMLOperatorShapeInferenceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorShapeInferenceContext> for &'a IMLOperatorAttributes {
-    fn from(value: &'a IMLOperatorShapeInferenceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorShapeInferenceContext> for IMLOperatorAttributes {
-    fn from(value: &IMLOperatorShapeInferenceContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorShapeInferenceContext, ::windows::core::IUnknown, IMLOperatorAttributes);
 impl ::core::clone::Clone for IMLOperatorShapeInferenceContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -598,21 +470,7 @@ impl IMLOperatorShapeInferrer {
         (::windows::core::Vtable::vtable(self).InferOutputShapes)(::windows::core::Vtable::as_raw(self), context.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMLOperatorShapeInferrer> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorShapeInferrer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorShapeInferrer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorShapeInferrer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorShapeInferrer> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorShapeInferrer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorShapeInferrer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLOperatorShapeInferrer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -667,21 +525,7 @@ impl IMLOperatorTensor {
         (::windows::core::Vtable::vtable(self).GetDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(datainterface.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<IMLOperatorTensor> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorTensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorTensor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorTensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorTensor> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorTensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorTensor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLOperatorTensor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -738,21 +582,7 @@ impl IMLOperatorTensorShapeDescription {
         (::windows::core::Vtable::vtable(self).GetOutputTensorShape)(::windows::core::Vtable::as_raw(self), outputindex, dimensions.len() as _, ::core::mem::transmute(dimensions.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IMLOperatorTensorShapeDescription> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorTensorShapeDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorTensorShapeDescription> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorTensorShapeDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorTensorShapeDescription> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorTensorShapeDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorTensorShapeDescription, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLOperatorTensorShapeDescription {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -835,36 +665,7 @@ impl IMLOperatorTypeInferenceContext {
         (::windows::core::Vtable::vtable(self).SetOutputEdgeDescription)(::windows::core::Vtable::as_raw(self), outputindex, ::core::mem::transmute(edgedescription)).ok()
     }
 }
-impl ::core::convert::From<IMLOperatorTypeInferenceContext> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorTypeInferenceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorTypeInferenceContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorTypeInferenceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorTypeInferenceContext> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorTypeInferenceContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMLOperatorTypeInferenceContext> for IMLOperatorAttributes {
-    fn from(value: IMLOperatorTypeInferenceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorTypeInferenceContext> for &'a IMLOperatorAttributes {
-    fn from(value: &'a IMLOperatorTypeInferenceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorTypeInferenceContext> for IMLOperatorAttributes {
-    fn from(value: &IMLOperatorTypeInferenceContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorTypeInferenceContext, ::windows::core::IUnknown, IMLOperatorAttributes);
 impl ::core::clone::Clone for IMLOperatorTypeInferenceContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -909,21 +710,7 @@ impl IMLOperatorTypeInferrer {
         (::windows::core::Vtable::vtable(self).InferOutputTypes)(::windows::core::Vtable::as_raw(self), context.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMLOperatorTypeInferrer> for ::windows::core::IUnknown {
-    fn from(value: IMLOperatorTypeInferrer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLOperatorTypeInferrer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLOperatorTypeInferrer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLOperatorTypeInferrer> for ::windows::core::IUnknown {
-    fn from(value: &IMLOperatorTypeInferrer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLOperatorTypeInferrer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLOperatorTypeInferrer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -974,21 +761,7 @@ impl IWinMLEvaluationContext {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWinMLEvaluationContext> for ::windows::core::IUnknown {
-    fn from(value: IWinMLEvaluationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinMLEvaluationContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWinMLEvaluationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinMLEvaluationContext> for ::windows::core::IUnknown {
-    fn from(value: &IWinMLEvaluationContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWinMLEvaluationContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWinMLEvaluationContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1049,21 +822,7 @@ impl IWinMLModel {
         (::windows::core::Vtable::vtable(self).EnumerateModelOutputs)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut WINML_VARIABLE_DESC>(result__)
     }
 }
-impl ::core::convert::From<IWinMLModel> for ::windows::core::IUnknown {
-    fn from(value: IWinMLModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinMLModel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWinMLModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinMLModel> for ::windows::core::IUnknown {
-    fn from(value: &IWinMLModel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWinMLModel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWinMLModel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1128,21 +887,7 @@ impl IWinMLRuntime {
         (::windows::core::Vtable::vtable(self).EvaluateModel)(::windows::core::Vtable::as_raw(self), pcontext.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWinMLRuntime> for ::windows::core::IUnknown {
-    fn from(value: IWinMLRuntime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinMLRuntime> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWinMLRuntime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinMLRuntime> for ::windows::core::IUnknown {
-    fn from(value: &IWinMLRuntime) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWinMLRuntime, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWinMLRuntime {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1185,21 +930,7 @@ impl IWinMLRuntimeFactory {
         (::windows::core::Vtable::vtable(self).CreateRuntime)(::windows::core::Vtable::as_raw(self), runtimetype, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWinMLRuntime>(result__)
     }
 }
-impl ::core::convert::From<IWinMLRuntimeFactory> for ::windows::core::IUnknown {
-    fn from(value: IWinMLRuntimeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinMLRuntimeFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWinMLRuntimeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinMLRuntimeFactory> for ::windows::core::IUnknown {
-    fn from(value: &IWinMLRuntimeFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWinMLRuntimeFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWinMLRuntimeFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
@@ -28,21 +28,7 @@ impl IITDatabase {
         (::windows::core::Vtable::vtable(self).GetObjectPersistence)(::windows::core::Vtable::as_raw(self), lpwszobject.into(), dwobjinstance, ::core::mem::transmute(ppvpersistence), fstream.into()).ok()
     }
 }
-impl ::core::convert::From<IITDatabase> for ::windows::core::IUnknown {
-    fn from(value: IITDatabase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IITDatabase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IITDatabase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IITDatabase> for ::windows::core::IUnknown {
-    fn from(value: &IITDatabase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IITDatabase, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IITDatabase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -205,59 +191,7 @@ impl IITPropList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IITPropList> for ::windows::core::IUnknown {
-    fn from(value: IITPropList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IITPropList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IITPropList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IITPropList> for ::windows::core::IUnknown {
-    fn from(value: &IITPropList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IITPropList> for super::super::System::Com::IPersist {
-    fn from(value: IITPropList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IITPropList> for &'a super::super::System::Com::IPersist {
-    fn from(value: &'a IITPropList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IITPropList> for super::super::System::Com::IPersist {
-    fn from(value: &IITPropList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IITPropList> for super::super::System::Com::IPersistStreamInit {
-    fn from(value: IITPropList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IITPropList> for &'a super::super::System::Com::IPersistStreamInit {
-    fn from(value: &'a IITPropList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IITPropList> for super::super::System::Com::IPersistStreamInit {
-    fn from(value: &IITPropList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IITPropList, ::windows::core::IUnknown, super::super::System::Com::IPersist, super::super::System::Com::IPersistStreamInit);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IITPropList {
     fn clone(&self) -> Self {
@@ -445,21 +379,7 @@ impl IITResultSet {
         (::windows::core::Vtable::vtable(self).GetColumnStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpcolstatus)).ok()
     }
 }
-impl ::core::convert::From<IITResultSet> for ::windows::core::IUnknown {
-    fn from(value: IITResultSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IITResultSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IITResultSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IITResultSet> for ::windows::core::IUnknown {
-    fn from(value: &IITResultSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IITResultSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IITResultSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -585,21 +505,7 @@ impl IITWordWheel {
         (::windows::core::Vtable::vtable(self).GetDataColumns)(::windows::core::Vtable::as_raw(self), prs.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IITWordWheel> for ::windows::core::IUnknown {
-    fn from(value: IITWordWheel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IITWordWheel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IITWordWheel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IITWordWheel> for ::windows::core::IUnknown {
-    fn from(value: &IITWordWheel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IITWordWheel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IITWordWheel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -660,21 +566,7 @@ impl IStemSink {
         (::windows::core::Vtable::vtable(self).PutWord)(::windows::core::Vtable::as_raw(self), pwcinbuf.into(), cwc).ok()
     }
 }
-impl ::core::convert::From<IStemSink> for ::windows::core::IUnknown {
-    fn from(value: IStemSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStemSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStemSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStemSink> for ::windows::core::IUnknown {
-    fn from(value: &IStemSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStemSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStemSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -729,21 +621,7 @@ impl IStemmerConfig {
         (::windows::core::Vtable::vtable(self).LoadExternalStemmerData)(::windows::core::Vtable::as_raw(self), pstream.into().abi(), dwextdatatype).ok()
     }
 }
-impl ::core::convert::From<IStemmerConfig> for ::windows::core::IUnknown {
-    fn from(value: IStemmerConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStemmerConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStemmerConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStemmerConfig> for ::windows::core::IUnknown {
-    fn from(value: &IStemmerConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStemmerConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStemmerConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -824,21 +702,7 @@ impl IWordBreakerConfig {
         (::windows::core::Vtable::vtable(self).GetWordStemmer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Search::IStemmer>(result__)
     }
 }
-impl ::core::convert::From<IWordBreakerConfig> for ::windows::core::IUnknown {
-    fn from(value: IWordBreakerConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWordBreakerConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWordBreakerConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWordBreakerConfig> for ::windows::core::IUnknown {
-    fn from(value: &IWordBreakerConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWordBreakerConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWordBreakerConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/mod.rs
@@ -49,41 +49,7 @@ impl IMXAttributes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXAttributes> for ::windows::core::IUnknown {
-    fn from(value: IMXAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXAttributes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMXAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXAttributes> for ::windows::core::IUnknown {
-    fn from(value: &IMXAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXAttributes> for super::super::super::System::Com::IDispatch {
-    fn from(value: IMXAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXAttributes> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IMXAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXAttributes> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IMXAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMXAttributes, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMXAttributes {
     fn clone(&self) -> Self {
@@ -189,21 +155,7 @@ impl IMXNamespaceManager {
         (::windows::core::Vtable::vtable(self).getURI)(::windows::core::Vtable::as_raw(self), pwchprefix.into(), pcontextnode.into().abi(), ::core::mem::transmute(pwchuri), ::core::mem::transmute(pcchuri)).ok()
     }
 }
-impl ::core::convert::From<IMXNamespaceManager> for ::windows::core::IUnknown {
-    fn from(value: IMXNamespaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMXNamespaceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMXNamespaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMXNamespaceManager> for ::windows::core::IUnknown {
-    fn from(value: &IMXNamespaceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMXNamespaceManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMXNamespaceManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -267,41 +219,7 @@ impl IMXNamespacePrefixes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXNamespacePrefixes> for ::windows::core::IUnknown {
-    fn from(value: IMXNamespacePrefixes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXNamespacePrefixes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMXNamespacePrefixes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXNamespacePrefixes> for ::windows::core::IUnknown {
-    fn from(value: &IMXNamespacePrefixes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXNamespacePrefixes> for super::super::super::System::Com::IDispatch {
-    fn from(value: IMXNamespacePrefixes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXNamespacePrefixes> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IMXNamespacePrefixes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXNamespacePrefixes> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IMXNamespacePrefixes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMXNamespacePrefixes, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMXNamespacePrefixes {
     fn clone(&self) -> Self {
@@ -356,41 +274,7 @@ impl IMXReaderControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXReaderControl> for ::windows::core::IUnknown {
-    fn from(value: IMXReaderControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXReaderControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMXReaderControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXReaderControl> for ::windows::core::IUnknown {
-    fn from(value: &IMXReaderControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXReaderControl> for super::super::super::System::Com::IDispatch {
-    fn from(value: IMXReaderControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXReaderControl> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IMXReaderControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXReaderControl> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IMXReaderControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMXReaderControl, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMXReaderControl {
     fn clone(&self) -> Self {
@@ -444,41 +328,7 @@ impl IMXSchemaDeclHandler {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXSchemaDeclHandler> for ::windows::core::IUnknown {
-    fn from(value: IMXSchemaDeclHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXSchemaDeclHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMXSchemaDeclHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXSchemaDeclHandler> for ::windows::core::IUnknown {
-    fn from(value: &IMXSchemaDeclHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXSchemaDeclHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: IMXSchemaDeclHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXSchemaDeclHandler> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IMXSchemaDeclHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXSchemaDeclHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IMXSchemaDeclHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMXSchemaDeclHandler, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMXSchemaDeclHandler {
     fn clone(&self) -> Self {
@@ -591,41 +441,7 @@ impl IMXWriter {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXWriter> for ::windows::core::IUnknown {
-    fn from(value: IMXWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMXWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXWriter> for ::windows::core::IUnknown {
-    fn from(value: &IMXWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXWriter> for super::super::super::System::Com::IDispatch {
-    fn from(value: IMXWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXWriter> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IMXWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXWriter> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IMXWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMXWriter, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMXWriter {
     fn clone(&self) -> Self {
@@ -752,41 +568,7 @@ impl IMXXMLFilter {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXXMLFilter> for ::windows::core::IUnknown {
-    fn from(value: IMXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXXMLFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXXMLFilter> for ::windows::core::IUnknown {
-    fn from(value: &IMXXMLFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMXXMLFilter> for super::super::super::System::Com::IDispatch {
-    fn from(value: IMXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMXXMLFilter> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IMXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMXXMLFilter> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IMXXMLFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMXXMLFilter, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMXXMLFilter {
     fn clone(&self) -> Self {
@@ -907,21 +689,7 @@ impl ISAXAttributes {
         (::windows::core::Vtable::vtable(self).getValueFromQName)(::windows::core::Vtable::as_raw(self), pwchqname.into(), cchqname, ::core::mem::transmute(ppwchvalue), ::core::mem::transmute(pcchvalue)).ok()
     }
 }
-impl ::core::convert::From<ISAXAttributes> for ::windows::core::IUnknown {
-    fn from(value: ISAXAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISAXAttributes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISAXAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISAXAttributes> for ::windows::core::IUnknown {
-    fn from(value: &ISAXAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISAXAttributes, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISAXAttributes {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1034,21 +802,7 @@ impl ISAXContentHandler {
         (::windows::core::Vtable::vtable(self).skippedEntity)(::windows::core::Vtable::as_raw(self), pwchname.into(), cchname).ok()
     }
 }
-impl ::core::convert::From<ISAXContentHandler> for ::windows::core::IUnknown {
-    fn from(value: ISAXContentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISAXContentHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISAXContentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISAXContentHandler> for ::windows::core::IUnknown {
-    fn from(value: &ISAXContentHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISAXContentHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISAXContentHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1109,21 +863,7 @@ impl ISAXDTDHandler {
         (::windows::core::Vtable::vtable(self).unparsedEntityDecl)(::windows::core::Vtable::as_raw(self), pwchname.into(), cchname, pwchpublicid.into(), cchpublicid, pwchsystemid.into(), cchsystemid, pwchnotationname.into(), cchnotationname).ok()
     }
 }
-impl ::core::convert::From<ISAXDTDHandler> for ::windows::core::IUnknown {
-    fn from(value: ISAXDTDHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISAXDTDHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISAXDTDHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISAXDTDHandler> for ::windows::core::IUnknown {
-    fn from(value: &ISAXDTDHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISAXDTDHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISAXDTDHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1190,21 +930,7 @@ impl ISAXDeclHandler {
         (::windows::core::Vtable::vtable(self).externalEntityDecl)(::windows::core::Vtable::as_raw(self), pwchname.into(), cchname, pwchpublicid.into(), cchpublicid, pwchsystemid.into(), cchsystemid).ok()
     }
 }
-impl ::core::convert::From<ISAXDeclHandler> for ::windows::core::IUnknown {
-    fn from(value: ISAXDeclHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISAXDeclHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISAXDeclHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISAXDeclHandler> for ::windows::core::IUnknown {
-    fn from(value: &ISAXDeclHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISAXDeclHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISAXDeclHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1251,21 +977,7 @@ impl ISAXEntityResolver {
         (::windows::core::Vtable::vtable(self).resolveEntity)(::windows::core::Vtable::as_raw(self), pwchpublicid.into(), pwchsystemid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::System::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<ISAXEntityResolver> for ::windows::core::IUnknown {
-    fn from(value: ISAXEntityResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISAXEntityResolver> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISAXEntityResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISAXEntityResolver> for ::windows::core::IUnknown {
-    fn from(value: &ISAXEntityResolver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISAXEntityResolver, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISAXEntityResolver {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1323,21 +1035,7 @@ impl ISAXErrorHandler {
         (::windows::core::Vtable::vtable(self).ignorableWarning)(::windows::core::Vtable::as_raw(self), plocator.into().abi(), pwcherrormessage.into(), hrerrorcode).ok()
     }
 }
-impl ::core::convert::From<ISAXErrorHandler> for ::windows::core::IUnknown {
-    fn from(value: ISAXErrorHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISAXErrorHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISAXErrorHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISAXErrorHandler> for ::windows::core::IUnknown {
-    fn from(value: &ISAXErrorHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISAXErrorHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISAXErrorHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1408,21 +1106,7 @@ impl ISAXLexicalHandler {
         (::windows::core::Vtable::vtable(self).comment)(::windows::core::Vtable::as_raw(self), pwchchars.into(), cchchars).ok()
     }
 }
-impl ::core::convert::From<ISAXLexicalHandler> for ::windows::core::IUnknown {
-    fn from(value: ISAXLexicalHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISAXLexicalHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISAXLexicalHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISAXLexicalHandler> for ::windows::core::IUnknown {
-    fn from(value: &ISAXLexicalHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISAXLexicalHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISAXLexicalHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1478,21 +1162,7 @@ impl ISAXLocator {
         (::windows::core::Vtable::vtable(self).getSystemId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut u16>(result__)
     }
 }
-impl ::core::convert::From<ISAXLocator> for ::windows::core::IUnknown {
-    fn from(value: ISAXLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISAXLocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISAXLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISAXLocator> for ::windows::core::IUnknown {
-    fn from(value: &ISAXLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISAXLocator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISAXLocator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1644,36 +1314,7 @@ impl ISAXXMLFilter {
         (::windows::core::Vtable::vtable(self).putParent)(::windows::core::Vtable::as_raw(self), preader.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISAXXMLFilter> for ::windows::core::IUnknown {
-    fn from(value: ISAXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISAXXMLFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISAXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISAXXMLFilter> for ::windows::core::IUnknown {
-    fn from(value: &ISAXXMLFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISAXXMLFilter> for ISAXXMLReader {
-    fn from(value: ISAXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISAXXMLFilter> for &'a ISAXXMLReader {
-    fn from(value: &'a ISAXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISAXXMLFilter> for ISAXXMLReader {
-    fn from(value: &ISAXXMLFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISAXXMLFilter, ::windows::core::IUnknown, ISAXXMLReader);
 impl ::core::clone::Clone for ISAXXMLFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1813,21 +1454,7 @@ impl ISAXXMLReader {
         (::windows::core::Vtable::vtable(self).parseURL)(::windows::core::Vtable::as_raw(self), pwchurl.into()).ok()
     }
 }
-impl ::core::convert::From<ISAXXMLReader> for ::windows::core::IUnknown {
-    fn from(value: ISAXXMLReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISAXXMLReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISAXXMLReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISAXXMLReader> for ::windows::core::IUnknown {
-    fn from(value: &ISAXXMLReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISAXXMLReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISAXXMLReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1975,59 +1602,7 @@ impl ISchema {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchema> for ::windows::core::IUnknown {
-    fn from(value: ISchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchema> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchema> for ::windows::core::IUnknown {
-    fn from(value: &ISchema) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchema> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchema> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchema> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchema) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchema> for ISchemaItem {
-    fn from(value: ISchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchema> for &'a ISchemaItem {
-    fn from(value: &'a ISchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchema> for ISchemaItem {
-    fn from(value: &ISchema) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchema, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ISchemaItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchema {
     fn clone(&self) -> Self {
@@ -2157,77 +1732,7 @@ impl ISchemaAny {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaAny> for ::windows::core::IUnknown {
-    fn from(value: ISchemaAny) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaAny> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaAny) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaAny> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaAny) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaAny> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaAny) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaAny> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaAny) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaAny> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaAny) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaAny> for ISchemaItem {
-    fn from(value: ISchemaAny) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaAny> for &'a ISchemaItem {
-    fn from(value: &'a ISchemaAny) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaAny> for ISchemaItem {
-    fn from(value: &ISchemaAny) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaAny> for ISchemaParticle {
-    fn from(value: ISchemaAny) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaAny> for &'a ISchemaParticle {
-    fn from(value: &'a ISchemaAny) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaAny> for ISchemaParticle {
-    fn from(value: &ISchemaAny) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaAny, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ISchemaItem, ISchemaParticle);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaAny {
     fn clone(&self) -> Self {
@@ -2338,59 +1843,7 @@ impl ISchemaAttribute {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaAttribute> for ::windows::core::IUnknown {
-    fn from(value: ISchemaAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaAttribute> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaAttribute> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaAttribute> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaAttribute> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaAttribute> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaAttribute> for ISchemaItem {
-    fn from(value: ISchemaAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaAttribute> for &'a ISchemaItem {
-    fn from(value: &'a ISchemaAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaAttribute> for ISchemaItem {
-    fn from(value: &ISchemaAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaAttribute, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ISchemaItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaAttribute {
     fn clone(&self) -> Self {
@@ -2492,59 +1945,7 @@ impl ISchemaAttributeGroup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaAttributeGroup> for ::windows::core::IUnknown {
-    fn from(value: ISchemaAttributeGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaAttributeGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaAttributeGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaAttributeGroup> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaAttributeGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaAttributeGroup> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaAttributeGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaAttributeGroup> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaAttributeGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaAttributeGroup> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaAttributeGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaAttributeGroup> for ISchemaItem {
-    fn from(value: ISchemaAttributeGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaAttributeGroup> for &'a ISchemaItem {
-    fn from(value: &'a ISchemaAttributeGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaAttributeGroup> for ISchemaItem {
-    fn from(value: &ISchemaAttributeGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaAttributeGroup, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ISchemaItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaAttributeGroup {
     fn clone(&self) -> Self {
@@ -2744,77 +2145,7 @@ impl ISchemaComplexType {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaComplexType> for ::windows::core::IUnknown {
-    fn from(value: ISchemaComplexType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaComplexType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaComplexType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaComplexType> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaComplexType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaComplexType> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaComplexType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaComplexType> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaComplexType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaComplexType> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaComplexType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaComplexType> for ISchemaItem {
-    fn from(value: ISchemaComplexType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaComplexType> for &'a ISchemaItem {
-    fn from(value: &'a ISchemaComplexType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaComplexType> for ISchemaItem {
-    fn from(value: &ISchemaComplexType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaComplexType> for ISchemaType {
-    fn from(value: ISchemaComplexType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaComplexType> for &'a ISchemaType {
-    fn from(value: &'a ISchemaComplexType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaComplexType> for ISchemaType {
-    fn from(value: &ISchemaComplexType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaComplexType, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ISchemaItem, ISchemaType);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaComplexType {
     fn clone(&self) -> Self {
@@ -2971,77 +2302,7 @@ impl ISchemaElement {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaElement> for ::windows::core::IUnknown {
-    fn from(value: ISchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaElement> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaElement> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaElement> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaElement> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaElement> for ISchemaItem {
-    fn from(value: ISchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaElement> for &'a ISchemaItem {
-    fn from(value: &'a ISchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaElement> for ISchemaItem {
-    fn from(value: &ISchemaElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaElement> for ISchemaParticle {
-    fn from(value: ISchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaElement> for &'a ISchemaParticle {
-    fn from(value: &'a ISchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaElement> for ISchemaParticle {
-    fn from(value: &ISchemaElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaElement, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ISchemaItem, ISchemaParticle);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaElement {
     fn clone(&self) -> Self {
@@ -3158,59 +2419,7 @@ impl ISchemaIdentityConstraint {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaIdentityConstraint> for ::windows::core::IUnknown {
-    fn from(value: ISchemaIdentityConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaIdentityConstraint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaIdentityConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaIdentityConstraint> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaIdentityConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaIdentityConstraint> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaIdentityConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaIdentityConstraint> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaIdentityConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaIdentityConstraint> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaIdentityConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaIdentityConstraint> for ISchemaItem {
-    fn from(value: ISchemaIdentityConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaIdentityConstraint> for &'a ISchemaItem {
-    fn from(value: &'a ISchemaIdentityConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaIdentityConstraint> for ISchemaItem {
-    fn from(value: &ISchemaIdentityConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaIdentityConstraint, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ISchemaItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaIdentityConstraint {
     fn clone(&self) -> Self {
@@ -3297,41 +2506,7 @@ impl ISchemaItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaItem> for ::windows::core::IUnknown {
-    fn from(value: ISchemaItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaItem> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaItem> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaItem> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaItem> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaItem, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaItem {
     fn clone(&self) -> Self {
@@ -3413,41 +2588,7 @@ impl ISchemaItemCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaItemCollection> for ::windows::core::IUnknown {
-    fn from(value: ISchemaItemCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaItemCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaItemCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaItemCollection> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaItemCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaItemCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaItemCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaItemCollection> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaItemCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaItemCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaItemCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaItemCollection, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaItemCollection {
     fn clone(&self) -> Self {
@@ -3557,77 +2698,7 @@ impl ISchemaModelGroup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaModelGroup> for ::windows::core::IUnknown {
-    fn from(value: ISchemaModelGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaModelGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaModelGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaModelGroup> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaModelGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaModelGroup> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaModelGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaModelGroup> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaModelGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaModelGroup> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaModelGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaModelGroup> for ISchemaItem {
-    fn from(value: ISchemaModelGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaModelGroup> for &'a ISchemaItem {
-    fn from(value: &'a ISchemaModelGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaModelGroup> for ISchemaItem {
-    fn from(value: &ISchemaModelGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaModelGroup> for ISchemaParticle {
-    fn from(value: ISchemaModelGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaModelGroup> for &'a ISchemaParticle {
-    fn from(value: &'a ISchemaModelGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaModelGroup> for ISchemaParticle {
-    fn from(value: &ISchemaModelGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaModelGroup, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ISchemaItem, ISchemaParticle);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaModelGroup {
     fn clone(&self) -> Self {
@@ -3717,59 +2788,7 @@ impl ISchemaNotation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaNotation> for ::windows::core::IUnknown {
-    fn from(value: ISchemaNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaNotation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaNotation> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaNotation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaNotation> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaNotation> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaNotation> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaNotation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaNotation> for ISchemaItem {
-    fn from(value: ISchemaNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaNotation> for &'a ISchemaItem {
-    fn from(value: &'a ISchemaNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaNotation> for ISchemaItem {
-    fn from(value: &ISchemaNotation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaNotation, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ISchemaItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaNotation {
     fn clone(&self) -> Self {
@@ -3861,59 +2880,7 @@ impl ISchemaParticle {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaParticle> for ::windows::core::IUnknown {
-    fn from(value: ISchemaParticle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaParticle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaParticle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaParticle> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaParticle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaParticle> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaParticle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaParticle> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaParticle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaParticle> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaParticle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaParticle> for ISchemaItem {
-    fn from(value: ISchemaParticle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaParticle> for &'a ISchemaItem {
-    fn from(value: &'a ISchemaParticle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaParticle> for ISchemaItem {
-    fn from(value: &ISchemaParticle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaParticle, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ISchemaItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaParticle {
     fn clone(&self) -> Self {
@@ -3976,41 +2943,7 @@ impl ISchemaStringCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaStringCollection> for ::windows::core::IUnknown {
-    fn from(value: ISchemaStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaStringCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaStringCollection> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaStringCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaStringCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaStringCollection> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaStringCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaStringCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaStringCollection, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaStringCollection {
     fn clone(&self) -> Self {
@@ -4175,59 +3108,7 @@ impl ISchemaType {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaType> for ::windows::core::IUnknown {
-    fn from(value: ISchemaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaType> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaType> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISchemaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaType> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISchemaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaType> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISchemaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchemaType> for ISchemaItem {
-    fn from(value: ISchemaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchemaType> for &'a ISchemaItem {
-    fn from(value: &'a ISchemaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchemaType> for ISchemaItem {
-    fn from(value: &ISchemaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaType, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ISchemaItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchemaType {
     fn clone(&self) -> Self {
@@ -4411,59 +3292,7 @@ impl IServerXMLHTTPRequest {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IServerXMLHTTPRequest> for ::windows::core::IUnknown {
-    fn from(value: IServerXMLHTTPRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IServerXMLHTTPRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServerXMLHTTPRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IServerXMLHTTPRequest> for ::windows::core::IUnknown {
-    fn from(value: &IServerXMLHTTPRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IServerXMLHTTPRequest> for super::super::super::System::Com::IDispatch {
-    fn from(value: IServerXMLHTTPRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IServerXMLHTTPRequest> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IServerXMLHTTPRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IServerXMLHTTPRequest> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IServerXMLHTTPRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IServerXMLHTTPRequest> for IXMLHTTPRequest {
-    fn from(value: IServerXMLHTTPRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IServerXMLHTTPRequest> for &'a IXMLHTTPRequest {
-    fn from(value: &'a IServerXMLHTTPRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IServerXMLHTTPRequest> for IXMLHTTPRequest {
-    fn from(value: &IServerXMLHTTPRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServerXMLHTTPRequest, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLHTTPRequest);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IServerXMLHTTPRequest {
     fn clone(&self) -> Self {
@@ -4631,77 +3460,7 @@ impl IServerXMLHTTPRequest2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IServerXMLHTTPRequest2> for ::windows::core::IUnknown {
-    fn from(value: IServerXMLHTTPRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IServerXMLHTTPRequest2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServerXMLHTTPRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IServerXMLHTTPRequest2> for ::windows::core::IUnknown {
-    fn from(value: &IServerXMLHTTPRequest2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IServerXMLHTTPRequest2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IServerXMLHTTPRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IServerXMLHTTPRequest2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IServerXMLHTTPRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IServerXMLHTTPRequest2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IServerXMLHTTPRequest2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IServerXMLHTTPRequest2> for IXMLHTTPRequest {
-    fn from(value: IServerXMLHTTPRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IServerXMLHTTPRequest2> for &'a IXMLHTTPRequest {
-    fn from(value: &'a IServerXMLHTTPRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IServerXMLHTTPRequest2> for IXMLHTTPRequest {
-    fn from(value: &IServerXMLHTTPRequest2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IServerXMLHTTPRequest2> for IServerXMLHTTPRequest {
-    fn from(value: IServerXMLHTTPRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IServerXMLHTTPRequest2> for &'a IServerXMLHTTPRequest {
-    fn from(value: &'a IServerXMLHTTPRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IServerXMLHTTPRequest2> for IServerXMLHTTPRequest {
-    fn from(value: &IServerXMLHTTPRequest2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServerXMLHTTPRequest2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLHTTPRequest, IServerXMLHTTPRequest);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IServerXMLHTTPRequest2 {
     fn clone(&self) -> Self {
@@ -4803,41 +3562,7 @@ impl IVBMXNamespaceManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBMXNamespaceManager> for ::windows::core::IUnknown {
-    fn from(value: IVBMXNamespaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBMXNamespaceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBMXNamespaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBMXNamespaceManager> for ::windows::core::IUnknown {
-    fn from(value: &IVBMXNamespaceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBMXNamespaceManager> for super::super::super::System::Com::IDispatch {
-    fn from(value: IVBMXNamespaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBMXNamespaceManager> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IVBMXNamespaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBMXNamespaceManager> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IVBMXNamespaceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBMXNamespaceManager, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IVBMXNamespaceManager {
     fn clone(&self) -> Self {
@@ -4954,41 +3679,7 @@ impl IVBSAXAttributes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXAttributes> for ::windows::core::IUnknown {
-    fn from(value: IVBSAXAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXAttributes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBSAXAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXAttributes> for ::windows::core::IUnknown {
-    fn from(value: &IVBSAXAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXAttributes> for super::super::super::System::Com::IDispatch {
-    fn from(value: IVBSAXAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXAttributes> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IVBSAXAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXAttributes> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IVBSAXAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBSAXAttributes, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IVBSAXAttributes {
     fn clone(&self) -> Self {
@@ -5086,41 +3777,7 @@ impl IVBSAXContentHandler {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXContentHandler> for ::windows::core::IUnknown {
-    fn from(value: IVBSAXContentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXContentHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBSAXContentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXContentHandler> for ::windows::core::IUnknown {
-    fn from(value: &IVBSAXContentHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXContentHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: IVBSAXContentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXContentHandler> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IVBSAXContentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXContentHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IVBSAXContentHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBSAXContentHandler, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IVBSAXContentHandler {
     fn clone(&self) -> Self {
@@ -5186,41 +3843,7 @@ impl IVBSAXDTDHandler {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXDTDHandler> for ::windows::core::IUnknown {
-    fn from(value: IVBSAXDTDHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXDTDHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBSAXDTDHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXDTDHandler> for ::windows::core::IUnknown {
-    fn from(value: &IVBSAXDTDHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXDTDHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: IVBSAXDTDHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXDTDHandler> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IVBSAXDTDHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXDTDHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IVBSAXDTDHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBSAXDTDHandler, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IVBSAXDTDHandler {
     fn clone(&self) -> Self {
@@ -5277,41 +3900,7 @@ impl IVBSAXDeclHandler {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXDeclHandler> for ::windows::core::IUnknown {
-    fn from(value: IVBSAXDeclHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXDeclHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBSAXDeclHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXDeclHandler> for ::windows::core::IUnknown {
-    fn from(value: &IVBSAXDeclHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXDeclHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: IVBSAXDeclHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXDeclHandler> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IVBSAXDeclHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXDeclHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IVBSAXDeclHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBSAXDeclHandler, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IVBSAXDeclHandler {
     fn clone(&self) -> Self {
@@ -5363,41 +3952,7 @@ impl IVBSAXEntityResolver {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXEntityResolver> for ::windows::core::IUnknown {
-    fn from(value: IVBSAXEntityResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXEntityResolver> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBSAXEntityResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXEntityResolver> for ::windows::core::IUnknown {
-    fn from(value: &IVBSAXEntityResolver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXEntityResolver> for super::super::super::System::Com::IDispatch {
-    fn from(value: IVBSAXEntityResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXEntityResolver> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IVBSAXEntityResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXEntityResolver> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IVBSAXEntityResolver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBSAXEntityResolver, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IVBSAXEntityResolver {
     fn clone(&self) -> Self {
@@ -5468,41 +4023,7 @@ impl IVBSAXErrorHandler {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXErrorHandler> for ::windows::core::IUnknown {
-    fn from(value: IVBSAXErrorHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXErrorHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBSAXErrorHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXErrorHandler> for ::windows::core::IUnknown {
-    fn from(value: &IVBSAXErrorHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXErrorHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: IVBSAXErrorHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXErrorHandler> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IVBSAXErrorHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXErrorHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IVBSAXErrorHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBSAXErrorHandler, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IVBSAXErrorHandler {
     fn clone(&self) -> Self {
@@ -5578,41 +4099,7 @@ impl IVBSAXLexicalHandler {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXLexicalHandler> for ::windows::core::IUnknown {
-    fn from(value: IVBSAXLexicalHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXLexicalHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBSAXLexicalHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXLexicalHandler> for ::windows::core::IUnknown {
-    fn from(value: &IVBSAXLexicalHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXLexicalHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: IVBSAXLexicalHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXLexicalHandler> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IVBSAXLexicalHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXLexicalHandler> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IVBSAXLexicalHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBSAXLexicalHandler, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IVBSAXLexicalHandler {
     fn clone(&self) -> Self {
@@ -5678,41 +4165,7 @@ impl IVBSAXLocator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXLocator> for ::windows::core::IUnknown {
-    fn from(value: IVBSAXLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXLocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBSAXLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXLocator> for ::windows::core::IUnknown {
-    fn from(value: &IVBSAXLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXLocator> for super::super::super::System::Com::IDispatch {
-    fn from(value: IVBSAXLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXLocator> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IVBSAXLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXLocator> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IVBSAXLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBSAXLocator, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IVBSAXLocator {
     fn clone(&self) -> Self {
@@ -5773,41 +4226,7 @@ impl IVBSAXXMLFilter {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXXMLFilter> for ::windows::core::IUnknown {
-    fn from(value: IVBSAXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXXMLFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBSAXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXXMLFilter> for ::windows::core::IUnknown {
-    fn from(value: &IVBSAXXMLFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXXMLFilter> for super::super::super::System::Com::IDispatch {
-    fn from(value: IVBSAXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXXMLFilter> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IVBSAXXMLFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXXMLFilter> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IVBSAXXMLFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBSAXXMLFilter, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IVBSAXXMLFilter {
     fn clone(&self) -> Self {
@@ -5960,41 +4379,7 @@ impl IVBSAXXMLReader {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXXMLReader> for ::windows::core::IUnknown {
-    fn from(value: IVBSAXXMLReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXXMLReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBSAXXMLReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXXMLReader> for ::windows::core::IUnknown {
-    fn from(value: &IVBSAXXMLReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IVBSAXXMLReader> for super::super::super::System::Com::IDispatch {
-    fn from(value: IVBSAXXMLReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IVBSAXXMLReader> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IVBSAXXMLReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IVBSAXXMLReader> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IVBSAXXMLReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBSAXXMLReader, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IVBSAXXMLReader {
     fn clone(&self) -> Self {
@@ -6096,41 +4481,7 @@ impl IXMLAttribute {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLAttribute> for ::windows::core::IUnknown {
-    fn from(value: IXMLAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLAttribute> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLAttribute> for ::windows::core::IUnknown {
-    fn from(value: &IXMLAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLAttribute> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLAttribute> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLAttribute> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLAttribute, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLAttribute {
     fn clone(&self) -> Self {
@@ -6388,59 +4739,7 @@ impl IXMLDOMAttribute {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMAttribute> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMAttribute> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMAttribute> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMAttribute> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMAttribute> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMAttribute> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMAttribute> for IXMLDOMNode {
-    fn from(value: IXMLDOMAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMAttribute> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMAttribute> for IXMLDOMNode {
-    fn from(value: &IXMLDOMAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMAttribute, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMAttribute {
     fn clone(&self) -> Self {
@@ -6719,95 +5018,7 @@ impl IXMLDOMCDATASection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMCDATASection> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMCDATASection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMCDATASection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMCDATASection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMCDATASection> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMCDATASection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMCDATASection> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMCDATASection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMCDATASection> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMCDATASection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMCDATASection> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMCDATASection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMCDATASection> for IXMLDOMNode {
-    fn from(value: IXMLDOMCDATASection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMCDATASection> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMCDATASection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMCDATASection> for IXMLDOMNode {
-    fn from(value: &IXMLDOMCDATASection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMCDATASection> for IXMLDOMCharacterData {
-    fn from(value: IXMLDOMCDATASection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMCDATASection> for &'a IXMLDOMCharacterData {
-    fn from(value: &'a IXMLDOMCDATASection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMCDATASection> for IXMLDOMCharacterData {
-    fn from(value: &IXMLDOMCDATASection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMCDATASection> for IXMLDOMText {
-    fn from(value: IXMLDOMCDATASection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMCDATASection> for &'a IXMLDOMText {
-    fn from(value: &'a IXMLDOMCDATASection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMCDATASection> for IXMLDOMText {
-    fn from(value: &IXMLDOMCDATASection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMCDATASection, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode, IXMLDOMCharacterData, IXMLDOMText);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMCDATASection {
     fn clone(&self) -> Self {
@@ -7071,59 +5282,7 @@ impl IXMLDOMCharacterData {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMCharacterData> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMCharacterData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMCharacterData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMCharacterData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMCharacterData> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMCharacterData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMCharacterData> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMCharacterData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMCharacterData> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMCharacterData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMCharacterData> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMCharacterData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMCharacterData> for IXMLDOMNode {
-    fn from(value: IXMLDOMCharacterData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMCharacterData> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMCharacterData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMCharacterData> for IXMLDOMNode {
-    fn from(value: &IXMLDOMCharacterData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMCharacterData, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMCharacterData {
     fn clone(&self) -> Self {
@@ -7395,77 +5554,7 @@ impl IXMLDOMComment {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMComment> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMComment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMComment> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMComment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMComment> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMComment> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMComment> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMComment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMComment> for IXMLDOMNode {
-    fn from(value: IXMLDOMComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMComment> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMComment> for IXMLDOMNode {
-    fn from(value: &IXMLDOMComment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMComment> for IXMLDOMCharacterData {
-    fn from(value: IXMLDOMComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMComment> for &'a IXMLDOMCharacterData {
-    fn from(value: &'a IXMLDOMComment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMComment> for IXMLDOMCharacterData {
-    fn from(value: &IXMLDOMComment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMComment, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode, IXMLDOMCharacterData);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMComment {
     fn clone(&self) -> Self {
@@ -7882,59 +5971,7 @@ impl IXMLDOMDocument {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument> for IXMLDOMNode {
-    fn from(value: IXMLDOMDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument> for IXMLDOMNode {
-    fn from(value: &IXMLDOMDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMDocument, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMDocument {
     fn clone(&self) -> Self {
@@ -8487,77 +6524,7 @@ impl IXMLDOMDocument2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument2> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument2> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument2> for IXMLDOMNode {
-    fn from(value: IXMLDOMDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument2> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument2> for IXMLDOMNode {
-    fn from(value: &IXMLDOMDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument2> for IXMLDOMDocument {
-    fn from(value: IXMLDOMDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument2> for &'a IXMLDOMDocument {
-    fn from(value: &'a IXMLDOMDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument2> for IXMLDOMDocument {
-    fn from(value: &IXMLDOMDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMDocument2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode, IXMLDOMDocument);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMDocument2 {
     fn clone(&self) -> Self {
@@ -9056,95 +7023,7 @@ impl IXMLDOMDocument3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument3> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMDocument3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMDocument3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument3> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMDocument3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument3> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMDocument3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument3> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMDocument3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument3> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMDocument3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument3> for IXMLDOMNode {
-    fn from(value: IXMLDOMDocument3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument3> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMDocument3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument3> for IXMLDOMNode {
-    fn from(value: &IXMLDOMDocument3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument3> for IXMLDOMDocument {
-    fn from(value: IXMLDOMDocument3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument3> for &'a IXMLDOMDocument {
-    fn from(value: &'a IXMLDOMDocument3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument3> for IXMLDOMDocument {
-    fn from(value: &IXMLDOMDocument3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocument3> for IXMLDOMDocument2 {
-    fn from(value: IXMLDOMDocument3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocument3> for &'a IXMLDOMDocument2 {
-    fn from(value: &'a IXMLDOMDocument3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocument3> for IXMLDOMDocument2 {
-    fn from(value: &IXMLDOMDocument3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMDocument3, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode, IXMLDOMDocument, IXMLDOMDocument2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMDocument3 {
     fn clone(&self) -> Self {
@@ -9392,59 +7271,7 @@ impl IXMLDOMDocumentFragment {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocumentFragment> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMDocumentFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocumentFragment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMDocumentFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocumentFragment> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMDocumentFragment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocumentFragment> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMDocumentFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocumentFragment> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMDocumentFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocumentFragment> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMDocumentFragment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocumentFragment> for IXMLDOMNode {
-    fn from(value: IXMLDOMDocumentFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocumentFragment> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMDocumentFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocumentFragment> for IXMLDOMNode {
-    fn from(value: &IXMLDOMDocumentFragment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMDocumentFragment, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMDocumentFragment {
     fn clone(&self) -> Self {
@@ -9699,59 +7526,7 @@ impl IXMLDOMDocumentType {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocumentType> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMDocumentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocumentType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMDocumentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocumentType> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMDocumentType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocumentType> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMDocumentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocumentType> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMDocumentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocumentType> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMDocumentType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMDocumentType> for IXMLDOMNode {
-    fn from(value: IXMLDOMDocumentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMDocumentType> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMDocumentType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMDocumentType> for IXMLDOMNode {
-    fn from(value: &IXMLDOMDocumentType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMDocumentType, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMDocumentType {
     fn clone(&self) -> Self {
@@ -10052,59 +7827,7 @@ impl IXMLDOMElement {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMElement> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMElement> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMElement> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMElement> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMElement> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMElement> for IXMLDOMNode {
-    fn from(value: IXMLDOMElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMElement> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMElement> for IXMLDOMNode {
-    fn from(value: &IXMLDOMElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMElement, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMElement {
     fn clone(&self) -> Self {
@@ -10384,59 +8107,7 @@ impl IXMLDOMEntity {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMEntity> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMEntity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMEntity> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMEntity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMEntity> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMEntity> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMEntity> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMEntity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMEntity> for IXMLDOMNode {
-    fn from(value: IXMLDOMEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMEntity> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMEntity> for IXMLDOMNode {
-    fn from(value: &IXMLDOMEntity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMEntity, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMEntity {
     fn clone(&self) -> Self {
@@ -10685,59 +8356,7 @@ impl IXMLDOMEntityReference {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMEntityReference> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMEntityReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMEntityReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMEntityReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMEntityReference> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMEntityReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMEntityReference> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMEntityReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMEntityReference> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMEntityReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMEntityReference> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMEntityReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMEntityReference> for IXMLDOMNode {
-    fn from(value: IXMLDOMEntityReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMEntityReference> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMEntityReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMEntityReference> for IXMLDOMNode {
-    fn from(value: &IXMLDOMEntityReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMEntityReference, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMEntityReference {
     fn clone(&self) -> Self {
@@ -10783,41 +8402,7 @@ impl IXMLDOMImplementation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMImplementation> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMImplementation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMImplementation> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMImplementation> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMImplementation> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMImplementation> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMImplementation, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMImplementation {
     fn clone(&self) -> Self {
@@ -10916,41 +8501,7 @@ impl IXMLDOMNamedNodeMap {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMNamedNodeMap> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMNamedNodeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMNamedNodeMap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMNamedNodeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMNamedNodeMap> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMNamedNodeMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMNamedNodeMap> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMNamedNodeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMNamedNodeMap> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMNamedNodeMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMNamedNodeMap> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMNamedNodeMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMNamedNodeMap, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMNamedNodeMap {
     fn clone(&self) -> Self {
@@ -11221,41 +8772,7 @@ impl IXMLDOMNode {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMNode> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMNode> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMNode> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMNode> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMNode> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMNode, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMNode {
     fn clone(&self) -> Self {
@@ -11425,41 +8942,7 @@ impl IXMLDOMNodeList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMNodeList> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMNodeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMNodeList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMNodeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMNodeList> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMNodeList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMNodeList> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMNodeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMNodeList> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMNodeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMNodeList> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMNodeList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMNodeList, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMNodeList {
     fn clone(&self) -> Self {
@@ -11720,59 +9203,7 @@ impl IXMLDOMNotation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMNotation> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMNotation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMNotation> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMNotation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMNotation> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMNotation> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMNotation> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMNotation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMNotation> for IXMLDOMNode {
-    fn from(value: IXMLDOMNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMNotation> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMNotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMNotation> for IXMLDOMNode {
-    fn from(value: &IXMLDOMNotation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMNotation, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMNotation {
     fn clone(&self) -> Self {
@@ -11844,41 +9275,7 @@ impl IXMLDOMParseError {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMParseError> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMParseError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMParseError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMParseError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMParseError> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMParseError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMParseError> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMParseError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMParseError> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMParseError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMParseError> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMParseError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMParseError, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMParseError {
     fn clone(&self) -> Self {
@@ -11967,59 +9364,7 @@ impl IXMLDOMParseError2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMParseError2> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMParseError2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMParseError2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMParseError2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMParseError2> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMParseError2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMParseError2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMParseError2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMParseError2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMParseError2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMParseError2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMParseError2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMParseError2> for IXMLDOMParseError {
-    fn from(value: IXMLDOMParseError2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMParseError2> for &'a IXMLDOMParseError {
-    fn from(value: &'a IXMLDOMParseError2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMParseError2> for IXMLDOMParseError {
-    fn from(value: &IXMLDOMParseError2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMParseError2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMParseError);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMParseError2 {
     fn clone(&self) -> Self {
@@ -12092,41 +9437,7 @@ impl IXMLDOMParseErrorCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMParseErrorCollection> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMParseErrorCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMParseErrorCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMParseErrorCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMParseErrorCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMParseErrorCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMParseErrorCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMParseErrorCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMParseErrorCollection> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMParseErrorCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMParseErrorCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMParseErrorCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMParseErrorCollection, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMParseErrorCollection {
     fn clone(&self) -> Self {
@@ -12386,59 +9697,7 @@ impl IXMLDOMProcessingInstruction {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMProcessingInstruction> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMProcessingInstruction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMProcessingInstruction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMProcessingInstruction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMProcessingInstruction> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMProcessingInstruction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMProcessingInstruction> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMProcessingInstruction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMProcessingInstruction> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMProcessingInstruction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMProcessingInstruction> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMProcessingInstruction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMProcessingInstruction> for IXMLDOMNode {
-    fn from(value: IXMLDOMProcessingInstruction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMProcessingInstruction> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMProcessingInstruction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMProcessingInstruction> for IXMLDOMNode {
-    fn from(value: &IXMLDOMProcessingInstruction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMProcessingInstruction, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMProcessingInstruction {
     fn clone(&self) -> Self {
@@ -12521,41 +9780,7 @@ impl IXMLDOMSchemaCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMSchemaCollection> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMSchemaCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMSchemaCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMSchemaCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMSchemaCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMSchemaCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMSchemaCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMSchemaCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMSchemaCollection> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMSchemaCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMSchemaCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMSchemaCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMSchemaCollection, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMSchemaCollection {
     fn clone(&self) -> Self {
@@ -12676,59 +9901,7 @@ impl IXMLDOMSchemaCollection2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMSchemaCollection2> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMSchemaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMSchemaCollection2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMSchemaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMSchemaCollection2> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMSchemaCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMSchemaCollection2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMSchemaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMSchemaCollection2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMSchemaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMSchemaCollection2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMSchemaCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMSchemaCollection2> for IXMLDOMSchemaCollection {
-    fn from(value: IXMLDOMSchemaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMSchemaCollection2> for &'a IXMLDOMSchemaCollection {
-    fn from(value: &'a IXMLDOMSchemaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMSchemaCollection2> for IXMLDOMSchemaCollection {
-    fn from(value: &IXMLDOMSchemaCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMSchemaCollection2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMSchemaCollection);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMSchemaCollection2 {
     fn clone(&self) -> Self {
@@ -12869,59 +10042,7 @@ impl IXMLDOMSelection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMSelection> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMSelection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMSelection> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMSelection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMSelection> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMSelection> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMSelection> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMSelection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMSelection> for IXMLDOMNodeList {
-    fn from(value: IXMLDOMSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMSelection> for &'a IXMLDOMNodeList {
-    fn from(value: &'a IXMLDOMSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMSelection> for IXMLDOMNodeList {
-    fn from(value: &IXMLDOMSelection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMSelection, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNodeList);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMSelection {
     fn clone(&self) -> Self {
@@ -13226,77 +10347,7 @@ impl IXMLDOMText {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMText> for ::windows::core::IUnknown {
-    fn from(value: IXMLDOMText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMText> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDOMText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMText> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDOMText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMText> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDOMText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMText> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDOMText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMText> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDOMText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMText> for IXMLDOMNode {
-    fn from(value: IXMLDOMText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMText> for &'a IXMLDOMNode {
-    fn from(value: &'a IXMLDOMText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMText> for IXMLDOMNode {
-    fn from(value: &IXMLDOMText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDOMText> for IXMLDOMCharacterData {
-    fn from(value: IXMLDOMText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDOMText> for &'a IXMLDOMCharacterData {
-    fn from(value: &'a IXMLDOMText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDOMText> for IXMLDOMCharacterData {
-    fn from(value: &IXMLDOMText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDOMText, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode, IXMLDOMCharacterData);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDOMText {
     fn clone(&self) -> Self {
@@ -13373,41 +10424,7 @@ impl IXMLDSOControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDSOControl> for ::windows::core::IUnknown {
-    fn from(value: IXMLDSOControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDSOControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDSOControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDSOControl> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDSOControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDSOControl> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDSOControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDSOControl> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDSOControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDSOControl> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDSOControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDSOControl, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDSOControl {
     fn clone(&self) -> Self {
@@ -13529,41 +10546,7 @@ impl IXMLDocument {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDocument> for ::windows::core::IUnknown {
-    fn from(value: IXMLDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDocument> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDocument> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDocument> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDocument> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDocument, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDocument {
     fn clone(&self) -> Self {
@@ -13695,41 +10678,7 @@ impl IXMLDocument2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDocument2> for ::windows::core::IUnknown {
-    fn from(value: IXMLDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDocument2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDocument2> for ::windows::core::IUnknown {
-    fn from(value: &IXMLDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLDocument2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLDocument2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLDocument2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLDocument2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLDocument2 {
     fn clone(&self) -> Self {
@@ -13857,41 +10806,7 @@ impl IXMLElement {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLElement> for ::windows::core::IUnknown {
-    fn from(value: IXMLElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLElement> for ::windows::core::IUnknown {
-    fn from(value: &IXMLElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLElement> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLElement> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLElement> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLElement, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLElement {
     fn clone(&self) -> Self {
@@ -14033,41 +10948,7 @@ impl IXMLElement2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLElement2> for ::windows::core::IUnknown {
-    fn from(value: IXMLElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLElement2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLElement2> for ::windows::core::IUnknown {
-    fn from(value: &IXMLElement2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLElement2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLElement2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLElement2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLElement2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLElement2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLElement2 {
     fn clone(&self) -> Self {
@@ -14165,41 +11046,7 @@ impl IXMLElementCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLElementCollection> for ::windows::core::IUnknown {
-    fn from(value: IXMLElementCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLElementCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLElementCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLElementCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXMLElementCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLElementCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLElementCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLElementCollection> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLElementCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLElementCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLElementCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLElementCollection, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLElementCollection {
     fn clone(&self) -> Self {
@@ -14249,21 +11096,7 @@ impl IXMLError {
         (::windows::core::Vtable::vtable(self).GetErrorInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(perrorreturn)).ok()
     }
 }
-impl ::core::convert::From<IXMLError> for ::windows::core::IUnknown {
-    fn from(value: IXMLError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXMLError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXMLError> for ::windows::core::IUnknown {
-    fn from(value: &IXMLError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLError, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXMLError {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14374,41 +11207,7 @@ impl IXMLHTTPRequest {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLHTTPRequest> for ::windows::core::IUnknown {
-    fn from(value: IXMLHTTPRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLHTTPRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLHTTPRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLHTTPRequest> for ::windows::core::IUnknown {
-    fn from(value: &IXMLHTTPRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLHTTPRequest> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLHTTPRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLHTTPRequest> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLHTTPRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLHTTPRequest> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLHTTPRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLHTTPRequest, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLHTTPRequest {
     fn clone(&self) -> Self {
@@ -14547,21 +11346,7 @@ impl IXMLHTTPRequest2 {
         (::windows::core::Vtable::vtable(self).GetResponseHeader)(::windows::core::Vtable::as_raw(self), pwszheader.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut u16>(result__)
     }
 }
-impl ::core::convert::From<IXMLHTTPRequest2> for ::windows::core::IUnknown {
-    fn from(value: IXMLHTTPRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXMLHTTPRequest2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLHTTPRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXMLHTTPRequest2> for ::windows::core::IUnknown {
-    fn from(value: &IXMLHTTPRequest2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLHTTPRequest2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXMLHTTPRequest2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14654,21 +11439,7 @@ impl IXMLHTTPRequest2Callback {
         (::windows::core::Vtable::vtable(self).OnError)(::windows::core::Vtable::as_raw(self), pxhr.into().abi(), hrerror).ok()
     }
 }
-impl ::core::convert::From<IXMLHTTPRequest2Callback> for ::windows::core::IUnknown {
-    fn from(value: IXMLHTTPRequest2Callback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXMLHTTPRequest2Callback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLHTTPRequest2Callback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXMLHTTPRequest2Callback> for ::windows::core::IUnknown {
-    fn from(value: &IXMLHTTPRequest2Callback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLHTTPRequest2Callback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXMLHTTPRequest2Callback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14785,36 +11556,7 @@ impl IXMLHTTPRequest3 {
         (::windows::core::Vtable::vtable(self).SetClientCertificate)(::windows::core::Vtable::as_raw(self), pbclientcertificatehash.len() as _, ::core::mem::transmute(pbclientcertificatehash.as_ptr()), pwszpin.into()).ok()
     }
 }
-impl ::core::convert::From<IXMLHTTPRequest3> for ::windows::core::IUnknown {
-    fn from(value: IXMLHTTPRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXMLHTTPRequest3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLHTTPRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXMLHTTPRequest3> for ::windows::core::IUnknown {
-    fn from(value: &IXMLHTTPRequest3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXMLHTTPRequest3> for IXMLHTTPRequest2 {
-    fn from(value: IXMLHTTPRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXMLHTTPRequest3> for &'a IXMLHTTPRequest2 {
-    fn from(value: &'a IXMLHTTPRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXMLHTTPRequest3> for IXMLHTTPRequest2 {
-    fn from(value: &IXMLHTTPRequest3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLHTTPRequest3, ::windows::core::IUnknown, IXMLHTTPRequest2);
 impl ::core::clone::Clone for IXMLHTTPRequest3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14898,36 +11640,7 @@ impl IXMLHTTPRequest3Callback {
         (::windows::core::Vtable::vtable(self).OnClientCertificateRequested)(::windows::core::Vtable::as_raw(self), pxhr.into().abi(), rgpwszissuerlist.len() as _, ::core::mem::transmute(rgpwszissuerlist.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IXMLHTTPRequest3Callback> for ::windows::core::IUnknown {
-    fn from(value: IXMLHTTPRequest3Callback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXMLHTTPRequest3Callback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLHTTPRequest3Callback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXMLHTTPRequest3Callback> for ::windows::core::IUnknown {
-    fn from(value: &IXMLHTTPRequest3Callback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXMLHTTPRequest3Callback> for IXMLHTTPRequest2Callback {
-    fn from(value: IXMLHTTPRequest3Callback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXMLHTTPRequest3Callback> for &'a IXMLHTTPRequest2Callback {
-    fn from(value: &'a IXMLHTTPRequest3Callback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXMLHTTPRequest3Callback> for IXMLHTTPRequest2Callback {
-    fn from(value: &IXMLHTTPRequest3Callback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLHTTPRequest3Callback, ::windows::core::IUnknown, IXMLHTTPRequest2Callback);
 impl ::core::clone::Clone for IXMLHTTPRequest3Callback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15039,41 +11752,7 @@ impl IXMLHttpRequest {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLHttpRequest> for ::windows::core::IUnknown {
-    fn from(value: IXMLHttpRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLHttpRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLHttpRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLHttpRequest> for ::windows::core::IUnknown {
-    fn from(value: &IXMLHttpRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXMLHttpRequest> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXMLHttpRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXMLHttpRequest> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXMLHttpRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXMLHttpRequest> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXMLHttpRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLHttpRequest, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXMLHttpRequest {
     fn clone(&self) -> Self {
@@ -15226,41 +11905,7 @@ impl IXSLProcessor {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXSLProcessor> for ::windows::core::IUnknown {
-    fn from(value: IXSLProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXSLProcessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXSLProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXSLProcessor> for ::windows::core::IUnknown {
-    fn from(value: &IXSLProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXSLProcessor> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXSLProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXSLProcessor> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXSLProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXSLProcessor> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXSLProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXSLProcessor, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXSLProcessor {
     fn clone(&self) -> Self {
@@ -15361,41 +12006,7 @@ impl IXSLTemplate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXSLTemplate> for ::windows::core::IUnknown {
-    fn from(value: IXSLTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXSLTemplate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXSLTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXSLTemplate> for ::windows::core::IUnknown {
-    fn from(value: &IXSLTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXSLTemplate> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXSLTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXSLTemplate> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXSLTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXSLTemplate> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXSLTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXSLTemplate, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXSLTemplate {
     fn clone(&self) -> Self {
@@ -15711,59 +12322,7 @@ impl IXTLRuntime {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXTLRuntime> for ::windows::core::IUnknown {
-    fn from(value: IXTLRuntime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXTLRuntime> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXTLRuntime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXTLRuntime> for ::windows::core::IUnknown {
-    fn from(value: &IXTLRuntime) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXTLRuntime> for super::super::super::System::Com::IDispatch {
-    fn from(value: IXTLRuntime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXTLRuntime> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IXTLRuntime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXTLRuntime> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IXTLRuntime) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXTLRuntime> for IXMLDOMNode {
-    fn from(value: IXTLRuntime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXTLRuntime> for &'a IXMLDOMNode {
-    fn from(value: &'a IXTLRuntime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXTLRuntime> for IXMLDOMNode {
-    fn from(value: &IXTLRuntime) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXTLRuntime, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IXMLDOMNode);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXTLRuntime {
     fn clone(&self) -> Self {
@@ -15835,41 +12394,7 @@ pub struct XMLDOMDocumentEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl XMLDOMDocumentEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<XMLDOMDocumentEvents> for ::windows::core::IUnknown {
-    fn from(value: XMLDOMDocumentEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a XMLDOMDocumentEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a XMLDOMDocumentEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&XMLDOMDocumentEvents> for ::windows::core::IUnknown {
-    fn from(value: &XMLDOMDocumentEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<XMLDOMDocumentEvents> for super::super::super::System::Com::IDispatch {
-    fn from(value: XMLDOMDocumentEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a XMLDOMDocumentEvents> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a XMLDOMDocumentEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&XMLDOMDocumentEvents> for super::super::super::System::Com::IDispatch {
-    fn from(value: &XMLDOMDocumentEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(XMLDOMDocumentEvents, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for XMLDOMDocumentEvents {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/mod.rs
@@ -183,21 +183,7 @@ impl IXmlReader {
         (::windows::core::Vtable::vtable(self).IsEOF)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IXmlReader> for ::windows::core::IUnknown {
-    fn from(value: IXmlReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXmlReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlReader> for ::windows::core::IUnknown {
-    fn from(value: &IXmlReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXmlReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXmlReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -271,21 +257,7 @@ impl IXmlResolver {
         (::windows::core::Vtable::vtable(self).ResolveUri)(::windows::core::Vtable::as_raw(self), pwszbaseuri.into(), pwszpublicidentifier.into(), pwszsystemidentifier.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IXmlResolver> for ::windows::core::IUnknown {
-    fn from(value: IXmlResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlResolver> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXmlResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlResolver> for ::windows::core::IUnknown {
-    fn from(value: &IXmlResolver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXmlResolver, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXmlResolver {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -483,21 +455,7 @@ impl IXmlWriter {
         (::windows::core::Vtable::vtable(self).Flush)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IXmlWriter> for ::windows::core::IUnknown {
-    fn from(value: IXmlWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXmlWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlWriter> for ::windows::core::IUnknown {
-    fn from(value: &IXmlWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXmlWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXmlWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -711,21 +669,7 @@ impl IXmlWriterLite {
         (::windows::core::Vtable::vtable(self).Flush)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IXmlWriterLite> for ::windows::core::IUnknown {
-    fn from(value: IXmlWriterLite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXmlWriterLite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXmlWriterLite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXmlWriterLite> for ::windows::core::IUnknown {
-    fn from(value: &IXmlWriterLite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXmlWriterLite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXmlWriterLite {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/mod.rs
@@ -32,21 +32,7 @@ impl ICreateDeviceAccessAsync {
         (::windows::core::Vtable::vtable(self).GetResult)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ICreateDeviceAccessAsync> for ::windows::core::IUnknown {
-    fn from(value: ICreateDeviceAccessAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateDeviceAccessAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateDeviceAccessAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateDeviceAccessAsync> for ::windows::core::IUnknown {
-    fn from(value: &ICreateDeviceAccessAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateDeviceAccessAsync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICreateDeviceAccessAsync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -105,21 +91,7 @@ impl IDeviceIoControl {
         (::windows::core::Vtable::vtable(self).CancelOperation)(::windows::core::Vtable::as_raw(self), cancelcontext).ok()
     }
 }
-impl ::core::convert::From<IDeviceIoControl> for ::windows::core::IUnknown {
-    fn from(value: IDeviceIoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDeviceIoControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeviceIoControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDeviceIoControl> for ::windows::core::IUnknown {
-    fn from(value: &IDeviceIoControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeviceIoControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDeviceIoControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -158,21 +130,7 @@ impl IDeviceRequestCompletionCallback {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self), requestresult, bytesreturned).ok()
     }
 }
-impl ::core::convert::From<IDeviceRequestCompletionCallback> for ::windows::core::IUnknown {
-    fn from(value: IDeviceRequestCompletionCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDeviceRequestCompletionCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeviceRequestCompletionCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDeviceRequestCompletionCallback> for ::windows::core::IUnknown {
-    fn from(value: &IDeviceRequestCompletionCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeviceRequestCompletionCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDeviceRequestCompletionCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
@@ -1350,21 +1350,7 @@ impl ICloneViewHelper {
         (::windows::core::Vtable::vtable(self).Commit)(::windows::core::Vtable::as_raw(self), ffinalcall.into()).ok()
     }
 }
-impl ::core::convert::From<ICloneViewHelper> for ::windows::core::IUnknown {
-    fn from(value: ICloneViewHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICloneViewHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICloneViewHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICloneViewHelper> for ::windows::core::IUnknown {
-    fn from(value: &ICloneViewHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICloneViewHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICloneViewHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1437,21 +1423,7 @@ impl IViewHelper {
         (::windows::core::Vtable::vtable(self).GetProceedOnNewConfiguration)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IViewHelper> for ::windows::core::IUnknown {
-    fn from(value: IViewHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IViewHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewHelper> for ::windows::core::IUnknown {
-    fn from(value: &IViewHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IViewHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IViewHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
@@ -129,21 +129,7 @@ impl IUPnPAddressFamilyControl {
         (::windows::core::Vtable::vtable(self).GetAddressFamily)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IUPnPAddressFamilyControl> for ::windows::core::IUnknown {
-    fn from(value: IUPnPAddressFamilyControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPAddressFamilyControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPAddressFamilyControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPAddressFamilyControl> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPAddressFamilyControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPAddressFamilyControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPAddressFamilyControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -181,21 +167,7 @@ impl IUPnPAsyncResult {
         (::windows::core::Vtable::vtable(self).AsyncOperationComplete)(::windows::core::Vtable::as_raw(self), ullrequestid).ok()
     }
 }
-impl ::core::convert::From<IUPnPAsyncResult> for ::windows::core::IUnknown {
-    fn from(value: IUPnPAsyncResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPAsyncResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPAsyncResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPAsyncResult> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPAsyncResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPAsyncResult, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPAsyncResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -264,41 +236,7 @@ impl IUPnPDescriptionDocument {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPDescriptionDocument> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDescriptionDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPDescriptionDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDescriptionDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPDescriptionDocument> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDescriptionDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPDescriptionDocument> for super::super::super::System::Com::IDispatch {
-    fn from(value: IUPnPDescriptionDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPDescriptionDocument> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IUPnPDescriptionDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPDescriptionDocument> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IUPnPDescriptionDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDescriptionDocument, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUPnPDescriptionDocument {
     fn clone(&self) -> Self {
@@ -354,21 +292,7 @@ impl IUPnPDescriptionDocumentCallback {
         (::windows::core::Vtable::vtable(self).LoadComplete)(::windows::core::Vtable::as_raw(self), hrloadresult).ok()
     }
 }
-impl ::core::convert::From<IUPnPDescriptionDocumentCallback> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDescriptionDocumentCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPDescriptionDocumentCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDescriptionDocumentCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPDescriptionDocumentCallback> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDescriptionDocumentCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDescriptionDocumentCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPDescriptionDocumentCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -489,41 +413,7 @@ impl IUPnPDevice {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPDevice> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPDevice> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPDevice> for super::super::super::System::Com::IDispatch {
-    fn from(value: IUPnPDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPDevice> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IUPnPDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPDevice> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IUPnPDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDevice, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUPnPDevice {
     fn clone(&self) -> Self {
@@ -603,21 +493,7 @@ impl IUPnPDeviceControl {
         (::windows::core::Vtable::vtable(self).GetServiceObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrudn), ::core::mem::transmute_copy(bstrserviceid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::System::Com::IDispatch>(result__)
     }
 }
-impl ::core::convert::From<IUPnPDeviceControl> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPDeviceControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPDeviceControl> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDeviceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDeviceControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPDeviceControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -659,21 +535,7 @@ impl IUPnPDeviceControlHttpHeaders {
         (::windows::core::Vtable::vtable(self).GetAdditionalResponseHeaders)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IUPnPDeviceControlHttpHeaders> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDeviceControlHttpHeaders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPDeviceControlHttpHeaders> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDeviceControlHttpHeaders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPDeviceControlHttpHeaders> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDeviceControlHttpHeaders) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDeviceControlHttpHeaders, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPDeviceControlHttpHeaders {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -711,21 +573,7 @@ impl IUPnPDeviceDocumentAccess {
         (::windows::core::Vtable::vtable(self).GetDocumentURL)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IUPnPDeviceDocumentAccess> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDeviceDocumentAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPDeviceDocumentAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDeviceDocumentAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPDeviceDocumentAccess> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDeviceDocumentAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDeviceDocumentAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPDeviceDocumentAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -763,21 +611,7 @@ impl IUPnPDeviceDocumentAccessEx {
         (::windows::core::Vtable::vtable(self).GetDocument)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IUPnPDeviceDocumentAccessEx> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDeviceDocumentAccessEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPDeviceDocumentAccessEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDeviceDocumentAccessEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPDeviceDocumentAccessEx> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDeviceDocumentAccessEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDeviceDocumentAccessEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPDeviceDocumentAccessEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -839,41 +673,7 @@ impl IUPnPDeviceFinder {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPDeviceFinder> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDeviceFinder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPDeviceFinder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDeviceFinder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPDeviceFinder> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDeviceFinder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPDeviceFinder> for super::super::super::System::Com::IDispatch {
-    fn from(value: IUPnPDeviceFinder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPDeviceFinder> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IUPnPDeviceFinder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPDeviceFinder> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IUPnPDeviceFinder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDeviceFinder, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUPnPDeviceFinder {
     fn clone(&self) -> Self {
@@ -932,21 +732,7 @@ impl IUPnPDeviceFinderAddCallbackWithInterface {
         (::windows::core::Vtable::vtable(self).DeviceAddedWithInterface)(::windows::core::Vtable::as_raw(self), lfinddata, pdevice.into().abi(), ::core::mem::transmute(pguidinterface)).ok()
     }
 }
-impl ::core::convert::From<IUPnPDeviceFinderAddCallbackWithInterface> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDeviceFinderAddCallbackWithInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPDeviceFinderAddCallbackWithInterface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDeviceFinderAddCallbackWithInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPDeviceFinderAddCallbackWithInterface> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDeviceFinderAddCallbackWithInterface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDeviceFinderAddCallbackWithInterface, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPDeviceFinderAddCallbackWithInterface {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -997,21 +783,7 @@ impl IUPnPDeviceFinderCallback {
         (::windows::core::Vtable::vtable(self).SearchComplete)(::windows::core::Vtable::as_raw(self), lfinddata).ok()
     }
 }
-impl ::core::convert::From<IUPnPDeviceFinderCallback> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDeviceFinderCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPDeviceFinderCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDeviceFinderCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPDeviceFinderCallback> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDeviceFinderCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDeviceFinderCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPDeviceFinderCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1056,21 +828,7 @@ impl IUPnPDeviceProvider {
         (::windows::core::Vtable::vtable(self).Stop)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUPnPDeviceProvider> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPDeviceProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPDeviceProvider> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDeviceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDeviceProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPDeviceProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1122,41 +880,7 @@ impl IUPnPDevices {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPDevices> for ::windows::core::IUnknown {
-    fn from(value: IUPnPDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPDevices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPDevices> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPDevices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPDevices> for super::super::super::System::Com::IDispatch {
-    fn from(value: IUPnPDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPDevices> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IUPnPDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPDevices> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IUPnPDevices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPDevices, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUPnPDevices {
     fn clone(&self) -> Self {
@@ -1213,21 +937,7 @@ impl IUPnPEventSink {
         (::windows::core::Vtable::vtable(self).OnStateChangedSafe)(::windows::core::Vtable::as_raw(self), varsadispidchanges.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUPnPEventSink> for ::windows::core::IUnknown {
-    fn from(value: IUPnPEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPEventSink> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1277,21 +987,7 @@ impl IUPnPEventSource {
         (::windows::core::Vtable::vtable(self).Unadvise)(::windows::core::Vtable::as_raw(self), pessubscriber.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUPnPEventSource> for ::windows::core::IUnknown {
-    fn from(value: IUPnPEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPEventSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPEventSource> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPEventSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPEventSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPEventSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1329,21 +1025,7 @@ impl IUPnPHttpHeaderControl {
         (::windows::core::Vtable::vtable(self).AddRequestHeaders)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrhttpheaders)).ok()
     }
 }
-impl ::core::convert::From<IUPnPHttpHeaderControl> for ::windows::core::IUnknown {
-    fn from(value: IUPnPHttpHeaderControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPHttpHeaderControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPHttpHeaderControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPHttpHeaderControl> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPHttpHeaderControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPHttpHeaderControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPHttpHeaderControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1406,21 +1088,7 @@ impl IUPnPRegistrar {
         (::windows::core::Vtable::vtable(self).UnregisterDeviceProvider)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrprovidername)).ok()
     }
 }
-impl ::core::convert::From<IUPnPRegistrar> for ::windows::core::IUnknown {
-    fn from(value: IUPnPRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPRegistrar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPRegistrar> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPRegistrar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPRegistrar, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPRegistrar {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1474,21 +1142,7 @@ impl IUPnPRemoteEndpointInfo {
         (::windows::core::Vtable::vtable(self).GetGuidValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrvaluename), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IUPnPRemoteEndpointInfo> for ::windows::core::IUnknown {
-    fn from(value: IUPnPRemoteEndpointInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPRemoteEndpointInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPRemoteEndpointInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPRemoteEndpointInfo> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPRemoteEndpointInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPRemoteEndpointInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPRemoteEndpointInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1533,21 +1187,7 @@ impl IUPnPReregistrar {
         (::windows::core::Vtable::vtable(self).ReregisterRunningDevice)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrdeviceidentifier), ::core::mem::transmute_copy(bstrxmldesc), punkdevicecontrol.into().abi(), ::core::mem::transmute_copy(bstrinitstring), ::core::mem::transmute_copy(bstrresourcepath), nlifetime).ok()
     }
 }
-impl ::core::convert::From<IUPnPReregistrar> for ::windows::core::IUnknown {
-    fn from(value: IUPnPReregistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPReregistrar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPReregistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPReregistrar> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPReregistrar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPReregistrar, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPReregistrar {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1617,41 +1257,7 @@ impl IUPnPService {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPService> for ::windows::core::IUnknown {
-    fn from(value: IUPnPService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPService> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPService> for super::super::super::System::Com::IDispatch {
-    fn from(value: IUPnPService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPService> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IUPnPService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPService> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IUPnPService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPService, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUPnPService {
     fn clone(&self) -> Self {
@@ -1755,21 +1361,7 @@ impl IUPnPServiceAsync {
         (::windows::core::Vtable::vtable(self).CancelAsyncOperation)(::windows::core::Vtable::as_raw(self), ullrequestid).ok()
     }
 }
-impl ::core::convert::From<IUPnPServiceAsync> for ::windows::core::IUnknown {
-    fn from(value: IUPnPServiceAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPServiceAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPServiceAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPServiceAsync> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPServiceAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPServiceAsync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPServiceAsync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1838,21 +1430,7 @@ impl IUPnPServiceCallback {
         (::windows::core::Vtable::vtable(self).ServiceInstanceDied)(::windows::core::Vtable::as_raw(self), pus.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUPnPServiceCallback> for ::windows::core::IUnknown {
-    fn from(value: IUPnPServiceCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPServiceCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPServiceCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPServiceCallback> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPServiceCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPServiceCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPServiceCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1901,21 +1479,7 @@ impl IUPnPServiceDocumentAccess {
         (::windows::core::Vtable::vtable(self).GetDocument)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IUPnPServiceDocumentAccess> for ::windows::core::IUnknown {
-    fn from(value: IUPnPServiceDocumentAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPServiceDocumentAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPServiceDocumentAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPServiceDocumentAccess> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPServiceDocumentAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPServiceDocumentAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPServiceDocumentAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1953,21 +1517,7 @@ impl IUPnPServiceEnumProperty {
         (::windows::core::Vtable::vtable(self).SetServiceEnumProperty)(::windows::core::Vtable::as_raw(self), dwmask).ok()
     }
 }
-impl ::core::convert::From<IUPnPServiceEnumProperty> for ::windows::core::IUnknown {
-    fn from(value: IUPnPServiceEnumProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUPnPServiceEnumProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPServiceEnumProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUPnPServiceEnumProperty> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPServiceEnumProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPServiceEnumProperty, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUPnPServiceEnumProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2018,41 +1568,7 @@ impl IUPnPServices {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPServices> for ::windows::core::IUnknown {
-    fn from(value: IUPnPServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPServices> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPServices> for super::super::super::System::Com::IDispatch {
-    fn from(value: IUPnPServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPServices> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IUPnPServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPServices> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IUPnPServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPServices, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUPnPServices {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Fax/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Fax/mod.rs
@@ -791,41 +791,7 @@ impl IFaxAccount {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccount> for ::windows::core::IUnknown {
-    fn from(value: IFaxAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccount> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccount> for ::windows::core::IUnknown {
-    fn from(value: &IFaxAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccount> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccount> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxAccount) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccount> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxAccount) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxAccount, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxAccount {
     fn clone(&self) -> Self {
@@ -899,41 +865,7 @@ impl IFaxAccountFolders {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountFolders> for ::windows::core::IUnknown {
-    fn from(value: IFaxAccountFolders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountFolders> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxAccountFolders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountFolders> for ::windows::core::IUnknown {
-    fn from(value: &IFaxAccountFolders) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountFolders> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxAccountFolders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountFolders> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxAccountFolders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountFolders> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxAccountFolders) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxAccountFolders, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxAccountFolders {
     fn clone(&self) -> Self {
@@ -1015,41 +947,7 @@ impl IFaxAccountIncomingArchive {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountIncomingArchive> for ::windows::core::IUnknown {
-    fn from(value: IFaxAccountIncomingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountIncomingArchive> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxAccountIncomingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountIncomingArchive> for ::windows::core::IUnknown {
-    fn from(value: &IFaxAccountIncomingArchive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountIncomingArchive> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxAccountIncomingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountIncomingArchive> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxAccountIncomingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountIncomingArchive> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxAccountIncomingArchive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxAccountIncomingArchive, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxAccountIncomingArchive {
     fn clone(&self) -> Self {
@@ -1115,41 +1013,7 @@ impl IFaxAccountIncomingQueue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountIncomingQueue> for ::windows::core::IUnknown {
-    fn from(value: IFaxAccountIncomingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountIncomingQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxAccountIncomingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountIncomingQueue> for ::windows::core::IUnknown {
-    fn from(value: &IFaxAccountIncomingQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountIncomingQueue> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxAccountIncomingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountIncomingQueue> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxAccountIncomingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountIncomingQueue> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxAccountIncomingQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxAccountIncomingQueue, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxAccountIncomingQueue {
     fn clone(&self) -> Self {
@@ -1199,41 +1063,7 @@ pub struct IFaxAccountNotify(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IFaxAccountNotify {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountNotify> for ::windows::core::IUnknown {
-    fn from(value: IFaxAccountNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxAccountNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountNotify> for ::windows::core::IUnknown {
-    fn from(value: &IFaxAccountNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountNotify> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxAccountNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountNotify> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxAccountNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountNotify> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxAccountNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxAccountNotify, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxAccountNotify {
     fn clone(&self) -> Self {
@@ -1299,41 +1129,7 @@ impl IFaxAccountOutgoingArchive {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountOutgoingArchive> for ::windows::core::IUnknown {
-    fn from(value: IFaxAccountOutgoingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountOutgoingArchive> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxAccountOutgoingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountOutgoingArchive> for ::windows::core::IUnknown {
-    fn from(value: &IFaxAccountOutgoingArchive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountOutgoingArchive> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxAccountOutgoingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountOutgoingArchive> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxAccountOutgoingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountOutgoingArchive> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxAccountOutgoingArchive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxAccountOutgoingArchive, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxAccountOutgoingArchive {
     fn clone(&self) -> Self {
@@ -1399,41 +1195,7 @@ impl IFaxAccountOutgoingQueue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountOutgoingQueue> for ::windows::core::IUnknown {
-    fn from(value: IFaxAccountOutgoingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountOutgoingQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxAccountOutgoingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountOutgoingQueue> for ::windows::core::IUnknown {
-    fn from(value: &IFaxAccountOutgoingQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountOutgoingQueue> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxAccountOutgoingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountOutgoingQueue> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxAccountOutgoingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountOutgoingQueue> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxAccountOutgoingQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxAccountOutgoingQueue, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxAccountOutgoingQueue {
     fn clone(&self) -> Self {
@@ -1505,41 +1267,7 @@ impl IFaxAccountSet {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountSet> for ::windows::core::IUnknown {
-    fn from(value: IFaxAccountSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxAccountSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountSet> for ::windows::core::IUnknown {
-    fn from(value: &IFaxAccountSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccountSet> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxAccountSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccountSet> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxAccountSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccountSet> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxAccountSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxAccountSet, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxAccountSet {
     fn clone(&self) -> Self {
@@ -1612,41 +1340,7 @@ impl IFaxAccounts {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccounts> for ::windows::core::IUnknown {
-    fn from(value: IFaxAccounts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccounts> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxAccounts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccounts> for ::windows::core::IUnknown {
-    fn from(value: &IFaxAccounts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxAccounts> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxAccounts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxAccounts> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxAccounts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxAccounts> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxAccounts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxAccounts, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxAccounts {
     fn clone(&self) -> Self {
@@ -1714,41 +1408,7 @@ impl IFaxActivity {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxActivity> for ::windows::core::IUnknown {
-    fn from(value: IFaxActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxActivity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxActivity> for ::windows::core::IUnknown {
-    fn from(value: &IFaxActivity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxActivity> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxActivity> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxActivity> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxActivity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxActivity, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxActivity {
     fn clone(&self) -> Self {
@@ -1823,41 +1483,7 @@ impl IFaxActivityLogging {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxActivityLogging> for ::windows::core::IUnknown {
-    fn from(value: IFaxActivityLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxActivityLogging> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxActivityLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxActivityLogging> for ::windows::core::IUnknown {
-    fn from(value: &IFaxActivityLogging) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxActivityLogging> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxActivityLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxActivityLogging> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxActivityLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxActivityLogging> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxActivityLogging) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxActivityLogging, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxActivityLogging {
     fn clone(&self) -> Self {
@@ -2055,41 +1681,7 @@ impl IFaxConfiguration {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxConfiguration> for ::windows::core::IUnknown {
-    fn from(value: IFaxConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &IFaxConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxConfiguration> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxConfiguration> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxConfiguration> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxConfiguration, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxConfiguration {
     fn clone(&self) -> Self {
@@ -2276,41 +1868,7 @@ impl IFaxDevice {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDevice> for ::windows::core::IUnknown {
-    fn from(value: IFaxDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDevice> for ::windows::core::IUnknown {
-    fn from(value: &IFaxDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDevice> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDevice> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDevice> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxDevice, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxDevice {
     fn clone(&self) -> Self {
@@ -2409,41 +1967,7 @@ impl IFaxDeviceIds {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDeviceIds> for ::windows::core::IUnknown {
-    fn from(value: IFaxDeviceIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDeviceIds> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxDeviceIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDeviceIds> for ::windows::core::IUnknown {
-    fn from(value: &IFaxDeviceIds) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDeviceIds> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxDeviceIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDeviceIds> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxDeviceIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDeviceIds> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxDeviceIds) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxDeviceIds, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxDeviceIds {
     fn clone(&self) -> Self {
@@ -2542,41 +2066,7 @@ impl IFaxDeviceProvider {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDeviceProvider> for ::windows::core::IUnknown {
-    fn from(value: IFaxDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDeviceProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDeviceProvider> for ::windows::core::IUnknown {
-    fn from(value: &IFaxDeviceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDeviceProvider> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDeviceProvider> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxDeviceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDeviceProvider> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxDeviceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxDeviceProvider, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxDeviceProvider {
     fn clone(&self) -> Self {
@@ -2651,41 +2141,7 @@ impl IFaxDeviceProviders {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDeviceProviders> for ::windows::core::IUnknown {
-    fn from(value: IFaxDeviceProviders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDeviceProviders> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxDeviceProviders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDeviceProviders> for ::windows::core::IUnknown {
-    fn from(value: &IFaxDeviceProviders) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDeviceProviders> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxDeviceProviders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDeviceProviders> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxDeviceProviders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDeviceProviders> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxDeviceProviders) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxDeviceProviders, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxDeviceProviders {
     fn clone(&self) -> Self {
@@ -2757,41 +2213,7 @@ impl IFaxDevices {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDevices> for ::windows::core::IUnknown {
-    fn from(value: IFaxDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDevices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDevices> for ::windows::core::IUnknown {
-    fn from(value: &IFaxDevices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDevices> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDevices> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDevices> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxDevices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxDevices, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxDevices {
     fn clone(&self) -> Self {
@@ -2983,41 +2405,7 @@ impl IFaxDocument {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDocument> for ::windows::core::IUnknown {
-    fn from(value: IFaxDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDocument> for ::windows::core::IUnknown {
-    fn from(value: &IFaxDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDocument> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDocument> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDocument> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxDocument, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxDocument {
     fn clone(&self) -> Self {
@@ -3282,59 +2670,7 @@ impl IFaxDocument2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDocument2> for ::windows::core::IUnknown {
-    fn from(value: IFaxDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDocument2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDocument2> for ::windows::core::IUnknown {
-    fn from(value: &IFaxDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDocument2> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDocument2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDocument2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxDocument2> for IFaxDocument {
-    fn from(value: IFaxDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxDocument2> for &'a IFaxDocument {
-    fn from(value: &'a IFaxDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxDocument2> for IFaxDocument {
-    fn from(value: &IFaxDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxDocument2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFaxDocument);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxDocument2 {
     fn clone(&self) -> Self {
@@ -3428,41 +2764,7 @@ impl IFaxEventLogging {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxEventLogging> for ::windows::core::IUnknown {
-    fn from(value: IFaxEventLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxEventLogging> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxEventLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxEventLogging> for ::windows::core::IUnknown {
-    fn from(value: &IFaxEventLogging) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxEventLogging> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxEventLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxEventLogging> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxEventLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxEventLogging> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxEventLogging) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxEventLogging, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxEventLogging {
     fn clone(&self) -> Self {
@@ -3539,41 +2841,7 @@ impl IFaxFolders {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxFolders> for ::windows::core::IUnknown {
-    fn from(value: IFaxFolders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxFolders> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxFolders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxFolders> for ::windows::core::IUnknown {
-    fn from(value: &IFaxFolders) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxFolders> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxFolders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxFolders> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxFolders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxFolders> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxFolders) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxFolders, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxFolders {
     fn clone(&self) -> Self {
@@ -3644,41 +2912,7 @@ impl IFaxInboundRouting {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxInboundRouting> for ::windows::core::IUnknown {
-    fn from(value: IFaxInboundRouting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxInboundRouting> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxInboundRouting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxInboundRouting> for ::windows::core::IUnknown {
-    fn from(value: &IFaxInboundRouting) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxInboundRouting> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxInboundRouting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxInboundRouting> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxInboundRouting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxInboundRouting> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxInboundRouting) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxInboundRouting, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxInboundRouting {
     fn clone(&self) -> Self {
@@ -3775,41 +3009,7 @@ impl IFaxInboundRoutingExtension {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxInboundRoutingExtension> for ::windows::core::IUnknown {
-    fn from(value: IFaxInboundRoutingExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxInboundRoutingExtension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxInboundRoutingExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxInboundRoutingExtension> for ::windows::core::IUnknown {
-    fn from(value: &IFaxInboundRoutingExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxInboundRoutingExtension> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxInboundRoutingExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxInboundRoutingExtension> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxInboundRoutingExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxInboundRoutingExtension> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxInboundRoutingExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxInboundRoutingExtension, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxInboundRoutingExtension {
     fn clone(&self) -> Self {
@@ -3883,41 +3083,7 @@ impl IFaxInboundRoutingExtensions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxInboundRoutingExtensions> for ::windows::core::IUnknown {
-    fn from(value: IFaxInboundRoutingExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxInboundRoutingExtensions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxInboundRoutingExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxInboundRoutingExtensions> for ::windows::core::IUnknown {
-    fn from(value: &IFaxInboundRoutingExtensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxInboundRoutingExtensions> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxInboundRoutingExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxInboundRoutingExtensions> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxInboundRoutingExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxInboundRoutingExtensions> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxInboundRoutingExtensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxInboundRoutingExtensions, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxInboundRoutingExtensions {
     fn clone(&self) -> Self {
@@ -3999,41 +3165,7 @@ impl IFaxInboundRoutingMethod {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxInboundRoutingMethod> for ::windows::core::IUnknown {
-    fn from(value: IFaxInboundRoutingMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxInboundRoutingMethod> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxInboundRoutingMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxInboundRoutingMethod> for ::windows::core::IUnknown {
-    fn from(value: &IFaxInboundRoutingMethod) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxInboundRoutingMethod> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxInboundRoutingMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxInboundRoutingMethod> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxInboundRoutingMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxInboundRoutingMethod> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxInboundRoutingMethod) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxInboundRoutingMethod, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxInboundRoutingMethod {
     fn clone(&self) -> Self {
@@ -4102,41 +3234,7 @@ impl IFaxInboundRoutingMethods {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxInboundRoutingMethods> for ::windows::core::IUnknown {
-    fn from(value: IFaxInboundRoutingMethods) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxInboundRoutingMethods> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxInboundRoutingMethods) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxInboundRoutingMethods> for ::windows::core::IUnknown {
-    fn from(value: &IFaxInboundRoutingMethods) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxInboundRoutingMethods> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxInboundRoutingMethods) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxInboundRoutingMethods> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxInboundRoutingMethods) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxInboundRoutingMethods> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxInboundRoutingMethods) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxInboundRoutingMethods, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxInboundRoutingMethods {
     fn clone(&self) -> Self {
@@ -4253,41 +3351,7 @@ impl IFaxIncomingArchive {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingArchive> for ::windows::core::IUnknown {
-    fn from(value: IFaxIncomingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingArchive> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxIncomingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingArchive> for ::windows::core::IUnknown {
-    fn from(value: &IFaxIncomingArchive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingArchive> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxIncomingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingArchive> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxIncomingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingArchive> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxIncomingArchive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxIncomingArchive, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxIncomingArchive {
     fn clone(&self) -> Self {
@@ -4427,41 +3491,7 @@ impl IFaxIncomingJob {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingJob> for ::windows::core::IUnknown {
-    fn from(value: IFaxIncomingJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxIncomingJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingJob> for ::windows::core::IUnknown {
-    fn from(value: &IFaxIncomingJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingJob> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxIncomingJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingJob> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxIncomingJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingJob> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxIncomingJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxIncomingJob, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxIncomingJob {
     fn clone(&self) -> Self {
@@ -4540,41 +3570,7 @@ impl IFaxIncomingJobs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingJobs> for ::windows::core::IUnknown {
-    fn from(value: IFaxIncomingJobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingJobs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxIncomingJobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingJobs> for ::windows::core::IUnknown {
-    fn from(value: &IFaxIncomingJobs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingJobs> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxIncomingJobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingJobs> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxIncomingJobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingJobs> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxIncomingJobs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxIncomingJobs, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxIncomingJobs {
     fn clone(&self) -> Self {
@@ -4673,41 +3669,7 @@ impl IFaxIncomingMessage {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingMessage> for ::windows::core::IUnknown {
-    fn from(value: IFaxIncomingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingMessage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxIncomingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingMessage> for ::windows::core::IUnknown {
-    fn from(value: &IFaxIncomingMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingMessage> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxIncomingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingMessage> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxIncomingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingMessage> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxIncomingMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxIncomingMessage, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxIncomingMessage {
     fn clone(&self) -> Self {
@@ -4868,59 +3830,7 @@ impl IFaxIncomingMessage2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingMessage2> for ::windows::core::IUnknown {
-    fn from(value: IFaxIncomingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingMessage2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxIncomingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingMessage2> for ::windows::core::IUnknown {
-    fn from(value: &IFaxIncomingMessage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingMessage2> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxIncomingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingMessage2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxIncomingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingMessage2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxIncomingMessage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingMessage2> for IFaxIncomingMessage {
-    fn from(value: IFaxIncomingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingMessage2> for &'a IFaxIncomingMessage {
-    fn from(value: &'a IFaxIncomingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingMessage2> for IFaxIncomingMessage {
-    fn from(value: &IFaxIncomingMessage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxIncomingMessage2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFaxIncomingMessage);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxIncomingMessage2 {
     fn clone(&self) -> Self {
@@ -5002,41 +3912,7 @@ impl IFaxIncomingMessageIterator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingMessageIterator> for ::windows::core::IUnknown {
-    fn from(value: IFaxIncomingMessageIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingMessageIterator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxIncomingMessageIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingMessageIterator> for ::windows::core::IUnknown {
-    fn from(value: &IFaxIncomingMessageIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingMessageIterator> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxIncomingMessageIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingMessageIterator> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxIncomingMessageIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingMessageIterator> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxIncomingMessageIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxIncomingMessageIterator, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxIncomingMessageIterator {
     fn clone(&self) -> Self {
@@ -5113,41 +3989,7 @@ impl IFaxIncomingQueue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingQueue> for ::windows::core::IUnknown {
-    fn from(value: IFaxIncomingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxIncomingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingQueue> for ::windows::core::IUnknown {
-    fn from(value: &IFaxIncomingQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxIncomingQueue> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxIncomingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxIncomingQueue> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxIncomingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxIncomingQueue> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxIncomingQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxIncomingQueue, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxIncomingQueue {
     fn clone(&self) -> Self {
@@ -5270,41 +4112,7 @@ impl IFaxJobStatus {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxJobStatus> for ::windows::core::IUnknown {
-    fn from(value: IFaxJobStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxJobStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxJobStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxJobStatus> for ::windows::core::IUnknown {
-    fn from(value: &IFaxJobStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxJobStatus> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxJobStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxJobStatus> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxJobStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxJobStatus> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxJobStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxJobStatus, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxJobStatus {
     fn clone(&self) -> Self {
@@ -5376,41 +4184,7 @@ impl IFaxLoggingOptions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxLoggingOptions> for ::windows::core::IUnknown {
-    fn from(value: IFaxLoggingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxLoggingOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxLoggingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxLoggingOptions> for ::windows::core::IUnknown {
-    fn from(value: &IFaxLoggingOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxLoggingOptions> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxLoggingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxLoggingOptions> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxLoggingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxLoggingOptions> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxLoggingOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxLoggingOptions, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxLoggingOptions {
     fn clone(&self) -> Self {
@@ -5473,41 +4247,7 @@ impl IFaxOutboundRouting {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutboundRouting> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutboundRouting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutboundRouting> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutboundRouting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutboundRouting> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutboundRouting) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutboundRouting> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutboundRouting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutboundRouting> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutboundRouting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutboundRouting> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutboundRouting) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutboundRouting, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutboundRouting {
     fn clone(&self) -> Self {
@@ -5572,41 +4312,7 @@ impl IFaxOutboundRoutingGroup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutboundRoutingGroup> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutboundRoutingGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutboundRoutingGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutboundRoutingGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutboundRoutingGroup> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutboundRoutingGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutboundRoutingGroup> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutboundRoutingGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutboundRoutingGroup> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutboundRoutingGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutboundRoutingGroup> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutboundRoutingGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutboundRoutingGroup, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutboundRoutingGroup {
     fn clone(&self) -> Self {
@@ -5686,41 +4392,7 @@ impl IFaxOutboundRoutingGroups {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutboundRoutingGroups> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutboundRoutingGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutboundRoutingGroups> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutboundRoutingGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutboundRoutingGroups> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutboundRoutingGroups) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutboundRoutingGroups> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutboundRoutingGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutboundRoutingGroups> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutboundRoutingGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutboundRoutingGroups> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutboundRoutingGroups) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutboundRoutingGroups, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutboundRoutingGroups {
     fn clone(&self) -> Self {
@@ -5816,41 +4488,7 @@ impl IFaxOutboundRoutingRule {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutboundRoutingRule> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutboundRoutingRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutboundRoutingRule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutboundRoutingRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutboundRoutingRule> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutboundRoutingRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutboundRoutingRule> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutboundRoutingRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutboundRoutingRule> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutboundRoutingRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutboundRoutingRule> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutboundRoutingRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutboundRoutingRule, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutboundRoutingRule {
     fn clone(&self) -> Self {
@@ -5936,41 +4574,7 @@ impl IFaxOutboundRoutingRules {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutboundRoutingRules> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutboundRoutingRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutboundRoutingRules> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutboundRoutingRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutboundRoutingRules> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutboundRoutingRules) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutboundRoutingRules> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutboundRoutingRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutboundRoutingRules> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutboundRoutingRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutboundRoutingRules> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutboundRoutingRules) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutboundRoutingRules, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutboundRoutingRules {
     fn clone(&self) -> Self {
@@ -6097,41 +4701,7 @@ impl IFaxOutgoingArchive {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingArchive> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutgoingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingArchive> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutgoingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingArchive> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutgoingArchive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingArchive> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutgoingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingArchive> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutgoingArchive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingArchive> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutgoingArchive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutgoingArchive, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutgoingArchive {
     fn clone(&self) -> Self {
@@ -6320,41 +4890,7 @@ impl IFaxOutgoingJob {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingJob> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutgoingJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutgoingJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingJob> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutgoingJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingJob> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutgoingJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingJob> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutgoingJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingJob> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutgoingJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutgoingJob, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutgoingJob {
     fn clone(&self) -> Self {
@@ -6568,59 +5104,7 @@ impl IFaxOutgoingJob2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingJob2> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutgoingJob2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingJob2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutgoingJob2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingJob2> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutgoingJob2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingJob2> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutgoingJob2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingJob2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutgoingJob2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingJob2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutgoingJob2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingJob2> for IFaxOutgoingJob {
-    fn from(value: IFaxOutgoingJob2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingJob2> for &'a IFaxOutgoingJob {
-    fn from(value: &'a IFaxOutgoingJob2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingJob2> for IFaxOutgoingJob {
-    fn from(value: &IFaxOutgoingJob2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutgoingJob2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFaxOutgoingJob);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutgoingJob2 {
     fn clone(&self) -> Self {
@@ -6683,41 +5167,7 @@ impl IFaxOutgoingJobs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingJobs> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutgoingJobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingJobs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutgoingJobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingJobs> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutgoingJobs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingJobs> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutgoingJobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingJobs> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutgoingJobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingJobs> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutgoingJobs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutgoingJobs, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutgoingJobs {
     fn clone(&self) -> Self {
@@ -6844,41 +5294,7 @@ impl IFaxOutgoingMessage {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingMessage> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutgoingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingMessage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutgoingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingMessage> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutgoingMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingMessage> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutgoingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingMessage> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutgoingMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingMessage> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutgoingMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutgoingMessage, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutgoingMessage {
     fn clone(&self) -> Self {
@@ -7049,59 +5465,7 @@ impl IFaxOutgoingMessage2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingMessage2> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutgoingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingMessage2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutgoingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingMessage2> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutgoingMessage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingMessage2> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutgoingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingMessage2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutgoingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingMessage2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutgoingMessage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingMessage2> for IFaxOutgoingMessage {
-    fn from(value: IFaxOutgoingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingMessage2> for &'a IFaxOutgoingMessage {
-    fn from(value: &'a IFaxOutgoingMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingMessage2> for IFaxOutgoingMessage {
-    fn from(value: &IFaxOutgoingMessage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutgoingMessage2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFaxOutgoingMessage);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutgoingMessage2 {
     fn clone(&self) -> Self {
@@ -7174,41 +5538,7 @@ impl IFaxOutgoingMessageIterator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingMessageIterator> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutgoingMessageIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingMessageIterator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutgoingMessageIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingMessageIterator> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutgoingMessageIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingMessageIterator> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutgoingMessageIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingMessageIterator> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutgoingMessageIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingMessageIterator> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutgoingMessageIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutgoingMessageIterator, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutgoingMessageIterator {
     fn clone(&self) -> Self {
@@ -7348,41 +5678,7 @@ impl IFaxOutgoingQueue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingQueue> for ::windows::core::IUnknown {
-    fn from(value: IFaxOutgoingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxOutgoingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingQueue> for ::windows::core::IUnknown {
-    fn from(value: &IFaxOutgoingQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxOutgoingQueue> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxOutgoingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxOutgoingQueue> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxOutgoingQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxOutgoingQueue> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxOutgoingQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxOutgoingQueue, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxOutgoingQueue {
     fn clone(&self) -> Self {
@@ -7517,41 +5813,7 @@ impl IFaxReceiptOptions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxReceiptOptions> for ::windows::core::IUnknown {
-    fn from(value: IFaxReceiptOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxReceiptOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxReceiptOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxReceiptOptions> for ::windows::core::IUnknown {
-    fn from(value: &IFaxReceiptOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxReceiptOptions> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxReceiptOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxReceiptOptions> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxReceiptOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxReceiptOptions> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxReceiptOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxReceiptOptions, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxReceiptOptions {
     fn clone(&self) -> Self {
@@ -7626,41 +5888,7 @@ impl IFaxRecipient {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxRecipient> for ::windows::core::IUnknown {
-    fn from(value: IFaxRecipient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxRecipient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxRecipient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxRecipient> for ::windows::core::IUnknown {
-    fn from(value: &IFaxRecipient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxRecipient> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxRecipient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxRecipient> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxRecipient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxRecipient> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxRecipient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxRecipient, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxRecipient {
     fn clone(&self) -> Self {
@@ -7730,41 +5958,7 @@ impl IFaxRecipients {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxRecipients> for ::windows::core::IUnknown {
-    fn from(value: IFaxRecipients) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxRecipients> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxRecipients) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxRecipients> for ::windows::core::IUnknown {
-    fn from(value: &IFaxRecipients) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxRecipients> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxRecipients) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxRecipients> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxRecipients) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxRecipients> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxRecipients) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxRecipients, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxRecipients {
     fn clone(&self) -> Self {
@@ -7849,41 +6043,7 @@ impl IFaxSecurity {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxSecurity> for ::windows::core::IUnknown {
-    fn from(value: IFaxSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxSecurity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxSecurity> for ::windows::core::IUnknown {
-    fn from(value: &IFaxSecurity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxSecurity> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxSecurity> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxSecurity> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxSecurity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxSecurity, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxSecurity {
     fn clone(&self) -> Self {
@@ -7970,41 +6130,7 @@ impl IFaxSecurity2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxSecurity2> for ::windows::core::IUnknown {
-    fn from(value: IFaxSecurity2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxSecurity2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxSecurity2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxSecurity2> for ::windows::core::IUnknown {
-    fn from(value: &IFaxSecurity2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxSecurity2> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxSecurity2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxSecurity2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxSecurity2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxSecurity2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxSecurity2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxSecurity2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxSecurity2 {
     fn clone(&self) -> Self {
@@ -8178,41 +6304,7 @@ impl IFaxSender {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxSender> for ::windows::core::IUnknown {
-    fn from(value: IFaxSender) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxSender> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxSender) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxSender> for ::windows::core::IUnknown {
-    fn from(value: &IFaxSender) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxSender> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxSender) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxSender> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxSender) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxSender> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxSender) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxSender, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxSender {
     fn clone(&self) -> Self {
@@ -8415,41 +6507,7 @@ impl IFaxServer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxServer> for ::windows::core::IUnknown {
-    fn from(value: IFaxServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxServer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxServer> for ::windows::core::IUnknown {
-    fn from(value: &IFaxServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxServer> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxServer> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxServer> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxServer, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxServer {
     fn clone(&self) -> Self {
@@ -8704,59 +6762,7 @@ impl IFaxServer2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxServer2> for ::windows::core::IUnknown {
-    fn from(value: IFaxServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxServer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxServer2> for ::windows::core::IUnknown {
-    fn from(value: &IFaxServer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxServer2> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxServer2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxServer2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxServer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxServer2> for IFaxServer {
-    fn from(value: IFaxServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxServer2> for &'a IFaxServer {
-    fn from(value: &'a IFaxServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxServer2> for IFaxServer {
-    fn from(value: &IFaxServer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxServer2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFaxServer);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxServer2 {
     fn clone(&self) -> Self {
@@ -8814,41 +6820,7 @@ pub struct IFaxServerNotify(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IFaxServerNotify {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxServerNotify> for ::windows::core::IUnknown {
-    fn from(value: IFaxServerNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxServerNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxServerNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxServerNotify> for ::windows::core::IUnknown {
-    fn from(value: &IFaxServerNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxServerNotify> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxServerNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxServerNotify> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxServerNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxServerNotify> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxServerNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxServerNotify, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxServerNotify {
     fn clone(&self) -> Self {
@@ -8890,41 +6862,7 @@ pub struct IFaxServerNotify2(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IFaxServerNotify2 {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxServerNotify2> for ::windows::core::IUnknown {
-    fn from(value: IFaxServerNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxServerNotify2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFaxServerNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxServerNotify2> for ::windows::core::IUnknown {
-    fn from(value: &IFaxServerNotify2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFaxServerNotify2> for super::super::System::Com::IDispatch {
-    fn from(value: IFaxServerNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFaxServerNotify2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFaxServerNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFaxServerNotify2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFaxServerNotify2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFaxServerNotify2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFaxServerNotify2 {
     fn clone(&self) -> Self {
@@ -9034,21 +6972,7 @@ impl IStiDevice {
         (::windows::core::Vtable::vtable(self).GetLastErrorInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<_ERROR_INFOW>(result__)
     }
 }
-impl ::core::convert::From<IStiDevice> for ::windows::core::IUnknown {
-    fn from(value: IStiDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStiDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStiDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStiDevice> for ::windows::core::IUnknown {
-    fn from(value: &IStiDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStiDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStiDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9165,21 +7089,7 @@ impl IStiDeviceControl {
         (::windows::core::Vtable::vtable(self).WriteToErrorLog)(::windows::core::Vtable::as_raw(self), dwmessagetype, pszmessage.into(), dwerrorcode).ok()
     }
 }
-impl ::core::convert::From<IStiDeviceControl> for ::windows::core::IUnknown {
-    fn from(value: IStiDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStiDeviceControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStiDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStiDeviceControl> for ::windows::core::IUnknown {
-    fn from(value: &IStiDeviceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStiDeviceControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStiDeviceControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9309,21 +7219,7 @@ impl IStiUSD {
         (::windows::core::Vtable::vtable(self).GetLastErrorInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<_ERROR_INFOW>(result__)
     }
 }
-impl ::core::convert::From<IStiUSD> for ::windows::core::IUnknown {
-    fn from(value: IStiUSD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStiUSD> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStiUSD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStiUSD> for ::windows::core::IUnknown {
-    fn from(value: &IStiUSD) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStiUSD, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStiUSD {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9484,21 +7380,7 @@ impl IStillImageW {
         (::windows::core::Vtable::vtable(self).WriteToErrorLog)(::windows::core::Vtable::as_raw(self), dwmessagetype, pszmessage.into()).ok()
     }
 }
-impl ::core::convert::From<IStillImageW> for ::windows::core::IUnknown {
-    fn from(value: IStillImageW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStillImageW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStillImageW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStillImageW> for ::windows::core::IUnknown {
-    fn from(value: &IStillImageW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStillImageW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStillImageW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9648,41 +7530,7 @@ impl _IFaxAccountNotify {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IFaxAccountNotify> for ::windows::core::IUnknown {
-    fn from(value: _IFaxAccountNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IFaxAccountNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IFaxAccountNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IFaxAccountNotify> for ::windows::core::IUnknown {
-    fn from(value: &_IFaxAccountNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IFaxAccountNotify> for super::super::System::Com::IDispatch {
-    fn from(value: _IFaxAccountNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IFaxAccountNotify> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _IFaxAccountNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IFaxAccountNotify> for super::super::System::Com::IDispatch {
-    fn from(value: &_IFaxAccountNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IFaxAccountNotify, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IFaxAccountNotify {
     fn clone(&self) -> Self {
@@ -9979,41 +7827,7 @@ impl _IFaxServerNotify2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IFaxServerNotify2> for ::windows::core::IUnknown {
-    fn from(value: _IFaxServerNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IFaxServerNotify2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IFaxServerNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IFaxServerNotify2> for ::windows::core::IUnknown {
-    fn from(value: &_IFaxServerNotify2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IFaxServerNotify2> for super::super::System::Com::IDispatch {
-    fn from(value: _IFaxServerNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IFaxServerNotify2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _IFaxServerNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IFaxServerNotify2> for super::super::System::Com::IDispatch {
-    fn from(value: &_IFaxServerNotify2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IFaxServerNotify2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IFaxServerNotify2 {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/mod.rs
@@ -60,21 +60,7 @@ impl IFunctionDiscovery {
         (::windows::core::Vtable::vtable(self).RemoveInstance)(::windows::core::Vtable::as_raw(self), enumsystemvisibility, pszcategory.into(), pszsubcategory.into(), pszcategoryidentity.into()).ok()
     }
 }
-impl ::core::convert::From<IFunctionDiscovery> for ::windows::core::IUnknown {
-    fn from(value: IFunctionDiscovery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFunctionDiscovery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFunctionDiscovery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFunctionDiscovery> for ::windows::core::IUnknown {
-    fn from(value: &IFunctionDiscovery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFunctionDiscovery, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFunctionDiscovery {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -145,21 +131,7 @@ impl IFunctionDiscoveryNotification {
         (::windows::core::Vtable::vtable(self).OnEvent)(::windows::core::Vtable::as_raw(self), dweventid, fdqcquerycontext, pszprovider.into()).ok()
     }
 }
-impl ::core::convert::From<IFunctionDiscoveryNotification> for ::windows::core::IUnknown {
-    fn from(value: IFunctionDiscoveryNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFunctionDiscoveryNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFunctionDiscoveryNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFunctionDiscoveryNotification> for ::windows::core::IUnknown {
-    fn from(value: &IFunctionDiscoveryNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFunctionDiscoveryNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFunctionDiscoveryNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -258,21 +230,7 @@ impl IFunctionDiscoveryProvider {
         (::windows::core::Vtable::vtable(self).InstanceReleased)(::windows::core::Vtable::as_raw(self), pifunctioninstance.into().abi(), iproviderinstancecontext).ok()
     }
 }
-impl ::core::convert::From<IFunctionDiscoveryProvider> for ::windows::core::IUnknown {
-    fn from(value: IFunctionDiscoveryProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFunctionDiscoveryProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFunctionDiscoveryProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFunctionDiscoveryProvider> for ::windows::core::IUnknown {
-    fn from(value: &IFunctionDiscoveryProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFunctionDiscoveryProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFunctionDiscoveryProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -350,21 +308,7 @@ impl IFunctionDiscoveryProviderFactory {
         (::windows::core::Vtable::vtable(self).CreateFunctionInstanceCollection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IFunctionInstanceCollection>(result__)
     }
 }
-impl ::core::convert::From<IFunctionDiscoveryProviderFactory> for ::windows::core::IUnknown {
-    fn from(value: IFunctionDiscoveryProviderFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFunctionDiscoveryProviderFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFunctionDiscoveryProviderFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFunctionDiscoveryProviderFactory> for ::windows::core::IUnknown {
-    fn from(value: &IFunctionDiscoveryProviderFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFunctionDiscoveryProviderFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFunctionDiscoveryProviderFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -424,21 +368,7 @@ impl IFunctionDiscoveryProviderQuery {
         (::windows::core::Vtable::vtable(self).GetPropertyConstraints)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IProviderPropertyConstraintCollection>(result__)
     }
 }
-impl ::core::convert::From<IFunctionDiscoveryProviderQuery> for ::windows::core::IUnknown {
-    fn from(value: IFunctionDiscoveryProviderQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFunctionDiscoveryProviderQuery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFunctionDiscoveryProviderQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFunctionDiscoveryProviderQuery> for ::windows::core::IUnknown {
-    fn from(value: &IFunctionDiscoveryProviderQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFunctionDiscoveryProviderQuery, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFunctionDiscoveryProviderQuery {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -491,21 +421,7 @@ impl IFunctionDiscoveryServiceProvider {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pifunctioninstance.into().abi(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IFunctionDiscoveryServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: IFunctionDiscoveryServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFunctionDiscoveryServiceProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFunctionDiscoveryServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFunctionDiscoveryServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: &IFunctionDiscoveryServiceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFunctionDiscoveryServiceProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFunctionDiscoveryServiceProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -567,41 +483,7 @@ impl IFunctionInstance {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFunctionInstance> for ::windows::core::IUnknown {
-    fn from(value: IFunctionInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFunctionInstance> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFunctionInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFunctionInstance> for ::windows::core::IUnknown {
-    fn from(value: &IFunctionInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFunctionInstance> for super::super::System::Com::IServiceProvider {
-    fn from(value: IFunctionInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFunctionInstance> for &'a super::super::System::Com::IServiceProvider {
-    fn from(value: &'a IFunctionInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFunctionInstance> for super::super::System::Com::IServiceProvider {
-    fn from(value: &IFunctionInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFunctionInstance, ::windows::core::IUnknown, super::super::System::Com::IServiceProvider);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFunctionInstance {
     fn clone(&self) -> Self {
@@ -686,21 +568,7 @@ impl IFunctionInstanceCollection {
         (::windows::core::Vtable::vtable(self).DeleteAll)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IFunctionInstanceCollection> for ::windows::core::IUnknown {
-    fn from(value: IFunctionInstanceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFunctionInstanceCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFunctionInstanceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFunctionInstanceCollection> for ::windows::core::IUnknown {
-    fn from(value: &IFunctionInstanceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFunctionInstanceCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFunctionInstanceCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -768,21 +636,7 @@ impl IFunctionInstanceCollectionQuery {
         (::windows::core::Vtable::vtable(self).Execute)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IFunctionInstanceCollection>(result__)
     }
 }
-impl ::core::convert::From<IFunctionInstanceCollectionQuery> for ::windows::core::IUnknown {
-    fn from(value: IFunctionInstanceCollectionQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFunctionInstanceCollectionQuery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFunctionInstanceCollectionQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFunctionInstanceCollectionQuery> for ::windows::core::IUnknown {
-    fn from(value: &IFunctionInstanceCollectionQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFunctionInstanceCollectionQuery, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFunctionInstanceCollectionQuery {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -827,21 +681,7 @@ impl IFunctionInstanceQuery {
         (::windows::core::Vtable::vtable(self).Execute)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IFunctionInstance>(result__)
     }
 }
-impl ::core::convert::From<IFunctionInstanceQuery> for ::windows::core::IUnknown {
-    fn from(value: IFunctionInstanceQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFunctionInstanceQuery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFunctionInstanceQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFunctionInstanceQuery> for ::windows::core::IUnknown {
-    fn from(value: &IFunctionInstanceQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFunctionInstanceQuery, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFunctionInstanceQuery {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -896,21 +736,7 @@ impl IPNPXAssociation {
         (::windows::core::Vtable::vtable(self).Delete)(::windows::core::Vtable::as_raw(self), pszsubcategory.into()).ok()
     }
 }
-impl ::core::convert::From<IPNPXAssociation> for ::windows::core::IUnknown {
-    fn from(value: IPNPXAssociation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPNPXAssociation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPNPXAssociation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPNPXAssociation> for ::windows::core::IUnknown {
-    fn from(value: &IPNPXAssociation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPNPXAssociation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPNPXAssociation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -967,21 +793,7 @@ impl IPNPXDeviceAssociation {
         (::windows::core::Vtable::vtable(self).Delete)(::windows::core::Vtable::as_raw(self), pszsubcategory.into(), pifunctiondiscoverynotification.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPNPXDeviceAssociation> for ::windows::core::IUnknown {
-    fn from(value: IPNPXDeviceAssociation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPNPXDeviceAssociation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPNPXDeviceAssociation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPNPXDeviceAssociation> for ::windows::core::IUnknown {
-    fn from(value: &IPNPXDeviceAssociation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPNPXDeviceAssociation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPNPXDeviceAssociation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1055,21 +867,7 @@ impl IPropertyStoreCollection {
         (::windows::core::Vtable::vtable(self).DeleteAll)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPropertyStoreCollection> for ::windows::core::IUnknown {
-    fn from(value: IPropertyStoreCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyStoreCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyStoreCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyStoreCollection> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyStoreCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyStoreCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyStoreCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1156,21 +954,7 @@ impl IProviderProperties {
         (::windows::core::Vtable::vtable(self).SetValue)(::windows::core::Vtable::as_raw(self), pifunctioninstance.into().abi(), iproviderinstancecontext, ::core::mem::transmute(key), ::core::mem::transmute(ppropvar)).ok()
     }
 }
-impl ::core::convert::From<IProviderProperties> for ::windows::core::IUnknown {
-    fn from(value: IProviderProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProviderProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProviderProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProviderProperties> for ::windows::core::IUnknown {
-    fn from(value: &IProviderProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProviderProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProviderProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1244,21 +1028,7 @@ impl IProviderPropertyConstraintCollection {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IProviderPropertyConstraintCollection> for ::windows::core::IUnknown {
-    fn from(value: IProviderPropertyConstraintCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProviderPropertyConstraintCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProviderPropertyConstraintCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProviderPropertyConstraintCollection> for ::windows::core::IUnknown {
-    fn from(value: &IProviderPropertyConstraintCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProviderPropertyConstraintCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProviderPropertyConstraintCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1323,21 +1093,7 @@ impl IProviderPublishing {
         (::windows::core::Vtable::vtable(self).RemoveInstance)(::windows::core::Vtable::as_raw(self), enumvisibilityflags, pszsubcategory.into(), pszproviderinstanceidentity.into()).ok()
     }
 }
-impl ::core::convert::From<IProviderPublishing> for ::windows::core::IUnknown {
-    fn from(value: IProviderPublishing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProviderPublishing> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProviderPublishing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProviderPublishing> for ::windows::core::IUnknown {
-    fn from(value: &IProviderPublishing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProviderPublishing, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProviderPublishing {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1398,21 +1154,7 @@ impl IProviderQueryConstraintCollection {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IProviderQueryConstraintCollection> for ::windows::core::IUnknown {
-    fn from(value: IProviderQueryConstraintCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProviderQueryConstraintCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProviderQueryConstraintCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProviderQueryConstraintCollection> for ::windows::core::IUnknown {
-    fn from(value: &IProviderQueryConstraintCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProviderQueryConstraintCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProviderQueryConstraintCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/mod.rs
@@ -47,36 +47,7 @@ impl ICivicAddressReport {
         (::windows::core::Vtable::vtable(self).GetDetailLevel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ICivicAddressReport> for ::windows::core::IUnknown {
-    fn from(value: ICivicAddressReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICivicAddressReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICivicAddressReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICivicAddressReport> for ::windows::core::IUnknown {
-    fn from(value: &ICivicAddressReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICivicAddressReport> for ILocationReport {
-    fn from(value: ICivicAddressReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICivicAddressReport> for &'a ILocationReport {
-    fn from(value: &'a ICivicAddressReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICivicAddressReport> for ILocationReport {
-    fn from(value: &ICivicAddressReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICivicAddressReport, ::windows::core::IUnknown, ILocationReport);
 impl ::core::clone::Clone for ICivicAddressReport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -152,59 +123,7 @@ impl ICivicAddressReportFactory {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICivicAddressReportFactory> for ::windows::core::IUnknown {
-    fn from(value: ICivicAddressReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICivicAddressReportFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICivicAddressReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICivicAddressReportFactory> for ::windows::core::IUnknown {
-    fn from(value: &ICivicAddressReportFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICivicAddressReportFactory> for super::super::System::Com::IDispatch {
-    fn from(value: ICivicAddressReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICivicAddressReportFactory> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ICivicAddressReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICivicAddressReportFactory> for super::super::System::Com::IDispatch {
-    fn from(value: &ICivicAddressReportFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICivicAddressReportFactory> for ILocationReportFactory {
-    fn from(value: ICivicAddressReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICivicAddressReportFactory> for &'a ILocationReportFactory {
-    fn from(value: &'a ICivicAddressReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICivicAddressReportFactory> for ILocationReportFactory {
-    fn from(value: &ICivicAddressReportFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICivicAddressReportFactory, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ILocationReportFactory);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICivicAddressReportFactory {
     fn clone(&self) -> Self {
@@ -258,21 +177,7 @@ impl IDefaultLocation {
         (::windows::core::Vtable::vtable(self).GetReport)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(reporttype), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ILocationReport>(result__)
     }
 }
-impl ::core::convert::From<IDefaultLocation> for ::windows::core::IUnknown {
-    fn from(value: IDefaultLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDefaultLocation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDefaultLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDefaultLocation> for ::windows::core::IUnknown {
-    fn from(value: &IDefaultLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDefaultLocation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDefaultLocation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -342,41 +247,7 @@ impl IDispCivicAddressReport {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDispCivicAddressReport> for ::windows::core::IUnknown {
-    fn from(value: IDispCivicAddressReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDispCivicAddressReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDispCivicAddressReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDispCivicAddressReport> for ::windows::core::IUnknown {
-    fn from(value: &IDispCivicAddressReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDispCivicAddressReport> for super::super::System::Com::IDispatch {
-    fn from(value: IDispCivicAddressReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDispCivicAddressReport> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDispCivicAddressReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDispCivicAddressReport> for super::super::System::Com::IDispatch {
-    fn from(value: &IDispCivicAddressReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDispCivicAddressReport, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDispCivicAddressReport {
     fn clone(&self) -> Self {
@@ -451,41 +322,7 @@ impl IDispLatLongReport {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDispLatLongReport> for ::windows::core::IUnknown {
-    fn from(value: IDispLatLongReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDispLatLongReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDispLatLongReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDispLatLongReport> for ::windows::core::IUnknown {
-    fn from(value: &IDispLatLongReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDispLatLongReport> for super::super::System::Com::IDispatch {
-    fn from(value: IDispLatLongReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDispLatLongReport> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDispLatLongReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDispLatLongReport> for super::super::System::Com::IDispatch {
-    fn from(value: &IDispLatLongReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDispLatLongReport, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDispLatLongReport {
     fn clone(&self) -> Self {
@@ -567,36 +404,7 @@ impl ILatLongReport {
         (::windows::core::Vtable::vtable(self).GetAltitudeError)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<f64>(result__)
     }
 }
-impl ::core::convert::From<ILatLongReport> for ::windows::core::IUnknown {
-    fn from(value: ILatLongReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILatLongReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILatLongReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILatLongReport> for ::windows::core::IUnknown {
-    fn from(value: &ILatLongReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILatLongReport> for ILocationReport {
-    fn from(value: ILatLongReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILatLongReport> for &'a ILocationReport {
-    fn from(value: &'a ILatLongReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILatLongReport> for ILocationReport {
-    fn from(value: &ILatLongReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILatLongReport, ::windows::core::IUnknown, ILocationReport);
 impl ::core::clone::Clone for ILatLongReport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -670,59 +478,7 @@ impl ILatLongReportFactory {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ILatLongReportFactory> for ::windows::core::IUnknown {
-    fn from(value: ILatLongReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ILatLongReportFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILatLongReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ILatLongReportFactory> for ::windows::core::IUnknown {
-    fn from(value: &ILatLongReportFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ILatLongReportFactory> for super::super::System::Com::IDispatch {
-    fn from(value: ILatLongReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ILatLongReportFactory> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ILatLongReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ILatLongReportFactory> for super::super::System::Com::IDispatch {
-    fn from(value: &ILatLongReportFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ILatLongReportFactory> for ILocationReportFactory {
-    fn from(value: ILatLongReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ILatLongReportFactory> for &'a ILocationReportFactory {
-    fn from(value: &'a ILatLongReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ILatLongReportFactory> for ILocationReportFactory {
-    fn from(value: &ILatLongReportFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILatLongReportFactory, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ILocationReportFactory);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ILatLongReportFactory {
     fn clone(&self) -> Self {
@@ -810,21 +566,7 @@ impl ILocation {
         (::windows::core::Vtable::vtable(self).RequestPermissions)(::windows::core::Vtable::as_raw(self), hparent.into(), ::core::mem::transmute(preporttypes.as_ptr()), preporttypes.len() as _, fmodal.into()).ok()
     }
 }
-impl ::core::convert::From<ILocation> for ::windows::core::IUnknown {
-    fn from(value: ILocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILocation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILocation> for ::windows::core::IUnknown {
-    fn from(value: &ILocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILocation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILocation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -884,21 +626,7 @@ impl ILocationEvents {
         (::windows::core::Vtable::vtable(self).OnStatusChanged)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(reporttype), newstatus).ok()
     }
 }
-impl ::core::convert::From<ILocationEvents> for ::windows::core::IUnknown {
-    fn from(value: ILocationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILocationEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILocationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILocationEvents> for ::windows::core::IUnknown {
-    fn from(value: &ILocationEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILocationEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILocationEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -939,21 +667,7 @@ impl ILocationPower {
         (::windows::core::Vtable::vtable(self).Disconnect)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ILocationPower> for ::windows::core::IUnknown {
-    fn from(value: ILocationPower) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILocationPower> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILocationPower) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILocationPower> for ::windows::core::IUnknown {
-    fn from(value: &ILocationPower) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILocationPower, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILocationPower {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1004,21 +718,7 @@ impl ILocationReport {
         (::windows::core::Vtable::vtable(self).GetValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pkey), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::StructuredStorage::PROPVARIANT>(result__)
     }
 }
-impl ::core::convert::From<ILocationReport> for ::windows::core::IUnknown {
-    fn from(value: ILocationReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILocationReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILocationReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILocationReport> for ::windows::core::IUnknown {
-    fn from(value: &ILocationReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILocationReport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILocationReport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1090,41 +790,7 @@ impl ILocationReportFactory {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ILocationReportFactory> for ::windows::core::IUnknown {
-    fn from(value: ILocationReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ILocationReportFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILocationReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ILocationReportFactory> for ::windows::core::IUnknown {
-    fn from(value: &ILocationReportFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ILocationReportFactory> for super::super::System::Com::IDispatch {
-    fn from(value: ILocationReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ILocationReportFactory> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ILocationReportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ILocationReportFactory> for super::super::System::Com::IDispatch {
-    fn from(value: &ILocationReportFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILocationReportFactory, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ILocationReportFactory {
     fn clone(&self) -> Self {
@@ -1174,41 +840,7 @@ pub struct _ICivicAddressReportFactoryEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _ICivicAddressReportFactoryEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_ICivicAddressReportFactoryEvents> for ::windows::core::IUnknown {
-    fn from(value: _ICivicAddressReportFactoryEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _ICivicAddressReportFactoryEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _ICivicAddressReportFactoryEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_ICivicAddressReportFactoryEvents> for ::windows::core::IUnknown {
-    fn from(value: &_ICivicAddressReportFactoryEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_ICivicAddressReportFactoryEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _ICivicAddressReportFactoryEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _ICivicAddressReportFactoryEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _ICivicAddressReportFactoryEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_ICivicAddressReportFactoryEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_ICivicAddressReportFactoryEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_ICivicAddressReportFactoryEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _ICivicAddressReportFactoryEvents {
     fn clone(&self) -> Self {
@@ -1250,41 +882,7 @@ pub struct _ILatLongReportFactoryEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _ILatLongReportFactoryEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_ILatLongReportFactoryEvents> for ::windows::core::IUnknown {
-    fn from(value: _ILatLongReportFactoryEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _ILatLongReportFactoryEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _ILatLongReportFactoryEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_ILatLongReportFactoryEvents> for ::windows::core::IUnknown {
-    fn from(value: &_ILatLongReportFactoryEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_ILatLongReportFactoryEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _ILatLongReportFactoryEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _ILatLongReportFactoryEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _ILatLongReportFactoryEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_ILatLongReportFactoryEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_ILatLongReportFactoryEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_ILatLongReportFactoryEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _ILatLongReportFactoryEvents {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -560,36 +560,7 @@ impl IDirectInput2A {
         (::windows::core::Vtable::vtable(self).FindDevice)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), param1.into(), ::core::mem::transmute(param2)).ok()
     }
 }
-impl ::core::convert::From<IDirectInput2A> for ::windows::core::IUnknown {
-    fn from(value: IDirectInput2A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput2A> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInput2A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput2A> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInput2A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInput2A> for IDirectInputA {
-    fn from(value: IDirectInput2A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput2A> for &'a IDirectInputA {
-    fn from(value: &'a IDirectInput2A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput2A> for IDirectInputA {
-    fn from(value: &IDirectInput2A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInput2A, ::windows::core::IUnknown, IDirectInputA);
 impl ::core::clone::Clone for IDirectInput2A {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -659,36 +630,7 @@ impl IDirectInput2W {
         (::windows::core::Vtable::vtable(self).FindDevice)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), param1.into(), ::core::mem::transmute(param2)).ok()
     }
 }
-impl ::core::convert::From<IDirectInput2W> for ::windows::core::IUnknown {
-    fn from(value: IDirectInput2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput2W> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInput2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput2W> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInput2W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInput2W> for IDirectInputW {
-    fn from(value: IDirectInput2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput2W> for &'a IDirectInputW {
-    fn from(value: &'a IDirectInput2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput2W> for IDirectInputW {
-    fn from(value: &IDirectInput2W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInput2W, ::windows::core::IUnknown, IDirectInputW);
 impl ::core::clone::Clone for IDirectInput2W {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -764,51 +706,7 @@ impl IDirectInput7A {
         (::windows::core::Vtable::vtable(self).CreateDeviceEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), ::core::mem::transmute(param1), ::core::mem::transmute(param2), param3.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDirectInput7A> for ::windows::core::IUnknown {
-    fn from(value: IDirectInput7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput7A> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInput7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput7A> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInput7A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInput7A> for IDirectInputA {
-    fn from(value: IDirectInput7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput7A> for &'a IDirectInputA {
-    fn from(value: &'a IDirectInput7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput7A> for IDirectInputA {
-    fn from(value: &IDirectInput7A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInput7A> for IDirectInput2A {
-    fn from(value: IDirectInput7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput7A> for &'a IDirectInput2A {
-    fn from(value: &'a IDirectInput7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput7A> for IDirectInput2A {
-    fn from(value: &IDirectInput7A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInput7A, ::windows::core::IUnknown, IDirectInputA, IDirectInput2A);
 impl ::core::clone::Clone for IDirectInput7A {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -884,51 +782,7 @@ impl IDirectInput7W {
         (::windows::core::Vtable::vtable(self).CreateDeviceEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), ::core::mem::transmute(param1), ::core::mem::transmute(param2), param3.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDirectInput7W> for ::windows::core::IUnknown {
-    fn from(value: IDirectInput7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput7W> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInput7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput7W> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInput7W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInput7W> for IDirectInputW {
-    fn from(value: IDirectInput7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput7W> for &'a IDirectInputW {
-    fn from(value: &'a IDirectInput7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput7W> for IDirectInputW {
-    fn from(value: &IDirectInput7W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInput7W> for IDirectInput2W {
-    fn from(value: IDirectInput7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput7W> for &'a IDirectInput2W {
-    fn from(value: &'a IDirectInput7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput7W> for IDirectInput2W {
-    fn from(value: &IDirectInput7W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInput7W, ::windows::core::IUnknown, IDirectInputW, IDirectInput2W);
 impl ::core::clone::Clone for IDirectInput7W {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1011,21 +865,7 @@ impl IDirectInput8A {
         (::windows::core::Vtable::vtable(self).ConfigureDevices)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), ::core::mem::transmute(param1), param2, ::core::mem::transmute(param3)).ok()
     }
 }
-impl ::core::convert::From<IDirectInput8A> for ::windows::core::IUnknown {
-    fn from(value: IDirectInput8A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput8A> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInput8A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput8A> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInput8A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInput8A, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInput8A {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1130,21 +970,7 @@ impl IDirectInput8W {
         (::windows::core::Vtable::vtable(self).ConfigureDevices)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), ::core::mem::transmute(param1), param2, ::core::mem::transmute(param3)).ok()
     }
 }
-impl ::core::convert::From<IDirectInput8W> for ::windows::core::IUnknown {
-    fn from(value: IDirectInput8W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInput8W> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInput8W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInput8W> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInput8W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInput8W, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInput8W {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1230,21 +1056,7 @@ impl IDirectInputA {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), param0.into(), param1).ok()
     }
 }
-impl ::core::convert::From<IDirectInputA> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputA> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInputA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1398,36 +1210,7 @@ impl IDirectInputDevice2A {
         (::windows::core::Vtable::vtable(self).SendDeviceData)(::windows::core::Vtable::as_raw(self), param0, ::core::mem::transmute(param1), ::core::mem::transmute(param2), param3).ok()
     }
 }
-impl ::core::convert::From<IDirectInputDevice2A> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputDevice2A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice2A> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputDevice2A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice2A> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputDevice2A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInputDevice2A> for IDirectInputDeviceA {
-    fn from(value: IDirectInputDevice2A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice2A> for &'a IDirectInputDeviceA {
-    fn from(value: &'a IDirectInputDevice2A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice2A> for IDirectInputDeviceA {
-    fn from(value: &IDirectInputDevice2A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputDevice2A, ::windows::core::IUnknown, IDirectInputDeviceA);
 impl ::core::clone::Clone for IDirectInputDevice2A {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1579,36 +1362,7 @@ impl IDirectInputDevice2W {
         (::windows::core::Vtable::vtable(self).SendDeviceData)(::windows::core::Vtable::as_raw(self), param0, ::core::mem::transmute(param1), ::core::mem::transmute(param2), param3).ok()
     }
 }
-impl ::core::convert::From<IDirectInputDevice2W> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputDevice2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice2W> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputDevice2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice2W> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputDevice2W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInputDevice2W> for IDirectInputDeviceW {
-    fn from(value: IDirectInputDevice2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice2W> for &'a IDirectInputDeviceW {
-    fn from(value: &'a IDirectInputDevice2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice2W> for IDirectInputDeviceW {
-    fn from(value: &IDirectInputDevice2W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputDevice2W, ::windows::core::IUnknown, IDirectInputDeviceW);
 impl ::core::clone::Clone for IDirectInputDevice2W {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1779,51 +1533,7 @@ impl IDirectInputDevice7A {
         (::windows::core::Vtable::vtable(self).WriteEffectToFile)(::windows::core::Vtable::as_raw(self), param0.into(), param1, ::core::mem::transmute(param2), param3).ok()
     }
 }
-impl ::core::convert::From<IDirectInputDevice7A> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputDevice7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice7A> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputDevice7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice7A> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputDevice7A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInputDevice7A> for IDirectInputDeviceA {
-    fn from(value: IDirectInputDevice7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice7A> for &'a IDirectInputDeviceA {
-    fn from(value: &'a IDirectInputDevice7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice7A> for IDirectInputDeviceA {
-    fn from(value: &IDirectInputDevice7A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInputDevice7A> for IDirectInputDevice2A {
-    fn from(value: IDirectInputDevice7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice7A> for &'a IDirectInputDevice2A {
-    fn from(value: &'a IDirectInputDevice7A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice7A> for IDirectInputDevice2A {
-    fn from(value: &IDirectInputDevice7A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputDevice7A, ::windows::core::IUnknown, IDirectInputDeviceA, IDirectInputDevice2A);
 impl ::core::clone::Clone for IDirectInputDevice7A {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1981,51 +1691,7 @@ impl IDirectInputDevice7W {
         (::windows::core::Vtable::vtable(self).WriteEffectToFile)(::windows::core::Vtable::as_raw(self), param0.into(), param1, ::core::mem::transmute(param2), param3).ok()
     }
 }
-impl ::core::convert::From<IDirectInputDevice7W> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputDevice7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice7W> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputDevice7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice7W> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputDevice7W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInputDevice7W> for IDirectInputDeviceW {
-    fn from(value: IDirectInputDevice7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice7W> for &'a IDirectInputDeviceW {
-    fn from(value: &'a IDirectInputDevice7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice7W> for IDirectInputDeviceW {
-    fn from(value: &IDirectInputDevice7W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectInputDevice7W> for IDirectInputDevice2W {
-    fn from(value: IDirectInputDevice7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice7W> for &'a IDirectInputDevice2W {
-    fn from(value: &'a IDirectInputDevice7W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice7W> for IDirectInputDevice2W {
-    fn from(value: &IDirectInputDevice7W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputDevice7W, ::windows::core::IUnknown, IDirectInputDeviceW, IDirectInputDevice2W);
 impl ::core::clone::Clone for IDirectInputDevice7W {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2210,21 +1876,7 @@ impl IDirectInputDevice8A {
         (::windows::core::Vtable::vtable(self).GetImageInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0)).ok()
     }
 }
-impl ::core::convert::From<IDirectInputDevice8A> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputDevice8A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice8A> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputDevice8A) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice8A> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputDevice8A) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputDevice8A, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInputDevice8A {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2469,21 +2121,7 @@ impl IDirectInputDevice8W {
         (::windows::core::Vtable::vtable(self).GetImageInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0)).ok()
     }
 }
-impl ::core::convert::From<IDirectInputDevice8W> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputDevice8W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDevice8W> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputDevice8W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDevice8W> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputDevice8W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputDevice8W, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInputDevice8W {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2652,21 +2290,7 @@ impl IDirectInputDeviceA {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), param0.into(), param1, ::core::mem::transmute(param2)).ok()
     }
 }
-impl ::core::convert::From<IDirectInputDeviceA> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputDeviceA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDeviceA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputDeviceA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDeviceA> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputDeviceA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputDeviceA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInputDeviceA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2802,21 +2426,7 @@ impl IDirectInputDeviceW {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), param0.into(), param1, ::core::mem::transmute(param2)).ok()
     }
 }
-impl ::core::convert::From<IDirectInputDeviceW> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputDeviceW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputDeviceW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputDeviceW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputDeviceW> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputDeviceW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputDeviceW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInputDeviceW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2914,21 +2524,7 @@ impl IDirectInputEffect {
         (::windows::core::Vtable::vtable(self).Escape)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0)).ok()
     }
 }
-impl ::core::convert::From<IDirectInputEffect> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputEffect, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInputEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3007,21 +2603,7 @@ impl IDirectInputEffectDriver {
         (::windows::core::Vtable::vtable(self).GetEffectStatus)(::windows::core::Vtable::as_raw(self), param0, param1, ::core::mem::transmute(param2)).ok()
     }
 }
-impl ::core::convert::From<IDirectInputEffectDriver> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputEffectDriver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputEffectDriver> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputEffectDriver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputEffectDriver> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputEffectDriver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputEffectDriver, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInputEffectDriver {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3141,21 +2723,7 @@ impl IDirectInputJoyConfig {
         (::windows::core::Vtable::vtable(self).OpenConfigKey)(::windows::core::Vtable::as_raw(self), param0, param1, ::core::mem::transmute(param2)).ok()
     }
 }
-impl ::core::convert::From<IDirectInputJoyConfig> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputJoyConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputJoyConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputJoyConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputJoyConfig> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputJoyConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputJoyConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInputJoyConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3296,21 +2864,7 @@ impl IDirectInputJoyConfig8 {
         (::windows::core::Vtable::vtable(self).OpenAppStatusKey)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0)).ok()
     }
 }
-impl ::core::convert::From<IDirectInputJoyConfig8> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputJoyConfig8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputJoyConfig8> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputJoyConfig8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputJoyConfig8> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputJoyConfig8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputJoyConfig8, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInputJoyConfig8 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3404,21 +2958,7 @@ impl IDirectInputW {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), param0.into(), param1).ok()
     }
 }
-impl ::core::convert::From<IDirectInputW> for ::windows::core::IUnknown {
-    fn from(value: IDirectInputW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectInputW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectInputW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectInputW> for ::windows::core::IUnknown {
-    fn from(value: &IDirectInputW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectInputW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectInputW {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
@@ -20,21 +20,7 @@ impl IEnumWIA_DEV_CAPS {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumWIA_DEV_CAPS> for ::windows::core::IUnknown {
-    fn from(value: IEnumWIA_DEV_CAPS) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumWIA_DEV_CAPS> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumWIA_DEV_CAPS) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumWIA_DEV_CAPS> for ::windows::core::IUnknown {
-    fn from(value: &IEnumWIA_DEV_CAPS) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumWIA_DEV_CAPS, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumWIA_DEV_CAPS {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -89,21 +75,7 @@ impl IEnumWIA_DEV_INFO {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumWIA_DEV_INFO> for ::windows::core::IUnknown {
-    fn from(value: IEnumWIA_DEV_INFO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumWIA_DEV_INFO> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumWIA_DEV_INFO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumWIA_DEV_INFO> for ::windows::core::IUnknown {
-    fn from(value: &IEnumWIA_DEV_INFO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumWIA_DEV_INFO, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumWIA_DEV_INFO {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -158,21 +130,7 @@ impl IEnumWIA_FORMAT_INFO {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumWIA_FORMAT_INFO> for ::windows::core::IUnknown {
-    fn from(value: IEnumWIA_FORMAT_INFO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumWIA_FORMAT_INFO> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumWIA_FORMAT_INFO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumWIA_FORMAT_INFO> for ::windows::core::IUnknown {
-    fn from(value: &IEnumWIA_FORMAT_INFO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumWIA_FORMAT_INFO, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumWIA_FORMAT_INFO {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -227,21 +185,7 @@ impl IEnumWiaItem {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumWiaItem> for ::windows::core::IUnknown {
-    fn from(value: IEnumWiaItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumWiaItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumWiaItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumWiaItem> for ::windows::core::IUnknown {
-    fn from(value: &IEnumWiaItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumWiaItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumWiaItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -296,21 +240,7 @@ impl IEnumWiaItem2 {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumWiaItem2> for ::windows::core::IUnknown {
-    fn from(value: IEnumWiaItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumWiaItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumWiaItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumWiaItem2> for ::windows::core::IUnknown {
-    fn from(value: &IEnumWiaItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumWiaItem2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumWiaItem2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -360,21 +290,7 @@ impl IWiaAppErrorHandler {
         (::windows::core::Vtable::vtable(self).ReportStatus)(::windows::core::Vtable::as_raw(self), lflags, pwiaitem2.into().abi(), hrstatus, lpercentcomplete).ok()
     }
 }
-impl ::core::convert::From<IWiaAppErrorHandler> for ::windows::core::IUnknown {
-    fn from(value: IWiaAppErrorHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaAppErrorHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaAppErrorHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaAppErrorHandler> for ::windows::core::IUnknown {
-    fn from(value: &IWiaAppErrorHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaAppErrorHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaAppErrorHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -415,21 +331,7 @@ impl IWiaDataCallback {
         (::windows::core::Vtable::vtable(self).BandedDataCallback)(::windows::core::Vtable::as_raw(self), lmessage, lstatus, lpercentcomplete, loffset, llength, lreserved, lreslength, ::core::mem::transmute(pbbuffer)).ok()
     }
 }
-impl ::core::convert::From<IWiaDataCallback> for ::windows::core::IUnknown {
-    fn from(value: IWiaDataCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaDataCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaDataCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaDataCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWiaDataCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaDataCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaDataCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -490,21 +392,7 @@ impl IWiaDataTransfer {
         (::windows::core::Vtable::vtable(self).idtGetExtendedTransferInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WIA_EXTENDED_TRANSFER_INFO>(result__)
     }
 }
-impl ::core::convert::From<IWiaDataTransfer> for ::windows::core::IUnknown {
-    fn from(value: IWiaDataTransfer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaDataTransfer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaDataTransfer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaDataTransfer> for ::windows::core::IUnknown {
-    fn from(value: &IWiaDataTransfer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaDataTransfer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaDataTransfer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -602,21 +490,7 @@ impl IWiaDevMgr {
         (::windows::core::Vtable::vtable(self).AddDeviceDlg)(::windows::core::Vtable::as_raw(self), hwndparent.into(), lflags).ok()
     }
 }
-impl ::core::convert::From<IWiaDevMgr> for ::windows::core::IUnknown {
-    fn from(value: IWiaDevMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaDevMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaDevMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaDevMgr> for ::windows::core::IUnknown {
-    fn from(value: &IWiaDevMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaDevMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaDevMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -715,21 +589,7 @@ impl IWiaDevMgr2 {
         (::windows::core::Vtable::vtable(self).GetImageDlg)(::windows::core::Vtable::as_raw(self), lflags, ::core::mem::transmute_copy(bstrdeviceid), hwndparent.into(), ::core::mem::transmute_copy(bstrfoldername), ::core::mem::transmute_copy(bstrfilename), ::core::mem::transmute(plnumfiles), ::core::mem::transmute(ppbstrfilepaths), ::core::mem::transmute(ppitem)).ok()
     }
 }
-impl ::core::convert::From<IWiaDevMgr2> for ::windows::core::IUnknown {
-    fn from(value: IWiaDevMgr2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaDevMgr2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaDevMgr2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaDevMgr2> for ::windows::core::IUnknown {
-    fn from(value: &IWiaDevMgr2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaDevMgr2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaDevMgr2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -831,21 +691,7 @@ impl IWiaDrvItem {
         (::windows::core::Vtable::vtable(self).DumpItemData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IWiaDrvItem> for ::windows::core::IUnknown {
-    fn from(value: IWiaDrvItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaDrvItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaDrvItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaDrvItem> for ::windows::core::IUnknown {
-    fn from(value: &IWiaDrvItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaDrvItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaDrvItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -907,21 +753,7 @@ impl IWiaErrorHandler {
         (::windows::core::Vtable::vtable(self).GetStatusDescription)(::windows::core::Vtable::as_raw(self), lflags, pwiaitem2.into().abi(), hrstatus, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IWiaErrorHandler> for ::windows::core::IUnknown {
-    fn from(value: IWiaErrorHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaErrorHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaErrorHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaErrorHandler> for ::windows::core::IUnknown {
-    fn from(value: &IWiaErrorHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaErrorHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaErrorHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -962,21 +794,7 @@ impl IWiaEventCallback {
         (::windows::core::Vtable::vtable(self).ImageEventCallback)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(peventguid), ::core::mem::transmute_copy(bstreventdescription), ::core::mem::transmute_copy(bstrdeviceid), ::core::mem::transmute_copy(bstrdevicedescription), dwdevicetype, ::core::mem::transmute_copy(bstrfullitemname), ::core::mem::transmute(puleventtype), ulreserved).ok()
     }
 }
-impl ::core::convert::From<IWiaEventCallback> for ::windows::core::IUnknown {
-    fn from(value: IWiaEventCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaEventCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaEventCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaEventCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWiaEventCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaEventCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaEventCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1038,21 +856,7 @@ impl IWiaImageFilter {
         (::windows::core::Vtable::vtable(self).ApplyProperties)(::windows::core::Vtable::as_raw(self), pwiapropertystorage.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWiaImageFilter> for ::windows::core::IUnknown {
-    fn from(value: IWiaImageFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaImageFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaImageFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaImageFilter> for ::windows::core::IUnknown {
-    fn from(value: &IWiaImageFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaImageFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaImageFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1152,21 +956,7 @@ impl IWiaItem {
         (::windows::core::Vtable::vtable(self).Diagnostic)(::windows::core::Vtable::as_raw(self), pbuffer.len() as _, ::core::mem::transmute(pbuffer.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IWiaItem> for ::windows::core::IUnknown {
-    fn from(value: IWiaItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaItem> for ::windows::core::IUnknown {
-    fn from(value: &IWiaItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1282,21 +1072,7 @@ impl IWiaItem2 {
         (::windows::core::Vtable::vtable(self).Diagnostic)(::windows::core::Vtable::as_raw(self), pbuffer.len() as _, ::core::mem::transmute(pbuffer.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IWiaItem2> for ::windows::core::IUnknown {
-    fn from(value: IWiaItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaItem2> for ::windows::core::IUnknown {
-    fn from(value: &IWiaItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaItem2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaItem2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1361,21 +1137,7 @@ impl IWiaItemExtras {
         (::windows::core::Vtable::vtable(self).CancelPendingIO)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWiaItemExtras> for ::windows::core::IUnknown {
-    fn from(value: IWiaItemExtras) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaItemExtras> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaItemExtras) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaItemExtras> for ::windows::core::IUnknown {
-    fn from(value: &IWiaItemExtras) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaItemExtras, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaItemExtras {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1420,21 +1182,7 @@ impl IWiaLog {
         (::windows::core::Vtable::vtable(self).Log)(::windows::core::Vtable::as_raw(self), lflags, lresid, ldetail, ::core::mem::transmute_copy(bstrtext)).ok()
     }
 }
-impl ::core::convert::From<IWiaLog> for ::windows::core::IUnknown {
-    fn from(value: IWiaLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaLog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaLog> for ::windows::core::IUnknown {
-    fn from(value: &IWiaLog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaLog, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaLog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1485,21 +1233,7 @@ impl IWiaLogEx {
         (::windows::core::Vtable::vtable(self).LogEx)(::windows::core::Vtable::as_raw(self), lmethodid, lflags, lresid, ldetail, ::core::mem::transmute_copy(bstrtext)).ok()
     }
 }
-impl ::core::convert::From<IWiaLogEx> for ::windows::core::IUnknown {
-    fn from(value: IWiaLogEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaLogEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaLogEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaLogEx> for ::windows::core::IUnknown {
-    fn from(value: &IWiaLogEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaLogEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaLogEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1608,21 +1342,7 @@ impl IWiaMiniDrv {
         (::windows::core::Vtable::vtable(self).drvUnInitializeWia)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(__midl__iwiaminidrv0064)).ok()
     }
 }
-impl ::core::convert::From<IWiaMiniDrv> for ::windows::core::IUnknown {
-    fn from(value: IWiaMiniDrv) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaMiniDrv> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaMiniDrv) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaMiniDrv> for ::windows::core::IUnknown {
-    fn from(value: &IWiaMiniDrv) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaMiniDrv, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaMiniDrv {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1689,21 +1409,7 @@ impl IWiaMiniDrvCallBack {
         (::windows::core::Vtable::vtable(self).MiniDrvCallback)(::windows::core::Vtable::as_raw(self), lreason, lstatus, lpercentcomplete, loffset, llength, ::core::mem::transmute(ptranctx), lreserved).ok()
     }
 }
-impl ::core::convert::From<IWiaMiniDrvCallBack> for ::windows::core::IUnknown {
-    fn from(value: IWiaMiniDrvCallBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaMiniDrvCallBack> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaMiniDrvCallBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaMiniDrvCallBack> for ::windows::core::IUnknown {
-    fn from(value: &IWiaMiniDrvCallBack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaMiniDrvCallBack, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaMiniDrvCallBack {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1749,21 +1455,7 @@ impl IWiaMiniDrvTransferCallback {
         (::windows::core::Vtable::vtable(self).SendMessage)(::windows::core::Vtable::as_raw(self), lflags, ::core::mem::transmute(pwiatransferparams)).ok()
     }
 }
-impl ::core::convert::From<IWiaMiniDrvTransferCallback> for ::windows::core::IUnknown {
-    fn from(value: IWiaMiniDrvTransferCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaMiniDrvTransferCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaMiniDrvTransferCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaMiniDrvTransferCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWiaMiniDrvTransferCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaMiniDrvTransferCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaMiniDrvTransferCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1804,21 +1496,7 @@ impl IWiaNotifyDevMgr {
         (::windows::core::Vtable::vtable(self).NewDeviceArrival)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWiaNotifyDevMgr> for ::windows::core::IUnknown {
-    fn from(value: IWiaNotifyDevMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaNotifyDevMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaNotifyDevMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaNotifyDevMgr> for ::windows::core::IUnknown {
-    fn from(value: &IWiaNotifyDevMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaNotifyDevMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaNotifyDevMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1872,21 +1550,7 @@ impl IWiaPreview {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWiaPreview> for ::windows::core::IUnknown {
-    fn from(value: IWiaPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaPreview> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaPreview) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaPreview> for ::windows::core::IUnknown {
-    fn from(value: &IWiaPreview) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaPreview, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaPreview {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1997,21 +1661,7 @@ impl IWiaPropertyStorage {
         (::windows::core::Vtable::vtable(self).SetPropertyStream)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcompatibilityid), pistream.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWiaPropertyStorage> for ::windows::core::IUnknown {
-    fn from(value: IWiaPropertyStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaPropertyStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaPropertyStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaPropertyStorage> for ::windows::core::IUnknown {
-    fn from(value: &IWiaPropertyStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaPropertyStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaPropertyStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2096,21 +1746,7 @@ impl IWiaSegmentationFilter {
         (::windows::core::Vtable::vtable(self).DetectRegions)(::windows::core::Vtable::as_raw(self), lflags, pinputstream.into().abi(), pwiaitem2.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWiaSegmentationFilter> for ::windows::core::IUnknown {
-    fn from(value: IWiaSegmentationFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaSegmentationFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaSegmentationFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaSegmentationFilter> for ::windows::core::IUnknown {
-    fn from(value: &IWiaSegmentationFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaSegmentationFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaSegmentationFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2169,21 +1805,7 @@ impl IWiaTransfer {
         (::windows::core::Vtable::vtable(self).EnumWIA_FORMAT_INFO)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumWIA_FORMAT_INFO>(result__)
     }
 }
-impl ::core::convert::From<IWiaTransfer> for ::windows::core::IUnknown {
-    fn from(value: IWiaTransfer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaTransfer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaTransfer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaTransfer> for ::windows::core::IUnknown {
-    fn from(value: &IWiaTransfer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaTransfer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaTransfer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2232,21 +1854,7 @@ impl IWiaTransferCallback {
         (::windows::core::Vtable::vtable(self).GetNextStream)(::windows::core::Vtable::as_raw(self), lflags, ::core::mem::transmute_copy(bstritemname), ::core::mem::transmute_copy(bstrfullitemname), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IWiaTransferCallback> for ::windows::core::IUnknown {
-    fn from(value: IWiaTransferCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaTransferCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaTransferCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaTransferCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWiaTransferCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaTransferCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaTransferCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2299,21 +1907,7 @@ impl IWiaUIExtension {
         (::windows::core::Vtable::vtable(self).GetDeviceBitmapLogo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrdeviceid), ::core::mem::transmute(phbitmap), nmaxwidth, nmaxheight).ok()
     }
 }
-impl ::core::convert::From<IWiaUIExtension> for ::windows::core::IUnknown {
-    fn from(value: IWiaUIExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaUIExtension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaUIExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaUIExtension> for ::windows::core::IUnknown {
-    fn from(value: &IWiaUIExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaUIExtension, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaUIExtension {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2368,21 +1962,7 @@ impl IWiaUIExtension2 {
         (::windows::core::Vtable::vtable(self).GetDeviceIcon)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrdeviceid), ::core::mem::transmute(phicon), nsize).ok()
     }
 }
-impl ::core::convert::From<IWiaUIExtension2> for ::windows::core::IUnknown {
-    fn from(value: IWiaUIExtension2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaUIExtension2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaUIExtension2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaUIExtension2> for ::windows::core::IUnknown {
-    fn from(value: &IWiaUIExtension2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaUIExtension2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaUIExtension2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2499,21 +2079,7 @@ impl IWiaVideo {
         (::windows::core::Vtable::vtable(self).GetCurrentState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WIAVIDEO_STATE>(result__)
     }
 }
-impl ::core::convert::From<IWiaVideo> for ::windows::core::IUnknown {
-    fn from(value: IWiaVideo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWiaVideo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWiaVideo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWiaVideo> for ::windows::core::IUnknown {
-    fn from(value: &IWiaVideo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWiaVideo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWiaVideo {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/mod.rs
@@ -19,21 +19,7 @@ impl IConnectionRequestCallback {
         (::windows::core::Vtable::vtable(self).OnComplete)(::windows::core::Vtable::as_raw(self), hrstatus).ok()
     }
 }
-impl ::core::convert::From<IConnectionRequestCallback> for ::windows::core::IUnknown {
-    fn from(value: IConnectionRequestCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConnectionRequestCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConnectionRequestCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConnectionRequestCallback> for ::windows::core::IUnknown {
-    fn from(value: &IConnectionRequestCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConnectionRequestCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConnectionRequestCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -80,21 +66,7 @@ impl IEnumPortableDeviceConnectors {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumPortableDeviceConnectors>(result__)
     }
 }
-impl ::core::convert::From<IEnumPortableDeviceConnectors> for ::windows::core::IUnknown {
-    fn from(value: IEnumPortableDeviceConnectors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumPortableDeviceConnectors> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumPortableDeviceConnectors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumPortableDeviceConnectors> for ::windows::core::IUnknown {
-    fn from(value: &IEnumPortableDeviceConnectors) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumPortableDeviceConnectors, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumPortableDeviceConnectors {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -147,21 +119,7 @@ impl IEnumPortableDeviceObjectIDs {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IEnumPortableDeviceObjectIDs> for ::windows::core::IUnknown {
-    fn from(value: IEnumPortableDeviceObjectIDs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumPortableDeviceObjectIDs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumPortableDeviceObjectIDs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumPortableDeviceObjectIDs> for ::windows::core::IUnknown {
-    fn from(value: &IEnumPortableDeviceObjectIDs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumPortableDeviceObjectIDs, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumPortableDeviceObjectIDs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -206,21 +164,7 @@ impl IMediaRadioManager {
         (::windows::core::Vtable::vtable(self).OnSystemRadioStateChange)(::windows::core::Vtable::as_raw(self), sysradiostate, utimeoutsec).ok()
     }
 }
-impl ::core::convert::From<IMediaRadioManager> for ::windows::core::IUnknown {
-    fn from(value: IMediaRadioManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaRadioManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaRadioManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaRadioManager> for ::windows::core::IUnknown {
-    fn from(value: &IMediaRadioManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaRadioManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMediaRadioManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -267,21 +211,7 @@ impl IMediaRadioManagerNotifySink {
         (::windows::core::Vtable::vtable(self).OnInstanceRadioChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrradioinstanceid), radiostate).ok()
     }
 }
-impl ::core::convert::From<IMediaRadioManagerNotifySink> for ::windows::core::IUnknown {
-    fn from(value: IMediaRadioManagerNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaRadioManagerNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaRadioManagerNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaRadioManagerNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &IMediaRadioManagerNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaRadioManagerNotifySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMediaRadioManagerNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -363,21 +293,7 @@ impl IPortableDevice {
         (::windows::core::Vtable::vtable(self).GetPnPDeviceID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IPortableDevice> for ::windows::core::IUnknown {
-    fn from(value: IPortableDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDevice> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -466,21 +382,7 @@ impl IPortableDeviceCapabilities {
         (::windows::core::Vtable::vtable(self).GetEventOptions)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(event), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPortableDeviceValues>(result__)
     }
 }
-impl ::core::convert::From<IPortableDeviceCapabilities> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceCapabilities, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceCapabilities {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -562,21 +464,7 @@ impl IPortableDeviceConnector {
         (::windows::core::Vtable::vtable(self).GetPnPID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IPortableDeviceConnector> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceConnector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceConnector> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceConnector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceConnector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -681,21 +569,7 @@ impl IPortableDeviceContent {
         (::windows::core::Vtable::vtable(self).Copy)(::windows::core::Vtable::as_raw(self), pobjectids.into().abi(), pszdestinationfolderobjectid.into(), ::core::mem::transmute(ppresults)).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceContent> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceContent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceContent> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceContent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceContent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -810,36 +684,7 @@ impl IPortableDeviceContent2 {
         (::windows::core::Vtable::vtable(self).UpdateObjectWithPropertiesAndData)(::windows::core::Vtable::as_raw(self), pszobjectid.into(), pproperties.into().abi(), ::core::mem::transmute(ppdata), ::core::mem::transmute(pdwoptimalwritebuffersize)).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceContent2> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceContent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceContent2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceContent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceContent2> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceContent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPortableDeviceContent2> for IPortableDeviceContent {
-    fn from(value: IPortableDeviceContent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceContent2> for &'a IPortableDeviceContent {
-    fn from(value: &'a IPortableDeviceContent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceContent2> for IPortableDeviceContent {
-    fn from(value: &IPortableDeviceContent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceContent2, ::windows::core::IUnknown, IPortableDeviceContent);
 impl ::core::clone::Clone for IPortableDeviceContent2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -946,59 +791,7 @@ impl IPortableDeviceDataStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPortableDeviceDataStream> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceDataStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPortableDeviceDataStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceDataStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPortableDeviceDataStream> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceDataStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPortableDeviceDataStream> for super::super::System::Com::ISequentialStream {
-    fn from(value: IPortableDeviceDataStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPortableDeviceDataStream> for &'a super::super::System::Com::ISequentialStream {
-    fn from(value: &'a IPortableDeviceDataStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPortableDeviceDataStream> for super::super::System::Com::ISequentialStream {
-    fn from(value: &IPortableDeviceDataStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPortableDeviceDataStream> for super::super::System::Com::IStream {
-    fn from(value: IPortableDeviceDataStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPortableDeviceDataStream> for &'a super::super::System::Com::IStream {
-    fn from(value: &'a IPortableDeviceDataStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPortableDeviceDataStream> for super::super::System::Com::IStream {
-    fn from(value: &IPortableDeviceDataStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceDataStream, ::windows::core::IUnknown, super::super::System::Com::ISequentialStream, super::super::System::Com::IStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPortableDeviceDataStream {
     fn clone(&self) -> Self {
@@ -1049,21 +842,7 @@ impl IPortableDeviceDispatchFactory {
         (::windows::core::Vtable::vtable(self).GetDeviceDispatch)(::windows::core::Vtable::as_raw(self), pszpnpdeviceid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IDispatch>(result__)
     }
 }
-impl ::core::convert::From<IPortableDeviceDispatchFactory> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceDispatchFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceDispatchFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceDispatchFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceDispatchFactory> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceDispatchFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceDispatchFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceDispatchFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1106,21 +885,7 @@ impl IPortableDeviceEventCallback {
         (::windows::core::Vtable::vtable(self).OnEvent)(::windows::core::Vtable::as_raw(self), peventparameters.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceEventCallback> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceEventCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceEventCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceEventCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceEventCallback> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceEventCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceEventCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceEventCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1173,21 +938,7 @@ impl IPortableDeviceKeyCollection {
         (::windows::core::Vtable::vtable(self).RemoveAt)(::windows::core::Vtable::as_raw(self), dwindex).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceKeyCollection> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceKeyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceKeyCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceKeyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceKeyCollection> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceKeyCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceKeyCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceKeyCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1265,21 +1016,7 @@ impl IPortableDeviceManager {
         (::windows::core::Vtable::vtable(self).GetPrivateDevices)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppnpdeviceids), ::core::mem::transmute(pcpnpdeviceids)).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceManager> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceManager> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1345,21 +1082,7 @@ impl IPortableDevicePropVariantCollection {
         (::windows::core::Vtable::vtable(self).RemoveAt)(::windows::core::Vtable::as_raw(self), dwindex).ok()
     }
 }
-impl ::core::convert::From<IPortableDevicePropVariantCollection> for ::windows::core::IUnknown {
-    fn from(value: IPortableDevicePropVariantCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDevicePropVariantCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDevicePropVariantCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDevicePropVariantCollection> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDevicePropVariantCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDevicePropVariantCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDevicePropVariantCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1447,21 +1170,7 @@ impl IPortableDeviceProperties {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceProperties> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceProperties> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1535,21 +1244,7 @@ impl IPortableDevicePropertiesBulk {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcontext)).ok()
     }
 }
-impl ::core::convert::From<IPortableDevicePropertiesBulk> for ::windows::core::IUnknown {
-    fn from(value: IPortableDevicePropertiesBulk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDevicePropertiesBulk> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDevicePropertiesBulk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDevicePropertiesBulk> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDevicePropertiesBulk) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDevicePropertiesBulk, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDevicePropertiesBulk {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1599,21 +1294,7 @@ impl IPortableDevicePropertiesBulkCallback {
         (::windows::core::Vtable::vtable(self).OnEnd)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcontext), hrstatus).ok()
     }
 }
-impl ::core::convert::From<IPortableDevicePropertiesBulkCallback> for ::windows::core::IUnknown {
-    fn from(value: IPortableDevicePropertiesBulkCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDevicePropertiesBulkCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDevicePropertiesBulkCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDevicePropertiesBulkCallback> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDevicePropertiesBulkCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDevicePropertiesBulkCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDevicePropertiesBulkCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1691,21 +1372,7 @@ impl IPortableDeviceResources {
         (::windows::core::Vtable::vtable(self).CreateResource)(::windows::core::Vtable::as_raw(self), presourceattributes.into().abi(), ::core::mem::transmute(ppdata), ::core::mem::transmute(pdwoptimalwritebuffersize), ::core::mem::transmute(ppszcookie)).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceResources> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceResources> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceResources> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceResources) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceResources, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceResources {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1807,21 +1474,7 @@ impl IPortableDeviceService {
         (::windows::core::Vtable::vtable(self).SendCommand)(::windows::core::Vtable::as_raw(self), dwflags, pparameters.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPortableDeviceValues>(result__)
     }
 }
-impl ::core::convert::From<IPortableDeviceService> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceService> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1876,21 +1529,7 @@ impl IPortableDeviceServiceActivation {
         (::windows::core::Vtable::vtable(self).CancelOpenAsync)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceServiceActivation> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceServiceActivation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceServiceActivation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceServiceActivation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceServiceActivation> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceServiceActivation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceServiceActivation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceServiceActivation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1996,21 +1635,7 @@ impl IPortableDeviceServiceCapabilities {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceServiceCapabilities> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceServiceCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceServiceCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceServiceCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceServiceCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceServiceCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceServiceCapabilities, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceServiceCapabilities {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2084,21 +1709,7 @@ impl IPortableDeviceServiceManager {
         (::windows::core::Vtable::vtable(self).GetDeviceForService)(::windows::core::Vtable::as_raw(self), pszpnpserviceid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IPortableDeviceServiceManager> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceServiceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceServiceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceServiceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceServiceManager> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceServiceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceServiceManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceServiceManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2139,21 +1750,7 @@ impl IPortableDeviceServiceMethodCallback {
         (::windows::core::Vtable::vtable(self).OnComplete)(::windows::core::Vtable::as_raw(self), hrstatus, presults.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceServiceMethodCallback> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceServiceMethodCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceServiceMethodCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceServiceMethodCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceServiceMethodCallback> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceServiceMethodCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceServiceMethodCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceServiceMethodCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2206,21 +1803,7 @@ impl IPortableDeviceServiceMethods {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self), pcallback.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceServiceMethods> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceServiceMethods) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceServiceMethods> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceServiceMethods) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceServiceMethods> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceServiceMethods) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceServiceMethods, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceServiceMethods {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2259,21 +1842,7 @@ impl IPortableDeviceServiceOpenCallback {
         (::windows::core::Vtable::vtable(self).OnComplete)(::windows::core::Vtable::as_raw(self), hrstatus).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceServiceOpenCallback> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceServiceOpenCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceServiceOpenCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceServiceOpenCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceServiceOpenCallback> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceServiceOpenCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceServiceOpenCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceServiceOpenCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2314,21 +1883,7 @@ impl IPortableDeviceUnitsStream {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceUnitsStream> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceUnitsStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceUnitsStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceUnitsStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceUnitsStream> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceUnitsStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceUnitsStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceUnitsStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2602,21 +2157,7 @@ impl IPortableDeviceValues {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceValues> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceValues) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceValues> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceValues) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceValues> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceValues) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceValues, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceValues {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2822,21 +2363,7 @@ impl IPortableDeviceValuesCollection {
         (::windows::core::Vtable::vtable(self).RemoveAt)(::windows::core::Vtable::as_raw(self), dwindex).ok()
     }
 }
-impl ::core::convert::From<IPortableDeviceValuesCollection> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceValuesCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPortableDeviceValuesCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceValuesCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPortableDeviceValuesCollection> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceValuesCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceValuesCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPortableDeviceValuesCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2892,41 +2419,7 @@ impl IPortableDeviceWebControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPortableDeviceWebControl> for ::windows::core::IUnknown {
-    fn from(value: IPortableDeviceWebControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPortableDeviceWebControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPortableDeviceWebControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPortableDeviceWebControl> for ::windows::core::IUnknown {
-    fn from(value: &IPortableDeviceWebControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPortableDeviceWebControl> for super::super::System::Com::IDispatch {
-    fn from(value: IPortableDeviceWebControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPortableDeviceWebControl> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPortableDeviceWebControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPortableDeviceWebControl> for super::super::System::Com::IDispatch {
-    fn from(value: &IPortableDeviceWebControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPortableDeviceWebControl, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPortableDeviceWebControl {
     fn clone(&self) -> Self {
@@ -3003,21 +2496,7 @@ impl IRadioInstance {
         (::windows::core::Vtable::vtable(self).IsAssociatingDevice)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IRadioInstance> for ::windows::core::IUnknown {
-    fn from(value: IRadioInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRadioInstance> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRadioInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRadioInstance> for ::windows::core::IUnknown {
-    fn from(value: &IRadioInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRadioInstance, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRadioInstance {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3071,21 +2550,7 @@ impl IRadioInstanceCollection {
         (::windows::core::Vtable::vtable(self).GetAt)(::windows::core::Vtable::as_raw(self), uindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRadioInstance>(result__)
     }
 }
-impl ::core::convert::From<IRadioInstanceCollection> for ::windows::core::IUnknown {
-    fn from(value: IRadioInstanceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRadioInstanceCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRadioInstanceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRadioInstanceCollection> for ::windows::core::IUnknown {
-    fn from(value: &IRadioInstanceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRadioInstanceCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRadioInstanceCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3143,21 +2608,7 @@ impl IWpdSerializer {
         (::windows::core::Vtable::vtable(self).GetSerializedSize)(::windows::core::Vtable::as_raw(self), psource.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IWpdSerializer> for ::windows::core::IUnknown {
-    fn from(value: IWpdSerializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWpdSerializer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWpdSerializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWpdSerializer> for ::windows::core::IUnknown {
-    fn from(value: &IWpdSerializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWpdSerializer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWpdSerializer {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Devices/Sensors/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Sensors/mod.rs
@@ -417,21 +417,7 @@ impl ILocationPermissions {
         (::windows::core::Vtable::vtable(self).CheckLocationCapability)(::windows::core::Vtable::as_raw(self), dwclientthreadid).ok()
     }
 }
-impl ::core::convert::From<ILocationPermissions> for ::windows::core::IUnknown {
-    fn from(value: ILocationPermissions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILocationPermissions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILocationPermissions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILocationPermissions> for ::windows::core::IUnknown {
-    fn from(value: &ILocationPermissions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILocationPermissions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILocationPermissions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -545,21 +531,7 @@ impl ISensor {
         (::windows::core::Vtable::vtable(self).SetEventSink)(::windows::core::Vtable::as_raw(self), pevents.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISensor> for ::windows::core::IUnknown {
-    fn from(value: ISensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISensor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISensor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISensor> for ::windows::core::IUnknown {
-    fn from(value: &ISensor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISensor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISensor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -648,21 +620,7 @@ impl ISensorCollection {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISensorCollection> for ::windows::core::IUnknown {
-    fn from(value: ISensorCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISensorCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISensorCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISensorCollection> for ::windows::core::IUnknown {
-    fn from(value: &ISensorCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISensorCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISensorCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -722,21 +680,7 @@ impl ISensorDataReport {
         (::windows::core::Vtable::vtable(self).GetSensorValues)(::windows::core::Vtable::as_raw(self), pkeys.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::PortableDevices::IPortableDeviceValues>(result__)
     }
 }
-impl ::core::convert::From<ISensorDataReport> for ::windows::core::IUnknown {
-    fn from(value: ISensorDataReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISensorDataReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISensorDataReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISensorDataReport> for ::windows::core::IUnknown {
-    fn from(value: &ISensorDataReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISensorDataReport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISensorDataReport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -806,21 +750,7 @@ impl ISensorEvents {
         (::windows::core::Vtable::vtable(self).OnLeave)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(id)).ok()
     }
 }
-impl ::core::convert::From<ISensorEvents> for ::windows::core::IUnknown {
-    fn from(value: ISensorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISensorEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISensorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISensorEvents> for ::windows::core::IUnknown {
-    fn from(value: &ISensorEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISensorEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISensorEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -888,21 +818,7 @@ impl ISensorManager {
         (::windows::core::Vtable::vtable(self).RequestPermissions)(::windows::core::Vtable::as_raw(self), hparent.into(), psensors.into().abi(), fmodal.into()).ok()
     }
 }
-impl ::core::convert::From<ISensorManager> for ::windows::core::IUnknown {
-    fn from(value: ISensorManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISensorManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISensorManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISensorManager> for ::windows::core::IUnknown {
-    fn from(value: &ISensorManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISensorManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISensorManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -949,21 +865,7 @@ impl ISensorManagerEvents {
         (::windows::core::Vtable::vtable(self).OnSensorEnter)(::windows::core::Vtable::as_raw(self), psensor.into().abi(), state).ok()
     }
 }
-impl ::core::convert::From<ISensorManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: ISensorManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISensorManagerEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISensorManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISensorManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: &ISensorManagerEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISensorManagerEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISensorManagerEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
@@ -2698,21 +2698,7 @@ impl IEnumACDGroup {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumACDGroup>(result__)
     }
 }
-impl ::core::convert::From<IEnumACDGroup> for ::windows::core::IUnknown {
-    fn from(value: IEnumACDGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumACDGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumACDGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumACDGroup> for ::windows::core::IUnknown {
-    fn from(value: &IEnumACDGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumACDGroup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumACDGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2767,21 +2753,7 @@ impl IEnumAddress {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumAddress>(result__)
     }
 }
-impl ::core::convert::From<IEnumAddress> for ::windows::core::IUnknown {
-    fn from(value: IEnumAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumAddress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumAddress> for ::windows::core::IUnknown {
-    fn from(value: &IEnumAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumAddress, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumAddress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2836,21 +2808,7 @@ impl IEnumAgent {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumAgent>(result__)
     }
 }
-impl ::core::convert::From<IEnumAgent> for ::windows::core::IUnknown {
-    fn from(value: IEnumAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumAgent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumAgent> for ::windows::core::IUnknown {
-    fn from(value: &IEnumAgent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumAgent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumAgent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2905,21 +2863,7 @@ impl IEnumAgentHandler {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumAgentHandler>(result__)
     }
 }
-impl ::core::convert::From<IEnumAgentHandler> for ::windows::core::IUnknown {
-    fn from(value: IEnumAgentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumAgentHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumAgentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumAgentHandler> for ::windows::core::IUnknown {
-    fn from(value: &IEnumAgentHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumAgentHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumAgentHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2974,21 +2918,7 @@ impl IEnumAgentSession {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumAgentSession>(result__)
     }
 }
-impl ::core::convert::From<IEnumAgentSession> for ::windows::core::IUnknown {
-    fn from(value: IEnumAgentSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumAgentSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumAgentSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumAgentSession> for ::windows::core::IUnknown {
-    fn from(value: &IEnumAgentSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumAgentSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumAgentSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3041,21 +2971,7 @@ impl IEnumBstr {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumBstr>(result__)
     }
 }
-impl ::core::convert::From<IEnumBstr> for ::windows::core::IUnknown {
-    fn from(value: IEnumBstr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumBstr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumBstr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumBstr> for ::windows::core::IUnknown {
-    fn from(value: &IEnumBstr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumBstr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumBstr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3107,21 +3023,7 @@ impl IEnumCall {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumCall>(result__)
     }
 }
-impl ::core::convert::From<IEnumCall> for ::windows::core::IUnknown {
-    fn from(value: IEnumCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumCall> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumCall> for ::windows::core::IUnknown {
-    fn from(value: &IEnumCall) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumCall, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumCall {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3176,21 +3078,7 @@ impl IEnumCallHub {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumCallHub>(result__)
     }
 }
-impl ::core::convert::From<IEnumCallHub> for ::windows::core::IUnknown {
-    fn from(value: IEnumCallHub) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumCallHub> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumCallHub) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumCallHub> for ::windows::core::IUnknown {
-    fn from(value: &IEnumCallHub) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumCallHub, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumCallHub {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3245,21 +3133,7 @@ impl IEnumCallingCard {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumCallingCard>(result__)
     }
 }
-impl ::core::convert::From<IEnumCallingCard> for ::windows::core::IUnknown {
-    fn from(value: IEnumCallingCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumCallingCard> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumCallingCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumCallingCard> for ::windows::core::IUnknown {
-    fn from(value: &IEnumCallingCard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumCallingCard, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumCallingCard {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3312,21 +3186,7 @@ impl IEnumDialableAddrs {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDialableAddrs>(result__)
     }
 }
-impl ::core::convert::From<IEnumDialableAddrs> for ::windows::core::IUnknown {
-    fn from(value: IEnumDialableAddrs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDialableAddrs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDialableAddrs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDialableAddrs> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDialableAddrs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDialableAddrs, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDialableAddrs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3378,21 +3238,7 @@ impl IEnumDirectory {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDirectory>(result__)
     }
 }
-impl ::core::convert::From<IEnumDirectory> for ::windows::core::IUnknown {
-    fn from(value: IEnumDirectory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDirectory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDirectory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDirectory> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDirectory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDirectory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDirectory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3447,21 +3293,7 @@ impl IEnumDirectoryObject {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDirectoryObject>(result__)
     }
 }
-impl ::core::convert::From<IEnumDirectoryObject> for ::windows::core::IUnknown {
-    fn from(value: IEnumDirectoryObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDirectoryObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDirectoryObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDirectoryObject> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDirectoryObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDirectoryObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDirectoryObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3516,21 +3348,7 @@ impl IEnumLocation {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumLocation>(result__)
     }
 }
-impl ::core::convert::From<IEnumLocation> for ::windows::core::IUnknown {
-    fn from(value: IEnumLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumLocation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumLocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumLocation> for ::windows::core::IUnknown {
-    fn from(value: &IEnumLocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumLocation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumLocation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3585,21 +3403,7 @@ impl IEnumMcastScope {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumMcastScope>(result__)
     }
 }
-impl ::core::convert::From<IEnumMcastScope> for ::windows::core::IUnknown {
-    fn from(value: IEnumMcastScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumMcastScope> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumMcastScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumMcastScope> for ::windows::core::IUnknown {
-    fn from(value: &IEnumMcastScope) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumMcastScope, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumMcastScope {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3654,21 +3458,7 @@ impl IEnumPhone {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumPhone>(result__)
     }
 }
-impl ::core::convert::From<IEnumPhone> for ::windows::core::IUnknown {
-    fn from(value: IEnumPhone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumPhone> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumPhone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumPhone> for ::windows::core::IUnknown {
-    fn from(value: &IEnumPhone) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumPhone, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumPhone {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3723,21 +3513,7 @@ impl IEnumPluggableSuperclassInfo {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumPluggableSuperclassInfo>(result__)
     }
 }
-impl ::core::convert::From<IEnumPluggableSuperclassInfo> for ::windows::core::IUnknown {
-    fn from(value: IEnumPluggableSuperclassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumPluggableSuperclassInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumPluggableSuperclassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumPluggableSuperclassInfo> for ::windows::core::IUnknown {
-    fn from(value: &IEnumPluggableSuperclassInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumPluggableSuperclassInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumPluggableSuperclassInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3792,21 +3568,7 @@ impl IEnumPluggableTerminalClassInfo {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumPluggableTerminalClassInfo>(result__)
     }
 }
-impl ::core::convert::From<IEnumPluggableTerminalClassInfo> for ::windows::core::IUnknown {
-    fn from(value: IEnumPluggableTerminalClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumPluggableTerminalClassInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumPluggableTerminalClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumPluggableTerminalClassInfo> for ::windows::core::IUnknown {
-    fn from(value: &IEnumPluggableTerminalClassInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumPluggableTerminalClassInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumPluggableTerminalClassInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3861,21 +3623,7 @@ impl IEnumQueue {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumQueue>(result__)
     }
 }
-impl ::core::convert::From<IEnumQueue> for ::windows::core::IUnknown {
-    fn from(value: IEnumQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumQueue> for ::windows::core::IUnknown {
-    fn from(value: &IEnumQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumQueue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumQueue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3930,21 +3678,7 @@ impl IEnumStream {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumStream>(result__)
     }
 }
-impl ::core::convert::From<IEnumStream> for ::windows::core::IUnknown {
-    fn from(value: IEnumStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumStream> for ::windows::core::IUnknown {
-    fn from(value: &IEnumStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3999,21 +3733,7 @@ impl IEnumSubStream {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSubStream>(result__)
     }
 }
-impl ::core::convert::From<IEnumSubStream> for ::windows::core::IUnknown {
-    fn from(value: IEnumSubStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSubStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSubStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSubStream> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSubStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSubStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSubStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4068,21 +3788,7 @@ impl IEnumTerminal {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumTerminal>(result__)
     }
 }
-impl ::core::convert::From<IEnumTerminal> for ::windows::core::IUnknown {
-    fn from(value: IEnumTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTerminal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTerminal> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTerminal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTerminal, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTerminal {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4135,21 +3841,7 @@ impl IEnumTerminalClass {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumTerminalClass>(result__)
     }
 }
-impl ::core::convert::From<IEnumTerminalClass> for ::windows::core::IUnknown {
-    fn from(value: IEnumTerminalClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTerminalClass> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTerminalClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTerminalClass> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTerminalClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTerminalClass, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTerminalClass {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4244,41 +3936,7 @@ impl IMcastAddressAllocation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMcastAddressAllocation> for ::windows::core::IUnknown {
-    fn from(value: IMcastAddressAllocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMcastAddressAllocation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMcastAddressAllocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMcastAddressAllocation> for ::windows::core::IUnknown {
-    fn from(value: &IMcastAddressAllocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMcastAddressAllocation> for super::super::System::Com::IDispatch {
-    fn from(value: IMcastAddressAllocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMcastAddressAllocation> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IMcastAddressAllocation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMcastAddressAllocation> for super::super::System::Com::IDispatch {
-    fn from(value: &IMcastAddressAllocation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMcastAddressAllocation, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMcastAddressAllocation {
     fn clone(&self) -> Self {
@@ -4386,41 +4044,7 @@ impl IMcastLeaseInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMcastLeaseInfo> for ::windows::core::IUnknown {
-    fn from(value: IMcastLeaseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMcastLeaseInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMcastLeaseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMcastLeaseInfo> for ::windows::core::IUnknown {
-    fn from(value: &IMcastLeaseInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMcastLeaseInfo> for super::super::System::Com::IDispatch {
-    fn from(value: IMcastLeaseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMcastLeaseInfo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IMcastLeaseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMcastLeaseInfo> for super::super::System::Com::IDispatch {
-    fn from(value: &IMcastLeaseInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMcastLeaseInfo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMcastLeaseInfo {
     fn clone(&self) -> Self {
@@ -4496,41 +4120,7 @@ impl IMcastScope {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMcastScope> for ::windows::core::IUnknown {
-    fn from(value: IMcastScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMcastScope> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMcastScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMcastScope> for ::windows::core::IUnknown {
-    fn from(value: &IMcastScope) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMcastScope> for super::super::System::Com::IDispatch {
-    fn from(value: IMcastScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMcastScope> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IMcastScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMcastScope> for super::super::System::Com::IDispatch {
-    fn from(value: &IMcastScope) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMcastScope, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMcastScope {
     fn clone(&self) -> Self {
@@ -4592,41 +4182,7 @@ impl ITACDGroup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITACDGroup> for ::windows::core::IUnknown {
-    fn from(value: ITACDGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITACDGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITACDGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITACDGroup> for ::windows::core::IUnknown {
-    fn from(value: &ITACDGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITACDGroup> for super::super::System::Com::IDispatch {
-    fn from(value: ITACDGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITACDGroup> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITACDGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITACDGroup> for super::super::System::Com::IDispatch {
-    fn from(value: &ITACDGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITACDGroup, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITACDGroup {
     fn clone(&self) -> Self {
@@ -4685,41 +4241,7 @@ impl ITACDGroupEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITACDGroupEvent> for ::windows::core::IUnknown {
-    fn from(value: ITACDGroupEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITACDGroupEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITACDGroupEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITACDGroupEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITACDGroupEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITACDGroupEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITACDGroupEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITACDGroupEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITACDGroupEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITACDGroupEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITACDGroupEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITACDGroupEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITACDGroupEvent {
     fn clone(&self) -> Self {
@@ -4775,21 +4297,7 @@ impl ITAMMediaFormat {
         (::windows::core::Vtable::vtable(self).SetMediaFormat)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmt)).ok()
     }
 }
-impl ::core::convert::From<ITAMMediaFormat> for ::windows::core::IUnknown {
-    fn from(value: ITAMMediaFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITAMMediaFormat> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAMMediaFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITAMMediaFormat> for ::windows::core::IUnknown {
-    fn from(value: &ITAMMediaFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAMMediaFormat, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITAMMediaFormat {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4849,41 +4357,7 @@ impl ITASRTerminalEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITASRTerminalEvent> for ::windows::core::IUnknown {
-    fn from(value: ITASRTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITASRTerminalEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITASRTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITASRTerminalEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITASRTerminalEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITASRTerminalEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITASRTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITASRTerminalEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITASRTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITASRTerminalEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITASRTerminalEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITASRTerminalEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITASRTerminalEvent {
     fn clone(&self) -> Self {
@@ -5008,41 +4482,7 @@ impl ITAddress {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddress> for ::windows::core::IUnknown {
-    fn from(value: ITAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddress> for ::windows::core::IUnknown {
-    fn from(value: &ITAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddress> for super::super::System::Com::IDispatch {
-    fn from(value: ITAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddress> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddress> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAddress, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAddress {
     fn clone(&self) -> Self {
@@ -5248,59 +4688,7 @@ impl ITAddress2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddress2> for ::windows::core::IUnknown {
-    fn from(value: ITAddress2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddress2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAddress2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddress2> for ::windows::core::IUnknown {
-    fn from(value: &ITAddress2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddress2> for super::super::System::Com::IDispatch {
-    fn from(value: ITAddress2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddress2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAddress2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddress2> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAddress2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddress2> for ITAddress {
-    fn from(value: ITAddress2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddress2> for &'a ITAddress {
-    fn from(value: &'a ITAddress2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddress2> for ITAddress {
-    fn from(value: &ITAddress2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAddress2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ITAddress);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAddress2 {
     fn clone(&self) -> Self {
@@ -5406,41 +4794,7 @@ impl ITAddressCapabilities {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddressCapabilities> for ::windows::core::IUnknown {
-    fn from(value: ITAddressCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddressCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAddressCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddressCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &ITAddressCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddressCapabilities> for super::super::System::Com::IDispatch {
-    fn from(value: ITAddressCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddressCapabilities> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAddressCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddressCapabilities> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAddressCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAddressCapabilities, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAddressCapabilities {
     fn clone(&self) -> Self {
@@ -5524,41 +4878,7 @@ impl ITAddressDeviceSpecificEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddressDeviceSpecificEvent> for ::windows::core::IUnknown {
-    fn from(value: ITAddressDeviceSpecificEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddressDeviceSpecificEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAddressDeviceSpecificEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddressDeviceSpecificEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITAddressDeviceSpecificEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddressDeviceSpecificEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITAddressDeviceSpecificEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddressDeviceSpecificEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAddressDeviceSpecificEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddressDeviceSpecificEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAddressDeviceSpecificEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAddressDeviceSpecificEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAddressDeviceSpecificEvent {
     fn clone(&self) -> Self {
@@ -5628,41 +4948,7 @@ impl ITAddressEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddressEvent> for ::windows::core::IUnknown {
-    fn from(value: ITAddressEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddressEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAddressEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddressEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITAddressEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddressEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITAddressEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddressEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAddressEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddressEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAddressEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAddressEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAddressEvent {
     fn clone(&self) -> Self {
@@ -5743,41 +5029,7 @@ impl ITAddressTranslation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddressTranslation> for ::windows::core::IUnknown {
-    fn from(value: ITAddressTranslation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddressTranslation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAddressTranslation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddressTranslation> for ::windows::core::IUnknown {
-    fn from(value: &ITAddressTranslation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddressTranslation> for super::super::System::Com::IDispatch {
-    fn from(value: ITAddressTranslation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddressTranslation> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAddressTranslation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddressTranslation> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAddressTranslation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAddressTranslation, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAddressTranslation {
     fn clone(&self) -> Self {
@@ -5855,41 +5107,7 @@ impl ITAddressTranslationInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddressTranslationInfo> for ::windows::core::IUnknown {
-    fn from(value: ITAddressTranslationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddressTranslationInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAddressTranslationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddressTranslationInfo> for ::windows::core::IUnknown {
-    fn from(value: &ITAddressTranslationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAddressTranslationInfo> for super::super::System::Com::IDispatch {
-    fn from(value: ITAddressTranslationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAddressTranslationInfo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAddressTranslationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAddressTranslationInfo> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAddressTranslationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAddressTranslationInfo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAddressTranslationInfo {
     fn clone(&self) -> Self {
@@ -6019,41 +5237,7 @@ impl ITAgent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgent> for ::windows::core::IUnknown {
-    fn from(value: ITAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgent> for ::windows::core::IUnknown {
-    fn from(value: &ITAgent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgent> for super::super::System::Com::IDispatch {
-    fn from(value: ITAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAgent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAgent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAgent {
     fn clone(&self) -> Self {
@@ -6135,41 +5319,7 @@ impl ITAgentEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgentEvent> for ::windows::core::IUnknown {
-    fn from(value: ITAgentEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgentEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAgentEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgentEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITAgentEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgentEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITAgentEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgentEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAgentEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgentEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAgentEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAgentEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAgentEvent {
     fn clone(&self) -> Self {
@@ -6253,41 +5403,7 @@ impl ITAgentHandler {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgentHandler> for ::windows::core::IUnknown {
-    fn from(value: ITAgentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgentHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAgentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgentHandler> for ::windows::core::IUnknown {
-    fn from(value: &ITAgentHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgentHandler> for super::super::System::Com::IDispatch {
-    fn from(value: ITAgentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgentHandler> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAgentHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgentHandler> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAgentHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAgentHandler, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAgentHandler {
     fn clone(&self) -> Self {
@@ -6359,41 +5475,7 @@ impl ITAgentHandlerEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgentHandlerEvent> for ::windows::core::IUnknown {
-    fn from(value: ITAgentHandlerEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgentHandlerEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAgentHandlerEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgentHandlerEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITAgentHandlerEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgentHandlerEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITAgentHandlerEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgentHandlerEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAgentHandlerEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgentHandlerEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAgentHandlerEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAgentHandlerEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAgentHandlerEvent {
     fn clone(&self) -> Self {
@@ -6516,41 +5598,7 @@ impl ITAgentSession {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgentSession> for ::windows::core::IUnknown {
-    fn from(value: ITAgentSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgentSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAgentSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgentSession> for ::windows::core::IUnknown {
-    fn from(value: &ITAgentSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgentSession> for super::super::System::Com::IDispatch {
-    fn from(value: ITAgentSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgentSession> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAgentSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgentSession> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAgentSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAgentSession, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAgentSession {
     fn clone(&self) -> Self {
@@ -6632,41 +5680,7 @@ impl ITAgentSessionEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgentSessionEvent> for ::windows::core::IUnknown {
-    fn from(value: ITAgentSessionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgentSessionEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAgentSessionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgentSessionEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITAgentSessionEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAgentSessionEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITAgentSessionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAgentSessionEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAgentSessionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAgentSessionEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAgentSessionEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAgentSessionEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAgentSessionEvent {
     fn clone(&self) -> Self {
@@ -6743,21 +5757,7 @@ impl ITAllocatorProperties {
         (::windows::core::Vtable::vtable(self).GetBufferSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ITAllocatorProperties> for ::windows::core::IUnknown {
-    fn from(value: ITAllocatorProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITAllocatorProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAllocatorProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITAllocatorProperties> for ::windows::core::IUnknown {
-    fn from(value: &ITAllocatorProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAllocatorProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITAllocatorProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6934,41 +5934,7 @@ impl ITAutomatedPhoneControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAutomatedPhoneControl> for ::windows::core::IUnknown {
-    fn from(value: ITAutomatedPhoneControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAutomatedPhoneControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITAutomatedPhoneControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAutomatedPhoneControl> for ::windows::core::IUnknown {
-    fn from(value: &ITAutomatedPhoneControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITAutomatedPhoneControl> for super::super::System::Com::IDispatch {
-    fn from(value: ITAutomatedPhoneControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITAutomatedPhoneControl> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITAutomatedPhoneControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITAutomatedPhoneControl> for super::super::System::Com::IDispatch {
-    fn from(value: &ITAutomatedPhoneControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITAutomatedPhoneControl, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITAutomatedPhoneControl {
     fn clone(&self) -> Self {
@@ -7066,41 +6032,7 @@ impl ITBasicAudioTerminal {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITBasicAudioTerminal> for ::windows::core::IUnknown {
-    fn from(value: ITBasicAudioTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITBasicAudioTerminal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITBasicAudioTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITBasicAudioTerminal> for ::windows::core::IUnknown {
-    fn from(value: &ITBasicAudioTerminal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITBasicAudioTerminal> for super::super::System::Com::IDispatch {
-    fn from(value: ITBasicAudioTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITBasicAudioTerminal> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITBasicAudioTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITBasicAudioTerminal> for super::super::System::Com::IDispatch {
-    fn from(value: &ITBasicAudioTerminal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITBasicAudioTerminal, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITBasicAudioTerminal {
     fn clone(&self) -> Self {
@@ -7217,41 +6149,7 @@ impl ITBasicCallControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITBasicCallControl> for ::windows::core::IUnknown {
-    fn from(value: ITBasicCallControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITBasicCallControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITBasicCallControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITBasicCallControl> for ::windows::core::IUnknown {
-    fn from(value: &ITBasicCallControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITBasicCallControl> for super::super::System::Com::IDispatch {
-    fn from(value: ITBasicCallControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITBasicCallControl> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITBasicCallControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITBasicCallControl> for super::super::System::Com::IDispatch {
-    fn from(value: &ITBasicCallControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITBasicCallControl, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITBasicCallControl {
     fn clone(&self) -> Self {
@@ -7413,59 +6311,7 @@ impl ITBasicCallControl2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITBasicCallControl2> for ::windows::core::IUnknown {
-    fn from(value: ITBasicCallControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITBasicCallControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITBasicCallControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITBasicCallControl2> for ::windows::core::IUnknown {
-    fn from(value: &ITBasicCallControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITBasicCallControl2> for super::super::System::Com::IDispatch {
-    fn from(value: ITBasicCallControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITBasicCallControl2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITBasicCallControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITBasicCallControl2> for super::super::System::Com::IDispatch {
-    fn from(value: &ITBasicCallControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITBasicCallControl2> for ITBasicCallControl {
-    fn from(value: ITBasicCallControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITBasicCallControl2> for &'a ITBasicCallControl {
-    fn from(value: &'a ITBasicCallControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITBasicCallControl2> for ITBasicCallControl {
-    fn from(value: &ITBasicCallControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITBasicCallControl2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ITBasicCallControl);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITBasicCallControl2 {
     fn clone(&self) -> Self {
@@ -7541,41 +6387,7 @@ impl ITCallHub {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallHub> for ::windows::core::IUnknown {
-    fn from(value: ITCallHub) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallHub> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCallHub) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallHub> for ::windows::core::IUnknown {
-    fn from(value: &ITCallHub) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallHub> for super::super::System::Com::IDispatch {
-    fn from(value: ITCallHub) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallHub> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCallHub) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallHub> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCallHub) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCallHub, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCallHub {
     fn clone(&self) -> Self {
@@ -7642,41 +6454,7 @@ impl ITCallHubEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallHubEvent> for ::windows::core::IUnknown {
-    fn from(value: ITCallHubEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallHubEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCallHubEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallHubEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITCallHubEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallHubEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITCallHubEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallHubEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCallHubEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallHubEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCallHubEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCallHubEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCallHubEvent {
     fn clone(&self) -> Self {
@@ -7785,41 +6563,7 @@ impl ITCallInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallInfo> for ::windows::core::IUnknown {
-    fn from(value: ITCallInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCallInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallInfo> for ::windows::core::IUnknown {
-    fn from(value: &ITCallInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallInfo> for super::super::System::Com::IDispatch {
-    fn from(value: ITCallInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallInfo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCallInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallInfo> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCallInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCallInfo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCallInfo {
     fn clone(&self) -> Self {
@@ -7951,59 +6695,7 @@ impl ITCallInfo2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallInfo2> for ::windows::core::IUnknown {
-    fn from(value: ITCallInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCallInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallInfo2> for ::windows::core::IUnknown {
-    fn from(value: &ITCallInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallInfo2> for super::super::System::Com::IDispatch {
-    fn from(value: ITCallInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallInfo2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCallInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallInfo2> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCallInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallInfo2> for ITCallInfo {
-    fn from(value: ITCallInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallInfo2> for &'a ITCallInfo {
-    fn from(value: &'a ITCallInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallInfo2> for ITCallInfo {
-    fn from(value: &ITCallInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCallInfo2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ITCallInfo);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCallInfo2 {
     fn clone(&self) -> Self {
@@ -8062,41 +6754,7 @@ impl ITCallInfoChangeEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallInfoChangeEvent> for ::windows::core::IUnknown {
-    fn from(value: ITCallInfoChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallInfoChangeEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCallInfoChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallInfoChangeEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITCallInfoChangeEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallInfoChangeEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITCallInfoChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallInfoChangeEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCallInfoChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallInfoChangeEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCallInfoChangeEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCallInfoChangeEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCallInfoChangeEvent {
     fn clone(&self) -> Self {
@@ -8175,41 +6833,7 @@ impl ITCallMediaEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallMediaEvent> for ::windows::core::IUnknown {
-    fn from(value: ITCallMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallMediaEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCallMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallMediaEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITCallMediaEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallMediaEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITCallMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallMediaEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCallMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallMediaEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCallMediaEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCallMediaEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCallMediaEvent {
     fn clone(&self) -> Self {
@@ -8281,41 +6905,7 @@ impl ITCallNotificationEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallNotificationEvent> for ::windows::core::IUnknown {
-    fn from(value: ITCallNotificationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallNotificationEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCallNotificationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallNotificationEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITCallNotificationEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallNotificationEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITCallNotificationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallNotificationEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCallNotificationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallNotificationEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCallNotificationEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCallNotificationEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCallNotificationEvent {
     fn clone(&self) -> Self {
@@ -8382,41 +6972,7 @@ impl ITCallStateEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallStateEvent> for ::windows::core::IUnknown {
-    fn from(value: ITCallStateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallStateEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCallStateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallStateEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITCallStateEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallStateEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITCallStateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallStateEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCallStateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallStateEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCallStateEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCallStateEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCallStateEvent {
     fn clone(&self) -> Self {
@@ -8494,41 +7050,7 @@ impl ITCallingCard {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallingCard> for ::windows::core::IUnknown {
-    fn from(value: ITCallingCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallingCard> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCallingCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallingCard> for ::windows::core::IUnknown {
-    fn from(value: &ITCallingCard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCallingCard> for super::super::System::Com::IDispatch {
-    fn from(value: ITCallingCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCallingCard> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCallingCard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCallingCard> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCallingCard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCallingCard, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCallingCard {
     fn clone(&self) -> Self {
@@ -8592,41 +7114,7 @@ impl ITCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCollection> for ::windows::core::IUnknown {
-    fn from(value: ITCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCollection> for ::windows::core::IUnknown {
-    fn from(value: &ITCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCollection> for super::super::System::Com::IDispatch {
-    fn from(value: ITCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCollection {
     fn clone(&self) -> Self {
@@ -8697,59 +7185,7 @@ impl ITCollection2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCollection2> for ::windows::core::IUnknown {
-    fn from(value: ITCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCollection2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCollection2> for ::windows::core::IUnknown {
-    fn from(value: &ITCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCollection2> for super::super::System::Com::IDispatch {
-    fn from(value: ITCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCollection2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCollection2> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCollection2> for ITCollection {
-    fn from(value: ITCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCollection2> for &'a ITCollection {
-    fn from(value: &'a ITCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCollection2> for ITCollection {
-    fn from(value: &ITCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCollection2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ITCollection);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCollection2 {
     fn clone(&self) -> Self {
@@ -8825,41 +7261,7 @@ impl ITCustomTone {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCustomTone> for ::windows::core::IUnknown {
-    fn from(value: ITCustomTone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCustomTone> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITCustomTone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCustomTone> for ::windows::core::IUnknown {
-    fn from(value: &ITCustomTone) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITCustomTone> for super::super::System::Com::IDispatch {
-    fn from(value: ITCustomTone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITCustomTone> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITCustomTone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITCustomTone> for super::super::System::Com::IDispatch {
-    fn from(value: &ITCustomTone) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITCustomTone, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITCustomTone {
     fn clone(&self) -> Self {
@@ -8931,41 +7333,7 @@ impl ITDetectTone {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDetectTone> for ::windows::core::IUnknown {
-    fn from(value: ITDetectTone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDetectTone> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITDetectTone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDetectTone> for ::windows::core::IUnknown {
-    fn from(value: &ITDetectTone) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDetectTone> for super::super::System::Com::IDispatch {
-    fn from(value: ITDetectTone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDetectTone> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITDetectTone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDetectTone> for super::super::System::Com::IDispatch {
-    fn from(value: &ITDetectTone) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITDetectTone, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITDetectTone {
     fn clone(&self) -> Self {
@@ -9036,41 +7404,7 @@ impl ITDigitDetectionEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDigitDetectionEvent> for ::windows::core::IUnknown {
-    fn from(value: ITDigitDetectionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDigitDetectionEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITDigitDetectionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDigitDetectionEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITDigitDetectionEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDigitDetectionEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITDigitDetectionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDigitDetectionEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITDigitDetectionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDigitDetectionEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITDigitDetectionEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITDigitDetectionEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITDigitDetectionEvent {
     fn clone(&self) -> Self {
@@ -9139,41 +7473,7 @@ impl ITDigitGenerationEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDigitGenerationEvent> for ::windows::core::IUnknown {
-    fn from(value: ITDigitGenerationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDigitGenerationEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITDigitGenerationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDigitGenerationEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITDigitGenerationEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDigitGenerationEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITDigitGenerationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDigitGenerationEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITDigitGenerationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDigitGenerationEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITDigitGenerationEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITDigitGenerationEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITDigitGenerationEvent {
     fn clone(&self) -> Self {
@@ -9245,41 +7545,7 @@ impl ITDigitsGatheredEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDigitsGatheredEvent> for ::windows::core::IUnknown {
-    fn from(value: ITDigitsGatheredEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDigitsGatheredEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITDigitsGatheredEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDigitsGatheredEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITDigitsGatheredEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDigitsGatheredEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITDigitsGatheredEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDigitsGatheredEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITDigitsGatheredEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDigitsGatheredEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITDigitsGatheredEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITDigitsGatheredEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITDigitsGatheredEvent {
     fn clone(&self) -> Self {
@@ -9400,41 +7666,7 @@ impl ITDirectory {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDirectory> for ::windows::core::IUnknown {
-    fn from(value: ITDirectory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDirectory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITDirectory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDirectory> for ::windows::core::IUnknown {
-    fn from(value: &ITDirectory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDirectory> for super::super::System::Com::IDispatch {
-    fn from(value: ITDirectory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDirectory> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITDirectory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDirectory> for super::super::System::Com::IDispatch {
-    fn from(value: &ITDirectory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITDirectory, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITDirectory {
     fn clone(&self) -> Self {
@@ -9541,41 +7773,7 @@ impl ITDirectoryObject {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDirectoryObject> for ::windows::core::IUnknown {
-    fn from(value: ITDirectoryObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDirectoryObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITDirectoryObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDirectoryObject> for ::windows::core::IUnknown {
-    fn from(value: &ITDirectoryObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDirectoryObject> for super::super::System::Com::IDispatch {
-    fn from(value: ITDirectoryObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDirectoryObject> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITDirectoryObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDirectoryObject> for super::super::System::Com::IDispatch {
-    fn from(value: &ITDirectoryObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITDirectoryObject, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITDirectoryObject {
     fn clone(&self) -> Self {
@@ -9687,41 +7885,7 @@ impl ITDirectoryObjectConference {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDirectoryObjectConference> for ::windows::core::IUnknown {
-    fn from(value: ITDirectoryObjectConference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDirectoryObjectConference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITDirectoryObjectConference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDirectoryObjectConference> for ::windows::core::IUnknown {
-    fn from(value: &ITDirectoryObjectConference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDirectoryObjectConference> for super::super::System::Com::IDispatch {
-    fn from(value: ITDirectoryObjectConference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDirectoryObjectConference> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITDirectoryObjectConference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDirectoryObjectConference> for super::super::System::Com::IDispatch {
-    fn from(value: &ITDirectoryObjectConference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITDirectoryObjectConference, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITDirectoryObjectConference {
     fn clone(&self) -> Self {
@@ -9786,41 +7950,7 @@ impl ITDirectoryObjectUser {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDirectoryObjectUser> for ::windows::core::IUnknown {
-    fn from(value: ITDirectoryObjectUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDirectoryObjectUser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITDirectoryObjectUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDirectoryObjectUser> for ::windows::core::IUnknown {
-    fn from(value: &ITDirectoryObjectUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDirectoryObjectUser> for super::super::System::Com::IDispatch {
-    fn from(value: ITDirectoryObjectUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDirectoryObjectUser> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITDirectoryObjectUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDirectoryObjectUser> for super::super::System::Com::IDispatch {
-    fn from(value: &ITDirectoryObjectUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITDirectoryObjectUser, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITDirectoryObjectUser {
     fn clone(&self) -> Self {
@@ -9874,41 +8004,7 @@ impl ITDispatchMapper {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDispatchMapper> for ::windows::core::IUnknown {
-    fn from(value: ITDispatchMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDispatchMapper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITDispatchMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDispatchMapper> for ::windows::core::IUnknown {
-    fn from(value: &ITDispatchMapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITDispatchMapper> for super::super::System::Com::IDispatch {
-    fn from(value: ITDispatchMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITDispatchMapper> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITDispatchMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITDispatchMapper> for super::super::System::Com::IDispatch {
-    fn from(value: &ITDispatchMapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITDispatchMapper, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITDispatchMapper {
     fn clone(&self) -> Self {
@@ -9985,41 +8081,7 @@ impl ITFileTerminalEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITFileTerminalEvent> for ::windows::core::IUnknown {
-    fn from(value: ITFileTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITFileTerminalEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITFileTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITFileTerminalEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITFileTerminalEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITFileTerminalEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITFileTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITFileTerminalEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITFileTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITFileTerminalEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITFileTerminalEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITFileTerminalEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITFileTerminalEvent {
     fn clone(&self) -> Self {
@@ -10114,41 +8176,7 @@ impl ITFileTrack {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITFileTrack> for ::windows::core::IUnknown {
-    fn from(value: ITFileTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITFileTrack> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITFileTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITFileTrack> for ::windows::core::IUnknown {
-    fn from(value: &ITFileTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITFileTrack> for super::super::System::Com::IDispatch {
-    fn from(value: ITFileTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITFileTrack> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITFileTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITFileTrack> for super::super::System::Com::IDispatch {
-    fn from(value: &ITFileTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITFileTrack, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITFileTrack {
     fn clone(&self) -> Self {
@@ -10239,41 +8267,7 @@ impl ITForwardInformation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITForwardInformation> for ::windows::core::IUnknown {
-    fn from(value: ITForwardInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITForwardInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITForwardInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITForwardInformation> for ::windows::core::IUnknown {
-    fn from(value: &ITForwardInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITForwardInformation> for super::super::System::Com::IDispatch {
-    fn from(value: ITForwardInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITForwardInformation> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITForwardInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITForwardInformation> for super::super::System::Com::IDispatch {
-    fn from(value: &ITForwardInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITForwardInformation, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITForwardInformation {
     fn clone(&self) -> Self {
@@ -10361,59 +8355,7 @@ impl ITForwardInformation2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITForwardInformation2> for ::windows::core::IUnknown {
-    fn from(value: ITForwardInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITForwardInformation2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITForwardInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITForwardInformation2> for ::windows::core::IUnknown {
-    fn from(value: &ITForwardInformation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITForwardInformation2> for super::super::System::Com::IDispatch {
-    fn from(value: ITForwardInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITForwardInformation2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITForwardInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITForwardInformation2> for super::super::System::Com::IDispatch {
-    fn from(value: &ITForwardInformation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITForwardInformation2> for ITForwardInformation {
-    fn from(value: ITForwardInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITForwardInformation2> for &'a ITForwardInformation {
-    fn from(value: &'a ITForwardInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITForwardInformation2> for ITForwardInformation {
-    fn from(value: &ITForwardInformation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITForwardInformation2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ITForwardInformation);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITForwardInformation2 {
     fn clone(&self) -> Self {
@@ -10467,41 +8409,7 @@ impl ITILSConfig {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITILSConfig> for ::windows::core::IUnknown {
-    fn from(value: ITILSConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITILSConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITILSConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITILSConfig> for ::windows::core::IUnknown {
-    fn from(value: &ITILSConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITILSConfig> for super::super::System::Com::IDispatch {
-    fn from(value: ITILSConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITILSConfig> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITILSConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITILSConfig> for super::super::System::Com::IDispatch {
-    fn from(value: &ITILSConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITILSConfig, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITILSConfig {
     fn clone(&self) -> Self {
@@ -10552,21 +8460,7 @@ impl ITLegacyAddressMediaControl {
         (::windows::core::Vtable::vtable(self).SetDevConfig)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(pdeviceclass), pdeviceconfig.len() as _, ::core::mem::transmute(pdeviceconfig.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<ITLegacyAddressMediaControl> for ::windows::core::IUnknown {
-    fn from(value: ITLegacyAddressMediaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITLegacyAddressMediaControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITLegacyAddressMediaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITLegacyAddressMediaControl> for ::windows::core::IUnknown {
-    fn from(value: &ITLegacyAddressMediaControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITLegacyAddressMediaControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITLegacyAddressMediaControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10627,36 +8521,7 @@ impl ITLegacyAddressMediaControl2 {
         (::windows::core::Vtable::vtable(self).ConfigDialogEdit)(::windows::core::Vtable::as_raw(self), hwndowner.into(), ::core::mem::transmute_copy(pdeviceclass), pdeviceconfigin.len() as _, ::core::mem::transmute(pdeviceconfigin.as_ptr()), ::core::mem::transmute(pdwsizeout), ::core::mem::transmute(ppdeviceconfigout)).ok()
     }
 }
-impl ::core::convert::From<ITLegacyAddressMediaControl2> for ::windows::core::IUnknown {
-    fn from(value: ITLegacyAddressMediaControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITLegacyAddressMediaControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITLegacyAddressMediaControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITLegacyAddressMediaControl2> for ::windows::core::IUnknown {
-    fn from(value: &ITLegacyAddressMediaControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITLegacyAddressMediaControl2> for ITLegacyAddressMediaControl {
-    fn from(value: ITLegacyAddressMediaControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITLegacyAddressMediaControl2> for &'a ITLegacyAddressMediaControl {
-    fn from(value: &'a ITLegacyAddressMediaControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITLegacyAddressMediaControl2> for ITLegacyAddressMediaControl {
-    fn from(value: &ITLegacyAddressMediaControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITLegacyAddressMediaControl2, ::windows::core::IUnknown, ITLegacyAddressMediaControl);
 impl ::core::clone::Clone for ITLegacyAddressMediaControl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10715,41 +8580,7 @@ impl ITLegacyCallMediaControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITLegacyCallMediaControl> for ::windows::core::IUnknown {
-    fn from(value: ITLegacyCallMediaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITLegacyCallMediaControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITLegacyCallMediaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITLegacyCallMediaControl> for ::windows::core::IUnknown {
-    fn from(value: &ITLegacyCallMediaControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITLegacyCallMediaControl> for super::super::System::Com::IDispatch {
-    fn from(value: ITLegacyCallMediaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITLegacyCallMediaControl> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITLegacyCallMediaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITLegacyCallMediaControl> for super::super::System::Com::IDispatch {
-    fn from(value: &ITLegacyCallMediaControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITLegacyCallMediaControl, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITLegacyCallMediaControl {
     fn clone(&self) -> Self {
@@ -10861,59 +8692,7 @@ impl ITLegacyCallMediaControl2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITLegacyCallMediaControl2> for ::windows::core::IUnknown {
-    fn from(value: ITLegacyCallMediaControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITLegacyCallMediaControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITLegacyCallMediaControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITLegacyCallMediaControl2> for ::windows::core::IUnknown {
-    fn from(value: &ITLegacyCallMediaControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITLegacyCallMediaControl2> for super::super::System::Com::IDispatch {
-    fn from(value: ITLegacyCallMediaControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITLegacyCallMediaControl2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITLegacyCallMediaControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITLegacyCallMediaControl2> for super::super::System::Com::IDispatch {
-    fn from(value: &ITLegacyCallMediaControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITLegacyCallMediaControl2> for ITLegacyCallMediaControl {
-    fn from(value: ITLegacyCallMediaControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITLegacyCallMediaControl2> for &'a ITLegacyCallMediaControl {
-    fn from(value: &'a ITLegacyCallMediaControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITLegacyCallMediaControl2> for ITLegacyCallMediaControl {
-    fn from(value: &ITLegacyCallMediaControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITLegacyCallMediaControl2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ITLegacyCallMediaControl);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITLegacyCallMediaControl2 {
     fn clone(&self) -> Self {
@@ -10985,41 +8764,7 @@ impl ITLegacyWaveSupport {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITLegacyWaveSupport> for ::windows::core::IUnknown {
-    fn from(value: ITLegacyWaveSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITLegacyWaveSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITLegacyWaveSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITLegacyWaveSupport> for ::windows::core::IUnknown {
-    fn from(value: &ITLegacyWaveSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITLegacyWaveSupport> for super::super::System::Com::IDispatch {
-    fn from(value: ITLegacyWaveSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITLegacyWaveSupport> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITLegacyWaveSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITLegacyWaveSupport> for super::super::System::Com::IDispatch {
-    fn from(value: &ITLegacyWaveSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITLegacyWaveSupport, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITLegacyWaveSupport {
     fn clone(&self) -> Self {
@@ -11107,41 +8852,7 @@ impl ITLocationInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITLocationInfo> for ::windows::core::IUnknown {
-    fn from(value: ITLocationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITLocationInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITLocationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITLocationInfo> for ::windows::core::IUnknown {
-    fn from(value: &ITLocationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITLocationInfo> for super::super::System::Com::IDispatch {
-    fn from(value: ITLocationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITLocationInfo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITLocationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITLocationInfo> for super::super::System::Com::IDispatch {
-    fn from(value: &ITLocationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITLocationInfo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITLocationInfo {
     fn clone(&self) -> Self {
@@ -11220,21 +8931,7 @@ impl ITMSPAddress {
         (::windows::core::Vtable::vtable(self).GetEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwsize), ::core::mem::transmute(peventbuffer)).ok()
     }
 }
-impl ::core::convert::From<ITMSPAddress> for ::windows::core::IUnknown {
-    fn from(value: ITMSPAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITMSPAddress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITMSPAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITMSPAddress> for ::windows::core::IUnknown {
-    fn from(value: &ITMSPAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITMSPAddress, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITMSPAddress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11289,41 +8986,7 @@ impl ITMediaControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITMediaControl> for ::windows::core::IUnknown {
-    fn from(value: ITMediaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITMediaControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITMediaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITMediaControl> for ::windows::core::IUnknown {
-    fn from(value: &ITMediaControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITMediaControl> for super::super::System::Com::IDispatch {
-    fn from(value: ITMediaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITMediaControl> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITMediaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITMediaControl> for super::super::System::Com::IDispatch {
-    fn from(value: &ITMediaControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITMediaControl, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITMediaControl {
     fn clone(&self) -> Self {
@@ -11384,41 +9047,7 @@ impl ITMediaPlayback {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITMediaPlayback> for ::windows::core::IUnknown {
-    fn from(value: ITMediaPlayback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITMediaPlayback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITMediaPlayback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITMediaPlayback> for ::windows::core::IUnknown {
-    fn from(value: &ITMediaPlayback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITMediaPlayback> for super::super::System::Com::IDispatch {
-    fn from(value: ITMediaPlayback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITMediaPlayback> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITMediaPlayback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITMediaPlayback> for super::super::System::Com::IDispatch {
-    fn from(value: &ITMediaPlayback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITMediaPlayback, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITMediaPlayback {
     fn clone(&self) -> Self {
@@ -11476,41 +9105,7 @@ impl ITMediaRecord {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITMediaRecord> for ::windows::core::IUnknown {
-    fn from(value: ITMediaRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITMediaRecord> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITMediaRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITMediaRecord> for ::windows::core::IUnknown {
-    fn from(value: &ITMediaRecord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITMediaRecord> for super::super::System::Com::IDispatch {
-    fn from(value: ITMediaRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITMediaRecord> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITMediaRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITMediaRecord> for super::super::System::Com::IDispatch {
-    fn from(value: &ITMediaRecord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITMediaRecord, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITMediaRecord {
     fn clone(&self) -> Self {
@@ -11563,41 +9158,7 @@ impl ITMediaSupport {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITMediaSupport> for ::windows::core::IUnknown {
-    fn from(value: ITMediaSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITMediaSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITMediaSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITMediaSupport> for ::windows::core::IUnknown {
-    fn from(value: &ITMediaSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITMediaSupport> for super::super::System::Com::IDispatch {
-    fn from(value: ITMediaSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITMediaSupport> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITMediaSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITMediaSupport> for super::super::System::Com::IDispatch {
-    fn from(value: &ITMediaSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITMediaSupport, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITMediaSupport {
     fn clone(&self) -> Self {
@@ -11674,41 +9235,7 @@ impl ITMultiTrackTerminal {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITMultiTrackTerminal> for ::windows::core::IUnknown {
-    fn from(value: ITMultiTrackTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITMultiTrackTerminal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITMultiTrackTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITMultiTrackTerminal> for ::windows::core::IUnknown {
-    fn from(value: &ITMultiTrackTerminal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITMultiTrackTerminal> for super::super::System::Com::IDispatch {
-    fn from(value: ITMultiTrackTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITMultiTrackTerminal> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITMultiTrackTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITMultiTrackTerminal> for super::super::System::Com::IDispatch {
-    fn from(value: &ITMultiTrackTerminal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITMultiTrackTerminal, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITMultiTrackTerminal {
     fn clone(&self) -> Self {
@@ -11906,41 +9433,7 @@ impl ITPhone {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPhone> for ::windows::core::IUnknown {
-    fn from(value: ITPhone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPhone> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITPhone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPhone> for ::windows::core::IUnknown {
-    fn from(value: &ITPhone) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPhone> for super::super::System::Com::IDispatch {
-    fn from(value: ITPhone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPhone> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITPhone) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPhone> for super::super::System::Com::IDispatch {
-    fn from(value: &ITPhone) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITPhone, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITPhone {
     fn clone(&self) -> Self {
@@ -12052,41 +9545,7 @@ impl ITPhoneDeviceSpecificEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPhoneDeviceSpecificEvent> for ::windows::core::IUnknown {
-    fn from(value: ITPhoneDeviceSpecificEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPhoneDeviceSpecificEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITPhoneDeviceSpecificEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPhoneDeviceSpecificEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITPhoneDeviceSpecificEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPhoneDeviceSpecificEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITPhoneDeviceSpecificEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPhoneDeviceSpecificEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITPhoneDeviceSpecificEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPhoneDeviceSpecificEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITPhoneDeviceSpecificEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITPhoneDeviceSpecificEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITPhoneDeviceSpecificEvent {
     fn clone(&self) -> Self {
@@ -12176,41 +9635,7 @@ impl ITPhoneEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPhoneEvent> for ::windows::core::IUnknown {
-    fn from(value: ITPhoneEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPhoneEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITPhoneEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPhoneEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITPhoneEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPhoneEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITPhoneEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPhoneEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITPhoneEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPhoneEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITPhoneEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITPhoneEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITPhoneEvent {
     fn clone(&self) -> Self {
@@ -12296,41 +9721,7 @@ impl ITPluggableTerminalClassInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPluggableTerminalClassInfo> for ::windows::core::IUnknown {
-    fn from(value: ITPluggableTerminalClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPluggableTerminalClassInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITPluggableTerminalClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPluggableTerminalClassInfo> for ::windows::core::IUnknown {
-    fn from(value: &ITPluggableTerminalClassInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPluggableTerminalClassInfo> for super::super::System::Com::IDispatch {
-    fn from(value: ITPluggableTerminalClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPluggableTerminalClassInfo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITPluggableTerminalClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPluggableTerminalClassInfo> for super::super::System::Com::IDispatch {
-    fn from(value: &ITPluggableTerminalClassInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITPluggableTerminalClassInfo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITPluggableTerminalClassInfo {
     fn clone(&self) -> Self {
@@ -12382,21 +9773,7 @@ impl ITPluggableTerminalEventSink {
         (::windows::core::Vtable::vtable(self).FireEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmspeventinfo)).ok()
     }
 }
-impl ::core::convert::From<ITPluggableTerminalEventSink> for ::windows::core::IUnknown {
-    fn from(value: ITPluggableTerminalEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITPluggableTerminalEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITPluggableTerminalEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITPluggableTerminalEventSink> for ::windows::core::IUnknown {
-    fn from(value: &ITPluggableTerminalEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITPluggableTerminalEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITPluggableTerminalEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12442,21 +9819,7 @@ impl ITPluggableTerminalEventSinkRegistration {
         (::windows::core::Vtable::vtable(self).UnregisterSink)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITPluggableTerminalEventSinkRegistration> for ::windows::core::IUnknown {
-    fn from(value: ITPluggableTerminalEventSinkRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITPluggableTerminalEventSinkRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITPluggableTerminalEventSinkRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITPluggableTerminalEventSinkRegistration> for ::windows::core::IUnknown {
-    fn from(value: &ITPluggableTerminalEventSinkRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITPluggableTerminalEventSinkRegistration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITPluggableTerminalEventSinkRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12502,41 +9865,7 @@ impl ITPluggableTerminalSuperclassInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPluggableTerminalSuperclassInfo> for ::windows::core::IUnknown {
-    fn from(value: ITPluggableTerminalSuperclassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPluggableTerminalSuperclassInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITPluggableTerminalSuperclassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPluggableTerminalSuperclassInfo> for ::windows::core::IUnknown {
-    fn from(value: &ITPluggableTerminalSuperclassInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPluggableTerminalSuperclassInfo> for super::super::System::Com::IDispatch {
-    fn from(value: ITPluggableTerminalSuperclassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPluggableTerminalSuperclassInfo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITPluggableTerminalSuperclassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPluggableTerminalSuperclassInfo> for super::super::System::Com::IDispatch {
-    fn from(value: &ITPluggableTerminalSuperclassInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITPluggableTerminalSuperclassInfo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITPluggableTerminalSuperclassInfo {
     fn clone(&self) -> Self {
@@ -12609,41 +9938,7 @@ impl ITPrivateEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPrivateEvent> for ::windows::core::IUnknown {
-    fn from(value: ITPrivateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPrivateEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITPrivateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPrivateEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITPrivateEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITPrivateEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITPrivateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITPrivateEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITPrivateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITPrivateEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITPrivateEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITPrivateEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITPrivateEvent {
     fn clone(&self) -> Self {
@@ -12717,41 +10012,7 @@ impl ITQOSEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITQOSEvent> for ::windows::core::IUnknown {
-    fn from(value: ITQOSEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITQOSEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITQOSEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITQOSEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITQOSEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITQOSEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITQOSEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITQOSEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITQOSEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITQOSEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITQOSEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITQOSEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITQOSEvent {
     fn clone(&self) -> Self {
@@ -12847,41 +10108,7 @@ impl ITQueue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITQueue> for ::windows::core::IUnknown {
-    fn from(value: ITQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITQueue> for ::windows::core::IUnknown {
-    fn from(value: &ITQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITQueue> for super::super::System::Com::IDispatch {
-    fn from(value: ITQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITQueue> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITQueue> for super::super::System::Com::IDispatch {
-    fn from(value: &ITQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITQueue, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITQueue {
     fn clone(&self) -> Self {
@@ -12946,41 +10173,7 @@ impl ITQueueEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITQueueEvent> for ::windows::core::IUnknown {
-    fn from(value: ITQueueEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITQueueEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITQueueEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITQueueEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITQueueEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITQueueEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITQueueEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITQueueEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITQueueEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITQueueEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITQueueEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITQueueEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITQueueEvent {
     fn clone(&self) -> Self {
@@ -13050,41 +10243,7 @@ impl ITRendezvous {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITRendezvous> for ::windows::core::IUnknown {
-    fn from(value: ITRendezvous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITRendezvous> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITRendezvous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITRendezvous> for ::windows::core::IUnknown {
-    fn from(value: &ITRendezvous) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITRendezvous> for super::super::System::Com::IDispatch {
-    fn from(value: ITRendezvous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITRendezvous> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITRendezvous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITRendezvous> for super::super::System::Com::IDispatch {
-    fn from(value: &ITRendezvous) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITRendezvous, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITRendezvous {
     fn clone(&self) -> Self {
@@ -13143,41 +10302,7 @@ impl ITRequest {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITRequest> for ::windows::core::IUnknown {
-    fn from(value: ITRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITRequest> for ::windows::core::IUnknown {
-    fn from(value: &ITRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITRequest> for super::super::System::Com::IDispatch {
-    fn from(value: ITRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITRequest> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITRequest> for super::super::System::Com::IDispatch {
-    fn from(value: &ITRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITRequest, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITRequest {
     fn clone(&self) -> Self {
@@ -13245,41 +10370,7 @@ impl ITRequestEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITRequestEvent> for ::windows::core::IUnknown {
-    fn from(value: ITRequestEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITRequestEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITRequestEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITRequestEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITRequestEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITRequestEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITRequestEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITRequestEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITRequestEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITRequestEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITRequestEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITRequestEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITRequestEvent {
     fn clone(&self) -> Self {
@@ -13370,41 +10461,7 @@ impl ITScriptableAudioFormat {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITScriptableAudioFormat> for ::windows::core::IUnknown {
-    fn from(value: ITScriptableAudioFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITScriptableAudioFormat> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITScriptableAudioFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITScriptableAudioFormat> for ::windows::core::IUnknown {
-    fn from(value: &ITScriptableAudioFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITScriptableAudioFormat> for super::super::System::Com::IDispatch {
-    fn from(value: ITScriptableAudioFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITScriptableAudioFormat> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITScriptableAudioFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITScriptableAudioFormat> for super::super::System::Com::IDispatch {
-    fn from(value: &ITScriptableAudioFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITScriptableAudioFormat, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITScriptableAudioFormat {
     fn clone(&self) -> Self {
@@ -13463,41 +10520,7 @@ impl ITStaticAudioTerminal {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITStaticAudioTerminal> for ::windows::core::IUnknown {
-    fn from(value: ITStaticAudioTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITStaticAudioTerminal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITStaticAudioTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITStaticAudioTerminal> for ::windows::core::IUnknown {
-    fn from(value: &ITStaticAudioTerminal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITStaticAudioTerminal> for super::super::System::Com::IDispatch {
-    fn from(value: ITStaticAudioTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITStaticAudioTerminal> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITStaticAudioTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITStaticAudioTerminal> for super::super::System::Com::IDispatch {
-    fn from(value: &ITStaticAudioTerminal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITStaticAudioTerminal, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITStaticAudioTerminal {
     fn clone(&self) -> Self {
@@ -13588,41 +10611,7 @@ impl ITStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITStream> for ::windows::core::IUnknown {
-    fn from(value: ITStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITStream> for ::windows::core::IUnknown {
-    fn from(value: &ITStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITStream> for super::super::System::Com::IDispatch {
-    fn from(value: ITStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITStream> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITStream> for super::super::System::Com::IDispatch {
-    fn from(value: &ITStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITStream, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITStream {
     fn clone(&self) -> Self {
@@ -13708,41 +10697,7 @@ impl ITStreamControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITStreamControl> for ::windows::core::IUnknown {
-    fn from(value: ITStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITStreamControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITStreamControl> for ::windows::core::IUnknown {
-    fn from(value: &ITStreamControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITStreamControl> for super::super::System::Com::IDispatch {
-    fn from(value: ITStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITStreamControl> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITStreamControl> for super::super::System::Com::IDispatch {
-    fn from(value: &ITStreamControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITStreamControl, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITStreamControl {
     fn clone(&self) -> Self {
@@ -13839,41 +10794,7 @@ impl ITSubStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITSubStream> for ::windows::core::IUnknown {
-    fn from(value: ITSubStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITSubStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITSubStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITSubStream> for ::windows::core::IUnknown {
-    fn from(value: &ITSubStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITSubStream> for super::super::System::Com::IDispatch {
-    fn from(value: ITSubStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITSubStream> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITSubStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITSubStream> for super::super::System::Com::IDispatch {
-    fn from(value: &ITSubStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITSubStream, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITSubStream {
     fn clone(&self) -> Self {
@@ -13960,41 +10881,7 @@ impl ITSubStreamControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITSubStreamControl> for ::windows::core::IUnknown {
-    fn from(value: ITSubStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITSubStreamControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITSubStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITSubStreamControl> for ::windows::core::IUnknown {
-    fn from(value: &ITSubStreamControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITSubStreamControl> for super::super::System::Com::IDispatch {
-    fn from(value: ITSubStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITSubStreamControl> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITSubStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITSubStreamControl> for super::super::System::Com::IDispatch {
-    fn from(value: &ITSubStreamControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITSubStreamControl, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITSubStreamControl {
     fn clone(&self) -> Self {
@@ -14124,41 +11011,7 @@ impl ITTAPI {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPI> for ::windows::core::IUnknown {
-    fn from(value: ITTAPI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITTAPI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPI> for ::windows::core::IUnknown {
-    fn from(value: &ITTAPI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPI> for super::super::System::Com::IDispatch {
-    fn from(value: ITTAPI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPI> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITTAPI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPI> for super::super::System::Com::IDispatch {
-    fn from(value: &ITTAPI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITTAPI, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITTAPI {
     fn clone(&self) -> Self {
@@ -14325,59 +11178,7 @@ impl ITTAPI2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPI2> for ::windows::core::IUnknown {
-    fn from(value: ITTAPI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPI2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITTAPI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPI2> for ::windows::core::IUnknown {
-    fn from(value: &ITTAPI2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPI2> for super::super::System::Com::IDispatch {
-    fn from(value: ITTAPI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPI2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITTAPI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPI2> for super::super::System::Com::IDispatch {
-    fn from(value: &ITTAPI2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPI2> for ITTAPI {
-    fn from(value: ITTAPI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPI2> for &'a ITTAPI {
-    fn from(value: &'a ITTAPI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPI2> for ITTAPI {
-    fn from(value: &ITTAPI2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITTAPI2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ITTAPI);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITTAPI2 {
     fn clone(&self) -> Self {
@@ -14439,41 +11240,7 @@ impl ITTAPICallCenter {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPICallCenter> for ::windows::core::IUnknown {
-    fn from(value: ITTAPICallCenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPICallCenter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITTAPICallCenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPICallCenter> for ::windows::core::IUnknown {
-    fn from(value: &ITTAPICallCenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPICallCenter> for super::super::System::Com::IDispatch {
-    fn from(value: ITTAPICallCenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPICallCenter> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITTAPICallCenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPICallCenter> for super::super::System::Com::IDispatch {
-    fn from(value: &ITTAPICallCenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITTAPICallCenter, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITTAPICallCenter {
     fn clone(&self) -> Self {
@@ -14520,41 +11287,7 @@ pub struct ITTAPIDispatchEventNotification(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl ITTAPIDispatchEventNotification {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPIDispatchEventNotification> for ::windows::core::IUnknown {
-    fn from(value: ITTAPIDispatchEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPIDispatchEventNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITTAPIDispatchEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPIDispatchEventNotification> for ::windows::core::IUnknown {
-    fn from(value: &ITTAPIDispatchEventNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPIDispatchEventNotification> for super::super::System::Com::IDispatch {
-    fn from(value: ITTAPIDispatchEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPIDispatchEventNotification> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITTAPIDispatchEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPIDispatchEventNotification> for super::super::System::Com::IDispatch {
-    fn from(value: &ITTAPIDispatchEventNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITTAPIDispatchEventNotification, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITTAPIDispatchEventNotification {
     fn clone(&self) -> Self {
@@ -14602,21 +11335,7 @@ impl ITTAPIEventNotification {
         (::windows::core::Vtable::vtable(self).Event)(::windows::core::Vtable::as_raw(self), tapievent, pevent.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITTAPIEventNotification> for ::windows::core::IUnknown {
-    fn from(value: ITTAPIEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITTAPIEventNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITTAPIEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITTAPIEventNotification> for ::windows::core::IUnknown {
-    fn from(value: &ITTAPIEventNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITTAPIEventNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITTAPIEventNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14676,41 +11395,7 @@ impl ITTAPIObjectEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPIObjectEvent> for ::windows::core::IUnknown {
-    fn from(value: ITTAPIObjectEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPIObjectEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITTAPIObjectEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPIObjectEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITTAPIObjectEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPIObjectEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITTAPIObjectEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPIObjectEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITTAPIObjectEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPIObjectEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITTAPIObjectEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITTAPIObjectEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITTAPIObjectEvent {
     fn clone(&self) -> Self {
@@ -14789,59 +11474,7 @@ impl ITTAPIObjectEvent2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPIObjectEvent2> for ::windows::core::IUnknown {
-    fn from(value: ITTAPIObjectEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPIObjectEvent2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITTAPIObjectEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPIObjectEvent2> for ::windows::core::IUnknown {
-    fn from(value: &ITTAPIObjectEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPIObjectEvent2> for super::super::System::Com::IDispatch {
-    fn from(value: ITTAPIObjectEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPIObjectEvent2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITTAPIObjectEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPIObjectEvent2> for super::super::System::Com::IDispatch {
-    fn from(value: &ITTAPIObjectEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTAPIObjectEvent2> for ITTAPIObjectEvent {
-    fn from(value: ITTAPIObjectEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTAPIObjectEvent2> for &'a ITTAPIObjectEvent {
-    fn from(value: &'a ITTAPIObjectEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTAPIObjectEvent2> for ITTAPIObjectEvent {
-    fn from(value: &ITTAPIObjectEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITTAPIObjectEvent2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ITTAPIObjectEvent);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITTAPIObjectEvent2 {
     fn clone(&self) -> Self {
@@ -14904,41 +11537,7 @@ impl ITTTSTerminalEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTTSTerminalEvent> for ::windows::core::IUnknown {
-    fn from(value: ITTTSTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTTSTerminalEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITTTSTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTTSTerminalEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITTTSTerminalEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTTSTerminalEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITTTSTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTTSTerminalEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITTTSTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTTSTerminalEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITTTSTerminalEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITTTSTerminalEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITTTSTerminalEvent {
     fn clone(&self) -> Self {
@@ -15014,41 +11613,7 @@ impl ITTerminal {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTerminal> for ::windows::core::IUnknown {
-    fn from(value: ITTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTerminal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTerminal> for ::windows::core::IUnknown {
-    fn from(value: &ITTerminal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTerminal> for super::super::System::Com::IDispatch {
-    fn from(value: ITTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTerminal> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITTerminal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTerminal> for super::super::System::Com::IDispatch {
-    fn from(value: &ITTerminal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITTerminal, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITTerminal {
     fn clone(&self) -> Self {
@@ -15129,41 +11694,7 @@ impl ITTerminalSupport {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTerminalSupport> for ::windows::core::IUnknown {
-    fn from(value: ITTerminalSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTerminalSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITTerminalSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTerminalSupport> for ::windows::core::IUnknown {
-    fn from(value: &ITTerminalSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTerminalSupport> for super::super::System::Com::IDispatch {
-    fn from(value: ITTerminalSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTerminalSupport> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITTerminalSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTerminalSupport> for super::super::System::Com::IDispatch {
-    fn from(value: &ITTerminalSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITTerminalSupport, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITTerminalSupport {
     fn clone(&self) -> Self {
@@ -15276,59 +11807,7 @@ impl ITTerminalSupport2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTerminalSupport2> for ::windows::core::IUnknown {
-    fn from(value: ITTerminalSupport2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTerminalSupport2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITTerminalSupport2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTerminalSupport2> for ::windows::core::IUnknown {
-    fn from(value: &ITTerminalSupport2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTerminalSupport2> for super::super::System::Com::IDispatch {
-    fn from(value: ITTerminalSupport2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTerminalSupport2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITTerminalSupport2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTerminalSupport2> for super::super::System::Com::IDispatch {
-    fn from(value: &ITTerminalSupport2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITTerminalSupport2> for ITTerminalSupport {
-    fn from(value: ITTerminalSupport2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITTerminalSupport2> for &'a ITTerminalSupport {
-    fn from(value: &'a ITTerminalSupport2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITTerminalSupport2> for ITTerminalSupport {
-    fn from(value: &ITTerminalSupport2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITTerminalSupport2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ITTerminalSupport);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITTerminalSupport2 {
     fn clone(&self) -> Self {
@@ -15399,41 +11878,7 @@ impl ITToneDetectionEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITToneDetectionEvent> for ::windows::core::IUnknown {
-    fn from(value: ITToneDetectionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITToneDetectionEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITToneDetectionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITToneDetectionEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITToneDetectionEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITToneDetectionEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITToneDetectionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITToneDetectionEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITToneDetectionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITToneDetectionEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITToneDetectionEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITToneDetectionEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITToneDetectionEvent {
     fn clone(&self) -> Self {
@@ -15499,41 +11944,7 @@ impl ITToneTerminalEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITToneTerminalEvent> for ::windows::core::IUnknown {
-    fn from(value: ITToneTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITToneTerminalEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITToneTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITToneTerminalEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITToneTerminalEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITToneTerminalEvent> for super::super::System::Com::IDispatch {
-    fn from(value: ITToneTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITToneTerminalEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITToneTerminalEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITToneTerminalEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &ITToneTerminalEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITToneTerminalEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITToneTerminalEvent {
     fn clone(&self) -> Self {
@@ -15622,21 +12033,7 @@ impl ITnef {
         (::windows::core::Vtable::vtable(self).FinishComponent)(::windows::core::Vtable::as_raw(self), ulflags, ulcomponentid, ::core::mem::transmute(lpcustomproplist), ::core::mem::transmute(lpcustomprops), ::core::mem::transmute(lpproplist), ::core::mem::transmute(lpproblems)).ok()
     }
 }
-impl ::core::convert::From<ITnef> for ::windows::core::IUnknown {
-    fn from(value: ITnef) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITnef> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITnef) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITnef> for ::windows::core::IUnknown {
-    fn from(value: &ITnef) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITnef, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITnef {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/mod.rs
@@ -385,21 +385,7 @@ impl IWSDAddress {
         (::windows::core::Vtable::vtable(self).Deserialize)(::windows::core::Vtable::as_raw(self), pszbuffer.into()).ok()
     }
 }
-impl ::core::convert::From<IWSDAddress> for ::windows::core::IUnknown {
-    fn from(value: IWSDAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDAddress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDAddress> for ::windows::core::IUnknown {
-    fn from(value: &IWSDAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDAddress, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDAddress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -444,21 +430,7 @@ impl IWSDAsyncCallback {
         (::windows::core::Vtable::vtable(self).AsyncOperationComplete)(::windows::core::Vtable::as_raw(self), pasyncresult.into().abi(), pasyncstate.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWSDAsyncCallback> for ::windows::core::IUnknown {
-    fn from(value: IWSDAsyncCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDAsyncCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDAsyncCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDAsyncCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWSDAsyncCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDAsyncCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDAsyncCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -525,21 +497,7 @@ impl IWSDAsyncResult {
         (::windows::core::Vtable::vtable(self).GetEndpointProxy)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWSDEndpointProxy>(result__)
     }
 }
-impl ::core::convert::From<IWSDAsyncResult> for ::windows::core::IUnknown {
-    fn from(value: IWSDAsyncResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDAsyncResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDAsyncResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDAsyncResult> for ::windows::core::IUnknown {
-    fn from(value: &IWSDAsyncResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDAsyncResult, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDAsyncResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -581,21 +539,7 @@ pub struct IWSDAsyncResult_Vtbl {
 #[repr(transparent)]
 pub struct IWSDAttachment(::windows::core::IUnknown);
 impl IWSDAttachment {}
-impl ::core::convert::From<IWSDAttachment> for ::windows::core::IUnknown {
-    fn from(value: IWSDAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDAttachment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDAttachment> for ::windows::core::IUnknown {
-    fn from(value: &IWSDAttachment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDAttachment, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDAttachment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -695,21 +639,7 @@ impl IWSDDeviceHost {
         (::windows::core::Vtable::vtable(self).SignalEvent)(::windows::core::Vtable::as_raw(self), pszserviceid.into(), ::core::mem::transmute(pbody.unwrap_or(::std::ptr::null())), ::core::mem::transmute(poperation)).ok()
     }
 }
-impl ::core::convert::From<IWSDDeviceHost> for ::windows::core::IUnknown {
-    fn from(value: IWSDDeviceHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDDeviceHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDDeviceHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDDeviceHost> for ::windows::core::IUnknown {
-    fn from(value: &IWSDDeviceHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDDeviceHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDDeviceHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -764,21 +694,7 @@ impl IWSDDeviceHostNotify {
         (::windows::core::Vtable::vtable(self).GetService)(::windows::core::Vtable::as_raw(self), pszserviceid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IWSDDeviceHostNotify> for ::windows::core::IUnknown {
-    fn from(value: IWSDDeviceHostNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDDeviceHostNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDDeviceHostNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDDeviceHostNotify> for ::windows::core::IUnknown {
-    fn from(value: &IWSDDeviceHostNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDDeviceHostNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDDeviceHostNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -863,21 +779,7 @@ impl IWSDDeviceProxy {
         (::windows::core::Vtable::vtable(self).GetEndpointProxy)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWSDEndpointProxy>(result__)
     }
 }
-impl ::core::convert::From<IWSDDeviceProxy> for ::windows::core::IUnknown {
-    fn from(value: IWSDDeviceProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDDeviceProxy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDDeviceProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDDeviceProxy> for ::windows::core::IUnknown {
-    fn from(value: &IWSDDeviceProxy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDDeviceProxy, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDDeviceProxy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -953,21 +855,7 @@ impl IWSDEndpointProxy {
         (::windows::core::Vtable::vtable(self).GetFaultInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut WSD_SOAP_FAULT>(result__)
     }
 }
-impl ::core::convert::From<IWSDEndpointProxy> for ::windows::core::IUnknown {
-    fn from(value: IWSDEndpointProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDEndpointProxy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDEndpointProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDEndpointProxy> for ::windows::core::IUnknown {
-    fn from(value: &IWSDEndpointProxy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDEndpointProxy, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDEndpointProxy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1028,21 +916,7 @@ impl IWSDEventingStatus {
         (::windows::core::Vtable::vtable(self).SubscriptionEnded)(::windows::core::Vtable::as_raw(self), pszsubscriptionaction.into())
     }
 }
-impl ::core::convert::From<IWSDEventingStatus> for ::windows::core::IUnknown {
-    fn from(value: IWSDEventingStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDEventingStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDEventingStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDEventingStatus> for ::windows::core::IUnknown {
-    fn from(value: &IWSDEventingStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDEventingStatus, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDEventingStatus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1139,51 +1013,7 @@ impl IWSDHttpAddress {
         (::windows::core::Vtable::vtable(self).SetPath)(::windows::core::Vtable::as_raw(self), pszpath.into()).ok()
     }
 }
-impl ::core::convert::From<IWSDHttpAddress> for ::windows::core::IUnknown {
-    fn from(value: IWSDHttpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDHttpAddress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDHttpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDHttpAddress> for ::windows::core::IUnknown {
-    fn from(value: &IWSDHttpAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDHttpAddress> for IWSDAddress {
-    fn from(value: IWSDHttpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDHttpAddress> for &'a IWSDAddress {
-    fn from(value: &'a IWSDHttpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDHttpAddress> for IWSDAddress {
-    fn from(value: &IWSDHttpAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDHttpAddress> for IWSDTransportAddress {
-    fn from(value: IWSDHttpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDHttpAddress> for &'a IWSDTransportAddress {
-    fn from(value: &'a IWSDHttpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDHttpAddress> for IWSDTransportAddress {
-    fn from(value: &IWSDHttpAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDHttpAddress, ::windows::core::IUnknown, IWSDAddress, IWSDTransportAddress);
 impl ::core::clone::Clone for IWSDHttpAddress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1233,21 +1063,7 @@ impl IWSDHttpAuthParameters {
         (::windows::core::Vtable::vtable(self).GetAuthType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IWSDHttpAuthParameters> for ::windows::core::IUnknown {
-    fn from(value: IWSDHttpAuthParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDHttpAuthParameters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDHttpAuthParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDHttpAuthParameters> for ::windows::core::IUnknown {
-    fn from(value: &IWSDHttpAuthParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDHttpAuthParameters, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDHttpAuthParameters {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1352,36 +1168,7 @@ impl IWSDHttpMessageParameters {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWSDHttpMessageParameters> for ::windows::core::IUnknown {
-    fn from(value: IWSDHttpMessageParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDHttpMessageParameters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDHttpMessageParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDHttpMessageParameters> for ::windows::core::IUnknown {
-    fn from(value: &IWSDHttpMessageParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDHttpMessageParameters> for IWSDMessageParameters {
-    fn from(value: IWSDHttpMessageParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDHttpMessageParameters> for &'a IWSDMessageParameters {
-    fn from(value: &'a IWSDHttpMessageParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDHttpMessageParameters> for IWSDMessageParameters {
-    fn from(value: &IWSDHttpMessageParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDHttpMessageParameters, ::windows::core::IUnknown, IWSDMessageParameters);
 impl ::core::clone::Clone for IWSDHttpMessageParameters {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1429,36 +1216,7 @@ impl IWSDInboundAttachment {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWSDInboundAttachment> for ::windows::core::IUnknown {
-    fn from(value: IWSDInboundAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDInboundAttachment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDInboundAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDInboundAttachment> for ::windows::core::IUnknown {
-    fn from(value: &IWSDInboundAttachment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDInboundAttachment> for IWSDAttachment {
-    fn from(value: IWSDInboundAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDInboundAttachment> for &'a IWSDAttachment {
-    fn from(value: &'a IWSDInboundAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDInboundAttachment> for IWSDAttachment {
-    fn from(value: &IWSDInboundAttachment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDInboundAttachment, ::windows::core::IUnknown, IWSDAttachment);
 impl ::core::clone::Clone for IWSDInboundAttachment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1517,21 +1275,7 @@ impl IWSDMessageParameters {
         (::windows::core::Vtable::vtable(self).GetLowerParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWSDMessageParameters>(result__)
     }
 }
-impl ::core::convert::From<IWSDMessageParameters> for ::windows::core::IUnknown {
-    fn from(value: IWSDMessageParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDMessageParameters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDMessageParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDMessageParameters> for ::windows::core::IUnknown {
-    fn from(value: &IWSDMessageParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDMessageParameters, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDMessageParameters {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1573,21 +1317,7 @@ impl IWSDMetadataExchange {
         (::windows::core::Vtable::vtable(self).GetMetadata)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut WSD_METADATA_SECTION_LIST>(result__)
     }
 }
-impl ::core::convert::From<IWSDMetadataExchange> for ::windows::core::IUnknown {
-    fn from(value: IWSDMetadataExchange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDMetadataExchange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDMetadataExchange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDMetadataExchange> for ::windows::core::IUnknown {
-    fn from(value: &IWSDMetadataExchange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDMetadataExchange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDMetadataExchange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1631,36 +1361,7 @@ impl IWSDOutboundAttachment {
         (::windows::core::Vtable::vtable(self).Abort)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWSDOutboundAttachment> for ::windows::core::IUnknown {
-    fn from(value: IWSDOutboundAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDOutboundAttachment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDOutboundAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDOutboundAttachment> for ::windows::core::IUnknown {
-    fn from(value: &IWSDOutboundAttachment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDOutboundAttachment> for IWSDAttachment {
-    fn from(value: IWSDOutboundAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDOutboundAttachment> for &'a IWSDAttachment {
-    fn from(value: &'a IWSDOutboundAttachment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDOutboundAttachment> for IWSDAttachment {
-    fn from(value: &IWSDOutboundAttachment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDOutboundAttachment, ::windows::core::IUnknown, IWSDAttachment);
 impl ::core::clone::Clone for IWSDOutboundAttachment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1708,21 +1409,7 @@ impl IWSDSSLClientCertificate {
         (::windows::core::Vtable::vtable(self).GetMappedAccessToken)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::HANDLE>(result__)
     }
 }
-impl ::core::convert::From<IWSDSSLClientCertificate> for ::windows::core::IUnknown {
-    fn from(value: IWSDSSLClientCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDSSLClientCertificate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDSSLClientCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDSSLClientCertificate> for ::windows::core::IUnknown {
-    fn from(value: &IWSDSSLClientCertificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDSSLClientCertificate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDSSLClientCertificate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1777,21 +1464,7 @@ impl IWSDScopeMatchingRule {
         (::windows::core::Vtable::vtable(self).MatchScopes)(::windows::core::Vtable::as_raw(self), pszscope1.into(), pszscope2.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWSDScopeMatchingRule> for ::windows::core::IUnknown {
-    fn from(value: IWSDScopeMatchingRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDScopeMatchingRule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDScopeMatchingRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDScopeMatchingRule> for ::windows::core::IUnknown {
-    fn from(value: &IWSDScopeMatchingRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDScopeMatchingRule, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDScopeMatchingRule {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1841,21 +1514,7 @@ impl IWSDServiceMessaging {
         (::windows::core::Vtable::vtable(self).FaultRequest)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prequestheader), pmessageparameters.into().abi(), ::core::mem::transmute(pfault.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IWSDServiceMessaging> for ::windows::core::IUnknown {
-    fn from(value: IWSDServiceMessaging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDServiceMessaging> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDServiceMessaging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDServiceMessaging> for ::windows::core::IUnknown {
-    fn from(value: &IWSDServiceMessaging) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDServiceMessaging, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDServiceMessaging {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1929,36 +1588,7 @@ impl IWSDServiceProxy {
         (::windows::core::Vtable::vtable(self).GetEndpointProxy)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWSDEndpointProxy>(result__)
     }
 }
-impl ::core::convert::From<IWSDServiceProxy> for ::windows::core::IUnknown {
-    fn from(value: IWSDServiceProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDServiceProxy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDServiceProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDServiceProxy> for ::windows::core::IUnknown {
-    fn from(value: &IWSDServiceProxy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDServiceProxy> for IWSDMetadataExchange {
-    fn from(value: IWSDServiceProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDServiceProxy> for &'a IWSDMetadataExchange {
-    fn from(value: &'a IWSDServiceProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDServiceProxy> for IWSDMetadataExchange {
-    fn from(value: &IWSDServiceProxy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDServiceProxy, ::windows::core::IUnknown, IWSDMetadataExchange);
 impl ::core::clone::Clone for IWSDServiceProxy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2125,51 +1755,7 @@ impl IWSDServiceProxyEventing {
         (::windows::core::Vtable::vtable(self).EndGetStatusForMultipleOperations)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(poperations.as_ptr()), poperations.len() as _, presult.into().abi(), ::core::mem::transmute(ppexpires.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ppany.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IWSDServiceProxyEventing> for ::windows::core::IUnknown {
-    fn from(value: IWSDServiceProxyEventing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDServiceProxyEventing> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDServiceProxyEventing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDServiceProxyEventing> for ::windows::core::IUnknown {
-    fn from(value: &IWSDServiceProxyEventing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDServiceProxyEventing> for IWSDMetadataExchange {
-    fn from(value: IWSDServiceProxyEventing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDServiceProxyEventing> for &'a IWSDMetadataExchange {
-    fn from(value: &'a IWSDServiceProxyEventing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDServiceProxyEventing> for IWSDMetadataExchange {
-    fn from(value: &IWSDServiceProxyEventing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDServiceProxyEventing> for IWSDServiceProxy {
-    fn from(value: IWSDServiceProxyEventing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDServiceProxyEventing> for &'a IWSDServiceProxy {
-    fn from(value: &'a IWSDServiceProxyEventing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDServiceProxyEventing> for IWSDServiceProxy {
-    fn from(value: &IWSDServiceProxyEventing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDServiceProxyEventing, ::windows::core::IUnknown, IWSDMetadataExchange, IWSDServiceProxy);
 impl ::core::clone::Clone for IWSDServiceProxyEventing {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2259,21 +1845,7 @@ impl IWSDSignatureProperty {
         (::windows::core::Vtable::vtable(self).GetSignedInfoHash)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbsignedinfohash.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pdwhashsize)).ok()
     }
 }
-impl ::core::convert::From<IWSDSignatureProperty> for ::windows::core::IUnknown {
-    fn from(value: IWSDSignatureProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDSignatureProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDSignatureProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDSignatureProperty> for ::windows::core::IUnknown {
-    fn from(value: &IWSDSignatureProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDSignatureProperty, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDSignatureProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2357,36 +1929,7 @@ impl IWSDTransportAddress {
         (::windows::core::Vtable::vtable(self).SetTransportAddress)(::windows::core::Vtable::as_raw(self), pszaddress.into()).ok()
     }
 }
-impl ::core::convert::From<IWSDTransportAddress> for ::windows::core::IUnknown {
-    fn from(value: IWSDTransportAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDTransportAddress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDTransportAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDTransportAddress> for ::windows::core::IUnknown {
-    fn from(value: &IWSDTransportAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDTransportAddress> for IWSDAddress {
-    fn from(value: IWSDTransportAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDTransportAddress> for &'a IWSDAddress {
-    fn from(value: &'a IWSDTransportAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDTransportAddress> for IWSDAddress {
-    fn from(value: &IWSDTransportAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDTransportAddress, ::windows::core::IUnknown, IWSDAddress);
 impl ::core::clone::Clone for IWSDTransportAddress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2510,51 +2053,7 @@ impl IWSDUdpAddress {
         (::windows::core::Vtable::vtable(self).GetAlias)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IWSDUdpAddress> for ::windows::core::IUnknown {
-    fn from(value: IWSDUdpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDUdpAddress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDUdpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDUdpAddress> for ::windows::core::IUnknown {
-    fn from(value: &IWSDUdpAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDUdpAddress> for IWSDAddress {
-    fn from(value: IWSDUdpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDUdpAddress> for &'a IWSDAddress {
-    fn from(value: &'a IWSDUdpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDUdpAddress> for IWSDAddress {
-    fn from(value: &IWSDUdpAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDUdpAddress> for IWSDTransportAddress {
-    fn from(value: IWSDUdpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDUdpAddress> for &'a IWSDTransportAddress {
-    fn from(value: &'a IWSDUdpAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDUdpAddress> for IWSDTransportAddress {
-    fn from(value: &IWSDUdpAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDUdpAddress, ::windows::core::IUnknown, IWSDAddress, IWSDTransportAddress);
 impl ::core::clone::Clone for IWSDUdpAddress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2637,36 +2136,7 @@ impl IWSDUdpMessageParameters {
         (::windows::core::Vtable::vtable(self).GetRetransmitParams)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WSDUdpRetransmitParams>(result__)
     }
 }
-impl ::core::convert::From<IWSDUdpMessageParameters> for ::windows::core::IUnknown {
-    fn from(value: IWSDUdpMessageParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDUdpMessageParameters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDUdpMessageParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDUdpMessageParameters> for ::windows::core::IUnknown {
-    fn from(value: &IWSDUdpMessageParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWSDUdpMessageParameters> for IWSDMessageParameters {
-    fn from(value: IWSDUdpMessageParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDUdpMessageParameters> for &'a IWSDMessageParameters {
-    fn from(value: &'a IWSDUdpMessageParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDUdpMessageParameters> for IWSDMessageParameters {
-    fn from(value: &IWSDUdpMessageParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDUdpMessageParameters, ::windows::core::IUnknown, IWSDMessageParameters);
 impl ::core::clone::Clone for IWSDUdpMessageParameters {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2723,21 +2193,7 @@ impl IWSDXMLContext {
         (::windows::core::Vtable::vtable(self).SetTypes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptypes.as_ptr()), ptypes.len() as _, blayernumber).ok()
     }
 }
-impl ::core::convert::From<IWSDXMLContext> for ::windows::core::IUnknown {
-    fn from(value: IWSDXMLContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDXMLContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDXMLContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDXMLContext> for ::windows::core::IUnknown {
-    fn from(value: &IWSDXMLContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDXMLContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDXMLContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2817,21 +2273,7 @@ impl IWSDiscoveredService {
         (::windows::core::Vtable::vtable(self).GetInstanceId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IWSDiscoveredService> for ::windows::core::IUnknown {
-    fn from(value: IWSDiscoveredService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDiscoveredService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDiscoveredService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDiscoveredService> for ::windows::core::IUnknown {
-    fn from(value: &IWSDiscoveredService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDiscoveredService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDiscoveredService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2912,21 +2354,7 @@ impl IWSDiscoveryProvider {
         (::windows::core::Vtable::vtable(self).GetXMLContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWSDXMLContext>(result__)
     }
 }
-impl ::core::convert::From<IWSDiscoveryProvider> for ::windows::core::IUnknown {
-    fn from(value: IWSDiscoveryProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDiscoveryProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDiscoveryProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDiscoveryProvider> for ::windows::core::IUnknown {
-    fn from(value: &IWSDiscoveryProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDiscoveryProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDiscoveryProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2990,21 +2418,7 @@ impl IWSDiscoveryProviderNotify {
         (::windows::core::Vtable::vtable(self).SearchComplete)(::windows::core::Vtable::as_raw(self), psztag.into()).ok()
     }
 }
-impl ::core::convert::From<IWSDiscoveryProviderNotify> for ::windows::core::IUnknown {
-    fn from(value: IWSDiscoveryProviderNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDiscoveryProviderNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDiscoveryProviderNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDiscoveryProviderNotify> for ::windows::core::IUnknown {
-    fn from(value: &IWSDiscoveryProviderNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDiscoveryProviderNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDiscoveryProviderNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3177,21 +2591,7 @@ impl IWSDiscoveryPublisher {
         (::windows::core::Vtable::vtable(self).GetXMLContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWSDXMLContext>(result__)
     }
 }
-impl ::core::convert::From<IWSDiscoveryPublisher> for ::windows::core::IUnknown {
-    fn from(value: IWSDiscoveryPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDiscoveryPublisher> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDiscoveryPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDiscoveryPublisher> for ::windows::core::IUnknown {
-    fn from(value: &IWSDiscoveryPublisher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDiscoveryPublisher, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDiscoveryPublisher {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3249,21 +2649,7 @@ impl IWSDiscoveryPublisherNotify {
         (::windows::core::Vtable::vtable(self).ResolveHandler)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(psoap), pmessageparameters.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWSDiscoveryPublisherNotify> for ::windows::core::IUnknown {
-    fn from(value: IWSDiscoveryPublisherNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSDiscoveryPublisherNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSDiscoveryPublisherNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSDiscoveryPublisherNotify> for ::windows::core::IUnknown {
-    fn from(value: &IWSDiscoveryPublisherNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSDiscoveryPublisherNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSDiscoveryPublisherNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Gaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Gaming/mod.rs
@@ -337,21 +337,7 @@ impl IGameExplorer {
         (::windows::core::Vtable::vtable(self).VerifyAccess)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrgdfbinarypath), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IGameExplorer> for ::windows::core::IUnknown {
-    fn from(value: IGameExplorer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameExplorer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGameExplorer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameExplorer> for ::windows::core::IUnknown {
-    fn from(value: &IGameExplorer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGameExplorer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGameExplorer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -413,21 +399,7 @@ impl IGameExplorer2 {
         (::windows::core::Vtable::vtable(self).CheckAccess)(::windows::core::Vtable::as_raw(self), binarygdfpath.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IGameExplorer2> for ::windows::core::IUnknown {
-    fn from(value: IGameExplorer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameExplorer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGameExplorer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameExplorer2> for ::windows::core::IUnknown {
-    fn from(value: &IGameExplorer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGameExplorer2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGameExplorer2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -521,21 +493,7 @@ impl IGameStatistics {
         (::windows::core::Vtable::vtable(self).GetLastPlayedCategory)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IGameStatistics> for ::windows::core::IUnknown {
-    fn from(value: IGameStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameStatistics> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGameStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameStatistics> for ::windows::core::IUnknown {
-    fn from(value: &IGameStatistics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGameStatistics, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGameStatistics {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -595,21 +553,7 @@ impl IGameStatisticsMgr {
         (::windows::core::Vtable::vtable(self).RemoveGameStatistics)(::windows::core::Vtable::as_raw(self), gdfbinarypath.into()).ok()
     }
 }
-impl ::core::convert::From<IGameStatisticsMgr> for ::windows::core::IUnknown {
-    fn from(value: IGameStatisticsMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGameStatisticsMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGameStatisticsMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGameStatisticsMgr> for ::windows::core::IUnknown {
-    fn from(value: &IGameStatisticsMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGameStatisticsMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGameStatisticsMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -685,21 +629,7 @@ impl IXblIdpAuthManager {
         (::windows::core::Vtable::vtable(self).GetTokenAndSignatureWithTokenResult)(::windows::core::Vtable::as_raw(self), msaaccountid.into(), appsid.into(), msatarget.into(), msapolicy.into(), httpmethod.into(), uri.into(), headers.into(), ::core::mem::transmute(body.as_ptr()), body.len() as _, forcerefresh.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXblIdpAuthTokenResult>(result__)
     }
 }
-impl ::core::convert::From<IXblIdpAuthManager> for ::windows::core::IUnknown {
-    fn from(value: IXblIdpAuthManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXblIdpAuthManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXblIdpAuthManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXblIdpAuthManager> for ::windows::core::IUnknown {
-    fn from(value: &IXblIdpAuthManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXblIdpAuthManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXblIdpAuthManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -821,21 +751,7 @@ impl IXblIdpAuthTokenResult {
         (::windows::core::Vtable::vtable(self).GetTitleRestrictions)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IXblIdpAuthTokenResult> for ::windows::core::IUnknown {
-    fn from(value: IXblIdpAuthTokenResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXblIdpAuthTokenResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXblIdpAuthTokenResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXblIdpAuthTokenResult> for ::windows::core::IUnknown {
-    fn from(value: &IXblIdpAuthTokenResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXblIdpAuthTokenResult, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXblIdpAuthTokenResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -900,21 +816,7 @@ impl IXblIdpAuthTokenResult2 {
         (::windows::core::Vtable::vtable(self).GetUniqueModernGamertag)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IXblIdpAuthTokenResult2> for ::windows::core::IUnknown {
-    fn from(value: IXblIdpAuthTokenResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXblIdpAuthTokenResult2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXblIdpAuthTokenResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXblIdpAuthTokenResult2> for ::windows::core::IUnknown {
-    fn from(value: &IXblIdpAuthTokenResult2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXblIdpAuthTokenResult2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXblIdpAuthTokenResult2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
@@ -11996,21 +11996,7 @@ impl IComprehensiveSpellCheckProvider {
         (::windows::core::Vtable::vtable(self).ComprehensiveCheck)(::windows::core::Vtable::as_raw(self), text.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSpellingError>(result__)
     }
 }
-impl ::core::convert::From<IComprehensiveSpellCheckProvider> for ::windows::core::IUnknown {
-    fn from(value: IComprehensiveSpellCheckProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComprehensiveSpellCheckProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComprehensiveSpellCheckProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComprehensiveSpellCheckProvider> for ::windows::core::IUnknown {
-    fn from(value: &IComprehensiveSpellCheckProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComprehensiveSpellCheckProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComprehensiveSpellCheckProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12057,21 +12043,7 @@ impl IEnumCodePage {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), celt).ok()
     }
 }
-impl ::core::convert::From<IEnumCodePage> for ::windows::core::IUnknown {
-    fn from(value: IEnumCodePage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumCodePage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumCodePage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumCodePage> for ::windows::core::IUnknown {
-    fn from(value: &IEnumCodePage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumCodePage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumCodePage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12121,21 +12093,7 @@ impl IEnumRfc1766 {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), celt).ok()
     }
 }
-impl ::core::convert::From<IEnumRfc1766> for ::windows::core::IUnknown {
-    fn from(value: IEnumRfc1766) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumRfc1766> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumRfc1766) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumRfc1766> for ::windows::core::IUnknown {
-    fn from(value: &IEnumRfc1766) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumRfc1766, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumRfc1766 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12185,21 +12143,7 @@ impl IEnumScript {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), celt).ok()
     }
 }
-impl ::core::convert::From<IEnumScript> for ::windows::core::IUnknown {
-    fn from(value: IEnumScript) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumScript> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumScript) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumScript> for ::windows::core::IUnknown {
-    fn from(value: &IEnumScript) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumScript, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumScript {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12240,21 +12184,7 @@ impl IEnumSpellingError {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISpellingError>(result__)
     }
 }
-impl ::core::convert::From<IEnumSpellingError> for ::windows::core::IUnknown {
-    fn from(value: IEnumSpellingError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSpellingError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSpellingError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSpellingError> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSpellingError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSpellingError, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSpellingError {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12303,21 +12233,7 @@ impl IMLangCodePages {
         (::windows::core::Vtable::vtable(self).CodePagesToCodePage)(::windows::core::Vtable::as_raw(self), dwcodepages, udefaultcodepage, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMLangCodePages> for ::windows::core::IUnknown {
-    fn from(value: IMLangCodePages) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangCodePages> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLangCodePages) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangCodePages> for ::windows::core::IUnknown {
-    fn from(value: &IMLangCodePages) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLangCodePages, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLangCodePages {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12384,21 +12300,7 @@ impl IMLangConvertCharset {
         (::windows::core::Vtable::vtable(self).DoConversionFromUnicode)(::windows::core::Vtable::as_raw(self), psrcstr.into(), ::core::mem::transmute(pcsrcsize.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pdststr), ::core::mem::transmute(pcdstsize.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMLangConvertCharset> for ::windows::core::IUnknown {
-    fn from(value: IMLangConvertCharset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangConvertCharset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLangConvertCharset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangConvertCharset> for ::windows::core::IUnknown {
-    fn from(value: &IMLangConvertCharset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLangConvertCharset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLangConvertCharset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12484,36 +12386,7 @@ impl IMLangFontLink {
         (::windows::core::Vtable::vtable(self).ResetFontMapping)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMLangFontLink> for ::windows::core::IUnknown {
-    fn from(value: IMLangFontLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangFontLink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLangFontLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangFontLink> for ::windows::core::IUnknown {
-    fn from(value: &IMLangFontLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMLangFontLink> for IMLangCodePages {
-    fn from(value: IMLangFontLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangFontLink> for &'a IMLangCodePages {
-    fn from(value: &'a IMLangFontLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangFontLink> for IMLangCodePages {
-    fn from(value: &IMLangFontLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLangFontLink, ::windows::core::IUnknown, IMLangCodePages);
 impl ::core::clone::Clone for IMLangFontLink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12620,36 +12493,7 @@ impl IMLangFontLink2 {
         (::windows::core::Vtable::vtable(self).CodePageToScriptID)(::windows::core::Vtable::as_raw(self), uicodepage, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u8>(result__)
     }
 }
-impl ::core::convert::From<IMLangFontLink2> for ::windows::core::IUnknown {
-    fn from(value: IMLangFontLink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangFontLink2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLangFontLink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangFontLink2> for ::windows::core::IUnknown {
-    fn from(value: &IMLangFontLink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMLangFontLink2> for IMLangCodePages {
-    fn from(value: IMLangFontLink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangFontLink2> for &'a IMLangCodePages {
-    fn from(value: &'a IMLangFontLink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangFontLink2> for IMLangCodePages {
-    fn from(value: &IMLangFontLink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLangFontLink2, ::windows::core::IUnknown, IMLangCodePages);
 impl ::core::clone::Clone for IMLangFontLink2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12713,21 +12557,7 @@ impl IMLangLineBreakConsole {
         (::windows::core::Vtable::vtable(self).BreakLineA)(::windows::core::Vtable::as_raw(self), locale, ucodepage, ::core::mem::transmute(pszsrc.as_ptr()), pszsrc.len() as _, cmaxcolumns, ::core::mem::transmute(pcchline.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pcchskip.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMLangLineBreakConsole> for ::windows::core::IUnknown {
-    fn from(value: IMLangLineBreakConsole) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangLineBreakConsole> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLangLineBreakConsole) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangLineBreakConsole> for ::windows::core::IUnknown {
-    fn from(value: &IMLangLineBreakConsole) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLangLineBreakConsole, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLangLineBreakConsole {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12787,21 +12617,7 @@ impl IMLangString {
         (::windows::core::Vtable::vtable(self).GetMLStr)(::windows::core::Vtable::as_raw(self), lsrcpos, lsrclen, punkouter.into().abi(), dwclscontext, ::core::mem::transmute(piid), ::core::mem::transmute(ppdestmlstr), ::core::mem::transmute(pldestpos.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pldestlen.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMLangString> for ::windows::core::IUnknown {
-    fn from(value: IMLangString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangString> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLangString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangString> for ::windows::core::IUnknown {
-    fn from(value: &IMLangString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLangString, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLangString {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12892,36 +12708,7 @@ impl IMLangStringAStr {
         (::windows::core::Vtable::vtable(self).GetLocale)(::windows::core::Vtable::as_raw(self), lsrcpos, lsrcmaxlen, ::core::mem::transmute(plocale.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pllocalepos.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pllocalelen.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMLangStringAStr> for ::windows::core::IUnknown {
-    fn from(value: IMLangStringAStr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangStringAStr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLangStringAStr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangStringAStr> for ::windows::core::IUnknown {
-    fn from(value: &IMLangStringAStr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMLangStringAStr> for IMLangString {
-    fn from(value: IMLangStringAStr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangStringAStr> for &'a IMLangString {
-    fn from(value: &'a IMLangStringAStr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangStringAStr> for IMLangString {
-    fn from(value: &IMLangStringAStr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLangStringAStr, ::windows::core::IUnknown, IMLangString);
 impl ::core::clone::Clone for IMLangStringAStr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12983,21 +12770,7 @@ impl IMLangStringBufA {
         (::windows::core::Vtable::vtable(self).Delete)(::windows::core::Vtable::as_raw(self), cchoffset, cchdelete).ok()
     }
 }
-impl ::core::convert::From<IMLangStringBufA> for ::windows::core::IUnknown {
-    fn from(value: IMLangStringBufA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangStringBufA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLangStringBufA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangStringBufA> for ::windows::core::IUnknown {
-    fn from(value: &IMLangStringBufA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLangStringBufA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLangStringBufA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13057,21 +12830,7 @@ impl IMLangStringBufW {
         (::windows::core::Vtable::vtable(self).Delete)(::windows::core::Vtable::as_raw(self), cchoffset, cchdelete).ok()
     }
 }
-impl ::core::convert::From<IMLangStringBufW> for ::windows::core::IUnknown {
-    fn from(value: IMLangStringBufW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangStringBufW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLangStringBufW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangStringBufW> for ::windows::core::IUnknown {
-    fn from(value: &IMLangStringBufW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLangStringBufW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMLangStringBufW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13160,36 +12919,7 @@ impl IMLangStringWStr {
         (::windows::core::Vtable::vtable(self).GetLocale)(::windows::core::Vtable::as_raw(self), lsrcpos, lsrcmaxlen, ::core::mem::transmute(plocale.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pllocalepos.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pllocalelen.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMLangStringWStr> for ::windows::core::IUnknown {
-    fn from(value: IMLangStringWStr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangStringWStr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMLangStringWStr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangStringWStr> for ::windows::core::IUnknown {
-    fn from(value: &IMLangStringWStr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMLangStringWStr> for IMLangString {
-    fn from(value: IMLangStringWStr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMLangStringWStr> for &'a IMLangString {
-    fn from(value: &'a IMLangStringWStr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMLangStringWStr> for IMLangString {
-    fn from(value: &IMLangStringWStr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMLangStringWStr, ::windows::core::IUnknown, IMLangString);
 impl ::core::clone::Clone for IMLangStringWStr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13290,21 +13020,7 @@ impl IMultiLanguage {
         (::windows::core::Vtable::vtable(self).CreateConvertCharset)(::windows::core::Vtable::as_raw(self), uisrccodepage, uidstcodepage, dwproperty, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMLangConvertCharset>(result__)
     }
 }
-impl ::core::convert::From<IMultiLanguage> for ::windows::core::IUnknown {
-    fn from(value: IMultiLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMultiLanguage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultiLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMultiLanguage> for ::windows::core::IUnknown {
-    fn from(value: &IMultiLanguage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultiLanguage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMultiLanguage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13483,21 +13199,7 @@ impl IMultiLanguage2 {
         (::windows::core::Vtable::vtable(self).ValidateCodePageEx)(::windows::core::Vtable::as_raw(self), uicodepage, hwnd.into(), dwfiodcontrol).ok()
     }
 }
-impl ::core::convert::From<IMultiLanguage2> for ::windows::core::IUnknown {
-    fn from(value: IMultiLanguage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMultiLanguage2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultiLanguage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMultiLanguage2> for ::windows::core::IUnknown {
-    fn from(value: &IMultiLanguage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultiLanguage2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMultiLanguage2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13715,36 +13417,7 @@ impl IMultiLanguage3 {
         (::windows::core::Vtable::vtable(self).DetectOutboundCodePageInIStream)(::windows::core::Vtable::as_raw(self), dwflags, pstrin.into().abi(), ::core::mem::transmute(puipreferredcodepages.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), puipreferredcodepages.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(puidetectedcodepages), ::core::mem::transmute(pndetectedcodepages), lpspecialchar.into()).ok()
     }
 }
-impl ::core::convert::From<IMultiLanguage3> for ::windows::core::IUnknown {
-    fn from(value: IMultiLanguage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMultiLanguage3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultiLanguage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMultiLanguage3> for ::windows::core::IUnknown {
-    fn from(value: &IMultiLanguage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMultiLanguage3> for IMultiLanguage2 {
-    fn from(value: IMultiLanguage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMultiLanguage3> for &'a IMultiLanguage2 {
-    fn from(value: &'a IMultiLanguage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMultiLanguage3> for IMultiLanguage2 {
-    fn from(value: &IMultiLanguage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultiLanguage3, ::windows::core::IUnknown, IMultiLanguage2);
 impl ::core::clone::Clone for IMultiLanguage3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13800,21 +13473,7 @@ impl IOptionDescription {
         (::windows::core::Vtable::vtable(self).Labels)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::System::Com::IEnumString>(result__)
     }
 }
-impl ::core::convert::From<IOptionDescription> for ::windows::core::IUnknown {
-    fn from(value: IOptionDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOptionDescription> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOptionDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOptionDescription> for ::windows::core::IUnknown {
-    fn from(value: &IOptionDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOptionDescription, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOptionDescription {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13916,21 +13575,7 @@ impl ISpellCheckProvider {
         (::windows::core::Vtable::vtable(self).InitializeWordlist)(::windows::core::Vtable::as_raw(self), wordlisttype, words.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISpellCheckProvider> for ::windows::core::IUnknown {
-    fn from(value: ISpellCheckProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpellCheckProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpellCheckProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpellCheckProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISpellCheckProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpellCheckProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpellCheckProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14004,21 +13649,7 @@ impl ISpellCheckProviderFactory {
         (::windows::core::Vtable::vtable(self).CreateSpellCheckProvider)(::windows::core::Vtable::as_raw(self), languagetag.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISpellCheckProvider>(result__)
     }
 }
-impl ::core::convert::From<ISpellCheckProviderFactory> for ::windows::core::IUnknown {
-    fn from(value: ISpellCheckProviderFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpellCheckProviderFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpellCheckProviderFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpellCheckProviderFactory> for ::windows::core::IUnknown {
-    fn from(value: &ISpellCheckProviderFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpellCheckProviderFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpellCheckProviderFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14144,21 +13775,7 @@ impl ISpellChecker {
         (::windows::core::Vtable::vtable(self).ComprehensiveCheck)(::windows::core::Vtable::as_raw(self), text.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSpellingError>(result__)
     }
 }
-impl ::core::convert::From<ISpellChecker> for ::windows::core::IUnknown {
-    fn from(value: ISpellChecker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpellChecker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpellChecker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpellChecker> for ::windows::core::IUnknown {
-    fn from(value: &ISpellChecker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpellChecker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpellChecker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14301,36 +13918,7 @@ impl ISpellChecker2 {
         (::windows::core::Vtable::vtable(self).Remove)(::windows::core::Vtable::as_raw(self), word.into()).ok()
     }
 }
-impl ::core::convert::From<ISpellChecker2> for ::windows::core::IUnknown {
-    fn from(value: ISpellChecker2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpellChecker2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpellChecker2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpellChecker2> for ::windows::core::IUnknown {
-    fn from(value: &ISpellChecker2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpellChecker2> for ISpellChecker {
-    fn from(value: ISpellChecker2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpellChecker2> for &'a ISpellChecker {
-    fn from(value: &'a ISpellChecker2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpellChecker2> for ISpellChecker {
-    fn from(value: &ISpellChecker2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpellChecker2, ::windows::core::IUnknown, ISpellChecker);
 impl ::core::clone::Clone for ISpellChecker2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14370,21 +13958,7 @@ impl ISpellCheckerChangedEventHandler {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self), sender.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISpellCheckerChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: ISpellCheckerChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpellCheckerChangedEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpellCheckerChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpellCheckerChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &ISpellCheckerChangedEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpellCheckerChangedEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpellCheckerChangedEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14440,21 +14014,7 @@ impl ISpellCheckerFactory {
         (::windows::core::Vtable::vtable(self).CreateSpellChecker)(::windows::core::Vtable::as_raw(self), languagetag.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISpellChecker>(result__)
     }
 }
-impl ::core::convert::From<ISpellCheckerFactory> for ::windows::core::IUnknown {
-    fn from(value: ISpellCheckerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpellCheckerFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpellCheckerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpellCheckerFactory> for ::windows::core::IUnknown {
-    fn from(value: &ISpellCheckerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpellCheckerFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpellCheckerFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14512,21 +14072,7 @@ impl ISpellingError {
         (::windows::core::Vtable::vtable(self).Replacement)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ISpellingError> for ::windows::core::IUnknown {
-    fn from(value: ISpellingError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpellingError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpellingError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpellingError> for ::windows::core::IUnknown {
-    fn from(value: &ISpellingError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpellingError, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpellingError {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14577,21 +14123,7 @@ impl IUserDictionariesRegistrar {
         (::windows::core::Vtable::vtable(self).UnregisterUserDictionary)(::windows::core::Vtable::as_raw(self), dictionarypath.into(), languagetag.into()).ok()
     }
 }
-impl ::core::convert::From<IUserDictionariesRegistrar> for ::windows::core::IUnknown {
-    fn from(value: IUserDictionariesRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserDictionariesRegistrar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserDictionariesRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserDictionariesRegistrar> for ::windows::core::IUnknown {
-    fn from(value: &IUserDictionariesRegistrar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserDictionariesRegistrar, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUserDictionariesRegistrar {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
@@ -32,36 +32,7 @@ impl ICompositionFramePresentStatistics {
         (::windows::core::Vtable::vtable(self).GetDisplayInstanceArray)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(displayinstancearraycount), ::core::mem::transmute(displayinstancearray))
     }
 }
-impl ::core::convert::From<ICompositionFramePresentStatistics> for ::windows::core::IUnknown {
-    fn from(value: ICompositionFramePresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionFramePresentStatistics> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositionFramePresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionFramePresentStatistics> for ::windows::core::IUnknown {
-    fn from(value: &ICompositionFramePresentStatistics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICompositionFramePresentStatistics> for IPresentStatistics {
-    fn from(value: ICompositionFramePresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionFramePresentStatistics> for &'a IPresentStatistics {
-    fn from(value: &'a ICompositionFramePresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionFramePresentStatistics> for IPresentStatistics {
-    fn from(value: &ICompositionFramePresentStatistics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositionFramePresentStatistics, ::windows::core::IUnknown, IPresentStatistics);
 impl ::core::clone::Clone for ICompositionFramePresentStatistics {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -129,36 +100,7 @@ impl IIndependentFlipFramePresentStatistics {
         result__
     }
 }
-impl ::core::convert::From<IIndependentFlipFramePresentStatistics> for ::windows::core::IUnknown {
-    fn from(value: IIndependentFlipFramePresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIndependentFlipFramePresentStatistics> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIndependentFlipFramePresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIndependentFlipFramePresentStatistics> for ::windows::core::IUnknown {
-    fn from(value: &IIndependentFlipFramePresentStatistics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IIndependentFlipFramePresentStatistics> for IPresentStatistics {
-    fn from(value: IIndependentFlipFramePresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIndependentFlipFramePresentStatistics> for &'a IPresentStatistics {
-    fn from(value: &'a IIndependentFlipFramePresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIndependentFlipFramePresentStatistics> for IPresentStatistics {
-    fn from(value: &IIndependentFlipFramePresentStatistics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIndependentFlipFramePresentStatistics, ::windows::core::IUnknown, IPresentStatistics);
 impl ::core::clone::Clone for IIndependentFlipFramePresentStatistics {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -205,21 +147,7 @@ impl IPresentStatistics {
         (::windows::core::Vtable::vtable(self).GetKind)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IPresentStatistics> for ::windows::core::IUnknown {
-    fn from(value: IPresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPresentStatistics> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPresentStatistics> for ::windows::core::IUnknown {
-    fn from(value: &IPresentStatistics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPresentStatistics, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPresentStatistics {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -266,36 +194,7 @@ impl IPresentStatusPresentStatistics {
         (::windows::core::Vtable::vtable(self).GetPresentStatus)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IPresentStatusPresentStatistics> for ::windows::core::IUnknown {
-    fn from(value: IPresentStatusPresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPresentStatusPresentStatistics> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPresentStatusPresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPresentStatusPresentStatistics> for ::windows::core::IUnknown {
-    fn from(value: &IPresentStatusPresentStatistics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPresentStatusPresentStatistics> for IPresentStatistics {
-    fn from(value: IPresentStatusPresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPresentStatusPresentStatistics> for &'a IPresentStatistics {
-    fn from(value: &'a IPresentStatusPresentStatistics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPresentStatusPresentStatistics> for IPresentStatistics {
-    fn from(value: &IPresentStatusPresentStatistics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPresentStatusPresentStatistics, ::windows::core::IUnknown, IPresentStatistics);
 impl ::core::clone::Clone for IPresentStatusPresentStatistics {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -340,21 +239,7 @@ impl IPresentationBuffer {
         (::windows::core::Vtable::vtable(self).IsAvailable)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u8>(result__)
     }
 }
-impl ::core::convert::From<IPresentationBuffer> for ::windows::core::IUnknown {
-    fn from(value: IPresentationBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPresentationBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPresentationBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPresentationBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IPresentationBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPresentationBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPresentationBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -395,21 +280,7 @@ impl IPresentationContent {
         (::windows::core::Vtable::vtable(self).SetTag)(::windows::core::Vtable::as_raw(self), tag)
     }
 }
-impl ::core::convert::From<IPresentationContent> for ::windows::core::IUnknown {
-    fn from(value: IPresentationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPresentationContent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPresentationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPresentationContent> for ::windows::core::IUnknown {
-    fn from(value: &IPresentationContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPresentationContent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPresentationContent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -453,21 +324,7 @@ impl IPresentationFactory {
         (::windows::core::Vtable::vtable(self).CreatePresentationManager)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPresentationManager>(result__)
     }
 }
-impl ::core::convert::From<IPresentationFactory> for ::windows::core::IUnknown {
-    fn from(value: IPresentationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPresentationFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPresentationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPresentationFactory> for ::windows::core::IUnknown {
-    fn from(value: &IPresentationFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPresentationFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPresentationFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -560,21 +417,7 @@ impl IPresentationManager {
         (::windows::core::Vtable::vtable(self).GetNextPresentStatistics)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPresentStatistics>(result__)
     }
 }
-impl ::core::convert::From<IPresentationManager> for ::windows::core::IUnknown {
-    fn from(value: IPresentationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPresentationManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPresentationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPresentationManager> for ::windows::core::IUnknown {
-    fn from(value: &IPresentationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPresentationManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPresentationManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -668,36 +511,7 @@ impl IPresentationSurface {
         (::windows::core::Vtable::vtable(self).SetLetterboxingMargins)(::windows::core::Vtable::as_raw(self), leftletterboxsize, topletterboxsize, rightletterboxsize, bottomletterboxsize).ok()
     }
 }
-impl ::core::convert::From<IPresentationSurface> for ::windows::core::IUnknown {
-    fn from(value: IPresentationSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPresentationSurface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPresentationSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPresentationSurface> for ::windows::core::IUnknown {
-    fn from(value: &IPresentationSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPresentationSurface> for IPresentationContent {
-    fn from(value: IPresentationSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPresentationSurface> for &'a IPresentationContent {
-    fn from(value: &'a IPresentationSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPresentationSurface> for IPresentationContent {
-    fn from(value: &IPresentationSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPresentationSurface, ::windows::core::IUnknown, IPresentationContent);
 impl ::core::clone::Clone for IPresentationSurface {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
@@ -51,21 +51,7 @@ impl IDXCoreAdapter {
         (::windows::core::Vtable::vtable(self).GetFactory)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDXCoreAdapter> for ::windows::core::IUnknown {
-    fn from(value: IDXCoreAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXCoreAdapter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXCoreAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXCoreAdapter> for ::windows::core::IUnknown {
-    fn from(value: &IDXCoreAdapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXCoreAdapter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXCoreAdapter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -137,21 +123,7 @@ impl IDXCoreAdapterFactory {
         (::windows::core::Vtable::vtable(self).UnregisterEventNotification)(::windows::core::Vtable::as_raw(self), eventcookie).ok()
     }
 }
-impl ::core::convert::From<IDXCoreAdapterFactory> for ::windows::core::IUnknown {
-    fn from(value: IDXCoreAdapterFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXCoreAdapterFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXCoreAdapterFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXCoreAdapterFactory> for ::windows::core::IUnknown {
-    fn from(value: &IDXCoreAdapterFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXCoreAdapterFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXCoreAdapterFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -218,21 +190,7 @@ impl IDXCoreAdapterList {
         (::windows::core::Vtable::vtable(self).IsAdapterPreferenceSupported)(::windows::core::Vtable::as_raw(self), preference)
     }
 }
-impl ::core::convert::From<IDXCoreAdapterList> for ::windows::core::IUnknown {
-    fn from(value: IDXCoreAdapterList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXCoreAdapterList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXCoreAdapterList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXCoreAdapterList> for ::windows::core::IUnknown {
-    fn from(value: &IDXCoreAdapterList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXCoreAdapterList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXCoreAdapterList {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
@@ -24,21 +24,7 @@ impl ID2D1SimplifiedGeometrySink {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ID2D1SimplifiedGeometrySink> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SimplifiedGeometrySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SimplifiedGeometrySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SimplifiedGeometrySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SimplifiedGeometrySink> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SimplifiedGeometrySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SimplifiedGeometrySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1SimplifiedGeometrySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
@@ -163,21 +163,7 @@ impl ID2D1AnalysisTransform {
         (::windows::core::Vtable::vtable(self).ProcessAnalysisResults)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(analysisdata.as_ptr()), analysisdata.len() as _).ok()
     }
 }
-impl ::core::convert::From<ID2D1AnalysisTransform> for ::windows::core::IUnknown {
-    fn from(value: ID2D1AnalysisTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1AnalysisTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1AnalysisTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1AnalysisTransform> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1AnalysisTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1AnalysisTransform, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1AnalysisTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -261,51 +247,7 @@ impl ID2D1Bitmap {
         (::windows::core::Vtable::vtable(self).CopyFromMemory)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(dstrect.unwrap_or(::std::ptr::null())), ::core::mem::transmute(srcdata), pitch).ok()
     }
 }
-impl ::core::convert::From<ID2D1Bitmap> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Bitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Bitmap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Bitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Bitmap> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Bitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Bitmap> for ID2D1Resource {
-    fn from(value: ID2D1Bitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Bitmap> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Bitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Bitmap> for ID2D1Resource {
-    fn from(value: &ID2D1Bitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Bitmap> for ID2D1Image {
-    fn from(value: ID2D1Bitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Bitmap> for &'a ID2D1Image {
-    fn from(value: &'a ID2D1Bitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Bitmap> for ID2D1Image {
-    fn from(value: &ID2D1Bitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Bitmap, ::windows::core::IUnknown, ID2D1Resource, ID2D1Image);
 impl ::core::clone::Clone for ID2D1Bitmap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -432,66 +374,7 @@ impl ID2D1Bitmap1 {
         (::windows::core::Vtable::vtable(self).Unmap)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ID2D1Bitmap1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Bitmap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Bitmap1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Bitmap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Bitmap1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Bitmap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Bitmap1> for ID2D1Resource {
-    fn from(value: ID2D1Bitmap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Bitmap1> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Bitmap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Bitmap1> for ID2D1Resource {
-    fn from(value: &ID2D1Bitmap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Bitmap1> for ID2D1Image {
-    fn from(value: ID2D1Bitmap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Bitmap1> for &'a ID2D1Image {
-    fn from(value: &'a ID2D1Bitmap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Bitmap1> for ID2D1Image {
-    fn from(value: &ID2D1Bitmap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Bitmap1> for ID2D1Bitmap {
-    fn from(value: ID2D1Bitmap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Bitmap1> for &'a ID2D1Bitmap {
-    fn from(value: &'a ID2D1Bitmap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Bitmap1> for ID2D1Bitmap {
-    fn from(value: &ID2D1Bitmap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Bitmap1, ::windows::core::IUnknown, ID2D1Resource, ID2D1Image, ID2D1Bitmap);
 impl ::core::clone::Clone for ID2D1Bitmap1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -580,51 +463,7 @@ impl ID2D1BitmapBrush {
         (::windows::core::Vtable::vtable(self).GetBitmap)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(bitmap.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<ID2D1BitmapBrush> for ::windows::core::IUnknown {
-    fn from(value: ID2D1BitmapBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BitmapBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1BitmapBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BitmapBrush> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1BitmapBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BitmapBrush> for ID2D1Resource {
-    fn from(value: ID2D1BitmapBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BitmapBrush> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1BitmapBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BitmapBrush> for ID2D1Resource {
-    fn from(value: &ID2D1BitmapBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BitmapBrush> for ID2D1Brush {
-    fn from(value: ID2D1BitmapBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BitmapBrush> for &'a ID2D1Brush {
-    fn from(value: &'a ID2D1BitmapBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BitmapBrush> for ID2D1Brush {
-    fn from(value: &ID2D1BitmapBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1BitmapBrush, ::windows::core::IUnknown, ID2D1Resource, ID2D1Brush);
 impl ::core::clone::Clone for ID2D1BitmapBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -719,66 +558,7 @@ impl ID2D1BitmapBrush1 {
         (::windows::core::Vtable::vtable(self).GetInterpolationMode1)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1BitmapBrush1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1BitmapBrush1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BitmapBrush1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1BitmapBrush1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BitmapBrush1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1BitmapBrush1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BitmapBrush1> for ID2D1Resource {
-    fn from(value: ID2D1BitmapBrush1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BitmapBrush1> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1BitmapBrush1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BitmapBrush1> for ID2D1Resource {
-    fn from(value: &ID2D1BitmapBrush1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BitmapBrush1> for ID2D1Brush {
-    fn from(value: ID2D1BitmapBrush1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BitmapBrush1> for &'a ID2D1Brush {
-    fn from(value: &'a ID2D1BitmapBrush1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BitmapBrush1> for ID2D1Brush {
-    fn from(value: &ID2D1BitmapBrush1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BitmapBrush1> for ID2D1BitmapBrush {
-    fn from(value: ID2D1BitmapBrush1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BitmapBrush1> for &'a ID2D1BitmapBrush {
-    fn from(value: &'a ID2D1BitmapBrush1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BitmapBrush1> for ID2D1BitmapBrush {
-    fn from(value: &ID2D1BitmapBrush1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1BitmapBrush1, ::windows::core::IUnknown, ID2D1Resource, ID2D1Brush, ID2D1BitmapBrush);
 impl ::core::clone::Clone for ID2D1BitmapBrush1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1144,51 +924,7 @@ impl ID2D1BitmapRenderTarget {
         (::windows::core::Vtable::vtable(self).GetBitmap)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1Bitmap>(result__)
     }
 }
-impl ::core::convert::From<ID2D1BitmapRenderTarget> for ::windows::core::IUnknown {
-    fn from(value: ID2D1BitmapRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BitmapRenderTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1BitmapRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BitmapRenderTarget> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1BitmapRenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BitmapRenderTarget> for ID2D1Resource {
-    fn from(value: ID2D1BitmapRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BitmapRenderTarget> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1BitmapRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BitmapRenderTarget> for ID2D1Resource {
-    fn from(value: &ID2D1BitmapRenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BitmapRenderTarget> for ID2D1RenderTarget {
-    fn from(value: ID2D1BitmapRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BitmapRenderTarget> for &'a ID2D1RenderTarget {
-    fn from(value: &'a ID2D1BitmapRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BitmapRenderTarget> for ID2D1RenderTarget {
-    fn from(value: &ID2D1BitmapRenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1BitmapRenderTarget, ::windows::core::IUnknown, ID2D1Resource, ID2D1RenderTarget);
 impl ::core::clone::Clone for ID2D1BitmapRenderTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1244,51 +980,7 @@ impl ID2D1BlendTransform {
         (::windows::core::Vtable::vtable(self).GetDescription)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(description))
     }
 }
-impl ::core::convert::From<ID2D1BlendTransform> for ::windows::core::IUnknown {
-    fn from(value: ID2D1BlendTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BlendTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1BlendTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BlendTransform> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1BlendTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BlendTransform> for ID2D1TransformNode {
-    fn from(value: ID2D1BlendTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BlendTransform> for &'a ID2D1TransformNode {
-    fn from(value: &'a ID2D1BlendTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BlendTransform> for ID2D1TransformNode {
-    fn from(value: &ID2D1BlendTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BlendTransform> for ID2D1ConcreteTransform {
-    fn from(value: ID2D1BlendTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BlendTransform> for &'a ID2D1ConcreteTransform {
-    fn from(value: &'a ID2D1BlendTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BlendTransform> for ID2D1ConcreteTransform {
-    fn from(value: &ID2D1BlendTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1BlendTransform, ::windows::core::IUnknown, ID2D1TransformNode, ID2D1ConcreteTransform);
 impl ::core::clone::Clone for ID2D1BlendTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1351,51 +1043,7 @@ impl ID2D1BorderTransform {
         (::windows::core::Vtable::vtable(self).GetExtendModeY)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1BorderTransform> for ::windows::core::IUnknown {
-    fn from(value: ID2D1BorderTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BorderTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1BorderTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BorderTransform> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1BorderTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BorderTransform> for ID2D1TransformNode {
-    fn from(value: ID2D1BorderTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BorderTransform> for &'a ID2D1TransformNode {
-    fn from(value: &'a ID2D1BorderTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BorderTransform> for ID2D1TransformNode {
-    fn from(value: &ID2D1BorderTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BorderTransform> for ID2D1ConcreteTransform {
-    fn from(value: ID2D1BorderTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BorderTransform> for &'a ID2D1ConcreteTransform {
-    fn from(value: &'a ID2D1BorderTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BorderTransform> for ID2D1ConcreteTransform {
-    fn from(value: &ID2D1BorderTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1BorderTransform, ::windows::core::IUnknown, ID2D1TransformNode, ID2D1ConcreteTransform);
 impl ::core::clone::Clone for ID2D1BorderTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1447,36 +1095,7 @@ impl ID2D1BoundsAdjustmentTransform {
         (::windows::core::Vtable::vtable(self).GetOutputBounds)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(outputbounds))
     }
 }
-impl ::core::convert::From<ID2D1BoundsAdjustmentTransform> for ::windows::core::IUnknown {
-    fn from(value: ID2D1BoundsAdjustmentTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BoundsAdjustmentTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1BoundsAdjustmentTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BoundsAdjustmentTransform> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1BoundsAdjustmentTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1BoundsAdjustmentTransform> for ID2D1TransformNode {
-    fn from(value: ID2D1BoundsAdjustmentTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1BoundsAdjustmentTransform> for &'a ID2D1TransformNode {
-    fn from(value: &'a ID2D1BoundsAdjustmentTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1BoundsAdjustmentTransform> for ID2D1TransformNode {
-    fn from(value: &ID2D1BoundsAdjustmentTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1BoundsAdjustmentTransform, ::windows::core::IUnknown, ID2D1TransformNode);
 impl ::core::clone::Clone for ID2D1BoundsAdjustmentTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1538,36 +1157,7 @@ impl ID2D1Brush {
         (::windows::core::Vtable::vtable(self).GetTransform)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(transform))
     }
 }
-impl ::core::convert::From<ID2D1Brush> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Brush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Brush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Brush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Brush> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Brush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Brush> for ID2D1Resource {
-    fn from(value: ID2D1Brush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Brush> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Brush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Brush> for ID2D1Resource {
-    fn from(value: &ID2D1Brush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Brush, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1Brush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1624,36 +1214,7 @@ impl ID2D1ColorContext {
         (::windows::core::Vtable::vtable(self).GetProfile)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(profile.as_ptr()), profile.len() as _).ok()
     }
 }
-impl ::core::convert::From<ID2D1ColorContext> for ::windows::core::IUnknown {
-    fn from(value: ID2D1ColorContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ColorContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1ColorContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ColorContext> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1ColorContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ColorContext> for ID2D1Resource {
-    fn from(value: ID2D1ColorContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ColorContext> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1ColorContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ColorContext> for ID2D1Resource {
-    fn from(value: &ID2D1ColorContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1ColorContext, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1ColorContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1717,51 +1278,7 @@ impl ID2D1ColorContext1 {
         (::windows::core::Vtable::vtable(self).GetSimpleColorProfile)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<D2D1_SIMPLE_COLOR_PROFILE>(result__)
     }
 }
-impl ::core::convert::From<ID2D1ColorContext1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1ColorContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ColorContext1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1ColorContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ColorContext1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1ColorContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ColorContext1> for ID2D1Resource {
-    fn from(value: ID2D1ColorContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ColorContext1> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1ColorContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ColorContext1> for ID2D1Resource {
-    fn from(value: &ID2D1ColorContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ColorContext1> for ID2D1ColorContext {
-    fn from(value: ID2D1ColorContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ColorContext1> for &'a ID2D1ColorContext {
-    fn from(value: &'a ID2D1ColorContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ColorContext1> for ID2D1ColorContext {
-    fn from(value: &ID2D1ColorContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1ColorContext1, ::windows::core::IUnknown, ID2D1Resource, ID2D1ColorContext);
 impl ::core::clone::Clone for ID2D1ColorContext1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1817,51 +1334,7 @@ impl ID2D1CommandList {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ID2D1CommandList> for ::windows::core::IUnknown {
-    fn from(value: ID2D1CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandList> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1CommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandList> for ID2D1Resource {
-    fn from(value: ID2D1CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandList> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandList> for ID2D1Resource {
-    fn from(value: &ID2D1CommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandList> for ID2D1Image {
-    fn from(value: ID2D1CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandList> for &'a ID2D1Image {
-    fn from(value: &'a ID2D1CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandList> for ID2D1Image {
-    fn from(value: &ID2D1CommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1CommandList, ::windows::core::IUnknown, ID2D1Resource, ID2D1Image);
 impl ::core::clone::Clone for ID2D1CommandList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2046,21 +1519,7 @@ impl ID2D1CommandSink {
         (::windows::core::Vtable::vtable(self).PopLayer)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ID2D1CommandSink> for ::windows::core::IUnknown {
-    fn from(value: ID2D1CommandSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1CommandSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1CommandSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1CommandSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1CommandSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2310,36 +1769,7 @@ impl ID2D1CommandSink1 {
         (::windows::core::Vtable::vtable(self).SetPrimitiveBlend1)(::windows::core::Vtable::as_raw(self), primitiveblend).ok()
     }
 }
-impl ::core::convert::From<ID2D1CommandSink1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1CommandSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1CommandSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1CommandSink1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink1> for ID2D1CommandSink {
-    fn from(value: ID2D1CommandSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink1> for &'a ID2D1CommandSink {
-    fn from(value: &'a ID2D1CommandSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink1> for ID2D1CommandSink {
-    fn from(value: &ID2D1CommandSink1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1CommandSink1, ::windows::core::IUnknown, ID2D1CommandSink);
 impl ::core::clone::Clone for ID2D1CommandSink1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2548,51 +1978,7 @@ impl ID2D1CommandSink2 {
         (::windows::core::Vtable::vtable(self).DrawGdiMetafile2)(::windows::core::Vtable::as_raw(self), gdimetafile.into().abi(), ::core::mem::transmute(destinationrectangle.unwrap_or(::std::ptr::null())), ::core::mem::transmute(sourcerectangle.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<ID2D1CommandSink2> for ::windows::core::IUnknown {
-    fn from(value: ID2D1CommandSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1CommandSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink2> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1CommandSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink2> for ID2D1CommandSink {
-    fn from(value: ID2D1CommandSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink2> for &'a ID2D1CommandSink {
-    fn from(value: &'a ID2D1CommandSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink2> for ID2D1CommandSink {
-    fn from(value: &ID2D1CommandSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink2> for ID2D1CommandSink1 {
-    fn from(value: ID2D1CommandSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink2> for &'a ID2D1CommandSink1 {
-    fn from(value: &'a ID2D1CommandSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink2> for ID2D1CommandSink1 {
-    fn from(value: &ID2D1CommandSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1CommandSink2, ::windows::core::IUnknown, ID2D1CommandSink, ID2D1CommandSink1);
 impl ::core::clone::Clone for ID2D1CommandSink2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2813,66 +2199,7 @@ impl ID2D1CommandSink3 {
         (::windows::core::Vtable::vtable(self).DrawSpriteBatch)(::windows::core::Vtable::as_raw(self), spritebatch.into().abi(), startindex, spritecount, bitmap.into().abi(), interpolationmode, spriteoptions).ok()
     }
 }
-impl ::core::convert::From<ID2D1CommandSink3> for ::windows::core::IUnknown {
-    fn from(value: ID2D1CommandSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1CommandSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink3> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1CommandSink3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink3> for ID2D1CommandSink {
-    fn from(value: ID2D1CommandSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink3> for &'a ID2D1CommandSink {
-    fn from(value: &'a ID2D1CommandSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink3> for ID2D1CommandSink {
-    fn from(value: &ID2D1CommandSink3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink3> for ID2D1CommandSink1 {
-    fn from(value: ID2D1CommandSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink3> for &'a ID2D1CommandSink1 {
-    fn from(value: &'a ID2D1CommandSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink3> for ID2D1CommandSink1 {
-    fn from(value: &ID2D1CommandSink3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink3> for ID2D1CommandSink2 {
-    fn from(value: ID2D1CommandSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink3> for &'a ID2D1CommandSink2 {
-    fn from(value: &'a ID2D1CommandSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink3> for ID2D1CommandSink2 {
-    fn from(value: &ID2D1CommandSink3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1CommandSink3, ::windows::core::IUnknown, ID2D1CommandSink, ID2D1CommandSink1, ID2D1CommandSink2);
 impl ::core::clone::Clone for ID2D1CommandSink3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3091,81 +2418,7 @@ impl ID2D1CommandSink4 {
         (::windows::core::Vtable::vtable(self).SetPrimitiveBlend2)(::windows::core::Vtable::as_raw(self), primitiveblend).ok()
     }
 }
-impl ::core::convert::From<ID2D1CommandSink4> for ::windows::core::IUnknown {
-    fn from(value: ID2D1CommandSink4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1CommandSink4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink4> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1CommandSink4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink4> for ID2D1CommandSink {
-    fn from(value: ID2D1CommandSink4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink4> for &'a ID2D1CommandSink {
-    fn from(value: &'a ID2D1CommandSink4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink4> for ID2D1CommandSink {
-    fn from(value: &ID2D1CommandSink4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink4> for ID2D1CommandSink1 {
-    fn from(value: ID2D1CommandSink4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink4> for &'a ID2D1CommandSink1 {
-    fn from(value: &'a ID2D1CommandSink4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink4> for ID2D1CommandSink1 {
-    fn from(value: &ID2D1CommandSink4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink4> for ID2D1CommandSink2 {
-    fn from(value: ID2D1CommandSink4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink4> for &'a ID2D1CommandSink2 {
-    fn from(value: &'a ID2D1CommandSink4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink4> for ID2D1CommandSink2 {
-    fn from(value: &ID2D1CommandSink4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink4> for ID2D1CommandSink3 {
-    fn from(value: ID2D1CommandSink4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink4> for &'a ID2D1CommandSink3 {
-    fn from(value: &'a ID2D1CommandSink4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink4> for ID2D1CommandSink3 {
-    fn from(value: &ID2D1CommandSink4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1CommandSink4, ::windows::core::IUnknown, ID2D1CommandSink, ID2D1CommandSink1, ID2D1CommandSink2, ID2D1CommandSink3);
 impl ::core::clone::Clone for ID2D1CommandSink4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3392,96 +2645,7 @@ impl ID2D1CommandSink5 {
         (::windows::core::Vtable::vtable(self).BlendImage)(::windows::core::Vtable::as_raw(self), image.into().abi(), blendmode, ::core::mem::transmute(targetoffset.unwrap_or(::std::ptr::null())), ::core::mem::transmute(imagerectangle.unwrap_or(::std::ptr::null())), interpolationmode).ok()
     }
 }
-impl ::core::convert::From<ID2D1CommandSink5> for ::windows::core::IUnknown {
-    fn from(value: ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink5> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1CommandSink5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink5> for ID2D1CommandSink {
-    fn from(value: ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink5> for &'a ID2D1CommandSink {
-    fn from(value: &'a ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink5> for ID2D1CommandSink {
-    fn from(value: &ID2D1CommandSink5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink5> for ID2D1CommandSink1 {
-    fn from(value: ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink5> for &'a ID2D1CommandSink1 {
-    fn from(value: &'a ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink5> for ID2D1CommandSink1 {
-    fn from(value: &ID2D1CommandSink5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink5> for ID2D1CommandSink2 {
-    fn from(value: ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink5> for &'a ID2D1CommandSink2 {
-    fn from(value: &'a ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink5> for ID2D1CommandSink2 {
-    fn from(value: &ID2D1CommandSink5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink5> for ID2D1CommandSink3 {
-    fn from(value: ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink5> for &'a ID2D1CommandSink3 {
-    fn from(value: &'a ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink5> for ID2D1CommandSink3 {
-    fn from(value: &ID2D1CommandSink5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1CommandSink5> for ID2D1CommandSink4 {
-    fn from(value: ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1CommandSink5> for &'a ID2D1CommandSink4 {
-    fn from(value: &'a ID2D1CommandSink5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1CommandSink5> for ID2D1CommandSink4 {
-    fn from(value: &ID2D1CommandSink5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1CommandSink5, ::windows::core::IUnknown, ID2D1CommandSink, ID2D1CommandSink1, ID2D1CommandSink2, ID2D1CommandSink3, ID2D1CommandSink4);
 impl ::core::clone::Clone for ID2D1CommandSink5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3549,36 +2713,7 @@ impl ID2D1ComputeInfo {
         (::windows::core::Vtable::vtable(self).SetResourceTexture)(::windows::core::Vtable::as_raw(self), textureindex, resourcetexture.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID2D1ComputeInfo> for ::windows::core::IUnknown {
-    fn from(value: ID2D1ComputeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ComputeInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1ComputeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ComputeInfo> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1ComputeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ComputeInfo> for ID2D1RenderInfo {
-    fn from(value: ID2D1ComputeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ComputeInfo> for &'a ID2D1RenderInfo {
-    fn from(value: &'a ID2D1ComputeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ComputeInfo> for ID2D1RenderInfo {
-    fn from(value: &ID2D1ComputeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1ComputeInfo, ::windows::core::IUnknown, ID2D1RenderInfo);
 impl ::core::clone::Clone for ID2D1ComputeInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3646,51 +2781,7 @@ impl ID2D1ComputeTransform {
         (::windows::core::Vtable::vtable(self).CalculateThreadgroups)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(outputrect), ::core::mem::transmute(dimensionx), ::core::mem::transmute(dimensiony), ::core::mem::transmute(dimensionz)).ok()
     }
 }
-impl ::core::convert::From<ID2D1ComputeTransform> for ::windows::core::IUnknown {
-    fn from(value: ID2D1ComputeTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ComputeTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1ComputeTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ComputeTransform> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1ComputeTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ComputeTransform> for ID2D1TransformNode {
-    fn from(value: ID2D1ComputeTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ComputeTransform> for &'a ID2D1TransformNode {
-    fn from(value: &'a ID2D1ComputeTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ComputeTransform> for ID2D1TransformNode {
-    fn from(value: &ID2D1ComputeTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ComputeTransform> for ID2D1Transform {
-    fn from(value: ID2D1ComputeTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ComputeTransform> for &'a ID2D1Transform {
-    fn from(value: &'a ID2D1ComputeTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ComputeTransform> for ID2D1Transform {
-    fn from(value: &ID2D1ComputeTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1ComputeTransform, ::windows::core::IUnknown, ID2D1TransformNode, ID2D1Transform);
 impl ::core::clone::Clone for ID2D1ComputeTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3744,36 +2835,7 @@ impl ID2D1ConcreteTransform {
         (::windows::core::Vtable::vtable(self).SetCached)(::windows::core::Vtable::as_raw(self), iscached.into())
     }
 }
-impl ::core::convert::From<ID2D1ConcreteTransform> for ::windows::core::IUnknown {
-    fn from(value: ID2D1ConcreteTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ConcreteTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1ConcreteTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ConcreteTransform> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1ConcreteTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ConcreteTransform> for ID2D1TransformNode {
-    fn from(value: ID2D1ConcreteTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ConcreteTransform> for &'a ID2D1TransformNode {
-    fn from(value: &'a ID2D1ConcreteTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ConcreteTransform> for ID2D1TransformNode {
-    fn from(value: &ID2D1ConcreteTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1ConcreteTransform, ::windows::core::IUnknown, ID2D1TransformNode);
 impl ::core::clone::Clone for ID2D1ConcreteTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4146,51 +3208,7 @@ impl ID2D1DCRenderTarget {
         (::windows::core::Vtable::vtable(self).BindDC)(::windows::core::Vtable::as_raw(self), hdc.into(), ::core::mem::transmute(psubrect)).ok()
     }
 }
-impl ::core::convert::From<ID2D1DCRenderTarget> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DCRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DCRenderTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DCRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DCRenderTarget> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DCRenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DCRenderTarget> for ID2D1Resource {
-    fn from(value: ID2D1DCRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DCRenderTarget> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1DCRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DCRenderTarget> for ID2D1Resource {
-    fn from(value: &ID2D1DCRenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DCRenderTarget> for ID2D1RenderTarget {
-    fn from(value: ID2D1DCRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DCRenderTarget> for &'a ID2D1RenderTarget {
-    fn from(value: &'a ID2D1DCRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DCRenderTarget> for ID2D1RenderTarget {
-    fn from(value: &ID2D1DCRenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DCRenderTarget, ::windows::core::IUnknown, ID2D1Resource, ID2D1RenderTarget);
 impl ::core::clone::Clone for ID2D1DCRenderTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4255,36 +3273,7 @@ impl ID2D1Device {
         (::windows::core::Vtable::vtable(self).ClearResources)(::windows::core::Vtable::as_raw(self), millisecondssinceuse)
     }
 }
-impl ::core::convert::From<ID2D1Device> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Device) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device> for ID2D1Resource {
-    fn from(value: ID2D1Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device> for ID2D1Resource {
-    fn from(value: &ID2D1Device) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Device, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1Device {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4363,51 +3352,7 @@ impl ID2D1Device1 {
         (::windows::core::Vtable::vtable(self).CreateDeviceContext2)(::windows::core::Vtable::as_raw(self), options, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1DeviceContext1>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Device1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device1> for ID2D1Resource {
-    fn from(value: ID2D1Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device1> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device1> for ID2D1Resource {
-    fn from(value: &ID2D1Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device1> for ID2D1Device {
-    fn from(value: ID2D1Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device1> for &'a ID2D1Device {
-    fn from(value: &'a ID2D1Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device1> for ID2D1Device {
-    fn from(value: &ID2D1Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Device1, ::windows::core::IUnknown, ID2D1Resource, ID2D1Device);
 impl ::core::clone::Clone for ID2D1Device1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4497,66 +3442,7 @@ impl ID2D1Device2 {
         (::windows::core::Vtable::vtable(self).GetDxgiDevice)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Dxgi::IDXGIDevice>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Device2> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device2> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device2> for ID2D1Resource {
-    fn from(value: ID2D1Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device2> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device2> for ID2D1Resource {
-    fn from(value: &ID2D1Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device2> for ID2D1Device {
-    fn from(value: ID2D1Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device2> for &'a ID2D1Device {
-    fn from(value: &'a ID2D1Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device2> for ID2D1Device {
-    fn from(value: &ID2D1Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device2> for ID2D1Device1 {
-    fn from(value: ID2D1Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device2> for &'a ID2D1Device1 {
-    fn from(value: &'a ID2D1Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device2> for ID2D1Device1 {
-    fn from(value: &ID2D1Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Device2, ::windows::core::IUnknown, ID2D1Resource, ID2D1Device, ID2D1Device1);
 impl ::core::clone::Clone for ID2D1Device2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4653,81 +3539,7 @@ impl ID2D1Device3 {
         (::windows::core::Vtable::vtable(self).CreateDeviceContext4)(::windows::core::Vtable::as_raw(self), options, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1DeviceContext3>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Device3> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device3> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device3> for ID2D1Resource {
-    fn from(value: ID2D1Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device3> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device3> for ID2D1Resource {
-    fn from(value: &ID2D1Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device3> for ID2D1Device {
-    fn from(value: ID2D1Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device3> for &'a ID2D1Device {
-    fn from(value: &'a ID2D1Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device3> for ID2D1Device {
-    fn from(value: &ID2D1Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device3> for ID2D1Device1 {
-    fn from(value: ID2D1Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device3> for &'a ID2D1Device1 {
-    fn from(value: &'a ID2D1Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device3> for ID2D1Device1 {
-    fn from(value: &ID2D1Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device3> for ID2D1Device2 {
-    fn from(value: ID2D1Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device3> for &'a ID2D1Device2 {
-    fn from(value: &'a ID2D1Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device3> for ID2D1Device2 {
-    fn from(value: &ID2D1Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Device3, ::windows::core::IUnknown, ID2D1Resource, ID2D1Device, ID2D1Device1, ID2D1Device2);
 impl ::core::clone::Clone for ID2D1Device3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4829,96 +3641,7 @@ impl ID2D1Device4 {
         (::windows::core::Vtable::vtable(self).GetMaximumColorGlyphCacheMemory)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1Device4> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device4> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device4> for ID2D1Resource {
-    fn from(value: ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device4> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device4> for ID2D1Resource {
-    fn from(value: &ID2D1Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device4> for ID2D1Device {
-    fn from(value: ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device4> for &'a ID2D1Device {
-    fn from(value: &'a ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device4> for ID2D1Device {
-    fn from(value: &ID2D1Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device4> for ID2D1Device1 {
-    fn from(value: ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device4> for &'a ID2D1Device1 {
-    fn from(value: &'a ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device4> for ID2D1Device1 {
-    fn from(value: &ID2D1Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device4> for ID2D1Device2 {
-    fn from(value: ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device4> for &'a ID2D1Device2 {
-    fn from(value: &'a ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device4> for ID2D1Device2 {
-    fn from(value: &ID2D1Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device4> for ID2D1Device3 {
-    fn from(value: ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device4> for &'a ID2D1Device3 {
-    fn from(value: &'a ID2D1Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device4> for ID2D1Device3 {
-    fn from(value: &ID2D1Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Device4, ::windows::core::IUnknown, ID2D1Resource, ID2D1Device, ID2D1Device1, ID2D1Device2, ID2D1Device3);
 impl ::core::clone::Clone for ID2D1Device4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5026,111 +3749,7 @@ impl ID2D1Device5 {
         (::windows::core::Vtable::vtable(self).CreateDeviceContext6)(::windows::core::Vtable::as_raw(self), options, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1DeviceContext5>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Device5> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device5> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device5> for ID2D1Resource {
-    fn from(value: ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device5> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device5> for ID2D1Resource {
-    fn from(value: &ID2D1Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device5> for ID2D1Device {
-    fn from(value: ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device5> for &'a ID2D1Device {
-    fn from(value: &'a ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device5> for ID2D1Device {
-    fn from(value: &ID2D1Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device5> for ID2D1Device1 {
-    fn from(value: ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device5> for &'a ID2D1Device1 {
-    fn from(value: &'a ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device5> for ID2D1Device1 {
-    fn from(value: &ID2D1Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device5> for ID2D1Device2 {
-    fn from(value: ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device5> for &'a ID2D1Device2 {
-    fn from(value: &'a ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device5> for ID2D1Device2 {
-    fn from(value: &ID2D1Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device5> for ID2D1Device3 {
-    fn from(value: ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device5> for &'a ID2D1Device3 {
-    fn from(value: &'a ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device5> for ID2D1Device3 {
-    fn from(value: &ID2D1Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device5> for ID2D1Device4 {
-    fn from(value: ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device5> for &'a ID2D1Device4 {
-    fn from(value: &'a ID2D1Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device5> for ID2D1Device4 {
-    fn from(value: &ID2D1Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Device5, ::windows::core::IUnknown, ID2D1Resource, ID2D1Device, ID2D1Device1, ID2D1Device2, ID2D1Device3, ID2D1Device4);
 impl ::core::clone::Clone for ID2D1Device5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5240,126 +3859,7 @@ impl ID2D1Device6 {
         (::windows::core::Vtable::vtable(self).CreateDeviceContext7)(::windows::core::Vtable::as_raw(self), options, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1DeviceContext6>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Device6> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device6> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device6> for ID2D1Resource {
-    fn from(value: ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device6> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device6> for ID2D1Resource {
-    fn from(value: &ID2D1Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device6> for ID2D1Device {
-    fn from(value: ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device6> for &'a ID2D1Device {
-    fn from(value: &'a ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device6> for ID2D1Device {
-    fn from(value: &ID2D1Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device6> for ID2D1Device1 {
-    fn from(value: ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device6> for &'a ID2D1Device1 {
-    fn from(value: &'a ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device6> for ID2D1Device1 {
-    fn from(value: &ID2D1Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device6> for ID2D1Device2 {
-    fn from(value: ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device6> for &'a ID2D1Device2 {
-    fn from(value: &'a ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device6> for ID2D1Device2 {
-    fn from(value: &ID2D1Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device6> for ID2D1Device3 {
-    fn from(value: ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device6> for &'a ID2D1Device3 {
-    fn from(value: &'a ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device6> for ID2D1Device3 {
-    fn from(value: &ID2D1Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device6> for ID2D1Device4 {
-    fn from(value: ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device6> for &'a ID2D1Device4 {
-    fn from(value: &'a ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device6> for ID2D1Device4 {
-    fn from(value: &ID2D1Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Device6> for ID2D1Device5 {
-    fn from(value: ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Device6> for &'a ID2D1Device5 {
-    fn from(value: &'a ID2D1Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Device6> for ID2D1Device5 {
-    fn from(value: &ID2D1Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Device6, ::windows::core::IUnknown, ID2D1Resource, ID2D1Device, ID2D1Device1, ID2D1Device2, ID2D1Device3, ID2D1Device4, ID2D1Device5);
 impl ::core::clone::Clone for ID2D1Device6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5944,51 +4444,7 @@ impl ID2D1DeviceContext {
         (::windows::core::Vtable::vtable(self).FillOpacityMask2)(::windows::core::Vtable::as_raw(self), opacitymask.into().abi(), brush.into().abi(), ::core::mem::transmute(destinationrectangle.unwrap_or(::std::ptr::null())), ::core::mem::transmute(sourcerectangle.unwrap_or(::std::ptr::null())))
     }
 }
-impl ::core::convert::From<ID2D1DeviceContext> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DeviceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DeviceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DeviceContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext> for ID2D1Resource {
-    fn from(value: ID2D1DeviceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1DeviceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext> for ID2D1Resource {
-    fn from(value: &ID2D1DeviceContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext> for ID2D1RenderTarget {
-    fn from(value: ID2D1DeviceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext> for &'a ID2D1RenderTarget {
-    fn from(value: &'a ID2D1DeviceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext> for ID2D1RenderTarget {
-    fn from(value: &ID2D1DeviceContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DeviceContext, ::windows::core::IUnknown, ID2D1Resource, ID2D1RenderTarget);
 impl ::core::clone::Clone for ID2D1DeviceContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6698,66 +5154,7 @@ impl ID2D1DeviceContext1 {
         (::windows::core::Vtable::vtable(self).DrawGeometryRealization)(::windows::core::Vtable::as_raw(self), geometryrealization.into().abi(), brush.into().abi())
     }
 }
-impl ::core::convert::From<ID2D1DeviceContext1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DeviceContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext1> for ID2D1Resource {
-    fn from(value: ID2D1DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext1> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext1> for ID2D1Resource {
-    fn from(value: &ID2D1DeviceContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext1> for ID2D1RenderTarget {
-    fn from(value: ID2D1DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext1> for &'a ID2D1RenderTarget {
-    fn from(value: &'a ID2D1DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext1> for ID2D1RenderTarget {
-    fn from(value: &ID2D1DeviceContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext1> for ID2D1DeviceContext {
-    fn from(value: ID2D1DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext1> for &'a ID2D1DeviceContext {
-    fn from(value: &'a ID2D1DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext1> for ID2D1DeviceContext {
-    fn from(value: &ID2D1DeviceContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DeviceContext1, ::windows::core::IUnknown, ID2D1Resource, ID2D1RenderTarget, ID2D1DeviceContext);
 impl ::core::clone::Clone for ID2D1DeviceContext1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7439,81 +5836,7 @@ impl ID2D1DeviceContext2 {
         (::windows::core::Vtable::vtable(self).CreateTransformedImageSource)(::windows::core::Vtable::as_raw(self), imagesource.into().abi(), ::core::mem::transmute(properties), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1TransformedImageSource>(result__)
     }
 }
-impl ::core::convert::From<ID2D1DeviceContext2> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext2> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DeviceContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext2> for ID2D1Resource {
-    fn from(value: ID2D1DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext2> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext2> for ID2D1Resource {
-    fn from(value: &ID2D1DeviceContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext2> for ID2D1RenderTarget {
-    fn from(value: ID2D1DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext2> for &'a ID2D1RenderTarget {
-    fn from(value: &'a ID2D1DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext2> for ID2D1RenderTarget {
-    fn from(value: &ID2D1DeviceContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext2> for ID2D1DeviceContext {
-    fn from(value: ID2D1DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext2> for &'a ID2D1DeviceContext {
-    fn from(value: &'a ID2D1DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext2> for ID2D1DeviceContext {
-    fn from(value: &ID2D1DeviceContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext2> for ID2D1DeviceContext1 {
-    fn from(value: ID2D1DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext2> for &'a ID2D1DeviceContext1 {
-    fn from(value: &'a ID2D1DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext2> for ID2D1DeviceContext1 {
-    fn from(value: &ID2D1DeviceContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DeviceContext2, ::windows::core::IUnknown, ID2D1Resource, ID2D1RenderTarget, ID2D1DeviceContext, ID2D1DeviceContext1);
 impl ::core::clone::Clone for ID2D1DeviceContext2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8232,96 +6555,7 @@ impl ID2D1DeviceContext3 {
         (::windows::core::Vtable::vtable(self).DrawSpriteBatch)(::windows::core::Vtable::as_raw(self), spritebatch.into().abi(), startindex, spritecount, bitmap.into().abi(), interpolationmode, spriteoptions)
     }
 }
-impl ::core::convert::From<ID2D1DeviceContext3> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext3> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DeviceContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext3> for ID2D1Resource {
-    fn from(value: ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext3> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext3> for ID2D1Resource {
-    fn from(value: &ID2D1DeviceContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext3> for ID2D1RenderTarget {
-    fn from(value: ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext3> for &'a ID2D1RenderTarget {
-    fn from(value: &'a ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext3> for ID2D1RenderTarget {
-    fn from(value: &ID2D1DeviceContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext3> for ID2D1DeviceContext {
-    fn from(value: ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext3> for &'a ID2D1DeviceContext {
-    fn from(value: &'a ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext3> for ID2D1DeviceContext {
-    fn from(value: &ID2D1DeviceContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext3> for ID2D1DeviceContext1 {
-    fn from(value: ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext3> for &'a ID2D1DeviceContext1 {
-    fn from(value: &'a ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext3> for ID2D1DeviceContext1 {
-    fn from(value: &ID2D1DeviceContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext3> for ID2D1DeviceContext2 {
-    fn from(value: ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext3> for &'a ID2D1DeviceContext2 {
-    fn from(value: &'a ID2D1DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext3> for ID2D1DeviceContext2 {
-    fn from(value: &ID2D1DeviceContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DeviceContext3, ::windows::core::IUnknown, ID2D1Resource, ID2D1RenderTarget, ID2D1DeviceContext, ID2D1DeviceContext1, ID2D1DeviceContext2);
 impl ::core::clone::Clone for ID2D1DeviceContext3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9071,111 +7305,7 @@ impl ID2D1DeviceContext4 {
         (::windows::core::Vtable::vtable(self).GetSvgGlyphImage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(glyphorigin), fontface.into().abi(), fontemsize, glyphindex, issideways.into(), ::core::mem::transmute(worldtransform.unwrap_or(::std::ptr::null())), defaultfillbrush.into().abi(), svgglyphstyle.into().abi(), colorpaletteindex, ::core::mem::transmute(glyphtransform), ::core::mem::transmute(glyphimage)).ok()
     }
 }
-impl ::core::convert::From<ID2D1DeviceContext4> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext4> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext4> for ID2D1Resource {
-    fn from(value: ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext4> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext4> for ID2D1Resource {
-    fn from(value: &ID2D1DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext4> for ID2D1RenderTarget {
-    fn from(value: ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext4> for &'a ID2D1RenderTarget {
-    fn from(value: &'a ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext4> for ID2D1RenderTarget {
-    fn from(value: &ID2D1DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext4> for ID2D1DeviceContext {
-    fn from(value: ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext4> for &'a ID2D1DeviceContext {
-    fn from(value: &'a ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext4> for ID2D1DeviceContext {
-    fn from(value: &ID2D1DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext4> for ID2D1DeviceContext1 {
-    fn from(value: ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext4> for &'a ID2D1DeviceContext1 {
-    fn from(value: &'a ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext4> for ID2D1DeviceContext1 {
-    fn from(value: &ID2D1DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext4> for ID2D1DeviceContext2 {
-    fn from(value: ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext4> for &'a ID2D1DeviceContext2 {
-    fn from(value: &'a ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext4> for ID2D1DeviceContext2 {
-    fn from(value: &ID2D1DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext4> for ID2D1DeviceContext3 {
-    fn from(value: ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext4> for &'a ID2D1DeviceContext3 {
-    fn from(value: &'a ID2D1DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext4> for ID2D1DeviceContext3 {
-    fn from(value: &ID2D1DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DeviceContext4, ::windows::core::IUnknown, ID2D1Resource, ID2D1RenderTarget, ID2D1DeviceContext, ID2D1DeviceContext1, ID2D1DeviceContext2, ID2D1DeviceContext3);
 impl ::core::clone::Clone for ID2D1DeviceContext4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9975,126 +8105,7 @@ impl ID2D1DeviceContext5 {
         (::windows::core::Vtable::vtable(self).CreateColorContextFromSimpleColorProfile)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(simpleprofile), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1ColorContext1>(result__)
     }
 }
-impl ::core::convert::From<ID2D1DeviceContext5> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext5> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DeviceContext5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext5> for ID2D1Resource {
-    fn from(value: ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext5> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext5> for ID2D1Resource {
-    fn from(value: &ID2D1DeviceContext5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext5> for ID2D1RenderTarget {
-    fn from(value: ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext5> for &'a ID2D1RenderTarget {
-    fn from(value: &'a ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext5> for ID2D1RenderTarget {
-    fn from(value: &ID2D1DeviceContext5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext5> for ID2D1DeviceContext {
-    fn from(value: ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext5> for &'a ID2D1DeviceContext {
-    fn from(value: &'a ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext5> for ID2D1DeviceContext {
-    fn from(value: &ID2D1DeviceContext5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext5> for ID2D1DeviceContext1 {
-    fn from(value: ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext5> for &'a ID2D1DeviceContext1 {
-    fn from(value: &'a ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext5> for ID2D1DeviceContext1 {
-    fn from(value: &ID2D1DeviceContext5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext5> for ID2D1DeviceContext2 {
-    fn from(value: ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext5> for &'a ID2D1DeviceContext2 {
-    fn from(value: &'a ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext5> for ID2D1DeviceContext2 {
-    fn from(value: &ID2D1DeviceContext5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext5> for ID2D1DeviceContext3 {
-    fn from(value: ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext5> for &'a ID2D1DeviceContext3 {
-    fn from(value: &'a ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext5> for ID2D1DeviceContext3 {
-    fn from(value: &ID2D1DeviceContext5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext5> for ID2D1DeviceContext4 {
-    fn from(value: ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext5> for &'a ID2D1DeviceContext4 {
-    fn from(value: &'a ID2D1DeviceContext5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext5> for ID2D1DeviceContext4 {
-    fn from(value: &ID2D1DeviceContext5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DeviceContext5, ::windows::core::IUnknown, ID2D1Resource, ID2D1RenderTarget, ID2D1DeviceContext, ID2D1DeviceContext1, ID2D1DeviceContext2, ID2D1DeviceContext3, ID2D1DeviceContext4);
 impl ::core::clone::Clone for ID2D1DeviceContext5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10890,141 +8901,7 @@ impl ID2D1DeviceContext6 {
         (::windows::core::Vtable::vtable(self).BlendImage)(::windows::core::Vtable::as_raw(self), image.into().abi(), blendmode, ::core::mem::transmute(targetoffset.unwrap_or(::std::ptr::null())), ::core::mem::transmute(imagerectangle.unwrap_or(::std::ptr::null())), interpolationmode)
     }
 }
-impl ::core::convert::From<ID2D1DeviceContext6> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext6> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DeviceContext6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext6> for ID2D1Resource {
-    fn from(value: ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext6> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext6> for ID2D1Resource {
-    fn from(value: &ID2D1DeviceContext6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext6> for ID2D1RenderTarget {
-    fn from(value: ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext6> for &'a ID2D1RenderTarget {
-    fn from(value: &'a ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext6> for ID2D1RenderTarget {
-    fn from(value: &ID2D1DeviceContext6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext6> for ID2D1DeviceContext {
-    fn from(value: ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext6> for &'a ID2D1DeviceContext {
-    fn from(value: &'a ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext6> for ID2D1DeviceContext {
-    fn from(value: &ID2D1DeviceContext6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext6> for ID2D1DeviceContext1 {
-    fn from(value: ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext6> for &'a ID2D1DeviceContext1 {
-    fn from(value: &'a ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext6> for ID2D1DeviceContext1 {
-    fn from(value: &ID2D1DeviceContext6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext6> for ID2D1DeviceContext2 {
-    fn from(value: ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext6> for &'a ID2D1DeviceContext2 {
-    fn from(value: &'a ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext6> for ID2D1DeviceContext2 {
-    fn from(value: &ID2D1DeviceContext6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext6> for ID2D1DeviceContext3 {
-    fn from(value: ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext6> for &'a ID2D1DeviceContext3 {
-    fn from(value: &'a ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext6> for ID2D1DeviceContext3 {
-    fn from(value: &ID2D1DeviceContext6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext6> for ID2D1DeviceContext4 {
-    fn from(value: ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext6> for &'a ID2D1DeviceContext4 {
-    fn from(value: &'a ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext6> for ID2D1DeviceContext4 {
-    fn from(value: &ID2D1DeviceContext6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DeviceContext6> for ID2D1DeviceContext5 {
-    fn from(value: ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DeviceContext6> for &'a ID2D1DeviceContext5 {
-    fn from(value: &'a ID2D1DeviceContext6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DeviceContext6> for ID2D1DeviceContext5 {
-    fn from(value: &ID2D1DeviceContext6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DeviceContext6, ::windows::core::IUnknown, ID2D1Resource, ID2D1RenderTarget, ID2D1DeviceContext, ID2D1DeviceContext1, ID2D1DeviceContext2, ID2D1DeviceContext3, ID2D1DeviceContext4, ID2D1DeviceContext5);
 impl ::core::clone::Clone for ID2D1DeviceContext6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11101,36 +8978,7 @@ impl ID2D1DrawInfo {
         (::windows::core::Vtable::vtable(self).SetVertexProcessing)(::windows::core::Vtable::as_raw(self), vertexbuffer.into().abi(), vertexoptions, ::core::mem::transmute(blenddescription.unwrap_or(::std::ptr::null())), ::core::mem::transmute(vertexrange.unwrap_or(::std::ptr::null())), ::core::mem::transmute(vertexshader.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<ID2D1DrawInfo> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DrawInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DrawInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DrawInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DrawInfo> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DrawInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DrawInfo> for ID2D1RenderInfo {
-    fn from(value: ID2D1DrawInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DrawInfo> for &'a ID2D1RenderInfo {
-    fn from(value: &'a ID2D1DrawInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DrawInfo> for ID2D1RenderInfo {
-    fn from(value: &ID2D1DrawInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DrawInfo, ::windows::core::IUnknown, ID2D1RenderInfo);
 impl ::core::clone::Clone for ID2D1DrawInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11195,51 +9043,7 @@ impl ID2D1DrawTransform {
         (::windows::core::Vtable::vtable(self).SetDrawInfo)(::windows::core::Vtable::as_raw(self), drawinfo.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID2D1DrawTransform> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DrawTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DrawTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DrawTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DrawTransform> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DrawTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DrawTransform> for ID2D1TransformNode {
-    fn from(value: ID2D1DrawTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DrawTransform> for &'a ID2D1TransformNode {
-    fn from(value: &'a ID2D1DrawTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DrawTransform> for ID2D1TransformNode {
-    fn from(value: &ID2D1DrawTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DrawTransform> for ID2D1Transform {
-    fn from(value: ID2D1DrawTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DrawTransform> for &'a ID2D1Transform {
-    fn from(value: &'a ID2D1DrawTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DrawTransform> for ID2D1Transform {
-    fn from(value: &ID2D1DrawTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DrawTransform, ::windows::core::IUnknown, ID2D1TransformNode, ID2D1Transform);
 impl ::core::clone::Clone for ID2D1DrawTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11301,36 +9105,7 @@ impl ID2D1DrawingStateBlock {
         (::windows::core::Vtable::vtable(self).GetTextRenderingParams)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(textrenderingparams.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<ID2D1DrawingStateBlock> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DrawingStateBlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DrawingStateBlock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DrawingStateBlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DrawingStateBlock> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DrawingStateBlock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DrawingStateBlock> for ID2D1Resource {
-    fn from(value: ID2D1DrawingStateBlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DrawingStateBlock> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1DrawingStateBlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DrawingStateBlock> for ID2D1Resource {
-    fn from(value: &ID2D1DrawingStateBlock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DrawingStateBlock, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1DrawingStateBlock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11417,51 +9192,7 @@ impl ID2D1DrawingStateBlock1 {
         (::windows::core::Vtable::vtable(self).SetDescription2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(statedescription))
     }
 }
-impl ::core::convert::From<ID2D1DrawingStateBlock1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1DrawingStateBlock1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DrawingStateBlock1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1DrawingStateBlock1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DrawingStateBlock1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1DrawingStateBlock1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DrawingStateBlock1> for ID2D1Resource {
-    fn from(value: ID2D1DrawingStateBlock1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DrawingStateBlock1> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1DrawingStateBlock1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DrawingStateBlock1> for ID2D1Resource {
-    fn from(value: &ID2D1DrawingStateBlock1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1DrawingStateBlock1> for ID2D1DrawingStateBlock {
-    fn from(value: ID2D1DrawingStateBlock1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1DrawingStateBlock1> for &'a ID2D1DrawingStateBlock {
-    fn from(value: &'a ID2D1DrawingStateBlock1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1DrawingStateBlock1> for ID2D1DrawingStateBlock {
-    fn from(value: &ID2D1DrawingStateBlock1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1DrawingStateBlock1, ::windows::core::IUnknown, ID2D1Resource, ID2D1DrawingStateBlock);
 impl ::core::clone::Clone for ID2D1DrawingStateBlock1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11568,36 +9299,7 @@ impl ID2D1Effect {
         (::windows::core::Vtable::vtable(self).GetOutput)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(outputimage))
     }
 }
-impl ::core::convert::From<ID2D1Effect> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Effect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Effect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Effect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Effect> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Effect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Effect> for ID2D1Properties {
-    fn from(value: ID2D1Effect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Effect> for &'a ID2D1Properties {
-    fn from(value: &'a ID2D1Effect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Effect> for ID2D1Properties {
-    fn from(value: &ID2D1Effect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Effect, ::windows::core::IUnknown, ID2D1Properties);
 impl ::core::clone::Clone for ID2D1Effect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11740,21 +9442,7 @@ impl ID2D1EffectContext {
         (::windows::core::Vtable::vtable(self).IsBufferPrecisionSupported)(::windows::core::Vtable::as_raw(self), bufferprecision)
     }
 }
-impl ::core::convert::From<ID2D1EffectContext> for ::windows::core::IUnknown {
-    fn from(value: ID2D1EffectContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1EffectContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1EffectContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1EffectContext> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1EffectContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1EffectContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1EffectContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11935,36 +9623,7 @@ impl ID2D1EffectContext1 {
         (::windows::core::Vtable::vtable(self).CreateLookupTable3D)(::windows::core::Vtable::as_raw(self), precision, ::core::mem::transmute(extents.as_ptr()), ::core::mem::transmute(data.as_ptr()), data.len() as _, ::core::mem::transmute(strides.as_ptr()), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1LookupTable3D>(result__)
     }
 }
-impl ::core::convert::From<ID2D1EffectContext1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1EffectContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1EffectContext1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1EffectContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1EffectContext1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1EffectContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1EffectContext1> for ID2D1EffectContext {
-    fn from(value: ID2D1EffectContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1EffectContext1> for &'a ID2D1EffectContext {
-    fn from(value: &'a ID2D1EffectContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1EffectContext1> for ID2D1EffectContext {
-    fn from(value: &ID2D1EffectContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1EffectContext1, ::windows::core::IUnknown, ID2D1EffectContext);
 impl ::core::clone::Clone for ID2D1EffectContext1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12116,51 +9775,7 @@ impl ID2D1EffectContext2 {
         (::windows::core::Vtable::vtable(self).CreateColorContextFromSimpleColorProfile)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(simpleprofile), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1ColorContext1>(result__)
     }
 }
-impl ::core::convert::From<ID2D1EffectContext2> for ::windows::core::IUnknown {
-    fn from(value: ID2D1EffectContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1EffectContext2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1EffectContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1EffectContext2> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1EffectContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1EffectContext2> for ID2D1EffectContext {
-    fn from(value: ID2D1EffectContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1EffectContext2> for &'a ID2D1EffectContext {
-    fn from(value: &'a ID2D1EffectContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1EffectContext2> for ID2D1EffectContext {
-    fn from(value: &ID2D1EffectContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1EffectContext2> for ID2D1EffectContext1 {
-    fn from(value: ID2D1EffectContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1EffectContext2> for &'a ID2D1EffectContext1 {
-    fn from(value: &'a ID2D1EffectContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1EffectContext2> for ID2D1EffectContext1 {
-    fn from(value: &ID2D1EffectContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1EffectContext2, ::windows::core::IUnknown, ID2D1EffectContext, ID2D1EffectContext1);
 impl ::core::clone::Clone for ID2D1EffectContext2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12219,21 +9834,7 @@ impl ID2D1EffectImpl {
         (::windows::core::Vtable::vtable(self).SetGraph)(::windows::core::Vtable::as_raw(self), transformgraph.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID2D1EffectImpl> for ::windows::core::IUnknown {
-    fn from(value: ID2D1EffectImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1EffectImpl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1EffectImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1EffectImpl> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1EffectImpl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1EffectImpl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1EffectImpl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12377,51 +9978,7 @@ impl ID2D1EllipseGeometry {
         (::windows::core::Vtable::vtable(self).GetEllipse)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ellipse))
     }
 }
-impl ::core::convert::From<ID2D1EllipseGeometry> for ::windows::core::IUnknown {
-    fn from(value: ID2D1EllipseGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1EllipseGeometry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1EllipseGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1EllipseGeometry> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1EllipseGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1EllipseGeometry> for ID2D1Resource {
-    fn from(value: ID2D1EllipseGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1EllipseGeometry> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1EllipseGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1EllipseGeometry> for ID2D1Resource {
-    fn from(value: &ID2D1EllipseGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1EllipseGeometry> for ID2D1Geometry {
-    fn from(value: ID2D1EllipseGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1EllipseGeometry> for &'a ID2D1Geometry {
-    fn from(value: &'a ID2D1EllipseGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1EllipseGeometry> for ID2D1Geometry {
-    fn from(value: &ID2D1EllipseGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1EllipseGeometry, ::windows::core::IUnknown, ID2D1Resource, ID2D1Geometry);
 impl ::core::clone::Clone for ID2D1EllipseGeometry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12546,21 +10103,7 @@ impl ID2D1Factory {
         (::windows::core::Vtable::vtable(self).CreateDCRenderTarget)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rendertargetproperties), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1DCRenderTarget>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Factory> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Factory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Factory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Factory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Factory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1Factory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12784,36 +10327,7 @@ impl ID2D1Factory1 {
         (::windows::core::Vtable::vtable(self).GetEffectProperties)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(effectid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1Properties>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Factory1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Factory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Factory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Factory1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory1> for ID2D1Factory {
-    fn from(value: ID2D1Factory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory1> for &'a ID2D1Factory {
-    fn from(value: &'a ID2D1Factory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory1> for ID2D1Factory {
-    fn from(value: &ID2D1Factory1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Factory1, ::windows::core::IUnknown, ID2D1Factory);
 impl ::core::clone::Clone for ID2D1Factory1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13024,51 +10538,7 @@ impl ID2D1Factory2 {
         (::windows::core::Vtable::vtable(self).CreateDevice2)(::windows::core::Vtable::as_raw(self), dxgidevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1Device1>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Factory2> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Factory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Factory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory2> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Factory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory2> for ID2D1Factory {
-    fn from(value: ID2D1Factory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory2> for &'a ID2D1Factory {
-    fn from(value: &'a ID2D1Factory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory2> for ID2D1Factory {
-    fn from(value: &ID2D1Factory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory2> for ID2D1Factory1 {
-    fn from(value: ID2D1Factory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory2> for &'a ID2D1Factory1 {
-    fn from(value: &'a ID2D1Factory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory2> for ID2D1Factory1 {
-    fn from(value: &ID2D1Factory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Factory2, ::windows::core::IUnknown, ID2D1Factory, ID2D1Factory1);
 impl ::core::clone::Clone for ID2D1Factory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13270,66 +10740,7 @@ impl ID2D1Factory3 {
         (::windows::core::Vtable::vtable(self).CreateDevice3)(::windows::core::Vtable::as_raw(self), dxgidevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1Device2>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Factory3> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Factory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Factory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory3> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Factory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory3> for ID2D1Factory {
-    fn from(value: ID2D1Factory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory3> for &'a ID2D1Factory {
-    fn from(value: &'a ID2D1Factory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory3> for ID2D1Factory {
-    fn from(value: &ID2D1Factory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory3> for ID2D1Factory1 {
-    fn from(value: ID2D1Factory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory3> for &'a ID2D1Factory1 {
-    fn from(value: &'a ID2D1Factory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory3> for ID2D1Factory1 {
-    fn from(value: &ID2D1Factory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory3> for ID2D1Factory2 {
-    fn from(value: ID2D1Factory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory3> for &'a ID2D1Factory2 {
-    fn from(value: &'a ID2D1Factory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory3> for ID2D1Factory2 {
-    fn from(value: &ID2D1Factory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Factory3, ::windows::core::IUnknown, ID2D1Factory, ID2D1Factory1, ID2D1Factory2);
 impl ::core::clone::Clone for ID2D1Factory3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13540,81 +10951,7 @@ impl ID2D1Factory4 {
         (::windows::core::Vtable::vtable(self).CreateDevice4)(::windows::core::Vtable::as_raw(self), dxgidevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1Device3>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Factory4> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Factory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Factory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory4> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Factory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory4> for ID2D1Factory {
-    fn from(value: ID2D1Factory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory4> for &'a ID2D1Factory {
-    fn from(value: &'a ID2D1Factory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory4> for ID2D1Factory {
-    fn from(value: &ID2D1Factory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory4> for ID2D1Factory1 {
-    fn from(value: ID2D1Factory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory4> for &'a ID2D1Factory1 {
-    fn from(value: &'a ID2D1Factory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory4> for ID2D1Factory1 {
-    fn from(value: &ID2D1Factory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory4> for ID2D1Factory2 {
-    fn from(value: ID2D1Factory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory4> for &'a ID2D1Factory2 {
-    fn from(value: &'a ID2D1Factory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory4> for ID2D1Factory2 {
-    fn from(value: &ID2D1Factory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory4> for ID2D1Factory3 {
-    fn from(value: ID2D1Factory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory4> for &'a ID2D1Factory3 {
-    fn from(value: &'a ID2D1Factory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory4> for ID2D1Factory3 {
-    fn from(value: &ID2D1Factory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Factory4, ::windows::core::IUnknown, ID2D1Factory, ID2D1Factory1, ID2D1Factory2, ID2D1Factory3);
 impl ::core::clone::Clone for ID2D1Factory4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13834,96 +11171,7 @@ impl ID2D1Factory5 {
         (::windows::core::Vtable::vtable(self).CreateDevice5)(::windows::core::Vtable::as_raw(self), dxgidevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1Device4>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Factory5> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory5> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Factory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory5> for ID2D1Factory {
-    fn from(value: ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory5> for &'a ID2D1Factory {
-    fn from(value: &'a ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory5> for ID2D1Factory {
-    fn from(value: &ID2D1Factory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory5> for ID2D1Factory1 {
-    fn from(value: ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory5> for &'a ID2D1Factory1 {
-    fn from(value: &'a ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory5> for ID2D1Factory1 {
-    fn from(value: &ID2D1Factory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory5> for ID2D1Factory2 {
-    fn from(value: ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory5> for &'a ID2D1Factory2 {
-    fn from(value: &'a ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory5> for ID2D1Factory2 {
-    fn from(value: &ID2D1Factory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory5> for ID2D1Factory3 {
-    fn from(value: ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory5> for &'a ID2D1Factory3 {
-    fn from(value: &'a ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory5> for ID2D1Factory3 {
-    fn from(value: &ID2D1Factory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory5> for ID2D1Factory4 {
-    fn from(value: ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory5> for &'a ID2D1Factory4 {
-    fn from(value: &'a ID2D1Factory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory5> for ID2D1Factory4 {
-    fn from(value: &ID2D1Factory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Factory5, ::windows::core::IUnknown, ID2D1Factory, ID2D1Factory1, ID2D1Factory2, ID2D1Factory3, ID2D1Factory4);
 impl ::core::clone::Clone for ID2D1Factory5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14152,111 +11400,7 @@ impl ID2D1Factory6 {
         (::windows::core::Vtable::vtable(self).CreateDevice6)(::windows::core::Vtable::as_raw(self), dxgidevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1Device5>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Factory6> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory6> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Factory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory6> for ID2D1Factory {
-    fn from(value: ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory6> for &'a ID2D1Factory {
-    fn from(value: &'a ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory6> for ID2D1Factory {
-    fn from(value: &ID2D1Factory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory6> for ID2D1Factory1 {
-    fn from(value: ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory6> for &'a ID2D1Factory1 {
-    fn from(value: &'a ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory6> for ID2D1Factory1 {
-    fn from(value: &ID2D1Factory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory6> for ID2D1Factory2 {
-    fn from(value: ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory6> for &'a ID2D1Factory2 {
-    fn from(value: &'a ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory6> for ID2D1Factory2 {
-    fn from(value: &ID2D1Factory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory6> for ID2D1Factory3 {
-    fn from(value: ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory6> for &'a ID2D1Factory3 {
-    fn from(value: &'a ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory6> for ID2D1Factory3 {
-    fn from(value: &ID2D1Factory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory6> for ID2D1Factory4 {
-    fn from(value: ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory6> for &'a ID2D1Factory4 {
-    fn from(value: &'a ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory6> for ID2D1Factory4 {
-    fn from(value: &ID2D1Factory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory6> for ID2D1Factory5 {
-    fn from(value: ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory6> for &'a ID2D1Factory5 {
-    fn from(value: &'a ID2D1Factory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory6> for ID2D1Factory5 {
-    fn from(value: &ID2D1Factory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Factory6, ::windows::core::IUnknown, ID2D1Factory, ID2D1Factory1, ID2D1Factory2, ID2D1Factory3, ID2D1Factory4, ID2D1Factory5);
 impl ::core::clone::Clone for ID2D1Factory6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14494,126 +11638,7 @@ impl ID2D1Factory7 {
         (::windows::core::Vtable::vtable(self).CreateDevice7)(::windows::core::Vtable::as_raw(self), dxgidevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1Device6>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Factory7> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory7> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Factory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory7> for ID2D1Factory {
-    fn from(value: ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory7> for &'a ID2D1Factory {
-    fn from(value: &'a ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory7> for ID2D1Factory {
-    fn from(value: &ID2D1Factory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory7> for ID2D1Factory1 {
-    fn from(value: ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory7> for &'a ID2D1Factory1 {
-    fn from(value: &'a ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory7> for ID2D1Factory1 {
-    fn from(value: &ID2D1Factory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory7> for ID2D1Factory2 {
-    fn from(value: ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory7> for &'a ID2D1Factory2 {
-    fn from(value: &'a ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory7> for ID2D1Factory2 {
-    fn from(value: &ID2D1Factory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory7> for ID2D1Factory3 {
-    fn from(value: ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory7> for &'a ID2D1Factory3 {
-    fn from(value: &'a ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory7> for ID2D1Factory3 {
-    fn from(value: &ID2D1Factory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory7> for ID2D1Factory4 {
-    fn from(value: ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory7> for &'a ID2D1Factory4 {
-    fn from(value: &'a ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory7> for ID2D1Factory4 {
-    fn from(value: &ID2D1Factory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory7> for ID2D1Factory5 {
-    fn from(value: ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory7> for &'a ID2D1Factory5 {
-    fn from(value: &'a ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory7> for ID2D1Factory5 {
-    fn from(value: &ID2D1Factory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Factory7> for ID2D1Factory6 {
-    fn from(value: ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Factory7> for &'a ID2D1Factory6 {
-    fn from(value: &'a ID2D1Factory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Factory7> for ID2D1Factory6 {
-    fn from(value: &ID2D1Factory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Factory7, ::windows::core::IUnknown, ID2D1Factory, ID2D1Factory1, ID2D1Factory2, ID2D1Factory3, ID2D1Factory4, ID2D1Factory5, ID2D1Factory6);
 impl ::core::clone::Clone for ID2D1Factory7 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14663,21 +11688,7 @@ impl ID2D1GdiInteropRenderTarget {
         (::windows::core::Vtable::vtable(self).ReleaseDC)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(update.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<ID2D1GdiInteropRenderTarget> for ::windows::core::IUnknown {
-    fn from(value: ID2D1GdiInteropRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GdiInteropRenderTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1GdiInteropRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GdiInteropRenderTarget> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1GdiInteropRenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1GdiInteropRenderTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1GdiInteropRenderTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14735,36 +11746,7 @@ impl ID2D1GdiMetafile {
         (::windows::core::Vtable::vtable(self).GetBounds)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<Common::D2D_RECT_F>(result__)
     }
 }
-impl ::core::convert::From<ID2D1GdiMetafile> for ::windows::core::IUnknown {
-    fn from(value: ID2D1GdiMetafile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GdiMetafile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1GdiMetafile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GdiMetafile> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1GdiMetafile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1GdiMetafile> for ID2D1Resource {
-    fn from(value: ID2D1GdiMetafile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GdiMetafile> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1GdiMetafile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GdiMetafile> for ID2D1Resource {
-    fn from(value: &ID2D1GdiMetafile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1GdiMetafile, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1GdiMetafile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14828,51 +11810,7 @@ impl ID2D1GdiMetafile1 {
         (::windows::core::Vtable::vtable(self).GetSourceBounds)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<Common::D2D_RECT_F>(result__)
     }
 }
-impl ::core::convert::From<ID2D1GdiMetafile1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1GdiMetafile1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GdiMetafile1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1GdiMetafile1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GdiMetafile1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1GdiMetafile1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1GdiMetafile1> for ID2D1Resource {
-    fn from(value: ID2D1GdiMetafile1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GdiMetafile1> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1GdiMetafile1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GdiMetafile1> for ID2D1Resource {
-    fn from(value: &ID2D1GdiMetafile1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1GdiMetafile1> for ID2D1GdiMetafile {
-    fn from(value: ID2D1GdiMetafile1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GdiMetafile1> for &'a ID2D1GdiMetafile {
-    fn from(value: &'a ID2D1GdiMetafile1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GdiMetafile1> for ID2D1GdiMetafile {
-    fn from(value: &ID2D1GdiMetafile1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1GdiMetafile1, ::windows::core::IUnknown, ID2D1Resource, ID2D1GdiMetafile);
 impl ::core::clone::Clone for ID2D1GdiMetafile1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14915,21 +11853,7 @@ impl ID2D1GdiMetafileSink {
         (::windows::core::Vtable::vtable(self).ProcessRecord)(::windows::core::Vtable::as_raw(self), recordtype, ::core::mem::transmute(recorddata.unwrap_or(::std::ptr::null())), recorddatasize).ok()
     }
 }
-impl ::core::convert::From<ID2D1GdiMetafileSink> for ::windows::core::IUnknown {
-    fn from(value: ID2D1GdiMetafileSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GdiMetafileSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1GdiMetafileSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GdiMetafileSink> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1GdiMetafileSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1GdiMetafileSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1GdiMetafileSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14971,36 +11895,7 @@ impl ID2D1GdiMetafileSink1 {
         (::windows::core::Vtable::vtable(self).ProcessRecord2)(::windows::core::Vtable::as_raw(self), recordtype, ::core::mem::transmute(recorddata.unwrap_or(::std::ptr::null())), recorddatasize, flags).ok()
     }
 }
-impl ::core::convert::From<ID2D1GdiMetafileSink1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1GdiMetafileSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GdiMetafileSink1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1GdiMetafileSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GdiMetafileSink1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1GdiMetafileSink1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1GdiMetafileSink1> for ID2D1GdiMetafileSink {
-    fn from(value: ID2D1GdiMetafileSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GdiMetafileSink1> for &'a ID2D1GdiMetafileSink {
-    fn from(value: &'a ID2D1GdiMetafileSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GdiMetafileSink1> for ID2D1GdiMetafileSink {
-    fn from(value: &ID2D1GdiMetafileSink1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1GdiMetafileSink1, ::windows::core::IUnknown, ID2D1GdiMetafileSink);
 impl ::core::clone::Clone for ID2D1GdiMetafileSink1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15137,36 +12032,7 @@ impl ID2D1Geometry {
         (::windows::core::Vtable::vtable(self).Widen)(::windows::core::Vtable::as_raw(self), strokewidth, strokestyle.into().abi(), ::core::mem::transmute(worldtransform.unwrap_or(::std::ptr::null())), flatteningtolerance, geometrysink.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID2D1Geometry> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Geometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Geometry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Geometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Geometry> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Geometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Geometry> for ID2D1Resource {
-    fn from(value: ID2D1Geometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Geometry> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Geometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Geometry> for ID2D1Resource {
-    fn from(value: &ID2D1Geometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Geometry, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1Geometry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15365,51 +12231,7 @@ impl ID2D1GeometryGroup {
         (::windows::core::Vtable::vtable(self).GetSourceGeometries)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(geometries.as_ptr()), geometries.len() as _)
     }
 }
-impl ::core::convert::From<ID2D1GeometryGroup> for ::windows::core::IUnknown {
-    fn from(value: ID2D1GeometryGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GeometryGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1GeometryGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GeometryGroup> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1GeometryGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1GeometryGroup> for ID2D1Resource {
-    fn from(value: ID2D1GeometryGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GeometryGroup> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1GeometryGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GeometryGroup> for ID2D1Resource {
-    fn from(value: &ID2D1GeometryGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1GeometryGroup> for ID2D1Geometry {
-    fn from(value: ID2D1GeometryGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GeometryGroup> for &'a ID2D1Geometry {
-    fn from(value: &'a ID2D1GeometryGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GeometryGroup> for ID2D1Geometry {
-    fn from(value: &ID2D1GeometryGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1GeometryGroup, ::windows::core::IUnknown, ID2D1Resource, ID2D1Geometry);
 impl ::core::clone::Clone for ID2D1GeometryGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15453,36 +12275,7 @@ impl ID2D1GeometryRealization {
         (::windows::core::Vtable::vtable(self).base__.GetFactory)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(factory))
     }
 }
-impl ::core::convert::From<ID2D1GeometryRealization> for ::windows::core::IUnknown {
-    fn from(value: ID2D1GeometryRealization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GeometryRealization> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1GeometryRealization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GeometryRealization> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1GeometryRealization) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1GeometryRealization> for ID2D1Resource {
-    fn from(value: ID2D1GeometryRealization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GeometryRealization> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1GeometryRealization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GeometryRealization> for ID2D1Resource {
-    fn from(value: &ID2D1GeometryRealization) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1GeometryRealization, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1GeometryRealization {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15580,41 +12373,7 @@ impl ID2D1GeometrySink {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl ::core::convert::From<ID2D1GeometrySink> for ::windows::core::IUnknown {
-    fn from(value: ID2D1GeometrySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl<'a> ::core::convert::From<&'a ID2D1GeometrySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1GeometrySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl ::core::convert::From<&ID2D1GeometrySink> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1GeometrySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl ::core::convert::From<ID2D1GeometrySink> for Common::ID2D1SimplifiedGeometrySink {
-    fn from(value: ID2D1GeometrySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl<'a> ::core::convert::From<&'a ID2D1GeometrySink> for &'a Common::ID2D1SimplifiedGeometrySink {
-    fn from(value: &'a ID2D1GeometrySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl ::core::convert::From<&ID2D1GeometrySink> for Common::ID2D1SimplifiedGeometrySink {
-    fn from(value: &ID2D1GeometrySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1GeometrySink, ::windows::core::IUnknown, Common::ID2D1SimplifiedGeometrySink);
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ::core::clone::Clone for ID2D1GeometrySink {
     fn clone(&self) -> Self {
@@ -15689,36 +12448,7 @@ impl ID2D1GradientMesh {
         (::windows::core::Vtable::vtable(self).GetPatches)(::windows::core::Vtable::as_raw(self), startindex, ::core::mem::transmute(patches.as_ptr()), patches.len() as _).ok()
     }
 }
-impl ::core::convert::From<ID2D1GradientMesh> for ::windows::core::IUnknown {
-    fn from(value: ID2D1GradientMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GradientMesh> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1GradientMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GradientMesh> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1GradientMesh) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1GradientMesh> for ID2D1Resource {
-    fn from(value: ID2D1GradientMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GradientMesh> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1GradientMesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GradientMesh> for ID2D1Resource {
-    fn from(value: &ID2D1GradientMesh) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1GradientMesh, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1GradientMesh {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15775,36 +12505,7 @@ impl ID2D1GradientStopCollection {
         (::windows::core::Vtable::vtable(self).GetExtendMode)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1GradientStopCollection> for ::windows::core::IUnknown {
-    fn from(value: ID2D1GradientStopCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GradientStopCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1GradientStopCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GradientStopCollection> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1GradientStopCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1GradientStopCollection> for ID2D1Resource {
-    fn from(value: ID2D1GradientStopCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GradientStopCollection> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1GradientStopCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GradientStopCollection> for ID2D1Resource {
-    fn from(value: &ID2D1GradientStopCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1GradientStopCollection, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1GradientStopCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15880,51 +12581,7 @@ impl ID2D1GradientStopCollection1 {
         (::windows::core::Vtable::vtable(self).GetColorInterpolationMode)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1GradientStopCollection1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1GradientStopCollection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GradientStopCollection1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1GradientStopCollection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GradientStopCollection1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1GradientStopCollection1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1GradientStopCollection1> for ID2D1Resource {
-    fn from(value: ID2D1GradientStopCollection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GradientStopCollection1> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1GradientStopCollection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GradientStopCollection1> for ID2D1Resource {
-    fn from(value: &ID2D1GradientStopCollection1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1GradientStopCollection1> for ID2D1GradientStopCollection {
-    fn from(value: ID2D1GradientStopCollection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1GradientStopCollection1> for &'a ID2D1GradientStopCollection {
-    fn from(value: &'a ID2D1GradientStopCollection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1GradientStopCollection1> for ID2D1GradientStopCollection {
-    fn from(value: &ID2D1GradientStopCollection1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1GradientStopCollection1, ::windows::core::IUnknown, ID2D1Resource, ID2D1GradientStopCollection);
 impl ::core::clone::Clone for ID2D1GradientStopCollection1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16305,51 +12962,7 @@ impl ID2D1HwndRenderTarget {
         (::windows::core::Vtable::vtable(self).GetHwnd)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1HwndRenderTarget> for ::windows::core::IUnknown {
-    fn from(value: ID2D1HwndRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1HwndRenderTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1HwndRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1HwndRenderTarget> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1HwndRenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1HwndRenderTarget> for ID2D1Resource {
-    fn from(value: ID2D1HwndRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1HwndRenderTarget> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1HwndRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1HwndRenderTarget> for ID2D1Resource {
-    fn from(value: &ID2D1HwndRenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1HwndRenderTarget> for ID2D1RenderTarget {
-    fn from(value: ID2D1HwndRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1HwndRenderTarget> for &'a ID2D1RenderTarget {
-    fn from(value: &'a ID2D1HwndRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1HwndRenderTarget> for ID2D1RenderTarget {
-    fn from(value: &ID2D1HwndRenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1HwndRenderTarget, ::windows::core::IUnknown, ID2D1Resource, ID2D1RenderTarget);
 impl ::core::clone::Clone for ID2D1HwndRenderTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16396,36 +13009,7 @@ impl ID2D1Image {
         (::windows::core::Vtable::vtable(self).base__.GetFactory)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(factory))
     }
 }
-impl ::core::convert::From<ID2D1Image> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Image) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Image> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Image) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Image> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Image) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Image> for ID2D1Resource {
-    fn from(value: ID2D1Image) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Image> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Image) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Image> for ID2D1Resource {
-    fn from(value: &ID2D1Image) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Image, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1Image {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16516,51 +13100,7 @@ impl ID2D1ImageBrush {
         (::windows::core::Vtable::vtable(self).GetSourceRectangle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(sourcerectangle))
     }
 }
-impl ::core::convert::From<ID2D1ImageBrush> for ::windows::core::IUnknown {
-    fn from(value: ID2D1ImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ImageBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1ImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ImageBrush> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1ImageBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ImageBrush> for ID2D1Resource {
-    fn from(value: ID2D1ImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ImageBrush> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1ImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ImageBrush> for ID2D1Resource {
-    fn from(value: &ID2D1ImageBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ImageBrush> for ID2D1Brush {
-    fn from(value: ID2D1ImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ImageBrush> for &'a ID2D1Brush {
-    fn from(value: &'a ID2D1ImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ImageBrush> for ID2D1Brush {
-    fn from(value: &ID2D1ImageBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1ImageBrush, ::windows::core::IUnknown, ID2D1Resource, ID2D1Brush);
 impl ::core::clone::Clone for ID2D1ImageBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16623,51 +13163,7 @@ impl ID2D1ImageSource {
         (::windows::core::Vtable::vtable(self).TryReclaimResources)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ID2D1ImageSource> for ::windows::core::IUnknown {
-    fn from(value: ID2D1ImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ImageSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1ImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ImageSource> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1ImageSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ImageSource> for ID2D1Resource {
-    fn from(value: ID2D1ImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ImageSource> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1ImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ImageSource> for ID2D1Resource {
-    fn from(value: &ID2D1ImageSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ImageSource> for ID2D1Image {
-    fn from(value: ID2D1ImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ImageSource> for &'a ID2D1Image {
-    fn from(value: &'a ID2D1ImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ImageSource> for ID2D1Image {
-    fn from(value: &ID2D1ImageSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1ImageSource, ::windows::core::IUnknown, ID2D1Resource, ID2D1Image);
 impl ::core::clone::Clone for ID2D1ImageSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16734,66 +13230,7 @@ impl ID2D1ImageSourceFromWic {
         (::windows::core::Vtable::vtable(self).GetSource)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(wicbitmapsource.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<ID2D1ImageSourceFromWic> for ::windows::core::IUnknown {
-    fn from(value: ID2D1ImageSourceFromWic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ImageSourceFromWic> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1ImageSourceFromWic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ImageSourceFromWic> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1ImageSourceFromWic) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ImageSourceFromWic> for ID2D1Resource {
-    fn from(value: ID2D1ImageSourceFromWic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ImageSourceFromWic> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1ImageSourceFromWic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ImageSourceFromWic> for ID2D1Resource {
-    fn from(value: &ID2D1ImageSourceFromWic) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ImageSourceFromWic> for ID2D1Image {
-    fn from(value: ID2D1ImageSourceFromWic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ImageSourceFromWic> for &'a ID2D1Image {
-    fn from(value: &'a ID2D1ImageSourceFromWic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ImageSourceFromWic> for ID2D1Image {
-    fn from(value: &ID2D1ImageSourceFromWic) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1ImageSourceFromWic> for ID2D1ImageSource {
-    fn from(value: ID2D1ImageSourceFromWic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ImageSourceFromWic> for &'a ID2D1ImageSource {
-    fn from(value: &'a ID2D1ImageSourceFromWic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ImageSourceFromWic> for ID2D1ImageSource {
-    fn from(value: &ID2D1ImageSourceFromWic) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1ImageSourceFromWic, ::windows::core::IUnknown, ID2D1Resource, ID2D1Image, ID2D1ImageSource);
 impl ::core::clone::Clone for ID2D1ImageSourceFromWic {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16887,36 +13324,7 @@ impl ID2D1Ink {
         (::windows::core::Vtable::vtable(self).GetBounds)(::windows::core::Vtable::as_raw(self), inkstyle.into().abi(), ::core::mem::transmute(worldtransform.unwrap_or(::std::ptr::null())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<Common::D2D_RECT_F>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Ink> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Ink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Ink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Ink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Ink> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Ink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Ink> for ID2D1Resource {
-    fn from(value: ID2D1Ink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Ink> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Ink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Ink> for ID2D1Resource {
-    fn from(value: &ID2D1Ink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Ink, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1Ink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16986,36 +13394,7 @@ impl ID2D1InkStyle {
         (::windows::core::Vtable::vtable(self).GetNibShape)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1InkStyle> for ::windows::core::IUnknown {
-    fn from(value: ID2D1InkStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1InkStyle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1InkStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1InkStyle> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1InkStyle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1InkStyle> for ID2D1Resource {
-    fn from(value: ID2D1InkStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1InkStyle> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1InkStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1InkStyle> for ID2D1Resource {
-    fn from(value: &ID2D1InkStyle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1InkStyle, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1InkStyle {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17070,36 +13449,7 @@ impl ID2D1Layer {
         result__
     }
 }
-impl ::core::convert::From<ID2D1Layer> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Layer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Layer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Layer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Layer> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Layer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Layer> for ID2D1Resource {
-    fn from(value: ID2D1Layer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Layer> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Layer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Layer> for ID2D1Resource {
-    fn from(value: &ID2D1Layer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Layer, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1Layer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17184,51 +13534,7 @@ impl ID2D1LinearGradientBrush {
         (::windows::core::Vtable::vtable(self).GetGradientStopCollection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(gradientstopcollection))
     }
 }
-impl ::core::convert::From<ID2D1LinearGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: ID2D1LinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1LinearGradientBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1LinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1LinearGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1LinearGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1LinearGradientBrush> for ID2D1Resource {
-    fn from(value: ID2D1LinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1LinearGradientBrush> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1LinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1LinearGradientBrush> for ID2D1Resource {
-    fn from(value: &ID2D1LinearGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1LinearGradientBrush> for ID2D1Brush {
-    fn from(value: ID2D1LinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1LinearGradientBrush> for &'a ID2D1Brush {
-    fn from(value: &'a ID2D1LinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1LinearGradientBrush> for ID2D1Brush {
-    fn from(value: &ID2D1LinearGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1LinearGradientBrush, ::windows::core::IUnknown, ID2D1Resource, ID2D1Brush);
 impl ::core::clone::Clone for ID2D1LinearGradientBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17283,36 +13589,7 @@ impl ID2D1LookupTable3D {
         (::windows::core::Vtable::vtable(self).base__.GetFactory)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(factory))
     }
 }
-impl ::core::convert::From<ID2D1LookupTable3D> for ::windows::core::IUnknown {
-    fn from(value: ID2D1LookupTable3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1LookupTable3D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1LookupTable3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1LookupTable3D> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1LookupTable3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1LookupTable3D> for ID2D1Resource {
-    fn from(value: ID2D1LookupTable3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1LookupTable3D> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1LookupTable3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1LookupTable3D> for ID2D1Resource {
-    fn from(value: &ID2D1LookupTable3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1LookupTable3D, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1LookupTable3D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17354,36 +13631,7 @@ impl ID2D1Mesh {
         (::windows::core::Vtable::vtable(self).Open)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1TessellationSink>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Mesh> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Mesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Mesh> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Mesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Mesh> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Mesh) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Mesh> for ID2D1Resource {
-    fn from(value: ID2D1Mesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Mesh> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1Mesh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Mesh> for ID2D1Resource {
-    fn from(value: &ID2D1Mesh) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Mesh, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1Mesh {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17430,21 +13678,7 @@ impl ID2D1Multithread {
         (::windows::core::Vtable::vtable(self).Leave)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1Multithread> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Multithread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Multithread> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Multithread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Multithread> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Multithread) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Multithread, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1Multithread {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17500,36 +13734,7 @@ impl ID2D1OffsetTransform {
         result__
     }
 }
-impl ::core::convert::From<ID2D1OffsetTransform> for ::windows::core::IUnknown {
-    fn from(value: ID2D1OffsetTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1OffsetTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1OffsetTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1OffsetTransform> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1OffsetTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1OffsetTransform> for ID2D1TransformNode {
-    fn from(value: ID2D1OffsetTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1OffsetTransform> for &'a ID2D1TransformNode {
-    fn from(value: &'a ID2D1OffsetTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1OffsetTransform> for ID2D1TransformNode {
-    fn from(value: &ID2D1OffsetTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1OffsetTransform, ::windows::core::IUnknown, ID2D1TransformNode);
 impl ::core::clone::Clone for ID2D1OffsetTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17695,51 +13900,7 @@ impl ID2D1PathGeometry {
         (::windows::core::Vtable::vtable(self).GetFigureCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ID2D1PathGeometry> for ::windows::core::IUnknown {
-    fn from(value: ID2D1PathGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1PathGeometry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1PathGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1PathGeometry> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1PathGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1PathGeometry> for ID2D1Resource {
-    fn from(value: ID2D1PathGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1PathGeometry> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1PathGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1PathGeometry> for ID2D1Resource {
-    fn from(value: &ID2D1PathGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1PathGeometry> for ID2D1Geometry {
-    fn from(value: ID2D1PathGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1PathGeometry> for &'a ID2D1Geometry {
-    fn from(value: &'a ID2D1PathGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1PathGeometry> for ID2D1Geometry {
-    fn from(value: &ID2D1PathGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1PathGeometry, ::windows::core::IUnknown, ID2D1Resource, ID2D1Geometry);
 impl ::core::clone::Clone for ID2D1PathGeometry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17913,66 +14074,7 @@ impl ID2D1PathGeometry1 {
         (::windows::core::Vtable::vtable(self).ComputePointAndSegmentAtLength)(::windows::core::Vtable::as_raw(self), length, startsegment, ::core::mem::transmute(worldtransform.unwrap_or(::std::ptr::null())), flatteningtolerance, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<D2D1_POINT_DESCRIPTION>(result__)
     }
 }
-impl ::core::convert::From<ID2D1PathGeometry1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1PathGeometry1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1PathGeometry1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1PathGeometry1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1PathGeometry1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1PathGeometry1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1PathGeometry1> for ID2D1Resource {
-    fn from(value: ID2D1PathGeometry1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1PathGeometry1> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1PathGeometry1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1PathGeometry1> for ID2D1Resource {
-    fn from(value: &ID2D1PathGeometry1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1PathGeometry1> for ID2D1Geometry {
-    fn from(value: ID2D1PathGeometry1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1PathGeometry1> for &'a ID2D1Geometry {
-    fn from(value: &'a ID2D1PathGeometry1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1PathGeometry1> for ID2D1Geometry {
-    fn from(value: &ID2D1PathGeometry1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1PathGeometry1> for ID2D1PathGeometry {
-    fn from(value: ID2D1PathGeometry1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1PathGeometry1> for &'a ID2D1PathGeometry {
-    fn from(value: &'a ID2D1PathGeometry1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1PathGeometry1> for ID2D1PathGeometry {
-    fn from(value: &ID2D1PathGeometry1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1PathGeometry1, ::windows::core::IUnknown, ID2D1Resource, ID2D1Geometry, ID2D1PathGeometry);
 impl ::core::clone::Clone for ID2D1PathGeometry1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18023,21 +14125,7 @@ impl ID2D1PrintControl {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ID2D1PrintControl> for ::windows::core::IUnknown {
-    fn from(value: ID2D1PrintControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1PrintControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1PrintControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1PrintControl> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1PrintControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1PrintControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1PrintControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18120,21 +14208,7 @@ impl ID2D1Properties {
         (::windows::core::Vtable::vtable(self).GetSubProperties)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1Properties>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Properties> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Properties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Properties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Properties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Properties> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Properties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Properties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1Properties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18238,51 +14312,7 @@ impl ID2D1RadialGradientBrush {
         (::windows::core::Vtable::vtable(self).GetGradientStopCollection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(gradientstopcollection))
     }
 }
-impl ::core::convert::From<ID2D1RadialGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: ID2D1RadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RadialGradientBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1RadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RadialGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1RadialGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1RadialGradientBrush> for ID2D1Resource {
-    fn from(value: ID2D1RadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RadialGradientBrush> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1RadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RadialGradientBrush> for ID2D1Resource {
-    fn from(value: &ID2D1RadialGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1RadialGradientBrush> for ID2D1Brush {
-    fn from(value: ID2D1RadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RadialGradientBrush> for &'a ID2D1Brush {
-    fn from(value: &'a ID2D1RadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RadialGradientBrush> for ID2D1Brush {
-    fn from(value: &ID2D1RadialGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1RadialGradientBrush, ::windows::core::IUnknown, ID2D1Resource, ID2D1Brush);
 impl ::core::clone::Clone for ID2D1RadialGradientBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18444,51 +14474,7 @@ impl ID2D1RectangleGeometry {
         (::windows::core::Vtable::vtable(self).GetRect)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rect))
     }
 }
-impl ::core::convert::From<ID2D1RectangleGeometry> for ::windows::core::IUnknown {
-    fn from(value: ID2D1RectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RectangleGeometry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1RectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RectangleGeometry> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1RectangleGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1RectangleGeometry> for ID2D1Resource {
-    fn from(value: ID2D1RectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RectangleGeometry> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1RectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RectangleGeometry> for ID2D1Resource {
-    fn from(value: &ID2D1RectangleGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1RectangleGeometry> for ID2D1Geometry {
-    fn from(value: ID2D1RectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RectangleGeometry> for &'a ID2D1Geometry {
-    fn from(value: &'a ID2D1RectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RectangleGeometry> for ID2D1Geometry {
-    fn from(value: &ID2D1RectangleGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1RectangleGeometry, ::windows::core::IUnknown, ID2D1Resource, ID2D1Geometry);
 impl ::core::clone::Clone for ID2D1RectangleGeometry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18544,21 +14530,7 @@ impl ID2D1RenderInfo {
         (::windows::core::Vtable::vtable(self).SetInstructionCountHint)(::windows::core::Vtable::as_raw(self), instructioncount)
     }
 }
-impl ::core::convert::From<ID2D1RenderInfo> for ::windows::core::IUnknown {
-    fn from(value: ID2D1RenderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RenderInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1RenderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RenderInfo> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1RenderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1RenderInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1RenderInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18925,36 +14897,7 @@ impl ID2D1RenderTarget {
         (::windows::core::Vtable::vtable(self).IsSupported)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rendertargetproperties))
     }
 }
-impl ::core::convert::From<ID2D1RenderTarget> for ::windows::core::IUnknown {
-    fn from(value: ID2D1RenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RenderTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1RenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RenderTarget> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1RenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1RenderTarget> for ID2D1Resource {
-    fn from(value: ID2D1RenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RenderTarget> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1RenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RenderTarget> for ID2D1Resource {
-    fn from(value: &ID2D1RenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1RenderTarget, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1RenderTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19144,21 +15087,7 @@ impl ID2D1Resource {
         (::windows::core::Vtable::vtable(self).GetFactory)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(factory))
     }
 }
-impl ::core::convert::From<ID2D1Resource> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Resource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Resource> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Resource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Resource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1Resource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19197,21 +15126,7 @@ impl ID2D1ResourceTexture {
         (::windows::core::Vtable::vtable(self).Update)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(minimumextents.unwrap_or(::std::ptr::null())), ::core::mem::transmute(maximimumextents.unwrap_or(::std::ptr::null())), ::core::mem::transmute(strides.unwrap_or(::std::ptr::null())), dimensions, ::core::mem::transmute(data.as_ptr()), data.len() as _).ok()
     }
 }
-impl ::core::convert::From<ID2D1ResourceTexture> for ::windows::core::IUnknown {
-    fn from(value: ID2D1ResourceTexture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1ResourceTexture> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1ResourceTexture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1ResourceTexture> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1ResourceTexture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1ResourceTexture, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1ResourceTexture {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19353,51 +15268,7 @@ impl ID2D1RoundedRectangleGeometry {
         (::windows::core::Vtable::vtable(self).GetRoundedRect)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(roundedrect))
     }
 }
-impl ::core::convert::From<ID2D1RoundedRectangleGeometry> for ::windows::core::IUnknown {
-    fn from(value: ID2D1RoundedRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RoundedRectangleGeometry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1RoundedRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RoundedRectangleGeometry> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1RoundedRectangleGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1RoundedRectangleGeometry> for ID2D1Resource {
-    fn from(value: ID2D1RoundedRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RoundedRectangleGeometry> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1RoundedRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RoundedRectangleGeometry> for ID2D1Resource {
-    fn from(value: &ID2D1RoundedRectangleGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1RoundedRectangleGeometry> for ID2D1Geometry {
-    fn from(value: ID2D1RoundedRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1RoundedRectangleGeometry> for &'a ID2D1Geometry {
-    fn from(value: &'a ID2D1RoundedRectangleGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1RoundedRectangleGeometry> for ID2D1Geometry {
-    fn from(value: &ID2D1RoundedRectangleGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1RoundedRectangleGeometry, ::windows::core::IUnknown, ID2D1Resource, ID2D1Geometry);
 impl ::core::clone::Clone for ID2D1RoundedRectangleGeometry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19467,51 +15338,7 @@ impl ID2D1SolidColorBrush {
         result__
     }
 }
-impl ::core::convert::From<ID2D1SolidColorBrush> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SolidColorBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SolidColorBrush> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SolidColorBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SolidColorBrush> for ID2D1Resource {
-    fn from(value: ID2D1SolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SolidColorBrush> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1SolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SolidColorBrush> for ID2D1Resource {
-    fn from(value: &ID2D1SolidColorBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SolidColorBrush> for ID2D1Brush {
-    fn from(value: ID2D1SolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SolidColorBrush> for &'a ID2D1Brush {
-    fn from(value: &'a ID2D1SolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SolidColorBrush> for ID2D1Brush {
-    fn from(value: &ID2D1SolidColorBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SolidColorBrush, ::windows::core::IUnknown, ID2D1Resource, ID2D1Brush);
 impl ::core::clone::Clone for ID2D1SolidColorBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19587,51 +15414,7 @@ impl ID2D1SourceTransform {
         (::windows::core::Vtable::vtable(self).Draw)(::windows::core::Vtable::as_raw(self), target.into().abi(), ::core::mem::transmute(drawrect), ::core::mem::transmute(targetorigin)).ok()
     }
 }
-impl ::core::convert::From<ID2D1SourceTransform> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SourceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SourceTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SourceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SourceTransform> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SourceTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SourceTransform> for ID2D1TransformNode {
-    fn from(value: ID2D1SourceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SourceTransform> for &'a ID2D1TransformNode {
-    fn from(value: &'a ID2D1SourceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SourceTransform> for ID2D1TransformNode {
-    fn from(value: &ID2D1SourceTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SourceTransform> for ID2D1Transform {
-    fn from(value: ID2D1SourceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SourceTransform> for &'a ID2D1Transform {
-    fn from(value: &'a ID2D1SourceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SourceTransform> for ID2D1Transform {
-    fn from(value: &ID2D1SourceTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SourceTransform, ::windows::core::IUnknown, ID2D1TransformNode, ID2D1Transform);
 impl ::core::clone::Clone for ID2D1SourceTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19695,36 +15478,7 @@ impl ID2D1SpriteBatch {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1SpriteBatch> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SpriteBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SpriteBatch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SpriteBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SpriteBatch> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SpriteBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SpriteBatch> for ID2D1Resource {
-    fn from(value: ID2D1SpriteBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SpriteBatch> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1SpriteBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SpriteBatch> for ID2D1Resource {
-    fn from(value: &ID2D1SpriteBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SpriteBatch, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1SpriteBatch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19803,36 +15557,7 @@ impl ID2D1StrokeStyle {
         (::windows::core::Vtable::vtable(self).GetDashes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(dashes.as_ptr()), dashes.len() as _)
     }
 }
-impl ::core::convert::From<ID2D1StrokeStyle> for ::windows::core::IUnknown {
-    fn from(value: ID2D1StrokeStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1StrokeStyle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1StrokeStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1StrokeStyle> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1StrokeStyle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1StrokeStyle> for ID2D1Resource {
-    fn from(value: ID2D1StrokeStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1StrokeStyle> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1StrokeStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1StrokeStyle> for ID2D1Resource {
-    fn from(value: &ID2D1StrokeStyle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1StrokeStyle, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1StrokeStyle {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19909,51 +15634,7 @@ impl ID2D1StrokeStyle1 {
         (::windows::core::Vtable::vtable(self).GetStrokeTransformType)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1StrokeStyle1> for ::windows::core::IUnknown {
-    fn from(value: ID2D1StrokeStyle1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1StrokeStyle1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1StrokeStyle1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1StrokeStyle1> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1StrokeStyle1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1StrokeStyle1> for ID2D1Resource {
-    fn from(value: ID2D1StrokeStyle1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1StrokeStyle1> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1StrokeStyle1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1StrokeStyle1> for ID2D1Resource {
-    fn from(value: &ID2D1StrokeStyle1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1StrokeStyle1> for ID2D1StrokeStyle {
-    fn from(value: ID2D1StrokeStyle1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1StrokeStyle1> for &'a ID2D1StrokeStyle {
-    fn from(value: &'a ID2D1StrokeStyle1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1StrokeStyle1> for ID2D1StrokeStyle {
-    fn from(value: &ID2D1StrokeStyle1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1StrokeStyle1, ::windows::core::IUnknown, ID2D1Resource, ID2D1StrokeStyle);
 impl ::core::clone::Clone for ID2D1StrokeStyle1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19999,36 +15680,7 @@ impl ID2D1SvgAttribute {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1SvgAttribute>(result__)
     }
 }
-impl ::core::convert::From<ID2D1SvgAttribute> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SvgAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgAttribute> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SvgAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgAttribute> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SvgAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgAttribute> for ID2D1Resource {
-    fn from(value: ID2D1SvgAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgAttribute> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1SvgAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgAttribute> for ID2D1Resource {
-    fn from(value: &ID2D1SvgAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SvgAttribute, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1SvgAttribute {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20137,36 +15789,7 @@ impl ID2D1SvgDocument {
         (::windows::core::Vtable::vtable(self).CreatePathData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(segmentdata.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), segmentdata.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(commands.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), commands.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1SvgPathData>(result__)
     }
 }
-impl ::core::convert::From<ID2D1SvgDocument> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SvgDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SvgDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgDocument> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SvgDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgDocument> for ID2D1Resource {
-    fn from(value: ID2D1SvgDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgDocument> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1SvgDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgDocument> for ID2D1Resource {
-    fn from(value: &ID2D1SvgDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SvgDocument, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1SvgDocument {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20390,36 +16013,7 @@ impl ID2D1SvgElement {
         (::windows::core::Vtable::vtable(self).GetAttributeValueLength)(::windows::core::Vtable::as_raw(self), name.into(), r#type, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ID2D1SvgElement> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SvgElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SvgElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgElement> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SvgElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgElement> for ID2D1Resource {
-    fn from(value: ID2D1SvgElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgElement> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1SvgElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgElement> for ID2D1Resource {
-    fn from(value: &ID2D1SvgElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SvgElement, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1SvgElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20523,36 +16117,7 @@ impl ID2D1SvgGlyphStyle {
         (::windows::core::Vtable::vtable(self).GetStroke)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(brush.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(strokewidth.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(dashes.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), dashes.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(dashoffset.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<ID2D1SvgGlyphStyle> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SvgGlyphStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgGlyphStyle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SvgGlyphStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgGlyphStyle> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SvgGlyphStyle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgGlyphStyle> for ID2D1Resource {
-    fn from(value: ID2D1SvgGlyphStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgGlyphStyle> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1SvgGlyphStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgGlyphStyle> for ID2D1Resource {
-    fn from(value: &ID2D1SvgGlyphStyle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SvgGlyphStyle, ::windows::core::IUnknown, ID2D1Resource);
 impl ::core::clone::Clone for ID2D1SvgGlyphStyle {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20630,51 +16195,7 @@ impl ID2D1SvgPaint {
         (::windows::core::Vtable::vtable(self).GetIdLength)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1SvgPaint> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SvgPaint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgPaint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SvgPaint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgPaint> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SvgPaint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgPaint> for ID2D1Resource {
-    fn from(value: ID2D1SvgPaint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgPaint> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1SvgPaint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgPaint> for ID2D1Resource {
-    fn from(value: &ID2D1SvgPaint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgPaint> for ID2D1SvgAttribute {
-    fn from(value: ID2D1SvgPaint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgPaint> for &'a ID2D1SvgAttribute {
-    fn from(value: &'a ID2D1SvgPaint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgPaint> for ID2D1SvgAttribute {
-    fn from(value: &ID2D1SvgPaint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SvgPaint, ::windows::core::IUnknown, ID2D1Resource, ID2D1SvgAttribute);
 impl ::core::clone::Clone for ID2D1SvgPaint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20762,51 +16283,7 @@ impl ID2D1SvgPathData {
         (::windows::core::Vtable::vtable(self).CreatePathGeometry)(::windows::core::Vtable::as_raw(self), fillmode, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID2D1PathGeometry1>(result__)
     }
 }
-impl ::core::convert::From<ID2D1SvgPathData> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SvgPathData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgPathData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SvgPathData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgPathData> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SvgPathData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgPathData> for ID2D1Resource {
-    fn from(value: ID2D1SvgPathData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgPathData> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1SvgPathData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgPathData> for ID2D1Resource {
-    fn from(value: &ID2D1SvgPathData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgPathData> for ID2D1SvgAttribute {
-    fn from(value: ID2D1SvgPathData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgPathData> for &'a ID2D1SvgAttribute {
-    fn from(value: &'a ID2D1SvgPathData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgPathData> for ID2D1SvgAttribute {
-    fn from(value: &ID2D1SvgPathData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SvgPathData, ::windows::core::IUnknown, ID2D1Resource, ID2D1SvgAttribute);
 impl ::core::clone::Clone for ID2D1SvgPathData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20879,51 +16356,7 @@ impl ID2D1SvgPointCollection {
         (::windows::core::Vtable::vtable(self).GetPointsCount)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1SvgPointCollection> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SvgPointCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgPointCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SvgPointCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgPointCollection> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SvgPointCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgPointCollection> for ID2D1Resource {
-    fn from(value: ID2D1SvgPointCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgPointCollection> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1SvgPointCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgPointCollection> for ID2D1Resource {
-    fn from(value: &ID2D1SvgPointCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgPointCollection> for ID2D1SvgAttribute {
-    fn from(value: ID2D1SvgPointCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgPointCollection> for &'a ID2D1SvgAttribute {
-    fn from(value: &'a ID2D1SvgPointCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgPointCollection> for ID2D1SvgAttribute {
-    fn from(value: &ID2D1SvgPointCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SvgPointCollection, ::windows::core::IUnknown, ID2D1Resource, ID2D1SvgAttribute);
 impl ::core::clone::Clone for ID2D1SvgPointCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20996,51 +16429,7 @@ impl ID2D1SvgStrokeDashArray {
         (::windows::core::Vtable::vtable(self).GetDashesCount)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1SvgStrokeDashArray> for ::windows::core::IUnknown {
-    fn from(value: ID2D1SvgStrokeDashArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgStrokeDashArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1SvgStrokeDashArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgStrokeDashArray> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1SvgStrokeDashArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgStrokeDashArray> for ID2D1Resource {
-    fn from(value: ID2D1SvgStrokeDashArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgStrokeDashArray> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1SvgStrokeDashArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgStrokeDashArray> for ID2D1Resource {
-    fn from(value: &ID2D1SvgStrokeDashArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1SvgStrokeDashArray> for ID2D1SvgAttribute {
-    fn from(value: ID2D1SvgStrokeDashArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1SvgStrokeDashArray> for &'a ID2D1SvgAttribute {
-    fn from(value: &'a ID2D1SvgStrokeDashArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1SvgStrokeDashArray> for ID2D1SvgAttribute {
-    fn from(value: &ID2D1SvgStrokeDashArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1SvgStrokeDashArray, ::windows::core::IUnknown, ID2D1Resource, ID2D1SvgAttribute);
 impl ::core::clone::Clone for ID2D1SvgStrokeDashArray {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21089,21 +16478,7 @@ impl ID2D1TessellationSink {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ID2D1TessellationSink> for ::windows::core::IUnknown {
-    fn from(value: ID2D1TessellationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1TessellationSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1TessellationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1TessellationSink> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1TessellationSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1TessellationSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1TessellationSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21162,36 +16537,7 @@ impl ID2D1Transform {
         (::windows::core::Vtable::vtable(self).MapInvalidRect)(::windows::core::Vtable::as_raw(self), inputindex, ::core::mem::transmute(invalidinputrect), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::RECT>(result__)
     }
 }
-impl ::core::convert::From<ID2D1Transform> for ::windows::core::IUnknown {
-    fn from(value: ID2D1Transform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Transform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1Transform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Transform> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1Transform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1Transform> for ID2D1TransformNode {
-    fn from(value: ID2D1Transform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1Transform> for &'a ID2D1TransformNode {
-    fn from(value: &'a ID2D1Transform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1Transform> for ID2D1TransformNode {
-    fn from(value: &ID2D1Transform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1Transform, ::windows::core::IUnknown, ID2D1TransformNode);
 impl ::core::clone::Clone for ID2D1Transform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21284,21 +16630,7 @@ impl ID2D1TransformGraph {
         (::windows::core::Vtable::vtable(self).SetPassthroughGraph)(::windows::core::Vtable::as_raw(self), effectinputindex).ok()
     }
 }
-impl ::core::convert::From<ID2D1TransformGraph> for ::windows::core::IUnknown {
-    fn from(value: ID2D1TransformGraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1TransformGraph> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1TransformGraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1TransformGraph> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1TransformGraph) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1TransformGraph, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1TransformGraph {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21345,21 +16677,7 @@ impl ID2D1TransformNode {
         (::windows::core::Vtable::vtable(self).GetInputCount)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID2D1TransformNode> for ::windows::core::IUnknown {
-    fn from(value: ID2D1TransformNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1TransformNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1TransformNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1TransformNode> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1TransformNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1TransformNode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1TransformNode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21504,51 +16822,7 @@ impl ID2D1TransformedGeometry {
         (::windows::core::Vtable::vtable(self).GetTransform)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(transform))
     }
 }
-impl ::core::convert::From<ID2D1TransformedGeometry> for ::windows::core::IUnknown {
-    fn from(value: ID2D1TransformedGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1TransformedGeometry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1TransformedGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1TransformedGeometry> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1TransformedGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1TransformedGeometry> for ID2D1Resource {
-    fn from(value: ID2D1TransformedGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1TransformedGeometry> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1TransformedGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1TransformedGeometry> for ID2D1Resource {
-    fn from(value: &ID2D1TransformedGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1TransformedGeometry> for ID2D1Geometry {
-    fn from(value: ID2D1TransformedGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1TransformedGeometry> for &'a ID2D1Geometry {
-    fn from(value: &'a ID2D1TransformedGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1TransformedGeometry> for ID2D1Geometry {
-    fn from(value: &ID2D1TransformedGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1TransformedGeometry, ::windows::core::IUnknown, ID2D1Resource, ID2D1Geometry);
 impl ::core::clone::Clone for ID2D1TransformedGeometry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21597,51 +16871,7 @@ impl ID2D1TransformedImageSource {
         (::windows::core::Vtable::vtable(self).GetProperties)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(properties))
     }
 }
-impl ::core::convert::From<ID2D1TransformedImageSource> for ::windows::core::IUnknown {
-    fn from(value: ID2D1TransformedImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1TransformedImageSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1TransformedImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1TransformedImageSource> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1TransformedImageSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1TransformedImageSource> for ID2D1Resource {
-    fn from(value: ID2D1TransformedImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1TransformedImageSource> for &'a ID2D1Resource {
-    fn from(value: &'a ID2D1TransformedImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1TransformedImageSource> for ID2D1Resource {
-    fn from(value: &ID2D1TransformedImageSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID2D1TransformedImageSource> for ID2D1Image {
-    fn from(value: ID2D1TransformedImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1TransformedImageSource> for &'a ID2D1Image {
-    fn from(value: &'a ID2D1TransformedImageSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1TransformedImageSource> for ID2D1Image {
-    fn from(value: &ID2D1TransformedImageSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1TransformedImageSource, ::windows::core::IUnknown, ID2D1Resource, ID2D1Image);
 impl ::core::clone::Clone for ID2D1TransformedImageSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21684,21 +16914,7 @@ impl ID2D1VertexBuffer {
         (::windows::core::Vtable::vtable(self).Unmap)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ID2D1VertexBuffer> for ::windows::core::IUnknown {
-    fn from(value: ID2D1VertexBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID2D1VertexBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID2D1VertexBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID2D1VertexBuffer> for ::windows::core::IUnknown {
-    fn from(value: &ID2D1VertexBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID2D1VertexBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID2D1VertexBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/mod.rs
@@ -38,21 +38,7 @@ impl IDxcAssembler {
         (::windows::core::Vtable::vtable(self).AssembleToContainer)(::windows::core::Vtable::as_raw(self), pshader.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDxcOperationResult>(result__)
     }
 }
-impl ::core::convert::From<IDxcAssembler> for ::windows::core::IUnknown {
-    fn from(value: IDxcAssembler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcAssembler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcAssembler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcAssembler> for ::windows::core::IUnknown {
-    fn from(value: &IDxcAssembler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcAssembler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcAssembler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -92,21 +78,7 @@ impl IDxcBlob {
         (::windows::core::Vtable::vtable(self).GetBufferSize)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDxcBlob> for ::windows::core::IUnknown {
-    fn from(value: IDxcBlob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcBlob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcBlob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcBlob> for ::windows::core::IUnknown {
-    fn from(value: &IDxcBlob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcBlob, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcBlob {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -152,36 +124,7 @@ impl IDxcBlobEncoding {
         (::windows::core::Vtable::vtable(self).GetEncoding)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pknown), ::core::mem::transmute(pcodepage)).ok()
     }
 }
-impl ::core::convert::From<IDxcBlobEncoding> for ::windows::core::IUnknown {
-    fn from(value: IDxcBlobEncoding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcBlobEncoding> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcBlobEncoding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcBlobEncoding> for ::windows::core::IUnknown {
-    fn from(value: &IDxcBlobEncoding) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDxcBlobEncoding> for IDxcBlob {
-    fn from(value: IDxcBlobEncoding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcBlobEncoding> for &'a IDxcBlob {
-    fn from(value: &'a IDxcBlobEncoding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcBlobEncoding> for IDxcBlob {
-    fn from(value: &IDxcBlobEncoding) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcBlobEncoding, ::windows::core::IUnknown, IDxcBlob);
 impl ::core::clone::Clone for IDxcBlobEncoding {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -235,51 +178,7 @@ impl IDxcBlobUtf16 {
         (::windows::core::Vtable::vtable(self).GetStringLength)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDxcBlobUtf16> for ::windows::core::IUnknown {
-    fn from(value: IDxcBlobUtf16) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcBlobUtf16> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcBlobUtf16) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcBlobUtf16> for ::windows::core::IUnknown {
-    fn from(value: &IDxcBlobUtf16) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDxcBlobUtf16> for IDxcBlob {
-    fn from(value: IDxcBlobUtf16) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcBlobUtf16> for &'a IDxcBlob {
-    fn from(value: &'a IDxcBlobUtf16) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcBlobUtf16> for IDxcBlob {
-    fn from(value: &IDxcBlobUtf16) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDxcBlobUtf16> for IDxcBlobEncoding {
-    fn from(value: IDxcBlobUtf16) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcBlobUtf16> for &'a IDxcBlobEncoding {
-    fn from(value: &'a IDxcBlobUtf16) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcBlobUtf16> for IDxcBlobEncoding {
-    fn from(value: &IDxcBlobUtf16) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcBlobUtf16, ::windows::core::IUnknown, IDxcBlob, IDxcBlobEncoding);
 impl ::core::clone::Clone for IDxcBlobUtf16 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -331,51 +230,7 @@ impl IDxcBlobUtf8 {
         (::windows::core::Vtable::vtable(self).GetStringLength)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDxcBlobUtf8> for ::windows::core::IUnknown {
-    fn from(value: IDxcBlobUtf8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcBlobUtf8> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcBlobUtf8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcBlobUtf8> for ::windows::core::IUnknown {
-    fn from(value: &IDxcBlobUtf8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDxcBlobUtf8> for IDxcBlob {
-    fn from(value: IDxcBlobUtf8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcBlobUtf8> for &'a IDxcBlob {
-    fn from(value: &'a IDxcBlobUtf8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcBlobUtf8> for IDxcBlob {
-    fn from(value: &IDxcBlobUtf8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDxcBlobUtf8> for IDxcBlobEncoding {
-    fn from(value: IDxcBlobUtf8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcBlobUtf8> for &'a IDxcBlobEncoding {
-    fn from(value: &'a IDxcBlobUtf8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcBlobUtf8> for IDxcBlobEncoding {
-    fn from(value: &IDxcBlobUtf8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcBlobUtf8, ::windows::core::IUnknown, IDxcBlob, IDxcBlobEncoding);
 impl ::core::clone::Clone for IDxcBlobUtf8 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -437,21 +292,7 @@ impl IDxcCompiler {
         (::windows::core::Vtable::vtable(self).Disassemble)(::windows::core::Vtable::as_raw(self), psource.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDxcBlobEncoding>(result__)
     }
 }
-impl ::core::convert::From<IDxcCompiler> for ::windows::core::IUnknown {
-    fn from(value: IDxcCompiler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcCompiler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcCompiler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcCompiler> for ::windows::core::IUnknown {
-    fn from(value: &IDxcCompiler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcCompiler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcCompiler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -539,36 +380,7 @@ impl IDxcCompiler2 {
         .ok()
     }
 }
-impl ::core::convert::From<IDxcCompiler2> for ::windows::core::IUnknown {
-    fn from(value: IDxcCompiler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcCompiler2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcCompiler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcCompiler2> for ::windows::core::IUnknown {
-    fn from(value: &IDxcCompiler2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDxcCompiler2> for IDxcCompiler {
-    fn from(value: IDxcCompiler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcCompiler2> for &'a IDxcCompiler {
-    fn from(value: &'a IDxcCompiler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcCompiler2> for IDxcCompiler {
-    fn from(value: &IDxcCompiler2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcCompiler2, ::windows::core::IUnknown, IDxcCompiler);
 impl ::core::clone::Clone for IDxcCompiler2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -611,21 +423,7 @@ impl IDxcCompiler3 {
         (::windows::core::Vtable::vtable(self).Disassemble)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pobject), ::core::mem::transmute(riid), ::core::mem::transmute(ppresult)).ok()
     }
 }
-impl ::core::convert::From<IDxcCompiler3> for ::windows::core::IUnknown {
-    fn from(value: IDxcCompiler3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcCompiler3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcCompiler3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcCompiler3> for ::windows::core::IUnknown {
-    fn from(value: &IDxcCompiler3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcCompiler3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcCompiler3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -675,21 +473,7 @@ impl IDxcCompilerArgs {
         (::windows::core::Vtable::vtable(self).AddDefines)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdefines.as_ptr()), pdefines.len() as _).ok()
     }
 }
-impl ::core::convert::From<IDxcCompilerArgs> for ::windows::core::IUnknown {
-    fn from(value: IDxcCompilerArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcCompilerArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcCompilerArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcCompilerArgs> for ::windows::core::IUnknown {
-    fn from(value: &IDxcCompilerArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcCompilerArgs, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcCompilerArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -746,21 +530,7 @@ impl IDxcContainerBuilder {
         (::windows::core::Vtable::vtable(self).SerializeContainer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDxcOperationResult>(result__)
     }
 }
-impl ::core::convert::From<IDxcContainerBuilder> for ::windows::core::IUnknown {
-    fn from(value: IDxcContainerBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcContainerBuilder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcContainerBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcContainerBuilder> for ::windows::core::IUnknown {
-    fn from(value: &IDxcContainerBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcContainerBuilder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcContainerBuilder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -822,21 +592,7 @@ impl IDxcContainerReflection {
         (::windows::core::Vtable::vtable(self).GetPartReflection)(::windows::core::Vtable::as_raw(self), idx, ::core::mem::transmute(iid), ::core::mem::transmute(ppvobject)).ok()
     }
 }
-impl ::core::convert::From<IDxcContainerReflection> for ::windows::core::IUnknown {
-    fn from(value: IDxcContainerReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcContainerReflection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcContainerReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcContainerReflection> for ::windows::core::IUnknown {
-    fn from(value: &IDxcContainerReflection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcContainerReflection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcContainerReflection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -884,21 +640,7 @@ impl IDxcExtraOutputs {
         (::windows::core::Vtable::vtable(self).GetOutput)(::windows::core::Vtable::as_raw(self), uindex, &<T as ::windows::core::Interface>::IID, result__ as *mut _ as *mut _, ::core::mem::transmute(ppoutputtype.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ppoutputname.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDxcExtraOutputs> for ::windows::core::IUnknown {
-    fn from(value: IDxcExtraOutputs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcExtraOutputs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcExtraOutputs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcExtraOutputs> for ::windows::core::IUnknown {
-    fn from(value: &IDxcExtraOutputs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcExtraOutputs, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcExtraOutputs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -940,21 +682,7 @@ impl IDxcIncludeHandler {
         (::windows::core::Vtable::vtable(self).LoadSource)(::windows::core::Vtable::as_raw(self), pfilename.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDxcBlob>(result__)
     }
 }
-impl ::core::convert::From<IDxcIncludeHandler> for ::windows::core::IUnknown {
-    fn from(value: IDxcIncludeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcIncludeHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcIncludeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcIncludeHandler> for ::windows::core::IUnknown {
-    fn from(value: &IDxcIncludeHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcIncludeHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcIncludeHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1054,21 +782,7 @@ impl IDxcLibrary {
         (::windows::core::Vtable::vtable(self).GetBlobAsUtf16)(::windows::core::Vtable::as_raw(self), pblob.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDxcBlobEncoding>(result__)
     }
 }
-impl ::core::convert::From<IDxcLibrary> for ::windows::core::IUnknown {
-    fn from(value: IDxcLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcLibrary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcLibrary> for ::windows::core::IUnknown {
-    fn from(value: &IDxcLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcLibrary, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcLibrary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1135,21 +849,7 @@ impl IDxcLinker {
         (::windows::core::Vtable::vtable(self).Link)(::windows::core::Vtable::as_raw(self), pentryname.into(), ptargetprofile.into(), ::core::mem::transmute(plibnames.as_ptr()), plibnames.len() as _, ::core::mem::transmute(parguments.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), parguments.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDxcOperationResult>(result__)
     }
 }
-impl ::core::convert::From<IDxcLinker> for ::windows::core::IUnknown {
-    fn from(value: IDxcLinker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcLinker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcLinker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcLinker> for ::windows::core::IUnknown {
-    fn from(value: &IDxcLinker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcLinker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcLinker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1196,21 +896,7 @@ impl IDxcOperationResult {
         (::windows::core::Vtable::vtable(self).GetErrorBuffer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDxcBlobEncoding>(result__)
     }
 }
-impl ::core::convert::From<IDxcOperationResult> for ::windows::core::IUnknown {
-    fn from(value: IDxcOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcOperationResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcOperationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcOperationResult> for ::windows::core::IUnknown {
-    fn from(value: &IDxcOperationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcOperationResult, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcOperationResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1260,21 +946,7 @@ impl IDxcOptimizer {
         (::windows::core::Vtable::vtable(self).RunOptimizer)(::windows::core::Vtable::as_raw(self), pblob.into().abi(), ::core::mem::transmute(ppoptions.as_ptr()), ppoptions.len() as _, ::core::mem::transmute(poutputmodule), ::core::mem::transmute(ppoutputtext.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDxcOptimizer> for ::windows::core::IUnknown {
-    fn from(value: IDxcOptimizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcOptimizer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcOptimizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcOptimizer> for ::windows::core::IUnknown {
-    fn from(value: &IDxcOptimizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcOptimizer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcOptimizer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1330,21 +1002,7 @@ impl IDxcOptimizerPass {
         (::windows::core::Vtable::vtable(self).GetOptionArgDescription)(::windows::core::Vtable::as_raw(self), argindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IDxcOptimizerPass> for ::windows::core::IUnknown {
-    fn from(value: IDxcOptimizerPass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcOptimizerPass> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcOptimizerPass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcOptimizerPass> for ::windows::core::IUnknown {
-    fn from(value: &IDxcOptimizerPass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcOptimizerPass, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcOptimizerPass {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1483,21 +1141,7 @@ impl IDxcPdbUtils {
         (::windows::core::Vtable::vtable(self).OverrideRootSignature)(::windows::core::Vtable::as_raw(self), prootsignature.into()).ok()
     }
 }
-impl ::core::convert::From<IDxcPdbUtils> for ::windows::core::IUnknown {
-    fn from(value: IDxcPdbUtils) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcPdbUtils> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcPdbUtils) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcPdbUtils> for ::windows::core::IUnknown {
-    fn from(value: &IDxcPdbUtils) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcPdbUtils, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcPdbUtils {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1589,36 +1233,7 @@ impl IDxcResult {
         (::windows::core::Vtable::vtable(self).PrimaryOutput)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDxcResult> for ::windows::core::IUnknown {
-    fn from(value: IDxcResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcResult> for ::windows::core::IUnknown {
-    fn from(value: &IDxcResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDxcResult> for IDxcOperationResult {
-    fn from(value: IDxcResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcResult> for &'a IDxcOperationResult {
-    fn from(value: &'a IDxcResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcResult> for IDxcOperationResult {
-    fn from(value: &IDxcResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcResult, ::windows::core::IUnknown, IDxcOperationResult);
 impl ::core::clone::Clone for IDxcResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1738,21 +1353,7 @@ impl IDxcUtils {
         (::windows::core::Vtable::vtable(self).GetPDBContents)(::windows::core::Vtable::as_raw(self), ppdbblob.into().abi(), ::core::mem::transmute(pphash), ::core::mem::transmute(ppcontainer)).ok()
     }
 }
-impl ::core::convert::From<IDxcUtils> for ::windows::core::IUnknown {
-    fn from(value: IDxcUtils) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcUtils> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcUtils) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcUtils> for ::windows::core::IUnknown {
-    fn from(value: &IDxcUtils) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcUtils, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcUtils {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1811,21 +1412,7 @@ impl IDxcValidator {
         (::windows::core::Vtable::vtable(self).Validate)(::windows::core::Vtable::as_raw(self), pshader.into().abi(), flags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDxcOperationResult>(result__)
     }
 }
-impl ::core::convert::From<IDxcValidator> for ::windows::core::IUnknown {
-    fn from(value: IDxcValidator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcValidator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcValidator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcValidator> for ::windows::core::IUnknown {
-    fn from(value: &IDxcValidator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcValidator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcValidator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1873,36 +1460,7 @@ impl IDxcValidator2 {
         (::windows::core::Vtable::vtable(self).ValidateWithDebug)(::windows::core::Vtable::as_raw(self), pshader.into().abi(), flags, ::core::mem::transmute(poptdebugbitcode.unwrap_or(::std::ptr::null())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDxcOperationResult>(result__)
     }
 }
-impl ::core::convert::From<IDxcValidator2> for ::windows::core::IUnknown {
-    fn from(value: IDxcValidator2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcValidator2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcValidator2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcValidator2> for ::windows::core::IUnknown {
-    fn from(value: &IDxcValidator2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDxcValidator2> for IDxcValidator {
-    fn from(value: IDxcValidator2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcValidator2> for &'a IDxcValidator {
-    fn from(value: &'a IDxcValidator2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcValidator2> for IDxcValidator {
-    fn from(value: &IDxcValidator2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcValidator2, ::windows::core::IUnknown, IDxcValidator);
 impl ::core::clone::Clone for IDxcValidator2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1943,21 +1501,7 @@ impl IDxcVersionInfo {
         (::windows::core::Vtable::vtable(self).GetFlags)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDxcVersionInfo> for ::windows::core::IUnknown {
-    fn from(value: IDxcVersionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcVersionInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcVersionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcVersionInfo> for ::windows::core::IUnknown {
-    fn from(value: &IDxcVersionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcVersionInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcVersionInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2002,36 +1546,7 @@ impl IDxcVersionInfo2 {
         (::windows::core::Vtable::vtable(self).GetCommitInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcommitcount), ::core::mem::transmute(pcommithash)).ok()
     }
 }
-impl ::core::convert::From<IDxcVersionInfo2> for ::windows::core::IUnknown {
-    fn from(value: IDxcVersionInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcVersionInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcVersionInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcVersionInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IDxcVersionInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDxcVersionInfo2> for IDxcVersionInfo {
-    fn from(value: IDxcVersionInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcVersionInfo2> for &'a IDxcVersionInfo {
-    fn from(value: &'a IDxcVersionInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcVersionInfo2> for IDxcVersionInfo {
-    fn from(value: &IDxcVersionInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcVersionInfo2, ::windows::core::IUnknown, IDxcVersionInfo);
 impl ::core::clone::Clone for IDxcVersionInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2069,21 +1584,7 @@ impl IDxcVersionInfo3 {
         (::windows::core::Vtable::vtable(self).GetCustomVersionString)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut i8>(result__)
     }
 }
-impl ::core::convert::From<IDxcVersionInfo3> for ::windows::core::IUnknown {
-    fn from(value: IDxcVersionInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDxcVersionInfo3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDxcVersionInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDxcVersionInfo3> for ::windows::core::IUnknown {
-    fn from(value: &IDxcVersionInfo3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDxcVersionInfo3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDxcVersionInfo3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
@@ -13,21 +13,7 @@ impl ID3DBlob {
         (::windows::core::Vtable::vtable(self).GetBufferSize)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3DBlob> for ::windows::core::IUnknown {
-    fn from(value: ID3DBlob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3DBlob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3DBlob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3DBlob> for ::windows::core::IUnknown {
-    fn from(value: &ID3DBlob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3DBlob, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3DBlob {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -71,21 +57,7 @@ impl ID3DDestructionNotifier {
         (::windows::core::Vtable::vtable(self).UnregisterDestructionCallback)(::windows::core::Vtable::as_raw(self), callbackid).ok()
     }
 }
-impl ::core::convert::From<ID3DDestructionNotifier> for ::windows::core::IUnknown {
-    fn from(value: ID3DDestructionNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3DDestructionNotifier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3DDestructionNotifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3DDestructionNotifier> for ::windows::core::IUnknown {
-    fn from(value: &ID3DDestructionNotifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3DDestructionNotifier, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3DDestructionNotifier {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
@@ -381,36 +381,7 @@ impl ID3D10Asynchronous {
         (::windows::core::Vtable::vtable(self).GetDataSize)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D10Asynchronous> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Asynchronous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Asynchronous> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Asynchronous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Asynchronous> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Asynchronous) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Asynchronous> for ID3D10DeviceChild {
-    fn from(value: ID3D10Asynchronous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Asynchronous> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10Asynchronous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Asynchronous> for ID3D10DeviceChild {
-    fn from(value: &ID3D10Asynchronous) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Asynchronous, ::windows::core::IUnknown, ID3D10DeviceChild);
 impl ::core::clone::Clone for ID3D10Asynchronous {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -469,36 +440,7 @@ impl ID3D10BlendState {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10BlendState> for ::windows::core::IUnknown {
-    fn from(value: ID3D10BlendState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10BlendState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10BlendState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10BlendState> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10BlendState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10BlendState> for ID3D10DeviceChild {
-    fn from(value: ID3D10BlendState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10BlendState> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10BlendState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10BlendState> for ID3D10DeviceChild {
-    fn from(value: &ID3D10BlendState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10BlendState, ::windows::core::IUnknown, ID3D10DeviceChild);
 impl ::core::clone::Clone for ID3D10BlendState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -562,51 +504,7 @@ impl ID3D10BlendState1 {
         (::windows::core::Vtable::vtable(self).GetDesc1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10BlendState1> for ::windows::core::IUnknown {
-    fn from(value: ID3D10BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10BlendState1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10BlendState1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10BlendState1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10BlendState1> for ID3D10DeviceChild {
-    fn from(value: ID3D10BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10BlendState1> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10BlendState1> for ID3D10DeviceChild {
-    fn from(value: &ID3D10BlendState1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10BlendState1> for ID3D10BlendState {
-    fn from(value: ID3D10BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10BlendState1> for &'a ID3D10BlendState {
-    fn from(value: &'a ID3D10BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10BlendState1> for ID3D10BlendState {
-    fn from(value: &ID3D10BlendState1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10BlendState1, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10BlendState);
 impl ::core::clone::Clone for ID3D10BlendState1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -678,51 +576,7 @@ impl ID3D10Buffer {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10Buffer> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Buffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Buffer> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Buffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Buffer> for ID3D10DeviceChild {
-    fn from(value: ID3D10Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Buffer> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Buffer> for ID3D10DeviceChild {
-    fn from(value: &ID3D10Buffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Buffer> for ID3D10Resource {
-    fn from(value: ID3D10Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Buffer> for &'a ID3D10Resource {
-    fn from(value: &'a ID3D10Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Buffer> for ID3D10Resource {
-    fn from(value: &ID3D10Buffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Buffer, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10Resource);
 impl ::core::clone::Clone for ID3D10Buffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -790,51 +644,7 @@ impl ID3D10Counter {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10Counter> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Counter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Counter> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Counter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Counter> for ID3D10DeviceChild {
-    fn from(value: ID3D10Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Counter> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Counter> for ID3D10DeviceChild {
-    fn from(value: &ID3D10Counter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Counter> for ID3D10Asynchronous {
-    fn from(value: ID3D10Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Counter> for &'a ID3D10Asynchronous {
-    fn from(value: &'a ID3D10Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Counter> for ID3D10Asynchronous {
-    fn from(value: &ID3D10Counter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Counter, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10Asynchronous);
 impl ::core::clone::Clone for ID3D10Counter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -899,21 +709,7 @@ impl ID3D10Debug {
         (::windows::core::Vtable::vtable(self).Validate)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ID3D10Debug> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Debug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Debug> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Debug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Debug> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Debug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Debug, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D10Debug {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -981,36 +777,7 @@ impl ID3D10DepthStencilState {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10DepthStencilState> for ::windows::core::IUnknown {
-    fn from(value: ID3D10DepthStencilState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10DepthStencilState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10DepthStencilState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10DepthStencilState> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10DepthStencilState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10DepthStencilState> for ID3D10DeviceChild {
-    fn from(value: ID3D10DepthStencilState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10DepthStencilState> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10DepthStencilState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10DepthStencilState> for ID3D10DeviceChild {
-    fn from(value: &ID3D10DepthStencilState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10DepthStencilState, ::windows::core::IUnknown, ID3D10DeviceChild);
 impl ::core::clone::Clone for ID3D10DepthStencilState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1072,51 +839,7 @@ impl ID3D10DepthStencilView {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10DepthStencilView> for ::windows::core::IUnknown {
-    fn from(value: ID3D10DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10DepthStencilView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10DepthStencilView> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10DepthStencilView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10DepthStencilView> for ID3D10DeviceChild {
-    fn from(value: ID3D10DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10DepthStencilView> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10DepthStencilView> for ID3D10DeviceChild {
-    fn from(value: &ID3D10DepthStencilView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10DepthStencilView> for ID3D10View {
-    fn from(value: ID3D10DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10DepthStencilView> for &'a ID3D10View {
-    fn from(value: &'a ID3D10DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10DepthStencilView> for ID3D10View {
-    fn from(value: &ID3D10DepthStencilView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10DepthStencilView, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10View);
 impl ::core::clone::Clone for ID3D10DepthStencilView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1575,21 +1298,7 @@ impl ID3D10Device {
         (::windows::core::Vtable::vtable(self).GetTextFilterSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwidth.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pheight.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<ID3D10Device> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Device> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Device> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Device) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Device, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D10Device {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2223,36 +1932,7 @@ impl ID3D10Device1 {
         (::windows::core::Vtable::vtable(self).GetFeatureLevel)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D10Device1> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Device1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Device1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Device1> for ID3D10Device {
-    fn from(value: ID3D10Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Device1> for &'a ID3D10Device {
-    fn from(value: &'a ID3D10Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Device1> for ID3D10Device {
-    fn from(value: &ID3D10Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Device1, ::windows::core::IUnknown, ID3D10Device);
 impl ::core::clone::Clone for ID3D10Device1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2311,21 +1991,7 @@ impl ID3D10DeviceChild {
         (::windows::core::Vtable::vtable(self).SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D10DeviceChild> for ::windows::core::IUnknown {
-    fn from(value: ID3D10DeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10DeviceChild> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10DeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10DeviceChild> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10DeviceChild) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10DeviceChild, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D10DeviceChild {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2425,21 +2091,7 @@ impl ID3D10Effect {
         (::windows::core::Vtable::vtable(self).IsOptimized)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D10Effect> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Effect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Effect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Effect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Effect> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Effect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Effect, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D10Effect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2604,21 +2256,7 @@ impl ID3D10EffectBlendVariable {
         (::windows::core::Vtable::vtable(self).GetBackingStore)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(pblenddesc)).ok()
     }
 }
-impl ::core::convert::From<ID3D10EffectBlendVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectBlendVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectBlendVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectBlendVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectBlendVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectBlendVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectBlendVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectBlendVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2771,21 +2409,7 @@ impl ID3D10EffectConstantBuffer {
         (::windows::core::Vtable::vtable(self).GetTextureBuffer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID3D10ShaderResourceView>(result__)
     }
 }
-impl ::core::convert::From<ID3D10EffectConstantBuffer> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectConstantBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectConstantBuffer> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectConstantBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectConstantBuffer> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectConstantBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectConstantBuffer, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectConstantBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2927,21 +2551,7 @@ impl ID3D10EffectDepthStencilVariable {
         (::windows::core::Vtable::vtable(self).GetBackingStore)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<D3D10_DEPTH_STENCIL_DESC>(result__)
     }
 }
-impl ::core::convert::From<ID3D10EffectDepthStencilVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectDepthStencilVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectDepthStencilVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectDepthStencilVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectDepthStencilVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectDepthStencilVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectDepthStencilVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectDepthStencilVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3090,21 +2700,7 @@ impl ID3D10EffectDepthStencilViewVariable {
         (::windows::core::Vtable::vtable(self).GetDepthStencilArray)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppresources.as_ptr()), offset, ppresources.len() as _).ok()
     }
 }
-impl ::core::convert::From<ID3D10EffectDepthStencilViewVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectDepthStencilViewVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectDepthStencilViewVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectDepthStencilViewVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectDepthStencilViewVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectDepthStencilViewVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectDepthStencilViewVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectDepthStencilViewVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3260,21 +2856,7 @@ impl ID3D10EffectMatrixVariable {
         (::windows::core::Vtable::vtable(self).GetMatrixTransposeArray)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdata), offset, count).ok()
     }
 }
-impl ::core::convert::From<ID3D10EffectMatrixVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectMatrixVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectMatrixVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectMatrixVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectMatrixVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectMatrixVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectMatrixVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectMatrixVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3401,21 +2983,7 @@ impl ID3D10EffectPool {
         (::windows::core::Vtable::vtable(self).AsEffect)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D10EffectPool> for ::windows::core::IUnknown {
-    fn from(value: ID3D10EffectPool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectPool> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10EffectPool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectPool> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10EffectPool) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectPool, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D10EffectPool {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3557,21 +3125,7 @@ impl ID3D10EffectRasterizerVariable {
         (::windows::core::Vtable::vtable(self).GetBackingStore)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<D3D10_RASTERIZER_DESC>(result__)
     }
 }
-impl ::core::convert::From<ID3D10EffectRasterizerVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectRasterizerVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectRasterizerVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectRasterizerVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectRasterizerVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectRasterizerVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectRasterizerVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectRasterizerVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3720,21 +3274,7 @@ impl ID3D10EffectRenderTargetViewVariable {
         (::windows::core::Vtable::vtable(self).GetRenderTargetArray)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppresources.as_ptr()), offset, ppresources.len() as _).ok()
     }
 }
-impl ::core::convert::From<ID3D10EffectRenderTargetViewVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectRenderTargetViewVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectRenderTargetViewVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectRenderTargetViewVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectRenderTargetViewVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectRenderTargetViewVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectRenderTargetViewVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectRenderTargetViewVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3874,21 +3414,7 @@ impl ID3D10EffectSamplerVariable {
         (::windows::core::Vtable::vtable(self).GetBackingStore)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<D3D10_SAMPLER_DESC>(result__)
     }
 }
-impl ::core::convert::From<ID3D10EffectSamplerVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectSamplerVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectSamplerVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectSamplerVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectSamplerVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectSamplerVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectSamplerVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectSamplerVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4068,21 +3594,7 @@ impl ID3D10EffectScalarVariable {
         (::windows::core::Vtable::vtable(self).GetBoolArray)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdata.as_ptr()), offset, pdata.len() as _).ok()
     }
 }
-impl ::core::convert::From<ID3D10EffectScalarVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectScalarVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectScalarVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectScalarVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectScalarVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectScalarVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectScalarVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectScalarVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4250,21 +3762,7 @@ impl ID3D10EffectShaderResourceVariable {
         (::windows::core::Vtable::vtable(self).GetResourceArray)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppresources.as_ptr()), offset, ppresources.len() as _).ok()
     }
 }
-impl ::core::convert::From<ID3D10EffectShaderResourceVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectShaderResourceVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectShaderResourceVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectShaderResourceVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectShaderResourceVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectShaderResourceVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectShaderResourceVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectShaderResourceVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4426,21 +3924,7 @@ impl ID3D10EffectShaderVariable {
         (::windows::core::Vtable::vtable(self).GetOutputSignatureElementDesc)(::windows::core::Vtable::as_raw(self), shaderindex, element, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<D3D10_SIGNATURE_PARAMETER_DESC>(result__)
     }
 }
-impl ::core::convert::From<ID3D10EffectShaderVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectShaderVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectShaderVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectShaderVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectShaderVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectShaderVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectShaderVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectShaderVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4590,21 +4074,7 @@ impl ID3D10EffectStringVariable {
         (::windows::core::Vtable::vtable(self).GetStringArray)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppstrings.as_ptr()), offset, ppstrings.len() as _).ok()
     }
 }
-impl ::core::convert::From<ID3D10EffectStringVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectStringVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectStringVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectStringVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectStringVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectStringVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectStringVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectStringVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5094,21 +4564,7 @@ impl ID3D10EffectVectorVariable {
         (::windows::core::Vtable::vtable(self).GetFloatVectorArray)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdata), offset, count).ok()
     }
 }
-impl ::core::convert::From<ID3D10EffectVectorVariable> for ID3D10EffectVariable {
-    fn from(value: ID3D10EffectVectorVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10EffectVectorVariable> for &'a ID3D10EffectVariable {
-    fn from(value: &'a ID3D10EffectVectorVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10EffectVectorVariable> for ID3D10EffectVariable {
-    fn from(value: &ID3D10EffectVectorVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10EffectVectorVariable, ID3D10EffectVariable);
 impl ::core::clone::Clone for ID3D10EffectVectorVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5179,36 +4635,7 @@ impl ID3D10GeometryShader {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D10GeometryShader> for ::windows::core::IUnknown {
-    fn from(value: ID3D10GeometryShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10GeometryShader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10GeometryShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10GeometryShader> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10GeometryShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10GeometryShader> for ID3D10DeviceChild {
-    fn from(value: ID3D10GeometryShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10GeometryShader> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10GeometryShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10GeometryShader> for ID3D10DeviceChild {
-    fn from(value: &ID3D10GeometryShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10GeometryShader, ::windows::core::IUnknown, ID3D10DeviceChild);
 impl ::core::clone::Clone for ID3D10GeometryShader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5382,21 +4809,7 @@ impl ID3D10InfoQueue {
         (::windows::core::Vtable::vtable(self).GetMuteDebugOutput)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D10InfoQueue> for ::windows::core::IUnknown {
-    fn from(value: ID3D10InfoQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10InfoQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10InfoQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10InfoQueue> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10InfoQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10InfoQueue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D10InfoQueue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5505,36 +4918,7 @@ impl ID3D10InputLayout {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D10InputLayout> for ::windows::core::IUnknown {
-    fn from(value: ID3D10InputLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10InputLayout> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10InputLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10InputLayout> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10InputLayout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10InputLayout> for ID3D10DeviceChild {
-    fn from(value: ID3D10InputLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10InputLayout> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10InputLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10InputLayout> for ID3D10DeviceChild {
-    fn from(value: &ID3D10InputLayout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10InputLayout, ::windows::core::IUnknown, ID3D10DeviceChild);
 impl ::core::clone::Clone for ID3D10InputLayout {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5588,21 +4972,7 @@ impl ID3D10Multithread {
         (::windows::core::Vtable::vtable(self).GetMultithreadProtected)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D10Multithread> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Multithread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Multithread> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Multithread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Multithread> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Multithread) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Multithread, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D10Multithread {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5662,36 +5032,7 @@ impl ID3D10PixelShader {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D10PixelShader> for ::windows::core::IUnknown {
-    fn from(value: ID3D10PixelShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10PixelShader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10PixelShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10PixelShader> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10PixelShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10PixelShader> for ID3D10DeviceChild {
-    fn from(value: ID3D10PixelShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10PixelShader> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10PixelShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10PixelShader> for ID3D10DeviceChild {
-    fn from(value: &ID3D10PixelShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10PixelShader, ::windows::core::IUnknown, ID3D10DeviceChild);
 impl ::core::clone::Clone for ID3D10PixelShader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5756,66 +5097,7 @@ impl ID3D10Predicate {
         (::windows::core::Vtable::vtable(self).base__.GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10Predicate> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Predicate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Predicate> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Predicate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Predicate> for ID3D10DeviceChild {
-    fn from(value: ID3D10Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Predicate> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Predicate> for ID3D10DeviceChild {
-    fn from(value: &ID3D10Predicate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Predicate> for ID3D10Asynchronous {
-    fn from(value: ID3D10Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Predicate> for &'a ID3D10Asynchronous {
-    fn from(value: &'a ID3D10Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Predicate> for ID3D10Asynchronous {
-    fn from(value: &ID3D10Predicate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Predicate> for ID3D10Query {
-    fn from(value: ID3D10Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Predicate> for &'a ID3D10Query {
-    fn from(value: &'a ID3D10Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Predicate> for ID3D10Query {
-    fn from(value: &ID3D10Predicate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Predicate, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10Asynchronous, ID3D10Query);
 impl ::core::clone::Clone for ID3D10Predicate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5880,51 +5162,7 @@ impl ID3D10Query {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10Query> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Query> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Query> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Query) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Query> for ID3D10DeviceChild {
-    fn from(value: ID3D10Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Query> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Query> for ID3D10DeviceChild {
-    fn from(value: &ID3D10Query) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Query> for ID3D10Asynchronous {
-    fn from(value: ID3D10Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Query> for &'a ID3D10Asynchronous {
-    fn from(value: &'a ID3D10Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Query> for ID3D10Asynchronous {
-    fn from(value: &ID3D10Query) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Query, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10Asynchronous);
 impl ::core::clone::Clone for ID3D10Query {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5980,36 +5218,7 @@ impl ID3D10RasterizerState {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10RasterizerState> for ::windows::core::IUnknown {
-    fn from(value: ID3D10RasterizerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10RasterizerState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10RasterizerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10RasterizerState> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10RasterizerState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10RasterizerState> for ID3D10DeviceChild {
-    fn from(value: ID3D10RasterizerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10RasterizerState> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10RasterizerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10RasterizerState> for ID3D10DeviceChild {
-    fn from(value: &ID3D10RasterizerState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10RasterizerState, ::windows::core::IUnknown, ID3D10DeviceChild);
 impl ::core::clone::Clone for ID3D10RasterizerState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6071,51 +5280,7 @@ impl ID3D10RenderTargetView {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10RenderTargetView> for ::windows::core::IUnknown {
-    fn from(value: ID3D10RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10RenderTargetView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10RenderTargetView> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10RenderTargetView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10RenderTargetView> for ID3D10DeviceChild {
-    fn from(value: ID3D10RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10RenderTargetView> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10RenderTargetView> for ID3D10DeviceChild {
-    fn from(value: &ID3D10RenderTargetView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10RenderTargetView> for ID3D10View {
-    fn from(value: ID3D10RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10RenderTargetView> for &'a ID3D10View {
-    fn from(value: &'a ID3D10RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10RenderTargetView> for ID3D10View {
-    fn from(value: &ID3D10RenderTargetView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10RenderTargetView, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10View);
 impl ::core::clone::Clone for ID3D10RenderTargetView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6178,36 +5343,7 @@ impl ID3D10Resource {
         (::windows::core::Vtable::vtable(self).GetEvictionPriority)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D10Resource> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Resource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Resource> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Resource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Resource> for ID3D10DeviceChild {
-    fn from(value: ID3D10Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Resource> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Resource> for ID3D10DeviceChild {
-    fn from(value: &ID3D10Resource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Resource, ::windows::core::IUnknown, ID3D10DeviceChild);
 impl ::core::clone::Clone for ID3D10Resource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6263,36 +5399,7 @@ impl ID3D10SamplerState {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10SamplerState> for ::windows::core::IUnknown {
-    fn from(value: ID3D10SamplerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10SamplerState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10SamplerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10SamplerState> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10SamplerState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10SamplerState> for ID3D10DeviceChild {
-    fn from(value: ID3D10SamplerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10SamplerState> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10SamplerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10SamplerState> for ID3D10DeviceChild {
-    fn from(value: &ID3D10SamplerState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10SamplerState, ::windows::core::IUnknown, ID3D10DeviceChild);
 impl ::core::clone::Clone for ID3D10SamplerState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6361,21 +5468,7 @@ impl ID3D10ShaderReflection {
         (::windows::core::Vtable::vtable(self).GetOutputParameterDesc)(::windows::core::Vtable::as_raw(self), parameterindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<D3D10_SIGNATURE_PARAMETER_DESC>(result__)
     }
 }
-impl ::core::convert::From<ID3D10ShaderReflection> for ::windows::core::IUnknown {
-    fn from(value: ID3D10ShaderReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10ShaderReflection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10ShaderReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10ShaderReflection> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10ShaderReflection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10ShaderReflection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D10ShaderReflection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6510,21 +5603,7 @@ impl ID3D10ShaderReflection1 {
         (::windows::core::Vtable::vtable(self).IsSampleFrequencyShader)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ID3D10ShaderReflection1> for ::windows::core::IUnknown {
-    fn from(value: ID3D10ShaderReflection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10ShaderReflection1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10ShaderReflection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10ShaderReflection1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10ShaderReflection1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10ShaderReflection1, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D10ShaderReflection1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6792,51 +5871,7 @@ impl ID3D10ShaderResourceView {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10ShaderResourceView> for ::windows::core::IUnknown {
-    fn from(value: ID3D10ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10ShaderResourceView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10ShaderResourceView> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10ShaderResourceView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10ShaderResourceView> for ID3D10DeviceChild {
-    fn from(value: ID3D10ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10ShaderResourceView> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10ShaderResourceView> for ID3D10DeviceChild {
-    fn from(value: &ID3D10ShaderResourceView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10ShaderResourceView> for ID3D10View {
-    fn from(value: ID3D10ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10ShaderResourceView> for &'a ID3D10View {
-    fn from(value: &'a ID3D10ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10ShaderResourceView> for ID3D10View {
-    fn from(value: &ID3D10ShaderResourceView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10ShaderResourceView, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10View);
 impl ::core::clone::Clone for ID3D10ShaderResourceView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6903,66 +5938,7 @@ impl ID3D10ShaderResourceView1 {
         (::windows::core::Vtable::vtable(self).GetDesc1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10ShaderResourceView1> for ::windows::core::IUnknown {
-    fn from(value: ID3D10ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10ShaderResourceView1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10ShaderResourceView1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10ShaderResourceView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10ShaderResourceView1> for ID3D10DeviceChild {
-    fn from(value: ID3D10ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10ShaderResourceView1> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10ShaderResourceView1> for ID3D10DeviceChild {
-    fn from(value: &ID3D10ShaderResourceView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10ShaderResourceView1> for ID3D10View {
-    fn from(value: ID3D10ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10ShaderResourceView1> for &'a ID3D10View {
-    fn from(value: &'a ID3D10ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10ShaderResourceView1> for ID3D10View {
-    fn from(value: &ID3D10ShaderResourceView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10ShaderResourceView1> for ID3D10ShaderResourceView {
-    fn from(value: ID3D10ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10ShaderResourceView1> for &'a ID3D10ShaderResourceView {
-    fn from(value: &'a ID3D10ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10ShaderResourceView1> for ID3D10ShaderResourceView {
-    fn from(value: &ID3D10ShaderResourceView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10ShaderResourceView1, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10View, ID3D10ShaderResourceView);
 impl ::core::clone::Clone for ID3D10ShaderResourceView1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7014,21 +5990,7 @@ impl ID3D10StateBlock {
         (::windows::core::Vtable::vtable(self).GetDevice)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID3D10Device>(result__)
     }
 }
-impl ::core::convert::From<ID3D10StateBlock> for ::windows::core::IUnknown {
-    fn from(value: ID3D10StateBlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10StateBlock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10StateBlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10StateBlock> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10StateBlock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10StateBlock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D10StateBlock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7080,21 +6042,7 @@ impl ID3D10SwitchToRef {
         (::windows::core::Vtable::vtable(self).GetUseRef)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D10SwitchToRef> for ::windows::core::IUnknown {
-    fn from(value: ID3D10SwitchToRef) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10SwitchToRef> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10SwitchToRef) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10SwitchToRef> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10SwitchToRef) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10SwitchToRef, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D10SwitchToRef {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7172,51 +6120,7 @@ impl ID3D10Texture1D {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10Texture1D> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Texture1D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Texture1D> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Texture1D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Texture1D> for ID3D10DeviceChild {
-    fn from(value: ID3D10Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Texture1D> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Texture1D> for ID3D10DeviceChild {
-    fn from(value: &ID3D10Texture1D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Texture1D> for ID3D10Resource {
-    fn from(value: ID3D10Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Texture1D> for &'a ID3D10Resource {
-    fn from(value: &'a ID3D10Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Texture1D> for ID3D10Resource {
-    fn from(value: &ID3D10Texture1D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Texture1D, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10Resource);
 impl ::core::clone::Clone for ID3D10Texture1D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7293,51 +6197,7 @@ impl ID3D10Texture2D {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10Texture2D> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Texture2D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Texture2D> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Texture2D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Texture2D> for ID3D10DeviceChild {
-    fn from(value: ID3D10Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Texture2D> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Texture2D> for ID3D10DeviceChild {
-    fn from(value: &ID3D10Texture2D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Texture2D> for ID3D10Resource {
-    fn from(value: ID3D10Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Texture2D> for &'a ID3D10Resource {
-    fn from(value: &'a ID3D10Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Texture2D> for ID3D10Resource {
-    fn from(value: &ID3D10Texture2D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Texture2D, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10Resource);
 impl ::core::clone::Clone for ID3D10Texture2D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7414,51 +6274,7 @@ impl ID3D10Texture3D {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D10Texture3D> for ::windows::core::IUnknown {
-    fn from(value: ID3D10Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Texture3D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Texture3D> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10Texture3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Texture3D> for ID3D10DeviceChild {
-    fn from(value: ID3D10Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Texture3D> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Texture3D> for ID3D10DeviceChild {
-    fn from(value: &ID3D10Texture3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10Texture3D> for ID3D10Resource {
-    fn from(value: ID3D10Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10Texture3D> for &'a ID3D10Resource {
-    fn from(value: &'a ID3D10Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10Texture3D> for ID3D10Resource {
-    fn from(value: &ID3D10Texture3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10Texture3D, ::windows::core::IUnknown, ID3D10DeviceChild, ID3D10Resource);
 impl ::core::clone::Clone for ID3D10Texture3D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7514,36 +6330,7 @@ impl ID3D10VertexShader {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D10VertexShader> for ::windows::core::IUnknown {
-    fn from(value: ID3D10VertexShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10VertexShader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10VertexShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10VertexShader> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10VertexShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10VertexShader> for ID3D10DeviceChild {
-    fn from(value: ID3D10VertexShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10VertexShader> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10VertexShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10VertexShader> for ID3D10DeviceChild {
-    fn from(value: &ID3D10VertexShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10VertexShader, ::windows::core::IUnknown, ID3D10DeviceChild);
 impl ::core::clone::Clone for ID3D10VertexShader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7596,36 +6383,7 @@ impl ID3D10View {
         (::windows::core::Vtable::vtable(self).GetResource)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppresource))
     }
 }
-impl ::core::convert::From<ID3D10View> for ::windows::core::IUnknown {
-    fn from(value: ID3D10View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10View> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D10View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10View> for ::windows::core::IUnknown {
-    fn from(value: &ID3D10View) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D10View> for ID3D10DeviceChild {
-    fn from(value: ID3D10View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D10View> for &'a ID3D10DeviceChild {
-    fn from(value: &'a ID3D10View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D10View> for ID3D10DeviceChild {
-    fn from(value: &ID3D10View) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D10View, ::windows::core::IUnknown, ID3D10DeviceChild);
 impl ::core::clone::Clone for ID3D10View {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -187,36 +187,7 @@ impl ID3D11Asynchronous {
         (::windows::core::Vtable::vtable(self).GetDataSize)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D11Asynchronous> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Asynchronous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Asynchronous> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Asynchronous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Asynchronous> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Asynchronous) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Asynchronous> for ID3D11DeviceChild {
-    fn from(value: ID3D11Asynchronous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Asynchronous> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Asynchronous) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Asynchronous> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Asynchronous) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Asynchronous, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11Asynchronous {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -279,36 +250,7 @@ impl ID3D11AuthenticatedChannel {
         (::windows::core::Vtable::vtable(self).GetChannelHandle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pchannelhandle))
     }
 }
-impl ::core::convert::From<ID3D11AuthenticatedChannel> for ::windows::core::IUnknown {
-    fn from(value: ID3D11AuthenticatedChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11AuthenticatedChannel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11AuthenticatedChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11AuthenticatedChannel> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11AuthenticatedChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11AuthenticatedChannel> for ID3D11DeviceChild {
-    fn from(value: ID3D11AuthenticatedChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11AuthenticatedChannel> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11AuthenticatedChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11AuthenticatedChannel> for ID3D11DeviceChild {
-    fn from(value: &ID3D11AuthenticatedChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11AuthenticatedChannel, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11AuthenticatedChannel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -369,36 +311,7 @@ impl ID3D11BlendState {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11BlendState> for ::windows::core::IUnknown {
-    fn from(value: ID3D11BlendState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11BlendState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11BlendState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11BlendState> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11BlendState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11BlendState> for ID3D11DeviceChild {
-    fn from(value: ID3D11BlendState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11BlendState> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11BlendState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11BlendState> for ID3D11DeviceChild {
-    fn from(value: &ID3D11BlendState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11BlendState, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11BlendState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -462,51 +375,7 @@ impl ID3D11BlendState1 {
         (::windows::core::Vtable::vtable(self).GetDesc1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11BlendState1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11BlendState1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11BlendState1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11BlendState1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11BlendState1> for ID3D11DeviceChild {
-    fn from(value: ID3D11BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11BlendState1> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11BlendState1> for ID3D11DeviceChild {
-    fn from(value: &ID3D11BlendState1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11BlendState1> for ID3D11BlendState {
-    fn from(value: ID3D11BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11BlendState1> for &'a ID3D11BlendState {
-    fn from(value: &'a ID3D11BlendState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11BlendState1> for ID3D11BlendState {
-    fn from(value: &ID3D11BlendState1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11BlendState1, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11BlendState);
 impl ::core::clone::Clone for ID3D11BlendState1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -572,51 +441,7 @@ impl ID3D11Buffer {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11Buffer> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Buffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Buffer> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Buffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Buffer> for ID3D11DeviceChild {
-    fn from(value: ID3D11Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Buffer> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Buffer> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Buffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Buffer> for ID3D11Resource {
-    fn from(value: ID3D11Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Buffer> for &'a ID3D11Resource {
-    fn from(value: &'a ID3D11Buffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Buffer> for ID3D11Resource {
-    fn from(value: &ID3D11Buffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Buffer, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11Resource);
 impl ::core::clone::Clone for ID3D11Buffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -681,36 +506,7 @@ impl ID3D11ClassInstance {
         (::windows::core::Vtable::vtable(self).GetTypeName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptypename), ::core::mem::transmute(pbufferlength))
     }
 }
-impl ::core::convert::From<ID3D11ClassInstance> for ::windows::core::IUnknown {
-    fn from(value: ID3D11ClassInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ClassInstance> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11ClassInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ClassInstance> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11ClassInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11ClassInstance> for ID3D11DeviceChild {
-    fn from(value: ID3D11ClassInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ClassInstance> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11ClassInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ClassInstance> for ID3D11DeviceChild {
-    fn from(value: &ID3D11ClassInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11ClassInstance, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11ClassInstance {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -781,36 +577,7 @@ impl ID3D11ClassLinkage {
         (::windows::core::Vtable::vtable(self).CreateClassInstance)(::windows::core::Vtable::as_raw(self), pclasstypename.into(), constantbufferoffset, constantvectoroffset, textureoffset, sampleroffset, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID3D11ClassInstance>(result__)
     }
 }
-impl ::core::convert::From<ID3D11ClassLinkage> for ::windows::core::IUnknown {
-    fn from(value: ID3D11ClassLinkage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ClassLinkage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11ClassLinkage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ClassLinkage> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11ClassLinkage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11ClassLinkage> for ID3D11DeviceChild {
-    fn from(value: ID3D11ClassLinkage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ClassLinkage> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11ClassLinkage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ClassLinkage> for ID3D11DeviceChild {
-    fn from(value: &ID3D11ClassLinkage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11ClassLinkage, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11ClassLinkage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -865,36 +632,7 @@ impl ID3D11CommandList {
         (::windows::core::Vtable::vtable(self).GetContextFlags)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D11CommandList> for ::windows::core::IUnknown {
-    fn from(value: ID3D11CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11CommandList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11CommandList> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11CommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11CommandList> for ID3D11DeviceChild {
-    fn from(value: ID3D11CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11CommandList> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11CommandList> for ID3D11DeviceChild {
-    fn from(value: &ID3D11CommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11CommandList, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11CommandList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -945,36 +683,7 @@ impl ID3D11ComputeShader {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D11ComputeShader> for ::windows::core::IUnknown {
-    fn from(value: ID3D11ComputeShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ComputeShader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11ComputeShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ComputeShader> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11ComputeShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11ComputeShader> for ID3D11DeviceChild {
-    fn from(value: ID3D11ComputeShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ComputeShader> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11ComputeShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ComputeShader> for ID3D11DeviceChild {
-    fn from(value: &ID3D11ComputeShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11ComputeShader, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11ComputeShader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1030,51 +739,7 @@ impl ID3D11Counter {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11Counter> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Counter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Counter> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Counter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Counter> for ID3D11DeviceChild {
-    fn from(value: ID3D11Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Counter> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Counter> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Counter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Counter> for ID3D11Asynchronous {
-    fn from(value: ID3D11Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Counter> for &'a ID3D11Asynchronous {
-    fn from(value: &'a ID3D11Counter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Counter> for ID3D11Asynchronous {
-    fn from(value: &ID3D11Counter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Counter, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11Asynchronous);
 impl ::core::clone::Clone for ID3D11Counter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1143,36 +808,7 @@ impl ID3D11CryptoSession {
         (::windows::core::Vtable::vtable(self).GetCryptoSessionHandle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcryptosessionhandle))
     }
 }
-impl ::core::convert::From<ID3D11CryptoSession> for ::windows::core::IUnknown {
-    fn from(value: ID3D11CryptoSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11CryptoSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11CryptoSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11CryptoSession> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11CryptoSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11CryptoSession> for ID3D11DeviceChild {
-    fn from(value: ID3D11CryptoSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11CryptoSession> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11CryptoSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11CryptoSession> for ID3D11DeviceChild {
-    fn from(value: &ID3D11CryptoSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11CryptoSession, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11CryptoSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1256,21 +892,7 @@ impl ID3D11Debug {
         (::windows::core::Vtable::vtable(self).ValidateContextForDispatch)(::windows::core::Vtable::as_raw(self), pcontext.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D11Debug> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Debug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Debug> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Debug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Debug> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Debug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Debug, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11Debug {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1340,36 +962,7 @@ impl ID3D11DepthStencilState {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11DepthStencilState> for ::windows::core::IUnknown {
-    fn from(value: ID3D11DepthStencilState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DepthStencilState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11DepthStencilState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DepthStencilState> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11DepthStencilState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DepthStencilState> for ID3D11DeviceChild {
-    fn from(value: ID3D11DepthStencilState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DepthStencilState> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11DepthStencilState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DepthStencilState> for ID3D11DeviceChild {
-    fn from(value: &ID3D11DepthStencilState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11DepthStencilState, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11DepthStencilState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1431,51 +1024,7 @@ impl ID3D11DepthStencilView {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11DepthStencilView> for ::windows::core::IUnknown {
-    fn from(value: ID3D11DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DepthStencilView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DepthStencilView> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11DepthStencilView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DepthStencilView> for ID3D11DeviceChild {
-    fn from(value: ID3D11DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DepthStencilView> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DepthStencilView> for ID3D11DeviceChild {
-    fn from(value: &ID3D11DepthStencilView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DepthStencilView> for ID3D11View {
-    fn from(value: ID3D11DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DepthStencilView> for &'a ID3D11View {
-    fn from(value: &'a ID3D11DepthStencilView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DepthStencilView> for ID3D11View {
-    fn from(value: &ID3D11DepthStencilView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11DepthStencilView, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11View);
 impl ::core::clone::Clone for ID3D11DepthStencilView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1743,21 +1292,7 @@ impl ID3D11Device {
         (::windows::core::Vtable::vtable(self).GetExceptionMode)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D11Device> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Device) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Device, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11Device {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2148,36 +1683,7 @@ impl ID3D11Device1 {
         (::windows::core::Vtable::vtable(self).OpenSharedResourceByName)(::windows::core::Vtable::as_raw(self), lpname.into(), dwdesiredaccess, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ID3D11Device1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device1> for ID3D11Device {
-    fn from(value: ID3D11Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device1> for &'a ID3D11Device {
-    fn from(value: &'a ID3D11Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device1> for ID3D11Device {
-    fn from(value: &ID3D11Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Device1, ::windows::core::IUnknown, ID3D11Device);
 impl ::core::clone::Clone for ID3D11Device1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2530,51 +2036,7 @@ impl ID3D11Device2 {
         (::windows::core::Vtable::vtable(self).CheckMultisampleQualityLevels1)(::windows::core::Vtable::as_raw(self), format, samplecount, flags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ID3D11Device2> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device2> for ID3D11Device {
-    fn from(value: ID3D11Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device2> for &'a ID3D11Device {
-    fn from(value: &'a ID3D11Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device2> for ID3D11Device {
-    fn from(value: &ID3D11Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device2> for ID3D11Device1 {
-    fn from(value: ID3D11Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device2> for &'a ID3D11Device1 {
-    fn from(value: &'a ID3D11Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device2> for ID3D11Device1 {
-    fn from(value: &ID3D11Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Device2, ::windows::core::IUnknown, ID3D11Device, ID3D11Device1);
 impl ::core::clone::Clone for ID3D11Device2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2983,66 +2445,7 @@ impl ID3D11Device3 {
         (::windows::core::Vtable::vtable(self).ReadFromSubresource)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdstdata), dstrowpitch, dstdepthpitch, psrcresource.into().abi(), srcsubresource, ::core::mem::transmute(psrcbox.unwrap_or(::std::ptr::null())))
     }
 }
-impl ::core::convert::From<ID3D11Device3> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device3> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device3> for ID3D11Device {
-    fn from(value: ID3D11Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device3> for &'a ID3D11Device {
-    fn from(value: &'a ID3D11Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device3> for ID3D11Device {
-    fn from(value: &ID3D11Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device3> for ID3D11Device1 {
-    fn from(value: ID3D11Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device3> for &'a ID3D11Device1 {
-    fn from(value: &'a ID3D11Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device3> for ID3D11Device1 {
-    fn from(value: &ID3D11Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device3> for ID3D11Device2 {
-    fn from(value: ID3D11Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device3> for &'a ID3D11Device2 {
-    fn from(value: &'a ID3D11Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device3> for ID3D11Device2 {
-    fn from(value: &ID3D11Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Device3, ::windows::core::IUnknown, ID3D11Device, ID3D11Device1, ID3D11Device2);
 impl ::core::clone::Clone for ID3D11Device3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3485,81 +2888,7 @@ impl ID3D11Device4 {
         (::windows::core::Vtable::vtable(self).UnregisterDeviceRemoved)(::windows::core::Vtable::as_raw(self), dwcookie)
     }
 }
-impl ::core::convert::From<ID3D11Device4> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device4> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device4> for ID3D11Device {
-    fn from(value: ID3D11Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device4> for &'a ID3D11Device {
-    fn from(value: &'a ID3D11Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device4> for ID3D11Device {
-    fn from(value: &ID3D11Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device4> for ID3D11Device1 {
-    fn from(value: ID3D11Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device4> for &'a ID3D11Device1 {
-    fn from(value: &'a ID3D11Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device4> for ID3D11Device1 {
-    fn from(value: &ID3D11Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device4> for ID3D11Device2 {
-    fn from(value: ID3D11Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device4> for &'a ID3D11Device2 {
-    fn from(value: &'a ID3D11Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device4> for ID3D11Device2 {
-    fn from(value: &ID3D11Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device4> for ID3D11Device3 {
-    fn from(value: ID3D11Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device4> for &'a ID3D11Device3 {
-    fn from(value: &'a ID3D11Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device4> for ID3D11Device3 {
-    fn from(value: &ID3D11Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Device4, ::windows::core::IUnknown, ID3D11Device, ID3D11Device1, ID3D11Device2, ID3D11Device3);
 impl ::core::clone::Clone for ID3D11Device4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3993,96 +3322,7 @@ impl ID3D11Device5 {
         (::windows::core::Vtable::vtable(self).CreateFence)(::windows::core::Vtable::as_raw(self), initialvalue, flags, &<T as ::windows::core::Interface>::IID, result__ as *mut _ as *mut _).ok()
     }
 }
-impl ::core::convert::From<ID3D11Device5> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device5> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device5> for ID3D11Device {
-    fn from(value: ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device5> for &'a ID3D11Device {
-    fn from(value: &'a ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device5> for ID3D11Device {
-    fn from(value: &ID3D11Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device5> for ID3D11Device1 {
-    fn from(value: ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device5> for &'a ID3D11Device1 {
-    fn from(value: &'a ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device5> for ID3D11Device1 {
-    fn from(value: &ID3D11Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device5> for ID3D11Device2 {
-    fn from(value: ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device5> for &'a ID3D11Device2 {
-    fn from(value: &'a ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device5> for ID3D11Device2 {
-    fn from(value: &ID3D11Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device5> for ID3D11Device3 {
-    fn from(value: ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device5> for &'a ID3D11Device3 {
-    fn from(value: &'a ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device5> for ID3D11Device3 {
-    fn from(value: &ID3D11Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Device5> for ID3D11Device4 {
-    fn from(value: ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Device5> for &'a ID3D11Device4 {
-    fn from(value: &'a ID3D11Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Device5> for ID3D11Device4 {
-    fn from(value: &ID3D11Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Device5, ::windows::core::IUnknown, ID3D11Device, ID3D11Device1, ID3D11Device2, ID3D11Device3, ID3D11Device4);
 impl ::core::clone::Clone for ID3D11Device5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4137,21 +3377,7 @@ impl ID3D11DeviceChild {
         (::windows::core::Vtable::vtable(self).SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D11DeviceChild> for ::windows::core::IUnknown {
-    fn from(value: ID3D11DeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceChild> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11DeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceChild> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11DeviceChild) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11DeviceChild, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11DeviceChild {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4675,36 +3901,7 @@ impl ID3D11DeviceContext {
         (::windows::core::Vtable::vtable(self).FinishCommandList)(::windows::core::Vtable::as_raw(self), restoredeferredcontextstate.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID3D11CommandList>(result__)
     }
 }
-impl ::core::convert::From<ID3D11DeviceContext> for ::windows::core::IUnknown {
-    fn from(value: ID3D11DeviceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11DeviceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11DeviceContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext> for ID3D11DeviceChild {
-    fn from(value: ID3D11DeviceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11DeviceContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext> for ID3D11DeviceChild {
-    fn from(value: &ID3D11DeviceContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11DeviceContext, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11DeviceContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5448,51 +4645,7 @@ impl ID3D11DeviceContext1 {
         (::windows::core::Vtable::vtable(self).DiscardView1)(::windows::core::Vtable::as_raw(self), presourceview.into().abi(), ::core::mem::transmute(prects.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), prects.as_deref().map_or(0, |slice| slice.len() as _))
     }
 }
-impl ::core::convert::From<ID3D11DeviceContext1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11DeviceContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext1> for ID3D11DeviceChild {
-    fn from(value: ID3D11DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext1> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext1> for ID3D11DeviceChild {
-    fn from(value: &ID3D11DeviceContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext1> for ID3D11DeviceContext {
-    fn from(value: ID3D11DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext1> for &'a ID3D11DeviceContext {
-    fn from(value: &'a ID3D11DeviceContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext1> for ID3D11DeviceContext {
-    fn from(value: &ID3D11DeviceContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11DeviceContext1, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11DeviceContext);
 impl ::core::clone::Clone for ID3D11DeviceContext1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6201,66 +5354,7 @@ impl ID3D11DeviceContext2 {
         (::windows::core::Vtable::vtable(self).EndEvent)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D11DeviceContext2> for ::windows::core::IUnknown {
-    fn from(value: ID3D11DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11DeviceContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext2> for ID3D11DeviceChild {
-    fn from(value: ID3D11DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext2> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext2> for ID3D11DeviceChild {
-    fn from(value: &ID3D11DeviceContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext2> for ID3D11DeviceContext {
-    fn from(value: ID3D11DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext2> for &'a ID3D11DeviceContext {
-    fn from(value: &'a ID3D11DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext2> for ID3D11DeviceContext {
-    fn from(value: &ID3D11DeviceContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext2> for ID3D11DeviceContext1 {
-    fn from(value: ID3D11DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext2> for &'a ID3D11DeviceContext1 {
-    fn from(value: &'a ID3D11DeviceContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext2> for ID3D11DeviceContext1 {
-    fn from(value: &ID3D11DeviceContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11DeviceContext2, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11DeviceContext, ID3D11DeviceContext1);
 impl ::core::clone::Clone for ID3D11DeviceContext2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6990,81 +6084,7 @@ impl ID3D11DeviceContext3 {
         (::windows::core::Vtable::vtable(self).GetHardwareProtectionState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phwprotectionenable))
     }
 }
-impl ::core::convert::From<ID3D11DeviceContext3> for ::windows::core::IUnknown {
-    fn from(value: ID3D11DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext3> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11DeviceContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext3> for ID3D11DeviceChild {
-    fn from(value: ID3D11DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext3> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext3> for ID3D11DeviceChild {
-    fn from(value: &ID3D11DeviceContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext3> for ID3D11DeviceContext {
-    fn from(value: ID3D11DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext3> for &'a ID3D11DeviceContext {
-    fn from(value: &'a ID3D11DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext3> for ID3D11DeviceContext {
-    fn from(value: &ID3D11DeviceContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext3> for ID3D11DeviceContext1 {
-    fn from(value: ID3D11DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext3> for &'a ID3D11DeviceContext1 {
-    fn from(value: &'a ID3D11DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext3> for ID3D11DeviceContext1 {
-    fn from(value: &ID3D11DeviceContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext3> for ID3D11DeviceContext2 {
-    fn from(value: ID3D11DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext3> for &'a ID3D11DeviceContext2 {
-    fn from(value: &'a ID3D11DeviceContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext3> for ID3D11DeviceContext2 {
-    fn from(value: &ID3D11DeviceContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11DeviceContext3, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11DeviceContext, ID3D11DeviceContext1, ID3D11DeviceContext2);
 impl ::core::clone::Clone for ID3D11DeviceContext3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7793,96 +6813,7 @@ impl ID3D11DeviceContext4 {
         (::windows::core::Vtable::vtable(self).Wait)(::windows::core::Vtable::as_raw(self), pfence.into().abi(), value).ok()
     }
 }
-impl ::core::convert::From<ID3D11DeviceContext4> for ::windows::core::IUnknown {
-    fn from(value: ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext4> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext4> for ID3D11DeviceChild {
-    fn from(value: ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext4> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext4> for ID3D11DeviceChild {
-    fn from(value: &ID3D11DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext4> for ID3D11DeviceContext {
-    fn from(value: ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext4> for &'a ID3D11DeviceContext {
-    fn from(value: &'a ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext4> for ID3D11DeviceContext {
-    fn from(value: &ID3D11DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext4> for ID3D11DeviceContext1 {
-    fn from(value: ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext4> for &'a ID3D11DeviceContext1 {
-    fn from(value: &'a ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext4> for ID3D11DeviceContext1 {
-    fn from(value: &ID3D11DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext4> for ID3D11DeviceContext2 {
-    fn from(value: ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext4> for &'a ID3D11DeviceContext2 {
-    fn from(value: &'a ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext4> for ID3D11DeviceContext2 {
-    fn from(value: &ID3D11DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DeviceContext4> for ID3D11DeviceContext3 {
-    fn from(value: ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DeviceContext4> for &'a ID3D11DeviceContext3 {
-    fn from(value: &'a ID3D11DeviceContext4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DeviceContext4> for ID3D11DeviceContext3 {
-    fn from(value: &ID3D11DeviceContext4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11DeviceContext4, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11DeviceContext, ID3D11DeviceContext1, ID3D11DeviceContext2, ID3D11DeviceContext3);
 impl ::core::clone::Clone for ID3D11DeviceContext4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7934,36 +6865,7 @@ impl ID3D11DomainShader {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D11DomainShader> for ::windows::core::IUnknown {
-    fn from(value: ID3D11DomainShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DomainShader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11DomainShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DomainShader> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11DomainShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11DomainShader> for ID3D11DeviceChild {
-    fn from(value: ID3D11DomainShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11DomainShader> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11DomainShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11DomainShader> for ID3D11DeviceChild {
-    fn from(value: &ID3D11DomainShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11DomainShader, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11DomainShader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8033,36 +6935,7 @@ impl ID3D11Fence {
         (::windows::core::Vtable::vtable(self).SetEventOnCompletion)(::windows::core::Vtable::as_raw(self), value, hevent.into()).ok()
     }
 }
-impl ::core::convert::From<ID3D11Fence> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Fence> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Fence> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Fence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Fence> for ID3D11DeviceChild {
-    fn from(value: ID3D11Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Fence> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Fence> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Fence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Fence, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11Fence {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8160,21 +7033,7 @@ impl ID3D11FunctionLinkingGraph {
         (::windows::core::Vtable::vtable(self).GenerateHlsl)(::windows::core::Vtable::as_raw(self), uflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Direct3D::ID3DBlob>(result__)
     }
 }
-impl ::core::convert::From<ID3D11FunctionLinkingGraph> for ::windows::core::IUnknown {
-    fn from(value: ID3D11FunctionLinkingGraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11FunctionLinkingGraph> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11FunctionLinkingGraph) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11FunctionLinkingGraph> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11FunctionLinkingGraph) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11FunctionLinkingGraph, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11FunctionLinkingGraph {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8390,36 +7249,7 @@ impl ID3D11GeometryShader {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D11GeometryShader> for ::windows::core::IUnknown {
-    fn from(value: ID3D11GeometryShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11GeometryShader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11GeometryShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11GeometryShader> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11GeometryShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11GeometryShader> for ID3D11DeviceChild {
-    fn from(value: ID3D11GeometryShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11GeometryShader> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11GeometryShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11GeometryShader> for ID3D11DeviceChild {
-    fn from(value: &ID3D11GeometryShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11GeometryShader, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11GeometryShader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8469,36 +7299,7 @@ impl ID3D11HullShader {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D11HullShader> for ::windows::core::IUnknown {
-    fn from(value: ID3D11HullShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11HullShader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11HullShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11HullShader> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11HullShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11HullShader> for ID3D11DeviceChild {
-    fn from(value: ID3D11HullShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11HullShader> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11HullShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11HullShader> for ID3D11DeviceChild {
-    fn from(value: &ID3D11HullShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11HullShader, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11HullShader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8672,21 +7473,7 @@ impl ID3D11InfoQueue {
         (::windows::core::Vtable::vtable(self).GetMuteDebugOutput)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D11InfoQueue> for ::windows::core::IUnknown {
-    fn from(value: ID3D11InfoQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11InfoQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11InfoQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11InfoQueue> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11InfoQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11InfoQueue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11InfoQueue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8795,36 +7582,7 @@ impl ID3D11InputLayout {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D11InputLayout> for ::windows::core::IUnknown {
-    fn from(value: ID3D11InputLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11InputLayout> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11InputLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11InputLayout> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11InputLayout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11InputLayout> for ID3D11DeviceChild {
-    fn from(value: ID3D11InputLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11InputLayout> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11InputLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11InputLayout> for ID3D11DeviceChild {
-    fn from(value: &ID3D11InputLayout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11InputLayout, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11InputLayout {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8866,21 +7624,7 @@ impl ID3D11LibraryReflection {
         (::windows::core::Vtable::vtable(self).GetFunctionByIndex)(::windows::core::Vtable::as_raw(self), functionindex)
     }
 }
-impl ::core::convert::From<ID3D11LibraryReflection> for ::windows::core::IUnknown {
-    fn from(value: ID3D11LibraryReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11LibraryReflection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11LibraryReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11LibraryReflection> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11LibraryReflection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11LibraryReflection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11LibraryReflection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8936,21 +7680,7 @@ impl ID3D11Linker {
         (::windows::core::Vtable::vtable(self).AddClipPlaneFromCBuffer)(::windows::core::Vtable::as_raw(self), ucbufferslot, ucbufferentry).ok()
     }
 }
-impl ::core::convert::From<ID3D11Linker> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Linker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Linker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Linker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Linker> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Linker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Linker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11Linker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8990,21 +7720,7 @@ pub struct ID3D11Linker_Vtbl {
 #[repr(transparent)]
 pub struct ID3D11LinkingNode(::windows::core::IUnknown);
 impl ID3D11LinkingNode {}
-impl ::core::convert::From<ID3D11LinkingNode> for ::windows::core::IUnknown {
-    fn from(value: ID3D11LinkingNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11LinkingNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11LinkingNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11LinkingNode> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11LinkingNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11LinkingNode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11LinkingNode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9046,21 +7762,7 @@ impl ID3D11Module {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), pnamespace.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID3D11ModuleInstance>(result__)
     }
 }
-impl ::core::convert::From<ID3D11Module> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Module) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Module> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Module) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Module> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Module) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Module, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11Module {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9141,21 +7843,7 @@ impl ID3D11ModuleInstance {
         (::windows::core::Vtable::vtable(self).BindResourceAsUnorderedAccessViewByName)(::windows::core::Vtable::as_raw(self), psrvname.into(), udstuavslot, ucount).ok()
     }
 }
-impl ::core::convert::From<ID3D11ModuleInstance> for ::windows::core::IUnknown {
-    fn from(value: ID3D11ModuleInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ModuleInstance> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11ModuleInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ModuleInstance> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11ModuleInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11ModuleInstance, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11ModuleInstance {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9219,21 +7907,7 @@ impl ID3D11Multithread {
         (::windows::core::Vtable::vtable(self).GetMultithreadProtected)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D11Multithread> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Multithread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Multithread> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Multithread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Multithread> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Multithread) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Multithread, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11Multithread {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9293,36 +7967,7 @@ impl ID3D11PixelShader {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D11PixelShader> for ::windows::core::IUnknown {
-    fn from(value: ID3D11PixelShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11PixelShader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11PixelShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11PixelShader> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11PixelShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11PixelShader> for ID3D11DeviceChild {
-    fn from(value: ID3D11PixelShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11PixelShader> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11PixelShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11PixelShader> for ID3D11DeviceChild {
-    fn from(value: &ID3D11PixelShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11PixelShader, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11PixelShader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9378,66 +8023,7 @@ impl ID3D11Predicate {
         (::windows::core::Vtable::vtable(self).base__.GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11Predicate> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Predicate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Predicate> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Predicate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Predicate> for ID3D11DeviceChild {
-    fn from(value: ID3D11Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Predicate> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Predicate> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Predicate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Predicate> for ID3D11Asynchronous {
-    fn from(value: ID3D11Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Predicate> for &'a ID3D11Asynchronous {
-    fn from(value: &'a ID3D11Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Predicate> for ID3D11Asynchronous {
-    fn from(value: &ID3D11Predicate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Predicate> for ID3D11Query {
-    fn from(value: ID3D11Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Predicate> for &'a ID3D11Query {
-    fn from(value: &'a ID3D11Predicate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Predicate> for ID3D11Query {
-    fn from(value: &ID3D11Predicate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Predicate, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11Asynchronous, ID3D11Query);
 impl ::core::clone::Clone for ID3D11Predicate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9493,51 +8079,7 @@ impl ID3D11Query {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11Query> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Query> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Query> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Query) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Query> for ID3D11DeviceChild {
-    fn from(value: ID3D11Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Query> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Query> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Query) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Query> for ID3D11Asynchronous {
-    fn from(value: ID3D11Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Query> for &'a ID3D11Asynchronous {
-    fn from(value: &'a ID3D11Query) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Query> for ID3D11Asynchronous {
-    fn from(value: &ID3D11Query) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Query, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11Asynchronous);
 impl ::core::clone::Clone for ID3D11Query {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9597,66 +8139,7 @@ impl ID3D11Query1 {
         (::windows::core::Vtable::vtable(self).GetDesc1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc1))
     }
 }
-impl ::core::convert::From<ID3D11Query1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Query1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Query1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Query1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Query1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Query1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Query1> for ID3D11DeviceChild {
-    fn from(value: ID3D11Query1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Query1> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Query1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Query1> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Query1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Query1> for ID3D11Asynchronous {
-    fn from(value: ID3D11Query1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Query1> for &'a ID3D11Asynchronous {
-    fn from(value: &'a ID3D11Query1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Query1> for ID3D11Asynchronous {
-    fn from(value: &ID3D11Query1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Query1> for ID3D11Query {
-    fn from(value: ID3D11Query1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Query1> for &'a ID3D11Query {
-    fn from(value: &'a ID3D11Query1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Query1> for ID3D11Query {
-    fn from(value: &ID3D11Query1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Query1, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11Asynchronous, ID3D11Query);
 impl ::core::clone::Clone for ID3D11Query1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9712,36 +8195,7 @@ impl ID3D11RasterizerState {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11RasterizerState> for ::windows::core::IUnknown {
-    fn from(value: ID3D11RasterizerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RasterizerState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11RasterizerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RasterizerState> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11RasterizerState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11RasterizerState> for ID3D11DeviceChild {
-    fn from(value: ID3D11RasterizerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RasterizerState> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11RasterizerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RasterizerState> for ID3D11DeviceChild {
-    fn from(value: &ID3D11RasterizerState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11RasterizerState, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11RasterizerState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9805,51 +8259,7 @@ impl ID3D11RasterizerState1 {
         (::windows::core::Vtable::vtable(self).GetDesc1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11RasterizerState1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11RasterizerState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RasterizerState1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11RasterizerState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RasterizerState1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11RasterizerState1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11RasterizerState1> for ID3D11DeviceChild {
-    fn from(value: ID3D11RasterizerState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RasterizerState1> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11RasterizerState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RasterizerState1> for ID3D11DeviceChild {
-    fn from(value: &ID3D11RasterizerState1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11RasterizerState1> for ID3D11RasterizerState {
-    fn from(value: ID3D11RasterizerState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RasterizerState1> for &'a ID3D11RasterizerState {
-    fn from(value: &'a ID3D11RasterizerState1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RasterizerState1> for ID3D11RasterizerState {
-    fn from(value: &ID3D11RasterizerState1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11RasterizerState1, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11RasterizerState);
 impl ::core::clone::Clone for ID3D11RasterizerState1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9918,66 +8328,7 @@ impl ID3D11RasterizerState2 {
         (::windows::core::Vtable::vtable(self).GetDesc2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11RasterizerState2> for ::windows::core::IUnknown {
-    fn from(value: ID3D11RasterizerState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RasterizerState2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11RasterizerState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RasterizerState2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11RasterizerState2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11RasterizerState2> for ID3D11DeviceChild {
-    fn from(value: ID3D11RasterizerState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RasterizerState2> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11RasterizerState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RasterizerState2> for ID3D11DeviceChild {
-    fn from(value: &ID3D11RasterizerState2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11RasterizerState2> for ID3D11RasterizerState {
-    fn from(value: ID3D11RasterizerState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RasterizerState2> for &'a ID3D11RasterizerState {
-    fn from(value: &'a ID3D11RasterizerState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RasterizerState2> for ID3D11RasterizerState {
-    fn from(value: &ID3D11RasterizerState2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11RasterizerState2> for ID3D11RasterizerState1 {
-    fn from(value: ID3D11RasterizerState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RasterizerState2> for &'a ID3D11RasterizerState1 {
-    fn from(value: &'a ID3D11RasterizerState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RasterizerState2> for ID3D11RasterizerState1 {
-    fn from(value: &ID3D11RasterizerState2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11RasterizerState2, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11RasterizerState, ID3D11RasterizerState1);
 impl ::core::clone::Clone for ID3D11RasterizerState2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10019,21 +8370,7 @@ impl ID3D11RefDefaultTrackingOptions {
         (::windows::core::Vtable::vtable(self).SetTrackingOptions)(::windows::core::Vtable::as_raw(self), resourcetypeflags, options).ok()
     }
 }
-impl ::core::convert::From<ID3D11RefDefaultTrackingOptions> for ::windows::core::IUnknown {
-    fn from(value: ID3D11RefDefaultTrackingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RefDefaultTrackingOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11RefDefaultTrackingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RefDefaultTrackingOptions> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11RefDefaultTrackingOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11RefDefaultTrackingOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11RefDefaultTrackingOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10072,21 +8409,7 @@ impl ID3D11RefTrackingOptions {
         (::windows::core::Vtable::vtable(self).SetTrackingOptions)(::windows::core::Vtable::as_raw(self), uoptions).ok()
     }
 }
-impl ::core::convert::From<ID3D11RefTrackingOptions> for ::windows::core::IUnknown {
-    fn from(value: ID3D11RefTrackingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RefTrackingOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11RefTrackingOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RefTrackingOptions> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11RefTrackingOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11RefTrackingOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11RefTrackingOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10145,51 +8468,7 @@ impl ID3D11RenderTargetView {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11RenderTargetView> for ::windows::core::IUnknown {
-    fn from(value: ID3D11RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RenderTargetView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RenderTargetView> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11RenderTargetView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11RenderTargetView> for ID3D11DeviceChild {
-    fn from(value: ID3D11RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RenderTargetView> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RenderTargetView> for ID3D11DeviceChild {
-    fn from(value: &ID3D11RenderTargetView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11RenderTargetView> for ID3D11View {
-    fn from(value: ID3D11RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RenderTargetView> for &'a ID3D11View {
-    fn from(value: &'a ID3D11RenderTargetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RenderTargetView> for ID3D11View {
-    fn from(value: &ID3D11RenderTargetView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11RenderTargetView, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11View);
 impl ::core::clone::Clone for ID3D11RenderTargetView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10256,66 +8535,7 @@ impl ID3D11RenderTargetView1 {
         (::windows::core::Vtable::vtable(self).GetDesc1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc1))
     }
 }
-impl ::core::convert::From<ID3D11RenderTargetView1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11RenderTargetView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RenderTargetView1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11RenderTargetView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RenderTargetView1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11RenderTargetView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11RenderTargetView1> for ID3D11DeviceChild {
-    fn from(value: ID3D11RenderTargetView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RenderTargetView1> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11RenderTargetView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RenderTargetView1> for ID3D11DeviceChild {
-    fn from(value: &ID3D11RenderTargetView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11RenderTargetView1> for ID3D11View {
-    fn from(value: ID3D11RenderTargetView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RenderTargetView1> for &'a ID3D11View {
-    fn from(value: &'a ID3D11RenderTargetView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RenderTargetView1> for ID3D11View {
-    fn from(value: &ID3D11RenderTargetView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11RenderTargetView1> for ID3D11RenderTargetView {
-    fn from(value: ID3D11RenderTargetView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11RenderTargetView1> for &'a ID3D11RenderTargetView {
-    fn from(value: &'a ID3D11RenderTargetView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11RenderTargetView1> for ID3D11RenderTargetView {
-    fn from(value: &ID3D11RenderTargetView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11RenderTargetView1, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11View, ID3D11RenderTargetView);
 impl ::core::clone::Clone for ID3D11RenderTargetView1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10378,36 +8598,7 @@ impl ID3D11Resource {
         (::windows::core::Vtable::vtable(self).GetEvictionPriority)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D11Resource> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Resource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Resource> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Resource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Resource> for ID3D11DeviceChild {
-    fn from(value: ID3D11Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Resource> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Resource> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Resource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Resource, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11Resource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10463,36 +8654,7 @@ impl ID3D11SamplerState {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11SamplerState> for ::windows::core::IUnknown {
-    fn from(value: ID3D11SamplerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11SamplerState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11SamplerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11SamplerState> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11SamplerState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11SamplerState> for ID3D11DeviceChild {
-    fn from(value: ID3D11SamplerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11SamplerState> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11SamplerState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11SamplerState> for ID3D11DeviceChild {
-    fn from(value: &ID3D11SamplerState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11SamplerState, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11SamplerState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10619,21 +8781,7 @@ impl ID3D11ShaderReflection {
         (::windows::core::Vtable::vtable(self).GetRequiresFlags)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D11ShaderReflection> for ::windows::core::IUnknown {
-    fn from(value: ID3D11ShaderReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ShaderReflection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11ShaderReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ShaderReflection> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11ShaderReflection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11ShaderReflection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11ShaderReflection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10953,51 +9101,7 @@ impl ID3D11ShaderResourceView {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11ShaderResourceView> for ::windows::core::IUnknown {
-    fn from(value: ID3D11ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ShaderResourceView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ShaderResourceView> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11ShaderResourceView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11ShaderResourceView> for ID3D11DeviceChild {
-    fn from(value: ID3D11ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ShaderResourceView> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ShaderResourceView> for ID3D11DeviceChild {
-    fn from(value: &ID3D11ShaderResourceView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11ShaderResourceView> for ID3D11View {
-    fn from(value: ID3D11ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ShaderResourceView> for &'a ID3D11View {
-    fn from(value: &'a ID3D11ShaderResourceView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ShaderResourceView> for ID3D11View {
-    fn from(value: &ID3D11ShaderResourceView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11ShaderResourceView, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11View);
 impl ::core::clone::Clone for ID3D11ShaderResourceView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11064,66 +9168,7 @@ impl ID3D11ShaderResourceView1 {
         (::windows::core::Vtable::vtable(self).GetDesc1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc1))
     }
 }
-impl ::core::convert::From<ID3D11ShaderResourceView1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ShaderResourceView1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ShaderResourceView1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11ShaderResourceView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11ShaderResourceView1> for ID3D11DeviceChild {
-    fn from(value: ID3D11ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ShaderResourceView1> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ShaderResourceView1> for ID3D11DeviceChild {
-    fn from(value: &ID3D11ShaderResourceView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11ShaderResourceView1> for ID3D11View {
-    fn from(value: ID3D11ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ShaderResourceView1> for &'a ID3D11View {
-    fn from(value: &'a ID3D11ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ShaderResourceView1> for ID3D11View {
-    fn from(value: &ID3D11ShaderResourceView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11ShaderResourceView1> for ID3D11ShaderResourceView {
-    fn from(value: ID3D11ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ShaderResourceView1> for &'a ID3D11ShaderResourceView {
-    fn from(value: &'a ID3D11ShaderResourceView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ShaderResourceView1> for ID3D11ShaderResourceView {
-    fn from(value: &ID3D11ShaderResourceView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11ShaderResourceView1, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11View, ID3D11ShaderResourceView);
 impl ::core::clone::Clone for ID3D11ShaderResourceView1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11194,21 +9239,7 @@ impl ID3D11ShaderTrace {
         (::windows::core::Vtable::vtable(self).GetReadRegister)(::windows::core::Vtable::as_raw(self), stepindex, readregisterindex, ::core::mem::transmute(pregister), ::core::mem::transmute(pvalue)).ok()
     }
 }
-impl ::core::convert::From<ID3D11ShaderTrace> for ::windows::core::IUnknown {
-    fn from(value: ID3D11ShaderTrace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ShaderTrace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11ShaderTrace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ShaderTrace> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11ShaderTrace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11ShaderTrace, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11ShaderTrace {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11264,21 +9295,7 @@ impl ID3D11ShaderTraceFactory {
         (::windows::core::Vtable::vtable(self).CreateShaderTrace)(::windows::core::Vtable::as_raw(self), pshader.into().abi(), ::core::mem::transmute(ptracedesc), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ID3D11ShaderTrace>(result__)
     }
 }
-impl ::core::convert::From<ID3D11ShaderTraceFactory> for ::windows::core::IUnknown {
-    fn from(value: ID3D11ShaderTraceFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11ShaderTraceFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11ShaderTraceFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11ShaderTraceFactory> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11ShaderTraceFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11ShaderTraceFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11ShaderTraceFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11327,21 +9344,7 @@ impl ID3D11SwitchToRef {
         (::windows::core::Vtable::vtable(self).GetUseRef)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D11SwitchToRef> for ::windows::core::IUnknown {
-    fn from(value: ID3D11SwitchToRef) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11SwitchToRef> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11SwitchToRef) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11SwitchToRef> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11SwitchToRef) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11SwitchToRef, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11SwitchToRef {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11413,51 +9416,7 @@ impl ID3D11Texture1D {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11Texture1D> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture1D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture1D> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Texture1D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture1D> for ID3D11DeviceChild {
-    fn from(value: ID3D11Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture1D> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture1D> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Texture1D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture1D> for ID3D11Resource {
-    fn from(value: ID3D11Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture1D> for &'a ID3D11Resource {
-    fn from(value: &'a ID3D11Texture1D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture1D> for ID3D11Resource {
-    fn from(value: &ID3D11Texture1D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Texture1D, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11Resource);
 impl ::core::clone::Clone for ID3D11Texture1D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11525,51 +9484,7 @@ impl ID3D11Texture2D {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11Texture2D> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture2D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture2D> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Texture2D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture2D> for ID3D11DeviceChild {
-    fn from(value: ID3D11Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture2D> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture2D> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Texture2D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture2D> for ID3D11Resource {
-    fn from(value: ID3D11Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture2D> for &'a ID3D11Resource {
-    fn from(value: &'a ID3D11Texture2D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture2D> for ID3D11Resource {
-    fn from(value: &ID3D11Texture2D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Texture2D, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11Resource);
 impl ::core::clone::Clone for ID3D11Texture2D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11642,66 +9557,7 @@ impl ID3D11Texture2D1 {
         (::windows::core::Vtable::vtable(self).GetDesc1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11Texture2D1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Texture2D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture2D1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Texture2D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture2D1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Texture2D1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture2D1> for ID3D11DeviceChild {
-    fn from(value: ID3D11Texture2D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture2D1> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Texture2D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture2D1> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Texture2D1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture2D1> for ID3D11Resource {
-    fn from(value: ID3D11Texture2D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture2D1> for &'a ID3D11Resource {
-    fn from(value: &'a ID3D11Texture2D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture2D1> for ID3D11Resource {
-    fn from(value: &ID3D11Texture2D1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture2D1> for ID3D11Texture2D {
-    fn from(value: ID3D11Texture2D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture2D1> for &'a ID3D11Texture2D {
-    fn from(value: &'a ID3D11Texture2D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture2D1> for ID3D11Texture2D {
-    fn from(value: &ID3D11Texture2D1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Texture2D1, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11Resource, ID3D11Texture2D);
 impl ::core::clone::Clone for ID3D11Texture2D1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11769,51 +9625,7 @@ impl ID3D11Texture3D {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11Texture3D> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture3D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture3D> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Texture3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture3D> for ID3D11DeviceChild {
-    fn from(value: ID3D11Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture3D> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture3D> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Texture3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture3D> for ID3D11Resource {
-    fn from(value: ID3D11Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture3D> for &'a ID3D11Resource {
-    fn from(value: &'a ID3D11Texture3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture3D> for ID3D11Resource {
-    fn from(value: &ID3D11Texture3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Texture3D, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11Resource);
 impl ::core::clone::Clone for ID3D11Texture3D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11886,66 +9698,7 @@ impl ID3D11Texture3D1 {
         (::windows::core::Vtable::vtable(self).GetDesc1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11Texture3D1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11Texture3D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture3D1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11Texture3D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture3D1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11Texture3D1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture3D1> for ID3D11DeviceChild {
-    fn from(value: ID3D11Texture3D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture3D1> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11Texture3D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture3D1> for ID3D11DeviceChild {
-    fn from(value: &ID3D11Texture3D1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture3D1> for ID3D11Resource {
-    fn from(value: ID3D11Texture3D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture3D1> for &'a ID3D11Resource {
-    fn from(value: &'a ID3D11Texture3D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture3D1> for ID3D11Resource {
-    fn from(value: &ID3D11Texture3D1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11Texture3D1> for ID3D11Texture3D {
-    fn from(value: ID3D11Texture3D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11Texture3D1> for &'a ID3D11Texture3D {
-    fn from(value: &'a ID3D11Texture3D1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11Texture3D1> for ID3D11Texture3D {
-    fn from(value: &ID3D11Texture3D1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11Texture3D1, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11Resource, ID3D11Texture3D);
 impl ::core::clone::Clone for ID3D11Texture3D1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11993,21 +9746,7 @@ impl ID3D11TracingDevice {
         (::windows::core::Vtable::vtable(self).SetShaderTrackingOptions)(::windows::core::Vtable::as_raw(self), pshader.into().abi(), options).ok()
     }
 }
-impl ::core::convert::From<ID3D11TracingDevice> for ::windows::core::IUnknown {
-    fn from(value: ID3D11TracingDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11TracingDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11TracingDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11TracingDevice> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11TracingDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11TracingDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11TracingDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12067,51 +9806,7 @@ impl ID3D11UnorderedAccessView {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11UnorderedAccessView> for ::windows::core::IUnknown {
-    fn from(value: ID3D11UnorderedAccessView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11UnorderedAccessView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11UnorderedAccessView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11UnorderedAccessView> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11UnorderedAccessView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11UnorderedAccessView> for ID3D11DeviceChild {
-    fn from(value: ID3D11UnorderedAccessView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11UnorderedAccessView> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11UnorderedAccessView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11UnorderedAccessView> for ID3D11DeviceChild {
-    fn from(value: &ID3D11UnorderedAccessView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11UnorderedAccessView> for ID3D11View {
-    fn from(value: ID3D11UnorderedAccessView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11UnorderedAccessView> for &'a ID3D11View {
-    fn from(value: &'a ID3D11UnorderedAccessView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11UnorderedAccessView> for ID3D11View {
-    fn from(value: &ID3D11UnorderedAccessView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11UnorderedAccessView, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11View);
 impl ::core::clone::Clone for ID3D11UnorderedAccessView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12178,66 +9873,7 @@ impl ID3D11UnorderedAccessView1 {
         (::windows::core::Vtable::vtable(self).GetDesc1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc1))
     }
 }
-impl ::core::convert::From<ID3D11UnorderedAccessView1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11UnorderedAccessView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11UnorderedAccessView1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11UnorderedAccessView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11UnorderedAccessView1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11UnorderedAccessView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11UnorderedAccessView1> for ID3D11DeviceChild {
-    fn from(value: ID3D11UnorderedAccessView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11UnorderedAccessView1> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11UnorderedAccessView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11UnorderedAccessView1> for ID3D11DeviceChild {
-    fn from(value: &ID3D11UnorderedAccessView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11UnorderedAccessView1> for ID3D11View {
-    fn from(value: ID3D11UnorderedAccessView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11UnorderedAccessView1> for &'a ID3D11View {
-    fn from(value: &'a ID3D11UnorderedAccessView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11UnorderedAccessView1> for ID3D11View {
-    fn from(value: &ID3D11UnorderedAccessView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11UnorderedAccessView1> for ID3D11UnorderedAccessView {
-    fn from(value: ID3D11UnorderedAccessView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11UnorderedAccessView1> for &'a ID3D11UnorderedAccessView {
-    fn from(value: &'a ID3D11UnorderedAccessView1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11UnorderedAccessView1> for ID3D11UnorderedAccessView {
-    fn from(value: &ID3D11UnorderedAccessView1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11UnorderedAccessView1, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11View, ID3D11UnorderedAccessView);
 impl ::core::clone::Clone for ID3D11UnorderedAccessView1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12291,36 +9927,7 @@ impl ID3D11VertexShader {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D11VertexShader> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VertexShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VertexShader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VertexShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VertexShader> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VertexShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VertexShader> for ID3D11DeviceChild {
-    fn from(value: ID3D11VertexShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VertexShader> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VertexShader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VertexShader> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VertexShader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VertexShader, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11VertexShader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12803,36 +10410,7 @@ impl ID3D11VideoContext {
         (::windows::core::Vtable::vtable(self).VideoProcessorGetStreamRotation)(::windows::core::Vtable::as_raw(self), pvideoprocessor.into().abi(), streamindex, ::core::mem::transmute(penable), ::core::mem::transmute(protation))
     }
 }
-impl ::core::convert::From<ID3D11VideoContext> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoContext> for ID3D11DeviceChild {
-    fn from(value: ID3D11VideoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VideoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VideoContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoContext, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11VideoContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13579,51 +11157,7 @@ impl ID3D11VideoContext1 {
         (::windows::core::Vtable::vtable(self).VideoProcessorGetBehaviorHints)(::windows::core::Vtable::as_raw(self), pvideoprocessor.into().abi(), outputwidth, outputheight, outputformat, pstreams.len() as _, ::core::mem::transmute(pstreams.as_ptr()), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ID3D11VideoContext1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoContext1> for ID3D11DeviceChild {
-    fn from(value: ID3D11VideoContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext1> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VideoContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext1> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VideoContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoContext1> for ID3D11VideoContext {
-    fn from(value: ID3D11VideoContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext1> for &'a ID3D11VideoContext {
-    fn from(value: &'a ID3D11VideoContext1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext1> for ID3D11VideoContext {
-    fn from(value: &ID3D11VideoContext1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoContext1, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11VideoContext);
 impl ::core::clone::Clone for ID3D11VideoContext1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14298,66 +11832,7 @@ impl ID3D11VideoContext2 {
         (::windows::core::Vtable::vtable(self).VideoProcessorGetStreamHDRMetaData)(::windows::core::Vtable::as_raw(self), pvideoprocessor.into().abi(), streamindex, ::core::mem::transmute(ptype), size, ::core::mem::transmute(pmetadata.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<ID3D11VideoContext2> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoContext2> for ID3D11DeviceChild {
-    fn from(value: ID3D11VideoContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext2> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VideoContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext2> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VideoContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoContext2> for ID3D11VideoContext {
-    fn from(value: ID3D11VideoContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext2> for &'a ID3D11VideoContext {
-    fn from(value: &'a ID3D11VideoContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext2> for ID3D11VideoContext {
-    fn from(value: &ID3D11VideoContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoContext2> for ID3D11VideoContext1 {
-    fn from(value: ID3D11VideoContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext2> for &'a ID3D11VideoContext1 {
-    fn from(value: &'a ID3D11VideoContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext2> for ID3D11VideoContext1 {
-    fn from(value: &ID3D11VideoContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoContext2, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11VideoContext, ID3D11VideoContext1);
 impl ::core::clone::Clone for ID3D11VideoContext2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15014,81 +12489,7 @@ impl ID3D11VideoContext3 {
         (::windows::core::Vtable::vtable(self).SubmitDecoderBuffers2)(::windows::core::Vtable::as_raw(self), pdecoder.into().abi(), pbufferdesc.len() as _, ::core::mem::transmute(pbufferdesc.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<ID3D11VideoContext3> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext3> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoContext3> for ID3D11DeviceChild {
-    fn from(value: ID3D11VideoContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext3> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VideoContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext3> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VideoContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoContext3> for ID3D11VideoContext {
-    fn from(value: ID3D11VideoContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext3> for &'a ID3D11VideoContext {
-    fn from(value: &'a ID3D11VideoContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext3> for ID3D11VideoContext {
-    fn from(value: &ID3D11VideoContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoContext3> for ID3D11VideoContext1 {
-    fn from(value: ID3D11VideoContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext3> for &'a ID3D11VideoContext1 {
-    fn from(value: &'a ID3D11VideoContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext3> for ID3D11VideoContext1 {
-    fn from(value: &ID3D11VideoContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoContext3> for ID3D11VideoContext2 {
-    fn from(value: ID3D11VideoContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoContext3> for &'a ID3D11VideoContext2 {
-    fn from(value: &'a ID3D11VideoContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoContext3> for ID3D11VideoContext2 {
-    fn from(value: &ID3D11VideoContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoContext3, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11VideoContext, ID3D11VideoContext1, ID3D11VideoContext2);
 impl ::core::clone::Clone for ID3D11VideoContext3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15151,36 +12552,7 @@ impl ID3D11VideoDecoder {
         (::windows::core::Vtable::vtable(self).GetDriverHandle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::HANDLE>(result__)
     }
 }
-impl ::core::convert::From<ID3D11VideoDecoder> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoDecoder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoDecoder> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoDecoder> for ID3D11DeviceChild {
-    fn from(value: ID3D11VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoDecoder> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoDecoder> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VideoDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoDecoder, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11VideoDecoder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15244,51 +12616,7 @@ impl ID3D11VideoDecoderOutputView {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11VideoDecoderOutputView> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoDecoderOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoDecoderOutputView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoDecoderOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoDecoderOutputView> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoDecoderOutputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoDecoderOutputView> for ID3D11DeviceChild {
-    fn from(value: ID3D11VideoDecoderOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoDecoderOutputView> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VideoDecoderOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoDecoderOutputView> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VideoDecoderOutputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoDecoderOutputView> for ID3D11View {
-    fn from(value: ID3D11VideoDecoderOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoDecoderOutputView> for &'a ID3D11View {
-    fn from(value: &'a ID3D11VideoDecoderOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoDecoderOutputView> for ID3D11View {
-    fn from(value: &ID3D11VideoDecoderOutputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoDecoderOutputView, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11View);
 impl ::core::clone::Clone for ID3D11VideoDecoderOutputView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15416,21 +12744,7 @@ impl ID3D11VideoDevice {
         (::windows::core::Vtable::vtable(self).SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D11VideoDevice> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoDevice> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11VideoDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15609,36 +12923,7 @@ impl ID3D11VideoDevice1 {
         (::windows::core::Vtable::vtable(self).RecommendVideoDecoderDownsampleParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinputdesc), inputcolorspace, ::core::mem::transmute(pinputconfig), ::core::mem::transmute(pframerate), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<D3D11_VIDEO_SAMPLE_DESC>(result__)
     }
 }
-impl ::core::convert::From<ID3D11VideoDevice1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoDevice1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoDevice1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoDevice1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoDevice1> for ID3D11VideoDevice {
-    fn from(value: ID3D11VideoDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoDevice1> for &'a ID3D11VideoDevice {
-    fn from(value: &'a ID3D11VideoDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoDevice1> for ID3D11VideoDevice {
-    fn from(value: &ID3D11VideoDevice1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoDevice1, ::windows::core::IUnknown, ID3D11VideoDevice);
 impl ::core::clone::Clone for ID3D11VideoDevice1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15807,51 +13092,7 @@ impl ID3D11VideoDevice2 {
         (::windows::core::Vtable::vtable(self).NegotiateCryptoSessionKeyExchangeMT)(::windows::core::Vtable::as_raw(self), pcryptosession.into().abi(), flags, datasize, ::core::mem::transmute(pdata)).ok()
     }
 }
-impl ::core::convert::From<ID3D11VideoDevice2> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoDevice2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoDevice2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoDevice2> for ID3D11VideoDevice {
-    fn from(value: ID3D11VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoDevice2> for &'a ID3D11VideoDevice {
-    fn from(value: &'a ID3D11VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoDevice2> for ID3D11VideoDevice {
-    fn from(value: &ID3D11VideoDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoDevice2> for ID3D11VideoDevice1 {
-    fn from(value: ID3D11VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoDevice2> for &'a ID3D11VideoDevice1 {
-    fn from(value: &'a ID3D11VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoDevice2> for ID3D11VideoDevice1 {
-    fn from(value: &ID3D11VideoDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoDevice2, ::windows::core::IUnknown, ID3D11VideoDevice, ID3D11VideoDevice1);
 impl ::core::clone::Clone for ID3D11VideoDevice2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15911,36 +13152,7 @@ impl ID3D11VideoProcessor {
         (::windows::core::Vtable::vtable(self).GetRateConversionCaps)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcaps))
     }
 }
-impl ::core::convert::From<ID3D11VideoProcessor> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessor> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoProcessor> for ID3D11DeviceChild {
-    fn from(value: ID3D11VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessor> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessor> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VideoProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoProcessor, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11VideoProcessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16025,36 +13237,7 @@ impl ID3D11VideoProcessorEnumerator {
         (::windows::core::Vtable::vtable(self).GetVideoProcessorFilterRange)(::windows::core::Vtable::as_raw(self), filter, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<D3D11_VIDEO_PROCESSOR_FILTER_RANGE>(result__)
     }
 }
-impl ::core::convert::From<ID3D11VideoProcessorEnumerator> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoProcessorEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessorEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoProcessorEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessorEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoProcessorEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoProcessorEnumerator> for ID3D11DeviceChild {
-    fn from(value: ID3D11VideoProcessorEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessorEnumerator> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VideoProcessorEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessorEnumerator> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VideoProcessorEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoProcessorEnumerator, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11VideoProcessorEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16155,51 +13338,7 @@ impl ID3D11VideoProcessorEnumerator1 {
         (::windows::core::Vtable::vtable(self).CheckVideoProcessorFormatConversion)(::windows::core::Vtable::as_raw(self), inputformat, inputcolorspace, outputformat, outputcolorspace, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ID3D11VideoProcessorEnumerator1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoProcessorEnumerator1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessorEnumerator1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoProcessorEnumerator1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessorEnumerator1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoProcessorEnumerator1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoProcessorEnumerator1> for ID3D11DeviceChild {
-    fn from(value: ID3D11VideoProcessorEnumerator1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessorEnumerator1> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VideoProcessorEnumerator1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessorEnumerator1> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VideoProcessorEnumerator1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoProcessorEnumerator1> for ID3D11VideoProcessorEnumerator {
-    fn from(value: ID3D11VideoProcessorEnumerator1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessorEnumerator1> for &'a ID3D11VideoProcessorEnumerator {
-    fn from(value: &'a ID3D11VideoProcessorEnumerator1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessorEnumerator1> for ID3D11VideoProcessorEnumerator {
-    fn from(value: &ID3D11VideoProcessorEnumerator1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoProcessorEnumerator1, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11VideoProcessorEnumerator);
 impl ::core::clone::Clone for ID3D11VideoProcessorEnumerator1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16259,51 +13398,7 @@ impl ID3D11VideoProcessorInputView {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11VideoProcessorInputView> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoProcessorInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessorInputView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoProcessorInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessorInputView> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoProcessorInputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoProcessorInputView> for ID3D11DeviceChild {
-    fn from(value: ID3D11VideoProcessorInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessorInputView> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VideoProcessorInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessorInputView> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VideoProcessorInputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoProcessorInputView> for ID3D11View {
-    fn from(value: ID3D11VideoProcessorInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessorInputView> for &'a ID3D11View {
-    fn from(value: &'a ID3D11VideoProcessorInputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessorInputView> for ID3D11View {
-    fn from(value: &ID3D11VideoProcessorInputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoProcessorInputView, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11View);
 impl ::core::clone::Clone for ID3D11VideoProcessorInputView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16360,51 +13455,7 @@ impl ID3D11VideoProcessorOutputView {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D11VideoProcessorOutputView> for ::windows::core::IUnknown {
-    fn from(value: ID3D11VideoProcessorOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessorOutputView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11VideoProcessorOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessorOutputView> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11VideoProcessorOutputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoProcessorOutputView> for ID3D11DeviceChild {
-    fn from(value: ID3D11VideoProcessorOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessorOutputView> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11VideoProcessorOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessorOutputView> for ID3D11DeviceChild {
-    fn from(value: &ID3D11VideoProcessorOutputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11VideoProcessorOutputView> for ID3D11View {
-    fn from(value: ID3D11VideoProcessorOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11VideoProcessorOutputView> for &'a ID3D11View {
-    fn from(value: &'a ID3D11VideoProcessorOutputView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11VideoProcessorOutputView> for ID3D11View {
-    fn from(value: &ID3D11VideoProcessorOutputView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11VideoProcessorOutputView, ::windows::core::IUnknown, ID3D11DeviceChild, ID3D11View);
 impl ::core::clone::Clone for ID3D11VideoProcessorOutputView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16458,36 +13509,7 @@ impl ID3D11View {
         (::windows::core::Vtable::vtable(self).GetResource)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppresource))
     }
 }
-impl ::core::convert::From<ID3D11View> for ::windows::core::IUnknown {
-    fn from(value: ID3D11View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11View> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11View> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11View) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11View> for ID3D11DeviceChild {
-    fn from(value: ID3D11View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11View> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3D11View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11View> for ID3D11DeviceChild {
-    fn from(value: &ID3D11View) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11View, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3D11View {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16538,36 +13560,7 @@ impl ID3DDeviceContextState {
         (::windows::core::Vtable::vtable(self).base__.SetPrivateDataInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3DDeviceContextState> for ::windows::core::IUnknown {
-    fn from(value: ID3DDeviceContextState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3DDeviceContextState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3DDeviceContextState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3DDeviceContextState> for ::windows::core::IUnknown {
-    fn from(value: &ID3DDeviceContextState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3DDeviceContextState> for ID3D11DeviceChild {
-    fn from(value: ID3DDeviceContextState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3DDeviceContextState> for &'a ID3D11DeviceChild {
-    fn from(value: &'a ID3DDeviceContextState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3DDeviceContextState> for ID3D11DeviceChild {
-    fn from(value: &ID3DDeviceContextState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3DDeviceContextState, ::windows::core::IUnknown, ID3D11DeviceChild);
 impl ::core::clone::Clone for ID3DDeviceContextState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16622,21 +13615,7 @@ impl ID3DUserDefinedAnnotation {
         (::windows::core::Vtable::vtable(self).GetStatus)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3DUserDefinedAnnotation> for ::windows::core::IUnknown {
-    fn from(value: ID3DUserDefinedAnnotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3DUserDefinedAnnotation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3DUserDefinedAnnotation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3DUserDefinedAnnotation> for ::windows::core::IUnknown {
-    fn from(value: &ID3DUserDefinedAnnotation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3DUserDefinedAnnotation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3DUserDefinedAnnotation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16705,21 +13684,7 @@ impl ID3DX11FFT {
         (::windows::core::Vtable::vtable(self).InverseTransform)(::windows::core::Vtable::as_raw(self), pinputbuffer.into().abi(), ::core::mem::transmute(ppoutputbuffer)).ok()
     }
 }
-impl ::core::convert::From<ID3DX11FFT> for ::windows::core::IUnknown {
-    fn from(value: ID3DX11FFT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3DX11FFT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3DX11FFT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3DX11FFT> for ::windows::core::IUnknown {
-    fn from(value: &ID3DX11FFT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3DX11FFT, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3DX11FFT {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16778,21 +13743,7 @@ impl ID3DX11Scan {
         (::windows::core::Vtable::vtable(self).Multiscan)(::windows::core::Vtable::as_raw(self), elementtype, opcode, elementscansize, elementscanpitch, scancount, psrc.into().abi(), pdst.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3DX11Scan> for ::windows::core::IUnknown {
-    fn from(value: ID3DX11Scan) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3DX11Scan> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3DX11Scan) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3DX11Scan> for ::windows::core::IUnknown {
-    fn from(value: &ID3DX11Scan) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3DX11Scan, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3DX11Scan {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16841,21 +13792,7 @@ impl ID3DX11SegmentedScan {
         (::windows::core::Vtable::vtable(self).SegScan)(::windows::core::Vtable::as_raw(self), elementtype, opcode, elementscansize, psrc.into().abi(), psrcelementflags.into().abi(), pdst.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3DX11SegmentedScan> for ::windows::core::IUnknown {
-    fn from(value: ID3DX11SegmentedScan) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3DX11SegmentedScan> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3DX11SegmentedScan) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3DX11SegmentedScan> for ::windows::core::IUnknown {
-    fn from(value: &ID3DX11SegmentedScan) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3DX11SegmentedScan, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3DX11SegmentedScan {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
@@ -47,21 +47,7 @@ impl ID3D11On12Device {
         (::windows::core::Vtable::vtable(self).AcquireWrappedResources)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppresources.as_ptr()), ppresources.len() as _)
     }
 }
-impl ::core::convert::From<ID3D11On12Device> for ::windows::core::IUnknown {
-    fn from(value: ID3D11On12Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11On12Device> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11On12Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11On12Device> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11On12Device) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11On12Device, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D11On12Device {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -134,36 +120,7 @@ impl ID3D11On12Device1 {
         (::windows::core::Vtable::vtable(self).GetD3D12Device)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ID3D11On12Device1> for ::windows::core::IUnknown {
-    fn from(value: ID3D11On12Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11On12Device1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11On12Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11On12Device1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11On12Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11On12Device1> for ID3D11On12Device {
-    fn from(value: ID3D11On12Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11On12Device1> for &'a ID3D11On12Device {
-    fn from(value: &'a ID3D11On12Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11On12Device1> for ID3D11On12Device {
-    fn from(value: &ID3D11On12Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11On12Device1, ::windows::core::IUnknown, ID3D11On12Device);
 impl ::core::clone::Clone for ID3D11On12Device1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -244,51 +201,7 @@ impl ID3D11On12Device2 {
         (::windows::core::Vtable::vtable(self).ReturnUnderlyingResource)(::windows::core::Vtable::as_raw(self), presource11.into().abi(), numsync, ::core::mem::transmute(psignalvalues), ::core::mem::transmute(ppfences)).ok()
     }
 }
-impl ::core::convert::From<ID3D11On12Device2> for ::windows::core::IUnknown {
-    fn from(value: ID3D11On12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11On12Device2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D11On12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11On12Device2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D11On12Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11On12Device2> for ID3D11On12Device {
-    fn from(value: ID3D11On12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11On12Device2> for &'a ID3D11On12Device {
-    fn from(value: &'a ID3D11On12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11On12Device2> for ID3D11On12Device {
-    fn from(value: &ID3D11On12Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D11On12Device2> for ID3D11On12Device1 {
-    fn from(value: ID3D11On12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D11On12Device2> for &'a ID3D11On12Device1 {
-    fn from(value: &'a ID3D11On12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D11On12Device2> for ID3D11On12Device1 {
-    fn from(value: &ID3D11On12Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D11On12Device2, ::windows::core::IUnknown, ID3D11On12Device, ID3D11On12Device1);
 impl ::core::clone::Clone for ID3D11On12Device2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -115,66 +115,7 @@ impl ID3D12CommandAllocator {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ID3D12CommandAllocator> for ::windows::core::IUnknown {
-    fn from(value: ID3D12CommandAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandAllocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12CommandAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandAllocator> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12CommandAllocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12CommandAllocator> for ID3D12Object {
-    fn from(value: ID3D12CommandAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandAllocator> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12CommandAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandAllocator> for ID3D12Object {
-    fn from(value: &ID3D12CommandAllocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12CommandAllocator> for ID3D12DeviceChild {
-    fn from(value: ID3D12CommandAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandAllocator> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12CommandAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandAllocator> for ID3D12DeviceChild {
-    fn from(value: &ID3D12CommandAllocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12CommandAllocator> for ID3D12Pageable {
-    fn from(value: ID3D12CommandAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandAllocator> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12CommandAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandAllocator> for ID3D12Pageable {
-    fn from(value: &ID3D12CommandAllocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12CommandAllocator, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ::core::clone::Clone for ID3D12CommandAllocator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -237,51 +178,7 @@ impl ID3D12CommandList {
         (::windows::core::Vtable::vtable(self).GetType)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12CommandList> for ::windows::core::IUnknown {
-    fn from(value: ID3D12CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandList> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12CommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12CommandList> for ID3D12Object {
-    fn from(value: ID3D12CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandList> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandList> for ID3D12Object {
-    fn from(value: &ID3D12CommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12CommandList> for ID3D12DeviceChild {
-    fn from(value: ID3D12CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandList> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12CommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandList> for ID3D12DeviceChild {
-    fn from(value: &ID3D12CommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12CommandList, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild);
 impl ::core::clone::Clone for ID3D12CommandList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -407,66 +304,7 @@ impl ID3D12CommandQueue {
         result__
     }
 }
-impl ::core::convert::From<ID3D12CommandQueue> for ::windows::core::IUnknown {
-    fn from(value: ID3D12CommandQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12CommandQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandQueue> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12CommandQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12CommandQueue> for ID3D12Object {
-    fn from(value: ID3D12CommandQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandQueue> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12CommandQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandQueue> for ID3D12Object {
-    fn from(value: &ID3D12CommandQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12CommandQueue> for ID3D12DeviceChild {
-    fn from(value: ID3D12CommandQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandQueue> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12CommandQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandQueue> for ID3D12DeviceChild {
-    fn from(value: &ID3D12CommandQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12CommandQueue> for ID3D12Pageable {
-    fn from(value: ID3D12CommandQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandQueue> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12CommandQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandQueue> for ID3D12Pageable {
-    fn from(value: &ID3D12CommandQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12CommandQueue, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ::core::clone::Clone for ID3D12CommandQueue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -542,66 +380,7 @@ impl ID3D12CommandSignature {
         (::windows::core::Vtable::vtable(self).base__.base__.GetDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, result__ as *mut _ as *mut _).ok()
     }
 }
-impl ::core::convert::From<ID3D12CommandSignature> for ::windows::core::IUnknown {
-    fn from(value: ID3D12CommandSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandSignature> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12CommandSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandSignature> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12CommandSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12CommandSignature> for ID3D12Object {
-    fn from(value: ID3D12CommandSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandSignature> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12CommandSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandSignature> for ID3D12Object {
-    fn from(value: &ID3D12CommandSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12CommandSignature> for ID3D12DeviceChild {
-    fn from(value: ID3D12CommandSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandSignature> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12CommandSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandSignature> for ID3D12DeviceChild {
-    fn from(value: &ID3D12CommandSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12CommandSignature> for ID3D12Pageable {
-    fn from(value: ID3D12CommandSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12CommandSignature> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12CommandSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12CommandSignature> for ID3D12Pageable {
-    fn from(value: &ID3D12CommandSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12CommandSignature, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ::core::clone::Clone for ID3D12CommandSignature {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -639,21 +418,7 @@ impl ID3D12Debug {
         (::windows::core::Vtable::vtable(self).EnableDebugLayer)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12Debug> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Debug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Debug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Debug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Debug, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12Debug {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -708,21 +473,7 @@ impl ID3D12Debug1 {
         (::windows::core::Vtable::vtable(self).SetEnableSynchronizedCommandQueueValidation)(::windows::core::Vtable::as_raw(self), enable.into())
     }
 }
-impl ::core::convert::From<ID3D12Debug1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Debug1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Debug1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Debug1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Debug1, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12Debug1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -769,21 +520,7 @@ impl ID3D12Debug2 {
         (::windows::core::Vtable::vtable(self).SetGPUBasedValidationFlags)(::windows::core::Vtable::as_raw(self), flags)
     }
 }
-impl ::core::convert::From<ID3D12Debug2> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Debug2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Debug2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Debug2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Debug2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12Debug2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -841,36 +578,7 @@ impl ID3D12Debug3 {
         (::windows::core::Vtable::vtable(self).SetGPUBasedValidationFlags)(::windows::core::Vtable::as_raw(self), flags)
     }
 }
-impl ::core::convert::From<ID3D12Debug3> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Debug3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Debug3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug3> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Debug3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Debug3> for ID3D12Debug {
-    fn from(value: ID3D12Debug3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug3> for &'a ID3D12Debug {
-    fn from(value: &'a ID3D12Debug3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug3> for ID3D12Debug {
-    fn from(value: &ID3D12Debug3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Debug3, ::windows::core::IUnknown, ID3D12Debug);
 impl ::core::clone::Clone for ID3D12Debug3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -939,51 +647,7 @@ impl ID3D12Debug4 {
         (::windows::core::Vtable::vtable(self).DisableDebugLayer)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12Debug4> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Debug4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Debug4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug4> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Debug4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Debug4> for ID3D12Debug {
-    fn from(value: ID3D12Debug4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug4> for &'a ID3D12Debug {
-    fn from(value: &'a ID3D12Debug4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug4> for ID3D12Debug {
-    fn from(value: &ID3D12Debug4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Debug4> for ID3D12Debug3 {
-    fn from(value: ID3D12Debug4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug4> for &'a ID3D12Debug3 {
-    fn from(value: &'a ID3D12Debug4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug4> for ID3D12Debug3 {
-    fn from(value: &ID3D12Debug4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Debug4, ::windows::core::IUnknown, ID3D12Debug, ID3D12Debug3);
 impl ::core::clone::Clone for ID3D12Debug4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1052,66 +716,7 @@ impl ID3D12Debug5 {
         (::windows::core::Vtable::vtable(self).SetEnableAutoName)(::windows::core::Vtable::as_raw(self), enable.into())
     }
 }
-impl ::core::convert::From<ID3D12Debug5> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Debug5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Debug5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug5> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Debug5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Debug5> for ID3D12Debug {
-    fn from(value: ID3D12Debug5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug5> for &'a ID3D12Debug {
-    fn from(value: &'a ID3D12Debug5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug5> for ID3D12Debug {
-    fn from(value: &ID3D12Debug5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Debug5> for ID3D12Debug3 {
-    fn from(value: ID3D12Debug5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug5> for &'a ID3D12Debug3 {
-    fn from(value: &'a ID3D12Debug5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug5> for ID3D12Debug3 {
-    fn from(value: &ID3D12Debug5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Debug5> for ID3D12Debug4 {
-    fn from(value: ID3D12Debug5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Debug5> for &'a ID3D12Debug4 {
-    fn from(value: &'a ID3D12Debug5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Debug5> for ID3D12Debug4 {
-    fn from(value: &ID3D12Debug5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Debug5, ::windows::core::IUnknown, ID3D12Debug, ID3D12Debug3, ID3D12Debug4);
 impl ::core::clone::Clone for ID3D12Debug5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1164,21 +769,7 @@ impl ID3D12DebugCommandList {
         (::windows::core::Vtable::vtable(self).GetFeatureMask)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12DebugCommandList> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DebugCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DebugCommandList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DebugCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DebugCommandList> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DebugCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DebugCommandList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12DebugCommandList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1233,21 +824,7 @@ impl ID3D12DebugCommandList1 {
         (::windows::core::Vtable::vtable(self).GetDebugParameter)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(pdata), datasize).ok()
     }
 }
-impl ::core::convert::From<ID3D12DebugCommandList1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DebugCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DebugCommandList1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DebugCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DebugCommandList1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DebugCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DebugCommandList1, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12DebugCommandList1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1308,36 +885,7 @@ impl ID3D12DebugCommandList2 {
         (::windows::core::Vtable::vtable(self).GetDebugParameter)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(pdata), datasize).ok()
     }
 }
-impl ::core::convert::From<ID3D12DebugCommandList2> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DebugCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DebugCommandList2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DebugCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DebugCommandList2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DebugCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12DebugCommandList2> for ID3D12DebugCommandList {
-    fn from(value: ID3D12DebugCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DebugCommandList2> for &'a ID3D12DebugCommandList {
-    fn from(value: &'a ID3D12DebugCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DebugCommandList2> for ID3D12DebugCommandList {
-    fn from(value: &ID3D12DebugCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DebugCommandList2, ::windows::core::IUnknown, ID3D12DebugCommandList);
 impl ::core::clone::Clone for ID3D12DebugCommandList2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1382,21 +930,7 @@ impl ID3D12DebugCommandQueue {
         (::windows::core::Vtable::vtable(self).AssertResourceState)(::windows::core::Vtable::as_raw(self), presource.into().abi(), subresource, state)
     }
 }
-impl ::core::convert::From<ID3D12DebugCommandQueue> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DebugCommandQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DebugCommandQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DebugCommandQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DebugCommandQueue> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DebugCommandQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DebugCommandQueue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12DebugCommandQueue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1444,21 +978,7 @@ impl ID3D12DebugDevice {
         (::windows::core::Vtable::vtable(self).ReportLiveDeviceObjects)(::windows::core::Vtable::as_raw(self), flags).ok()
     }
 }
-impl ::core::convert::From<ID3D12DebugDevice> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DebugDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DebugDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DebugDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DebugDevice> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DebugDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DebugDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12DebugDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1505,21 +1025,7 @@ impl ID3D12DebugDevice1 {
         (::windows::core::Vtable::vtable(self).ReportLiveDeviceObjects)(::windows::core::Vtable::as_raw(self), flags).ok()
     }
 }
-impl ::core::convert::From<ID3D12DebugDevice1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DebugDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DebugDevice1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DebugDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DebugDevice1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DebugDevice1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DebugDevice1, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12DebugDevice1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1572,36 +1078,7 @@ impl ID3D12DebugDevice2 {
         (::windows::core::Vtable::vtable(self).GetDebugParameter)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(pdata), datasize).ok()
     }
 }
-impl ::core::convert::From<ID3D12DebugDevice2> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DebugDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DebugDevice2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DebugDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DebugDevice2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DebugDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12DebugDevice2> for ID3D12DebugDevice {
-    fn from(value: ID3D12DebugDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DebugDevice2> for &'a ID3D12DebugDevice {
-    fn from(value: &'a ID3D12DebugDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DebugDevice2> for ID3D12DebugDevice {
-    fn from(value: &ID3D12DebugDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DebugDevice2, ::windows::core::IUnknown, ID3D12DebugDevice);
 impl ::core::clone::Clone for ID3D12DebugDevice2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1677,66 +1154,7 @@ impl ID3D12DescriptorHeap {
         result__
     }
 }
-impl ::core::convert::From<ID3D12DescriptorHeap> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DescriptorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DescriptorHeap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DescriptorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DescriptorHeap> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DescriptorHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12DescriptorHeap> for ID3D12Object {
-    fn from(value: ID3D12DescriptorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DescriptorHeap> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12DescriptorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DescriptorHeap> for ID3D12Object {
-    fn from(value: &ID3D12DescriptorHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12DescriptorHeap> for ID3D12DeviceChild {
-    fn from(value: ID3D12DescriptorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DescriptorHeap> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12DescriptorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DescriptorHeap> for ID3D12DeviceChild {
-    fn from(value: &ID3D12DescriptorHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12DescriptorHeap> for ID3D12Pageable {
-    fn from(value: ID3D12DescriptorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DescriptorHeap> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12DescriptorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DescriptorHeap> for ID3D12Pageable {
-    fn from(value: &ID3D12DescriptorHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DescriptorHeap, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ::core::clone::Clone for ID3D12DescriptorHeap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2034,36 +1452,7 @@ impl ID3D12Device {
         result__
     }
 }
-impl ::core::convert::From<ID3D12Device> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Device) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device> for ID3D12Object {
-    fn from(value: ID3D12Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device> for ID3D12Object {
-    fn from(value: &ID3D12Device) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Device, ::windows::core::IUnknown, ID3D12Object);
 impl ::core::clone::Clone for ID3D12Device {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2458,51 +1847,7 @@ impl ID3D12Device1 {
         (::windows::core::Vtable::vtable(self).SetResidencyPriority)(::windows::core::Vtable::as_raw(self), numobjects, ::core::mem::transmute(ppobjects), ::core::mem::transmute(ppriorities)).ok()
     }
 }
-impl ::core::convert::From<ID3D12Device1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device1> for ID3D12Object {
-    fn from(value: ID3D12Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device1> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device1> for ID3D12Object {
-    fn from(value: &ID3D12Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device1> for ID3D12Device {
-    fn from(value: ID3D12Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device1> for &'a ID3D12Device {
-    fn from(value: &'a ID3D12Device1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device1> for ID3D12Device {
-    fn from(value: &ID3D12Device1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Device1, ::windows::core::IUnknown, ID3D12Object, ID3D12Device);
 impl ::core::clone::Clone for ID3D12Device1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2828,66 +2173,7 @@ impl ID3D12Device2 {
         (::windows::core::Vtable::vtable(self).CreatePipelineState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ID3D12Device2> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device2> for ID3D12Object {
-    fn from(value: ID3D12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device2> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device2> for ID3D12Object {
-    fn from(value: &ID3D12Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device2> for ID3D12Device {
-    fn from(value: ID3D12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device2> for &'a ID3D12Device {
-    fn from(value: &'a ID3D12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device2> for ID3D12Device {
-    fn from(value: &ID3D12Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device2> for ID3D12Device1 {
-    fn from(value: ID3D12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device2> for &'a ID3D12Device1 {
-    fn from(value: &'a ID3D12Device2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device2> for ID3D12Device1 {
-    fn from(value: &ID3D12Device2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Device2, ::windows::core::IUnknown, ID3D12Object, ID3D12Device, ID3D12Device1);
 impl ::core::clone::Clone for ID3D12Device2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3231,81 +2517,7 @@ impl ID3D12Device3 {
         (::windows::core::Vtable::vtable(self).EnqueueMakeResident)(::windows::core::Vtable::as_raw(self), flags, ppobjects.len() as _, ::core::mem::transmute(ppobjects.as_ptr()), pfencetosignal.into().abi(), fencevaluetosignal).ok()
     }
 }
-impl ::core::convert::From<ID3D12Device3> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device3> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device3> for ID3D12Object {
-    fn from(value: ID3D12Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device3> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device3> for ID3D12Object {
-    fn from(value: &ID3D12Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device3> for ID3D12Device {
-    fn from(value: ID3D12Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device3> for &'a ID3D12Device {
-    fn from(value: &'a ID3D12Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device3> for ID3D12Device {
-    fn from(value: &ID3D12Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device3> for ID3D12Device1 {
-    fn from(value: ID3D12Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device3> for &'a ID3D12Device1 {
-    fn from(value: &'a ID3D12Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device3> for ID3D12Device1 {
-    fn from(value: &ID3D12Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device3> for ID3D12Device2 {
-    fn from(value: ID3D12Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device3> for &'a ID3D12Device2 {
-    fn from(value: &'a ID3D12Device3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device3> for ID3D12Device2 {
-    fn from(value: &ID3D12Device3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Device3, ::windows::core::IUnknown, ID3D12Object, ID3D12Device, ID3D12Device1, ID3D12Device2);
 impl ::core::clone::Clone for ID3D12Device3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3700,96 +2912,7 @@ impl ID3D12Device4 {
         result__
     }
 }
-impl ::core::convert::From<ID3D12Device4> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device4> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device4> for ID3D12Object {
-    fn from(value: ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device4> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device4> for ID3D12Object {
-    fn from(value: &ID3D12Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device4> for ID3D12Device {
-    fn from(value: ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device4> for &'a ID3D12Device {
-    fn from(value: &'a ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device4> for ID3D12Device {
-    fn from(value: &ID3D12Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device4> for ID3D12Device1 {
-    fn from(value: ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device4> for &'a ID3D12Device1 {
-    fn from(value: &'a ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device4> for ID3D12Device1 {
-    fn from(value: &ID3D12Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device4> for ID3D12Device2 {
-    fn from(value: ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device4> for &'a ID3D12Device2 {
-    fn from(value: &'a ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device4> for ID3D12Device2 {
-    fn from(value: &ID3D12Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device4> for ID3D12Device3 {
-    fn from(value: ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device4> for &'a ID3D12Device3 {
-    fn from(value: &'a ID3D12Device4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device4> for ID3D12Device3 {
-    fn from(value: &ID3D12Device4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Device4, ::windows::core::IUnknown, ID3D12Object, ID3D12Device, ID3D12Device1, ID3D12Device2, ID3D12Device3);
 impl ::core::clone::Clone for ID3D12Device4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4232,111 +3355,7 @@ impl ID3D12Device5 {
         (::windows::core::Vtable::vtable(self).CheckDriverMatchingIdentifier)(::windows::core::Vtable::as_raw(self), serializeddatatype, ::core::mem::transmute(pidentifiertocheck))
     }
 }
-impl ::core::convert::From<ID3D12Device5> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device5> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device5> for ID3D12Object {
-    fn from(value: ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device5> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device5> for ID3D12Object {
-    fn from(value: &ID3D12Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device5> for ID3D12Device {
-    fn from(value: ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device5> for &'a ID3D12Device {
-    fn from(value: &'a ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device5> for ID3D12Device {
-    fn from(value: &ID3D12Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device5> for ID3D12Device1 {
-    fn from(value: ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device5> for &'a ID3D12Device1 {
-    fn from(value: &'a ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device5> for ID3D12Device1 {
-    fn from(value: &ID3D12Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device5> for ID3D12Device2 {
-    fn from(value: ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device5> for &'a ID3D12Device2 {
-    fn from(value: &'a ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device5> for ID3D12Device2 {
-    fn from(value: &ID3D12Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device5> for ID3D12Device3 {
-    fn from(value: ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device5> for &'a ID3D12Device3 {
-    fn from(value: &'a ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device5> for ID3D12Device3 {
-    fn from(value: &ID3D12Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device5> for ID3D12Device4 {
-    fn from(value: ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device5> for &'a ID3D12Device4 {
-    fn from(value: &'a ID3D12Device5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device5> for ID3D12Device4 {
-    fn from(value: &ID3D12Device5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Device5, ::windows::core::IUnknown, ID3D12Object, ID3D12Device, ID3D12Device1, ID3D12Device2, ID3D12Device3, ID3D12Device4);
 impl ::core::clone::Clone for ID3D12Device5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4784,126 +3803,7 @@ impl ID3D12Device6 {
         (::windows::core::Vtable::vtable(self).SetBackgroundProcessingMode)(::windows::core::Vtable::as_raw(self), mode, measurementsaction, heventtosignaluponcompletion.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ID3D12Device6> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device6> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device6> for ID3D12Object {
-    fn from(value: ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device6> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device6> for ID3D12Object {
-    fn from(value: &ID3D12Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device6> for ID3D12Device {
-    fn from(value: ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device6> for &'a ID3D12Device {
-    fn from(value: &'a ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device6> for ID3D12Device {
-    fn from(value: &ID3D12Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device6> for ID3D12Device1 {
-    fn from(value: ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device6> for &'a ID3D12Device1 {
-    fn from(value: &'a ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device6> for ID3D12Device1 {
-    fn from(value: &ID3D12Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device6> for ID3D12Device2 {
-    fn from(value: ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device6> for &'a ID3D12Device2 {
-    fn from(value: &'a ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device6> for ID3D12Device2 {
-    fn from(value: &ID3D12Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device6> for ID3D12Device3 {
-    fn from(value: ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device6> for &'a ID3D12Device3 {
-    fn from(value: &'a ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device6> for ID3D12Device3 {
-    fn from(value: &ID3D12Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device6> for ID3D12Device4 {
-    fn from(value: ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device6> for &'a ID3D12Device4 {
-    fn from(value: &'a ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device6> for ID3D12Device4 {
-    fn from(value: &ID3D12Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device6> for ID3D12Device5 {
-    fn from(value: ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device6> for &'a ID3D12Device5 {
-    fn from(value: &'a ID3D12Device6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device6> for ID3D12Device5 {
-    fn from(value: &ID3D12Device6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Device6, ::windows::core::IUnknown, ID3D12Object, ID3D12Device, ID3D12Device1, ID3D12Device2, ID3D12Device3, ID3D12Device4, ID3D12Device5);
 impl ::core::clone::Clone for ID3D12Device6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5359,141 +4259,7 @@ impl ID3D12Device7 {
         (::windows::core::Vtable::vtable(self).CreateProtectedResourceSession1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ID3D12Device7> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device7> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Device7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device7> for ID3D12Object {
-    fn from(value: ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device7> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device7> for ID3D12Object {
-    fn from(value: &ID3D12Device7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device7> for ID3D12Device {
-    fn from(value: ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device7> for &'a ID3D12Device {
-    fn from(value: &'a ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device7> for ID3D12Device {
-    fn from(value: &ID3D12Device7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device7> for ID3D12Device1 {
-    fn from(value: ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device7> for &'a ID3D12Device1 {
-    fn from(value: &'a ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device7> for ID3D12Device1 {
-    fn from(value: &ID3D12Device7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device7> for ID3D12Device2 {
-    fn from(value: ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device7> for &'a ID3D12Device2 {
-    fn from(value: &'a ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device7> for ID3D12Device2 {
-    fn from(value: &ID3D12Device7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device7> for ID3D12Device3 {
-    fn from(value: ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device7> for &'a ID3D12Device3 {
-    fn from(value: &'a ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device7> for ID3D12Device3 {
-    fn from(value: &ID3D12Device7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device7> for ID3D12Device4 {
-    fn from(value: ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device7> for &'a ID3D12Device4 {
-    fn from(value: &'a ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device7> for ID3D12Device4 {
-    fn from(value: &ID3D12Device7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device7> for ID3D12Device5 {
-    fn from(value: ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device7> for &'a ID3D12Device5 {
-    fn from(value: &'a ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device7> for ID3D12Device5 {
-    fn from(value: &ID3D12Device7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device7> for ID3D12Device6 {
-    fn from(value: ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device7> for &'a ID3D12Device6 {
-    fn from(value: &'a ID3D12Device7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device7> for ID3D12Device6 {
-    fn from(value: &ID3D12Device7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Device7, ::windows::core::IUnknown, ID3D12Object, ID3D12Device, ID3D12Device1, ID3D12Device2, ID3D12Device3, ID3D12Device4, ID3D12Device5, ID3D12Device6);
 impl ::core::clone::Clone for ID3D12Device7 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5984,156 +4750,7 @@ impl ID3D12Device8 {
         (::windows::core::Vtable::vtable(self).GetCopyableFootprints1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(presourcedesc), firstsubresource, numsubresources, baseoffset, ::core::mem::transmute(playouts.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pnumrows.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(prowsizeinbytes.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ptotalbytes.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<ID3D12Device8> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device8> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device8> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Device8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device8> for ID3D12Object {
-    fn from(value: ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device8> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device8> for ID3D12Object {
-    fn from(value: &ID3D12Device8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device8> for ID3D12Device {
-    fn from(value: ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device8> for &'a ID3D12Device {
-    fn from(value: &'a ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device8> for ID3D12Device {
-    fn from(value: &ID3D12Device8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device8> for ID3D12Device1 {
-    fn from(value: ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device8> for &'a ID3D12Device1 {
-    fn from(value: &'a ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device8> for ID3D12Device1 {
-    fn from(value: &ID3D12Device8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device8> for ID3D12Device2 {
-    fn from(value: ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device8> for &'a ID3D12Device2 {
-    fn from(value: &'a ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device8> for ID3D12Device2 {
-    fn from(value: &ID3D12Device8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device8> for ID3D12Device3 {
-    fn from(value: ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device8> for &'a ID3D12Device3 {
-    fn from(value: &'a ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device8> for ID3D12Device3 {
-    fn from(value: &ID3D12Device8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device8> for ID3D12Device4 {
-    fn from(value: ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device8> for &'a ID3D12Device4 {
-    fn from(value: &'a ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device8> for ID3D12Device4 {
-    fn from(value: &ID3D12Device8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device8> for ID3D12Device5 {
-    fn from(value: ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device8> for &'a ID3D12Device5 {
-    fn from(value: &'a ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device8> for ID3D12Device5 {
-    fn from(value: &ID3D12Device8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device8> for ID3D12Device6 {
-    fn from(value: ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device8> for &'a ID3D12Device6 {
-    fn from(value: &'a ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device8> for ID3D12Device6 {
-    fn from(value: &ID3D12Device8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device8> for ID3D12Device7 {
-    fn from(value: ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device8> for &'a ID3D12Device7 {
-    fn from(value: &'a ID3D12Device8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device8> for ID3D12Device7 {
-    fn from(value: &ID3D12Device8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Device8, ::windows::core::IUnknown, ID3D12Object, ID3D12Device, ID3D12Device1, ID3D12Device2, ID3D12Device3, ID3D12Device4, ID3D12Device5, ID3D12Device6, ID3D12Device7);
 impl ::core::clone::Clone for ID3D12Device8 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6655,171 +5272,7 @@ impl ID3D12Device9 {
         (::windows::core::Vtable::vtable(self).CreateCommandQueue1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc), ::core::mem::transmute(creatorid), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ID3D12Device9> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device9> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Device9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device9> for ID3D12Object {
-    fn from(value: ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device9> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device9> for ID3D12Object {
-    fn from(value: &ID3D12Device9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device9> for ID3D12Device {
-    fn from(value: ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device9> for &'a ID3D12Device {
-    fn from(value: &'a ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device9> for ID3D12Device {
-    fn from(value: &ID3D12Device9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device9> for ID3D12Device1 {
-    fn from(value: ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device9> for &'a ID3D12Device1 {
-    fn from(value: &'a ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device9> for ID3D12Device1 {
-    fn from(value: &ID3D12Device9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device9> for ID3D12Device2 {
-    fn from(value: ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device9> for &'a ID3D12Device2 {
-    fn from(value: &'a ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device9> for ID3D12Device2 {
-    fn from(value: &ID3D12Device9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device9> for ID3D12Device3 {
-    fn from(value: ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device9> for &'a ID3D12Device3 {
-    fn from(value: &'a ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device9> for ID3D12Device3 {
-    fn from(value: &ID3D12Device9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device9> for ID3D12Device4 {
-    fn from(value: ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device9> for &'a ID3D12Device4 {
-    fn from(value: &'a ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device9> for ID3D12Device4 {
-    fn from(value: &ID3D12Device9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device9> for ID3D12Device5 {
-    fn from(value: ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device9> for &'a ID3D12Device5 {
-    fn from(value: &'a ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device9> for ID3D12Device5 {
-    fn from(value: &ID3D12Device9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device9> for ID3D12Device6 {
-    fn from(value: ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device9> for &'a ID3D12Device6 {
-    fn from(value: &'a ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device9> for ID3D12Device6 {
-    fn from(value: &ID3D12Device9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device9> for ID3D12Device7 {
-    fn from(value: ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device9> for &'a ID3D12Device7 {
-    fn from(value: &'a ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device9> for ID3D12Device7 {
-    fn from(value: &ID3D12Device9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Device9> for ID3D12Device8 {
-    fn from(value: ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Device9> for &'a ID3D12Device8 {
-    fn from(value: &'a ID3D12Device9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Device9> for ID3D12Device8 {
-    fn from(value: &ID3D12Device9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Device9, ::windows::core::IUnknown, ID3D12Object, ID3D12Device, ID3D12Device1, ID3D12Device2, ID3D12Device3, ID3D12Device4, ID3D12Device5, ID3D12Device6, ID3D12Device7, ID3D12Device8);
 impl ::core::clone::Clone for ID3D12Device9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6881,36 +5334,7 @@ impl ID3D12DeviceChild {
         (::windows::core::Vtable::vtable(self).GetDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, result__ as *mut _ as *mut _).ok()
     }
 }
-impl ::core::convert::From<ID3D12DeviceChild> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DeviceChild> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DeviceChild> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DeviceChild) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12DeviceChild> for ID3D12Object {
-    fn from(value: ID3D12DeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DeviceChild> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12DeviceChild) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DeviceChild> for ID3D12Object {
-    fn from(value: &ID3D12DeviceChild) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DeviceChild, ::windows::core::IUnknown, ID3D12Object);
 impl ::core::clone::Clone for ID3D12DeviceChild {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6954,21 +5378,7 @@ impl ID3D12DeviceRemovedExtendedData {
         (::windows::core::Vtable::vtable(self).GetPageFaultAllocationOutput)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<D3D12_DRED_PAGE_FAULT_OUTPUT>(result__)
     }
 }
-impl ::core::convert::From<ID3D12DeviceRemovedExtendedData> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DeviceRemovedExtendedData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DeviceRemovedExtendedData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DeviceRemovedExtendedData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DeviceRemovedExtendedData> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DeviceRemovedExtendedData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DeviceRemovedExtendedData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12DeviceRemovedExtendedData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7021,36 +5431,7 @@ impl ID3D12DeviceRemovedExtendedData1 {
         (::windows::core::Vtable::vtable(self).GetPageFaultAllocationOutput1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<D3D12_DRED_PAGE_FAULT_OUTPUT1>(result__)
     }
 }
-impl ::core::convert::From<ID3D12DeviceRemovedExtendedData1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DeviceRemovedExtendedData1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DeviceRemovedExtendedData1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DeviceRemovedExtendedData1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DeviceRemovedExtendedData1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DeviceRemovedExtendedData1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12DeviceRemovedExtendedData1> for ID3D12DeviceRemovedExtendedData {
-    fn from(value: ID3D12DeviceRemovedExtendedData1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DeviceRemovedExtendedData1> for &'a ID3D12DeviceRemovedExtendedData {
-    fn from(value: &'a ID3D12DeviceRemovedExtendedData1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DeviceRemovedExtendedData1> for ID3D12DeviceRemovedExtendedData {
-    fn from(value: &ID3D12DeviceRemovedExtendedData1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DeviceRemovedExtendedData1, ::windows::core::IUnknown, ID3D12DeviceRemovedExtendedData);
 impl ::core::clone::Clone for ID3D12DeviceRemovedExtendedData1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7110,51 +5491,7 @@ impl ID3D12DeviceRemovedExtendedData2 {
         (::windows::core::Vtable::vtable(self).GetDeviceState)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12DeviceRemovedExtendedData2> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DeviceRemovedExtendedData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DeviceRemovedExtendedData2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DeviceRemovedExtendedData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DeviceRemovedExtendedData2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DeviceRemovedExtendedData2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12DeviceRemovedExtendedData2> for ID3D12DeviceRemovedExtendedData {
-    fn from(value: ID3D12DeviceRemovedExtendedData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DeviceRemovedExtendedData2> for &'a ID3D12DeviceRemovedExtendedData {
-    fn from(value: &'a ID3D12DeviceRemovedExtendedData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DeviceRemovedExtendedData2> for ID3D12DeviceRemovedExtendedData {
-    fn from(value: &ID3D12DeviceRemovedExtendedData2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12DeviceRemovedExtendedData2> for ID3D12DeviceRemovedExtendedData1 {
-    fn from(value: ID3D12DeviceRemovedExtendedData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DeviceRemovedExtendedData2> for &'a ID3D12DeviceRemovedExtendedData1 {
-    fn from(value: &'a ID3D12DeviceRemovedExtendedData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DeviceRemovedExtendedData2> for ID3D12DeviceRemovedExtendedData1 {
-    fn from(value: &ID3D12DeviceRemovedExtendedData2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DeviceRemovedExtendedData2, ::windows::core::IUnknown, ID3D12DeviceRemovedExtendedData, ID3D12DeviceRemovedExtendedData1);
 impl ::core::clone::Clone for ID3D12DeviceRemovedExtendedData2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7200,21 +5537,7 @@ impl ID3D12DeviceRemovedExtendedDataSettings {
         (::windows::core::Vtable::vtable(self).SetWatsonDumpEnablement)(::windows::core::Vtable::as_raw(self), enablement)
     }
 }
-impl ::core::convert::From<ID3D12DeviceRemovedExtendedDataSettings> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DeviceRemovedExtendedDataSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DeviceRemovedExtendedDataSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DeviceRemovedExtendedDataSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DeviceRemovedExtendedDataSettings> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DeviceRemovedExtendedDataSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DeviceRemovedExtendedDataSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12DeviceRemovedExtendedDataSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7264,36 +5587,7 @@ impl ID3D12DeviceRemovedExtendedDataSettings1 {
         (::windows::core::Vtable::vtable(self).SetBreadcrumbContextEnablement)(::windows::core::Vtable::as_raw(self), enablement)
     }
 }
-impl ::core::convert::From<ID3D12DeviceRemovedExtendedDataSettings1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12DeviceRemovedExtendedDataSettings1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DeviceRemovedExtendedDataSettings1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12DeviceRemovedExtendedDataSettings1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DeviceRemovedExtendedDataSettings1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12DeviceRemovedExtendedDataSettings1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12DeviceRemovedExtendedDataSettings1> for ID3D12DeviceRemovedExtendedDataSettings {
-    fn from(value: ID3D12DeviceRemovedExtendedDataSettings1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12DeviceRemovedExtendedDataSettings1> for &'a ID3D12DeviceRemovedExtendedDataSettings {
-    fn from(value: &'a ID3D12DeviceRemovedExtendedDataSettings1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12DeviceRemovedExtendedDataSettings1> for ID3D12DeviceRemovedExtendedDataSettings {
-    fn from(value: &ID3D12DeviceRemovedExtendedDataSettings1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12DeviceRemovedExtendedDataSettings1, ::windows::core::IUnknown, ID3D12DeviceRemovedExtendedDataSettings);
 impl ::core::clone::Clone for ID3D12DeviceRemovedExtendedDataSettings1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7367,66 +5661,7 @@ impl ID3D12Fence {
         (::windows::core::Vtable::vtable(self).Signal)(::windows::core::Vtable::as_raw(self), value).ok()
     }
 }
-impl ::core::convert::From<ID3D12Fence> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Fence> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Fence> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Fence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Fence> for ID3D12Object {
-    fn from(value: ID3D12Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Fence> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Fence> for ID3D12Object {
-    fn from(value: &ID3D12Fence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Fence> for ID3D12DeviceChild {
-    fn from(value: ID3D12Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Fence> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Fence> for ID3D12DeviceChild {
-    fn from(value: &ID3D12Fence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Fence> for ID3D12Pageable {
-    fn from(value: ID3D12Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Fence> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12Fence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Fence> for ID3D12Pageable {
-    fn from(value: &ID3D12Fence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Fence, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ::core::clone::Clone for ID3D12Fence {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7508,81 +5743,7 @@ impl ID3D12Fence1 {
         (::windows::core::Vtable::vtable(self).GetCreationFlags)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12Fence1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Fence1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Fence1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Fence1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Fence1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Fence1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Fence1> for ID3D12Object {
-    fn from(value: ID3D12Fence1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Fence1> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Fence1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Fence1> for ID3D12Object {
-    fn from(value: &ID3D12Fence1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Fence1> for ID3D12DeviceChild {
-    fn from(value: ID3D12Fence1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Fence1> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12Fence1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Fence1> for ID3D12DeviceChild {
-    fn from(value: &ID3D12Fence1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Fence1> for ID3D12Pageable {
-    fn from(value: ID3D12Fence1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Fence1> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12Fence1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Fence1> for ID3D12Pageable {
-    fn from(value: &ID3D12Fence1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Fence1> for ID3D12Fence {
-    fn from(value: ID3D12Fence1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Fence1> for &'a ID3D12Fence {
-    fn from(value: &'a ID3D12Fence1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Fence1> for ID3D12Fence {
-    fn from(value: &ID3D12Fence1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Fence1, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable, ID3D12Fence);
 impl ::core::clone::Clone for ID3D12Fence1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8030,66 +6191,7 @@ impl ID3D12GraphicsCommandList {
         (::windows::core::Vtable::vtable(self).ExecuteIndirect)(::windows::core::Vtable::as_raw(self), pcommandsignature.into().abi(), maxcommandcount, pargumentbuffer.into().abi(), argumentbufferoffset, pcountbuffer.into().abi(), countbufferoffset)
     }
 }
-impl ::core::convert::From<ID3D12GraphicsCommandList> for ::windows::core::IUnknown {
-    fn from(value: ID3D12GraphicsCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12GraphicsCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12GraphicsCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList> for ID3D12Object {
-    fn from(value: ID3D12GraphicsCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12GraphicsCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList> for ID3D12Object {
-    fn from(value: &ID3D12GraphicsCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList> for ID3D12DeviceChild {
-    fn from(value: ID3D12GraphicsCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12GraphicsCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList> for ID3D12DeviceChild {
-    fn from(value: &ID3D12GraphicsCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList> for ID3D12CommandList {
-    fn from(value: ID3D12GraphicsCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList> for &'a ID3D12CommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList> for ID3D12CommandList {
-    fn from(value: &ID3D12GraphicsCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12GraphicsCommandList, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12CommandList);
 impl ::core::clone::Clone for ID3D12GraphicsCommandList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8512,81 +6614,7 @@ impl ID3D12GraphicsCommandList1 {
         (::windows::core::Vtable::vtable(self).SetViewInstanceMask)(::windows::core::Vtable::as_raw(self), mask)
     }
 }
-impl ::core::convert::From<ID3D12GraphicsCommandList1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12GraphicsCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12GraphicsCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12GraphicsCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList1> for ID3D12Object {
-    fn from(value: ID3D12GraphicsCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList1> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12GraphicsCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList1> for ID3D12Object {
-    fn from(value: &ID3D12GraphicsCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList1> for ID3D12DeviceChild {
-    fn from(value: ID3D12GraphicsCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList1> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12GraphicsCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList1> for ID3D12DeviceChild {
-    fn from(value: &ID3D12GraphicsCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList1> for ID3D12CommandList {
-    fn from(value: ID3D12GraphicsCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList1> for &'a ID3D12CommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList1> for ID3D12CommandList {
-    fn from(value: &ID3D12GraphicsCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList1> for ID3D12GraphicsCommandList {
-    fn from(value: ID3D12GraphicsCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList1> for &'a ID3D12GraphicsCommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList1> for ID3D12GraphicsCommandList {
-    fn from(value: &ID3D12GraphicsCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12GraphicsCommandList1, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12CommandList, ID3D12GraphicsCommandList);
 impl ::core::clone::Clone for ID3D12GraphicsCommandList1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8934,96 +6962,7 @@ impl ID3D12GraphicsCommandList2 {
         (::windows::core::Vtable::vtable(self).WriteBufferImmediate)(::windows::core::Vtable::as_raw(self), count, ::core::mem::transmute(pparams), ::core::mem::transmute(pmodes.unwrap_or(::std::ptr::null())))
     }
 }
-impl ::core::convert::From<ID3D12GraphicsCommandList2> for ::windows::core::IUnknown {
-    fn from(value: ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12GraphicsCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList2> for ID3D12Object {
-    fn from(value: ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList2> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList2> for ID3D12Object {
-    fn from(value: &ID3D12GraphicsCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList2> for ID3D12DeviceChild {
-    fn from(value: ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList2> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList2> for ID3D12DeviceChild {
-    fn from(value: &ID3D12GraphicsCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList2> for ID3D12CommandList {
-    fn from(value: ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList2> for &'a ID3D12CommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList2> for ID3D12CommandList {
-    fn from(value: &ID3D12GraphicsCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList2> for ID3D12GraphicsCommandList {
-    fn from(value: ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList2> for &'a ID3D12GraphicsCommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList2> for ID3D12GraphicsCommandList {
-    fn from(value: &ID3D12GraphicsCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList2> for ID3D12GraphicsCommandList1 {
-    fn from(value: ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList2> for &'a ID3D12GraphicsCommandList1 {
-    fn from(value: &'a ID3D12GraphicsCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList2> for ID3D12GraphicsCommandList1 {
-    fn from(value: &ID3D12GraphicsCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12GraphicsCommandList2, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12CommandList, ID3D12GraphicsCommandList, ID3D12GraphicsCommandList1);
 impl ::core::clone::Clone for ID3D12GraphicsCommandList2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9369,111 +7308,7 @@ impl ID3D12GraphicsCommandList3 {
         (::windows::core::Vtable::vtable(self).SetProtectedResourceSession)(::windows::core::Vtable::as_raw(self), pprotectedresourcesession.into().abi())
     }
 }
-impl ::core::convert::From<ID3D12GraphicsCommandList3> for ::windows::core::IUnknown {
-    fn from(value: ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList3> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12GraphicsCommandList3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList3> for ID3D12Object {
-    fn from(value: ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList3> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList3> for ID3D12Object {
-    fn from(value: &ID3D12GraphicsCommandList3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList3> for ID3D12DeviceChild {
-    fn from(value: ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList3> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList3> for ID3D12DeviceChild {
-    fn from(value: &ID3D12GraphicsCommandList3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList3> for ID3D12CommandList {
-    fn from(value: ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList3> for &'a ID3D12CommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList3> for ID3D12CommandList {
-    fn from(value: &ID3D12GraphicsCommandList3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList3> for ID3D12GraphicsCommandList {
-    fn from(value: ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList3> for &'a ID3D12GraphicsCommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList3> for ID3D12GraphicsCommandList {
-    fn from(value: &ID3D12GraphicsCommandList3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList3> for ID3D12GraphicsCommandList1 {
-    fn from(value: ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList3> for &'a ID3D12GraphicsCommandList1 {
-    fn from(value: &'a ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList3> for ID3D12GraphicsCommandList1 {
-    fn from(value: &ID3D12GraphicsCommandList3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList3> for ID3D12GraphicsCommandList2 {
-    fn from(value: ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList3> for &'a ID3D12GraphicsCommandList2 {
-    fn from(value: &'a ID3D12GraphicsCommandList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList3> for ID3D12GraphicsCommandList2 {
-    fn from(value: &ID3D12GraphicsCommandList3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12GraphicsCommandList3, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12CommandList, ID3D12GraphicsCommandList, ID3D12GraphicsCommandList1, ID3D12GraphicsCommandList2);
 impl ::core::clone::Clone for ID3D12GraphicsCommandList3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9859,126 +7694,7 @@ impl ID3D12GraphicsCommandList4 {
         (::windows::core::Vtable::vtable(self).DispatchRays)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc))
     }
 }
-impl ::core::convert::From<ID3D12GraphicsCommandList4> for ::windows::core::IUnknown {
-    fn from(value: ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList4> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12GraphicsCommandList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList4> for ID3D12Object {
-    fn from(value: ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList4> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList4> for ID3D12Object {
-    fn from(value: &ID3D12GraphicsCommandList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList4> for ID3D12DeviceChild {
-    fn from(value: ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList4> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList4> for ID3D12DeviceChild {
-    fn from(value: &ID3D12GraphicsCommandList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList4> for ID3D12CommandList {
-    fn from(value: ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList4> for &'a ID3D12CommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList4> for ID3D12CommandList {
-    fn from(value: &ID3D12GraphicsCommandList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList4> for ID3D12GraphicsCommandList {
-    fn from(value: ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList4> for &'a ID3D12GraphicsCommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList4> for ID3D12GraphicsCommandList {
-    fn from(value: &ID3D12GraphicsCommandList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList4> for ID3D12GraphicsCommandList1 {
-    fn from(value: ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList4> for &'a ID3D12GraphicsCommandList1 {
-    fn from(value: &'a ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList4> for ID3D12GraphicsCommandList1 {
-    fn from(value: &ID3D12GraphicsCommandList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList4> for ID3D12GraphicsCommandList2 {
-    fn from(value: ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList4> for &'a ID3D12GraphicsCommandList2 {
-    fn from(value: &'a ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList4> for ID3D12GraphicsCommandList2 {
-    fn from(value: &ID3D12GraphicsCommandList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList4> for ID3D12GraphicsCommandList3 {
-    fn from(value: ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList4> for &'a ID3D12GraphicsCommandList3 {
-    fn from(value: &'a ID3D12GraphicsCommandList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList4> for ID3D12GraphicsCommandList3 {
-    fn from(value: &ID3D12GraphicsCommandList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12GraphicsCommandList4, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12CommandList, ID3D12GraphicsCommandList, ID3D12GraphicsCommandList1, ID3D12GraphicsCommandList2, ID3D12GraphicsCommandList3);
 impl ::core::clone::Clone for ID3D12GraphicsCommandList4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10387,141 +8103,7 @@ impl ID3D12GraphicsCommandList5 {
         (::windows::core::Vtable::vtable(self).RSSetShadingRateImage)(::windows::core::Vtable::as_raw(self), shadingrateimage.into().abi())
     }
 }
-impl ::core::convert::From<ID3D12GraphicsCommandList5> for ::windows::core::IUnknown {
-    fn from(value: ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList5> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12GraphicsCommandList5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList5> for ID3D12Object {
-    fn from(value: ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList5> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList5> for ID3D12Object {
-    fn from(value: &ID3D12GraphicsCommandList5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList5> for ID3D12DeviceChild {
-    fn from(value: ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList5> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList5> for ID3D12DeviceChild {
-    fn from(value: &ID3D12GraphicsCommandList5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList5> for ID3D12CommandList {
-    fn from(value: ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList5> for &'a ID3D12CommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList5> for ID3D12CommandList {
-    fn from(value: &ID3D12GraphicsCommandList5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList5> for ID3D12GraphicsCommandList {
-    fn from(value: ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList5> for &'a ID3D12GraphicsCommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList5> for ID3D12GraphicsCommandList {
-    fn from(value: &ID3D12GraphicsCommandList5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList5> for ID3D12GraphicsCommandList1 {
-    fn from(value: ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList5> for &'a ID3D12GraphicsCommandList1 {
-    fn from(value: &'a ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList5> for ID3D12GraphicsCommandList1 {
-    fn from(value: &ID3D12GraphicsCommandList5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList5> for ID3D12GraphicsCommandList2 {
-    fn from(value: ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList5> for &'a ID3D12GraphicsCommandList2 {
-    fn from(value: &'a ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList5> for ID3D12GraphicsCommandList2 {
-    fn from(value: &ID3D12GraphicsCommandList5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList5> for ID3D12GraphicsCommandList3 {
-    fn from(value: ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList5> for &'a ID3D12GraphicsCommandList3 {
-    fn from(value: &'a ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList5> for ID3D12GraphicsCommandList3 {
-    fn from(value: &ID3D12GraphicsCommandList5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList5> for ID3D12GraphicsCommandList4 {
-    fn from(value: ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList5> for &'a ID3D12GraphicsCommandList4 {
-    fn from(value: &'a ID3D12GraphicsCommandList5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList5> for ID3D12GraphicsCommandList4 {
-    fn from(value: &ID3D12GraphicsCommandList5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12GraphicsCommandList5, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12CommandList, ID3D12GraphicsCommandList, ID3D12GraphicsCommandList1, ID3D12GraphicsCommandList2, ID3D12GraphicsCommandList3, ID3D12GraphicsCommandList4);
 impl ::core::clone::Clone for ID3D12GraphicsCommandList5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10920,156 +8502,7 @@ impl ID3D12GraphicsCommandList6 {
         (::windows::core::Vtable::vtable(self).DispatchMesh)(::windows::core::Vtable::as_raw(self), threadgroupcountx, threadgroupcounty, threadgroupcountz)
     }
 }
-impl ::core::convert::From<ID3D12GraphicsCommandList6> for ::windows::core::IUnknown {
-    fn from(value: ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList6> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12GraphicsCommandList6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList6> for ID3D12Object {
-    fn from(value: ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList6> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList6> for ID3D12Object {
-    fn from(value: &ID3D12GraphicsCommandList6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList6> for ID3D12DeviceChild {
-    fn from(value: ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList6> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList6> for ID3D12DeviceChild {
-    fn from(value: &ID3D12GraphicsCommandList6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList6> for ID3D12CommandList {
-    fn from(value: ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList6> for &'a ID3D12CommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList6> for ID3D12CommandList {
-    fn from(value: &ID3D12GraphicsCommandList6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList {
-    fn from(value: ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList6> for &'a ID3D12GraphicsCommandList {
-    fn from(value: &'a ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList {
-    fn from(value: &ID3D12GraphicsCommandList6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList1 {
-    fn from(value: ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList6> for &'a ID3D12GraphicsCommandList1 {
-    fn from(value: &'a ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList1 {
-    fn from(value: &ID3D12GraphicsCommandList6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList2 {
-    fn from(value: ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList6> for &'a ID3D12GraphicsCommandList2 {
-    fn from(value: &'a ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList2 {
-    fn from(value: &ID3D12GraphicsCommandList6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList3 {
-    fn from(value: ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList6> for &'a ID3D12GraphicsCommandList3 {
-    fn from(value: &'a ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList3 {
-    fn from(value: &ID3D12GraphicsCommandList6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList4 {
-    fn from(value: ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList6> for &'a ID3D12GraphicsCommandList4 {
-    fn from(value: &'a ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList4 {
-    fn from(value: &ID3D12GraphicsCommandList6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList5 {
-    fn from(value: ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12GraphicsCommandList6> for &'a ID3D12GraphicsCommandList5 {
-    fn from(value: &'a ID3D12GraphicsCommandList6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12GraphicsCommandList6> for ID3D12GraphicsCommandList5 {
-    fn from(value: &ID3D12GraphicsCommandList6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12GraphicsCommandList6, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12CommandList, ID3D12GraphicsCommandList, ID3D12GraphicsCommandList1, ID3D12GraphicsCommandList2, ID3D12GraphicsCommandList3, ID3D12GraphicsCommandList4, ID3D12GraphicsCommandList5);
 impl ::core::clone::Clone for ID3D12GraphicsCommandList6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11134,66 +8567,7 @@ impl ID3D12Heap {
         result__
     }
 }
-impl ::core::convert::From<ID3D12Heap> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Heap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Heap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Heap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Heap> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Heap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Heap> for ID3D12Object {
-    fn from(value: ID3D12Heap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Heap> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Heap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Heap> for ID3D12Object {
-    fn from(value: &ID3D12Heap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Heap> for ID3D12DeviceChild {
-    fn from(value: ID3D12Heap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Heap> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12Heap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Heap> for ID3D12DeviceChild {
-    fn from(value: &ID3D12Heap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Heap> for ID3D12Pageable {
-    fn from(value: ID3D12Heap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Heap> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12Heap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Heap> for ID3D12Pageable {
-    fn from(value: &ID3D12Heap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Heap, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ::core::clone::Clone for ID3D12Heap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11264,81 +8638,7 @@ impl ID3D12Heap1 {
         (::windows::core::Vtable::vtable(self).GetProtectedResourceSession)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, result__ as *mut _ as *mut _).ok()
     }
 }
-impl ::core::convert::From<ID3D12Heap1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Heap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Heap1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Heap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Heap1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Heap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Heap1> for ID3D12Object {
-    fn from(value: ID3D12Heap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Heap1> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Heap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Heap1> for ID3D12Object {
-    fn from(value: &ID3D12Heap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Heap1> for ID3D12DeviceChild {
-    fn from(value: ID3D12Heap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Heap1> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12Heap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Heap1> for ID3D12DeviceChild {
-    fn from(value: &ID3D12Heap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Heap1> for ID3D12Pageable {
-    fn from(value: ID3D12Heap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Heap1> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12Heap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Heap1> for ID3D12Pageable {
-    fn from(value: &ID3D12Heap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Heap1> for ID3D12Heap {
-    fn from(value: ID3D12Heap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Heap1> for &'a ID3D12Heap {
-    fn from(value: &'a ID3D12Heap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Heap1> for ID3D12Heap {
-    fn from(value: &ID3D12Heap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Heap1, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable, ID3D12Heap);
 impl ::core::clone::Clone for ID3D12Heap1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11513,21 +8813,7 @@ impl ID3D12InfoQueue {
         (::windows::core::Vtable::vtable(self).GetMuteDebugOutput)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12InfoQueue> for ::windows::core::IUnknown {
-    fn from(value: ID3D12InfoQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12InfoQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12InfoQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12InfoQueue> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12InfoQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12InfoQueue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12InfoQueue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11766,36 +9052,7 @@ impl ID3D12InfoQueue1 {
         (::windows::core::Vtable::vtable(self).UnregisterMessageCallback)(::windows::core::Vtable::as_raw(self), callbackcookie).ok()
     }
 }
-impl ::core::convert::From<ID3D12InfoQueue1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12InfoQueue1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12InfoQueue1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12InfoQueue1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12InfoQueue1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12InfoQueue1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12InfoQueue1> for ID3D12InfoQueue {
-    fn from(value: ID3D12InfoQueue1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12InfoQueue1> for &'a ID3D12InfoQueue {
-    fn from(value: &'a ID3D12InfoQueue1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12InfoQueue1> for ID3D12InfoQueue {
-    fn from(value: &ID3D12InfoQueue1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12InfoQueue1, ::windows::core::IUnknown, ID3D12InfoQueue);
 impl ::core::clone::Clone for ID3D12InfoQueue1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11839,21 +9096,7 @@ impl ID3D12LibraryReflection {
         (::windows::core::Vtable::vtable(self).GetFunctionByIndex)(::windows::core::Vtable::as_raw(self), functionindex)
     }
 }
-impl ::core::convert::From<ID3D12LibraryReflection> for ::windows::core::IUnknown {
-    fn from(value: ID3D12LibraryReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12LibraryReflection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12LibraryReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12LibraryReflection> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12LibraryReflection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12LibraryReflection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12LibraryReflection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11893,21 +9136,7 @@ impl ID3D12LifetimeOwner {
         (::windows::core::Vtable::vtable(self).LifetimeStateUpdated)(::windows::core::Vtable::as_raw(self), newstate)
     }
 }
-impl ::core::convert::From<ID3D12LifetimeOwner> for ::windows::core::IUnknown {
-    fn from(value: ID3D12LifetimeOwner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12LifetimeOwner> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12LifetimeOwner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12LifetimeOwner> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12LifetimeOwner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12LifetimeOwner, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12LifetimeOwner {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11973,51 +9202,7 @@ impl ID3D12LifetimeTracker {
         (::windows::core::Vtable::vtable(self).DestroyOwnedObject)(::windows::core::Vtable::as_raw(self), pobject.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ID3D12LifetimeTracker> for ::windows::core::IUnknown {
-    fn from(value: ID3D12LifetimeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12LifetimeTracker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12LifetimeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12LifetimeTracker> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12LifetimeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12LifetimeTracker> for ID3D12Object {
-    fn from(value: ID3D12LifetimeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12LifetimeTracker> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12LifetimeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12LifetimeTracker> for ID3D12Object {
-    fn from(value: &ID3D12LifetimeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12LifetimeTracker> for ID3D12DeviceChild {
-    fn from(value: ID3D12LifetimeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12LifetimeTracker> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12LifetimeTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12LifetimeTracker> for ID3D12DeviceChild {
-    fn from(value: &ID3D12LifetimeTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12LifetimeTracker, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild);
 impl ::core::clone::Clone for ID3D12LifetimeTracker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12080,66 +9265,7 @@ impl ID3D12MetaCommand {
         (::windows::core::Vtable::vtable(self).GetRequiredParameterResourceSize)(::windows::core::Vtable::as_raw(self), stage, parameterindex)
     }
 }
-impl ::core::convert::From<ID3D12MetaCommand> for ::windows::core::IUnknown {
-    fn from(value: ID3D12MetaCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12MetaCommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12MetaCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12MetaCommand> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12MetaCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12MetaCommand> for ID3D12Object {
-    fn from(value: ID3D12MetaCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12MetaCommand> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12MetaCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12MetaCommand> for ID3D12Object {
-    fn from(value: &ID3D12MetaCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12MetaCommand> for ID3D12DeviceChild {
-    fn from(value: ID3D12MetaCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12MetaCommand> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12MetaCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12MetaCommand> for ID3D12DeviceChild {
-    fn from(value: &ID3D12MetaCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12MetaCommand> for ID3D12Pageable {
-    fn from(value: ID3D12MetaCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12MetaCommand> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12MetaCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12MetaCommand> for ID3D12Pageable {
-    fn from(value: &ID3D12MetaCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12MetaCommand, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ::core::clone::Clone for ID3D12MetaCommand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12193,21 +9319,7 @@ impl ID3D12Object {
         (::windows::core::Vtable::vtable(self).SetName)(::windows::core::Vtable::as_raw(self), name.into()).ok()
     }
 }
-impl ::core::convert::From<ID3D12Object> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Object) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Object> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Object) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Object> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Object) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Object, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12Object {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12270,51 +9382,7 @@ impl ID3D12Pageable {
         (::windows::core::Vtable::vtable(self).base__.GetDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, result__ as *mut _ as *mut _).ok()
     }
 }
-impl ::core::convert::From<ID3D12Pageable> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Pageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Pageable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Pageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Pageable> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Pageable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Pageable> for ID3D12Object {
-    fn from(value: ID3D12Pageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Pageable> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Pageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Pageable> for ID3D12Object {
-    fn from(value: &ID3D12Pageable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Pageable> for ID3D12DeviceChild {
-    fn from(value: ID3D12Pageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Pageable> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12Pageable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Pageable> for ID3D12DeviceChild {
-    fn from(value: &ID3D12Pageable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Pageable, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild);
 impl ::core::clone::Clone for ID3D12Pageable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12404,51 +9472,7 @@ impl ID3D12PipelineLibrary {
         (::windows::core::Vtable::vtable(self).Serialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdata.as_ptr()), pdata.len() as _).ok()
     }
 }
-impl ::core::convert::From<ID3D12PipelineLibrary> for ::windows::core::IUnknown {
-    fn from(value: ID3D12PipelineLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12PipelineLibrary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12PipelineLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12PipelineLibrary> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12PipelineLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12PipelineLibrary> for ID3D12Object {
-    fn from(value: ID3D12PipelineLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12PipelineLibrary> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12PipelineLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12PipelineLibrary> for ID3D12Object {
-    fn from(value: &ID3D12PipelineLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12PipelineLibrary> for ID3D12DeviceChild {
-    fn from(value: ID3D12PipelineLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12PipelineLibrary> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12PipelineLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12PipelineLibrary> for ID3D12DeviceChild {
-    fn from(value: &ID3D12PipelineLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12PipelineLibrary, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild);
 impl ::core::clone::Clone for ID3D12PipelineLibrary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12554,66 +9578,7 @@ impl ID3D12PipelineLibrary1 {
         (::windows::core::Vtable::vtable(self).LoadPipeline)(::windows::core::Vtable::as_raw(self), pname.into(), ::core::mem::transmute(pdesc), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ID3D12PipelineLibrary1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12PipelineLibrary1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12PipelineLibrary1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12PipelineLibrary1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12PipelineLibrary1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12PipelineLibrary1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12PipelineLibrary1> for ID3D12Object {
-    fn from(value: ID3D12PipelineLibrary1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12PipelineLibrary1> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12PipelineLibrary1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12PipelineLibrary1> for ID3D12Object {
-    fn from(value: &ID3D12PipelineLibrary1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12PipelineLibrary1> for ID3D12DeviceChild {
-    fn from(value: ID3D12PipelineLibrary1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12PipelineLibrary1> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12PipelineLibrary1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12PipelineLibrary1> for ID3D12DeviceChild {
-    fn from(value: &ID3D12PipelineLibrary1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12PipelineLibrary1> for ID3D12PipelineLibrary {
-    fn from(value: ID3D12PipelineLibrary1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12PipelineLibrary1> for &'a ID3D12PipelineLibrary {
-    fn from(value: &'a ID3D12PipelineLibrary1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12PipelineLibrary1> for ID3D12PipelineLibrary {
-    fn from(value: &ID3D12PipelineLibrary1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12PipelineLibrary1, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12PipelineLibrary);
 impl ::core::clone::Clone for ID3D12PipelineLibrary1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12679,66 +9644,7 @@ impl ID3D12PipelineState {
         (::windows::core::Vtable::vtable(self).GetCachedBlob)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Direct3D::ID3DBlob>(result__)
     }
 }
-impl ::core::convert::From<ID3D12PipelineState> for ::windows::core::IUnknown {
-    fn from(value: ID3D12PipelineState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12PipelineState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12PipelineState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12PipelineState> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12PipelineState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12PipelineState> for ID3D12Object {
-    fn from(value: ID3D12PipelineState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12PipelineState> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12PipelineState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12PipelineState> for ID3D12Object {
-    fn from(value: &ID3D12PipelineState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12PipelineState> for ID3D12DeviceChild {
-    fn from(value: ID3D12PipelineState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12PipelineState> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12PipelineState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12PipelineState> for ID3D12DeviceChild {
-    fn from(value: &ID3D12PipelineState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12PipelineState> for ID3D12Pageable {
-    fn from(value: ID3D12PipelineState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12PipelineState> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12PipelineState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12PipelineState> for ID3D12Pageable {
-    fn from(value: &ID3D12PipelineState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12PipelineState, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ::core::clone::Clone for ID3D12PipelineState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12815,66 +9721,7 @@ impl ID3D12ProtectedResourceSession {
         result__
     }
 }
-impl ::core::convert::From<ID3D12ProtectedResourceSession> for ::windows::core::IUnknown {
-    fn from(value: ID3D12ProtectedResourceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedResourceSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12ProtectedResourceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedResourceSession> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12ProtectedResourceSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12ProtectedResourceSession> for ID3D12Object {
-    fn from(value: ID3D12ProtectedResourceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedResourceSession> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12ProtectedResourceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedResourceSession> for ID3D12Object {
-    fn from(value: &ID3D12ProtectedResourceSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12ProtectedResourceSession> for ID3D12DeviceChild {
-    fn from(value: ID3D12ProtectedResourceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedResourceSession> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12ProtectedResourceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedResourceSession> for ID3D12DeviceChild {
-    fn from(value: &ID3D12ProtectedResourceSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12ProtectedResourceSession> for ID3D12ProtectedSession {
-    fn from(value: ID3D12ProtectedResourceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedResourceSession> for &'a ID3D12ProtectedSession {
-    fn from(value: &'a ID3D12ProtectedResourceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedResourceSession> for ID3D12ProtectedSession {
-    fn from(value: &ID3D12ProtectedResourceSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12ProtectedResourceSession, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12ProtectedSession);
 impl ::core::clone::Clone for ID3D12ProtectedResourceSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12953,81 +9800,7 @@ impl ID3D12ProtectedResourceSession1 {
         result__
     }
 }
-impl ::core::convert::From<ID3D12ProtectedResourceSession1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12ProtectedResourceSession1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedResourceSession1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12ProtectedResourceSession1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedResourceSession1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12ProtectedResourceSession1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12ProtectedResourceSession1> for ID3D12Object {
-    fn from(value: ID3D12ProtectedResourceSession1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedResourceSession1> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12ProtectedResourceSession1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedResourceSession1> for ID3D12Object {
-    fn from(value: &ID3D12ProtectedResourceSession1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12ProtectedResourceSession1> for ID3D12DeviceChild {
-    fn from(value: ID3D12ProtectedResourceSession1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedResourceSession1> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12ProtectedResourceSession1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedResourceSession1> for ID3D12DeviceChild {
-    fn from(value: &ID3D12ProtectedResourceSession1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12ProtectedResourceSession1> for ID3D12ProtectedSession {
-    fn from(value: ID3D12ProtectedResourceSession1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedResourceSession1> for &'a ID3D12ProtectedSession {
-    fn from(value: &'a ID3D12ProtectedResourceSession1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedResourceSession1> for ID3D12ProtectedSession {
-    fn from(value: &ID3D12ProtectedResourceSession1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12ProtectedResourceSession1> for ID3D12ProtectedResourceSession {
-    fn from(value: ID3D12ProtectedResourceSession1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedResourceSession1> for &'a ID3D12ProtectedResourceSession {
-    fn from(value: &'a ID3D12ProtectedResourceSession1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedResourceSession1> for ID3D12ProtectedResourceSession {
-    fn from(value: &ID3D12ProtectedResourceSession1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12ProtectedResourceSession1, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12ProtectedSession, ID3D12ProtectedResourceSession);
 impl ::core::clone::Clone for ID3D12ProtectedResourceSession1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13096,51 +9869,7 @@ impl ID3D12ProtectedSession {
         (::windows::core::Vtable::vtable(self).GetSessionStatus)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12ProtectedSession> for ::windows::core::IUnknown {
-    fn from(value: ID3D12ProtectedSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12ProtectedSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedSession> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12ProtectedSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12ProtectedSession> for ID3D12Object {
-    fn from(value: ID3D12ProtectedSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedSession> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12ProtectedSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedSession> for ID3D12Object {
-    fn from(value: &ID3D12ProtectedSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12ProtectedSession> for ID3D12DeviceChild {
-    fn from(value: ID3D12ProtectedSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ProtectedSession> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12ProtectedSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ProtectedSession> for ID3D12DeviceChild {
-    fn from(value: &ID3D12ProtectedSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12ProtectedSession, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild);
 impl ::core::clone::Clone for ID3D12ProtectedSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13201,66 +9930,7 @@ impl ID3D12QueryHeap {
         (::windows::core::Vtable::vtable(self).base__.base__.GetDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, result__ as *mut _ as *mut _).ok()
     }
 }
-impl ::core::convert::From<ID3D12QueryHeap> for ::windows::core::IUnknown {
-    fn from(value: ID3D12QueryHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12QueryHeap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12QueryHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12QueryHeap> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12QueryHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12QueryHeap> for ID3D12Object {
-    fn from(value: ID3D12QueryHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12QueryHeap> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12QueryHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12QueryHeap> for ID3D12Object {
-    fn from(value: &ID3D12QueryHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12QueryHeap> for ID3D12DeviceChild {
-    fn from(value: ID3D12QueryHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12QueryHeap> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12QueryHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12QueryHeap> for ID3D12DeviceChild {
-    fn from(value: &ID3D12QueryHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12QueryHeap> for ID3D12Pageable {
-    fn from(value: ID3D12QueryHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12QueryHeap> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12QueryHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12QueryHeap> for ID3D12Pageable {
-    fn from(value: &ID3D12QueryHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12QueryHeap, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ::core::clone::Clone for ID3D12QueryHeap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13344,66 +10014,7 @@ impl ID3D12Resource {
         (::windows::core::Vtable::vtable(self).GetHeapProperties)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pheapproperties.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pheapflags.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<ID3D12Resource> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Resource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource> for ID3D12Object {
-    fn from(value: ID3D12Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource> for ID3D12Object {
-    fn from(value: &ID3D12Resource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource> for ID3D12DeviceChild {
-    fn from(value: ID3D12Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource> for ID3D12DeviceChild {
-    fn from(value: &ID3D12Resource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource> for ID3D12Pageable {
-    fn from(value: ID3D12Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12Resource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource> for ID3D12Pageable {
-    fn from(value: &ID3D12Resource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Resource, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ::core::clone::Clone for ID3D12Resource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13503,81 +10114,7 @@ impl ID3D12Resource1 {
         (::windows::core::Vtable::vtable(self).GetProtectedResourceSession)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, result__ as *mut _ as *mut _).ok()
     }
 }
-impl ::core::convert::From<ID3D12Resource1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Resource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Resource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Resource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource1> for ID3D12Object {
-    fn from(value: ID3D12Resource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource1> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Resource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource1> for ID3D12Object {
-    fn from(value: &ID3D12Resource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource1> for ID3D12DeviceChild {
-    fn from(value: ID3D12Resource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource1> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12Resource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource1> for ID3D12DeviceChild {
-    fn from(value: &ID3D12Resource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource1> for ID3D12Pageable {
-    fn from(value: ID3D12Resource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource1> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12Resource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource1> for ID3D12Pageable {
-    fn from(value: &ID3D12Resource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource1> for ID3D12Resource {
-    fn from(value: ID3D12Resource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource1> for &'a ID3D12Resource {
-    fn from(value: &'a ID3D12Resource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource1> for ID3D12Resource {
-    fn from(value: &ID3D12Resource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Resource1, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable, ID3D12Resource);
 impl ::core::clone::Clone for ID3D12Resource1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13675,96 +10212,7 @@ impl ID3D12Resource2 {
         result__
     }
 }
-impl ::core::convert::From<ID3D12Resource2> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Resource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource2> for ID3D12Object {
-    fn from(value: ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource2> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource2> for ID3D12Object {
-    fn from(value: &ID3D12Resource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource2> for ID3D12DeviceChild {
-    fn from(value: ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource2> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource2> for ID3D12DeviceChild {
-    fn from(value: &ID3D12Resource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource2> for ID3D12Pageable {
-    fn from(value: ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource2> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource2> for ID3D12Pageable {
-    fn from(value: &ID3D12Resource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource2> for ID3D12Resource {
-    fn from(value: ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource2> for &'a ID3D12Resource {
-    fn from(value: &'a ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource2> for ID3D12Resource {
-    fn from(value: &ID3D12Resource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12Resource2> for ID3D12Resource1 {
-    fn from(value: ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Resource2> for &'a ID3D12Resource1 {
-    fn from(value: &'a ID3D12Resource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Resource2> for ID3D12Resource1 {
-    fn from(value: &ID3D12Resource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Resource2, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable, ID3D12Resource, ID3D12Resource1);
 impl ::core::clone::Clone for ID3D12Resource2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13827,51 +10275,7 @@ impl ID3D12RootSignature {
         (::windows::core::Vtable::vtable(self).base__.GetDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, result__ as *mut _ as *mut _).ok()
     }
 }
-impl ::core::convert::From<ID3D12RootSignature> for ::windows::core::IUnknown {
-    fn from(value: ID3D12RootSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12RootSignature> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12RootSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12RootSignature> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12RootSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12RootSignature> for ID3D12Object {
-    fn from(value: ID3D12RootSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12RootSignature> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12RootSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12RootSignature> for ID3D12Object {
-    fn from(value: &ID3D12RootSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12RootSignature> for ID3D12DeviceChild {
-    fn from(value: ID3D12RootSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12RootSignature> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12RootSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12RootSignature> for ID3D12DeviceChild {
-    fn from(value: &ID3D12RootSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12RootSignature, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild);
 impl ::core::clone::Clone for ID3D12RootSignature {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13909,21 +10313,7 @@ impl ID3D12RootSignatureDeserializer {
         (::windows::core::Vtable::vtable(self).GetRootSignatureDesc)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12RootSignatureDeserializer> for ::windows::core::IUnknown {
-    fn from(value: ID3D12RootSignatureDeserializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12RootSignatureDeserializer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12RootSignatureDeserializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12RootSignatureDeserializer> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12RootSignatureDeserializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12RootSignatureDeserializer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12RootSignatureDeserializer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13965,21 +10355,7 @@ impl ID3D12SDKConfiguration {
         (::windows::core::Vtable::vtable(self).SetSDKVersion)(::windows::core::Vtable::as_raw(self), sdkversion, sdkpath.into()).ok()
     }
 }
-impl ::core::convert::From<ID3D12SDKConfiguration> for ::windows::core::IUnknown {
-    fn from(value: ID3D12SDKConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12SDKConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12SDKConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12SDKConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12SDKConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12SDKConfiguration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12SDKConfiguration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14053,51 +10429,7 @@ impl ID3D12ShaderCacheSession {
         result__
     }
 }
-impl ::core::convert::From<ID3D12ShaderCacheSession> for ::windows::core::IUnknown {
-    fn from(value: ID3D12ShaderCacheSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ShaderCacheSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12ShaderCacheSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ShaderCacheSession> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12ShaderCacheSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12ShaderCacheSession> for ID3D12Object {
-    fn from(value: ID3D12ShaderCacheSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ShaderCacheSession> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12ShaderCacheSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ShaderCacheSession> for ID3D12Object {
-    fn from(value: &ID3D12ShaderCacheSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12ShaderCacheSession> for ID3D12DeviceChild {
-    fn from(value: ID3D12ShaderCacheSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ShaderCacheSession> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12ShaderCacheSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ShaderCacheSession> for ID3D12DeviceChild {
-    fn from(value: &ID3D12ShaderCacheSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12ShaderCacheSession, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild);
 impl ::core::clone::Clone for ID3D12ShaderCacheSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14227,21 +10559,7 @@ impl ID3D12ShaderReflection {
         (::windows::core::Vtable::vtable(self).GetRequiresFlags)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12ShaderReflection> for ::windows::core::IUnknown {
-    fn from(value: ID3D12ShaderReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12ShaderReflection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12ShaderReflection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12ShaderReflection> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12ShaderReflection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12ShaderReflection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12ShaderReflection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14559,21 +10877,7 @@ impl ID3D12SharingContract {
         (::windows::core::Vtable::vtable(self).EndCapturableWork)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid))
     }
 }
-impl ::core::convert::From<ID3D12SharingContract> for ::windows::core::IUnknown {
-    fn from(value: ID3D12SharingContract) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12SharingContract> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12SharingContract) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12SharingContract> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12SharingContract) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12SharingContract, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12SharingContract {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14639,66 +10943,7 @@ impl ID3D12StateObject {
         (::windows::core::Vtable::vtable(self).base__.base__.GetDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, result__ as *mut _ as *mut _).ok()
     }
 }
-impl ::core::convert::From<ID3D12StateObject> for ::windows::core::IUnknown {
-    fn from(value: ID3D12StateObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12StateObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12StateObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12StateObject> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12StateObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12StateObject> for ID3D12Object {
-    fn from(value: ID3D12StateObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12StateObject> for &'a ID3D12Object {
-    fn from(value: &'a ID3D12StateObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12StateObject> for ID3D12Object {
-    fn from(value: &ID3D12StateObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12StateObject> for ID3D12DeviceChild {
-    fn from(value: ID3D12StateObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12StateObject> for &'a ID3D12DeviceChild {
-    fn from(value: &'a ID3D12StateObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12StateObject> for ID3D12DeviceChild {
-    fn from(value: &ID3D12StateObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12StateObject> for ID3D12Pageable {
-    fn from(value: ID3D12StateObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12StateObject> for &'a ID3D12Pageable {
-    fn from(value: &'a ID3D12StateObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12StateObject> for ID3D12Pageable {
-    fn from(value: &ID3D12StateObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12StateObject, ::windows::core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ::core::clone::Clone for ID3D12StateObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14751,21 +10996,7 @@ impl ID3D12StateObjectProperties {
         (::windows::core::Vtable::vtable(self).SetPipelineStackSize)(::windows::core::Vtable::as_raw(self), pipelinestacksizeinbytes)
     }
 }
-impl ::core::convert::From<ID3D12StateObjectProperties> for ::windows::core::IUnknown {
-    fn from(value: ID3D12StateObjectProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12StateObjectProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12StateObjectProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12StateObjectProperties> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12StateObjectProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12StateObjectProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12StateObjectProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14828,21 +11059,7 @@ impl ID3D12SwapChainAssistant {
         (::windows::core::Vtable::vtable(self).InsertImplicitSync)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ID3D12SwapChainAssistant> for ::windows::core::IUnknown {
-    fn from(value: ID3D12SwapChainAssistant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12SwapChainAssistant> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12SwapChainAssistant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12SwapChainAssistant> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12SwapChainAssistant) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12SwapChainAssistant, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12SwapChainAssistant {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14897,21 +11114,7 @@ impl ID3D12Tools {
         (::windows::core::Vtable::vtable(self).ShaderInstrumentationEnabled)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12Tools> for ::windows::core::IUnknown {
-    fn from(value: ID3D12Tools) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12Tools> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12Tools) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12Tools> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12Tools) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12Tools, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12Tools {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14961,21 +11164,7 @@ impl ID3D12VersionedRootSignatureDeserializer {
         (::windows::core::Vtable::vtable(self).GetUnconvertedRootSignatureDesc)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ID3D12VersionedRootSignatureDeserializer> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VersionedRootSignatureDeserializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12VersionedRootSignatureDeserializer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VersionedRootSignatureDeserializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12VersionedRootSignatureDeserializer> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VersionedRootSignatureDeserializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VersionedRootSignatureDeserializer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12VersionedRootSignatureDeserializer {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
@@ -156,21 +156,7 @@ impl IDirect3D9 {
         (::windows::core::Vtable::vtable(self).CreateDevice)(::windows::core::Vtable::as_raw(self), adapter, devicetype, hfocuswindow.into(), behaviorflags, ::core::mem::transmute(ppresentationparameters), ::core::mem::transmute(ppreturneddeviceinterface)).ok()
     }
 }
-impl ::core::convert::From<IDirect3D9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3D9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3D9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3D9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3D9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3D9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3D9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3D9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -315,36 +301,7 @@ impl IDirect3D9Ex {
         (::windows::core::Vtable::vtable(self).GetAdapterLUID)(::windows::core::Vtable::as_raw(self), adapter, ::core::mem::transmute(pluid)).ok()
     }
 }
-impl ::core::convert::From<IDirect3D9Ex> for ::windows::core::IUnknown {
-    fn from(value: IDirect3D9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3D9Ex> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3D9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3D9Ex> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3D9Ex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3D9Ex> for IDirect3D9 {
-    fn from(value: IDirect3D9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3D9Ex> for &'a IDirect3D9 {
-    fn from(value: &'a IDirect3D9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3D9Ex> for IDirect3D9 {
-    fn from(value: &IDirect3D9Ex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3D9Ex, ::windows::core::IUnknown, IDirect3D9);
 impl ::core::clone::Clone for IDirect3D9Ex {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -431,36 +388,7 @@ impl IDirect3DBaseTexture9 {
         (::windows::core::Vtable::vtable(self).GenerateMipSubLevels)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDirect3DBaseTexture9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DBaseTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DBaseTexture9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DBaseTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DBaseTexture9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DBaseTexture9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DBaseTexture9> for IDirect3DResource9 {
-    fn from(value: IDirect3DBaseTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DBaseTexture9> for &'a IDirect3DResource9 {
-    fn from(value: &'a IDirect3DBaseTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DBaseTexture9> for IDirect3DResource9 {
-    fn from(value: &IDirect3DBaseTexture9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DBaseTexture9, ::windows::core::IUnknown, IDirect3DResource9);
 impl ::core::clone::Clone for IDirect3DBaseTexture9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -562,51 +490,7 @@ impl IDirect3DCubeTexture9 {
         (::windows::core::Vtable::vtable(self).AddDirtyRect)(::windows::core::Vtable::as_raw(self), facetype, ::core::mem::transmute(pdirtyrect)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DCubeTexture9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DCubeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DCubeTexture9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DCubeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DCubeTexture9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DCubeTexture9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DCubeTexture9> for IDirect3DResource9 {
-    fn from(value: IDirect3DCubeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DCubeTexture9> for &'a IDirect3DResource9 {
-    fn from(value: &'a IDirect3DCubeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DCubeTexture9> for IDirect3DResource9 {
-    fn from(value: &IDirect3DCubeTexture9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DCubeTexture9> for IDirect3DBaseTexture9 {
-    fn from(value: IDirect3DCubeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DCubeTexture9> for &'a IDirect3DBaseTexture9 {
-    fn from(value: &'a IDirect3DCubeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DCubeTexture9> for IDirect3DBaseTexture9 {
-    fn from(value: &IDirect3DCubeTexture9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DCubeTexture9, ::windows::core::IUnknown, IDirect3DResource9, IDirect3DBaseTexture9);
 impl ::core::clone::Clone for IDirect3DCubeTexture9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1158,21 +1042,7 @@ impl IDirect3DDevice9 {
         (::windows::core::Vtable::vtable(self).CreateQuery)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDirect3DQuery9>(result__)
     }
 }
-impl ::core::convert::From<IDirect3DDevice9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DDevice9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DDevice9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DDevice9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DDevice9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DDevice9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DDevice9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DDevice9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2009,36 +1879,7 @@ impl IDirect3DDevice9Ex {
         (::windows::core::Vtable::vtable(self).GetDisplayModeEx)(::windows::core::Vtable::as_raw(self), iswapchain, ::core::mem::transmute(pmode), ::core::mem::transmute(protation)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DDevice9Ex> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DDevice9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DDevice9Ex> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DDevice9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DDevice9Ex> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DDevice9Ex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DDevice9Ex> for IDirect3DDevice9 {
-    fn from(value: IDirect3DDevice9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DDevice9Ex> for &'a IDirect3DDevice9 {
-    fn from(value: &'a IDirect3DDevice9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DDevice9Ex> for IDirect3DDevice9 {
-    fn from(value: &IDirect3DDevice9Ex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DDevice9Ex, ::windows::core::IUnknown, IDirect3DDevice9);
 impl ::core::clone::Clone for IDirect3DDevice9Ex {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2138,36 +1979,7 @@ impl IDirect3DIndexBuffer9 {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DIndexBuffer9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DIndexBuffer9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DIndexBuffer9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DIndexBuffer9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DIndexBuffer9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DIndexBuffer9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DIndexBuffer9> for IDirect3DResource9 {
-    fn from(value: IDirect3DIndexBuffer9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DIndexBuffer9> for &'a IDirect3DResource9 {
-    fn from(value: &'a IDirect3DIndexBuffer9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DIndexBuffer9> for IDirect3DResource9 {
-    fn from(value: &IDirect3DIndexBuffer9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DIndexBuffer9, ::windows::core::IUnknown, IDirect3DResource9);
 impl ::core::clone::Clone for IDirect3DIndexBuffer9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2210,21 +2022,7 @@ impl IDirect3DPixelShader9 {
         (::windows::core::Vtable::vtable(self).GetFunction)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), ::core::mem::transmute(psizeofdata)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DPixelShader9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DPixelShader9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DPixelShader9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DPixelShader9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DPixelShader9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DPixelShader9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DPixelShader9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DPixelShader9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2275,21 +2073,7 @@ impl IDirect3DQuery9 {
         (::windows::core::Vtable::vtable(self).GetData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdata), dwsize, dwgetdataflags).ok()
     }
 }
-impl ::core::convert::From<IDirect3DQuery9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DQuery9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DQuery9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DQuery9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DQuery9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DQuery9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DQuery9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DQuery9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2352,21 +2136,7 @@ impl IDirect3DResource9 {
         (::windows::core::Vtable::vtable(self).GetType)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDirect3DResource9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DResource9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DResource9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DResource9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DResource9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DResource9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DResource9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DResource9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2417,21 +2187,7 @@ impl IDirect3DStateBlock9 {
         (::windows::core::Vtable::vtable(self).Apply)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DStateBlock9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DStateBlock9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DStateBlock9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DStateBlock9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DStateBlock9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DStateBlock9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DStateBlock9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DStateBlock9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2519,36 +2275,7 @@ impl IDirect3DSurface9 {
         (::windows::core::Vtable::vtable(self).ReleaseDC)(::windows::core::Vtable::as_raw(self), hdc.into()).ok()
     }
 }
-impl ::core::convert::From<IDirect3DSurface9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DSurface9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DSurface9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DSurface9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DSurface9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DSurface9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DSurface9> for IDirect3DResource9 {
-    fn from(value: IDirect3DSurface9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DSurface9> for &'a IDirect3DResource9 {
-    fn from(value: &'a IDirect3DSurface9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DSurface9> for IDirect3DResource9 {
-    fn from(value: &IDirect3DSurface9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DSurface9, ::windows::core::IUnknown, IDirect3DResource9);
 impl ::core::clone::Clone for IDirect3DSurface9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2631,21 +2358,7 @@ impl IDirect3DSwapChain9 {
         (::windows::core::Vtable::vtable(self).GetPresentParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppresentationparameters)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DSwapChain9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DSwapChain9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DSwapChain9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DSwapChain9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DSwapChain9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DSwapChain9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DSwapChain9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DSwapChain9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2738,36 +2451,7 @@ impl IDirect3DSwapChain9Ex {
         (::windows::core::Vtable::vtable(self).GetDisplayModeEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmode), ::core::mem::transmute(protation)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DSwapChain9Ex> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DSwapChain9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DSwapChain9Ex> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DSwapChain9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DSwapChain9Ex> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DSwapChain9Ex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DSwapChain9Ex> for IDirect3DSwapChain9 {
-    fn from(value: IDirect3DSwapChain9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DSwapChain9Ex> for &'a IDirect3DSwapChain9 {
-    fn from(value: &'a IDirect3DSwapChain9Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DSwapChain9Ex> for IDirect3DSwapChain9 {
-    fn from(value: &IDirect3DSwapChain9Ex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DSwapChain9Ex, ::windows::core::IUnknown, IDirect3DSwapChain9);
 impl ::core::clone::Clone for IDirect3DSwapChain9Ex {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2866,51 +2550,7 @@ impl IDirect3DTexture9 {
         (::windows::core::Vtable::vtable(self).AddDirtyRect)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdirtyrect)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DTexture9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DTexture9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DTexture9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DTexture9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DTexture9> for IDirect3DResource9 {
-    fn from(value: IDirect3DTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DTexture9> for &'a IDirect3DResource9 {
-    fn from(value: &'a IDirect3DTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DTexture9> for IDirect3DResource9 {
-    fn from(value: &IDirect3DTexture9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DTexture9> for IDirect3DBaseTexture9 {
-    fn from(value: IDirect3DTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DTexture9> for &'a IDirect3DBaseTexture9 {
-    fn from(value: &'a IDirect3DTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DTexture9> for IDirect3DBaseTexture9 {
-    fn from(value: &IDirect3DTexture9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DTexture9, ::windows::core::IUnknown, IDirect3DResource9, IDirect3DBaseTexture9);
 impl ::core::clone::Clone for IDirect3DTexture9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2988,36 +2628,7 @@ impl IDirect3DVertexBuffer9 {
         (::windows::core::Vtable::vtable(self).GetDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DVertexBuffer9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DVertexBuffer9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DVertexBuffer9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DVertexBuffer9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DVertexBuffer9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DVertexBuffer9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DVertexBuffer9> for IDirect3DResource9 {
-    fn from(value: IDirect3DVertexBuffer9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DVertexBuffer9> for &'a IDirect3DResource9 {
-    fn from(value: &'a IDirect3DVertexBuffer9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DVertexBuffer9> for IDirect3DResource9 {
-    fn from(value: &IDirect3DVertexBuffer9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DVertexBuffer9, ::windows::core::IUnknown, IDirect3DResource9);
 impl ::core::clone::Clone for IDirect3DVertexBuffer9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3060,21 +2671,7 @@ impl IDirect3DVertexDeclaration9 {
         (::windows::core::Vtable::vtable(self).GetDeclaration)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pelement), ::core::mem::transmute(pnumelements)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DVertexDeclaration9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DVertexDeclaration9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DVertexDeclaration9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DVertexDeclaration9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DVertexDeclaration9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DVertexDeclaration9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DVertexDeclaration9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DVertexDeclaration9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3116,21 +2713,7 @@ impl IDirect3DVertexShader9 {
         (::windows::core::Vtable::vtable(self).GetFunction)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), ::core::mem::transmute(psizeofdata)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DVertexShader9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DVertexShader9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DVertexShader9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DVertexShader9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DVertexShader9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DVertexShader9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DVertexShader9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DVertexShader9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3190,21 +2773,7 @@ impl IDirect3DVolume9 {
         (::windows::core::Vtable::vtable(self).UnlockBox)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DVolume9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DVolume9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DVolume9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DVolume9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DVolume9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DVolume9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DVolume9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DVolume9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3304,51 +2873,7 @@ impl IDirect3DVolumeTexture9 {
         (::windows::core::Vtable::vtable(self).AddDirtyBox)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdirtybox)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DVolumeTexture9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DVolumeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DVolumeTexture9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DVolumeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DVolumeTexture9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DVolumeTexture9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DVolumeTexture9> for IDirect3DResource9 {
-    fn from(value: IDirect3DVolumeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DVolumeTexture9> for &'a IDirect3DResource9 {
-    fn from(value: &'a IDirect3DVolumeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DVolumeTexture9> for IDirect3DResource9 {
-    fn from(value: &IDirect3DVolumeTexture9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirect3DVolumeTexture9> for IDirect3DBaseTexture9 {
-    fn from(value: IDirect3DVolumeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DVolumeTexture9> for &'a IDirect3DBaseTexture9 {
-    fn from(value: &'a IDirect3DVolumeTexture9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DVolumeTexture9> for IDirect3DBaseTexture9 {
-    fn from(value: &IDirect3DVolumeTexture9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DVolumeTexture9, ::windows::core::IUnknown, IDirect3DResource9, IDirect3DBaseTexture9);
 impl ::core::clone::Clone for IDirect3DVolumeTexture9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/mod.rs
@@ -43,21 +43,7 @@ impl IDirect3DDevice9On12 {
         (::windows::core::Vtable::vtable(self).ReturnUnderlyingResource)(::windows::core::Vtable::as_raw(self), presource.into().abi(), numsync, ::core::mem::transmute(psignalvalues), ::core::mem::transmute(ppfences)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DDevice9On12> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DDevice9On12) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DDevice9On12> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DDevice9On12) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DDevice9On12> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DDevice9On12) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DDevice9On12, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DDevice9On12 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/mod.rs
@@ -174,51 +174,7 @@ impl IDCompositionAffineTransform2DEffect {
         (::windows::core::Vtable::vtable(self).SetSharpness2)(::windows::core::Vtable::as_raw(self), sharpness).ok()
     }
 }
-impl ::core::convert::From<IDCompositionAffineTransform2DEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionAffineTransform2DEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionAffineTransform2DEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionAffineTransform2DEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionAffineTransform2DEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionAffineTransform2DEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionAffineTransform2DEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionAffineTransform2DEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionAffineTransform2DEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionAffineTransform2DEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionAffineTransform2DEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionAffineTransform2DEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionAffineTransform2DEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionAffineTransform2DEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionAffineTransform2DEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionAffineTransform2DEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionAffineTransform2DEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionAffineTransform2DEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionAffineTransform2DEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionAffineTransform2DEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -285,21 +241,7 @@ impl IDCompositionAnimation {
         (::windows::core::Vtable::vtable(self).End)(::windows::core::Vtable::as_raw(self), endoffset, endvalue).ok()
     }
 }
-impl ::core::convert::From<IDCompositionAnimation> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionAnimation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionAnimation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionAnimation> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionAnimation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionAnimation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionAnimation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -393,51 +335,7 @@ impl IDCompositionArithmeticCompositeEffect {
         (::windows::core::Vtable::vtable(self).SetCoefficient42)(::windows::core::Vtable::as_raw(self), coefficient4).ok()
     }
 }
-impl ::core::convert::From<IDCompositionArithmeticCompositeEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionArithmeticCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionArithmeticCompositeEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionArithmeticCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionArithmeticCompositeEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionArithmeticCompositeEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionArithmeticCompositeEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionArithmeticCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionArithmeticCompositeEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionArithmeticCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionArithmeticCompositeEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionArithmeticCompositeEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionArithmeticCompositeEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionArithmeticCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionArithmeticCompositeEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionArithmeticCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionArithmeticCompositeEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionArithmeticCompositeEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionArithmeticCompositeEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionArithmeticCompositeEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -497,51 +395,7 @@ impl IDCompositionBlendEffect {
         (::windows::core::Vtable::vtable(self).SetMode)(::windows::core::Vtable::as_raw(self), mode).ok()
     }
 }
-impl ::core::convert::From<IDCompositionBlendEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionBlendEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionBlendEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionBlendEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionBlendEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionBlendEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionBlendEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionBlendEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionBlendEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionBlendEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionBlendEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionBlendEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionBlendEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionBlendEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionBlendEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionBlendEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionBlendEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionBlendEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionBlendEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionBlendEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -630,51 +484,7 @@ impl IDCompositionBrightnessEffect {
         (::windows::core::Vtable::vtable(self).SetBlackPointY2)(::windows::core::Vtable::as_raw(self), blackpointy).ok()
     }
 }
-impl ::core::convert::From<IDCompositionBrightnessEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionBrightnessEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionBrightnessEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionBrightnessEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionBrightnessEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionBrightnessEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionBrightnessEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionBrightnessEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionBrightnessEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionBrightnessEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionBrightnessEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionBrightnessEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionBrightnessEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionBrightnessEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionBrightnessEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionBrightnessEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionBrightnessEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionBrightnessEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionBrightnessEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionBrightnessEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -722,21 +532,7 @@ pub struct IDCompositionBrightnessEffect_Vtbl {
 #[repr(transparent)]
 pub struct IDCompositionClip(::windows::core::IUnknown);
 impl IDCompositionClip {}
-impl ::core::convert::From<IDCompositionClip> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionClip> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionClip> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionClip, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionClip {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -802,51 +598,7 @@ impl IDCompositionColorMatrixEffect {
         (::windows::core::Vtable::vtable(self).SetClampOutput)(::windows::core::Vtable::as_raw(self), clamp.into()).ok()
     }
 }
-impl ::core::convert::From<IDCompositionColorMatrixEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionColorMatrixEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionColorMatrixEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionColorMatrixEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionColorMatrixEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionColorMatrixEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionColorMatrixEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionColorMatrixEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionColorMatrixEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionColorMatrixEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionColorMatrixEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionColorMatrixEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionColorMatrixEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionColorMatrixEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionColorMatrixEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionColorMatrixEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionColorMatrixEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionColorMatrixEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionColorMatrixEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionColorMatrixEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -904,51 +656,7 @@ impl IDCompositionCompositeEffect {
         (::windows::core::Vtable::vtable(self).SetMode)(::windows::core::Vtable::as_raw(self), mode).ok()
     }
 }
-impl ::core::convert::From<IDCompositionCompositeEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionCompositeEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionCompositeEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionCompositeEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionCompositeEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionCompositeEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionCompositeEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionCompositeEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionCompositeEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionCompositeEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionCompositeEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionCompositeEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionCompositeEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionCompositeEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionCompositeEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1001,21 +709,7 @@ impl IDCompositionDelegatedInkTrail {
         (::windows::core::Vtable::vtable(self).StartNewTrail)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(color)).ok()
     }
 }
-impl ::core::convert::From<IDCompositionDelegatedInkTrail> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionDelegatedInkTrail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionDelegatedInkTrail> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionDelegatedInkTrail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionDelegatedInkTrail> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionDelegatedInkTrail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionDelegatedInkTrail, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionDelegatedInkTrail {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1174,36 +868,7 @@ impl IDCompositionDesktopDevice {
         (::windows::core::Vtable::vtable(self).CreateSurfaceFromHwnd)(::windows::core::Vtable::as_raw(self), hwnd.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IDCompositionDesktopDevice> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionDesktopDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionDesktopDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionDesktopDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionDesktopDevice> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionDesktopDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionDesktopDevice> for IDCompositionDevice2 {
-    fn from(value: IDCompositionDesktopDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionDesktopDevice> for &'a IDCompositionDevice2 {
-    fn from(value: &'a IDCompositionDesktopDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionDesktopDevice> for IDCompositionDevice2 {
-    fn from(value: &IDCompositionDesktopDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionDesktopDevice, ::windows::core::IUnknown, IDCompositionDevice2);
 impl ::core::clone::Clone for IDCompositionDesktopDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1366,21 +1031,7 @@ impl IDCompositionDevice {
         (::windows::core::Vtable::vtable(self).CheckDeviceState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IDCompositionDevice> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionDevice> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1549,21 +1200,7 @@ impl IDCompositionDevice2 {
         (::windows::core::Vtable::vtable(self).CreateAnimation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDCompositionAnimation>(result__)
     }
 }
-impl ::core::convert::From<IDCompositionDevice2> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionDevice2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionDevice2> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionDevice2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionDevice2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1769,36 +1406,7 @@ impl IDCompositionDevice3 {
         (::windows::core::Vtable::vtable(self).CreateAffineTransform2DEffect)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDCompositionAffineTransform2DEffect>(result__)
     }
 }
-impl ::core::convert::From<IDCompositionDevice3> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionDevice3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionDevice3> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionDevice3> for IDCompositionDevice2 {
-    fn from(value: IDCompositionDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionDevice3> for &'a IDCompositionDevice2 {
-    fn from(value: &'a IDCompositionDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionDevice3> for IDCompositionDevice2 {
-    fn from(value: &IDCompositionDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionDevice3, ::windows::core::IUnknown, IDCompositionDevice2);
 impl ::core::clone::Clone for IDCompositionDevice3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1850,21 +1458,7 @@ impl IDCompositionDeviceDebug {
         (::windows::core::Vtable::vtable(self).DisableDebugCounters)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDCompositionDeviceDebug> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionDeviceDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionDeviceDebug> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionDeviceDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionDeviceDebug> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionDeviceDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionDeviceDebug, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionDeviceDebug {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1898,21 +1492,7 @@ pub struct IDCompositionDeviceDebug_Vtbl {
 #[repr(transparent)]
 pub struct IDCompositionEffect(::windows::core::IUnknown);
 impl IDCompositionEffect {}
-impl ::core::convert::From<IDCompositionEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionEffect, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1960,36 +1540,7 @@ impl IDCompositionEffectGroup {
         (::windows::core::Vtable::vtable(self).SetTransform3D)(::windows::core::Vtable::as_raw(self), transform3d.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDCompositionEffectGroup> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionEffectGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionEffectGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionEffectGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionEffectGroup> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionEffectGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionEffectGroup> for IDCompositionEffect {
-    fn from(value: IDCompositionEffectGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionEffectGroup> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionEffectGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionEffectGroup> for IDCompositionEffect {
-    fn from(value: &IDCompositionEffectGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionEffectGroup, ::windows::core::IUnknown, IDCompositionEffect);
 impl ::core::clone::Clone for IDCompositionEffectGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2031,36 +1582,7 @@ impl IDCompositionFilterEffect {
         (::windows::core::Vtable::vtable(self).SetInput)(::windows::core::Vtable::as_raw(self), index, input.into().abi(), flags).ok()
     }
 }
-impl ::core::convert::From<IDCompositionFilterEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionFilterEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionFilterEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionFilterEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionFilterEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionFilterEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionFilterEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionFilterEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionFilterEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionFilterEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionFilterEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionFilterEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionFilterEffect, ::windows::core::IUnknown, IDCompositionEffect);
 impl ::core::clone::Clone for IDCompositionFilterEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2114,51 +1636,7 @@ impl IDCompositionGaussianBlurEffect {
         (::windows::core::Vtable::vtable(self).SetBorderMode)(::windows::core::Vtable::as_raw(self), mode).ok()
     }
 }
-impl ::core::convert::From<IDCompositionGaussianBlurEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionGaussianBlurEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionGaussianBlurEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionGaussianBlurEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionGaussianBlurEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionGaussianBlurEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionGaussianBlurEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionGaussianBlurEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionGaussianBlurEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionGaussianBlurEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionGaussianBlurEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionGaussianBlurEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionGaussianBlurEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionGaussianBlurEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionGaussianBlurEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionGaussianBlurEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionGaussianBlurEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionGaussianBlurEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionGaussianBlurEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionGaussianBlurEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2212,51 +1690,7 @@ impl IDCompositionHueRotationEffect {
         (::windows::core::Vtable::vtable(self).SetAngle2)(::windows::core::Vtable::as_raw(self), amountdegrees).ok()
     }
 }
-impl ::core::convert::From<IDCompositionHueRotationEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionHueRotationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionHueRotationEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionHueRotationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionHueRotationEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionHueRotationEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionHueRotationEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionHueRotationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionHueRotationEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionHueRotationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionHueRotationEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionHueRotationEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionHueRotationEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionHueRotationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionHueRotationEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionHueRotationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionHueRotationEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionHueRotationEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionHueRotationEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionHueRotationEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2302,21 +1736,7 @@ impl IDCompositionInkTrailDevice {
         (::windows::core::Vtable::vtable(self).CreateDelegatedInkTrailForSwapChain)(::windows::core::Vtable::as_raw(self), swapchain.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDCompositionDelegatedInkTrail>(result__)
     }
 }
-impl ::core::convert::From<IDCompositionInkTrailDevice> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionInkTrailDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionInkTrailDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionInkTrailDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionInkTrailDevice> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionInkTrailDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionInkTrailDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionInkTrailDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2469,51 +1889,7 @@ impl IDCompositionLinearTransferEffect {
         (::windows::core::Vtable::vtable(self).SetClampOutput)(::windows::core::Vtable::as_raw(self), clampoutput.into()).ok()
     }
 }
-impl ::core::convert::From<IDCompositionLinearTransferEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionLinearTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionLinearTransferEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionLinearTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionLinearTransferEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionLinearTransferEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionLinearTransferEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionLinearTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionLinearTransferEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionLinearTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionLinearTransferEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionLinearTransferEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionLinearTransferEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionLinearTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionLinearTransferEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionLinearTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionLinearTransferEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionLinearTransferEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionLinearTransferEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionLinearTransferEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2596,66 +1972,7 @@ impl IDCompositionMatrixTransform {
         (::windows::core::Vtable::vtable(self).SetMatrixElement2)(::windows::core::Vtable::as_raw(self), row, column, value).ok()
     }
 }
-impl ::core::convert::From<IDCompositionMatrixTransform> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionMatrixTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionMatrixTransform> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionMatrixTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionMatrixTransform> for IDCompositionEffect {
-    fn from(value: IDCompositionMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionMatrixTransform> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionMatrixTransform> for IDCompositionEffect {
-    fn from(value: &IDCompositionMatrixTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionMatrixTransform> for IDCompositionTransform3D {
-    fn from(value: IDCompositionMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionMatrixTransform> for &'a IDCompositionTransform3D {
-    fn from(value: &'a IDCompositionMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionMatrixTransform> for IDCompositionTransform3D {
-    fn from(value: &IDCompositionMatrixTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionMatrixTransform> for IDCompositionTransform {
-    fn from(value: IDCompositionMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionMatrixTransform> for &'a IDCompositionTransform {
-    fn from(value: &'a IDCompositionMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionMatrixTransform> for IDCompositionTransform {
-    fn from(value: &IDCompositionMatrixTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionMatrixTransform, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionTransform3D, IDCompositionTransform);
 impl ::core::clone::Clone for IDCompositionMatrixTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2708,51 +2025,7 @@ impl IDCompositionMatrixTransform3D {
         (::windows::core::Vtable::vtable(self).SetMatrixElement2)(::windows::core::Vtable::as_raw(self), row, column, value).ok()
     }
 }
-impl ::core::convert::From<IDCompositionMatrixTransform3D> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionMatrixTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionMatrixTransform3D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionMatrixTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionMatrixTransform3D> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionMatrixTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionMatrixTransform3D> for IDCompositionEffect {
-    fn from(value: IDCompositionMatrixTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionMatrixTransform3D> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionMatrixTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionMatrixTransform3D> for IDCompositionEffect {
-    fn from(value: &IDCompositionMatrixTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionMatrixTransform3D> for IDCompositionTransform3D {
-    fn from(value: IDCompositionMatrixTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionMatrixTransform3D> for &'a IDCompositionTransform3D {
-    fn from(value: &'a IDCompositionMatrixTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionMatrixTransform3D> for IDCompositionTransform3D {
-    fn from(value: &IDCompositionMatrixTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionMatrixTransform3D, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionTransform3D);
 impl ::core::clone::Clone for IDCompositionMatrixTransform3D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2899,36 +2172,7 @@ impl IDCompositionRectangleClip {
         (::windows::core::Vtable::vtable(self).SetBottomRightRadiusY2)(::windows::core::Vtable::as_raw(self), radius).ok()
     }
 }
-impl ::core::convert::From<IDCompositionRectangleClip> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionRectangleClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionRectangleClip> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionRectangleClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionRectangleClip> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionRectangleClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionRectangleClip> for IDCompositionClip {
-    fn from(value: IDCompositionRectangleClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionRectangleClip> for &'a IDCompositionClip {
-    fn from(value: &'a IDCompositionRectangleClip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionRectangleClip> for IDCompositionClip {
-    fn from(value: &IDCompositionRectangleClip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionRectangleClip, ::windows::core::IUnknown, IDCompositionClip);
 impl ::core::clone::Clone for IDCompositionRectangleClip {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3012,66 +2256,7 @@ impl IDCompositionRotateTransform {
         (::windows::core::Vtable::vtable(self).SetCenterY2)(::windows::core::Vtable::as_raw(self), centery).ok()
     }
 }
-impl ::core::convert::From<IDCompositionRotateTransform> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionRotateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionRotateTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionRotateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionRotateTransform> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionRotateTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionRotateTransform> for IDCompositionEffect {
-    fn from(value: IDCompositionRotateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionRotateTransform> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionRotateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionRotateTransform> for IDCompositionEffect {
-    fn from(value: &IDCompositionRotateTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionRotateTransform> for IDCompositionTransform3D {
-    fn from(value: IDCompositionRotateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionRotateTransform> for &'a IDCompositionTransform3D {
-    fn from(value: &'a IDCompositionRotateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionRotateTransform> for IDCompositionTransform3D {
-    fn from(value: &IDCompositionRotateTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionRotateTransform> for IDCompositionTransform {
-    fn from(value: IDCompositionRotateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionRotateTransform> for &'a IDCompositionTransform {
-    fn from(value: &'a IDCompositionRotateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionRotateTransform> for IDCompositionTransform {
-    fn from(value: &IDCompositionRotateTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionRotateTransform, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionTransform3D, IDCompositionTransform);
 impl ::core::clone::Clone for IDCompositionRotateTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3173,51 +2358,7 @@ impl IDCompositionRotateTransform3D {
         (::windows::core::Vtable::vtable(self).SetCenterZ2)(::windows::core::Vtable::as_raw(self), centerz).ok()
     }
 }
-impl ::core::convert::From<IDCompositionRotateTransform3D> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionRotateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionRotateTransform3D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionRotateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionRotateTransform3D> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionRotateTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionRotateTransform3D> for IDCompositionEffect {
-    fn from(value: IDCompositionRotateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionRotateTransform3D> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionRotateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionRotateTransform3D> for IDCompositionEffect {
-    fn from(value: &IDCompositionRotateTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionRotateTransform3D> for IDCompositionTransform3D {
-    fn from(value: IDCompositionRotateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionRotateTransform3D> for &'a IDCompositionTransform3D {
-    fn from(value: &'a IDCompositionRotateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionRotateTransform3D> for IDCompositionTransform3D {
-    fn from(value: &IDCompositionRotateTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionRotateTransform3D, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionTransform3D);
 impl ::core::clone::Clone for IDCompositionRotateTransform3D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3279,51 +2420,7 @@ impl IDCompositionSaturationEffect {
         (::windows::core::Vtable::vtable(self).SetSaturation2)(::windows::core::Vtable::as_raw(self), ratio).ok()
     }
 }
-impl ::core::convert::From<IDCompositionSaturationEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionSaturationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionSaturationEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionSaturationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionSaturationEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionSaturationEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionSaturationEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionSaturationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionSaturationEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionSaturationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionSaturationEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionSaturationEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionSaturationEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionSaturationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionSaturationEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionSaturationEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionSaturationEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionSaturationEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionSaturationEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionSaturationEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3394,66 +2491,7 @@ impl IDCompositionScaleTransform {
         (::windows::core::Vtable::vtable(self).SetCenterY2)(::windows::core::Vtable::as_raw(self), centery).ok()
     }
 }
-impl ::core::convert::From<IDCompositionScaleTransform> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionScaleTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionScaleTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionScaleTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionScaleTransform> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionScaleTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionScaleTransform> for IDCompositionEffect {
-    fn from(value: IDCompositionScaleTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionScaleTransform> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionScaleTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionScaleTransform> for IDCompositionEffect {
-    fn from(value: &IDCompositionScaleTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionScaleTransform> for IDCompositionTransform3D {
-    fn from(value: IDCompositionScaleTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionScaleTransform> for &'a IDCompositionTransform3D {
-    fn from(value: &'a IDCompositionScaleTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionScaleTransform> for IDCompositionTransform3D {
-    fn from(value: &IDCompositionScaleTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionScaleTransform> for IDCompositionTransform {
-    fn from(value: IDCompositionScaleTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionScaleTransform> for &'a IDCompositionTransform {
-    fn from(value: &'a IDCompositionScaleTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionScaleTransform> for IDCompositionTransform {
-    fn from(value: &IDCompositionScaleTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionScaleTransform, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionTransform3D, IDCompositionTransform);
 impl ::core::clone::Clone for IDCompositionScaleTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3548,51 +2586,7 @@ impl IDCompositionScaleTransform3D {
         (::windows::core::Vtable::vtable(self).SetCenterZ2)(::windows::core::Vtable::as_raw(self), centerz).ok()
     }
 }
-impl ::core::convert::From<IDCompositionScaleTransform3D> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionScaleTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionScaleTransform3D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionScaleTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionScaleTransform3D> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionScaleTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionScaleTransform3D> for IDCompositionEffect {
-    fn from(value: IDCompositionScaleTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionScaleTransform3D> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionScaleTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionScaleTransform3D> for IDCompositionEffect {
-    fn from(value: &IDCompositionScaleTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionScaleTransform3D> for IDCompositionTransform3D {
-    fn from(value: IDCompositionScaleTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionScaleTransform3D> for &'a IDCompositionTransform3D {
-    fn from(value: &'a IDCompositionScaleTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionScaleTransform3D> for IDCompositionTransform3D {
-    fn from(value: &IDCompositionScaleTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionScaleTransform3D, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionTransform3D);
 impl ::core::clone::Clone for IDCompositionScaleTransform3D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3693,51 +2687,7 @@ impl IDCompositionShadowEffect {
         (::windows::core::Vtable::vtable(self).SetAlpha2)(::windows::core::Vtable::as_raw(self), amount).ok()
     }
 }
-impl ::core::convert::From<IDCompositionShadowEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionShadowEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionShadowEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionShadowEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionShadowEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionShadowEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionShadowEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionShadowEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionShadowEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionShadowEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionShadowEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionShadowEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionShadowEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionShadowEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionShadowEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionShadowEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionShadowEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionShadowEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionShadowEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionShadowEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3820,66 +2770,7 @@ impl IDCompositionSkewTransform {
         (::windows::core::Vtable::vtable(self).SetCenterY2)(::windows::core::Vtable::as_raw(self), centery).ok()
     }
 }
-impl ::core::convert::From<IDCompositionSkewTransform> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionSkewTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionSkewTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionSkewTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionSkewTransform> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionSkewTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionSkewTransform> for IDCompositionEffect {
-    fn from(value: IDCompositionSkewTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionSkewTransform> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionSkewTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionSkewTransform> for IDCompositionEffect {
-    fn from(value: &IDCompositionSkewTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionSkewTransform> for IDCompositionTransform3D {
-    fn from(value: IDCompositionSkewTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionSkewTransform> for &'a IDCompositionTransform3D {
-    fn from(value: &'a IDCompositionSkewTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionSkewTransform> for IDCompositionTransform3D {
-    fn from(value: &IDCompositionSkewTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionSkewTransform> for IDCompositionTransform {
-    fn from(value: IDCompositionSkewTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionSkewTransform> for &'a IDCompositionTransform {
-    fn from(value: &'a IDCompositionSkewTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionSkewTransform> for IDCompositionTransform {
-    fn from(value: &IDCompositionSkewTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionSkewTransform, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionTransform3D, IDCompositionTransform);
 impl ::core::clone::Clone for IDCompositionSkewTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3939,21 +2830,7 @@ impl IDCompositionSurface {
         (::windows::core::Vtable::vtable(self).Scroll)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(scrollrect.unwrap_or(::std::ptr::null())), ::core::mem::transmute(cliprect.unwrap_or(::std::ptr::null())), offsetx, offsety).ok()
     }
 }
-impl ::core::convert::From<IDCompositionSurface> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionSurface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionSurface> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionSurface, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionSurface {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4009,21 +2886,7 @@ impl IDCompositionSurfaceFactory {
         (::windows::core::Vtable::vtable(self).CreateVirtualSurface)(::windows::core::Vtable::as_raw(self), initialwidth, initialheight, pixelformat, alphamode, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDCompositionVirtualSurface>(result__)
     }
 }
-impl ::core::convert::From<IDCompositionSurfaceFactory> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionSurfaceFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionSurfaceFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionSurfaceFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionSurfaceFactory> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionSurfaceFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionSurfaceFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionSurfaceFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4158,51 +3021,7 @@ impl IDCompositionTableTransferEffect {
         (::windows::core::Vtable::vtable(self).SetAlphaTableValue2)(::windows::core::Vtable::as_raw(self), index, value).ok()
     }
 }
-impl ::core::convert::From<IDCompositionTableTransferEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionTableTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTableTransferEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionTableTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTableTransferEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionTableTransferEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTableTransferEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionTableTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTableTransferEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionTableTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTableTransferEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionTableTransferEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTableTransferEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionTableTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTableTransferEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionTableTransferEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTableTransferEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionTableTransferEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionTableTransferEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionTableTransferEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4273,21 +3092,7 @@ impl IDCompositionTarget {
         (::windows::core::Vtable::vtable(self).SetRoot)(::windows::core::Vtable::as_raw(self), visual.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDCompositionTarget> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTarget> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4320,51 +3125,7 @@ pub struct IDCompositionTarget_Vtbl {
 #[repr(transparent)]
 pub struct IDCompositionTransform(::windows::core::IUnknown);
 impl IDCompositionTransform {}
-impl ::core::convert::From<IDCompositionTransform> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTransform> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTransform> for IDCompositionEffect {
-    fn from(value: IDCompositionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTransform> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTransform> for IDCompositionEffect {
-    fn from(value: &IDCompositionTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTransform> for IDCompositionTransform3D {
-    fn from(value: IDCompositionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTransform> for &'a IDCompositionTransform3D {
-    fn from(value: &'a IDCompositionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTransform> for IDCompositionTransform3D {
-    fn from(value: &IDCompositionTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionTransform, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionTransform3D);
 impl ::core::clone::Clone for IDCompositionTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4396,36 +3157,7 @@ pub struct IDCompositionTransform_Vtbl {
 #[repr(transparent)]
 pub struct IDCompositionTransform3D(::windows::core::IUnknown);
 impl IDCompositionTransform3D {}
-impl ::core::convert::From<IDCompositionTransform3D> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTransform3D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTransform3D> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTransform3D> for IDCompositionEffect {
-    fn from(value: IDCompositionTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTransform3D> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTransform3D> for IDCompositionEffect {
-    fn from(value: &IDCompositionTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionTransform3D, ::windows::core::IUnknown, IDCompositionEffect);
 impl ::core::clone::Clone for IDCompositionTransform3D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4476,66 +3208,7 @@ impl IDCompositionTranslateTransform {
         (::windows::core::Vtable::vtable(self).SetOffsetY2)(::windows::core::Vtable::as_raw(self), offsety).ok()
     }
 }
-impl ::core::convert::From<IDCompositionTranslateTransform> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionTranslateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTranslateTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionTranslateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTranslateTransform> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionTranslateTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTranslateTransform> for IDCompositionEffect {
-    fn from(value: IDCompositionTranslateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTranslateTransform> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionTranslateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTranslateTransform> for IDCompositionEffect {
-    fn from(value: &IDCompositionTranslateTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTranslateTransform> for IDCompositionTransform3D {
-    fn from(value: IDCompositionTranslateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTranslateTransform> for &'a IDCompositionTransform3D {
-    fn from(value: &'a IDCompositionTranslateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTranslateTransform> for IDCompositionTransform3D {
-    fn from(value: &IDCompositionTranslateTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTranslateTransform> for IDCompositionTransform {
-    fn from(value: IDCompositionTranslateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTranslateTransform> for &'a IDCompositionTransform {
-    fn from(value: &'a IDCompositionTranslateTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTranslateTransform> for IDCompositionTransform {
-    fn from(value: &IDCompositionTranslateTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionTranslateTransform, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionTransform3D, IDCompositionTransform);
 impl ::core::clone::Clone for IDCompositionTranslateTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4599,51 +3272,7 @@ impl IDCompositionTranslateTransform3D {
         (::windows::core::Vtable::vtable(self).SetOffsetZ2)(::windows::core::Vtable::as_raw(self), offsetz).ok()
     }
 }
-impl ::core::convert::From<IDCompositionTranslateTransform3D> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionTranslateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTranslateTransform3D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionTranslateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTranslateTransform3D> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionTranslateTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTranslateTransform3D> for IDCompositionEffect {
-    fn from(value: IDCompositionTranslateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTranslateTransform3D> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionTranslateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTranslateTransform3D> for IDCompositionEffect {
-    fn from(value: &IDCompositionTranslateTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTranslateTransform3D> for IDCompositionTransform3D {
-    fn from(value: IDCompositionTranslateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTranslateTransform3D> for &'a IDCompositionTransform3D {
-    fn from(value: &'a IDCompositionTranslateTransform3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTranslateTransform3D> for IDCompositionTransform3D {
-    fn from(value: &IDCompositionTranslateTransform3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionTranslateTransform3D, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionTransform3D);
 impl ::core::clone::Clone for IDCompositionTranslateTransform3D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4722,51 +3351,7 @@ impl IDCompositionTurbulenceEffect {
         (::windows::core::Vtable::vtable(self).SetStitchable)(::windows::core::Vtable::as_raw(self), stitchable.into()).ok()
     }
 }
-impl ::core::convert::From<IDCompositionTurbulenceEffect> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionTurbulenceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTurbulenceEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionTurbulenceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTurbulenceEffect> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionTurbulenceEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTurbulenceEffect> for IDCompositionEffect {
-    fn from(value: IDCompositionTurbulenceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTurbulenceEffect> for &'a IDCompositionEffect {
-    fn from(value: &'a IDCompositionTurbulenceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTurbulenceEffect> for IDCompositionEffect {
-    fn from(value: &IDCompositionTurbulenceEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionTurbulenceEffect> for IDCompositionFilterEffect {
-    fn from(value: IDCompositionTurbulenceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionTurbulenceEffect> for &'a IDCompositionFilterEffect {
-    fn from(value: &'a IDCompositionTurbulenceEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionTurbulenceEffect> for IDCompositionFilterEffect {
-    fn from(value: &IDCompositionTurbulenceEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionTurbulenceEffect, ::windows::core::IUnknown, IDCompositionEffect, IDCompositionFilterEffect);
 impl ::core::clone::Clone for IDCompositionTurbulenceEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4848,36 +3433,7 @@ impl IDCompositionVirtualSurface {
         (::windows::core::Vtable::vtable(self).Trim)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rectangles.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), rectangles.as_deref().map_or(0, |slice| slice.len() as _)).ok()
     }
 }
-impl ::core::convert::From<IDCompositionVirtualSurface> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionVirtualSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVirtualSurface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionVirtualSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVirtualSurface> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionVirtualSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionVirtualSurface> for IDCompositionSurface {
-    fn from(value: IDCompositionVirtualSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVirtualSurface> for &'a IDCompositionSurface {
-    fn from(value: &'a IDCompositionVirtualSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVirtualSurface> for IDCompositionSurface {
-    fn from(value: &IDCompositionVirtualSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionVirtualSurface, ::windows::core::IUnknown, IDCompositionSurface);
 impl ::core::clone::Clone for IDCompositionVirtualSurface {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5001,21 +3557,7 @@ impl IDCompositionVisual {
         (::windows::core::Vtable::vtable(self).SetCompositeMode)(::windows::core::Vtable::as_raw(self), compositemode).ok()
     }
 }
-impl ::core::convert::From<IDCompositionVisual> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVisual> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVisual> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionVisual, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCompositionVisual {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5166,36 +3708,7 @@ impl IDCompositionVisual2 {
         (::windows::core::Vtable::vtable(self).SetBackFaceVisibility)(::windows::core::Vtable::as_raw(self), visibility).ok()
     }
 }
-impl ::core::convert::From<IDCompositionVisual2> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionVisual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVisual2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionVisual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVisual2> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionVisual2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionVisual2> for IDCompositionVisual {
-    fn from(value: IDCompositionVisual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVisual2> for &'a IDCompositionVisual {
-    fn from(value: &'a IDCompositionVisual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVisual2> for IDCompositionVisual {
-    fn from(value: &IDCompositionVisual2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionVisual2, ::windows::core::IUnknown, IDCompositionVisual);
 impl ::core::clone::Clone for IDCompositionVisual2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5376,66 +3889,7 @@ impl IDCompositionVisual3 {
         (::windows::core::Vtable::vtable(self).SetVisible)(::windows::core::Vtable::as_raw(self), visible.into()).ok()
     }
 }
-impl ::core::convert::From<IDCompositionVisual3> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionVisual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVisual3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionVisual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVisual3> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionVisual3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionVisual3> for IDCompositionVisual {
-    fn from(value: IDCompositionVisual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVisual3> for &'a IDCompositionVisual {
-    fn from(value: &'a IDCompositionVisual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVisual3> for IDCompositionVisual {
-    fn from(value: &IDCompositionVisual3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionVisual3> for IDCompositionVisual2 {
-    fn from(value: IDCompositionVisual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVisual3> for &'a IDCompositionVisual2 {
-    fn from(value: &'a IDCompositionVisual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVisual3> for IDCompositionVisual2 {
-    fn from(value: &IDCompositionVisual3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionVisual3> for IDCompositionVisualDebug {
-    fn from(value: IDCompositionVisual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVisual3> for &'a IDCompositionVisualDebug {
-    fn from(value: &'a IDCompositionVisual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVisual3> for IDCompositionVisualDebug {
-    fn from(value: &IDCompositionVisual3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionVisual3, ::windows::core::IUnknown, IDCompositionVisual, IDCompositionVisual2, IDCompositionVisualDebug);
 impl ::core::clone::Clone for IDCompositionVisual3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5588,51 +4042,7 @@ impl IDCompositionVisualDebug {
         (::windows::core::Vtable::vtable(self).DisableRedrawRegions)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDCompositionVisualDebug> for ::windows::core::IUnknown {
-    fn from(value: IDCompositionVisualDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVisualDebug> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCompositionVisualDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVisualDebug> for ::windows::core::IUnknown {
-    fn from(value: &IDCompositionVisualDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionVisualDebug> for IDCompositionVisual {
-    fn from(value: IDCompositionVisualDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVisualDebug> for &'a IDCompositionVisual {
-    fn from(value: &'a IDCompositionVisualDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVisualDebug> for IDCompositionVisual {
-    fn from(value: &IDCompositionVisualDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDCompositionVisualDebug> for IDCompositionVisual2 {
-    fn from(value: IDCompositionVisualDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCompositionVisualDebug> for &'a IDCompositionVisual2 {
-    fn from(value: &'a IDCompositionVisualDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCompositionVisualDebug> for IDCompositionVisual2 {
-    fn from(value: &IDCompositionVisualDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCompositionVisualDebug, ::windows::core::IUnknown, IDCompositionVisual, IDCompositionVisual2);
 impl ::core::clone::Clone for IDCompositionVisualDebug {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
@@ -96,21 +96,7 @@ impl IDDVideoPortContainer {
         (::windows::core::Vtable::vtable(self).QueryVideoPortStatus)(::windows::core::Vtable::as_raw(self), param0, ::core::mem::transmute(param1)).ok()
     }
 }
-impl ::core::convert::From<IDDVideoPortContainer> for ::windows::core::IUnknown {
-    fn from(value: IDDVideoPortContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDDVideoPortContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDDVideoPortContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDDVideoPortContainer> for ::windows::core::IUnknown {
-    fn from(value: &IDDVideoPortContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDDVideoPortContainer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDDVideoPortContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -236,21 +222,7 @@ impl IDirectDraw {
         (::windows::core::Vtable::vtable(self).WaitForVerticalBlank)(::windows::core::Vtable::as_raw(self), param0, param1.into()).ok()
     }
 }
-impl ::core::convert::From<IDirectDraw> for ::windows::core::IUnknown {
-    fn from(value: IDirectDraw) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDraw> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDraw) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDraw> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDraw) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDraw, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDraw {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -401,21 +373,7 @@ impl IDirectDraw2 {
         (::windows::core::Vtable::vtable(self).GetAvailableVidMem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), ::core::mem::transmute(param1), ::core::mem::transmute(param2)).ok()
     }
 }
-impl ::core::convert::From<IDirectDraw2> for ::windows::core::IUnknown {
-    fn from(value: IDirectDraw2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDraw2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDraw2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDraw2> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDraw2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDraw2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDraw2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -587,21 +545,7 @@ impl IDirectDraw4 {
         (::windows::core::Vtable::vtable(self).GetDeviceIdentifier)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), param1).ok()
     }
 }
-impl ::core::convert::From<IDirectDraw4> for ::windows::core::IUnknown {
-    fn from(value: IDirectDraw4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDraw4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDraw4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDraw4> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDraw4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDraw4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDraw4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -791,21 +735,7 @@ impl IDirectDraw7 {
         (::windows::core::Vtable::vtable(self).EvaluateMode)(::windows::core::Vtable::as_raw(self), param0, ::core::mem::transmute(param1)).ok()
     }
 }
-impl ::core::convert::From<IDirectDraw7> for ::windows::core::IUnknown {
-    fn from(value: IDirectDraw7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDraw7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDraw7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDraw7> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDraw7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDraw7, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDraw7 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -917,21 +847,7 @@ impl IDirectDrawClipper {
         (::windows::core::Vtable::vtable(self).SetHWnd)(::windows::core::Vtable::as_raw(self), param0, param1.into()).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawClipper> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawClipper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawClipper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawClipper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawClipper> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawClipper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawClipper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawClipper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -991,21 +907,7 @@ impl IDirectDrawColorControl {
         (::windows::core::Vtable::vtable(self).SetColorControls)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0)).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawColorControl> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawColorControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawColorControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawColorControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawColorControl> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawColorControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawColorControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawColorControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1046,21 +948,7 @@ impl IDirectDrawGammaControl {
         (::windows::core::Vtable::vtable(self).SetGammaRamp)(::windows::core::Vtable::as_raw(self), param0, ::core::mem::transmute(param1)).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawGammaControl> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawGammaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawGammaControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawGammaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawGammaControl> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawGammaControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawGammaControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawGammaControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1104,21 +992,7 @@ impl IDirectDrawKernel {
         (::windows::core::Vtable::vtable(self).ReleaseKernelHandle)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawKernel> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawKernel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawKernel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawKernel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawKernel> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawKernel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawKernel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawKernel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1175,21 +1049,7 @@ impl IDirectDrawPalette {
         (::windows::core::Vtable::vtable(self).SetEntries)(::windows::core::Vtable::as_raw(self), param0, param1, param2, ::core::mem::transmute(param3)).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawPalette> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawPalette) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawPalette> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawPalette) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawPalette> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawPalette) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawPalette, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawPalette {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1388,21 +1248,7 @@ impl IDirectDrawSurface {
         (::windows::core::Vtable::vtable(self).UpdateOverlayZOrder)(::windows::core::Vtable::as_raw(self), param0, param1.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawSurface> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawSurface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawSurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawSurface> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawSurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawSurface, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawSurface {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1654,21 +1500,7 @@ impl IDirectDrawSurface2 {
         (::windows::core::Vtable::vtable(self).PageUnlock)(::windows::core::Vtable::as_raw(self), param0).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawSurface2> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawSurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawSurface2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawSurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawSurface2> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawSurface2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawSurface2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawSurface2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1926,21 +1758,7 @@ impl IDirectDrawSurface3 {
         (::windows::core::Vtable::vtable(self).SetSurfaceDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), param1).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawSurface3> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawSurface3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawSurface3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawSurface3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawSurface3> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawSurface3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawSurface3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawSurface3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2216,21 +2034,7 @@ impl IDirectDrawSurface4 {
         (::windows::core::Vtable::vtable(self).ChangeUniquenessValue)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawSurface4> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawSurface4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawSurface4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawSurface4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawSurface4> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawSurface4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawSurface4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawSurface4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2526,21 +2330,7 @@ impl IDirectDrawSurface7 {
         (::windows::core::Vtable::vtable(self).GetLOD)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0)).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawSurface7> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawSurface7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawSurface7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawSurface7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawSurface7> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawSurface7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawSurface7, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawSurface7 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2652,21 +2442,7 @@ impl IDirectDrawSurfaceKernel {
         (::windows::core::Vtable::vtable(self).ReleaseKernelHandle)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawSurfaceKernel> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawSurfaceKernel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawSurfaceKernel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawSurfaceKernel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawSurfaceKernel> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawSurfaceKernel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawSurfaceKernel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawSurfaceKernel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2753,21 +2529,7 @@ impl IDirectDrawVideoPort {
         (::windows::core::Vtable::vtable(self).WaitForSync)(::windows::core::Vtable::as_raw(self), param0, param1, param2).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawVideoPort> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawVideoPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawVideoPort> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawVideoPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawVideoPort> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawVideoPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawVideoPort, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawVideoPort {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2833,21 +2595,7 @@ impl IDirectDrawVideoPortNotify {
         (::windows::core::Vtable::vtable(self).ReleaseNotification)(::windows::core::Vtable::as_raw(self), param0.into()).ok()
     }
 }
-impl ::core::convert::From<IDirectDrawVideoPortNotify> for ::windows::core::IUnknown {
-    fn from(value: IDirectDrawVideoPortNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectDrawVideoPortNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectDrawVideoPortNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectDrawVideoPortNotify> for ::windows::core::IUnknown {
-    fn from(value: &IDirectDrawVideoPortNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectDrawVideoPortNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectDrawVideoPortNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/mod.rs
@@ -6,21 +6,7 @@ impl IDirectManipulationAutoScrollBehavior {
         (::windows::core::Vtable::vtable(self).SetConfiguration)(::windows::core::Vtable::as_raw(self), motiontypes, scrollmotion).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationAutoScrollBehavior> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationAutoScrollBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationAutoScrollBehavior> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationAutoScrollBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationAutoScrollBehavior> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationAutoScrollBehavior) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationAutoScrollBehavior, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationAutoScrollBehavior {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -78,21 +64,7 @@ impl IDirectManipulationCompositor {
         (::windows::core::Vtable::vtable(self).Flush)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationCompositor> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationCompositor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationCompositor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationCompositor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationCompositor> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationCompositor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationCompositor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationCompositor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -162,36 +134,7 @@ impl IDirectManipulationCompositor2 {
         (::windows::core::Vtable::vtable(self).AddContentWithCrossProcessChaining)(::windows::core::Vtable::as_raw(self), content.into().abi(), device.into().abi(), parentvisual.into().abi(), childvisual.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationCompositor2> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationCompositor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationCompositor2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationCompositor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationCompositor2> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationCompositor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectManipulationCompositor2> for IDirectManipulationCompositor {
-    fn from(value: IDirectManipulationCompositor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationCompositor2> for &'a IDirectManipulationCompositor {
-    fn from(value: &'a IDirectManipulationCompositor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationCompositor2> for IDirectManipulationCompositor {
-    fn from(value: &IDirectManipulationCompositor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationCompositor2, ::windows::core::IUnknown, IDirectManipulationCompositor);
 impl ::core::clone::Clone for IDirectManipulationCompositor2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -264,21 +207,7 @@ impl IDirectManipulationContent {
         (::windows::core::Vtable::vtable(self).SyncContentTransform)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(matrix.as_ptr()), matrix.len() as _).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationContent> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationContent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationContent> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationContent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationContent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -334,21 +263,7 @@ impl IDirectManipulationDeferContactService {
         (::windows::core::Vtable::vtable(self).CancelDeferral)(::windows::core::Vtable::as_raw(self), pointerid).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationDeferContactService> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationDeferContactService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationDeferContactService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationDeferContactService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationDeferContactService> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationDeferContactService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationDeferContactService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationDeferContactService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -391,21 +306,7 @@ impl IDirectManipulationDragDropBehavior {
         (::windows::core::Vtable::vtable(self).GetStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DIRECTMANIPULATION_DRAG_DROP_STATUS>(result__)
     }
 }
-impl ::core::convert::From<IDirectManipulationDragDropBehavior> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationDragDropBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationDragDropBehavior> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationDragDropBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationDragDropBehavior> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationDragDropBehavior) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationDragDropBehavior, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationDragDropBehavior {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -446,21 +347,7 @@ impl IDirectManipulationDragDropEventHandler {
         (::windows::core::Vtable::vtable(self).OnDragDropStatusChange)(::windows::core::Vtable::as_raw(self), viewport.into().abi(), current, previous).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationDragDropEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationDragDropEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationDragDropEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationDragDropEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationDragDropEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationDragDropEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationDragDropEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationDragDropEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -497,21 +384,7 @@ impl IDirectManipulationFrameInfoProvider {
         (::windows::core::Vtable::vtable(self).GetNextFrameInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(time), ::core::mem::transmute(processtime), ::core::mem::transmute(compositiontime)).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationFrameInfoProvider> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationFrameInfoProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationFrameInfoProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationFrameInfoProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationFrameInfoProvider> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationFrameInfoProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationFrameInfoProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationFrameInfoProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -551,21 +424,7 @@ impl IDirectManipulationInteractionEventHandler {
         (::windows::core::Vtable::vtable(self).OnInteraction)(::windows::core::Vtable::as_raw(self), viewport.into().abi(), interaction).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationInteractionEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationInteractionEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationInteractionEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationInteractionEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationInteractionEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationInteractionEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationInteractionEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationInteractionEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -656,21 +515,7 @@ impl IDirectManipulationManager {
         (::windows::core::Vtable::vtable(self).CreateContent)(::windows::core::Vtable::as_raw(self), frameinfo.into().abi(), ::core::mem::transmute(clsid), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDirectManipulationManager> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationManager> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -789,36 +634,7 @@ impl IDirectManipulationManager2 {
         (::windows::core::Vtable::vtable(self).CreateBehavior)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clsid), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDirectManipulationManager2> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationManager2> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectManipulationManager2> for IDirectManipulationManager {
-    fn from(value: IDirectManipulationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationManager2> for &'a IDirectManipulationManager {
-    fn from(value: &'a IDirectManipulationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationManager2> for IDirectManipulationManager {
-    fn from(value: &IDirectManipulationManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationManager2, ::windows::core::IUnknown, IDirectManipulationManager);
 impl ::core::clone::Clone for IDirectManipulationManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -923,51 +739,7 @@ impl IDirectManipulationManager3 {
         (::windows::core::Vtable::vtable(self).GetService)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clsid), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDirectManipulationManager3> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationManager3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationManager3> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationManager3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectManipulationManager3> for IDirectManipulationManager {
-    fn from(value: IDirectManipulationManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationManager3> for &'a IDirectManipulationManager {
-    fn from(value: &'a IDirectManipulationManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationManager3> for IDirectManipulationManager {
-    fn from(value: &IDirectManipulationManager3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectManipulationManager3> for IDirectManipulationManager2 {
-    fn from(value: IDirectManipulationManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationManager3> for &'a IDirectManipulationManager2 {
-    fn from(value: &'a IDirectManipulationManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationManager3> for IDirectManipulationManager2 {
-    fn from(value: &IDirectManipulationManager3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationManager3, ::windows::core::IUnknown, IDirectManipulationManager, IDirectManipulationManager2);
 impl ::core::clone::Clone for IDirectManipulationManager3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1028,21 +800,7 @@ impl IDirectManipulationPrimaryContent {
         (::windows::core::Vtable::vtable(self).GetCenterPoint)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(centerx), ::core::mem::transmute(centery)).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationPrimaryContent> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationPrimaryContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationPrimaryContent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationPrimaryContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationPrimaryContent> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationPrimaryContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationPrimaryContent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationPrimaryContent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1087,21 +845,7 @@ impl IDirectManipulationUpdateHandler {
         (::windows::core::Vtable::vtable(self).Update)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationUpdateHandler> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationUpdateHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationUpdateHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationUpdateHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationUpdateHandler> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationUpdateHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationUpdateHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationUpdateHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1154,21 +898,7 @@ impl IDirectManipulationUpdateManager {
         (::windows::core::Vtable::vtable(self).Update)(::windows::core::Vtable::as_raw(self), frameinfo.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationUpdateManager> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationUpdateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationUpdateManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationUpdateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationUpdateManager> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationUpdateManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationUpdateManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationUpdateManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1325,21 +1055,7 @@ impl IDirectManipulationViewport {
         (::windows::core::Vtable::vtable(self).Abandon)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationViewport> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationViewport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationViewport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationViewport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationViewport> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationViewport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationViewport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationViewport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1543,36 +1259,7 @@ impl IDirectManipulationViewport2 {
         (::windows::core::Vtable::vtable(self).RemoveAllBehaviors)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationViewport2> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationViewport2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationViewport2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationViewport2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationViewport2> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationViewport2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectManipulationViewport2> for IDirectManipulationViewport {
-    fn from(value: IDirectManipulationViewport2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationViewport2> for &'a IDirectManipulationViewport {
-    fn from(value: &'a IDirectManipulationViewport2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationViewport2> for IDirectManipulationViewport {
-    fn from(value: &IDirectManipulationViewport2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationViewport2, ::windows::core::IUnknown, IDirectManipulationViewport);
 impl ::core::clone::Clone for IDirectManipulationViewport2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1627,21 +1314,7 @@ impl IDirectManipulationViewportEventHandler {
         (::windows::core::Vtable::vtable(self).OnContentUpdated)(::windows::core::Vtable::as_raw(self), viewport.into().abi(), content.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDirectManipulationViewportEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IDirectManipulationViewportEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectManipulationViewportEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectManipulationViewportEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectManipulationViewportEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IDirectManipulationViewportEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectManipulationViewportEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectManipulationViewportEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
@@ -24,21 +24,7 @@ impl IDWriteAsyncResult {
         (::windows::core::Vtable::vtable(self).GetResult)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDWriteAsyncResult> for ::windows::core::IUnknown {
-    fn from(value: IDWriteAsyncResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteAsyncResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteAsyncResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteAsyncResult> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteAsyncResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteAsyncResult, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteAsyncResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -113,21 +99,7 @@ impl IDWriteBitmapRenderTarget {
         (::windows::core::Vtable::vtable(self).Resize)(::windows::core::Vtable::as_raw(self), width, height).ok()
     }
 }
-impl ::core::convert::From<IDWriteBitmapRenderTarget> for ::windows::core::IUnknown {
-    fn from(value: IDWriteBitmapRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteBitmapRenderTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteBitmapRenderTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteBitmapRenderTarget> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteBitmapRenderTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteBitmapRenderTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteBitmapRenderTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -220,36 +192,7 @@ impl IDWriteBitmapRenderTarget1 {
         (::windows::core::Vtable::vtable(self).SetTextAntialiasMode)(::windows::core::Vtable::as_raw(self), antialiasmode).ok()
     }
 }
-impl ::core::convert::From<IDWriteBitmapRenderTarget1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteBitmapRenderTarget1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteBitmapRenderTarget1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteBitmapRenderTarget1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteBitmapRenderTarget1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteBitmapRenderTarget1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteBitmapRenderTarget1> for IDWriteBitmapRenderTarget {
-    fn from(value: IDWriteBitmapRenderTarget1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteBitmapRenderTarget1> for &'a IDWriteBitmapRenderTarget {
-    fn from(value: &'a IDWriteBitmapRenderTarget1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteBitmapRenderTarget1> for IDWriteBitmapRenderTarget {
-    fn from(value: &IDWriteBitmapRenderTarget1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteBitmapRenderTarget1, ::windows::core::IUnknown, IDWriteBitmapRenderTarget);
 impl ::core::clone::Clone for IDWriteBitmapRenderTarget1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -296,21 +239,7 @@ impl IDWriteColorGlyphRunEnumerator {
         (::windows::core::Vtable::vtable(self).GetCurrentRun)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut DWRITE_COLOR_GLYPH_RUN>(result__)
     }
 }
-impl ::core::convert::From<IDWriteColorGlyphRunEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IDWriteColorGlyphRunEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteColorGlyphRunEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteColorGlyphRunEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteColorGlyphRunEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteColorGlyphRunEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteColorGlyphRunEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteColorGlyphRunEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -369,36 +298,7 @@ impl IDWriteColorGlyphRunEnumerator1 {
         (::windows::core::Vtable::vtable(self).GetCurrentRun2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut DWRITE_COLOR_GLYPH_RUN1>(result__)
     }
 }
-impl ::core::convert::From<IDWriteColorGlyphRunEnumerator1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteColorGlyphRunEnumerator1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteColorGlyphRunEnumerator1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteColorGlyphRunEnumerator1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteColorGlyphRunEnumerator1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteColorGlyphRunEnumerator1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteColorGlyphRunEnumerator1> for IDWriteColorGlyphRunEnumerator {
-    fn from(value: IDWriteColorGlyphRunEnumerator1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteColorGlyphRunEnumerator1> for &'a IDWriteColorGlyphRunEnumerator {
-    fn from(value: &'a IDWriteColorGlyphRunEnumerator1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteColorGlyphRunEnumerator1> for IDWriteColorGlyphRunEnumerator {
-    fn from(value: &IDWriteColorGlyphRunEnumerator1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteColorGlyphRunEnumerator1, ::windows::core::IUnknown, IDWriteColorGlyphRunEnumerator);
 impl ::core::clone::Clone for IDWriteColorGlyphRunEnumerator1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -572,21 +472,7 @@ impl IDWriteFactory {
         (::windows::core::Vtable::vtable(self).CreateGlyphRunAnalysis)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(glyphrun), pixelsperdip, ::core::mem::transmute(transform.unwrap_or(::std::ptr::null())), renderingmode, measuringmode, baselineoriginx, baselineoriginy, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteGlyphRunAnalysis>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFactory> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -807,36 +693,7 @@ impl IDWriteFactory1 {
         (::windows::core::Vtable::vtable(self).CreateCustomRenderingParams2)(::windows::core::Vtable::as_raw(self), gamma, enhancedcontrast, enhancedcontrastgrayscale, cleartypelevel, pixelgeometry, renderingmode, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteRenderingParams1>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFactory1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFactory1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory1> for IDWriteFactory {
-    fn from(value: IDWriteFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory1> for &'a IDWriteFactory {
-    fn from(value: &'a IDWriteFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory1> for IDWriteFactory {
-    fn from(value: &IDWriteFactory1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFactory1, ::windows::core::IUnknown, IDWriteFactory);
 impl ::core::clone::Clone for IDWriteFactory1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1047,51 +904,7 @@ impl IDWriteFactory2 {
         (::windows::core::Vtable::vtable(self).CreateGlyphRunAnalysis2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(glyphrun), ::core::mem::transmute(transform.unwrap_or(::std::ptr::null())), renderingmode, measuringmode, gridfitmode, antialiasmode, baselineoriginx, baselineoriginy, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteGlyphRunAnalysis>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFactory2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory2> for IDWriteFactory {
-    fn from(value: IDWriteFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory2> for &'a IDWriteFactory {
-    fn from(value: &'a IDWriteFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory2> for IDWriteFactory {
-    fn from(value: &IDWriteFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory2> for IDWriteFactory1 {
-    fn from(value: IDWriteFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory2> for &'a IDWriteFactory1 {
-    fn from(value: &'a IDWriteFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory2> for IDWriteFactory1 {
-    fn from(value: &IDWriteFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFactory2, ::windows::core::IUnknown, IDWriteFactory, IDWriteFactory1);
 impl ::core::clone::Clone for IDWriteFactory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1362,66 +1175,7 @@ impl IDWriteFactory3 {
         (::windows::core::Vtable::vtable(self).GetFontDownloadQueue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontDownloadQueue>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFactory3> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory3> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFactory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory3> for IDWriteFactory {
-    fn from(value: IDWriteFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory3> for &'a IDWriteFactory {
-    fn from(value: &'a IDWriteFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory3> for IDWriteFactory {
-    fn from(value: &IDWriteFactory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory3> for IDWriteFactory1 {
-    fn from(value: IDWriteFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory3> for &'a IDWriteFactory1 {
-    fn from(value: &'a IDWriteFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory3> for IDWriteFactory1 {
-    fn from(value: &IDWriteFactory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory3> for IDWriteFactory2 {
-    fn from(value: IDWriteFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory3> for &'a IDWriteFactory2 {
-    fn from(value: &'a IDWriteFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory3> for IDWriteFactory2 {
-    fn from(value: &IDWriteFactory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFactory3, ::windows::core::IUnknown, IDWriteFactory, IDWriteFactory1, IDWriteFactory2);
 impl ::core::clone::Clone for IDWriteFactory3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1717,81 +1471,7 @@ impl IDWriteFactory4 {
         (::windows::core::Vtable::vtable(self).ComputeGlyphOrigins2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(glyphrun), measuringmode, ::core::mem::transmute(baselineorigin), ::core::mem::transmute(worldanddpitransform.unwrap_or(::std::ptr::null())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Direct2D::Common::D2D_POINT_2F>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFactory4> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory4> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory4> for IDWriteFactory {
-    fn from(value: IDWriteFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory4> for &'a IDWriteFactory {
-    fn from(value: &'a IDWriteFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory4> for IDWriteFactory {
-    fn from(value: &IDWriteFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory4> for IDWriteFactory1 {
-    fn from(value: IDWriteFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory4> for &'a IDWriteFactory1 {
-    fn from(value: &'a IDWriteFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory4> for IDWriteFactory1 {
-    fn from(value: &IDWriteFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory4> for IDWriteFactory2 {
-    fn from(value: IDWriteFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory4> for &'a IDWriteFactory2 {
-    fn from(value: &'a IDWriteFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory4> for IDWriteFactory2 {
-    fn from(value: &IDWriteFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory4> for IDWriteFactory3 {
-    fn from(value: IDWriteFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory4> for &'a IDWriteFactory3 {
-    fn from(value: &'a IDWriteFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory4> for IDWriteFactory3 {
-    fn from(value: &IDWriteFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFactory4, ::windows::core::IUnknown, IDWriteFactory, IDWriteFactory1, IDWriteFactory2, IDWriteFactory3);
 impl ::core::clone::Clone for IDWriteFactory4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2104,96 +1784,7 @@ impl IDWriteFactory5 {
         (::windows::core::Vtable::vtable(self).UnpackFontFile)(::windows::core::Vtable::as_raw(self), containertype, ::core::mem::transmute(filedata), filedatasize, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFileStream>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFactory5> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory5> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory5> for IDWriteFactory {
-    fn from(value: IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory5> for &'a IDWriteFactory {
-    fn from(value: &'a IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory5> for IDWriteFactory {
-    fn from(value: &IDWriteFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory5> for IDWriteFactory1 {
-    fn from(value: IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory5> for &'a IDWriteFactory1 {
-    fn from(value: &'a IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory5> for IDWriteFactory1 {
-    fn from(value: &IDWriteFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory5> for IDWriteFactory2 {
-    fn from(value: IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory5> for &'a IDWriteFactory2 {
-    fn from(value: &'a IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory5> for IDWriteFactory2 {
-    fn from(value: &IDWriteFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory5> for IDWriteFactory3 {
-    fn from(value: IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory5> for &'a IDWriteFactory3 {
-    fn from(value: &'a IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory5> for IDWriteFactory3 {
-    fn from(value: &IDWriteFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory5> for IDWriteFactory4 {
-    fn from(value: IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory5> for &'a IDWriteFactory4 {
-    fn from(value: &'a IDWriteFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory5> for IDWriteFactory4 {
-    fn from(value: &IDWriteFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFactory5, ::windows::core::IUnknown, IDWriteFactory, IDWriteFactory1, IDWriteFactory2, IDWriteFactory3, IDWriteFactory4);
 impl ::core::clone::Clone for IDWriteFactory5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2551,111 +2142,7 @@ impl IDWriteFactory6 {
         (::windows::core::Vtable::vtable(self).CreateTextFormat2)(::windows::core::Vtable::as_raw(self), fontfamilyname.into(), fontcollection.into().abi(), ::core::mem::transmute(fontaxisvalues.as_ptr()), fontaxisvalues.len() as _, fontsize, localename.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteTextFormat3>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFactory6> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory6> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory6> for IDWriteFactory {
-    fn from(value: IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory6> for &'a IDWriteFactory {
-    fn from(value: &'a IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory6> for IDWriteFactory {
-    fn from(value: &IDWriteFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory6> for IDWriteFactory1 {
-    fn from(value: IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory6> for &'a IDWriteFactory1 {
-    fn from(value: &'a IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory6> for IDWriteFactory1 {
-    fn from(value: &IDWriteFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory6> for IDWriteFactory2 {
-    fn from(value: IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory6> for &'a IDWriteFactory2 {
-    fn from(value: &'a IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory6> for IDWriteFactory2 {
-    fn from(value: &IDWriteFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory6> for IDWriteFactory3 {
-    fn from(value: IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory6> for &'a IDWriteFactory3 {
-    fn from(value: &'a IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory6> for IDWriteFactory3 {
-    fn from(value: &IDWriteFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory6> for IDWriteFactory4 {
-    fn from(value: IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory6> for &'a IDWriteFactory4 {
-    fn from(value: &'a IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory6> for IDWriteFactory4 {
-    fn from(value: &IDWriteFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory6> for IDWriteFactory5 {
-    fn from(value: IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory6> for &'a IDWriteFactory5 {
-    fn from(value: &'a IDWriteFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory6> for IDWriteFactory5 {
-    fn from(value: &IDWriteFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFactory6, ::windows::core::IUnknown, IDWriteFactory, IDWriteFactory1, IDWriteFactory2, IDWriteFactory3, IDWriteFactory4, IDWriteFactory5);
 impl ::core::clone::Clone for IDWriteFactory6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3039,126 +2526,7 @@ impl IDWriteFactory7 {
         (::windows::core::Vtable::vtable(self).GetSystemFontCollection4)(::windows::core::Vtable::as_raw(self), includedownloadablefonts.into(), fontfamilymodel, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontCollection3>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFactory7> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory7> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory7> for IDWriteFactory {
-    fn from(value: IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory7> for &'a IDWriteFactory {
-    fn from(value: &'a IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory7> for IDWriteFactory {
-    fn from(value: &IDWriteFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory7> for IDWriteFactory1 {
-    fn from(value: IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory7> for &'a IDWriteFactory1 {
-    fn from(value: &'a IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory7> for IDWriteFactory1 {
-    fn from(value: &IDWriteFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory7> for IDWriteFactory2 {
-    fn from(value: IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory7> for &'a IDWriteFactory2 {
-    fn from(value: &'a IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory7> for IDWriteFactory2 {
-    fn from(value: &IDWriteFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory7> for IDWriteFactory3 {
-    fn from(value: IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory7> for &'a IDWriteFactory3 {
-    fn from(value: &'a IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory7> for IDWriteFactory3 {
-    fn from(value: &IDWriteFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory7> for IDWriteFactory4 {
-    fn from(value: IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory7> for &'a IDWriteFactory4 {
-    fn from(value: &'a IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory7> for IDWriteFactory4 {
-    fn from(value: &IDWriteFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory7> for IDWriteFactory5 {
-    fn from(value: IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory7> for &'a IDWriteFactory5 {
-    fn from(value: &'a IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory7> for IDWriteFactory5 {
-    fn from(value: &IDWriteFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFactory7> for IDWriteFactory6 {
-    fn from(value: IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFactory7> for &'a IDWriteFactory6 {
-    fn from(value: &'a IDWriteFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFactory7> for IDWriteFactory6 {
-    fn from(value: &IDWriteFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFactory7, ::windows::core::IUnknown, IDWriteFactory, IDWriteFactory1, IDWriteFactory2, IDWriteFactory3, IDWriteFactory4, IDWriteFactory5, IDWriteFactory6);
 impl ::core::clone::Clone for IDWriteFactory7 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3242,21 +2610,7 @@ impl IDWriteFont {
         (::windows::core::Vtable::vtable(self).CreateFontFace)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFace>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFont> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFont> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFont> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFont) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFont, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFont {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3368,36 +2722,7 @@ impl IDWriteFont1 {
         (::windows::core::Vtable::vtable(self).IsMonospacedFont)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteFont1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFont1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFont1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFont1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFont1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFont1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFont1> for IDWriteFont {
-    fn from(value: IDWriteFont1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFont1> for &'a IDWriteFont {
-    fn from(value: &'a IDWriteFont1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFont1> for IDWriteFont {
-    fn from(value: &IDWriteFont1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFont1, ::windows::core::IUnknown, IDWriteFont);
 impl ::core::clone::Clone for IDWriteFont1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3504,51 +2829,7 @@ impl IDWriteFont2 {
         (::windows::core::Vtable::vtable(self).IsColorFont)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteFont2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFont2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFont2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFont2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFont2> for IDWriteFont {
-    fn from(value: IDWriteFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFont2> for &'a IDWriteFont {
-    fn from(value: &'a IDWriteFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFont2> for IDWriteFont {
-    fn from(value: &IDWriteFont2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFont2> for IDWriteFont1 {
-    fn from(value: IDWriteFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFont2> for &'a IDWriteFont1 {
-    fn from(value: &'a IDWriteFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFont2> for IDWriteFont1 {
-    fn from(value: &IDWriteFont2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFont2, ::windows::core::IUnknown, IDWriteFont, IDWriteFont1);
 impl ::core::clone::Clone for IDWriteFont2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3673,66 +2954,7 @@ impl IDWriteFont3 {
         (::windows::core::Vtable::vtable(self).GetLocality)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteFont3> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFont3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFont3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFont3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFont3> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFont3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFont3> for IDWriteFont {
-    fn from(value: IDWriteFont3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFont3> for &'a IDWriteFont {
-    fn from(value: &'a IDWriteFont3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFont3> for IDWriteFont {
-    fn from(value: &IDWriteFont3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFont3> for IDWriteFont1 {
-    fn from(value: IDWriteFont3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFont3> for &'a IDWriteFont1 {
-    fn from(value: &'a IDWriteFont3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFont3> for IDWriteFont1 {
-    fn from(value: &IDWriteFont3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFont3> for IDWriteFont2 {
-    fn from(value: IDWriteFont3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFont3> for &'a IDWriteFont2 {
-    fn from(value: &'a IDWriteFont3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFont3> for IDWriteFont2 {
-    fn from(value: &IDWriteFont3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFont3, ::windows::core::IUnknown, IDWriteFont, IDWriteFont1, IDWriteFont2);
 impl ::core::clone::Clone for IDWriteFont3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3798,21 +3020,7 @@ impl IDWriteFontCollection {
         (::windows::core::Vtable::vtable(self).GetFontFromFontFace)(::windows::core::Vtable::as_raw(self), fontface.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFont>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontCollection> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontCollection> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3882,36 +3090,7 @@ impl IDWriteFontCollection1 {
         (::windows::core::Vtable::vtable(self).GetFontFamily2)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFamily1>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontCollection1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontCollection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontCollection1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontCollection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontCollection1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontCollection1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontCollection1> for IDWriteFontCollection {
-    fn from(value: IDWriteFontCollection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontCollection1> for &'a IDWriteFontCollection {
-    fn from(value: &'a IDWriteFontCollection1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontCollection1> for IDWriteFontCollection {
-    fn from(value: &IDWriteFontCollection1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontCollection1, ::windows::core::IUnknown, IDWriteFontCollection);
 impl ::core::clone::Clone for IDWriteFontCollection1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3994,51 +3173,7 @@ impl IDWriteFontCollection2 {
         (::windows::core::Vtable::vtable(self).GetFontSet2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontSet1>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontCollection2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontCollection2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontCollection2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontCollection2> for IDWriteFontCollection {
-    fn from(value: IDWriteFontCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontCollection2> for &'a IDWriteFontCollection {
-    fn from(value: &'a IDWriteFontCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontCollection2> for IDWriteFontCollection {
-    fn from(value: &IDWriteFontCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontCollection2> for IDWriteFontCollection1 {
-    fn from(value: IDWriteFontCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontCollection2> for &'a IDWriteFontCollection1 {
-    fn from(value: &'a IDWriteFontCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontCollection2> for IDWriteFontCollection1 {
-    fn from(value: &IDWriteFontCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontCollection2, ::windows::core::IUnknown, IDWriteFontCollection, IDWriteFontCollection1);
 impl ::core::clone::Clone for IDWriteFontCollection2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4128,66 +3263,7 @@ impl IDWriteFontCollection3 {
         (::windows::core::Vtable::vtable(self).GetExpirationEvent)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteFontCollection3> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontCollection3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontCollection3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontCollection3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontCollection3> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontCollection3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontCollection3> for IDWriteFontCollection {
-    fn from(value: IDWriteFontCollection3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontCollection3> for &'a IDWriteFontCollection {
-    fn from(value: &'a IDWriteFontCollection3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontCollection3> for IDWriteFontCollection {
-    fn from(value: &IDWriteFontCollection3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontCollection3> for IDWriteFontCollection1 {
-    fn from(value: IDWriteFontCollection3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontCollection3> for &'a IDWriteFontCollection1 {
-    fn from(value: &'a IDWriteFontCollection3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontCollection3> for IDWriteFontCollection1 {
-    fn from(value: &IDWriteFontCollection3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontCollection3> for IDWriteFontCollection2 {
-    fn from(value: IDWriteFontCollection3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontCollection3> for &'a IDWriteFontCollection2 {
-    fn from(value: &'a IDWriteFontCollection3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontCollection3> for IDWriteFontCollection2 {
-    fn from(value: &IDWriteFontCollection3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontCollection3, ::windows::core::IUnknown, IDWriteFontCollection, IDWriteFontCollection1, IDWriteFontCollection2);
 impl ::core::clone::Clone for IDWriteFontCollection3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4231,21 +3307,7 @@ impl IDWriteFontCollectionLoader {
         (::windows::core::Vtable::vtable(self).CreateEnumeratorFromKey)(::windows::core::Vtable::as_raw(self), factory.into().abi(), ::core::mem::transmute(collectionkey), collectionkeysize, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFileEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontCollectionLoader> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontCollectionLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontCollectionLoader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontCollectionLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontCollectionLoader> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontCollectionLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontCollectionLoader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontCollectionLoader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4286,21 +3348,7 @@ impl IDWriteFontDownloadListener {
         (::windows::core::Vtable::vtable(self).DownloadCompleted)(::windows::core::Vtable::as_raw(self), downloadqueue.into().abi(), context.into().abi(), downloadresult)
     }
 }
-impl ::core::convert::From<IDWriteFontDownloadListener> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontDownloadListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontDownloadListener> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontDownloadListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontDownloadListener> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontDownloadListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontDownloadListener, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontDownloadListener {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4361,21 +3409,7 @@ impl IDWriteFontDownloadQueue {
         (::windows::core::Vtable::vtable(self).GetGenerationCount)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteFontDownloadQueue> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontDownloadQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontDownloadQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontDownloadQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontDownloadQueue> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontDownloadQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontDownloadQueue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontDownloadQueue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4490,21 +3524,7 @@ impl IDWriteFontFace {
         (::windows::core::Vtable::vtable(self).GetGdiCompatibleGlyphMetrics)(::windows::core::Vtable::as_raw(self), emsize, pixelsperdip, ::core::mem::transmute(transform.unwrap_or(::std::ptr::null())), usegdinatural.into(), ::core::mem::transmute(glyphindices), glyphcount, ::core::mem::transmute(glyphmetrics), issideways.into()).ok()
     }
 }
-impl ::core::convert::From<IDWriteFontFace> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFace, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontFace {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4707,36 +3727,7 @@ impl IDWriteFontFace1 {
         (::windows::core::Vtable::vtable(self).HasVerticalGlyphVariants)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteFontFace1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFace1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFace1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFace1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace1> for IDWriteFontFace {
-    fn from(value: IDWriteFontFace1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace1> for &'a IDWriteFontFace {
-    fn from(value: &'a IDWriteFontFace1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace1> for IDWriteFontFace {
-    fn from(value: &IDWriteFontFace1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFace1, ::windows::core::IUnknown, IDWriteFontFace);
 impl ::core::clone::Clone for IDWriteFontFace1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4968,51 +3959,7 @@ impl IDWriteFontFace2 {
         (::windows::core::Vtable::vtable(self).GetRecommendedRenderingMode3)(::windows::core::Vtable::as_raw(self), fontemsize, dpix, dpiy, ::core::mem::transmute(transform.unwrap_or(::std::ptr::null())), issideways.into(), outlinethreshold, measuringmode, renderingparams.into().abi(), ::core::mem::transmute(renderingmode), ::core::mem::transmute(gridfitmode)).ok()
     }
 }
-impl ::core::convert::From<IDWriteFontFace2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFace2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace2> for IDWriteFontFace {
-    fn from(value: IDWriteFontFace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace2> for &'a IDWriteFontFace {
-    fn from(value: &'a IDWriteFontFace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace2> for IDWriteFontFace {
-    fn from(value: &IDWriteFontFace2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace2> for IDWriteFontFace1 {
-    fn from(value: IDWriteFontFace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace2> for &'a IDWriteFontFace1 {
-    fn from(value: &'a IDWriteFontFace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace2> for IDWriteFontFace1 {
-    fn from(value: &IDWriteFontFace2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFace2, ::windows::core::IUnknown, IDWriteFontFace, IDWriteFontFace1);
 impl ::core::clone::Clone for IDWriteFontFace2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5290,66 +4237,7 @@ impl IDWriteFontFace3 {
         (::windows::core::Vtable::vtable(self).AreGlyphsLocal)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(glyphindices.as_ptr()), glyphindices.len() as _, enqueueifnotlocal.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontFace3> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace3> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFace3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace3> for IDWriteFontFace {
-    fn from(value: IDWriteFontFace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace3> for &'a IDWriteFontFace {
-    fn from(value: &'a IDWriteFontFace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace3> for IDWriteFontFace {
-    fn from(value: &IDWriteFontFace3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace3> for IDWriteFontFace1 {
-    fn from(value: IDWriteFontFace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace3> for &'a IDWriteFontFace1 {
-    fn from(value: &'a IDWriteFontFace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace3> for IDWriteFontFace1 {
-    fn from(value: &IDWriteFontFace3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace3> for IDWriteFontFace2 {
-    fn from(value: IDWriteFontFace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace3> for &'a IDWriteFontFace2 {
-    fn from(value: &'a IDWriteFontFace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace3> for IDWriteFontFace2 {
-    fn from(value: &IDWriteFontFace3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFace3, ::windows::core::IUnknown, IDWriteFontFace, IDWriteFontFace1, IDWriteFontFace2);
 impl ::core::clone::Clone for IDWriteFontFace3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5666,81 +4554,7 @@ impl IDWriteFontFace4 {
         (::windows::core::Vtable::vtable(self).ReleaseGlyphImageData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(glyphdatacontext))
     }
 }
-impl ::core::convert::From<IDWriteFontFace4> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFace4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFace4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace4> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFace4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace4> for IDWriteFontFace {
-    fn from(value: IDWriteFontFace4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace4> for &'a IDWriteFontFace {
-    fn from(value: &'a IDWriteFontFace4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace4> for IDWriteFontFace {
-    fn from(value: &IDWriteFontFace4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace4> for IDWriteFontFace1 {
-    fn from(value: IDWriteFontFace4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace4> for &'a IDWriteFontFace1 {
-    fn from(value: &'a IDWriteFontFace4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace4> for IDWriteFontFace1 {
-    fn from(value: &IDWriteFontFace4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace4> for IDWriteFontFace2 {
-    fn from(value: IDWriteFontFace4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace4> for &'a IDWriteFontFace2 {
-    fn from(value: &'a IDWriteFontFace4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace4> for IDWriteFontFace2 {
-    fn from(value: &IDWriteFontFace4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace4> for IDWriteFontFace3 {
-    fn from(value: IDWriteFontFace4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace4> for &'a IDWriteFontFace3 {
-    fn from(value: &'a IDWriteFontFace4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace4> for IDWriteFontFace3 {
-    fn from(value: &IDWriteFontFace4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFace4, ::windows::core::IUnknown, IDWriteFontFace, IDWriteFontFace1, IDWriteFontFace2, IDWriteFontFace3);
 impl ::core::clone::Clone for IDWriteFontFace4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6052,96 +4866,7 @@ impl IDWriteFontFace5 {
         (::windows::core::Vtable::vtable(self).Equals)(::windows::core::Vtable::as_raw(self), fontface.into().abi())
     }
 }
-impl ::core::convert::From<IDWriteFontFace5> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace5> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFace5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace5> for IDWriteFontFace {
-    fn from(value: IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace5> for &'a IDWriteFontFace {
-    fn from(value: &'a IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace5> for IDWriteFontFace {
-    fn from(value: &IDWriteFontFace5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace5> for IDWriteFontFace1 {
-    fn from(value: IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace5> for &'a IDWriteFontFace1 {
-    fn from(value: &'a IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace5> for IDWriteFontFace1 {
-    fn from(value: &IDWriteFontFace5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace5> for IDWriteFontFace2 {
-    fn from(value: IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace5> for &'a IDWriteFontFace2 {
-    fn from(value: &'a IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace5> for IDWriteFontFace2 {
-    fn from(value: &IDWriteFontFace5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace5> for IDWriteFontFace3 {
-    fn from(value: IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace5> for &'a IDWriteFontFace3 {
-    fn from(value: &'a IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace5> for IDWriteFontFace3 {
-    fn from(value: &IDWriteFontFace5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace5> for IDWriteFontFace4 {
-    fn from(value: IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace5> for &'a IDWriteFontFace4 {
-    fn from(value: &'a IDWriteFontFace5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace5> for IDWriteFontFace4 {
-    fn from(value: &IDWriteFontFace5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFace5, ::windows::core::IUnknown, IDWriteFontFace, IDWriteFontFace1, IDWriteFontFace2, IDWriteFontFace3, IDWriteFontFace4);
 impl ::core::clone::Clone for IDWriteFontFace5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6465,111 +5190,7 @@ impl IDWriteFontFace6 {
         (::windows::core::Vtable::vtable(self).GetFaceNames2)(::windows::core::Vtable::as_raw(self), fontfamilymodel, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteLocalizedStrings>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontFace6> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace6> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFace6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace6> for IDWriteFontFace {
-    fn from(value: IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace6> for &'a IDWriteFontFace {
-    fn from(value: &'a IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace6> for IDWriteFontFace {
-    fn from(value: &IDWriteFontFace6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace6> for IDWriteFontFace1 {
-    fn from(value: IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace6> for &'a IDWriteFontFace1 {
-    fn from(value: &'a IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace6> for IDWriteFontFace1 {
-    fn from(value: &IDWriteFontFace6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace6> for IDWriteFontFace2 {
-    fn from(value: IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace6> for &'a IDWriteFontFace2 {
-    fn from(value: &'a IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace6> for IDWriteFontFace2 {
-    fn from(value: &IDWriteFontFace6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace6> for IDWriteFontFace3 {
-    fn from(value: IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace6> for &'a IDWriteFontFace3 {
-    fn from(value: &'a IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace6> for IDWriteFontFace3 {
-    fn from(value: &IDWriteFontFace6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace6> for IDWriteFontFace4 {
-    fn from(value: IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace6> for &'a IDWriteFontFace4 {
-    fn from(value: &'a IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace6> for IDWriteFontFace4 {
-    fn from(value: &IDWriteFontFace6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFace6> for IDWriteFontFace5 {
-    fn from(value: IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFace6> for &'a IDWriteFontFace5 {
-    fn from(value: &'a IDWriteFontFace6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFace6> for IDWriteFontFace5 {
-    fn from(value: &IDWriteFontFace6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFace6, ::windows::core::IUnknown, IDWriteFontFace, IDWriteFontFace1, IDWriteFontFace2, IDWriteFontFace3, IDWriteFontFace4, IDWriteFontFace5);
 impl ::core::clone::Clone for IDWriteFontFace6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6657,21 +5278,7 @@ impl IDWriteFontFaceReference {
         (::windows::core::Vtable::vtable(self).EnqueueFileFragmentDownloadRequest)(::windows::core::Vtable::as_raw(self), fileoffset, fragmentsize).ok()
     }
 }
-impl ::core::convert::From<IDWriteFontFaceReference> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFaceReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFaceReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFaceReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFaceReference> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFaceReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFaceReference, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontFaceReference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6787,36 +5394,7 @@ impl IDWriteFontFaceReference1 {
         (::windows::core::Vtable::vtable(self).GetFontAxisValues)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(fontaxisvalues.as_ptr()), fontaxisvalues.len() as _).ok()
     }
 }
-impl ::core::convert::From<IDWriteFontFaceReference1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFaceReference1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFaceReference1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFaceReference1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFaceReference1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFaceReference1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFaceReference1> for IDWriteFontFaceReference {
-    fn from(value: IDWriteFontFaceReference1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFaceReference1> for &'a IDWriteFontFaceReference {
-    fn from(value: &'a IDWriteFontFaceReference1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFaceReference1> for IDWriteFontFaceReference {
-    fn from(value: &IDWriteFontFaceReference1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFaceReference1, ::windows::core::IUnknown, IDWriteFontFaceReference);
 impl ::core::clone::Clone for IDWriteFontFaceReference1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6860,21 +5438,7 @@ impl IDWriteFontFallback {
         (::windows::core::Vtable::vtable(self).MapCharacters)(::windows::core::Vtable::as_raw(self), analysissource.into().abi(), textposition, textlength, basefontcollection.into().abi(), basefamilyname.into(), baseweight, basestyle, basestretch, ::core::mem::transmute(mappedlength), ::core::mem::transmute(mappedfont.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(scale)).ok()
     }
 }
-impl ::core::convert::From<IDWriteFontFallback> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFallback> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontFallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6924,36 +5488,7 @@ impl IDWriteFontFallback1 {
         (::windows::core::Vtable::vtable(self).MapCharacters2)(::windows::core::Vtable::as_raw(self), analysissource.into().abi(), textposition, textlength, basefontcollection.into().abi(), basefamilyname.into(), ::core::mem::transmute(fontaxisvalues.as_ptr()), fontaxisvalues.len() as _, ::core::mem::transmute(mappedlength), ::core::mem::transmute(scale), ::core::mem::transmute(mappedfontface)).ok()
     }
 }
-impl ::core::convert::From<IDWriteFontFallback1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFallback1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFallback1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFallback1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFallback1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFallback1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFallback1> for IDWriteFontFallback {
-    fn from(value: IDWriteFontFallback1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFallback1> for &'a IDWriteFontFallback {
-    fn from(value: &'a IDWriteFontFallback1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFallback1> for IDWriteFontFallback {
-    fn from(value: &IDWriteFontFallback1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFallback1, ::windows::core::IUnknown, IDWriteFontFallback);
 impl ::core::clone::Clone for IDWriteFontFallback1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7005,21 +5540,7 @@ impl IDWriteFontFallbackBuilder {
         (::windows::core::Vtable::vtable(self).CreateFontFallback)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFallback>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontFallbackBuilder> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFallbackBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFallbackBuilder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFallbackBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFallbackBuilder> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFallbackBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFallbackBuilder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontFallbackBuilder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7078,36 +5599,7 @@ impl IDWriteFontFamily {
         (::windows::core::Vtable::vtable(self).GetMatchingFonts)(::windows::core::Vtable::as_raw(self), weight, stretch, style, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontList>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontFamily> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFamily) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFamily> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFamily) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFamily> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFamily) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFamily> for IDWriteFontList {
-    fn from(value: IDWriteFontFamily) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFamily> for &'a IDWriteFontList {
-    fn from(value: &'a IDWriteFontFamily) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFamily> for IDWriteFontList {
-    fn from(value: &IDWriteFontFamily) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFamily, ::windows::core::IUnknown, IDWriteFontList);
 impl ::core::clone::Clone for IDWriteFontFamily {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7177,51 +5669,7 @@ impl IDWriteFontFamily1 {
         (::windows::core::Vtable::vtable(self).GetFontFaceReference)(::windows::core::Vtable::as_raw(self), listindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFaceReference>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontFamily1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFamily1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFamily1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFamily1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFamily1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFamily1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFamily1> for IDWriteFontList {
-    fn from(value: IDWriteFontFamily1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFamily1> for &'a IDWriteFontList {
-    fn from(value: &'a IDWriteFontFamily1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFamily1> for IDWriteFontList {
-    fn from(value: &IDWriteFontFamily1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFamily1> for IDWriteFontFamily {
-    fn from(value: IDWriteFontFamily1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFamily1> for &'a IDWriteFontFamily {
-    fn from(value: &'a IDWriteFontFamily1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFamily1> for IDWriteFontFamily {
-    fn from(value: &IDWriteFontFamily1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFamily1, ::windows::core::IUnknown, IDWriteFontList, IDWriteFontFamily);
 impl ::core::clone::Clone for IDWriteFontFamily1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7299,66 +5747,7 @@ impl IDWriteFontFamily2 {
         (::windows::core::Vtable::vtable(self).GetFontSet)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontSet1>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontFamily2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFamily2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFamily2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFamily2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFamily2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFamily2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFamily2> for IDWriteFontList {
-    fn from(value: IDWriteFontFamily2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFamily2> for &'a IDWriteFontList {
-    fn from(value: &'a IDWriteFontFamily2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFamily2> for IDWriteFontList {
-    fn from(value: &IDWriteFontFamily2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFamily2> for IDWriteFontFamily {
-    fn from(value: IDWriteFontFamily2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFamily2> for &'a IDWriteFontFamily {
-    fn from(value: &'a IDWriteFontFamily2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFamily2> for IDWriteFontFamily {
-    fn from(value: &IDWriteFontFamily2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontFamily2> for IDWriteFontFamily1 {
-    fn from(value: IDWriteFontFamily2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFamily2> for &'a IDWriteFontFamily1 {
-    fn from(value: &'a IDWriteFontFamily2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFamily2> for IDWriteFontFamily1 {
-    fn from(value: &IDWriteFontFamily2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFamily2, ::windows::core::IUnknown, IDWriteFontList, IDWriteFontFamily, IDWriteFontFamily1);
 impl ::core::clone::Clone for IDWriteFontFamily2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7405,21 +5794,7 @@ impl IDWriteFontFile {
         (::windows::core::Vtable::vtable(self).Analyze)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(issupportedfonttype), ::core::mem::transmute(fontfiletype), ::core::mem::transmute(fontfacetype.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(numberoffaces)).ok()
     }
 }
-impl ::core::convert::From<IDWriteFontFile> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFile> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFile, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontFile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7468,21 +5843,7 @@ impl IDWriteFontFileEnumerator {
         (::windows::core::Vtable::vtable(self).GetCurrentFontFile)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFile>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontFileEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFileEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFileEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFileEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFileEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFileEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFileEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontFileEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7524,21 +5885,7 @@ impl IDWriteFontFileLoader {
         (::windows::core::Vtable::vtable(self).CreateStreamFromKey)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(fontfilereferencekey), fontfilereferencekeysize, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFileStream>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontFileLoader> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFileLoader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFileLoader> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFileLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFileLoader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontFileLoader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7586,21 +5933,7 @@ impl IDWriteFontFileStream {
         (::windows::core::Vtable::vtable(self).GetLastWriteTime)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontFileStream> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontFileStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontFileStream> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontFileStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontFileStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontFileStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7648,21 +5981,7 @@ impl IDWriteFontList {
         (::windows::core::Vtable::vtable(self).GetFont)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFont>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontList> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontList> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7720,36 +6039,7 @@ impl IDWriteFontList1 {
         (::windows::core::Vtable::vtable(self).GetFontFaceReference)(::windows::core::Vtable::as_raw(self), listindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFaceReference>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontList1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontList1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontList1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontList1> for IDWriteFontList {
-    fn from(value: IDWriteFontList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontList1> for &'a IDWriteFontList {
-    fn from(value: &'a IDWriteFontList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontList1> for IDWriteFontList {
-    fn from(value: &IDWriteFontList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontList1, ::windows::core::IUnknown, IDWriteFontList);
 impl ::core::clone::Clone for IDWriteFontList1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7811,51 +6101,7 @@ impl IDWriteFontList2 {
         (::windows::core::Vtable::vtable(self).GetFontSet)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontSet1>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontList2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontList2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontList2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontList2> for IDWriteFontList {
-    fn from(value: IDWriteFontList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontList2> for &'a IDWriteFontList {
-    fn from(value: &'a IDWriteFontList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontList2> for IDWriteFontList {
-    fn from(value: &IDWriteFontList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontList2> for IDWriteFontList1 {
-    fn from(value: IDWriteFontList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontList2> for &'a IDWriteFontList1 {
-    fn from(value: &'a IDWriteFontList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontList2> for IDWriteFontList1 {
-    fn from(value: &IDWriteFontList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontList2, ::windows::core::IUnknown, IDWriteFontList, IDWriteFontList1);
 impl ::core::clone::Clone for IDWriteFontList2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7931,21 +6177,7 @@ impl IDWriteFontResource {
         (::windows::core::Vtable::vtable(self).CreateFontFaceReference)(::windows::core::Vtable::as_raw(self), fontsimulations, ::core::mem::transmute(fontaxisvalues.as_ptr()), fontaxisvalues.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFaceReference1>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontResource> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontResource> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontResource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8047,21 +6279,7 @@ impl IDWriteFontSet {
         (::windows::core::Vtable::vtable(self).GetMatchingFonts2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(properties.as_ptr()), properties.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontSet>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontSet> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSet> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8234,36 +6452,7 @@ impl IDWriteFontSet1 {
         (::windows::core::Vtable::vtable(self).GetFontLocality)(::windows::core::Vtable::as_raw(self), listindex)
     }
 }
-impl ::core::convert::From<IDWriteFontSet1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontSet1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSet1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontSet1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSet1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontSet1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontSet1> for IDWriteFontSet {
-    fn from(value: IDWriteFontSet1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSet1> for &'a IDWriteFontSet {
-    fn from(value: &'a IDWriteFontSet1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSet1> for IDWriteFontSet {
-    fn from(value: &IDWriteFontSet1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontSet1, ::windows::core::IUnknown, IDWriteFontSet);
 impl ::core::clone::Clone for IDWriteFontSet1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8447,51 +6636,7 @@ impl IDWriteFontSet2 {
         (::windows::core::Vtable::vtable(self).GetExpirationEvent)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteFontSet2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontSet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSet2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontSet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSet2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontSet2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontSet2> for IDWriteFontSet {
-    fn from(value: IDWriteFontSet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSet2> for &'a IDWriteFontSet {
-    fn from(value: &'a IDWriteFontSet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSet2> for IDWriteFontSet {
-    fn from(value: &IDWriteFontSet2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontSet2> for IDWriteFontSet1 {
-    fn from(value: IDWriteFontSet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSet2> for &'a IDWriteFontSet1 {
-    fn from(value: &'a IDWriteFontSet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSet2> for IDWriteFontSet1 {
-    fn from(value: &IDWriteFontSet2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontSet2, ::windows::core::IUnknown, IDWriteFontSet, IDWriteFontSet1);
 impl ::core::clone::Clone for IDWriteFontSet2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8663,66 +6808,7 @@ impl IDWriteFontSet3 {
         (::windows::core::Vtable::vtable(self).GetFontSourceName)(::windows::core::Vtable::as_raw(self), listindex, ::core::mem::transmute(stringbuffer.as_ptr()), stringbuffer.len() as _).ok()
     }
 }
-impl ::core::convert::From<IDWriteFontSet3> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontSet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSet3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontSet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSet3> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontSet3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontSet3> for IDWriteFontSet {
-    fn from(value: IDWriteFontSet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSet3> for &'a IDWriteFontSet {
-    fn from(value: &'a IDWriteFontSet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSet3> for IDWriteFontSet {
-    fn from(value: &IDWriteFontSet3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontSet3> for IDWriteFontSet1 {
-    fn from(value: IDWriteFontSet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSet3> for &'a IDWriteFontSet1 {
-    fn from(value: &'a IDWriteFontSet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSet3> for IDWriteFontSet1 {
-    fn from(value: &IDWriteFontSet3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontSet3> for IDWriteFontSet2 {
-    fn from(value: IDWriteFontSet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSet3> for &'a IDWriteFontSet2 {
-    fn from(value: &'a IDWriteFontSet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSet3> for IDWriteFontSet2 {
-    fn from(value: &IDWriteFontSet3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontSet3, ::windows::core::IUnknown, IDWriteFontSet, IDWriteFontSet1, IDWriteFontSet2);
 impl ::core::clone::Clone for IDWriteFontSet3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8780,21 +6866,7 @@ impl IDWriteFontSetBuilder {
         (::windows::core::Vtable::vtable(self).CreateFontSet)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontSet>(result__)
     }
 }
-impl ::core::convert::From<IDWriteFontSetBuilder> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontSetBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSetBuilder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontSetBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSetBuilder> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontSetBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontSetBuilder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteFontSetBuilder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8859,36 +6931,7 @@ impl IDWriteFontSetBuilder1 {
         (::windows::core::Vtable::vtable(self).AddFontFile)(::windows::core::Vtable::as_raw(self), fontfile.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDWriteFontSetBuilder1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontSetBuilder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSetBuilder1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontSetBuilder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSetBuilder1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontSetBuilder1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontSetBuilder1> for IDWriteFontSetBuilder {
-    fn from(value: IDWriteFontSetBuilder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSetBuilder1> for &'a IDWriteFontSetBuilder {
-    fn from(value: &'a IDWriteFontSetBuilder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSetBuilder1> for IDWriteFontSetBuilder {
-    fn from(value: &IDWriteFontSetBuilder1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontSetBuilder1, ::windows::core::IUnknown, IDWriteFontSetBuilder);
 impl ::core::clone::Clone for IDWriteFontSetBuilder1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8962,51 +7005,7 @@ impl IDWriteFontSetBuilder2 {
         (::windows::core::Vtable::vtable(self).AddFontFile2)(::windows::core::Vtable::as_raw(self), filepath.into()).ok()
     }
 }
-impl ::core::convert::From<IDWriteFontSetBuilder2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteFontSetBuilder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSetBuilder2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteFontSetBuilder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSetBuilder2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteFontSetBuilder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontSetBuilder2> for IDWriteFontSetBuilder {
-    fn from(value: IDWriteFontSetBuilder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSetBuilder2> for &'a IDWriteFontSetBuilder {
-    fn from(value: &'a IDWriteFontSetBuilder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSetBuilder2> for IDWriteFontSetBuilder {
-    fn from(value: &IDWriteFontSetBuilder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteFontSetBuilder2> for IDWriteFontSetBuilder1 {
-    fn from(value: IDWriteFontSetBuilder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteFontSetBuilder2> for &'a IDWriteFontSetBuilder1 {
-    fn from(value: &'a IDWriteFontSetBuilder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteFontSetBuilder2> for IDWriteFontSetBuilder1 {
-    fn from(value: &IDWriteFontSetBuilder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteFontSetBuilder2, ::windows::core::IUnknown, IDWriteFontSetBuilder, IDWriteFontSetBuilder1);
 impl ::core::clone::Clone for IDWriteFontSetBuilder2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9082,21 +7081,7 @@ impl IDWriteGdiInterop {
         (::windows::core::Vtable::vtable(self).CreateBitmapRenderTarget)(::windows::core::Vtable::as_raw(self), hdc.into(), width, height, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteBitmapRenderTarget>(result__)
     }
 }
-impl ::core::convert::From<IDWriteGdiInterop> for ::windows::core::IUnknown {
-    fn from(value: IDWriteGdiInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteGdiInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteGdiInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteGdiInterop> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteGdiInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteGdiInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteGdiInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9226,36 +7211,7 @@ impl IDWriteGdiInterop1 {
         (::windows::core::Vtable::vtable(self).GetMatchingFontsByLOGFONT)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(logfont), fontset.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontSet>(result__)
     }
 }
-impl ::core::convert::From<IDWriteGdiInterop1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteGdiInterop1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteGdiInterop1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteGdiInterop1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteGdiInterop1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteGdiInterop1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteGdiInterop1> for IDWriteGdiInterop {
-    fn from(value: IDWriteGdiInterop1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteGdiInterop1> for &'a IDWriteGdiInterop {
-    fn from(value: &'a IDWriteGdiInterop1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteGdiInterop1> for IDWriteGdiInterop {
-    fn from(value: &IDWriteGdiInterop1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteGdiInterop1, ::windows::core::IUnknown, IDWriteGdiInterop);
 impl ::core::clone::Clone for IDWriteGdiInterop1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9321,21 +7277,7 @@ impl IDWriteGlyphRunAnalysis {
         (::windows::core::Vtable::vtable(self).GetAlphaBlendParams)(::windows::core::Vtable::as_raw(self), renderingparams.into().abi(), ::core::mem::transmute(blendgamma), ::core::mem::transmute(blendenhancedcontrast), ::core::mem::transmute(blendcleartypelevel)).ok()
     }
 }
-impl ::core::convert::From<IDWriteGlyphRunAnalysis> for ::windows::core::IUnknown {
-    fn from(value: IDWriteGlyphRunAnalysis) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteGlyphRunAnalysis> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteGlyphRunAnalysis) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteGlyphRunAnalysis> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteGlyphRunAnalysis) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteGlyphRunAnalysis, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteGlyphRunAnalysis {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9392,36 +7334,7 @@ impl IDWriteInMemoryFontFileLoader {
         (::windows::core::Vtable::vtable(self).GetFileCount)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteInMemoryFontFileLoader> for ::windows::core::IUnknown {
-    fn from(value: IDWriteInMemoryFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteInMemoryFontFileLoader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteInMemoryFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteInMemoryFontFileLoader> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteInMemoryFontFileLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteInMemoryFontFileLoader> for IDWriteFontFileLoader {
-    fn from(value: IDWriteInMemoryFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteInMemoryFontFileLoader> for &'a IDWriteFontFileLoader {
-    fn from(value: &'a IDWriteInMemoryFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteInMemoryFontFileLoader> for IDWriteFontFileLoader {
-    fn from(value: &IDWriteInMemoryFontFileLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteInMemoryFontFileLoader, ::windows::core::IUnknown, IDWriteFontFileLoader);
 impl ::core::clone::Clone for IDWriteInMemoryFontFileLoader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9480,21 +7393,7 @@ impl IDWriteInlineObject {
         (::windows::core::Vtable::vtable(self).GetBreakConditions)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(breakconditionbefore), ::core::mem::transmute(breakconditionafter)).ok()
     }
 }
-impl ::core::convert::From<IDWriteInlineObject> for ::windows::core::IUnknown {
-    fn from(value: IDWriteInlineObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteInlineObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteInlineObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteInlineObject> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteInlineObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteInlineObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteInlineObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9554,36 +7453,7 @@ impl IDWriteLocalFontFileLoader {
         (::windows::core::Vtable::vtable(self).GetLastWriteTimeFromKey)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(fontfilereferencekey), fontfilereferencekeysize, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::FILETIME>(result__)
     }
 }
-impl ::core::convert::From<IDWriteLocalFontFileLoader> for ::windows::core::IUnknown {
-    fn from(value: IDWriteLocalFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteLocalFontFileLoader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteLocalFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteLocalFontFileLoader> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteLocalFontFileLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteLocalFontFileLoader> for IDWriteFontFileLoader {
-    fn from(value: IDWriteLocalFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteLocalFontFileLoader> for &'a IDWriteFontFileLoader {
-    fn from(value: &'a IDWriteLocalFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteLocalFontFileLoader> for IDWriteFontFileLoader {
-    fn from(value: &IDWriteLocalFontFileLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteLocalFontFileLoader, ::windows::core::IUnknown, IDWriteFontFileLoader);
 impl ::core::clone::Clone for IDWriteLocalFontFileLoader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9647,21 +7517,7 @@ impl IDWriteLocalizedStrings {
         (::windows::core::Vtable::vtable(self).GetString)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(stringbuffer.as_ptr()), stringbuffer.len() as _).ok()
     }
 }
-impl ::core::convert::From<IDWriteLocalizedStrings> for ::windows::core::IUnknown {
-    fn from(value: IDWriteLocalizedStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteLocalizedStrings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteLocalizedStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteLocalizedStrings> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteLocalizedStrings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteLocalizedStrings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteLocalizedStrings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9702,21 +7558,7 @@ pub struct IDWriteLocalizedStrings_Vtbl {
 #[repr(transparent)]
 pub struct IDWriteNumberSubstitution(::windows::core::IUnknown);
 impl IDWriteNumberSubstitution {}
-impl ::core::convert::From<IDWriteNumberSubstitution> for ::windows::core::IUnknown {
-    fn from(value: IDWriteNumberSubstitution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteNumberSubstitution> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteNumberSubstitution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteNumberSubstitution> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteNumberSubstitution) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteNumberSubstitution, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteNumberSubstitution {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9763,21 +7605,7 @@ impl IDWritePixelSnapping {
         (::windows::core::Vtable::vtable(self).GetPixelsPerDip)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clientdrawingcontext.unwrap_or(::std::ptr::null())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<f32>(result__)
     }
 }
-impl ::core::convert::From<IDWritePixelSnapping> for ::windows::core::IUnknown {
-    fn from(value: IDWritePixelSnapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWritePixelSnapping> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWritePixelSnapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWritePixelSnapping> for ::windows::core::IUnknown {
-    fn from(value: &IDWritePixelSnapping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWritePixelSnapping, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWritePixelSnapping {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9837,36 +7665,7 @@ impl IDWriteRemoteFontFileLoader {
         (::windows::core::Vtable::vtable(self).CreateFontFileReferenceFromUrl)(::windows::core::Vtable::as_raw(self), factory.into().abi(), baseurl.into(), fontfileurl.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFile>(result__)
     }
 }
-impl ::core::convert::From<IDWriteRemoteFontFileLoader> for ::windows::core::IUnknown {
-    fn from(value: IDWriteRemoteFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRemoteFontFileLoader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteRemoteFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRemoteFontFileLoader> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteRemoteFontFileLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteRemoteFontFileLoader> for IDWriteFontFileLoader {
-    fn from(value: IDWriteRemoteFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRemoteFontFileLoader> for &'a IDWriteFontFileLoader {
-    fn from(value: &'a IDWriteRemoteFontFileLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRemoteFontFileLoader> for IDWriteFontFileLoader {
-    fn from(value: &IDWriteRemoteFontFileLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteRemoteFontFileLoader, ::windows::core::IUnknown, IDWriteFontFileLoader);
 impl ::core::clone::Clone for IDWriteRemoteFontFileLoader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9932,36 +7731,7 @@ impl IDWriteRemoteFontFileStream {
         (::windows::core::Vtable::vtable(self).BeginDownload)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(downloadoperationid), ::core::mem::transmute(filefragments.as_ptr()), filefragments.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteAsyncResult>(result__)
     }
 }
-impl ::core::convert::From<IDWriteRemoteFontFileStream> for ::windows::core::IUnknown {
-    fn from(value: IDWriteRemoteFontFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRemoteFontFileStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteRemoteFontFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRemoteFontFileStream> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteRemoteFontFileStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteRemoteFontFileStream> for IDWriteFontFileStream {
-    fn from(value: IDWriteRemoteFontFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRemoteFontFileStream> for &'a IDWriteFontFileStream {
-    fn from(value: &'a IDWriteRemoteFontFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRemoteFontFileStream> for IDWriteFontFileStream {
-    fn from(value: &IDWriteRemoteFontFileStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteRemoteFontFileStream, ::windows::core::IUnknown, IDWriteFontFileStream);
 impl ::core::clone::Clone for IDWriteRemoteFontFileStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10016,21 +7786,7 @@ impl IDWriteRenderingParams {
         (::windows::core::Vtable::vtable(self).GetRenderingMode)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteRenderingParams> for ::windows::core::IUnknown {
-    fn from(value: IDWriteRenderingParams) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRenderingParams> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteRenderingParams) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRenderingParams> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteRenderingParams) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteRenderingParams, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteRenderingParams {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10086,36 +7842,7 @@ impl IDWriteRenderingParams1 {
         (::windows::core::Vtable::vtable(self).GetGrayscaleEnhancedContrast)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteRenderingParams1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteRenderingParams1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRenderingParams1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteRenderingParams1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRenderingParams1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteRenderingParams1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteRenderingParams1> for IDWriteRenderingParams {
-    fn from(value: IDWriteRenderingParams1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRenderingParams1> for &'a IDWriteRenderingParams {
-    fn from(value: &'a IDWriteRenderingParams1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRenderingParams1> for IDWriteRenderingParams {
-    fn from(value: &IDWriteRenderingParams1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteRenderingParams1, ::windows::core::IUnknown, IDWriteRenderingParams);
 impl ::core::clone::Clone for IDWriteRenderingParams1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10170,51 +7897,7 @@ impl IDWriteRenderingParams2 {
         (::windows::core::Vtable::vtable(self).GetGridFitMode)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteRenderingParams2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteRenderingParams2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRenderingParams2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteRenderingParams2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRenderingParams2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteRenderingParams2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteRenderingParams2> for IDWriteRenderingParams {
-    fn from(value: IDWriteRenderingParams2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRenderingParams2> for &'a IDWriteRenderingParams {
-    fn from(value: &'a IDWriteRenderingParams2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRenderingParams2> for IDWriteRenderingParams {
-    fn from(value: &IDWriteRenderingParams2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteRenderingParams2> for IDWriteRenderingParams1 {
-    fn from(value: IDWriteRenderingParams2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRenderingParams2> for &'a IDWriteRenderingParams1 {
-    fn from(value: &'a IDWriteRenderingParams2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRenderingParams2> for IDWriteRenderingParams1 {
-    fn from(value: &IDWriteRenderingParams2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteRenderingParams2, ::windows::core::IUnknown, IDWriteRenderingParams, IDWriteRenderingParams1);
 impl ::core::clone::Clone for IDWriteRenderingParams2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10272,66 +7955,7 @@ impl IDWriteRenderingParams3 {
         (::windows::core::Vtable::vtable(self).GetRenderingMode1)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDWriteRenderingParams3> for ::windows::core::IUnknown {
-    fn from(value: IDWriteRenderingParams3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRenderingParams3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteRenderingParams3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRenderingParams3> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteRenderingParams3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteRenderingParams3> for IDWriteRenderingParams {
-    fn from(value: IDWriteRenderingParams3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRenderingParams3> for &'a IDWriteRenderingParams {
-    fn from(value: &'a IDWriteRenderingParams3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRenderingParams3> for IDWriteRenderingParams {
-    fn from(value: &IDWriteRenderingParams3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteRenderingParams3> for IDWriteRenderingParams1 {
-    fn from(value: IDWriteRenderingParams3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRenderingParams3> for &'a IDWriteRenderingParams1 {
-    fn from(value: &'a IDWriteRenderingParams3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRenderingParams3> for IDWriteRenderingParams1 {
-    fn from(value: &IDWriteRenderingParams3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteRenderingParams3> for IDWriteRenderingParams2 {
-    fn from(value: IDWriteRenderingParams3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteRenderingParams3> for &'a IDWriteRenderingParams2 {
-    fn from(value: &'a IDWriteRenderingParams3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteRenderingParams3> for IDWriteRenderingParams2 {
-    fn from(value: &IDWriteRenderingParams3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteRenderingParams3, ::windows::core::IUnknown, IDWriteRenderingParams, IDWriteRenderingParams1, IDWriteRenderingParams2);
 impl ::core::clone::Clone for IDWriteRenderingParams3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10382,21 +8006,7 @@ impl IDWriteStringList {
         (::windows::core::Vtable::vtable(self).GetString)(::windows::core::Vtable::as_raw(self), listindex, ::core::mem::transmute(stringbuffer.as_ptr()), stringbuffer.len() as _).ok()
     }
 }
-impl ::core::convert::From<IDWriteStringList> for ::windows::core::IUnknown {
-    fn from(value: IDWriteStringList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteStringList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteStringList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteStringList> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteStringList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteStringList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteStringList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10449,21 +8059,7 @@ impl IDWriteTextAnalysisSink {
         (::windows::core::Vtable::vtable(self).SetNumberSubstitution)(::windows::core::Vtable::as_raw(self), textposition, textlength, numbersubstitution.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextAnalysisSink> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextAnalysisSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalysisSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextAnalysisSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalysisSink> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextAnalysisSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextAnalysisSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteTextAnalysisSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10524,36 +8120,7 @@ impl IDWriteTextAnalysisSink1 {
         (::windows::core::Vtable::vtable(self).SetGlyphOrientation)(::windows::core::Vtable::as_raw(self), textposition, textlength, glyphorientationangle, adjustedbidilevel, issideways.into(), isrighttoleft.into()).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextAnalysisSink1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextAnalysisSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalysisSink1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextAnalysisSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalysisSink1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextAnalysisSink1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextAnalysisSink1> for IDWriteTextAnalysisSink {
-    fn from(value: IDWriteTextAnalysisSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalysisSink1> for &'a IDWriteTextAnalysisSink {
-    fn from(value: &'a IDWriteTextAnalysisSink1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalysisSink1> for IDWriteTextAnalysisSink {
-    fn from(value: &IDWriteTextAnalysisSink1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextAnalysisSink1, ::windows::core::IUnknown, IDWriteTextAnalysisSink);
 impl ::core::clone::Clone for IDWriteTextAnalysisSink1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10605,21 +8172,7 @@ impl IDWriteTextAnalysisSource {
         (::windows::core::Vtable::vtable(self).GetNumberSubstitution)(::windows::core::Vtable::as_raw(self), textposition, ::core::mem::transmute(textlength), ::core::mem::transmute(numbersubstitution)).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextAnalysisSource> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextAnalysisSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalysisSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextAnalysisSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalysisSource> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextAnalysisSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextAnalysisSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteTextAnalysisSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10675,36 +8228,7 @@ impl IDWriteTextAnalysisSource1 {
         (::windows::core::Vtable::vtable(self).GetVerticalGlyphOrientation)(::windows::core::Vtable::as_raw(self), textposition, ::core::mem::transmute(textlength), ::core::mem::transmute(glyphorientation), ::core::mem::transmute(bidilevel)).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextAnalysisSource1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextAnalysisSource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalysisSource1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextAnalysisSource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalysisSource1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextAnalysisSource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextAnalysisSource1> for IDWriteTextAnalysisSource {
-    fn from(value: IDWriteTextAnalysisSource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalysisSource1> for &'a IDWriteTextAnalysisSource {
-    fn from(value: &'a IDWriteTextAnalysisSource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalysisSource1> for IDWriteTextAnalysisSource {
-    fn from(value: &IDWriteTextAnalysisSource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextAnalysisSource1, ::windows::core::IUnknown, IDWriteTextAnalysisSource);
 impl ::core::clone::Clone for IDWriteTextAnalysisSource1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10869,21 +8393,7 @@ impl IDWriteTextAnalyzer {
         .ok()
     }
 }
-impl ::core::convert::From<IDWriteTextAnalyzer> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextAnalyzer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalyzer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextAnalyzer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalyzer> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextAnalyzer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextAnalyzer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteTextAnalyzer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11166,36 +8676,7 @@ impl IDWriteTextAnalyzer1 {
         .ok()
     }
 }
-impl ::core::convert::From<IDWriteTextAnalyzer1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextAnalyzer1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalyzer1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextAnalyzer1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalyzer1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextAnalyzer1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextAnalyzer1> for IDWriteTextAnalyzer {
-    fn from(value: IDWriteTextAnalyzer1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalyzer1> for &'a IDWriteTextAnalyzer {
-    fn from(value: &'a IDWriteTextAnalyzer1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalyzer1> for IDWriteTextAnalyzer {
-    fn from(value: &IDWriteTextAnalyzer1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextAnalyzer1, ::windows::core::IUnknown, IDWriteTextAnalyzer);
 impl ::core::clone::Clone for IDWriteTextAnalyzer1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11481,51 +8962,7 @@ impl IDWriteTextAnalyzer2 {
         (::windows::core::Vtable::vtable(self).CheckTypographicFeature)(::windows::core::Vtable::as_raw(self), fontface.into().abi(), ::core::mem::transmute(scriptanalysis), localename.into(), featuretag, glyphcount, ::core::mem::transmute(glyphindices), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u8>(result__)
     }
 }
-impl ::core::convert::From<IDWriteTextAnalyzer2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextAnalyzer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalyzer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextAnalyzer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalyzer2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextAnalyzer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextAnalyzer2> for IDWriteTextAnalyzer {
-    fn from(value: IDWriteTextAnalyzer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalyzer2> for &'a IDWriteTextAnalyzer {
-    fn from(value: &'a IDWriteTextAnalyzer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalyzer2> for IDWriteTextAnalyzer {
-    fn from(value: &IDWriteTextAnalyzer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextAnalyzer2> for IDWriteTextAnalyzer1 {
-    fn from(value: IDWriteTextAnalyzer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextAnalyzer2> for &'a IDWriteTextAnalyzer1 {
-    fn from(value: &'a IDWriteTextAnalyzer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextAnalyzer2> for IDWriteTextAnalyzer1 {
-    fn from(value: &IDWriteTextAnalyzer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextAnalyzer2, ::windows::core::IUnknown, IDWriteTextAnalyzer, IDWriteTextAnalyzer1);
 impl ::core::clone::Clone for IDWriteTextAnalyzer2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11643,21 +9080,7 @@ impl IDWriteTextFormat {
         (::windows::core::Vtable::vtable(self).GetLocaleName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(localename.as_ptr()), localename.len() as _).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextFormat> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextFormat> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextFormat> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextFormat, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteTextFormat {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11829,36 +9252,7 @@ impl IDWriteTextFormat1 {
         (::windows::core::Vtable::vtable(self).GetFontFallback)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFallback>(result__)
     }
 }
-impl ::core::convert::From<IDWriteTextFormat1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextFormat1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextFormat1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextFormat1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextFormat1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextFormat1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextFormat1> for IDWriteTextFormat {
-    fn from(value: IDWriteTextFormat1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextFormat1> for &'a IDWriteTextFormat {
-    fn from(value: &'a IDWriteTextFormat1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextFormat1> for IDWriteTextFormat {
-    fn from(value: &IDWriteTextFormat1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextFormat1, ::windows::core::IUnknown, IDWriteTextFormat);
 impl ::core::clone::Clone for IDWriteTextFormat1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12026,51 +9420,7 @@ impl IDWriteTextFormat2 {
         (::windows::core::Vtable::vtable(self).GetLineSpacing2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DWRITE_LINE_SPACING>(result__)
     }
 }
-impl ::core::convert::From<IDWriteTextFormat2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextFormat2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextFormat2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextFormat2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextFormat2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextFormat2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextFormat2> for IDWriteTextFormat {
-    fn from(value: IDWriteTextFormat2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextFormat2> for &'a IDWriteTextFormat {
-    fn from(value: &'a IDWriteTextFormat2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextFormat2> for IDWriteTextFormat {
-    fn from(value: &IDWriteTextFormat2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextFormat2> for IDWriteTextFormat1 {
-    fn from(value: IDWriteTextFormat2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextFormat2> for &'a IDWriteTextFormat1 {
-    fn from(value: &'a IDWriteTextFormat2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextFormat2> for IDWriteTextFormat1 {
-    fn from(value: &IDWriteTextFormat2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextFormat2, ::windows::core::IUnknown, IDWriteTextFormat, IDWriteTextFormat1);
 impl ::core::clone::Clone for IDWriteTextFormat2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12241,66 +9591,7 @@ impl IDWriteTextFormat3 {
         (::windows::core::Vtable::vtable(self).SetAutomaticFontAxes)(::windows::core::Vtable::as_raw(self), automaticfontaxes).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextFormat3> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextFormat3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextFormat3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextFormat3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextFormat3> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextFormat3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextFormat3> for IDWriteTextFormat {
-    fn from(value: IDWriteTextFormat3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextFormat3> for &'a IDWriteTextFormat {
-    fn from(value: &'a IDWriteTextFormat3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextFormat3> for IDWriteTextFormat {
-    fn from(value: &IDWriteTextFormat3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextFormat3> for IDWriteTextFormat1 {
-    fn from(value: IDWriteTextFormat3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextFormat3> for &'a IDWriteTextFormat1 {
-    fn from(value: &'a IDWriteTextFormat3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextFormat3> for IDWriteTextFormat1 {
-    fn from(value: &IDWriteTextFormat3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextFormat3> for IDWriteTextFormat2 {
-    fn from(value: IDWriteTextFormat3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextFormat3> for &'a IDWriteTextFormat2 {
-    fn from(value: &'a IDWriteTextFormat3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextFormat3> for IDWriteTextFormat2 {
-    fn from(value: &IDWriteTextFormat3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextFormat3, ::windows::core::IUnknown, IDWriteTextFormat, IDWriteTextFormat1, IDWriteTextFormat2);
 impl ::core::clone::Clone for IDWriteTextFormat3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12583,36 +9874,7 @@ impl IDWriteTextLayout {
         (::windows::core::Vtable::vtable(self).HitTestTextRange)(::windows::core::Vtable::as_raw(self), textposition, textlength, originx, originy, ::core::mem::transmute(hittestmetrics.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), hittestmetrics.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(actualhittestmetricscount)).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextLayout> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextLayout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout> for IDWriteTextFormat {
-    fn from(value: IDWriteTextLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout> for &'a IDWriteTextFormat {
-    fn from(value: &'a IDWriteTextLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout> for IDWriteTextFormat {
-    fn from(value: &IDWriteTextLayout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextLayout, ::windows::core::IUnknown, IDWriteTextFormat);
 impl ::core::clone::Clone for IDWriteTextLayout {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12972,51 +10234,7 @@ impl IDWriteTextLayout1 {
         (::windows::core::Vtable::vtable(self).GetCharacterSpacing)(::windows::core::Vtable::as_raw(self), currentposition, ::core::mem::transmute(leadingspacing), ::core::mem::transmute(trailingspacing), ::core::mem::transmute(minimumadvancewidth), ::core::mem::transmute(textrange.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextLayout1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextLayout1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextLayout1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextLayout1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout1> for IDWriteTextFormat {
-    fn from(value: IDWriteTextLayout1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout1> for &'a IDWriteTextFormat {
-    fn from(value: &'a IDWriteTextLayout1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout1> for IDWriteTextFormat {
-    fn from(value: &IDWriteTextLayout1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout1> for IDWriteTextLayout {
-    fn from(value: IDWriteTextLayout1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout1> for &'a IDWriteTextLayout {
-    fn from(value: &'a IDWriteTextLayout1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout1> for IDWriteTextLayout {
-    fn from(value: &IDWriteTextLayout1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextLayout1, ::windows::core::IUnknown, IDWriteTextFormat, IDWriteTextLayout);
 impl ::core::clone::Clone for IDWriteTextLayout1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13362,66 +10580,7 @@ impl IDWriteTextLayout2 {
         (::windows::core::Vtable::vtable(self).GetFontFallback)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDWriteFontFallback>(result__)
     }
 }
-impl ::core::convert::From<IDWriteTextLayout2> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextLayout2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextLayout2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout2> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextLayout2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout2> for IDWriteTextFormat {
-    fn from(value: IDWriteTextLayout2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout2> for &'a IDWriteTextFormat {
-    fn from(value: &'a IDWriteTextLayout2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout2> for IDWriteTextFormat {
-    fn from(value: &IDWriteTextLayout2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout2> for IDWriteTextLayout {
-    fn from(value: IDWriteTextLayout2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout2> for &'a IDWriteTextLayout {
-    fn from(value: &'a IDWriteTextLayout2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout2> for IDWriteTextLayout {
-    fn from(value: &IDWriteTextLayout2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout2> for IDWriteTextLayout1 {
-    fn from(value: IDWriteTextLayout2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout2> for &'a IDWriteTextLayout1 {
-    fn from(value: &'a IDWriteTextLayout2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout2> for IDWriteTextLayout1 {
-    fn from(value: &IDWriteTextLayout2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextLayout2, ::windows::core::IUnknown, IDWriteTextFormat, IDWriteTextLayout, IDWriteTextLayout1);
 impl ::core::clone::Clone for IDWriteTextLayout2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13787,81 +10946,7 @@ impl IDWriteTextLayout3 {
         (::windows::core::Vtable::vtable(self).GetLineMetrics2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(linemetrics.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), linemetrics.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(actuallinecount)).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextLayout3> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextLayout3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextLayout3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout3> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextLayout3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout3> for IDWriteTextFormat {
-    fn from(value: IDWriteTextLayout3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout3> for &'a IDWriteTextFormat {
-    fn from(value: &'a IDWriteTextLayout3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout3> for IDWriteTextFormat {
-    fn from(value: &IDWriteTextLayout3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout3> for IDWriteTextLayout {
-    fn from(value: IDWriteTextLayout3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout3> for &'a IDWriteTextLayout {
-    fn from(value: &'a IDWriteTextLayout3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout3> for IDWriteTextLayout {
-    fn from(value: &IDWriteTextLayout3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout3> for IDWriteTextLayout1 {
-    fn from(value: IDWriteTextLayout3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout3> for &'a IDWriteTextLayout1 {
-    fn from(value: &'a IDWriteTextLayout3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout3> for IDWriteTextLayout1 {
-    fn from(value: &IDWriteTextLayout3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout3> for IDWriteTextLayout2 {
-    fn from(value: IDWriteTextLayout3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout3> for &'a IDWriteTextLayout2 {
-    fn from(value: &'a IDWriteTextLayout3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout3> for IDWriteTextLayout2 {
-    fn from(value: &IDWriteTextLayout3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextLayout3, ::windows::core::IUnknown, IDWriteTextFormat, IDWriteTextLayout, IDWriteTextLayout1, IDWriteTextLayout2);
 impl ::core::clone::Clone for IDWriteTextLayout3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14234,96 +11319,7 @@ impl IDWriteTextLayout4 {
         (::windows::core::Vtable::vtable(self).SetAutomaticFontAxes)(::windows::core::Vtable::as_raw(self), automaticfontaxes).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextLayout4> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout4> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextLayout4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout4> for IDWriteTextFormat {
-    fn from(value: IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout4> for &'a IDWriteTextFormat {
-    fn from(value: &'a IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout4> for IDWriteTextFormat {
-    fn from(value: &IDWriteTextLayout4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout4> for IDWriteTextLayout {
-    fn from(value: IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout4> for &'a IDWriteTextLayout {
-    fn from(value: &'a IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout4> for IDWriteTextLayout {
-    fn from(value: &IDWriteTextLayout4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout4> for IDWriteTextLayout1 {
-    fn from(value: IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout4> for &'a IDWriteTextLayout1 {
-    fn from(value: &'a IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout4> for IDWriteTextLayout1 {
-    fn from(value: &IDWriteTextLayout4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout4> for IDWriteTextLayout2 {
-    fn from(value: IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout4> for &'a IDWriteTextLayout2 {
-    fn from(value: &'a IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout4> for IDWriteTextLayout2 {
-    fn from(value: &IDWriteTextLayout4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextLayout4> for IDWriteTextLayout3 {
-    fn from(value: IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextLayout4> for &'a IDWriteTextLayout3 {
-    fn from(value: &'a IDWriteTextLayout4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextLayout4> for IDWriteTextLayout3 {
-    fn from(value: &IDWriteTextLayout4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextLayout4, ::windows::core::IUnknown, IDWriteTextFormat, IDWriteTextLayout, IDWriteTextLayout1, IDWriteTextLayout2, IDWriteTextLayout3);
 impl ::core::clone::Clone for IDWriteTextLayout4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14406,36 +11402,7 @@ impl IDWriteTextRenderer {
         (::windows::core::Vtable::vtable(self).DrawInlineObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clientdrawingcontext.unwrap_or(::std::ptr::null())), originx, originy, inlineobject.into().abi(), issideways.into(), isrighttoleft.into(), clientdrawingeffect.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextRenderer> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextRenderer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextRenderer> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextRenderer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextRenderer> for IDWritePixelSnapping {
-    fn from(value: IDWriteTextRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextRenderer> for &'a IDWritePixelSnapping {
-    fn from(value: &'a IDWriteTextRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextRenderer> for IDWritePixelSnapping {
-    fn from(value: &IDWriteTextRenderer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextRenderer, ::windows::core::IUnknown, IDWritePixelSnapping);
 impl ::core::clone::Clone for IDWriteTextRenderer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14554,51 +11521,7 @@ impl IDWriteTextRenderer1 {
         (::windows::core::Vtable::vtable(self).DrawInlineObject2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clientdrawingcontext.unwrap_or(::std::ptr::null())), originx, originy, orientationangle, inlineobject.into().abi(), issideways.into(), isrighttoleft.into(), clientdrawingeffect.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDWriteTextRenderer1> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTextRenderer1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextRenderer1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTextRenderer1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextRenderer1> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTextRenderer1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextRenderer1> for IDWritePixelSnapping {
-    fn from(value: IDWriteTextRenderer1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextRenderer1> for &'a IDWritePixelSnapping {
-    fn from(value: &'a IDWriteTextRenderer1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextRenderer1> for IDWritePixelSnapping {
-    fn from(value: &IDWriteTextRenderer1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDWriteTextRenderer1> for IDWriteTextRenderer {
-    fn from(value: IDWriteTextRenderer1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTextRenderer1> for &'a IDWriteTextRenderer {
-    fn from(value: &'a IDWriteTextRenderer1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTextRenderer1> for IDWriteTextRenderer {
-    fn from(value: &IDWriteTextRenderer1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTextRenderer1, ::windows::core::IUnknown, IDWritePixelSnapping, IDWriteTextRenderer);
 impl ::core::clone::Clone for IDWriteTextRenderer1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14651,21 +11574,7 @@ impl IDWriteTypography {
         (::windows::core::Vtable::vtable(self).GetFontFeature)(::windows::core::Vtable::as_raw(self), fontfeatureindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DWRITE_FONT_FEATURE>(result__)
     }
 }
-impl ::core::convert::From<IDWriteTypography> for ::windows::core::IUnknown {
-    fn from(value: IDWriteTypography) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDWriteTypography> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDWriteTypography) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDWriteTypography> for ::windows::core::IUnknown {
-    fn from(value: &IDWriteTypography) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDWriteTypography, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDWriteTypography {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
@@ -99,36 +99,7 @@ impl IDXGIAdapter {
         (::windows::core::Vtable::vtable(self).CheckInterfaceSupport)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(interfacename), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i64>(result__)
     }
 }
-impl ::core::convert::From<IDXGIAdapter> for ::windows::core::IUnknown {
-    fn from(value: IDXGIAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIAdapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter> for IDXGIObject {
-    fn from(value: IDXGIAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIAdapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter> for IDXGIObject {
-    fn from(value: &IDXGIAdapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIAdapter, ::windows::core::IUnknown, IDXGIObject);
 impl ::core::clone::Clone for IDXGIAdapter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -206,51 +177,7 @@ impl IDXGIAdapter1 {
         (::windows::core::Vtable::vtable(self).GetDesc1)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DXGI_ADAPTER_DESC1>(result__)
     }
 }
-impl ::core::convert::From<IDXGIAdapter1> for ::windows::core::IUnknown {
-    fn from(value: IDXGIAdapter1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIAdapter1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter1> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIAdapter1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter1> for IDXGIObject {
-    fn from(value: IDXGIAdapter1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter1> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIAdapter1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter1> for IDXGIObject {
-    fn from(value: &IDXGIAdapter1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter1> for IDXGIAdapter {
-    fn from(value: IDXGIAdapter1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter1> for &'a IDXGIAdapter {
-    fn from(value: &'a IDXGIAdapter1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter1> for IDXGIAdapter {
-    fn from(value: &IDXGIAdapter1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIAdapter1, ::windows::core::IUnknown, IDXGIObject, IDXGIAdapter);
 impl ::core::clone::Clone for IDXGIAdapter1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -332,66 +259,7 @@ impl IDXGIAdapter2 {
         (::windows::core::Vtable::vtable(self).GetDesc2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DXGI_ADAPTER_DESC2>(result__)
     }
 }
-impl ::core::convert::From<IDXGIAdapter2> for ::windows::core::IUnknown {
-    fn from(value: IDXGIAdapter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIAdapter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter2> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIAdapter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter2> for IDXGIObject {
-    fn from(value: IDXGIAdapter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter2> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIAdapter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter2> for IDXGIObject {
-    fn from(value: &IDXGIAdapter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter2> for IDXGIAdapter {
-    fn from(value: IDXGIAdapter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter2> for &'a IDXGIAdapter {
-    fn from(value: &'a IDXGIAdapter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter2> for IDXGIAdapter {
-    fn from(value: &IDXGIAdapter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter2> for IDXGIAdapter1 {
-    fn from(value: IDXGIAdapter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter2> for &'a IDXGIAdapter1 {
-    fn from(value: &'a IDXGIAdapter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter2> for IDXGIAdapter1 {
-    fn from(value: &IDXGIAdapter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIAdapter2, ::windows::core::IUnknown, IDXGIObject, IDXGIAdapter, IDXGIAdapter1);
 impl ::core::clone::Clone for IDXGIAdapter2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -504,81 +372,7 @@ impl IDXGIAdapter3 {
         (::windows::core::Vtable::vtable(self).UnregisterVideoMemoryBudgetChangeNotification)(::windows::core::Vtable::as_raw(self), dwcookie)
     }
 }
-impl ::core::convert::From<IDXGIAdapter3> for ::windows::core::IUnknown {
-    fn from(value: IDXGIAdapter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIAdapter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter3> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIAdapter3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter3> for IDXGIObject {
-    fn from(value: IDXGIAdapter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter3> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIAdapter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter3> for IDXGIObject {
-    fn from(value: &IDXGIAdapter3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter3> for IDXGIAdapter {
-    fn from(value: IDXGIAdapter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter3> for &'a IDXGIAdapter {
-    fn from(value: &'a IDXGIAdapter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter3> for IDXGIAdapter {
-    fn from(value: &IDXGIAdapter3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter3> for IDXGIAdapter1 {
-    fn from(value: IDXGIAdapter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter3> for &'a IDXGIAdapter1 {
-    fn from(value: &'a IDXGIAdapter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter3> for IDXGIAdapter1 {
-    fn from(value: &IDXGIAdapter3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter3> for IDXGIAdapter2 {
-    fn from(value: IDXGIAdapter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter3> for &'a IDXGIAdapter2 {
-    fn from(value: &'a IDXGIAdapter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter3> for IDXGIAdapter2 {
-    fn from(value: &IDXGIAdapter3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIAdapter3, ::windows::core::IUnknown, IDXGIObject, IDXGIAdapter, IDXGIAdapter1, IDXGIAdapter2);
 impl ::core::clone::Clone for IDXGIAdapter3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -705,96 +499,7 @@ impl IDXGIAdapter4 {
         (::windows::core::Vtable::vtable(self).GetDesc3)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DXGI_ADAPTER_DESC3>(result__)
     }
 }
-impl ::core::convert::From<IDXGIAdapter4> for ::windows::core::IUnknown {
-    fn from(value: IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter4> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIAdapter4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter4> for IDXGIObject {
-    fn from(value: IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter4> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter4> for IDXGIObject {
-    fn from(value: &IDXGIAdapter4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter4> for IDXGIAdapter {
-    fn from(value: IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter4> for &'a IDXGIAdapter {
-    fn from(value: &'a IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter4> for IDXGIAdapter {
-    fn from(value: &IDXGIAdapter4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter4> for IDXGIAdapter1 {
-    fn from(value: IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter4> for &'a IDXGIAdapter1 {
-    fn from(value: &'a IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter4> for IDXGIAdapter1 {
-    fn from(value: &IDXGIAdapter4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter4> for IDXGIAdapter2 {
-    fn from(value: IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter4> for &'a IDXGIAdapter2 {
-    fn from(value: &'a IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter4> for IDXGIAdapter2 {
-    fn from(value: &IDXGIAdapter4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIAdapter4> for IDXGIAdapter3 {
-    fn from(value: IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIAdapter4> for &'a IDXGIAdapter3 {
-    fn from(value: &'a IDXGIAdapter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIAdapter4> for IDXGIAdapter3 {
-    fn from(value: &IDXGIAdapter4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIAdapter4, ::windows::core::IUnknown, IDXGIObject, IDXGIAdapter, IDXGIAdapter1, IDXGIAdapter2, IDXGIAdapter3);
 impl ::core::clone::Clone for IDXGIAdapter4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -834,21 +539,7 @@ impl IDXGIDebug {
         (::windows::core::Vtable::vtable(self).ReportLiveObjects)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(apiid), flags).ok()
     }
 }
-impl ::core::convert::From<IDXGIDebug> for ::windows::core::IUnknown {
-    fn from(value: IDXGIDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDebug> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDebug> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIDebug, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXGIDebug {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -896,36 +587,7 @@ impl IDXGIDebug1 {
         (::windows::core::Vtable::vtable(self).IsLeakTrackingEnabledForThread)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDXGIDebug1> for ::windows::core::IUnknown {
-    fn from(value: IDXGIDebug1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDebug1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIDebug1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDebug1> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIDebug1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDebug1> for IDXGIDebug {
-    fn from(value: IDXGIDebug1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDebug1> for &'a IDXGIDebug {
-    fn from(value: &'a IDXGIDebug1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDebug1> for IDXGIDebug {
-    fn from(value: &IDXGIDebug1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIDebug1, ::windows::core::IUnknown, IDXGIDebug);
 impl ::core::clone::Clone for IDXGIDebug1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1001,21 +663,7 @@ impl IDXGIDecodeSwapChain {
         (::windows::core::Vtable::vtable(self).GetColorSpace)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDXGIDecodeSwapChain> for ::windows::core::IUnknown {
-    fn from(value: IDXGIDecodeSwapChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDecodeSwapChain> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIDecodeSwapChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDecodeSwapChain> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIDecodeSwapChain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIDecodeSwapChain, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXGIDecodeSwapChain {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1107,36 +755,7 @@ impl IDXGIDevice {
         (::windows::core::Vtable::vtable(self).GetGPUThreadPriority)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IDXGIDevice> for ::windows::core::IUnknown {
-    fn from(value: IDXGIDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice> for IDXGIObject {
-    fn from(value: IDXGIDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice> for IDXGIObject {
-    fn from(value: &IDXGIDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIDevice, ::windows::core::IUnknown, IDXGIObject);
 impl ::core::clone::Clone for IDXGIDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1222,51 +841,7 @@ impl IDXGIDevice1 {
         (::windows::core::Vtable::vtable(self).GetMaximumFrameLatency)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDXGIDevice1> for ::windows::core::IUnknown {
-    fn from(value: IDXGIDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice1> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIDevice1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice1> for IDXGIObject {
-    fn from(value: IDXGIDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice1> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice1> for IDXGIObject {
-    fn from(value: &IDXGIDevice1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice1> for IDXGIDevice {
-    fn from(value: IDXGIDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice1> for &'a IDXGIDevice {
-    fn from(value: &'a IDXGIDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice1> for IDXGIDevice {
-    fn from(value: &IDXGIDevice1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIDevice1, ::windows::core::IUnknown, IDXGIObject, IDXGIDevice);
 impl ::core::clone::Clone for IDXGIDevice1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1363,66 +938,7 @@ impl IDXGIDevice2 {
         (::windows::core::Vtable::vtable(self).EnqueueSetEvent)(::windows::core::Vtable::as_raw(self), hevent.into()).ok()
     }
 }
-impl ::core::convert::From<IDXGIDevice2> for ::windows::core::IUnknown {
-    fn from(value: IDXGIDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice2> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice2> for IDXGIObject {
-    fn from(value: IDXGIDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice2> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice2> for IDXGIObject {
-    fn from(value: &IDXGIDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice2> for IDXGIDevice {
-    fn from(value: IDXGIDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice2> for &'a IDXGIDevice {
-    fn from(value: &'a IDXGIDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice2> for IDXGIDevice {
-    fn from(value: &IDXGIDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice2> for IDXGIDevice1 {
-    fn from(value: IDXGIDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice2> for &'a IDXGIDevice1 {
-    fn from(value: &'a IDXGIDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice2> for IDXGIDevice1 {
-    fn from(value: &IDXGIDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIDevice2, ::windows::core::IUnknown, IDXGIObject, IDXGIDevice, IDXGIDevice1);
 impl ::core::clone::Clone for IDXGIDevice2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1529,81 +1045,7 @@ impl IDXGIDevice3 {
         (::windows::core::Vtable::vtable(self).Trim)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDXGIDevice3> for ::windows::core::IUnknown {
-    fn from(value: IDXGIDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice3> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice3> for IDXGIObject {
-    fn from(value: IDXGIDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice3> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice3> for IDXGIObject {
-    fn from(value: &IDXGIDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice3> for IDXGIDevice {
-    fn from(value: IDXGIDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice3> for &'a IDXGIDevice {
-    fn from(value: &'a IDXGIDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice3> for IDXGIDevice {
-    fn from(value: &IDXGIDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice3> for IDXGIDevice1 {
-    fn from(value: IDXGIDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice3> for &'a IDXGIDevice1 {
-    fn from(value: &'a IDXGIDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice3> for IDXGIDevice1 {
-    fn from(value: &IDXGIDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice3> for IDXGIDevice2 {
-    fn from(value: IDXGIDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice3> for &'a IDXGIDevice2 {
-    fn from(value: &'a IDXGIDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice3> for IDXGIDevice2 {
-    fn from(value: &IDXGIDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIDevice3, ::windows::core::IUnknown, IDXGIObject, IDXGIDevice, IDXGIDevice1, IDXGIDevice2);
 impl ::core::clone::Clone for IDXGIDevice3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1709,96 +1151,7 @@ impl IDXGIDevice4 {
         (::windows::core::Vtable::vtable(self).ReclaimResources1)(::windows::core::Vtable::as_raw(self), numresources, ::core::mem::transmute(ppresources), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DXGI_RECLAIM_RESOURCE_RESULTS>(result__)
     }
 }
-impl ::core::convert::From<IDXGIDevice4> for ::windows::core::IUnknown {
-    fn from(value: IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice4> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIDevice4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice4> for IDXGIObject {
-    fn from(value: IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice4> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice4> for IDXGIObject {
-    fn from(value: &IDXGIDevice4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice4> for IDXGIDevice {
-    fn from(value: IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice4> for &'a IDXGIDevice {
-    fn from(value: &'a IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice4> for IDXGIDevice {
-    fn from(value: &IDXGIDevice4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice4> for IDXGIDevice1 {
-    fn from(value: IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice4> for &'a IDXGIDevice1 {
-    fn from(value: &'a IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice4> for IDXGIDevice1 {
-    fn from(value: &IDXGIDevice4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice4> for IDXGIDevice2 {
-    fn from(value: IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice4> for &'a IDXGIDevice2 {
-    fn from(value: &'a IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice4> for IDXGIDevice2 {
-    fn from(value: &IDXGIDevice4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDevice4> for IDXGIDevice3 {
-    fn from(value: IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDevice4> for &'a IDXGIDevice3 {
-    fn from(value: &'a IDXGIDevice4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDevice4> for IDXGIDevice3 {
-    fn from(value: &IDXGIDevice4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIDevice4, ::windows::core::IUnknown, IDXGIObject, IDXGIDevice, IDXGIDevice1, IDXGIDevice2, IDXGIDevice3);
 impl ::core::clone::Clone for IDXGIDevice4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1859,36 +1212,7 @@ impl IDXGIDeviceSubObject {
         (::windows::core::Vtable::vtable(self).GetDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDXGIDeviceSubObject> for ::windows::core::IUnknown {
-    fn from(value: IDXGIDeviceSubObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDeviceSubObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIDeviceSubObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDeviceSubObject> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIDeviceSubObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIDeviceSubObject> for IDXGIObject {
-    fn from(value: IDXGIDeviceSubObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDeviceSubObject> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIDeviceSubObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDeviceSubObject> for IDXGIObject {
-    fn from(value: &IDXGIDeviceSubObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIDeviceSubObject, ::windows::core::IUnknown, IDXGIObject);
 impl ::core::clone::Clone for IDXGIDeviceSubObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1935,21 +1259,7 @@ impl IDXGIDisplayControl {
         (::windows::core::Vtable::vtable(self).SetStereoEnabled)(::windows::core::Vtable::as_raw(self), enabled.into())
     }
 }
-impl ::core::convert::From<IDXGIDisplayControl> for ::windows::core::IUnknown {
-    fn from(value: IDXGIDisplayControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIDisplayControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIDisplayControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIDisplayControl> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIDisplayControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIDisplayControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXGIDisplayControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2044,36 +1354,7 @@ impl IDXGIFactory {
         (::windows::core::Vtable::vtable(self).CreateSoftwareAdapter)(::windows::core::Vtable::as_raw(self), module.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDXGIAdapter>(result__)
     }
 }
-impl ::core::convert::From<IDXGIFactory> for ::windows::core::IUnknown {
-    fn from(value: IDXGIFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory> for IDXGIObject {
-    fn from(value: IDXGIFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory> for IDXGIObject {
-    fn from(value: &IDXGIFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIFactory, ::windows::core::IUnknown, IDXGIObject);
 impl ::core::clone::Clone for IDXGIFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2186,51 +1467,7 @@ impl IDXGIFactory1 {
         (::windows::core::Vtable::vtable(self).IsCurrent)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDXGIFactory1> for ::windows::core::IUnknown {
-    fn from(value: IDXGIFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory1> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIFactory1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory1> for IDXGIObject {
-    fn from(value: IDXGIFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory1> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory1> for IDXGIObject {
-    fn from(value: &IDXGIFactory1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory1> for IDXGIFactory {
-    fn from(value: IDXGIFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory1> for &'a IDXGIFactory {
-    fn from(value: &'a IDXGIFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory1> for IDXGIFactory {
-    fn from(value: &IDXGIFactory1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIFactory1, ::windows::core::IUnknown, IDXGIObject, IDXGIFactory);
 impl ::core::clone::Clone for IDXGIFactory1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2419,66 +1656,7 @@ impl IDXGIFactory2 {
         (::windows::core::Vtable::vtable(self).CreateSwapChainForComposition)(::windows::core::Vtable::as_raw(self), pdevice.into().abi(), ::core::mem::transmute(pdesc), prestricttooutput.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDXGISwapChain1>(result__)
     }
 }
-impl ::core::convert::From<IDXGIFactory2> for ::windows::core::IUnknown {
-    fn from(value: IDXGIFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory2> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory2> for IDXGIObject {
-    fn from(value: IDXGIFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory2> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory2> for IDXGIObject {
-    fn from(value: &IDXGIFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory2> for IDXGIFactory {
-    fn from(value: IDXGIFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory2> for &'a IDXGIFactory {
-    fn from(value: &'a IDXGIFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory2> for IDXGIFactory {
-    fn from(value: &IDXGIFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory2> for IDXGIFactory1 {
-    fn from(value: IDXGIFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory2> for &'a IDXGIFactory1 {
-    fn from(value: &'a IDXGIFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory2> for IDXGIFactory1 {
-    fn from(value: &IDXGIFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIFactory2, ::windows::core::IUnknown, IDXGIObject, IDXGIFactory, IDXGIFactory1);
 impl ::core::clone::Clone for IDXGIFactory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2703,81 +1881,7 @@ impl IDXGIFactory3 {
         (::windows::core::Vtable::vtable(self).GetCreationFlags)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDXGIFactory3> for ::windows::core::IUnknown {
-    fn from(value: IDXGIFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory3> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIFactory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory3> for IDXGIObject {
-    fn from(value: IDXGIFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory3> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory3> for IDXGIObject {
-    fn from(value: &IDXGIFactory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory3> for IDXGIFactory {
-    fn from(value: IDXGIFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory3> for &'a IDXGIFactory {
-    fn from(value: &'a IDXGIFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory3> for IDXGIFactory {
-    fn from(value: &IDXGIFactory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory3> for IDXGIFactory1 {
-    fn from(value: IDXGIFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory3> for &'a IDXGIFactory1 {
-    fn from(value: &'a IDXGIFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory3> for IDXGIFactory1 {
-    fn from(value: &IDXGIFactory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory3> for IDXGIFactory2 {
-    fn from(value: IDXGIFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory3> for &'a IDXGIFactory2 {
-    fn from(value: &'a IDXGIFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory3> for IDXGIFactory2 {
-    fn from(value: &IDXGIFactory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIFactory3, ::windows::core::IUnknown, IDXGIObject, IDXGIFactory, IDXGIFactory1, IDXGIFactory2);
 impl ::core::clone::Clone for IDXGIFactory3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2981,96 +2085,7 @@ impl IDXGIFactory4 {
         (::windows::core::Vtable::vtable(self).EnumWarpAdapter)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDXGIFactory4> for ::windows::core::IUnknown {
-    fn from(value: IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory4> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory4> for IDXGIObject {
-    fn from(value: IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory4> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory4> for IDXGIObject {
-    fn from(value: &IDXGIFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory4> for IDXGIFactory {
-    fn from(value: IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory4> for &'a IDXGIFactory {
-    fn from(value: &'a IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory4> for IDXGIFactory {
-    fn from(value: &IDXGIFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory4> for IDXGIFactory1 {
-    fn from(value: IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory4> for &'a IDXGIFactory1 {
-    fn from(value: &'a IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory4> for IDXGIFactory1 {
-    fn from(value: &IDXGIFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory4> for IDXGIFactory2 {
-    fn from(value: IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory4> for &'a IDXGIFactory2 {
-    fn from(value: &'a IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory4> for IDXGIFactory2 {
-    fn from(value: &IDXGIFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory4> for IDXGIFactory3 {
-    fn from(value: IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory4> for &'a IDXGIFactory3 {
-    fn from(value: &'a IDXGIFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory4> for IDXGIFactory3 {
-    fn from(value: &IDXGIFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIFactory4, ::windows::core::IUnknown, IDXGIObject, IDXGIFactory, IDXGIFactory1, IDXGIFactory2, IDXGIFactory3);
 impl ::core::clone::Clone for IDXGIFactory4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3281,111 +2296,7 @@ impl IDXGIFactory5 {
         (::windows::core::Vtable::vtable(self).CheckFeatureSupport)(::windows::core::Vtable::as_raw(self), feature, ::core::mem::transmute(pfeaturesupportdata), featuresupportdatasize).ok()
     }
 }
-impl ::core::convert::From<IDXGIFactory5> for ::windows::core::IUnknown {
-    fn from(value: IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory5> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory5> for IDXGIObject {
-    fn from(value: IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory5> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory5> for IDXGIObject {
-    fn from(value: &IDXGIFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory5> for IDXGIFactory {
-    fn from(value: IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory5> for &'a IDXGIFactory {
-    fn from(value: &'a IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory5> for IDXGIFactory {
-    fn from(value: &IDXGIFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory5> for IDXGIFactory1 {
-    fn from(value: IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory5> for &'a IDXGIFactory1 {
-    fn from(value: &'a IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory5> for IDXGIFactory1 {
-    fn from(value: &IDXGIFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory5> for IDXGIFactory2 {
-    fn from(value: IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory5> for &'a IDXGIFactory2 {
-    fn from(value: &'a IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory5> for IDXGIFactory2 {
-    fn from(value: &IDXGIFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory5> for IDXGIFactory3 {
-    fn from(value: IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory5> for &'a IDXGIFactory3 {
-    fn from(value: &'a IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory5> for IDXGIFactory3 {
-    fn from(value: &IDXGIFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory5> for IDXGIFactory4 {
-    fn from(value: IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory5> for &'a IDXGIFactory4 {
-    fn from(value: &'a IDXGIFactory5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory5> for IDXGIFactory4 {
-    fn from(value: &IDXGIFactory5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIFactory5, ::windows::core::IUnknown, IDXGIObject, IDXGIFactory, IDXGIFactory1, IDXGIFactory2, IDXGIFactory3, IDXGIFactory4);
 impl ::core::clone::Clone for IDXGIFactory5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3599,126 +2510,7 @@ impl IDXGIFactory6 {
         (::windows::core::Vtable::vtable(self).EnumAdapterByGpuPreference)(::windows::core::Vtable::as_raw(self), adapter, gpupreference, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDXGIFactory6> for ::windows::core::IUnknown {
-    fn from(value: IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory6> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory6> for IDXGIObject {
-    fn from(value: IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory6> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory6> for IDXGIObject {
-    fn from(value: &IDXGIFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory6> for IDXGIFactory {
-    fn from(value: IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory6> for &'a IDXGIFactory {
-    fn from(value: &'a IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory6> for IDXGIFactory {
-    fn from(value: &IDXGIFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory6> for IDXGIFactory1 {
-    fn from(value: IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory6> for &'a IDXGIFactory1 {
-    fn from(value: &'a IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory6> for IDXGIFactory1 {
-    fn from(value: &IDXGIFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory6> for IDXGIFactory2 {
-    fn from(value: IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory6> for &'a IDXGIFactory2 {
-    fn from(value: &'a IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory6> for IDXGIFactory2 {
-    fn from(value: &IDXGIFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory6> for IDXGIFactory3 {
-    fn from(value: IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory6> for &'a IDXGIFactory3 {
-    fn from(value: &'a IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory6> for IDXGIFactory3 {
-    fn from(value: &IDXGIFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory6> for IDXGIFactory4 {
-    fn from(value: IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory6> for &'a IDXGIFactory4 {
-    fn from(value: &'a IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory6> for IDXGIFactory4 {
-    fn from(value: &IDXGIFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory6> for IDXGIFactory5 {
-    fn from(value: IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory6> for &'a IDXGIFactory5 {
-    fn from(value: &'a IDXGIFactory6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory6> for IDXGIFactory5 {
-    fn from(value: &IDXGIFactory6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIFactory6, ::windows::core::IUnknown, IDXGIObject, IDXGIFactory, IDXGIFactory1, IDXGIFactory2, IDXGIFactory3, IDXGIFactory4, IDXGIFactory5);
 impl ::core::clone::Clone for IDXGIFactory6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3944,141 +2736,7 @@ impl IDXGIFactory7 {
         (::windows::core::Vtable::vtable(self).UnregisterAdaptersChangedEvent)(::windows::core::Vtable::as_raw(self), dwcookie).ok()
     }
 }
-impl ::core::convert::From<IDXGIFactory7> for ::windows::core::IUnknown {
-    fn from(value: IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory7> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory7> for IDXGIObject {
-    fn from(value: IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory7> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory7> for IDXGIObject {
-    fn from(value: &IDXGIFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory7> for IDXGIFactory {
-    fn from(value: IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory7> for &'a IDXGIFactory {
-    fn from(value: &'a IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory7> for IDXGIFactory {
-    fn from(value: &IDXGIFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory7> for IDXGIFactory1 {
-    fn from(value: IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory7> for &'a IDXGIFactory1 {
-    fn from(value: &'a IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory7> for IDXGIFactory1 {
-    fn from(value: &IDXGIFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory7> for IDXGIFactory2 {
-    fn from(value: IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory7> for &'a IDXGIFactory2 {
-    fn from(value: &'a IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory7> for IDXGIFactory2 {
-    fn from(value: &IDXGIFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory7> for IDXGIFactory3 {
-    fn from(value: IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory7> for &'a IDXGIFactory3 {
-    fn from(value: &'a IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory7> for IDXGIFactory3 {
-    fn from(value: &IDXGIFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory7> for IDXGIFactory4 {
-    fn from(value: IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory7> for &'a IDXGIFactory4 {
-    fn from(value: &'a IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory7> for IDXGIFactory4 {
-    fn from(value: &IDXGIFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory7> for IDXGIFactory5 {
-    fn from(value: IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory7> for &'a IDXGIFactory5 {
-    fn from(value: &'a IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory7> for IDXGIFactory5 {
-    fn from(value: &IDXGIFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIFactory7> for IDXGIFactory6 {
-    fn from(value: IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactory7> for &'a IDXGIFactory6 {
-    fn from(value: &'a IDXGIFactory7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactory7> for IDXGIFactory6 {
-    fn from(value: &IDXGIFactory7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIFactory7, ::windows::core::IUnknown, IDXGIObject, IDXGIFactory, IDXGIFactory1, IDXGIFactory2, IDXGIFactory3, IDXGIFactory4, IDXGIFactory5, IDXGIFactory6);
 impl ::core::clone::Clone for IDXGIFactory7 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4139,21 +2797,7 @@ impl IDXGIFactoryMedia {
         (::windows::core::Vtable::vtable(self).CreateDecodeSwapChainForCompositionSurfaceHandle)(::windows::core::Vtable::as_raw(self), pdevice.into().abi(), hsurface.into(), ::core::mem::transmute(pdesc), pyuvdecodebuffers.into().abi(), prestricttooutput.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDXGIDecodeSwapChain>(result__)
     }
 }
-impl ::core::convert::From<IDXGIFactoryMedia> for ::windows::core::IUnknown {
-    fn from(value: IDXGIFactoryMedia) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIFactoryMedia> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIFactoryMedia) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIFactoryMedia> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIFactoryMedia) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIFactoryMedia, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXGIFactoryMedia {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4339,21 +2983,7 @@ impl IDXGIInfoQueue {
         (::windows::core::Vtable::vtable(self).GetMuteDebugOutput)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(producer))
     }
 }
-impl ::core::convert::From<IDXGIInfoQueue> for ::windows::core::IUnknown {
-    fn from(value: IDXGIInfoQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIInfoQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIInfoQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIInfoQueue> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIInfoQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIInfoQueue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXGIInfoQueue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4479,51 +3109,7 @@ impl IDXGIKeyedMutex {
         (::windows::core::Vtable::vtable(self).ReleaseSync)(::windows::core::Vtable::as_raw(self), key).ok()
     }
 }
-impl ::core::convert::From<IDXGIKeyedMutex> for ::windows::core::IUnknown {
-    fn from(value: IDXGIKeyedMutex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIKeyedMutex> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIKeyedMutex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIKeyedMutex> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIKeyedMutex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIKeyedMutex> for IDXGIObject {
-    fn from(value: IDXGIKeyedMutex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIKeyedMutex> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIKeyedMutex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIKeyedMutex> for IDXGIObject {
-    fn from(value: &IDXGIKeyedMutex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIKeyedMutex> for IDXGIDeviceSubObject {
-    fn from(value: IDXGIKeyedMutex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIKeyedMutex> for &'a IDXGIDeviceSubObject {
-    fn from(value: &'a IDXGIKeyedMutex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIKeyedMutex> for IDXGIDeviceSubObject {
-    fn from(value: &IDXGIKeyedMutex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIKeyedMutex, ::windows::core::IUnknown, IDXGIObject, IDXGIDeviceSubObject);
 impl ::core::clone::Clone for IDXGIKeyedMutex {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4577,21 +3163,7 @@ impl IDXGIObject {
         (::windows::core::Vtable::vtable(self).GetParent)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDXGIObject> for ::windows::core::IUnknown {
-    fn from(value: IDXGIObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIObject> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXGIObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4714,36 +3286,7 @@ impl IDXGIOutput {
         (::windows::core::Vtable::vtable(self).GetFrameStatistics)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DXGI_FRAME_STATISTICS>(result__)
     }
 }
-impl ::core::convert::From<IDXGIOutput> for ::windows::core::IUnknown {
-    fn from(value: IDXGIOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIOutput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput> for IDXGIObject {
-    fn from(value: IDXGIOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput> for IDXGIObject {
-    fn from(value: &IDXGIOutput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIOutput, ::windows::core::IUnknown, IDXGIObject);
 impl ::core::clone::Clone for IDXGIOutput {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4921,51 +3464,7 @@ impl IDXGIOutput1 {
         (::windows::core::Vtable::vtable(self).DuplicateOutput)(::windows::core::Vtable::as_raw(self), pdevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDXGIOutputDuplication>(result__)
     }
 }
-impl ::core::convert::From<IDXGIOutput1> for ::windows::core::IUnknown {
-    fn from(value: IDXGIOutput1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIOutput1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput1> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIOutput1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput1> for IDXGIObject {
-    fn from(value: IDXGIOutput1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput1> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIOutput1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput1> for IDXGIObject {
-    fn from(value: &IDXGIOutput1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput1> for IDXGIOutput {
-    fn from(value: IDXGIOutput1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput1> for &'a IDXGIOutput {
-    fn from(value: &'a IDXGIOutput1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput1> for IDXGIOutput {
-    fn from(value: &IDXGIOutput1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIOutput1, ::windows::core::IUnknown, IDXGIObject, IDXGIOutput);
 impl ::core::clone::Clone for IDXGIOutput1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5125,66 +3624,7 @@ impl IDXGIOutput2 {
         (::windows::core::Vtable::vtable(self).SupportsOverlays)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDXGIOutput2> for ::windows::core::IUnknown {
-    fn from(value: IDXGIOutput2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIOutput2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput2> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIOutput2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput2> for IDXGIObject {
-    fn from(value: IDXGIOutput2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput2> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIOutput2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput2> for IDXGIObject {
-    fn from(value: &IDXGIOutput2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput2> for IDXGIOutput {
-    fn from(value: IDXGIOutput2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput2> for &'a IDXGIOutput {
-    fn from(value: &'a IDXGIOutput2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput2> for IDXGIOutput {
-    fn from(value: &IDXGIOutput2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput2> for IDXGIOutput1 {
-    fn from(value: IDXGIOutput2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput2> for &'a IDXGIOutput1 {
-    fn from(value: &'a IDXGIOutput2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput2> for IDXGIOutput1 {
-    fn from(value: &IDXGIOutput2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIOutput2, ::windows::core::IUnknown, IDXGIObject, IDXGIOutput, IDXGIOutput1);
 impl ::core::clone::Clone for IDXGIOutput2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5347,81 +3787,7 @@ impl IDXGIOutput3 {
         (::windows::core::Vtable::vtable(self).CheckOverlaySupport)(::windows::core::Vtable::as_raw(self), enumformat, pconcerneddevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDXGIOutput3> for ::windows::core::IUnknown {
-    fn from(value: IDXGIOutput3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIOutput3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput3> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIOutput3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput3> for IDXGIObject {
-    fn from(value: IDXGIOutput3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput3> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIOutput3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput3> for IDXGIObject {
-    fn from(value: &IDXGIOutput3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput3> for IDXGIOutput {
-    fn from(value: IDXGIOutput3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput3> for &'a IDXGIOutput {
-    fn from(value: &'a IDXGIOutput3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput3> for IDXGIOutput {
-    fn from(value: &IDXGIOutput3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput3> for IDXGIOutput1 {
-    fn from(value: IDXGIOutput3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput3> for &'a IDXGIOutput1 {
-    fn from(value: &'a IDXGIOutput3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput3> for IDXGIOutput1 {
-    fn from(value: &IDXGIOutput3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput3> for IDXGIOutput2 {
-    fn from(value: IDXGIOutput3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput3> for &'a IDXGIOutput2 {
-    fn from(value: &'a IDXGIOutput3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput3> for IDXGIOutput2 {
-    fn from(value: &IDXGIOutput3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIOutput3, ::windows::core::IUnknown, IDXGIObject, IDXGIOutput, IDXGIOutput1, IDXGIOutput2);
 impl ::core::clone::Clone for IDXGIOutput3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5593,96 +3959,7 @@ impl IDXGIOutput4 {
         (::windows::core::Vtable::vtable(self).CheckOverlayColorSpaceSupport)(::windows::core::Vtable::as_raw(self), format, colorspace, pconcerneddevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDXGIOutput4> for ::windows::core::IUnknown {
-    fn from(value: IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput4> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIOutput4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput4> for IDXGIObject {
-    fn from(value: IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput4> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput4> for IDXGIObject {
-    fn from(value: &IDXGIOutput4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput4> for IDXGIOutput {
-    fn from(value: IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput4> for &'a IDXGIOutput {
-    fn from(value: &'a IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput4> for IDXGIOutput {
-    fn from(value: &IDXGIOutput4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput4> for IDXGIOutput1 {
-    fn from(value: IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput4> for &'a IDXGIOutput1 {
-    fn from(value: &'a IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput4> for IDXGIOutput1 {
-    fn from(value: &IDXGIOutput4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput4> for IDXGIOutput2 {
-    fn from(value: IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput4> for &'a IDXGIOutput2 {
-    fn from(value: &'a IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput4> for IDXGIOutput2 {
-    fn from(value: &IDXGIOutput4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput4> for IDXGIOutput3 {
-    fn from(value: IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput4> for &'a IDXGIOutput3 {
-    fn from(value: &'a IDXGIOutput4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput4> for IDXGIOutput3 {
-    fn from(value: &IDXGIOutput4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIOutput4, ::windows::core::IUnknown, IDXGIObject, IDXGIOutput, IDXGIOutput1, IDXGIOutput2, IDXGIOutput3);
 impl ::core::clone::Clone for IDXGIOutput4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5863,111 +4140,7 @@ impl IDXGIOutput5 {
         (::windows::core::Vtable::vtable(self).DuplicateOutput1)(::windows::core::Vtable::as_raw(self), pdevice.into().abi(), flags, psupportedformats.len() as _, ::core::mem::transmute(psupportedformats.as_ptr()), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDXGIOutputDuplication>(result__)
     }
 }
-impl ::core::convert::From<IDXGIOutput5> for ::windows::core::IUnknown {
-    fn from(value: IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput5> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIOutput5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput5> for IDXGIObject {
-    fn from(value: IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput5> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput5> for IDXGIObject {
-    fn from(value: &IDXGIOutput5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput5> for IDXGIOutput {
-    fn from(value: IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput5> for &'a IDXGIOutput {
-    fn from(value: &'a IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput5> for IDXGIOutput {
-    fn from(value: &IDXGIOutput5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput5> for IDXGIOutput1 {
-    fn from(value: IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput5> for &'a IDXGIOutput1 {
-    fn from(value: &'a IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput5> for IDXGIOutput1 {
-    fn from(value: &IDXGIOutput5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput5> for IDXGIOutput2 {
-    fn from(value: IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput5> for &'a IDXGIOutput2 {
-    fn from(value: &'a IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput5> for IDXGIOutput2 {
-    fn from(value: &IDXGIOutput5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput5> for IDXGIOutput3 {
-    fn from(value: IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput5> for &'a IDXGIOutput3 {
-    fn from(value: &'a IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput5> for IDXGIOutput3 {
-    fn from(value: &IDXGIOutput5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput5> for IDXGIOutput4 {
-    fn from(value: IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput5> for &'a IDXGIOutput4 {
-    fn from(value: &'a IDXGIOutput5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput5> for IDXGIOutput4 {
-    fn from(value: &IDXGIOutput5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIOutput5, ::windows::core::IUnknown, IDXGIObject, IDXGIOutput, IDXGIOutput1, IDXGIOutput2, IDXGIOutput3, IDXGIOutput4);
 impl ::core::clone::Clone for IDXGIOutput5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6158,126 +4331,7 @@ impl IDXGIOutput6 {
         (::windows::core::Vtable::vtable(self).CheckHardwareCompositionSupport)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDXGIOutput6> for ::windows::core::IUnknown {
-    fn from(value: IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput6> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIOutput6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput6> for IDXGIObject {
-    fn from(value: IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput6> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput6> for IDXGIObject {
-    fn from(value: &IDXGIOutput6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput6> for IDXGIOutput {
-    fn from(value: IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput6> for &'a IDXGIOutput {
-    fn from(value: &'a IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput6> for IDXGIOutput {
-    fn from(value: &IDXGIOutput6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput6> for IDXGIOutput1 {
-    fn from(value: IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput6> for &'a IDXGIOutput1 {
-    fn from(value: &'a IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput6> for IDXGIOutput1 {
-    fn from(value: &IDXGIOutput6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput6> for IDXGIOutput2 {
-    fn from(value: IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput6> for &'a IDXGIOutput2 {
-    fn from(value: &'a IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput6> for IDXGIOutput2 {
-    fn from(value: &IDXGIOutput6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput6> for IDXGIOutput3 {
-    fn from(value: IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput6> for &'a IDXGIOutput3 {
-    fn from(value: &'a IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput6> for IDXGIOutput3 {
-    fn from(value: &IDXGIOutput6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput6> for IDXGIOutput4 {
-    fn from(value: IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput6> for &'a IDXGIOutput4 {
-    fn from(value: &'a IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput6> for IDXGIOutput4 {
-    fn from(value: &IDXGIOutput6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutput6> for IDXGIOutput5 {
-    fn from(value: IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutput6> for &'a IDXGIOutput5 {
-    fn from(value: &'a IDXGIOutput6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutput6> for IDXGIOutput5 {
-    fn from(value: &IDXGIOutput6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIOutput6, ::windows::core::IUnknown, IDXGIObject, IDXGIOutput, IDXGIOutput1, IDXGIOutput2, IDXGIOutput3, IDXGIOutput4, IDXGIOutput5);
 impl ::core::clone::Clone for IDXGIOutput6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6369,36 +4423,7 @@ impl IDXGIOutputDuplication {
         (::windows::core::Vtable::vtable(self).ReleaseFrame)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDXGIOutputDuplication> for ::windows::core::IUnknown {
-    fn from(value: IDXGIOutputDuplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutputDuplication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIOutputDuplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutputDuplication> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIOutputDuplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIOutputDuplication> for IDXGIObject {
-    fn from(value: IDXGIOutputDuplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIOutputDuplication> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIOutputDuplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIOutputDuplication> for IDXGIObject {
-    fn from(value: &IDXGIOutputDuplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIOutputDuplication, ::windows::core::IUnknown, IDXGIObject);
 impl ::core::clone::Clone for IDXGIOutputDuplication {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6497,51 +4522,7 @@ impl IDXGIResource {
         (::windows::core::Vtable::vtable(self).GetEvictionPriority)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDXGIResource> for ::windows::core::IUnknown {
-    fn from(value: IDXGIResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIResource> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIResource> for IDXGIObject {
-    fn from(value: IDXGIResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIResource> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIResource> for IDXGIObject {
-    fn from(value: &IDXGIResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIResource> for IDXGIDeviceSubObject {
-    fn from(value: IDXGIResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIResource> for &'a IDXGIDeviceSubObject {
-    fn from(value: &'a IDXGIResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIResource> for IDXGIDeviceSubObject {
-    fn from(value: &IDXGIResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIResource, ::windows::core::IUnknown, IDXGIObject, IDXGIDeviceSubObject);
 impl ::core::clone::Clone for IDXGIResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6637,66 +4618,7 @@ impl IDXGIResource1 {
         (::windows::core::Vtable::vtable(self).CreateSharedHandle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pattributes.unwrap_or(::std::ptr::null())), dwaccess, lpname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::HANDLE>(result__)
     }
 }
-impl ::core::convert::From<IDXGIResource1> for ::windows::core::IUnknown {
-    fn from(value: IDXGIResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIResource1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGIResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIResource1> for ::windows::core::IUnknown {
-    fn from(value: &IDXGIResource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIResource1> for IDXGIObject {
-    fn from(value: IDXGIResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIResource1> for &'a IDXGIObject {
-    fn from(value: &'a IDXGIResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIResource1> for IDXGIObject {
-    fn from(value: &IDXGIResource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIResource1> for IDXGIDeviceSubObject {
-    fn from(value: IDXGIResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIResource1> for &'a IDXGIDeviceSubObject {
-    fn from(value: &'a IDXGIResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIResource1> for IDXGIDeviceSubObject {
-    fn from(value: &IDXGIResource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGIResource1> for IDXGIResource {
-    fn from(value: IDXGIResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGIResource1> for &'a IDXGIResource {
-    fn from(value: &'a IDXGIResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGIResource1> for IDXGIResource {
-    fn from(value: &IDXGIResource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGIResource1, ::windows::core::IUnknown, IDXGIObject, IDXGIDeviceSubObject, IDXGIResource);
 impl ::core::clone::Clone for IDXGIResource1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6772,51 +4694,7 @@ impl IDXGISurface {
         (::windows::core::Vtable::vtable(self).Unmap)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDXGISurface> for ::windows::core::IUnknown {
-    fn from(value: IDXGISurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGISurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface> for ::windows::core::IUnknown {
-    fn from(value: &IDXGISurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISurface> for IDXGIObject {
-    fn from(value: IDXGISurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface> for &'a IDXGIObject {
-    fn from(value: &'a IDXGISurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface> for IDXGIObject {
-    fn from(value: &IDXGISurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISurface> for IDXGIDeviceSubObject {
-    fn from(value: IDXGISurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface> for &'a IDXGIDeviceSubObject {
-    fn from(value: &'a IDXGISurface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface> for IDXGIDeviceSubObject {
-    fn from(value: &IDXGISurface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGISurface, ::windows::core::IUnknown, IDXGIObject, IDXGIDeviceSubObject);
 impl ::core::clone::Clone for IDXGISurface {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6907,66 +4785,7 @@ impl IDXGISurface1 {
         (::windows::core::Vtable::vtable(self).ReleaseDC)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdirtyrect.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IDXGISurface1> for ::windows::core::IUnknown {
-    fn from(value: IDXGISurface1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGISurface1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface1> for ::windows::core::IUnknown {
-    fn from(value: &IDXGISurface1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISurface1> for IDXGIObject {
-    fn from(value: IDXGISurface1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface1> for &'a IDXGIObject {
-    fn from(value: &'a IDXGISurface1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface1> for IDXGIObject {
-    fn from(value: &IDXGISurface1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISurface1> for IDXGIDeviceSubObject {
-    fn from(value: IDXGISurface1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface1> for &'a IDXGIDeviceSubObject {
-    fn from(value: &'a IDXGISurface1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface1> for IDXGIDeviceSubObject {
-    fn from(value: &IDXGISurface1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISurface1> for IDXGISurface {
-    fn from(value: IDXGISurface1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface1> for &'a IDXGISurface {
-    fn from(value: &'a IDXGISurface1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface1> for IDXGISurface {
-    fn from(value: &IDXGISurface1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGISurface1, ::windows::core::IUnknown, IDXGIObject, IDXGIDeviceSubObject, IDXGISurface);
 impl ::core::clone::Clone for IDXGISurface1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7066,81 +4885,7 @@ impl IDXGISurface2 {
         (::windows::core::Vtable::vtable(self).GetResource)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _, ::core::mem::transmute(psubresourceindex)).and_some(result__)
     }
 }
-impl ::core::convert::From<IDXGISurface2> for ::windows::core::IUnknown {
-    fn from(value: IDXGISurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGISurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface2> for ::windows::core::IUnknown {
-    fn from(value: &IDXGISurface2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISurface2> for IDXGIObject {
-    fn from(value: IDXGISurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface2> for &'a IDXGIObject {
-    fn from(value: &'a IDXGISurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface2> for IDXGIObject {
-    fn from(value: &IDXGISurface2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISurface2> for IDXGIDeviceSubObject {
-    fn from(value: IDXGISurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface2> for &'a IDXGIDeviceSubObject {
-    fn from(value: &'a IDXGISurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface2> for IDXGIDeviceSubObject {
-    fn from(value: &IDXGISurface2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISurface2> for IDXGISurface {
-    fn from(value: IDXGISurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface2> for &'a IDXGISurface {
-    fn from(value: &'a IDXGISurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface2> for IDXGISurface {
-    fn from(value: &IDXGISurface2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISurface2> for IDXGISurface1 {
-    fn from(value: IDXGISurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISurface2> for &'a IDXGISurface1 {
-    fn from(value: &'a IDXGISurface2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISurface2> for IDXGISurface1 {
-    fn from(value: &IDXGISurface2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGISurface2, ::windows::core::IUnknown, IDXGIObject, IDXGIDeviceSubObject, IDXGISurface, IDXGISurface1);
 impl ::core::clone::Clone for IDXGISurface2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7252,51 +4997,7 @@ impl IDXGISwapChain {
         (::windows::core::Vtable::vtable(self).GetLastPresentCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDXGISwapChain> for ::windows::core::IUnknown {
-    fn from(value: IDXGISwapChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGISwapChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain> for ::windows::core::IUnknown {
-    fn from(value: &IDXGISwapChain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain> for IDXGIObject {
-    fn from(value: IDXGISwapChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain> for &'a IDXGIObject {
-    fn from(value: &'a IDXGISwapChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain> for IDXGIObject {
-    fn from(value: &IDXGISwapChain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain> for IDXGIDeviceSubObject {
-    fn from(value: IDXGISwapChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain> for &'a IDXGIDeviceSubObject {
-    fn from(value: &'a IDXGISwapChain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain> for IDXGIDeviceSubObject {
-    fn from(value: &IDXGISwapChain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGISwapChain, ::windows::core::IUnknown, IDXGIObject, IDXGIDeviceSubObject);
 impl ::core::clone::Clone for IDXGISwapChain {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7489,66 +5190,7 @@ impl IDXGISwapChain1 {
         (::windows::core::Vtable::vtable(self).GetRotation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<Common::DXGI_MODE_ROTATION>(result__)
     }
 }
-impl ::core::convert::From<IDXGISwapChain1> for ::windows::core::IUnknown {
-    fn from(value: IDXGISwapChain1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGISwapChain1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain1> for ::windows::core::IUnknown {
-    fn from(value: &IDXGISwapChain1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain1> for IDXGIObject {
-    fn from(value: IDXGISwapChain1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain1> for &'a IDXGIObject {
-    fn from(value: &'a IDXGISwapChain1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain1> for IDXGIObject {
-    fn from(value: &IDXGISwapChain1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain1> for IDXGIDeviceSubObject {
-    fn from(value: IDXGISwapChain1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain1> for &'a IDXGIDeviceSubObject {
-    fn from(value: &'a IDXGISwapChain1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain1> for IDXGIDeviceSubObject {
-    fn from(value: &IDXGISwapChain1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain1> for IDXGISwapChain {
-    fn from(value: IDXGISwapChain1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain1> for &'a IDXGISwapChain {
-    fn from(value: &'a IDXGISwapChain1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain1> for IDXGISwapChain {
-    fn from(value: &IDXGISwapChain1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGISwapChain1, ::windows::core::IUnknown, IDXGIObject, IDXGIDeviceSubObject, IDXGISwapChain);
 impl ::core::clone::Clone for IDXGISwapChain1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7773,81 +5415,7 @@ impl IDXGISwapChain2 {
         (::windows::core::Vtable::vtable(self).GetMatrixTransform)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DXGI_MATRIX_3X2_F>(result__)
     }
 }
-impl ::core::convert::From<IDXGISwapChain2> for ::windows::core::IUnknown {
-    fn from(value: IDXGISwapChain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGISwapChain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain2> for ::windows::core::IUnknown {
-    fn from(value: &IDXGISwapChain2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain2> for IDXGIObject {
-    fn from(value: IDXGISwapChain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain2> for &'a IDXGIObject {
-    fn from(value: &'a IDXGISwapChain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain2> for IDXGIObject {
-    fn from(value: &IDXGISwapChain2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain2> for IDXGIDeviceSubObject {
-    fn from(value: IDXGISwapChain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain2> for &'a IDXGIDeviceSubObject {
-    fn from(value: &'a IDXGISwapChain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain2> for IDXGIDeviceSubObject {
-    fn from(value: &IDXGISwapChain2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain2> for IDXGISwapChain {
-    fn from(value: IDXGISwapChain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain2> for &'a IDXGISwapChain {
-    fn from(value: &'a IDXGISwapChain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain2> for IDXGISwapChain {
-    fn from(value: &IDXGISwapChain2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain2> for IDXGISwapChain1 {
-    fn from(value: IDXGISwapChain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain2> for &'a IDXGISwapChain1 {
-    fn from(value: &'a IDXGISwapChain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain2> for IDXGISwapChain1 {
-    fn from(value: &IDXGISwapChain2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGISwapChain2, ::windows::core::IUnknown, IDXGIObject, IDXGIDeviceSubObject, IDXGISwapChain, IDXGISwapChain1);
 impl ::core::clone::Clone for IDXGISwapChain2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8069,96 +5637,7 @@ impl IDXGISwapChain3 {
         (::windows::core::Vtable::vtable(self).ResizeBuffers1)(::windows::core::Vtable::as_raw(self), buffercount, width, height, format, swapchainflags, ::core::mem::transmute(pcreationnodemask), ::core::mem::transmute(pppresentqueue)).ok()
     }
 }
-impl ::core::convert::From<IDXGISwapChain3> for ::windows::core::IUnknown {
-    fn from(value: IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain3> for ::windows::core::IUnknown {
-    fn from(value: &IDXGISwapChain3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain3> for IDXGIObject {
-    fn from(value: IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain3> for &'a IDXGIObject {
-    fn from(value: &'a IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain3> for IDXGIObject {
-    fn from(value: &IDXGISwapChain3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain3> for IDXGIDeviceSubObject {
-    fn from(value: IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain3> for &'a IDXGIDeviceSubObject {
-    fn from(value: &'a IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain3> for IDXGIDeviceSubObject {
-    fn from(value: &IDXGISwapChain3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain3> for IDXGISwapChain {
-    fn from(value: IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain3> for &'a IDXGISwapChain {
-    fn from(value: &'a IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain3> for IDXGISwapChain {
-    fn from(value: &IDXGISwapChain3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain3> for IDXGISwapChain1 {
-    fn from(value: IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain3> for &'a IDXGISwapChain1 {
-    fn from(value: &'a IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain3> for IDXGISwapChain1 {
-    fn from(value: &IDXGISwapChain3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain3> for IDXGISwapChain2 {
-    fn from(value: IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain3> for &'a IDXGISwapChain2 {
-    fn from(value: &'a IDXGISwapChain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain3> for IDXGISwapChain2 {
-    fn from(value: &IDXGISwapChain3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGISwapChain3, ::windows::core::IUnknown, IDXGIObject, IDXGIDeviceSubObject, IDXGISwapChain, IDXGISwapChain1, IDXGISwapChain2);
 impl ::core::clone::Clone for IDXGISwapChain3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8386,111 +5865,7 @@ impl IDXGISwapChain4 {
         (::windows::core::Vtable::vtable(self).SetHDRMetaData)(::windows::core::Vtable::as_raw(self), r#type, pmetadata.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(pmetadata.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr()))).ok()
     }
 }
-impl ::core::convert::From<IDXGISwapChain4> for ::windows::core::IUnknown {
-    fn from(value: IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain4> for ::windows::core::IUnknown {
-    fn from(value: &IDXGISwapChain4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain4> for IDXGIObject {
-    fn from(value: IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain4> for &'a IDXGIObject {
-    fn from(value: &'a IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain4> for IDXGIObject {
-    fn from(value: &IDXGISwapChain4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain4> for IDXGIDeviceSubObject {
-    fn from(value: IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain4> for &'a IDXGIDeviceSubObject {
-    fn from(value: &'a IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain4> for IDXGIDeviceSubObject {
-    fn from(value: &IDXGISwapChain4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain4> for IDXGISwapChain {
-    fn from(value: IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain4> for &'a IDXGISwapChain {
-    fn from(value: &'a IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain4> for IDXGISwapChain {
-    fn from(value: &IDXGISwapChain4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain4> for IDXGISwapChain1 {
-    fn from(value: IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain4> for &'a IDXGISwapChain1 {
-    fn from(value: &'a IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain4> for IDXGISwapChain1 {
-    fn from(value: &IDXGISwapChain4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain4> for IDXGISwapChain2 {
-    fn from(value: IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain4> for &'a IDXGISwapChain2 {
-    fn from(value: &'a IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain4> for IDXGISwapChain2 {
-    fn from(value: &IDXGISwapChain4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDXGISwapChain4> for IDXGISwapChain3 {
-    fn from(value: IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChain4> for &'a IDXGISwapChain3 {
-    fn from(value: &'a IDXGISwapChain4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChain4> for IDXGISwapChain3 {
-    fn from(value: &IDXGISwapChain4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGISwapChain4, ::windows::core::IUnknown, IDXGIObject, IDXGIDeviceSubObject, IDXGISwapChain, IDXGISwapChain1, IDXGISwapChain2, IDXGISwapChain3);
 impl ::core::clone::Clone for IDXGISwapChain4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8534,21 +5909,7 @@ impl IDXGISwapChainMedia {
         (::windows::core::Vtable::vtable(self).CheckPresentDurationSupport)(::windows::core::Vtable::as_raw(self), desiredpresentduration, ::core::mem::transmute(pclosestsmallerpresentduration), ::core::mem::transmute(pclosestlargerpresentduration)).ok()
     }
 }
-impl ::core::convert::From<IDXGISwapChainMedia> for ::windows::core::IUnknown {
-    fn from(value: IDXGISwapChainMedia) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGISwapChainMedia> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGISwapChainMedia) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGISwapChainMedia> for ::windows::core::IUnknown {
-    fn from(value: &IDXGISwapChainMedia) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGISwapChainMedia, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXGISwapChainMedia {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8590,21 +5951,7 @@ impl IDXGraphicsAnalysis {
         (::windows::core::Vtable::vtable(self).EndCapture)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDXGraphicsAnalysis> for ::windows::core::IUnknown {
-    fn from(value: IDXGraphicsAnalysis) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXGraphicsAnalysis> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXGraphicsAnalysis) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXGraphicsAnalysis> for ::windows::core::IUnknown {
-    fn from(value: &IDXGraphicsAnalysis) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXGraphicsAnalysis, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXGraphicsAnalysis {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/mod.rs
@@ -30,21 +30,7 @@ impl IWICImageEncoder {
         (::windows::core::Vtable::vtable(self).WriteThumbnail)(::windows::core::Vtable::as_raw(self), pimage.into().abi(), pencoder.into().abi(), ::core::mem::transmute(pimageparameters)).ok()
     }
 }
-impl ::core::convert::From<IWICImageEncoder> for ::windows::core::IUnknown {
-    fn from(value: IWICImageEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICImageEncoder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICImageEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICImageEncoder> for ::windows::core::IUnknown {
-    fn from(value: &IWICImageEncoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICImageEncoder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICImageEncoder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -236,36 +222,7 @@ impl IWICImagingFactory2 {
         (::windows::core::Vtable::vtable(self).CreateImageEncoder)(::windows::core::Vtable::as_raw(self), pd2ddevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICImageEncoder>(result__)
     }
 }
-impl ::core::convert::From<IWICImagingFactory2> for ::windows::core::IUnknown {
-    fn from(value: IWICImagingFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICImagingFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICImagingFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICImagingFactory2> for ::windows::core::IUnknown {
-    fn from(value: &IWICImagingFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICImagingFactory2> for super::IWICImagingFactory {
-    fn from(value: IWICImagingFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICImagingFactory2> for &'a super::IWICImagingFactory {
-    fn from(value: &'a IWICImagingFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICImagingFactory2> for super::IWICImagingFactory {
-    fn from(value: &IWICImagingFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICImagingFactory2, ::windows::core::IUnknown, super::IWICImagingFactory);
 impl ::core::clone::Clone for IWICImagingFactory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
@@ -153,36 +153,7 @@ impl IWICBitmap {
         (::windows::core::Vtable::vtable(self).SetResolution)(::windows::core::Vtable::as_raw(self), dpix, dpiy).ok()
     }
 }
-impl ::core::convert::From<IWICBitmap> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmap> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICBitmap> for IWICBitmapSource {
-    fn from(value: IWICBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmap> for &'a IWICBitmapSource {
-    fn from(value: &'a IWICBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmap> for IWICBitmapSource {
-    fn from(value: &IWICBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmap, ::windows::core::IUnknown, IWICBitmapSource);
 impl ::core::clone::Clone for IWICBitmap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -243,36 +214,7 @@ impl IWICBitmapClipper {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pisource.into().abi(), ::core::mem::transmute(prc)).ok()
     }
 }
-impl ::core::convert::From<IWICBitmapClipper> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapClipper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapClipper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapClipper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapClipper> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapClipper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICBitmapClipper> for IWICBitmapSource {
-    fn from(value: IWICBitmapClipper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapClipper> for &'a IWICBitmapSource {
-    fn from(value: &'a IWICBitmapClipper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapClipper> for IWICBitmapSource {
-    fn from(value: &IWICBitmapClipper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapClipper, ::windows::core::IUnknown, IWICBitmapSource);
 impl ::core::clone::Clone for IWICBitmapClipper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -389,36 +331,7 @@ impl IWICBitmapCodecInfo {
         (::windows::core::Vtable::vtable(self).MatchesMimeType)(::windows::core::Vtable::as_raw(self), wzmimetype.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWICBitmapCodecInfo> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapCodecInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapCodecInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapCodecInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapCodecInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapCodecInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICBitmapCodecInfo> for IWICComponentInfo {
-    fn from(value: IWICBitmapCodecInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapCodecInfo> for &'a IWICComponentInfo {
-    fn from(value: &'a IWICBitmapCodecInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapCodecInfo> for IWICComponentInfo {
-    fn from(value: &IWICBitmapCodecInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapCodecInfo, ::windows::core::IUnknown, IWICComponentInfo);
 impl ::core::clone::Clone for IWICBitmapCodecInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -481,21 +394,7 @@ impl IWICBitmapCodecProgressNotification {
         (::windows::core::Vtable::vtable(self).RegisterProgressNotification)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfnprogressnotification), ::core::mem::transmute(pvdata.unwrap_or(::std::ptr::null())), dwprogressflags).ok()
     }
 }
-impl ::core::convert::From<IWICBitmapCodecProgressNotification> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapCodecProgressNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapCodecProgressNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapCodecProgressNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapCodecProgressNotification> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapCodecProgressNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapCodecProgressNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICBitmapCodecProgressNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -583,21 +482,7 @@ impl IWICBitmapDecoder {
         (::windows::core::Vtable::vtable(self).GetFrame)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICBitmapFrameDecode>(result__)
     }
 }
-impl ::core::convert::From<IWICBitmapDecoder> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapDecoder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapDecoder> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapDecoder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICBitmapDecoder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -748,51 +633,7 @@ impl IWICBitmapDecoderInfo {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICBitmapDecoder>(result__)
     }
 }
-impl ::core::convert::From<IWICBitmapDecoderInfo> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapDecoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapDecoderInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapDecoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapDecoderInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapDecoderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICBitmapDecoderInfo> for IWICComponentInfo {
-    fn from(value: IWICBitmapDecoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapDecoderInfo> for &'a IWICComponentInfo {
-    fn from(value: &'a IWICBitmapDecoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapDecoderInfo> for IWICComponentInfo {
-    fn from(value: &IWICBitmapDecoderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICBitmapDecoderInfo> for IWICBitmapCodecInfo {
-    fn from(value: IWICBitmapDecoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapDecoderInfo> for &'a IWICBitmapCodecInfo {
-    fn from(value: &'a IWICBitmapDecoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapDecoderInfo> for IWICBitmapCodecInfo {
-    fn from(value: &IWICBitmapDecoderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapDecoderInfo, ::windows::core::IUnknown, IWICComponentInfo, IWICBitmapCodecInfo);
 impl ::core::clone::Clone for IWICBitmapDecoderInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -883,21 +724,7 @@ impl IWICBitmapEncoder {
         (::windows::core::Vtable::vtable(self).GetMetadataQueryWriter)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICMetadataQueryWriter>(result__)
     }
 }
-impl ::core::convert::From<IWICBitmapEncoder> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapEncoder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapEncoder> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapEncoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapEncoder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICBitmapEncoder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1033,51 +860,7 @@ impl IWICBitmapEncoderInfo {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICBitmapEncoder>(result__)
     }
 }
-impl ::core::convert::From<IWICBitmapEncoderInfo> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapEncoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapEncoderInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapEncoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapEncoderInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapEncoderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICBitmapEncoderInfo> for IWICComponentInfo {
-    fn from(value: IWICBitmapEncoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapEncoderInfo> for &'a IWICComponentInfo {
-    fn from(value: &'a IWICBitmapEncoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapEncoderInfo> for IWICComponentInfo {
-    fn from(value: &IWICBitmapEncoderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICBitmapEncoderInfo> for IWICBitmapCodecInfo {
-    fn from(value: IWICBitmapEncoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapEncoderInfo> for &'a IWICBitmapCodecInfo {
-    fn from(value: &'a IWICBitmapEncoderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapEncoderInfo> for IWICBitmapCodecInfo {
-    fn from(value: &IWICBitmapEncoderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapEncoderInfo, ::windows::core::IUnknown, IWICComponentInfo, IWICBitmapCodecInfo);
 impl ::core::clone::Clone for IWICBitmapEncoderInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1136,36 +919,7 @@ impl IWICBitmapFlipRotator {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pisource.into().abi(), options).ok()
     }
 }
-impl ::core::convert::From<IWICBitmapFlipRotator> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapFlipRotator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapFlipRotator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapFlipRotator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapFlipRotator> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapFlipRotator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICBitmapFlipRotator> for IWICBitmapSource {
-    fn from(value: IWICBitmapFlipRotator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapFlipRotator> for &'a IWICBitmapSource {
-    fn from(value: &'a IWICBitmapFlipRotator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapFlipRotator> for IWICBitmapSource {
-    fn from(value: &IWICBitmapFlipRotator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapFlipRotator, ::windows::core::IUnknown, IWICBitmapSource);
 impl ::core::clone::Clone for IWICBitmapFlipRotator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1229,36 +983,7 @@ impl IWICBitmapFrameDecode {
         (::windows::core::Vtable::vtable(self).GetThumbnail)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICBitmapSource>(result__)
     }
 }
-impl ::core::convert::From<IWICBitmapFrameDecode> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapFrameDecode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapFrameDecode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapFrameDecode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapFrameDecode> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapFrameDecode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICBitmapFrameDecode> for IWICBitmapSource {
-    fn from(value: IWICBitmapFrameDecode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapFrameDecode> for &'a IWICBitmapSource {
-    fn from(value: &'a IWICBitmapFrameDecode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapFrameDecode> for IWICBitmapSource {
-    fn from(value: &IWICBitmapFrameDecode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapFrameDecode, ::windows::core::IUnknown, IWICBitmapSource);
 impl ::core::clone::Clone for IWICBitmapFrameDecode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1342,21 +1067,7 @@ impl IWICBitmapFrameEncode {
         (::windows::core::Vtable::vtable(self).GetMetadataQueryWriter)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICMetadataQueryWriter>(result__)
     }
 }
-impl ::core::convert::From<IWICBitmapFrameEncode> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapFrameEncode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapFrameEncode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapFrameEncode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapFrameEncode> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapFrameEncode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapFrameEncode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICBitmapFrameEncode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1417,21 +1128,7 @@ impl IWICBitmapLock {
         (::windows::core::Vtable::vtable(self).GetPixelFormat)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IWICBitmapLock> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapLock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapLock> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapLock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapLock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICBitmapLock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1493,36 +1190,7 @@ impl IWICBitmapScaler {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pisource.into().abi(), uiwidth, uiheight, mode).ok()
     }
 }
-impl ::core::convert::From<IWICBitmapScaler> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapScaler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapScaler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapScaler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapScaler> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapScaler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICBitmapScaler> for IWICBitmapSource {
-    fn from(value: IWICBitmapScaler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapScaler> for &'a IWICBitmapSource {
-    fn from(value: &'a IWICBitmapScaler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapScaler> for IWICBitmapSource {
-    fn from(value: &IWICBitmapScaler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapScaler, ::windows::core::IUnknown, IWICBitmapSource);
 impl ::core::clone::Clone for IWICBitmapScaler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1575,21 +1243,7 @@ impl IWICBitmapSource {
         (::windows::core::Vtable::vtable(self).CopyPixels)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prc), cbstride, pbbuffer.len() as _, ::core::mem::transmute(pbbuffer.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IWICBitmapSource> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapSource> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICBitmapSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1642,21 +1296,7 @@ impl IWICBitmapSourceTransform {
         (::windows::core::Vtable::vtable(self).DoesSupportTransform)(::windows::core::Vtable::as_raw(self), dsttransform, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWICBitmapSourceTransform> for ::windows::core::IUnknown {
-    fn from(value: IWICBitmapSourceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICBitmapSourceTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICBitmapSourceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICBitmapSourceTransform> for ::windows::core::IUnknown {
-    fn from(value: &IWICBitmapSourceTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICBitmapSourceTransform, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICBitmapSourceTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1719,21 +1359,7 @@ impl IWICColorContext {
         (::windows::core::Vtable::vtable(self).GetExifColorSpace)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IWICColorContext> for ::windows::core::IUnknown {
-    fn from(value: IWICColorContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICColorContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICColorContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICColorContext> for ::windows::core::IUnknown {
-    fn from(value: &IWICColorContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICColorContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICColorContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1799,36 +1425,7 @@ impl IWICColorTransform {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pibitmapsource.into().abi(), picontextsource.into().abi(), picontextdest.into().abi(), ::core::mem::transmute(pixelfmtdest)).ok()
     }
 }
-impl ::core::convert::From<IWICColorTransform> for ::windows::core::IUnknown {
-    fn from(value: IWICColorTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICColorTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICColorTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICColorTransform> for ::windows::core::IUnknown {
-    fn from(value: &IWICColorTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICColorTransform> for IWICBitmapSource {
-    fn from(value: IWICColorTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICColorTransform> for &'a IWICBitmapSource {
-    fn from(value: &'a IWICColorTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICColorTransform> for IWICBitmapSource {
-    fn from(value: &IWICColorTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICColorTransform, ::windows::core::IUnknown, IWICBitmapSource);
 impl ::core::clone::Clone for IWICColorTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2049,36 +1646,7 @@ impl IWICComponentFactory {
         (::windows::core::Vtable::vtable(self).CreateEncoderPropertyBag)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppropoptions.as_ptr()), ppropoptions.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::StructuredStorage::IPropertyBag2>(result__)
     }
 }
-impl ::core::convert::From<IWICComponentFactory> for ::windows::core::IUnknown {
-    fn from(value: IWICComponentFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICComponentFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICComponentFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICComponentFactory> for ::windows::core::IUnknown {
-    fn from(value: &IWICComponentFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICComponentFactory> for IWICImagingFactory {
-    fn from(value: IWICComponentFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICComponentFactory> for &'a IWICImagingFactory {
-    fn from(value: &'a IWICComponentFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICComponentFactory> for IWICImagingFactory {
-    fn from(value: &IWICComponentFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICComponentFactory, ::windows::core::IUnknown, IWICImagingFactory);
 impl ::core::clone::Clone for IWICComponentFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2155,21 +1723,7 @@ impl IWICComponentInfo {
         (::windows::core::Vtable::vtable(self).GetFriendlyName)(::windows::core::Vtable::as_raw(self), wzfriendlyname.len() as _, ::core::mem::transmute(wzfriendlyname.as_ptr()), ::core::mem::transmute(pcchactual)).ok()
     }
 }
-impl ::core::convert::From<IWICComponentInfo> for ::windows::core::IUnknown {
-    fn from(value: IWICComponentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICComponentInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICComponentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICComponentInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWICComponentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICComponentInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICComponentInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2220,21 +1774,7 @@ impl IWICDdsDecoder {
         (::windows::core::Vtable::vtable(self).GetFrame)(::windows::core::Vtable::as_raw(self), arrayindex, miplevel, sliceindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICBitmapFrameDecode>(result__)
     }
 }
-impl ::core::convert::From<IWICDdsDecoder> for ::windows::core::IUnknown {
-    fn from(value: IWICDdsDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICDdsDecoder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICDdsDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICDdsDecoder> for ::windows::core::IUnknown {
-    fn from(value: &IWICDdsDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICDdsDecoder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICDdsDecoder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2286,21 +1826,7 @@ impl IWICDdsEncoder {
         (::windows::core::Vtable::vtable(self).CreateNewFrame)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppiframeencode), ::core::mem::transmute(parrayindex), ::core::mem::transmute(pmiplevel), ::core::mem::transmute(psliceindex)).ok()
     }
 }
-impl ::core::convert::From<IWICDdsEncoder> for ::windows::core::IUnknown {
-    fn from(value: IWICDdsEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICDdsEncoder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICDdsEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICDdsEncoder> for ::windows::core::IUnknown {
-    fn from(value: &IWICDdsEncoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICDdsEncoder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICDdsEncoder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2354,21 +1880,7 @@ impl IWICDdsFrameDecode {
         (::windows::core::Vtable::vtable(self).CopyBlocks)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prcboundsinblocks), cbstride, pbbuffer.len() as _, ::core::mem::transmute(pbbuffer.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IWICDdsFrameDecode> for ::windows::core::IUnknown {
-    fn from(value: IWICDdsFrameDecode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICDdsFrameDecode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICDdsFrameDecode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICDdsFrameDecode> for ::windows::core::IUnknown {
-    fn from(value: &IWICDdsFrameDecode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICDdsFrameDecode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICDdsFrameDecode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2553,51 +2065,7 @@ impl IWICDevelopRaw {
         (::windows::core::Vtable::vtable(self).SetNotificationCallback)(::windows::core::Vtable::as_raw(self), pcallback.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWICDevelopRaw> for ::windows::core::IUnknown {
-    fn from(value: IWICDevelopRaw) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICDevelopRaw> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICDevelopRaw) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICDevelopRaw> for ::windows::core::IUnknown {
-    fn from(value: &IWICDevelopRaw) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICDevelopRaw> for IWICBitmapSource {
-    fn from(value: IWICDevelopRaw) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICDevelopRaw> for &'a IWICBitmapSource {
-    fn from(value: &'a IWICDevelopRaw) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICDevelopRaw> for IWICBitmapSource {
-    fn from(value: &IWICDevelopRaw) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICDevelopRaw> for IWICBitmapFrameDecode {
-    fn from(value: IWICDevelopRaw) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICDevelopRaw> for &'a IWICBitmapFrameDecode {
-    fn from(value: &'a IWICDevelopRaw) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICDevelopRaw> for IWICBitmapFrameDecode {
-    fn from(value: &IWICDevelopRaw) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICDevelopRaw, ::windows::core::IUnknown, IWICBitmapSource, IWICBitmapFrameDecode);
 impl ::core::clone::Clone for IWICDevelopRaw {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2668,21 +2136,7 @@ impl IWICDevelopRawNotificationCallback {
         (::windows::core::Vtable::vtable(self).Notify)(::windows::core::Vtable::as_raw(self), notificationmask).ok()
     }
 }
-impl ::core::convert::From<IWICDevelopRawNotificationCallback> for ::windows::core::IUnknown {
-    fn from(value: IWICDevelopRawNotificationCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICDevelopRawNotificationCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICDevelopRawNotificationCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICDevelopRawNotificationCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWICDevelopRawNotificationCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICDevelopRawNotificationCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICDevelopRawNotificationCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2731,21 +2185,7 @@ impl IWICEnumMetadataItem {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICEnumMetadataItem>(result__)
     }
 }
-impl ::core::convert::From<IWICEnumMetadataItem> for ::windows::core::IUnknown {
-    fn from(value: IWICEnumMetadataItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICEnumMetadataItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICEnumMetadataItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICEnumMetadataItem> for ::windows::core::IUnknown {
-    fn from(value: &IWICEnumMetadataItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICEnumMetadataItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICEnumMetadataItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2792,21 +2232,7 @@ impl IWICFastMetadataEncoder {
         (::windows::core::Vtable::vtable(self).GetMetadataQueryWriter)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICMetadataQueryWriter>(result__)
     }
 }
-impl ::core::convert::From<IWICFastMetadataEncoder> for ::windows::core::IUnknown {
-    fn from(value: IWICFastMetadataEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICFastMetadataEncoder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICFastMetadataEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICFastMetadataEncoder> for ::windows::core::IUnknown {
-    fn from(value: &IWICFastMetadataEncoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICFastMetadataEncoder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICFastMetadataEncoder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2873,36 +2299,7 @@ impl IWICFormatConverter {
         (::windows::core::Vtable::vtable(self).CanConvert)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(srcpixelformat), ::core::mem::transmute(dstpixelformat), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWICFormatConverter> for ::windows::core::IUnknown {
-    fn from(value: IWICFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICFormatConverter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICFormatConverter> for ::windows::core::IUnknown {
-    fn from(value: &IWICFormatConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICFormatConverter> for IWICBitmapSource {
-    fn from(value: IWICFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICFormatConverter> for &'a IWICBitmapSource {
-    fn from(value: &'a IWICFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICFormatConverter> for IWICBitmapSource {
-    fn from(value: &IWICFormatConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICFormatConverter, ::windows::core::IUnknown, IWICBitmapSource);
 impl ::core::clone::Clone for IWICFormatConverter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2975,36 +2372,7 @@ impl IWICFormatConverterInfo {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICFormatConverter>(result__)
     }
 }
-impl ::core::convert::From<IWICFormatConverterInfo> for ::windows::core::IUnknown {
-    fn from(value: IWICFormatConverterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICFormatConverterInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICFormatConverterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICFormatConverterInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWICFormatConverterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICFormatConverterInfo> for IWICComponentInfo {
-    fn from(value: IWICFormatConverterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICFormatConverterInfo> for &'a IWICComponentInfo {
-    fn from(value: &'a IWICFormatConverterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICFormatConverterInfo> for IWICComponentInfo {
-    fn from(value: &IWICFormatConverterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICFormatConverterInfo, ::windows::core::IUnknown, IWICComponentInfo);
 impl ::core::clone::Clone for IWICFormatConverterInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3177,21 +2545,7 @@ impl IWICImagingFactory {
         (::windows::core::Vtable::vtable(self).CreateQueryWriterFromReader)(::windows::core::Vtable::as_raw(self), piqueryreader.into().abi(), ::core::mem::transmute(pguidvendor), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICMetadataQueryWriter>(result__)
     }
 }
-impl ::core::convert::From<IWICImagingFactory> for ::windows::core::IUnknown {
-    fn from(value: IWICImagingFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICImagingFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICImagingFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICImagingFactory> for ::windows::core::IUnknown {
-    fn from(value: &IWICImagingFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICImagingFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICImagingFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3308,21 +2662,7 @@ impl IWICJpegFrameDecode {
         (::windows::core::Vtable::vtable(self).CopyMinimalStream)(::windows::core::Vtable::as_raw(self), streamoffset, pbstreamdata.len() as _, ::core::mem::transmute(pbstreamdata.as_ptr()), ::core::mem::transmute(pcbstreamdataactual)).ok()
     }
 }
-impl ::core::convert::From<IWICJpegFrameDecode> for ::windows::core::IUnknown {
-    fn from(value: IWICJpegFrameDecode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICJpegFrameDecode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICJpegFrameDecode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICJpegFrameDecode> for ::windows::core::IUnknown {
-    fn from(value: &IWICJpegFrameDecode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICJpegFrameDecode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICJpegFrameDecode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3398,21 +2738,7 @@ impl IWICJpegFrameEncode {
         (::windows::core::Vtable::vtable(self).WriteScan)(::windows::core::Vtable::as_raw(self), pbscandata.len() as _, ::core::mem::transmute(pbscandata.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IWICJpegFrameEncode> for ::windows::core::IUnknown {
-    fn from(value: IWICJpegFrameEncode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICJpegFrameEncode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICJpegFrameEncode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICJpegFrameEncode> for ::windows::core::IUnknown {
-    fn from(value: &IWICJpegFrameEncode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICJpegFrameEncode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICJpegFrameEncode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3476,21 +2802,7 @@ impl IWICMetadataBlockReader {
         (::windows::core::Vtable::vtable(self).GetEnumerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IEnumUnknown>(result__)
     }
 }
-impl ::core::convert::From<IWICMetadataBlockReader> for ::windows::core::IUnknown {
-    fn from(value: IWICMetadataBlockReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataBlockReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICMetadataBlockReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataBlockReader> for ::windows::core::IUnknown {
-    fn from(value: &IWICMetadataBlockReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICMetadataBlockReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICMetadataBlockReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3573,36 +2885,7 @@ impl IWICMetadataBlockWriter {
         (::windows::core::Vtable::vtable(self).RemoveWriterByIndex)(::windows::core::Vtable::as_raw(self), nindex).ok()
     }
 }
-impl ::core::convert::From<IWICMetadataBlockWriter> for ::windows::core::IUnknown {
-    fn from(value: IWICMetadataBlockWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataBlockWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICMetadataBlockWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataBlockWriter> for ::windows::core::IUnknown {
-    fn from(value: &IWICMetadataBlockWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICMetadataBlockWriter> for IWICMetadataBlockReader {
-    fn from(value: IWICMetadataBlockWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataBlockWriter> for &'a IWICMetadataBlockReader {
-    fn from(value: &'a IWICMetadataBlockWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataBlockWriter> for IWICMetadataBlockReader {
-    fn from(value: &IWICMetadataBlockWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICMetadataBlockWriter, ::windows::core::IUnknown, IWICMetadataBlockReader);
 impl ::core::clone::Clone for IWICMetadataBlockWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3699,36 +2982,7 @@ impl IWICMetadataHandlerInfo {
         (::windows::core::Vtable::vtable(self).DoesRequireFixedSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWICMetadataHandlerInfo> for ::windows::core::IUnknown {
-    fn from(value: IWICMetadataHandlerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataHandlerInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICMetadataHandlerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataHandlerInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWICMetadataHandlerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICMetadataHandlerInfo> for IWICComponentInfo {
-    fn from(value: IWICMetadataHandlerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataHandlerInfo> for &'a IWICComponentInfo {
-    fn from(value: &'a IWICMetadataHandlerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataHandlerInfo> for IWICComponentInfo {
-    fn from(value: &IWICMetadataHandlerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICMetadataHandlerInfo, ::windows::core::IUnknown, IWICComponentInfo);
 impl ::core::clone::Clone for IWICMetadataHandlerInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3798,21 +3052,7 @@ impl IWICMetadataQueryReader {
         (::windows::core::Vtable::vtable(self).GetEnumerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IEnumString>(result__)
     }
 }
-impl ::core::convert::From<IWICMetadataQueryReader> for ::windows::core::IUnknown {
-    fn from(value: IWICMetadataQueryReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataQueryReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICMetadataQueryReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataQueryReader> for ::windows::core::IUnknown {
-    fn from(value: &IWICMetadataQueryReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICMetadataQueryReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICMetadataQueryReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3890,36 +3130,7 @@ impl IWICMetadataQueryWriter {
         (::windows::core::Vtable::vtable(self).RemoveMetadataByName)(::windows::core::Vtable::as_raw(self), wzname.into()).ok()
     }
 }
-impl ::core::convert::From<IWICMetadataQueryWriter> for ::windows::core::IUnknown {
-    fn from(value: IWICMetadataQueryWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataQueryWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICMetadataQueryWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataQueryWriter> for ::windows::core::IUnknown {
-    fn from(value: &IWICMetadataQueryWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICMetadataQueryWriter> for IWICMetadataQueryReader {
-    fn from(value: IWICMetadataQueryWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataQueryWriter> for &'a IWICMetadataQueryReader {
-    fn from(value: &'a IWICMetadataQueryWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataQueryWriter> for IWICMetadataQueryReader {
-    fn from(value: &IWICMetadataQueryWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICMetadataQueryWriter, ::windows::core::IUnknown, IWICMetadataQueryReader);
 impl ::core::clone::Clone for IWICMetadataQueryWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3983,21 +3194,7 @@ impl IWICMetadataReader {
         (::windows::core::Vtable::vtable(self).GetEnumerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICEnumMetadataItem>(result__)
     }
 }
-impl ::core::convert::From<IWICMetadataReader> for ::windows::core::IUnknown {
-    fn from(value: IWICMetadataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICMetadataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataReader> for ::windows::core::IUnknown {
-    fn from(value: &IWICMetadataReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICMetadataReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICMetadataReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4117,51 +3314,7 @@ impl IWICMetadataReaderInfo {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICMetadataReader>(result__)
     }
 }
-impl ::core::convert::From<IWICMetadataReaderInfo> for ::windows::core::IUnknown {
-    fn from(value: IWICMetadataReaderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataReaderInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICMetadataReaderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataReaderInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWICMetadataReaderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICMetadataReaderInfo> for IWICComponentInfo {
-    fn from(value: IWICMetadataReaderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataReaderInfo> for &'a IWICComponentInfo {
-    fn from(value: &'a IWICMetadataReaderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataReaderInfo> for IWICComponentInfo {
-    fn from(value: &IWICMetadataReaderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICMetadataReaderInfo> for IWICMetadataHandlerInfo {
-    fn from(value: IWICMetadataReaderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataReaderInfo> for &'a IWICMetadataHandlerInfo {
-    fn from(value: &'a IWICMetadataReaderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataReaderInfo> for IWICMetadataHandlerInfo {
-    fn from(value: &IWICMetadataReaderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICMetadataReaderInfo, ::windows::core::IUnknown, IWICComponentInfo, IWICMetadataHandlerInfo);
 impl ::core::clone::Clone for IWICMetadataReaderInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4244,36 +3397,7 @@ impl IWICMetadataWriter {
         (::windows::core::Vtable::vtable(self).RemoveValueByIndex)(::windows::core::Vtable::as_raw(self), nindex).ok()
     }
 }
-impl ::core::convert::From<IWICMetadataWriter> for ::windows::core::IUnknown {
-    fn from(value: IWICMetadataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICMetadataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataWriter> for ::windows::core::IUnknown {
-    fn from(value: &IWICMetadataWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICMetadataWriter> for IWICMetadataReader {
-    fn from(value: IWICMetadataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataWriter> for &'a IWICMetadataReader {
-    fn from(value: &'a IWICMetadataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataWriter> for IWICMetadataReader {
-    fn from(value: &IWICMetadataWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICMetadataWriter, ::windows::core::IUnknown, IWICMetadataReader);
 impl ::core::clone::Clone for IWICMetadataWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4385,51 +3509,7 @@ impl IWICMetadataWriterInfo {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWICMetadataWriter>(result__)
     }
 }
-impl ::core::convert::From<IWICMetadataWriterInfo> for ::windows::core::IUnknown {
-    fn from(value: IWICMetadataWriterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataWriterInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICMetadataWriterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataWriterInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWICMetadataWriterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICMetadataWriterInfo> for IWICComponentInfo {
-    fn from(value: IWICMetadataWriterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataWriterInfo> for &'a IWICComponentInfo {
-    fn from(value: &'a IWICMetadataWriterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataWriterInfo> for IWICComponentInfo {
-    fn from(value: &IWICMetadataWriterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICMetadataWriterInfo> for IWICMetadataHandlerInfo {
-    fn from(value: IWICMetadataWriterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICMetadataWriterInfo> for &'a IWICMetadataHandlerInfo {
-    fn from(value: &'a IWICMetadataWriterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICMetadataWriterInfo> for IWICMetadataHandlerInfo {
-    fn from(value: &IWICMetadataWriterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICMetadataWriterInfo, ::windows::core::IUnknown, IWICComponentInfo, IWICMetadataHandlerInfo);
 impl ::core::clone::Clone for IWICMetadataWriterInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4519,21 +3599,7 @@ impl IWICPalette {
         (::windows::core::Vtable::vtable(self).HasAlpha)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWICPalette> for ::windows::core::IUnknown {
-    fn from(value: IWICPalette) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICPalette> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICPalette) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICPalette> for ::windows::core::IUnknown {
-    fn from(value: &IWICPalette) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICPalette, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICPalette {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4645,59 +3711,7 @@ impl IWICPersistStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWICPersistStream> for ::windows::core::IUnknown {
-    fn from(value: IWICPersistStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWICPersistStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICPersistStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWICPersistStream> for ::windows::core::IUnknown {
-    fn from(value: &IWICPersistStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWICPersistStream> for super::super::System::Com::IPersist {
-    fn from(value: IWICPersistStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWICPersistStream> for &'a super::super::System::Com::IPersist {
-    fn from(value: &'a IWICPersistStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWICPersistStream> for super::super::System::Com::IPersist {
-    fn from(value: &IWICPersistStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWICPersistStream> for super::super::System::Com::IPersistStream {
-    fn from(value: IWICPersistStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWICPersistStream> for &'a super::super::System::Com::IPersistStream {
-    fn from(value: &'a IWICPersistStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWICPersistStream> for super::super::System::Com::IPersistStream {
-    fn from(value: &IWICPersistStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICPersistStream, ::windows::core::IUnknown, super::super::System::Com::IPersist, super::super::System::Com::IPersistStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWICPersistStream {
     fn clone(&self) -> Self {
@@ -4792,36 +3806,7 @@ impl IWICPixelFormatInfo {
         (::windows::core::Vtable::vtable(self).GetChannelMask)(::windows::core::Vtable::as_raw(self), uichannelindex, pbmaskbuffer.len() as _, ::core::mem::transmute(pbmaskbuffer.as_ptr()), ::core::mem::transmute(pcbactual)).ok()
     }
 }
-impl ::core::convert::From<IWICPixelFormatInfo> for ::windows::core::IUnknown {
-    fn from(value: IWICPixelFormatInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICPixelFormatInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICPixelFormatInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICPixelFormatInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWICPixelFormatInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICPixelFormatInfo> for IWICComponentInfo {
-    fn from(value: IWICPixelFormatInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICPixelFormatInfo> for &'a IWICComponentInfo {
-    fn from(value: &'a IWICPixelFormatInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICPixelFormatInfo> for IWICComponentInfo {
-    fn from(value: &IWICPixelFormatInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICPixelFormatInfo, ::windows::core::IUnknown, IWICComponentInfo);
 impl ::core::clone::Clone for IWICPixelFormatInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4916,51 +3901,7 @@ impl IWICPixelFormatInfo2 {
         (::windows::core::Vtable::vtable(self).GetNumericRepresentation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WICPixelFormatNumericRepresentation>(result__)
     }
 }
-impl ::core::convert::From<IWICPixelFormatInfo2> for ::windows::core::IUnknown {
-    fn from(value: IWICPixelFormatInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICPixelFormatInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICPixelFormatInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICPixelFormatInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IWICPixelFormatInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICPixelFormatInfo2> for IWICComponentInfo {
-    fn from(value: IWICPixelFormatInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICPixelFormatInfo2> for &'a IWICComponentInfo {
-    fn from(value: &'a IWICPixelFormatInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICPixelFormatInfo2> for IWICComponentInfo {
-    fn from(value: &IWICPixelFormatInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICPixelFormatInfo2> for IWICPixelFormatInfo {
-    fn from(value: IWICPixelFormatInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICPixelFormatInfo2> for &'a IWICPixelFormatInfo {
-    fn from(value: &'a IWICPixelFormatInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICPixelFormatInfo2> for IWICPixelFormatInfo {
-    fn from(value: &IWICPixelFormatInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICPixelFormatInfo2, ::windows::core::IUnknown, IWICComponentInfo, IWICPixelFormatInfo);
 impl ::core::clone::Clone for IWICPixelFormatInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5004,21 +3945,7 @@ impl IWICPlanarBitmapFrameEncode {
         (::windows::core::Vtable::vtable(self).WriteSource)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppplanes.as_ptr()), ppplanes.len() as _, ::core::mem::transmute(prcsource)).ok()
     }
 }
-impl ::core::convert::From<IWICPlanarBitmapFrameEncode> for ::windows::core::IUnknown {
-    fn from(value: IWICPlanarBitmapFrameEncode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICPlanarBitmapFrameEncode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICPlanarBitmapFrameEncode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICPlanarBitmapFrameEncode> for ::windows::core::IUnknown {
-    fn from(value: &IWICPlanarBitmapFrameEncode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICPlanarBitmapFrameEncode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICPlanarBitmapFrameEncode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5061,21 +3988,7 @@ impl IWICPlanarBitmapSourceTransform {
         (::windows::core::Vtable::vtable(self).CopyPixels)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prcsource), uiwidth, uiheight, dsttransform, dstplanaroptions, ::core::mem::transmute(pdstplanes.as_ptr()), pdstplanes.len() as _).ok()
     }
 }
-impl ::core::convert::From<IWICPlanarBitmapSourceTransform> for ::windows::core::IUnknown {
-    fn from(value: IWICPlanarBitmapSourceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICPlanarBitmapSourceTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICPlanarBitmapSourceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICPlanarBitmapSourceTransform> for ::windows::core::IUnknown {
-    fn from(value: &IWICPlanarBitmapSourceTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICPlanarBitmapSourceTransform, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICPlanarBitmapSourceTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5144,36 +4057,7 @@ impl IWICPlanarFormatConverter {
         (::windows::core::Vtable::vtable(self).CanConvert)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(psrcpixelformats.as_ptr()), psrcpixelformats.len() as _, ::core::mem::transmute(dstpixelformat), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWICPlanarFormatConverter> for ::windows::core::IUnknown {
-    fn from(value: IWICPlanarFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICPlanarFormatConverter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICPlanarFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICPlanarFormatConverter> for ::windows::core::IUnknown {
-    fn from(value: &IWICPlanarFormatConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWICPlanarFormatConverter> for IWICBitmapSource {
-    fn from(value: IWICPlanarFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICPlanarFormatConverter> for &'a IWICBitmapSource {
-    fn from(value: &'a IWICPlanarFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICPlanarFormatConverter> for IWICBitmapSource {
-    fn from(value: &IWICPlanarFormatConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICPlanarFormatConverter, ::windows::core::IUnknown, IWICBitmapSource);
 impl ::core::clone::Clone for IWICPlanarFormatConverter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5214,21 +4098,7 @@ impl IWICProgressCallback {
         (::windows::core::Vtable::vtable(self).Notify)(::windows::core::Vtable::as_raw(self), uframenum, operation, dblprogress).ok()
     }
 }
-impl ::core::convert::From<IWICProgressCallback> for ::windows::core::IUnknown {
-    fn from(value: IWICProgressCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICProgressCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICProgressCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICProgressCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWICProgressCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICProgressCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICProgressCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5273,21 +4143,7 @@ impl IWICProgressiveLevelControl {
         (::windows::core::Vtable::vtable(self).SetCurrentLevel)(::windows::core::Vtable::as_raw(self), nlevel).ok()
     }
 }
-impl ::core::convert::From<IWICProgressiveLevelControl> for ::windows::core::IUnknown {
-    fn from(value: IWICProgressiveLevelControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICProgressiveLevelControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICProgressiveLevelControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICProgressiveLevelControl> for ::windows::core::IUnknown {
-    fn from(value: &IWICProgressiveLevelControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICProgressiveLevelControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICProgressiveLevelControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5411,59 +4267,7 @@ impl IWICStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWICStream> for ::windows::core::IUnknown {
-    fn from(value: IWICStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWICStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWICStream> for ::windows::core::IUnknown {
-    fn from(value: &IWICStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWICStream> for super::super::System::Com::ISequentialStream {
-    fn from(value: IWICStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWICStream> for &'a super::super::System::Com::ISequentialStream {
-    fn from(value: &'a IWICStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWICStream> for super::super::System::Com::ISequentialStream {
-    fn from(value: &IWICStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWICStream> for super::super::System::Com::IStream {
-    fn from(value: IWICStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWICStream> for &'a super::super::System::Com::IStream {
-    fn from(value: &'a IWICStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWICStream> for super::super::System::Com::IStream {
-    fn from(value: &IWICStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICStream, ::windows::core::IUnknown, super::super::System::Com::ISequentialStream, super::super::System::Com::IStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWICStream {
     fn clone(&self) -> Self {
@@ -5530,21 +4334,7 @@ impl IWICStreamProvider {
         (::windows::core::Vtable::vtable(self).RefreshStream)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWICStreamProvider> for ::windows::core::IUnknown {
-    fn from(value: IWICStreamProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWICStreamProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWICStreamProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWICStreamProvider> for ::windows::core::IUnknown {
-    fn from(value: &IWICStreamProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWICStreamProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWICStreamProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
@@ -2891,36 +2891,7 @@ impl IAsyncGetSendNotificationCookie {
         (::windows::core::Vtable::vtable(self).FinishAsyncCallWithData)(::windows::core::Vtable::as_raw(self), param0.into().abi(), param1.into()).ok()
     }
 }
-impl ::core::convert::From<IAsyncGetSendNotificationCookie> for ::windows::core::IUnknown {
-    fn from(value: IAsyncGetSendNotificationCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncGetSendNotificationCookie> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAsyncGetSendNotificationCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncGetSendNotificationCookie> for ::windows::core::IUnknown {
-    fn from(value: &IAsyncGetSendNotificationCookie) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAsyncGetSendNotificationCookie> for IPrintAsyncCookie {
-    fn from(value: IAsyncGetSendNotificationCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncGetSendNotificationCookie> for &'a IPrintAsyncCookie {
-    fn from(value: &'a IAsyncGetSendNotificationCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncGetSendNotificationCookie> for IPrintAsyncCookie {
-    fn from(value: &IAsyncGetSendNotificationCookie) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAsyncGetSendNotificationCookie, ::windows::core::IUnknown, IPrintAsyncCookie);
 impl ::core::clone::Clone for IAsyncGetSendNotificationCookie {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2969,21 +2940,7 @@ impl IAsyncGetSrvReferralCookie {
         (::windows::core::Vtable::vtable(self).FinishAsyncCallWithData)(::windows::core::Vtable::as_raw(self), param0.into()).ok()
     }
 }
-impl ::core::convert::From<IAsyncGetSrvReferralCookie> for ::windows::core::IUnknown {
-    fn from(value: IAsyncGetSrvReferralCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncGetSrvReferralCookie> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAsyncGetSrvReferralCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncGetSrvReferralCookie> for ::windows::core::IUnknown {
-    fn from(value: &IAsyncGetSrvReferralCookie) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAsyncGetSrvReferralCookie, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAsyncGetSrvReferralCookie {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3054,36 +3011,7 @@ impl IBidiAsyncNotifyChannel {
         (::windows::core::Vtable::vtable(self).AsyncCloseChannel)(::windows::core::Vtable::as_raw(self), param0.into().abi(), param1.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IBidiAsyncNotifyChannel> for ::windows::core::IUnknown {
-    fn from(value: IBidiAsyncNotifyChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBidiAsyncNotifyChannel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBidiAsyncNotifyChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBidiAsyncNotifyChannel> for ::windows::core::IUnknown {
-    fn from(value: &IBidiAsyncNotifyChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBidiAsyncNotifyChannel> for IPrintAsyncNotifyChannel {
-    fn from(value: IBidiAsyncNotifyChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBidiAsyncNotifyChannel> for &'a IPrintAsyncNotifyChannel {
-    fn from(value: &'a IBidiAsyncNotifyChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBidiAsyncNotifyChannel> for IPrintAsyncNotifyChannel {
-    fn from(value: &IBidiAsyncNotifyChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBidiAsyncNotifyChannel, ::windows::core::IUnknown, IPrintAsyncNotifyChannel);
 impl ::core::clone::Clone for IBidiAsyncNotifyChannel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3141,21 +3069,7 @@ impl IBidiRequest {
         (::windows::core::Vtable::vtable(self).GetEnumCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IBidiRequest> for ::windows::core::IUnknown {
-    fn from(value: IBidiRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBidiRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBidiRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBidiRequest> for ::windows::core::IUnknown {
-    fn from(value: &IBidiRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBidiRequest, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBidiRequest {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3209,21 +3123,7 @@ impl IBidiRequestContainer {
         (::windows::core::Vtable::vtable(self).GetRequestCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IBidiRequestContainer> for ::windows::core::IUnknown {
-    fn from(value: IBidiRequestContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBidiRequestContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBidiRequestContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBidiRequestContainer> for ::windows::core::IUnknown {
-    fn from(value: &IBidiRequestContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBidiRequestContainer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBidiRequestContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3285,21 +3185,7 @@ impl IBidiSpl {
         (::windows::core::Vtable::vtable(self).MultiSendRecv)(::windows::core::Vtable::as_raw(self), pszaction.into(), prequestcontainer.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IBidiSpl> for ::windows::core::IUnknown {
-    fn from(value: IBidiSpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBidiSpl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBidiSpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBidiSpl> for ::windows::core::IUnknown {
-    fn from(value: &IBidiSpl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBidiSpl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBidiSpl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3358,21 +3244,7 @@ impl IBidiSpl2 {
         (::windows::core::Vtable::vtable(self).SendRecvXMLStream)(::windows::core::Vtable::as_raw(self), psrequest.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IBidiSpl2> for ::windows::core::IUnknown {
-    fn from(value: IBidiSpl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBidiSpl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBidiSpl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBidiSpl2> for ::windows::core::IUnknown {
-    fn from(value: &IBidiSpl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBidiSpl2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBidiSpl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3426,21 +3298,7 @@ impl IFixedDocument {
         (::windows::core::Vtable::vtable(self).SetPrintTicket)(::windows::core::Vtable::as_raw(self), pprintticket.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IFixedDocument> for ::windows::core::IUnknown {
-    fn from(value: IFixedDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFixedDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFixedDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFixedDocument> for ::windows::core::IUnknown {
-    fn from(value: &IFixedDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFixedDocument, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFixedDocument {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3490,21 +3348,7 @@ impl IFixedDocumentSequence {
         (::windows::core::Vtable::vtable(self).SetPrintTicket)(::windows::core::Vtable::as_raw(self), pprintticket.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IFixedDocumentSequence> for ::windows::core::IUnknown {
-    fn from(value: IFixedDocumentSequence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFixedDocumentSequence> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFixedDocumentSequence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFixedDocumentSequence> for ::windows::core::IUnknown {
-    fn from(value: &IFixedDocumentSequence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFixedDocumentSequence, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFixedDocumentSequence {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3592,36 +3436,7 @@ impl IFixedPage {
         (::windows::core::Vtable::vtable(self).GetXpsPartIterator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsPartIterator>(result__)
     }
 }
-impl ::core::convert::From<IFixedPage> for ::windows::core::IUnknown {
-    fn from(value: IFixedPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFixedPage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFixedPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFixedPage> for ::windows::core::IUnknown {
-    fn from(value: &IFixedPage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFixedPage> for IPartBase {
-    fn from(value: IFixedPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFixedPage> for &'a IPartBase {
-    fn from(value: &'a IFixedPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFixedPage> for IPartBase {
-    fn from(value: &IFixedPage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFixedPage, ::windows::core::IUnknown, IPartBase);
 impl ::core::clone::Clone for IFixedPage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3701,41 +3516,7 @@ impl IImgCreateErrorInfo {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IImgCreateErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: IImgCreateErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IImgCreateErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImgCreateErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IImgCreateErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &IImgCreateErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IImgCreateErrorInfo> for super::super::System::Ole::ICreateErrorInfo {
-    fn from(value: IImgCreateErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IImgCreateErrorInfo> for &'a super::super::System::Ole::ICreateErrorInfo {
-    fn from(value: &'a IImgCreateErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IImgCreateErrorInfo> for super::super::System::Ole::ICreateErrorInfo {
-    fn from(value: &IImgCreateErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImgCreateErrorInfo, ::windows::core::IUnknown, super::super::System::Ole::ICreateErrorInfo);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IImgCreateErrorInfo {
     fn clone(&self) -> Self {
@@ -3837,41 +3618,7 @@ impl IImgErrorInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IImgErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: IImgErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IImgErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImgErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IImgErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &IImgErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IImgErrorInfo> for super::super::System::Com::IErrorInfo {
-    fn from(value: IImgErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IImgErrorInfo> for &'a super::super::System::Com::IErrorInfo {
-    fn from(value: &'a IImgErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IImgErrorInfo> for super::super::System::Com::IErrorInfo {
-    fn from(value: &IImgErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImgErrorInfo, ::windows::core::IUnknown, super::super::System::Com::IErrorInfo);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IImgErrorInfo {
     fn clone(&self) -> Self {
@@ -3924,21 +3671,7 @@ impl IInterFilterCommunicator {
         (::windows::core::Vtable::vtable(self).RequestWriter)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppiwriter)).ok()
     }
 }
-impl ::core::convert::From<IInterFilterCommunicator> for ::windows::core::IUnknown {
-    fn from(value: IInterFilterCommunicator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInterFilterCommunicator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInterFilterCommunicator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInterFilterCommunicator> for ::windows::core::IUnknown {
-    fn from(value: &IInterFilterCommunicator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInterFilterCommunicator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInterFilterCommunicator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3988,21 +3721,7 @@ impl IPartBase {
         (::windows::core::Vtable::vtable(self).SetPartCompression)(::windows::core::Vtable::as_raw(self), compression).ok()
     }
 }
-impl ::core::convert::From<IPartBase> for ::windows::core::IUnknown {
-    fn from(value: IPartBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPartBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartBase> for ::windows::core::IUnknown {
-    fn from(value: &IPartBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPartBase, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPartBase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4054,36 +3773,7 @@ impl IPartColorProfile {
         (::windows::core::Vtable::vtable(self).base__.SetPartCompression)(::windows::core::Vtable::as_raw(self), compression).ok()
     }
 }
-impl ::core::convert::From<IPartColorProfile> for ::windows::core::IUnknown {
-    fn from(value: IPartColorProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartColorProfile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPartColorProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartColorProfile> for ::windows::core::IUnknown {
-    fn from(value: &IPartColorProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPartColorProfile> for IPartBase {
-    fn from(value: IPartColorProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartColorProfile> for &'a IPartBase {
-    fn from(value: &'a IPartColorProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartColorProfile> for IPartBase {
-    fn from(value: &IPartColorProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPartColorProfile, ::windows::core::IUnknown, IPartBase);
 impl ::core::clone::Clone for IPartColorProfile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4119,21 +3809,7 @@ impl IPartDiscardControl {
         (::windows::core::Vtable::vtable(self).GetDiscardProperties)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(urisentinelpage), ::core::mem::transmute(uriparttodiscard)).ok()
     }
 }
-impl ::core::convert::From<IPartDiscardControl> for ::windows::core::IUnknown {
-    fn from(value: IPartDiscardControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartDiscardControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPartDiscardControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartDiscardControl> for ::windows::core::IUnknown {
-    fn from(value: &IPartDiscardControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPartDiscardControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPartDiscardControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4194,36 +3870,7 @@ impl IPartFont {
         (::windows::core::Vtable::vtable(self).SetFontOptions)(::windows::core::Vtable::as_raw(self), options).ok()
     }
 }
-impl ::core::convert::From<IPartFont> for ::windows::core::IUnknown {
-    fn from(value: IPartFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartFont> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPartFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartFont> for ::windows::core::IUnknown {
-    fn from(value: &IPartFont) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPartFont> for IPartBase {
-    fn from(value: IPartFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartFont> for &'a IPartBase {
-    fn from(value: &'a IPartFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartFont> for IPartBase {
-    fn from(value: &IPartFont) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPartFont, ::windows::core::IUnknown, IPartBase);
 impl ::core::clone::Clone for IPartFont {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4290,51 +3937,7 @@ impl IPartFont2 {
         (::windows::core::Vtable::vtable(self).GetFontRestriction)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<EXpsFontRestriction>(result__)
     }
 }
-impl ::core::convert::From<IPartFont2> for ::windows::core::IUnknown {
-    fn from(value: IPartFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartFont2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPartFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartFont2> for ::windows::core::IUnknown {
-    fn from(value: &IPartFont2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPartFont2> for IPartBase {
-    fn from(value: IPartFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartFont2> for &'a IPartBase {
-    fn from(value: &'a IPartFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartFont2> for IPartBase {
-    fn from(value: &IPartFont2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPartFont2> for IPartFont {
-    fn from(value: IPartFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartFont2> for &'a IPartFont {
-    fn from(value: &'a IPartFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartFont2> for IPartFont {
-    fn from(value: &IPartFont2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPartFont2, ::windows::core::IUnknown, IPartBase, IPartFont);
 impl ::core::clone::Clone for IPartFont2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4393,36 +3996,7 @@ impl IPartImage {
         (::windows::core::Vtable::vtable(self).SetImageContent)(::windows::core::Vtable::as_raw(self), pcontenttype.into()).ok()
     }
 }
-impl ::core::convert::From<IPartImage> for ::windows::core::IUnknown {
-    fn from(value: IPartImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartImage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPartImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartImage> for ::windows::core::IUnknown {
-    fn from(value: &IPartImage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPartImage> for IPartBase {
-    fn from(value: IPartImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartImage> for &'a IPartBase {
-    fn from(value: &'a IPartImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartImage> for IPartBase {
-    fn from(value: &IPartImage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPartImage, ::windows::core::IUnknown, IPartBase);
 impl ::core::clone::Clone for IPartImage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4472,36 +4046,7 @@ impl IPartPrintTicket {
         (::windows::core::Vtable::vtable(self).base__.SetPartCompression)(::windows::core::Vtable::as_raw(self), compression).ok()
     }
 }
-impl ::core::convert::From<IPartPrintTicket> for ::windows::core::IUnknown {
-    fn from(value: IPartPrintTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartPrintTicket> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPartPrintTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartPrintTicket> for ::windows::core::IUnknown {
-    fn from(value: &IPartPrintTicket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPartPrintTicket> for IPartBase {
-    fn from(value: IPartPrintTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartPrintTicket> for &'a IPartBase {
-    fn from(value: &'a IPartPrintTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartPrintTicket> for IPartBase {
-    fn from(value: &IPartPrintTicket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPartPrintTicket, ::windows::core::IUnknown, IPartBase);
 impl ::core::clone::Clone for IPartPrintTicket {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4549,36 +4094,7 @@ impl IPartResourceDictionary {
         (::windows::core::Vtable::vtable(self).base__.SetPartCompression)(::windows::core::Vtable::as_raw(self), compression).ok()
     }
 }
-impl ::core::convert::From<IPartResourceDictionary> for ::windows::core::IUnknown {
-    fn from(value: IPartResourceDictionary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartResourceDictionary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPartResourceDictionary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartResourceDictionary> for ::windows::core::IUnknown {
-    fn from(value: &IPartResourceDictionary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPartResourceDictionary> for IPartBase {
-    fn from(value: IPartResourceDictionary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartResourceDictionary> for &'a IPartBase {
-    fn from(value: &'a IPartResourceDictionary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartResourceDictionary> for IPartBase {
-    fn from(value: &IPartResourceDictionary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPartResourceDictionary, ::windows::core::IUnknown, IPartBase);
 impl ::core::clone::Clone for IPartResourceDictionary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4636,36 +4152,7 @@ impl IPartThumbnail {
         (::windows::core::Vtable::vtable(self).SetThumbnailContent)(::windows::core::Vtable::as_raw(self), pcontenttype.into()).ok()
     }
 }
-impl ::core::convert::From<IPartThumbnail> for ::windows::core::IUnknown {
-    fn from(value: IPartThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartThumbnail> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPartThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartThumbnail> for ::windows::core::IUnknown {
-    fn from(value: &IPartThumbnail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPartThumbnail> for IPartBase {
-    fn from(value: IPartThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartThumbnail> for &'a IPartBase {
-    fn from(value: &'a IPartThumbnail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartThumbnail> for IPartBase {
-    fn from(value: &IPartThumbnail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPartThumbnail, ::windows::core::IUnknown, IPartBase);
 impl ::core::clone::Clone for IPartThumbnail {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4706,21 +4193,7 @@ impl IPrintAsyncCookie {
         (::windows::core::Vtable::vtable(self).CancelAsyncCall)(::windows::core::Vtable::as_raw(self), param0).ok()
     }
 }
-impl ::core::convert::From<IPrintAsyncCookie> for ::windows::core::IUnknown {
-    fn from(value: IPrintAsyncCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintAsyncCookie> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintAsyncCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintAsyncCookie> for ::windows::core::IUnknown {
-    fn from(value: &IPrintAsyncCookie) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintAsyncCookie, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintAsyncCookie {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4764,36 +4237,7 @@ impl IPrintAsyncNewChannelCookie {
         (::windows::core::Vtable::vtable(self).FinishAsyncCallWithData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), param1).ok()
     }
 }
-impl ::core::convert::From<IPrintAsyncNewChannelCookie> for ::windows::core::IUnknown {
-    fn from(value: IPrintAsyncNewChannelCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintAsyncNewChannelCookie> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintAsyncNewChannelCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintAsyncNewChannelCookie> for ::windows::core::IUnknown {
-    fn from(value: &IPrintAsyncNewChannelCookie) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintAsyncNewChannelCookie> for IPrintAsyncCookie {
-    fn from(value: IPrintAsyncNewChannelCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintAsyncNewChannelCookie> for &'a IPrintAsyncCookie {
-    fn from(value: &'a IPrintAsyncNewChannelCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintAsyncNewChannelCookie> for IPrintAsyncCookie {
-    fn from(value: &IPrintAsyncNewChannelCookie) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintAsyncNewChannelCookie, ::windows::core::IUnknown, IPrintAsyncCookie);
 impl ::core::clone::Clone for IPrintAsyncNewChannelCookie {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4841,21 +4285,7 @@ impl IPrintAsyncNotify {
         (::windows::core::Vtable::vtable(self).CreatePrintAsyncNotifyRegistration)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(param0), param1, param2, param3.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPrintAsyncNotifyRegistration>(result__)
     }
 }
-impl ::core::convert::From<IPrintAsyncNotify> for ::windows::core::IUnknown {
-    fn from(value: IPrintAsyncNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintAsyncNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintAsyncNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintAsyncNotify> for ::windows::core::IUnknown {
-    fn from(value: &IPrintAsyncNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintAsyncNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintAsyncNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4904,21 +4334,7 @@ impl IPrintAsyncNotifyCallback {
         (::windows::core::Vtable::vtable(self).ChannelClosed)(::windows::core::Vtable::as_raw(self), pchannel.into().abi(), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPrintAsyncNotifyCallback> for ::windows::core::IUnknown {
-    fn from(value: IPrintAsyncNotifyCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintAsyncNotifyCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintAsyncNotifyCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintAsyncNotifyCallback> for ::windows::core::IUnknown {
-    fn from(value: &IPrintAsyncNotifyCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintAsyncNotifyCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintAsyncNotifyCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4965,21 +4381,7 @@ impl IPrintAsyncNotifyChannel {
         (::windows::core::Vtable::vtable(self).CloseChannel)(::windows::core::Vtable::as_raw(self), pdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPrintAsyncNotifyChannel> for ::windows::core::IUnknown {
-    fn from(value: IPrintAsyncNotifyChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintAsyncNotifyChannel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintAsyncNotifyChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintAsyncNotifyChannel> for ::windows::core::IUnknown {
-    fn from(value: &IPrintAsyncNotifyChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintAsyncNotifyChannel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintAsyncNotifyChannel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5020,21 +4422,7 @@ impl IPrintAsyncNotifyDataObject {
         (::windows::core::Vtable::vtable(self).ReleaseData)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrintAsyncNotifyDataObject> for ::windows::core::IUnknown {
-    fn from(value: IPrintAsyncNotifyDataObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintAsyncNotifyDataObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintAsyncNotifyDataObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintAsyncNotifyDataObject> for ::windows::core::IUnknown {
-    fn from(value: &IPrintAsyncNotifyDataObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintAsyncNotifyDataObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintAsyncNotifyDataObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5075,21 +4463,7 @@ impl IPrintAsyncNotifyRegistration {
         (::windows::core::Vtable::vtable(self).UnregisterForNotifications)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrintAsyncNotifyRegistration> for ::windows::core::IUnknown {
-    fn from(value: IPrintAsyncNotifyRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintAsyncNotifyRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintAsyncNotifyRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintAsyncNotifyRegistration> for ::windows::core::IUnknown {
-    fn from(value: &IPrintAsyncNotifyRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintAsyncNotifyRegistration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintAsyncNotifyRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5140,21 +4514,7 @@ impl IPrintAsyncNotifyServerReferral {
         (::windows::core::Vtable::vtable(self).SetServerReferral)(::windows::core::Vtable::as_raw(self), prmtserverreferral.into()).ok()
     }
 }
-impl ::core::convert::From<IPrintAsyncNotifyServerReferral> for ::windows::core::IUnknown {
-    fn from(value: IPrintAsyncNotifyServerReferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintAsyncNotifyServerReferral> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintAsyncNotifyServerReferral) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintAsyncNotifyServerReferral> for ::windows::core::IUnknown {
-    fn from(value: &IPrintAsyncNotifyServerReferral) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintAsyncNotifyServerReferral, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintAsyncNotifyServerReferral {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5202,36 +4562,7 @@ impl IPrintBidiAsyncNotifyRegistration {
         (::windows::core::Vtable::vtable(self).AsyncGetNewChannel)(::windows::core::Vtable::as_raw(self), param0.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPrintBidiAsyncNotifyRegistration> for ::windows::core::IUnknown {
-    fn from(value: IPrintBidiAsyncNotifyRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintBidiAsyncNotifyRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintBidiAsyncNotifyRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintBidiAsyncNotifyRegistration> for ::windows::core::IUnknown {
-    fn from(value: &IPrintBidiAsyncNotifyRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintBidiAsyncNotifyRegistration> for IPrintAsyncNotifyRegistration {
-    fn from(value: IPrintBidiAsyncNotifyRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintBidiAsyncNotifyRegistration> for &'a IPrintAsyncNotifyRegistration {
-    fn from(value: &'a IPrintBidiAsyncNotifyRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintBidiAsyncNotifyRegistration> for IPrintAsyncNotifyRegistration {
-    fn from(value: &IPrintBidiAsyncNotifyRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintBidiAsyncNotifyRegistration, ::windows::core::IUnknown, IPrintAsyncNotifyRegistration);
 impl ::core::clone::Clone for IPrintBidiAsyncNotifyRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5271,21 +4602,7 @@ impl IPrintClassObjectFactory {
         (::windows::core::Vtable::vtable(self).GetPrintClassObject)(::windows::core::Vtable::as_raw(self), pszprintername.into(), ::core::mem::transmute(riid), ::core::mem::transmute(ppnewobject)).ok()
     }
 }
-impl ::core::convert::From<IPrintClassObjectFactory> for ::windows::core::IUnknown {
-    fn from(value: IPrintClassObjectFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintClassObjectFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintClassObjectFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintClassObjectFactory> for ::windows::core::IUnknown {
-    fn from(value: &IPrintClassObjectFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintClassObjectFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintClassObjectFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5381,21 +4698,7 @@ impl IPrintCoreHelper {
         (::windows::core::Vtable::vtable(self).CreateInstanceOfMSXMLObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid), punkouter.into().abi(), dwclscontext, ::core::mem::transmute(riid), ::core::mem::transmute(ppv)).ok()
     }
 }
-impl ::core::convert::From<IPrintCoreHelper> for ::windows::core::IUnknown {
-    fn from(value: IPrintCoreHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCoreHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintCoreHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCoreHelper> for ::windows::core::IUnknown {
-    fn from(value: &IPrintCoreHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintCoreHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintCoreHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5532,36 +4835,7 @@ impl IPrintCoreHelperPS {
         (::windows::core::Vtable::vtable(self).GetOptionAttribute)(::windows::core::Vtable::as_raw(self), pszfeaturekeyword.into(), pszoptionkeyword.into(), pszattribute.into(), ::core::mem::transmute(pdwdatatype), ::core::mem::transmute(ppbdata), ::core::mem::transmute(pcbsize)).ok()
     }
 }
-impl ::core::convert::From<IPrintCoreHelperPS> for ::windows::core::IUnknown {
-    fn from(value: IPrintCoreHelperPS) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCoreHelperPS> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintCoreHelperPS) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCoreHelperPS> for ::windows::core::IUnknown {
-    fn from(value: &IPrintCoreHelperPS) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintCoreHelperPS> for IPrintCoreHelper {
-    fn from(value: IPrintCoreHelperPS) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCoreHelperPS> for &'a IPrintCoreHelper {
-    fn from(value: &'a IPrintCoreHelperPS) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCoreHelperPS> for IPrintCoreHelper {
-    fn from(value: &IPrintCoreHelperPS) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintCoreHelperPS, ::windows::core::IUnknown, IPrintCoreHelper);
 impl ::core::clone::Clone for IPrintCoreHelperPS {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5670,36 +4944,7 @@ impl IPrintCoreHelperUni {
         (::windows::core::Vtable::vtable(self).CreateDefaultGDLSnapshot)(::windows::core::Vtable::as_raw(self), dwflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IPrintCoreHelperUni> for ::windows::core::IUnknown {
-    fn from(value: IPrintCoreHelperUni) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCoreHelperUni> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintCoreHelperUni) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCoreHelperUni> for ::windows::core::IUnknown {
-    fn from(value: &IPrintCoreHelperUni) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintCoreHelperUni> for IPrintCoreHelper {
-    fn from(value: IPrintCoreHelperUni) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCoreHelperUni> for &'a IPrintCoreHelper {
-    fn from(value: &'a IPrintCoreHelperUni) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCoreHelperUni> for IPrintCoreHelper {
-    fn from(value: &IPrintCoreHelperUni) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintCoreHelperUni, ::windows::core::IUnknown, IPrintCoreHelper);
 impl ::core::clone::Clone for IPrintCoreHelperUni {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5821,51 +5066,7 @@ impl IPrintCoreHelperUni2 {
         (::windows::core::Vtable::vtable(self).GetNamedCommand)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdevmode.unwrap_or(::std::ptr::null())), cbsize, pszcommandname.into(), ::core::mem::transmute(ppcommandbytes), ::core::mem::transmute(pcbcommandsize)).ok()
     }
 }
-impl ::core::convert::From<IPrintCoreHelperUni2> for ::windows::core::IUnknown {
-    fn from(value: IPrintCoreHelperUni2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCoreHelperUni2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintCoreHelperUni2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCoreHelperUni2> for ::windows::core::IUnknown {
-    fn from(value: &IPrintCoreHelperUni2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintCoreHelperUni2> for IPrintCoreHelper {
-    fn from(value: IPrintCoreHelperUni2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCoreHelperUni2> for &'a IPrintCoreHelper {
-    fn from(value: &'a IPrintCoreHelperUni2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCoreHelperUni2> for IPrintCoreHelper {
-    fn from(value: &IPrintCoreHelperUni2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintCoreHelperUni2> for IPrintCoreHelperUni {
-    fn from(value: IPrintCoreHelperUni2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCoreHelperUni2> for &'a IPrintCoreHelperUni {
-    fn from(value: &'a IPrintCoreHelperUni2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCoreHelperUni2> for IPrintCoreHelperUni {
-    fn from(value: &IPrintCoreHelperUni2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintCoreHelperUni2, ::windows::core::IUnknown, IPrintCoreHelper, IPrintCoreHelperUni);
 impl ::core::clone::Clone for IPrintCoreHelperUni2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5997,36 +5198,7 @@ impl IPrintCoreUI2 {
         (::windows::core::Vtable::vtable(self).QuerySimulationSupport)(::windows::core::Vtable::as_raw(self), hprinter.into(), dwlevel, ::core::mem::transmute(pcaps.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), pcaps.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(pcbneeded)).ok()
     }
 }
-impl ::core::convert::From<IPrintCoreUI2> for ::windows::core::IUnknown {
-    fn from(value: IPrintCoreUI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCoreUI2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintCoreUI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCoreUI2> for ::windows::core::IUnknown {
-    fn from(value: &IPrintCoreUI2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintCoreUI2> for IPrintOemDriverUI {
-    fn from(value: IPrintCoreUI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintCoreUI2> for &'a IPrintOemDriverUI {
-    fn from(value: &'a IPrintCoreUI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintCoreUI2> for IPrintOemDriverUI {
-    fn from(value: &IPrintCoreUI2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintCoreUI2, ::windows::core::IUnknown, IPrintOemDriverUI);
 impl ::core::clone::Clone for IPrintCoreUI2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6126,21 +5298,7 @@ impl IPrintJob {
         (::windows::core::Vtable::vtable(self).RequestCancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrintJob> for ::windows::core::IUnknown {
-    fn from(value: IPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintJob> for ::windows::core::IUnknown {
-    fn from(value: &IPrintJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintJob, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintJob {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6195,41 +5353,7 @@ impl IPrintJobCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintJobCollection> for ::windows::core::IUnknown {
-    fn from(value: IPrintJobCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintJobCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintJobCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintJobCollection> for ::windows::core::IUnknown {
-    fn from(value: &IPrintJobCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintJobCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintJobCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintJobCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintJobCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintJobCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintJobCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintJobCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintJobCollection {
     fn clone(&self) -> Self {
@@ -6280,21 +5404,7 @@ impl IPrintOemCommon {
         (::windows::core::Vtable::vtable(self).DevMode)(::windows::core::Vtable::as_raw(self), dwmode, ::core::mem::transmute(poemdmparam)).ok()
     }
 }
-impl ::core::convert::From<IPrintOemCommon> for ::windows::core::IUnknown {
-    fn from(value: IPrintOemCommon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintOemCommon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintOemCommon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintOemCommon> for ::windows::core::IUnknown {
-    fn from(value: &IPrintOemCommon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintOemCommon, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintOemCommon {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6351,21 +5461,7 @@ impl IPrintOemDriverUI {
         (::windows::core::Vtable::vtable(self).DrvUpdateUISetting)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pci), ::core::mem::transmute(poptitem), dwpreviousselection, dwmode).ok()
     }
 }
-impl ::core::convert::From<IPrintOemDriverUI> for ::windows::core::IUnknown {
-    fn from(value: IPrintOemDriverUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintOemDriverUI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintOemDriverUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintOemDriverUI> for ::windows::core::IUnknown {
-    fn from(value: &IPrintOemDriverUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintOemDriverUI, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintOemDriverUI {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6501,36 +5597,7 @@ impl IPrintOemUI {
         (::windows::core::Vtable::vtable(self).UpdateExternalFonts)(::windows::core::Vtable::as_raw(self), hprinter.into(), hheap.into(), pwstrcartridges.into()).ok()
     }
 }
-impl ::core::convert::From<IPrintOemUI> for ::windows::core::IUnknown {
-    fn from(value: IPrintOemUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintOemUI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintOemUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintOemUI> for ::windows::core::IUnknown {
-    fn from(value: &IPrintOemUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintOemUI> for IPrintOemCommon {
-    fn from(value: IPrintOemUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintOemUI> for &'a IPrintOemCommon {
-    fn from(value: &'a IPrintOemUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintOemUI> for IPrintOemCommon {
-    fn from(value: &IPrintOemUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintOemUI, ::windows::core::IUnknown, IPrintOemCommon);
 impl ::core::clone::Clone for IPrintOemUI {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6722,51 +5789,7 @@ impl IPrintOemUI2 {
         (::windows::core::Vtable::vtable(self).DocumentEvent)(::windows::core::Vtable::as_raw(self), hprinter.into(), hdc.into(), iesc, cbin, ::core::mem::transmute(pvin), cbout, ::core::mem::transmute(pvout), ::core::mem::transmute(piresult)).ok()
     }
 }
-impl ::core::convert::From<IPrintOemUI2> for ::windows::core::IUnknown {
-    fn from(value: IPrintOemUI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintOemUI2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintOemUI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintOemUI2> for ::windows::core::IUnknown {
-    fn from(value: &IPrintOemUI2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintOemUI2> for IPrintOemCommon {
-    fn from(value: IPrintOemUI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintOemUI2> for &'a IPrintOemCommon {
-    fn from(value: &'a IPrintOemUI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintOemUI2> for IPrintOemCommon {
-    fn from(value: &IPrintOemUI2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintOemUI2> for IPrintOemUI {
-    fn from(value: IPrintOemUI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintOemUI2> for &'a IPrintOemUI {
-    fn from(value: &'a IPrintOemUI2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintOemUI2> for IPrintOemUI {
-    fn from(value: &IPrintOemUI2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintOemUI2, ::windows::core::IUnknown, IPrintOemCommon, IPrintOemUI);
 impl ::core::clone::Clone for IPrintOemUI2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6832,21 +5855,7 @@ impl IPrintOemUIMXDC {
         (::windows::core::Vtable::vtable(self).AdjustDPI)(::windows::core::Vtable::as_raw(self), hprinter.into(), cbdevmode, ::core::mem::transmute(pdevmode), cboemdm, ::core::mem::transmute(poemdm), ::core::mem::transmute(pdpi)).ok()
     }
 }
-impl ::core::convert::From<IPrintOemUIMXDC> for ::windows::core::IUnknown {
-    fn from(value: IPrintOemUIMXDC) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintOemUIMXDC> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintOemUIMXDC) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintOemUIMXDC> for ::windows::core::IUnknown {
-    fn from(value: &IPrintOemUIMXDC) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintOemUIMXDC, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintOemUIMXDC {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6905,21 +5914,7 @@ impl IPrintPipelineFilter {
         (::windows::core::Vtable::vtable(self).StartOperation)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrintPipelineFilter> for ::windows::core::IUnknown {
-    fn from(value: IPrintPipelineFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintPipelineFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintPipelineFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintPipelineFilter> for ::windows::core::IUnknown {
-    fn from(value: &IPrintPipelineFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintPipelineFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintPipelineFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6966,21 +5961,7 @@ impl IPrintPipelineManagerControl {
         (::windows::core::Vtable::vtable(self).FilterFinished)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrintPipelineManagerControl> for ::windows::core::IUnknown {
-    fn from(value: IPrintPipelineManagerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintPipelineManagerControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintPipelineManagerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintPipelineManagerControl> for ::windows::core::IUnknown {
-    fn from(value: &IPrintPipelineManagerControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintPipelineManagerControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintPipelineManagerControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7021,21 +6002,7 @@ impl IPrintPipelineProgressReport {
         (::windows::core::Vtable::vtable(self).ReportProgress)(::windows::core::Vtable::as_raw(self), update).ok()
     }
 }
-impl ::core::convert::From<IPrintPipelineProgressReport> for ::windows::core::IUnknown {
-    fn from(value: IPrintPipelineProgressReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintPipelineProgressReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintPipelineProgressReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintPipelineProgressReport> for ::windows::core::IUnknown {
-    fn from(value: &IPrintPipelineProgressReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintPipelineProgressReport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintPipelineProgressReport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7094,21 +6061,7 @@ impl IPrintPipelinePropertyBag {
         (::windows::core::Vtable::vtable(self).DeleteProperty)(::windows::core::Vtable::as_raw(self), pszname.into())
     }
 }
-impl ::core::convert::From<IPrintPipelinePropertyBag> for ::windows::core::IUnknown {
-    fn from(value: IPrintPipelinePropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintPipelinePropertyBag> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintPipelinePropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintPipelinePropertyBag> for ::windows::core::IUnknown {
-    fn from(value: &IPrintPipelinePropertyBag) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintPipelinePropertyBag, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintPipelinePropertyBag {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7167,21 +6120,7 @@ impl IPrintPreviewDxgiPackageTarget {
         (::windows::core::Vtable::vtable(self).InvalidatePreview)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrintPreviewDxgiPackageTarget> for ::windows::core::IUnknown {
-    fn from(value: IPrintPreviewDxgiPackageTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintPreviewDxgiPackageTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintPreviewDxgiPackageTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintPreviewDxgiPackageTarget> for ::windows::core::IUnknown {
-    fn from(value: &IPrintPreviewDxgiPackageTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintPreviewDxgiPackageTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintPreviewDxgiPackageTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7229,21 +6168,7 @@ impl IPrintReadStream {
         (::windows::core::Vtable::vtable(self).ReadBytes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvbuffer), cbrequested, ::core::mem::transmute(pcbread), ::core::mem::transmute(pbendoffile)).ok()
     }
 }
-impl ::core::convert::From<IPrintReadStream> for ::windows::core::IUnknown {
-    fn from(value: IPrintReadStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintReadStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintReadStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintReadStream> for ::windows::core::IUnknown {
-    fn from(value: &IPrintReadStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintReadStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintReadStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7285,21 +6210,7 @@ impl IPrintReadStreamFactory {
         (::windows::core::Vtable::vtable(self).GetStream)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPrintReadStream>(result__)
     }
 }
-impl ::core::convert::From<IPrintReadStreamFactory> for ::windows::core::IUnknown {
-    fn from(value: IPrintReadStreamFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintReadStreamFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintReadStreamFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintReadStreamFactory> for ::windows::core::IUnknown {
-    fn from(value: &IPrintReadStreamFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintReadStreamFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintReadStreamFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7342,41 +6253,7 @@ impl IPrintSchemaAsyncOperation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaAsyncOperation> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaAsyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaAsyncOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaAsyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaAsyncOperation> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaAsyncOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaAsyncOperation> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaAsyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaAsyncOperation> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaAsyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaAsyncOperation> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaAsyncOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaAsyncOperation, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaAsyncOperation {
     fn clone(&self) -> Self {
@@ -7429,41 +6306,7 @@ impl IPrintSchemaAsyncOperationEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaAsyncOperationEvent> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaAsyncOperationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaAsyncOperationEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaAsyncOperationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaAsyncOperationEvent> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaAsyncOperationEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaAsyncOperationEvent> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaAsyncOperationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaAsyncOperationEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaAsyncOperationEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaAsyncOperationEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaAsyncOperationEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaAsyncOperationEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaAsyncOperationEvent {
     fn clone(&self) -> Self {
@@ -7566,59 +6409,7 @@ impl IPrintSchemaCapabilities {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaCapabilities> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaCapabilities> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaCapabilities> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaCapabilities> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaCapabilities> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaCapabilities> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaCapabilities> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaCapabilities, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaCapabilities {
     fn clone(&self) -> Self {
@@ -7745,77 +6536,7 @@ impl IPrintSchemaCapabilities2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaCapabilities2> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaCapabilities2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaCapabilities2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaCapabilities2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaCapabilities2> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaCapabilities2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaCapabilities2> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaCapabilities2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaCapabilities2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaCapabilities2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaCapabilities2> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaCapabilities2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaCapabilities2> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaCapabilities2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaCapabilities2> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaCapabilities2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaCapabilities2> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaCapabilities2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaCapabilities2> for IPrintSchemaCapabilities {
-    fn from(value: IPrintSchemaCapabilities2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaCapabilities2> for &'a IPrintSchemaCapabilities {
-    fn from(value: &'a IPrintSchemaCapabilities2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaCapabilities2> for IPrintSchemaCapabilities {
-    fn from(value: &IPrintSchemaCapabilities2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaCapabilities2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement, IPrintSchemaCapabilities);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaCapabilities2 {
     fn clone(&self) -> Self {
@@ -7878,59 +6599,7 @@ impl IPrintSchemaDisplayableElement {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaDisplayableElement> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaDisplayableElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaDisplayableElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaDisplayableElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaDisplayableElement> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaDisplayableElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaDisplayableElement> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaDisplayableElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaDisplayableElement> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaDisplayableElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaDisplayableElement> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaDisplayableElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaDisplayableElement> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaDisplayableElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaDisplayableElement> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaDisplayableElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaDisplayableElement> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaDisplayableElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaDisplayableElement, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaDisplayableElement {
     fn clone(&self) -> Self {
@@ -7986,41 +6655,7 @@ impl IPrintSchemaElement {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaElement> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaElement> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaElement> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaElement> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaElement> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaElement, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaElement {
     fn clone(&self) -> Self {
@@ -8112,77 +6747,7 @@ impl IPrintSchemaFeature {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaFeature> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaFeature> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaFeature> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaFeature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaFeature> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaFeature> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaFeature> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaFeature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaFeature> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaFeature> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaFeature> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaFeature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaFeature> for IPrintSchemaDisplayableElement {
-    fn from(value: IPrintSchemaFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaFeature> for &'a IPrintSchemaDisplayableElement {
-    fn from(value: &'a IPrintSchemaFeature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaFeature> for IPrintSchemaDisplayableElement {
-    fn from(value: &IPrintSchemaFeature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaFeature, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement, IPrintSchemaDisplayableElement);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaFeature {
     fn clone(&self) -> Self {
@@ -8276,95 +6841,7 @@ impl IPrintSchemaNUpOption {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaNUpOption> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaNUpOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaNUpOption> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaNUpOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaNUpOption> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaNUpOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaNUpOption> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaNUpOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaNUpOption> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaNUpOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaNUpOption> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaNUpOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaNUpOption> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaNUpOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaNUpOption> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaNUpOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaNUpOption> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaNUpOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaNUpOption> for IPrintSchemaDisplayableElement {
-    fn from(value: IPrintSchemaNUpOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaNUpOption> for &'a IPrintSchemaDisplayableElement {
-    fn from(value: &'a IPrintSchemaNUpOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaNUpOption> for IPrintSchemaDisplayableElement {
-    fn from(value: &IPrintSchemaNUpOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaNUpOption> for IPrintSchemaOption {
-    fn from(value: IPrintSchemaNUpOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaNUpOption> for &'a IPrintSchemaOption {
-    fn from(value: &'a IPrintSchemaNUpOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaNUpOption> for IPrintSchemaOption {
-    fn from(value: &IPrintSchemaNUpOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaNUpOption, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement, IPrintSchemaDisplayableElement, IPrintSchemaOption);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaNUpOption {
     fn clone(&self) -> Self {
@@ -8438,77 +6915,7 @@ impl IPrintSchemaOption {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaOption> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaOption> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaOption> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaOption> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaOption> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaOption> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaOption> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaOption> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaOption> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaOption> for IPrintSchemaDisplayableElement {
-    fn from(value: IPrintSchemaOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaOption> for &'a IPrintSchemaDisplayableElement {
-    fn from(value: &'a IPrintSchemaOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaOption> for IPrintSchemaDisplayableElement {
-    fn from(value: &IPrintSchemaOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaOption, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement, IPrintSchemaDisplayableElement);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaOption {
     fn clone(&self) -> Self {
@@ -8571,41 +6978,7 @@ impl IPrintSchemaOptionCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaOptionCollection> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaOptionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaOptionCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaOptionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaOptionCollection> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaOptionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaOptionCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaOptionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaOptionCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaOptionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaOptionCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaOptionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaOptionCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaOptionCollection {
     fn clone(&self) -> Self {
@@ -8690,59 +7063,7 @@ impl IPrintSchemaPageImageableSize {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaPageImageableSize> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaPageImageableSize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaPageImageableSize> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaPageImageableSize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaPageImageableSize> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaPageImageableSize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaPageImageableSize> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaPageImageableSize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaPageImageableSize> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaPageImageableSize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaPageImageableSize> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaPageImageableSize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaPageImageableSize> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaPageImageableSize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaPageImageableSize> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaPageImageableSize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaPageImageableSize> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaPageImageableSize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaPageImageableSize, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaPageImageableSize {
     fn clone(&self) -> Self {
@@ -8829,95 +7150,7 @@ impl IPrintSchemaPageMediaSizeOption {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaPageMediaSizeOption> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaPageMediaSizeOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaPageMediaSizeOption> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaPageMediaSizeOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaPageMediaSizeOption> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaPageMediaSizeOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaPageMediaSizeOption> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaPageMediaSizeOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaPageMediaSizeOption> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaPageMediaSizeOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaPageMediaSizeOption> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaPageMediaSizeOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaPageMediaSizeOption> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaPageMediaSizeOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaPageMediaSizeOption> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaPageMediaSizeOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaPageMediaSizeOption> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaPageMediaSizeOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaPageMediaSizeOption> for IPrintSchemaDisplayableElement {
-    fn from(value: IPrintSchemaPageMediaSizeOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaPageMediaSizeOption> for &'a IPrintSchemaDisplayableElement {
-    fn from(value: &'a IPrintSchemaPageMediaSizeOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaPageMediaSizeOption> for IPrintSchemaDisplayableElement {
-    fn from(value: &IPrintSchemaPageMediaSizeOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaPageMediaSizeOption> for IPrintSchemaOption {
-    fn from(value: IPrintSchemaPageMediaSizeOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaPageMediaSizeOption> for &'a IPrintSchemaOption {
-    fn from(value: &'a IPrintSchemaPageMediaSizeOption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaPageMediaSizeOption> for IPrintSchemaOption {
-    fn from(value: &IPrintSchemaPageMediaSizeOption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaPageMediaSizeOption, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement, IPrintSchemaDisplayableElement, IPrintSchemaOption);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaPageMediaSizeOption {
     fn clone(&self) -> Self {
@@ -9000,77 +7233,7 @@ impl IPrintSchemaParameterDefinition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaParameterDefinition> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaParameterDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaParameterDefinition> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaParameterDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaParameterDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaParameterDefinition> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaParameterDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaParameterDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaParameterDefinition> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaParameterDefinition> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaParameterDefinition> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaParameterDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaParameterDefinition> for IPrintSchemaDisplayableElement {
-    fn from(value: IPrintSchemaParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaParameterDefinition> for &'a IPrintSchemaDisplayableElement {
-    fn from(value: &'a IPrintSchemaParameterDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaParameterDefinition> for IPrintSchemaDisplayableElement {
-    fn from(value: &IPrintSchemaParameterDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaParameterDefinition, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement, IPrintSchemaDisplayableElement);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaParameterDefinition {
     fn clone(&self) -> Self {
@@ -9144,59 +7307,7 @@ impl IPrintSchemaParameterInitializer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaParameterInitializer> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaParameterInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaParameterInitializer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaParameterInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaParameterInitializer> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaParameterInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaParameterInitializer> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaParameterInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaParameterInitializer> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaParameterInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaParameterInitializer> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaParameterInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaParameterInitializer> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaParameterInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaParameterInitializer> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaParameterInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaParameterInitializer> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaParameterInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaParameterInitializer, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaParameterInitializer {
     fn clone(&self) -> Self {
@@ -9302,59 +7413,7 @@ impl IPrintSchemaTicket {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaTicket> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaTicket> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaTicket> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaTicket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaTicket> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaTicket> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaTicket> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaTicket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaTicket> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaTicket> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaTicket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaTicket> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaTicket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaTicket, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaTicket {
     fn clone(&self) -> Self {
@@ -9481,77 +7540,7 @@ impl IPrintSchemaTicket2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaTicket2> for ::windows::core::IUnknown {
-    fn from(value: IPrintSchemaTicket2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaTicket2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintSchemaTicket2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaTicket2> for ::windows::core::IUnknown {
-    fn from(value: &IPrintSchemaTicket2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaTicket2> for super::super::System::Com::IDispatch {
-    fn from(value: IPrintSchemaTicket2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaTicket2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintSchemaTicket2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaTicket2> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrintSchemaTicket2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaTicket2> for IPrintSchemaElement {
-    fn from(value: IPrintSchemaTicket2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaTicket2> for &'a IPrintSchemaElement {
-    fn from(value: &'a IPrintSchemaTicket2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaTicket2> for IPrintSchemaElement {
-    fn from(value: &IPrintSchemaTicket2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintSchemaTicket2> for IPrintSchemaTicket {
-    fn from(value: IPrintSchemaTicket2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintSchemaTicket2> for &'a IPrintSchemaTicket {
-    fn from(value: &'a IPrintSchemaTicket2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintSchemaTicket2> for IPrintSchemaTicket {
-    fn from(value: &IPrintSchemaTicket2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintSchemaTicket2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrintSchemaElement, IPrintSchemaTicket);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintSchemaTicket2 {
     fn clone(&self) -> Self {
@@ -9647,21 +7636,7 @@ impl IPrintTicketProvider {
         (::windows::core::Vtable::vtable(self).ValidatePrintTicket)(::windows::core::Vtable::as_raw(self), pbaseticket.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPrintTicketProvider> for ::windows::core::IUnknown {
-    fn from(value: IPrintTicketProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTicketProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintTicketProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTicketProvider> for ::windows::core::IUnknown {
-    fn from(value: &IPrintTicketProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintTicketProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintTicketProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9790,36 +7765,7 @@ impl IPrintTicketProvider2 {
         (::windows::core::Vtable::vtable(self).GetPrintDeviceResources)(::windows::core::Vtable::as_raw(self), pszlocalename.into(), pprintticket.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Data::Xml::MsXml::IXMLDOMDocument2>(result__)
     }
 }
-impl ::core::convert::From<IPrintTicketProvider2> for ::windows::core::IUnknown {
-    fn from(value: IPrintTicketProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTicketProvider2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintTicketProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTicketProvider2> for ::windows::core::IUnknown {
-    fn from(value: &IPrintTicketProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintTicketProvider2> for IPrintTicketProvider {
-    fn from(value: IPrintTicketProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintTicketProvider2> for &'a IPrintTicketProvider {
-    fn from(value: &'a IPrintTicketProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintTicketProvider2> for IPrintTicketProvider {
-    fn from(value: &IPrintTicketProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintTicketProvider2, ::windows::core::IUnknown, IPrintTicketProvider);
 impl ::core::clone::Clone for IPrintTicketProvider2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9872,36 +7818,7 @@ impl IPrintUnidiAsyncNotifyRegistration {
         (::windows::core::Vtable::vtable(self).AsyncGetNotification)(::windows::core::Vtable::as_raw(self), param0.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPrintUnidiAsyncNotifyRegistration> for ::windows::core::IUnknown {
-    fn from(value: IPrintUnidiAsyncNotifyRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintUnidiAsyncNotifyRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintUnidiAsyncNotifyRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintUnidiAsyncNotifyRegistration> for ::windows::core::IUnknown {
-    fn from(value: &IPrintUnidiAsyncNotifyRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintUnidiAsyncNotifyRegistration> for IPrintAsyncNotifyRegistration {
-    fn from(value: IPrintUnidiAsyncNotifyRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintUnidiAsyncNotifyRegistration> for &'a IPrintAsyncNotifyRegistration {
-    fn from(value: &'a IPrintUnidiAsyncNotifyRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintUnidiAsyncNotifyRegistration> for IPrintAsyncNotifyRegistration {
-    fn from(value: &IPrintUnidiAsyncNotifyRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintUnidiAsyncNotifyRegistration, ::windows::core::IUnknown, IPrintAsyncNotifyRegistration);
 impl ::core::clone::Clone for IPrintUnidiAsyncNotifyRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9942,21 +7859,7 @@ impl IPrintWriteStream {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IPrintWriteStream> for ::windows::core::IUnknown {
-    fn from(value: IPrintWriteStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintWriteStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintWriteStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintWriteStream> for ::windows::core::IUnknown {
-    fn from(value: &IPrintWriteStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintWriteStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintWriteStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9994,21 +7897,7 @@ impl IPrintWriteStreamFlush {
         (::windows::core::Vtable::vtable(self).FlushData)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrintWriteStreamFlush> for ::windows::core::IUnknown {
-    fn from(value: IPrintWriteStreamFlush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintWriteStreamFlush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintWriteStreamFlush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintWriteStreamFlush> for ::windows::core::IUnknown {
-    fn from(value: &IPrintWriteStreamFlush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintWriteStreamFlush, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintWriteStreamFlush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10045,21 +7934,7 @@ impl IPrinterBidiSetRequestCallback {
         (::windows::core::Vtable::vtable(self).Completed)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrresponse), hrstatus).ok()
     }
 }
-impl ::core::convert::From<IPrinterBidiSetRequestCallback> for ::windows::core::IUnknown {
-    fn from(value: IPrinterBidiSetRequestCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrinterBidiSetRequestCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterBidiSetRequestCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrinterBidiSetRequestCallback> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterBidiSetRequestCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterBidiSetRequestCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrinterBidiSetRequestCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10096,21 +7971,7 @@ impl IPrinterExtensionAsyncOperation {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrinterExtensionAsyncOperation> for ::windows::core::IUnknown {
-    fn from(value: IPrinterExtensionAsyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrinterExtensionAsyncOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterExtensionAsyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrinterExtensionAsyncOperation> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterExtensionAsyncOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterExtensionAsyncOperation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrinterExtensionAsyncOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10171,41 +8032,7 @@ impl IPrinterExtensionContext {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterExtensionContext> for ::windows::core::IUnknown {
-    fn from(value: IPrinterExtensionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterExtensionContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterExtensionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterExtensionContext> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterExtensionContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterExtensionContext> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterExtensionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterExtensionContext> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterExtensionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterExtensionContext> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterExtensionContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterExtensionContext, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterExtensionContext {
     fn clone(&self) -> Self {
@@ -10278,41 +8105,7 @@ impl IPrinterExtensionContextCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterExtensionContextCollection> for ::windows::core::IUnknown {
-    fn from(value: IPrinterExtensionContextCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterExtensionContextCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterExtensionContextCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterExtensionContextCollection> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterExtensionContextCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterExtensionContextCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterExtensionContextCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterExtensionContextCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterExtensionContextCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterExtensionContextCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterExtensionContextCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterExtensionContextCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterExtensionContextCollection {
     fn clone(&self) -> Self {
@@ -10377,41 +8170,7 @@ impl IPrinterExtensionEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterExtensionEvent> for ::windows::core::IUnknown {
-    fn from(value: IPrinterExtensionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterExtensionEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterExtensionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterExtensionEvent> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterExtensionEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterExtensionEvent> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterExtensionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterExtensionEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterExtensionEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterExtensionEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterExtensionEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterExtensionEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterExtensionEvent {
     fn clone(&self) -> Self {
@@ -10520,59 +8279,7 @@ impl IPrinterExtensionEventArgs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterExtensionEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IPrinterExtensionEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterExtensionEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterExtensionEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterExtensionEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterExtensionEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterExtensionEventArgs> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterExtensionEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterExtensionEventArgs> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterExtensionEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterExtensionEventArgs> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterExtensionEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterExtensionEventArgs> for IPrinterExtensionContext {
-    fn from(value: IPrinterExtensionEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterExtensionEventArgs> for &'a IPrinterExtensionContext {
-    fn from(value: &'a IPrinterExtensionEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterExtensionEventArgs> for IPrinterExtensionContext {
-    fn from(value: &IPrinterExtensionEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterExtensionEventArgs, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrinterExtensionContext);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterExtensionEventArgs {
     fn clone(&self) -> Self {
@@ -10634,21 +8341,7 @@ impl IPrinterExtensionManager {
         (::windows::core::Vtable::vtable(self).DisableEvents)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrinterExtensionManager> for ::windows::core::IUnknown {
-    fn from(value: IPrinterExtensionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrinterExtensionManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterExtensionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrinterExtensionManager> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterExtensionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterExtensionManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrinterExtensionManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10692,41 +8385,7 @@ impl IPrinterExtensionRequest {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterExtensionRequest> for ::windows::core::IUnknown {
-    fn from(value: IPrinterExtensionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterExtensionRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterExtensionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterExtensionRequest> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterExtensionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterExtensionRequest> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterExtensionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterExtensionRequest> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterExtensionRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterExtensionRequest> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterExtensionRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterExtensionRequest, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterExtensionRequest {
     fn clone(&self) -> Self {
@@ -10817,41 +8476,7 @@ impl IPrinterPropertyBag {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterPropertyBag> for ::windows::core::IUnknown {
-    fn from(value: IPrinterPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterPropertyBag> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterPropertyBag> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterPropertyBag) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterPropertyBag> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterPropertyBag> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterPropertyBag> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterPropertyBag) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterPropertyBag, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterPropertyBag {
     fn clone(&self) -> Self {
@@ -10935,41 +8560,7 @@ impl IPrinterQueue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterQueue> for ::windows::core::IUnknown {
-    fn from(value: IPrinterQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterQueue> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterQueue> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterQueue> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterQueue> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterQueue, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterQueue {
     fn clone(&self) -> Self {
@@ -11054,59 +8645,7 @@ impl IPrinterQueue2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterQueue2> for ::windows::core::IUnknown {
-    fn from(value: IPrinterQueue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterQueue2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterQueue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterQueue2> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterQueue2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterQueue2> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterQueue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterQueue2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterQueue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterQueue2> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterQueue2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterQueue2> for IPrinterQueue {
-    fn from(value: IPrinterQueue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterQueue2> for &'a IPrinterQueue {
-    fn from(value: &'a IPrinterQueue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterQueue2> for IPrinterQueue {
-    fn from(value: &IPrinterQueue2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterQueue2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrinterQueue);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterQueue2 {
     fn clone(&self) -> Self {
@@ -11157,41 +8696,7 @@ impl IPrinterQueueEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterQueueEvent> for ::windows::core::IUnknown {
-    fn from(value: IPrinterQueueEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterQueueEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterQueueEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterQueueEvent> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterQueueEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterQueueEvent> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterQueueEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterQueueEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterQueueEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterQueueEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterQueueEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterQueueEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterQueueEvent {
     fn clone(&self) -> Self {
@@ -11238,41 +8743,7 @@ impl IPrinterQueueView {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterQueueView> for ::windows::core::IUnknown {
-    fn from(value: IPrinterQueueView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterQueueView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterQueueView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterQueueView> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterQueueView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterQueueView> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterQueueView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterQueueView> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterQueueView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterQueueView> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterQueueView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterQueueView, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterQueueView {
     fn clone(&self) -> Self {
@@ -11324,41 +8795,7 @@ impl IPrinterQueueViewEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterQueueViewEvent> for ::windows::core::IUnknown {
-    fn from(value: IPrinterQueueViewEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterQueueViewEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterQueueViewEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterQueueViewEvent> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterQueueViewEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterQueueViewEvent> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterQueueViewEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterQueueViewEvent> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterQueueViewEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterQueueViewEvent> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterQueueViewEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterQueueViewEvent, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterQueueViewEvent {
     fn clone(&self) -> Self {
@@ -11423,41 +8860,7 @@ impl IPrinterScriptContext {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptContext> for ::windows::core::IUnknown {
-    fn from(value: IPrinterScriptContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterScriptContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptContext> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterScriptContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptContext> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterScriptContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptContext> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterScriptContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptContext> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterScriptContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterScriptContext, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterScriptContext {
     fn clone(&self) -> Self {
@@ -11566,41 +8969,7 @@ impl IPrinterScriptablePropertyBag {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptablePropertyBag> for ::windows::core::IUnknown {
-    fn from(value: IPrinterScriptablePropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptablePropertyBag> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterScriptablePropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptablePropertyBag> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterScriptablePropertyBag) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptablePropertyBag> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterScriptablePropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptablePropertyBag> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterScriptablePropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptablePropertyBag> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterScriptablePropertyBag) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterScriptablePropertyBag, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterScriptablePropertyBag {
     fn clone(&self) -> Self {
@@ -11729,59 +9098,7 @@ impl IPrinterScriptablePropertyBag2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptablePropertyBag2> for ::windows::core::IUnknown {
-    fn from(value: IPrinterScriptablePropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptablePropertyBag2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterScriptablePropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptablePropertyBag2> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterScriptablePropertyBag2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptablePropertyBag2> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterScriptablePropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptablePropertyBag2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterScriptablePropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptablePropertyBag2> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterScriptablePropertyBag2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptablePropertyBag2> for IPrinterScriptablePropertyBag {
-    fn from(value: IPrinterScriptablePropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptablePropertyBag2> for &'a IPrinterScriptablePropertyBag {
-    fn from(value: &'a IPrinterScriptablePropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptablePropertyBag2> for IPrinterScriptablePropertyBag {
-    fn from(value: &IPrinterScriptablePropertyBag2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterScriptablePropertyBag2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrinterScriptablePropertyBag);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterScriptablePropertyBag2 {
     fn clone(&self) -> Self {
@@ -11840,41 +9157,7 @@ impl IPrinterScriptableSequentialStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptableSequentialStream> for ::windows::core::IUnknown {
-    fn from(value: IPrinterScriptableSequentialStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptableSequentialStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterScriptableSequentialStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptableSequentialStream> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterScriptableSequentialStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptableSequentialStream> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterScriptableSequentialStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptableSequentialStream> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterScriptableSequentialStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptableSequentialStream> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterScriptableSequentialStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterScriptableSequentialStream, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterScriptableSequentialStream {
     fn clone(&self) -> Self {
@@ -11952,59 +9235,7 @@ impl IPrinterScriptableStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptableStream> for ::windows::core::IUnknown {
-    fn from(value: IPrinterScriptableStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptableStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinterScriptableStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptableStream> for ::windows::core::IUnknown {
-    fn from(value: &IPrinterScriptableStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptableStream> for super::super::System::Com::IDispatch {
-    fn from(value: IPrinterScriptableStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptableStream> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrinterScriptableStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptableStream> for super::super::System::Com::IDispatch {
-    fn from(value: &IPrinterScriptableStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrinterScriptableStream> for IPrinterScriptableSequentialStream {
-    fn from(value: IPrinterScriptableStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrinterScriptableStream> for &'a IPrinterScriptableSequentialStream {
-    fn from(value: &'a IPrinterScriptableStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrinterScriptableStream> for IPrinterScriptableSequentialStream {
-    fn from(value: &IPrinterScriptableStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinterScriptableStream, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IPrinterScriptableSequentialStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrinterScriptableStream {
     fn clone(&self) -> Self {
@@ -12060,21 +9291,7 @@ impl IXpsDocument {
         (::windows::core::Vtable::vtable(self).SetThumbnail)(::windows::core::Vtable::as_raw(self), pthumbnail.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsDocument> for ::windows::core::IUnknown {
-    fn from(value: IXpsDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsDocument> for ::windows::core::IUnknown {
-    fn from(value: &IXpsDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsDocument, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsDocument {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12148,21 +9365,7 @@ impl IXpsDocumentConsumer {
         (::windows::core::Vtable::vtable(self).GetNewEmptyPart)(::windows::core::Vtable::as_raw(self), uri.into(), ::core::mem::transmute(riid), ::core::mem::transmute(ppnewobject), ::core::mem::transmute(ppwritestream)).ok()
     }
 }
-impl ::core::convert::From<IXpsDocumentConsumer> for ::windows::core::IUnknown {
-    fn from(value: IXpsDocumentConsumer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsDocumentConsumer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsDocumentConsumer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsDocumentConsumer> for ::windows::core::IUnknown {
-    fn from(value: &IXpsDocumentConsumer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsDocumentConsumer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsDocumentConsumer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12206,21 +9409,7 @@ impl IXpsDocumentProvider {
         (::windows::core::Vtable::vtable(self).GetXpsPart)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IXpsDocumentProvider> for ::windows::core::IUnknown {
-    fn from(value: IXpsDocumentProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsDocumentProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsDocumentProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsDocumentProvider> for ::windows::core::IUnknown {
-    fn from(value: &IXpsDocumentProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsDocumentProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsDocumentProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12268,21 +9457,7 @@ impl IXpsPartIterator {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IXpsPartIterator> for ::windows::core::IUnknown {
-    fn from(value: IXpsPartIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsPartIterator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsPartIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsPartIterator> for ::windows::core::IUnknown {
-    fn from(value: &IXpsPartIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsPartIterator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsPartIterator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12331,21 +9506,7 @@ impl IXpsRasterizationFactory {
         (::windows::core::Vtable::vtable(self).CreateRasterizer)(::windows::core::Vtable::as_raw(self), xpspage.into().abi(), dpi, nontextrenderingmode, textrenderingmode, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsRasterizer>(result__)
     }
 }
-impl ::core::convert::From<IXpsRasterizationFactory> for ::windows::core::IUnknown {
-    fn from(value: IXpsRasterizationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsRasterizationFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsRasterizationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsRasterizationFactory> for ::windows::core::IUnknown {
-    fn from(value: &IXpsRasterizationFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsRasterizationFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsRasterizationFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12391,21 +9552,7 @@ impl IXpsRasterizationFactory1 {
         (::windows::core::Vtable::vtable(self).CreateRasterizer)(::windows::core::Vtable::as_raw(self), xpspage.into().abi(), dpi, nontextrenderingmode, textrenderingmode, pixelformat, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsRasterizer>(result__)
     }
 }
-impl ::core::convert::From<IXpsRasterizationFactory1> for ::windows::core::IUnknown {
-    fn from(value: IXpsRasterizationFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsRasterizationFactory1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsRasterizationFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsRasterizationFactory1> for ::windows::core::IUnknown {
-    fn from(value: &IXpsRasterizationFactory1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsRasterizationFactory1, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsRasterizationFactory1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12451,21 +9598,7 @@ impl IXpsRasterizationFactory2 {
         (::windows::core::Vtable::vtable(self).CreateRasterizer)(::windows::core::Vtable::as_raw(self), xpspage.into().abi(), dpix, dpiy, nontextrenderingmode, textrenderingmode, pixelformat, backgroundcolor, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsRasterizer>(result__)
     }
 }
-impl ::core::convert::From<IXpsRasterizationFactory2> for ::windows::core::IUnknown {
-    fn from(value: IXpsRasterizationFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsRasterizationFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsRasterizationFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsRasterizationFactory2> for ::windows::core::IUnknown {
-    fn from(value: &IXpsRasterizationFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsRasterizationFactory2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsRasterizationFactory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12514,21 +9647,7 @@ impl IXpsRasterizer {
         (::windows::core::Vtable::vtable(self).SetMinimalLineWidth)(::windows::core::Vtable::as_raw(self), width).ok()
     }
 }
-impl ::core::convert::From<IXpsRasterizer> for ::windows::core::IUnknown {
-    fn from(value: IXpsRasterizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsRasterizer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsRasterizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsRasterizer> for ::windows::core::IUnknown {
-    fn from(value: &IXpsRasterizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsRasterizer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsRasterizer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12569,21 +9688,7 @@ impl IXpsRasterizerNotificationCallback {
         (::windows::core::Vtable::vtable(self).Continue)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IXpsRasterizerNotificationCallback> for ::windows::core::IUnknown {
-    fn from(value: IXpsRasterizerNotificationCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsRasterizerNotificationCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsRasterizerNotificationCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsRasterizerNotificationCallback> for ::windows::core::IUnknown {
-    fn from(value: &IXpsRasterizerNotificationCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsRasterizerNotificationCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsRasterizerNotificationCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
@@ -2,21 +2,7 @@
 #[repr(transparent)]
 pub struct IApoAcousticEchoCancellation(::windows::core::IUnknown);
 impl IApoAcousticEchoCancellation {}
-impl ::core::convert::From<IApoAcousticEchoCancellation> for ::windows::core::IUnknown {
-    fn from(value: IApoAcousticEchoCancellation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApoAcousticEchoCancellation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApoAcousticEchoCancellation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApoAcousticEchoCancellation> for ::windows::core::IUnknown {
-    fn from(value: &IApoAcousticEchoCancellation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApoAcousticEchoCancellation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApoAcousticEchoCancellation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -62,21 +48,7 @@ impl IApoAuxiliaryInputConfiguration {
         (::windows::core::Vtable::vtable(self).IsInputFormatSupported)(::windows::core::Vtable::as_raw(self), prequestedinputformat.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAudioMediaType>(result__)
     }
 }
-impl ::core::convert::From<IApoAuxiliaryInputConfiguration> for ::windows::core::IUnknown {
-    fn from(value: IApoAuxiliaryInputConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApoAuxiliaryInputConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApoAuxiliaryInputConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApoAuxiliaryInputConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &IApoAuxiliaryInputConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApoAuxiliaryInputConfiguration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApoAuxiliaryInputConfiguration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -115,21 +87,7 @@ impl IApoAuxiliaryInputRT {
         (::windows::core::Vtable::vtable(self).AcceptInput)(::windows::core::Vtable::as_raw(self), dwinputid, ::core::mem::transmute(pinputconnection))
     }
 }
-impl ::core::convert::From<IApoAuxiliaryInputRT> for ::windows::core::IUnknown {
-    fn from(value: IApoAuxiliaryInputRT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApoAuxiliaryInputRT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApoAuxiliaryInputRT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApoAuxiliaryInputRT> for ::windows::core::IUnknown {
-    fn from(value: &IApoAuxiliaryInputRT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApoAuxiliaryInputRT, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApoAuxiliaryInputRT {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -169,21 +127,7 @@ impl IAudioDeviceModulesClient {
         (::windows::core::Vtable::vtable(self).SetAudioDeviceModulesManager)(::windows::core::Vtable::as_raw(self), paudiodevicemodulesmanager.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAudioDeviceModulesClient> for ::windows::core::IUnknown {
-    fn from(value: IAudioDeviceModulesClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioDeviceModulesClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioDeviceModulesClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioDeviceModulesClient> for ::windows::core::IUnknown {
-    fn from(value: &IAudioDeviceModulesClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioDeviceModulesClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioDeviceModulesClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -237,21 +181,7 @@ impl IAudioMediaType {
         (::windows::core::Vtable::vtable(self).GetUncompressedAudioFormat)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<UNCOMPRESSEDAUDIOFORMAT>(result__)
     }
 }
-impl ::core::convert::From<IAudioMediaType> for ::windows::core::IUnknown {
-    fn from(value: IAudioMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioMediaType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioMediaType> for ::windows::core::IUnknown {
-    fn from(value: &IAudioMediaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioMediaType, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioMediaType {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -325,21 +255,7 @@ impl IAudioProcessingObject {
         (::windows::core::Vtable::vtable(self).GetInputChannelCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAudioProcessingObject> for ::windows::core::IUnknown {
-    fn from(value: IAudioProcessingObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioProcessingObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioProcessingObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioProcessingObject> for ::windows::core::IUnknown {
-    fn from(value: &IAudioProcessingObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioProcessingObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioProcessingObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -385,21 +301,7 @@ impl IAudioProcessingObjectConfiguration {
         (::windows::core::Vtable::vtable(self).UnlockForProcess)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAudioProcessingObjectConfiguration> for ::windows::core::IUnknown {
-    fn from(value: IAudioProcessingObjectConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioProcessingObjectConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioProcessingObjectConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioProcessingObjectConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &IAudioProcessingObjectConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioProcessingObjectConfiguration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioProcessingObjectConfiguration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -440,21 +342,7 @@ impl IAudioProcessingObjectLoggingService {
         (::windows::core::Vtable::vtable(self).ApoLog)(::windows::core::Vtable::as_raw(self), level, format.into())
     }
 }
-impl ::core::convert::From<IAudioProcessingObjectLoggingService> for ::windows::core::IUnknown {
-    fn from(value: IAudioProcessingObjectLoggingService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioProcessingObjectLoggingService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioProcessingObjectLoggingService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioProcessingObjectLoggingService> for ::windows::core::IUnknown {
-    fn from(value: &IAudioProcessingObjectLoggingService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioProcessingObjectLoggingService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioProcessingObjectLoggingService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -496,21 +384,7 @@ impl IAudioProcessingObjectNotifications {
         (::windows::core::Vtable::vtable(self).HandleNotification)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(aponotification))
     }
 }
-impl ::core::convert::From<IAudioProcessingObjectNotifications> for ::windows::core::IUnknown {
-    fn from(value: IAudioProcessingObjectNotifications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioProcessingObjectNotifications> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioProcessingObjectNotifications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioProcessingObjectNotifications> for ::windows::core::IUnknown {
-    fn from(value: &IAudioProcessingObjectNotifications) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioProcessingObjectNotifications, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioProcessingObjectNotifications {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -557,21 +431,7 @@ impl IAudioProcessingObjectRT {
         (::windows::core::Vtable::vtable(self).CalcOutputFrames)(::windows::core::Vtable::as_raw(self), u32inputframecount)
     }
 }
-impl ::core::convert::From<IAudioProcessingObjectRT> for ::windows::core::IUnknown {
-    fn from(value: IAudioProcessingObjectRT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioProcessingObjectRT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioProcessingObjectRT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioProcessingObjectRT> for ::windows::core::IUnknown {
-    fn from(value: &IAudioProcessingObjectRT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioProcessingObjectRT, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioProcessingObjectRT {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -611,21 +471,7 @@ impl IAudioProcessingObjectRTQueueService {
         (::windows::core::Vtable::vtable(self).GetRealTimeWorkQueue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAudioProcessingObjectRTQueueService> for ::windows::core::IUnknown {
-    fn from(value: IAudioProcessingObjectRTQueueService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioProcessingObjectRTQueueService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioProcessingObjectRTQueueService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioProcessingObjectRTQueueService> for ::windows::core::IUnknown {
-    fn from(value: &IAudioProcessingObjectRTQueueService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioProcessingObjectRTQueueService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioProcessingObjectRTQueueService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -667,21 +513,7 @@ impl IAudioProcessingObjectVBR {
         (::windows::core::Vtable::vtable(self).CalcMaxOutputFrames)(::windows::core::Vtable::as_raw(self), u32maxinputframecount, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAudioProcessingObjectVBR> for ::windows::core::IUnknown {
-    fn from(value: IAudioProcessingObjectVBR) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioProcessingObjectVBR> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioProcessingObjectVBR) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioProcessingObjectVBR> for ::windows::core::IUnknown {
-    fn from(value: &IAudioProcessingObjectVBR) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioProcessingObjectVBR, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioProcessingObjectVBR {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -715,21 +547,7 @@ pub struct IAudioProcessingObjectVBR_Vtbl {
 #[repr(transparent)]
 pub struct IAudioSystemEffects(::windows::core::IUnknown);
 impl IAudioSystemEffects {}
-impl ::core::convert::From<IAudioSystemEffects> for ::windows::core::IUnknown {
-    fn from(value: IAudioSystemEffects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSystemEffects> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSystemEffects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSystemEffects> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSystemEffects) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSystemEffects, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioSystemEffects {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -770,36 +588,7 @@ impl IAudioSystemEffects2 {
         (::windows::core::Vtable::vtable(self).GetEffectsList)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppeffectsids.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pceffects), event.into()).ok()
     }
 }
-impl ::core::convert::From<IAudioSystemEffects2> for ::windows::core::IUnknown {
-    fn from(value: IAudioSystemEffects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSystemEffects2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSystemEffects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSystemEffects2> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSystemEffects2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioSystemEffects2> for IAudioSystemEffects {
-    fn from(value: IAudioSystemEffects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSystemEffects2> for &'a IAudioSystemEffects {
-    fn from(value: &'a IAudioSystemEffects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSystemEffects2> for IAudioSystemEffects {
-    fn from(value: &IAudioSystemEffects2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSystemEffects2, ::windows::core::IUnknown, IAudioSystemEffects);
 impl ::core::clone::Clone for IAudioSystemEffects2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -855,51 +644,7 @@ impl IAudioSystemEffects3 {
         (::windows::core::Vtable::vtable(self).SetAudioSystemEffectState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(effectid), state).ok()
     }
 }
-impl ::core::convert::From<IAudioSystemEffects3> for ::windows::core::IUnknown {
-    fn from(value: IAudioSystemEffects3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSystemEffects3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSystemEffects3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSystemEffects3> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSystemEffects3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioSystemEffects3> for IAudioSystemEffects {
-    fn from(value: IAudioSystemEffects3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSystemEffects3> for &'a IAudioSystemEffects {
-    fn from(value: &'a IAudioSystemEffects3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSystemEffects3> for IAudioSystemEffects {
-    fn from(value: &IAudioSystemEffects3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioSystemEffects3> for IAudioSystemEffects2 {
-    fn from(value: IAudioSystemEffects3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSystemEffects3> for &'a IAudioSystemEffects2 {
-    fn from(value: &'a IAudioSystemEffects3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSystemEffects3> for IAudioSystemEffects2 {
-    fn from(value: &IAudioSystemEffects3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSystemEffects3, ::windows::core::IUnknown, IAudioSystemEffects, IAudioSystemEffects2);
 impl ::core::clone::Clone for IAudioSystemEffects3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -949,21 +694,7 @@ impl IAudioSystemEffectsCustomFormats {
         (::windows::core::Vtable::vtable(self).GetFormatRepresentation)(::windows::core::Vtable::as_raw(self), nformat, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IAudioSystemEffectsCustomFormats> for ::windows::core::IUnknown {
-    fn from(value: IAudioSystemEffectsCustomFormats) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSystemEffectsCustomFormats> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSystemEffectsCustomFormats) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSystemEffectsCustomFormats> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSystemEffectsCustomFormats) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSystemEffectsCustomFormats, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioSystemEffectsCustomFormats {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
@@ -49,21 +49,7 @@ impl IDirectMusic {
         (::windows::core::Vtable::vtable(self).SetDirectSound)(::windows::core::Vtable::as_raw(self), pdirectsound.into().abi(), hwnd.into()).ok()
     }
 }
-impl ::core::convert::From<IDirectMusic> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusic> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusic> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusic) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusic, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectMusic {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -166,36 +152,7 @@ impl IDirectMusic8 {
         (::windows::core::Vtable::vtable(self).SetExternalMasterClock)(::windows::core::Vtable::as_raw(self), pclock.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDirectMusic8> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusic8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusic8> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusic8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusic8> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusic8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectMusic8> for IDirectMusic {
-    fn from(value: IDirectMusic8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusic8> for &'a IDirectMusic {
-    fn from(value: &'a IDirectMusic8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusic8> for IDirectMusic {
-    fn from(value: &IDirectMusic8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusic8, ::windows::core::IUnknown, IDirectMusic);
 impl ::core::clone::Clone for IDirectMusic8 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -268,21 +225,7 @@ impl IDirectMusicBuffer {
         (::windows::core::Vtable::vtable(self).SetUsedBytes)(::windows::core::Vtable::as_raw(self), cb).ok()
     }
 }
-impl ::core::convert::From<IDirectMusicBuffer> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusicBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusicBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusicBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusicBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectMusicBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -338,21 +281,7 @@ impl IDirectMusicCollection {
         (::windows::core::Vtable::vtable(self).EnumInstrument)(::windows::core::Vtable::as_raw(self), dwindex, ::core::mem::transmute(pdwpatch), pwszname.into(), dwnamelen).ok()
     }
 }
-impl ::core::convert::From<IDirectMusicCollection> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusicCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusicCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicCollection> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusicCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusicCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectMusicCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -390,21 +319,7 @@ impl IDirectMusicDownload {
         (::windows::core::Vtable::vtable(self).GetBuffer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppvbuffer), ::core::mem::transmute(pdwsize)).ok()
     }
 }
-impl ::core::convert::From<IDirectMusicDownload> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusicDownload) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicDownload> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusicDownload) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicDownload> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusicDownload) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusicDownload, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectMusicDownload {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -437,21 +352,7 @@ pub struct IDirectMusicDownload_Vtbl {
 #[repr(transparent)]
 pub struct IDirectMusicDownloadedInstrument(::windows::core::IUnknown);
 impl IDirectMusicDownloadedInstrument {}
-impl ::core::convert::From<IDirectMusicDownloadedInstrument> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusicDownloadedInstrument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicDownloadedInstrument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusicDownloadedInstrument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicDownloadedInstrument> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusicDownloadedInstrument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusicDownloadedInstrument, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectMusicDownloadedInstrument {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -490,21 +391,7 @@ impl IDirectMusicInstrument {
         (::windows::core::Vtable::vtable(self).SetPatch)(::windows::core::Vtable::as_raw(self), dwpatch).ok()
     }
 }
-impl ::core::convert::From<IDirectMusicInstrument> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusicInstrument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicInstrument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusicInstrument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicInstrument> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusicInstrument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusicInstrument, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectMusicInstrument {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -621,21 +508,7 @@ impl IDirectMusicPort {
         (::windows::core::Vtable::vtable(self).GetFormat)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwaveformatex), ::core::mem::transmute(pdwwaveformatexsize), ::core::mem::transmute(pdwbuffersize)).ok()
     }
 }
-impl ::core::convert::From<IDirectMusicPort> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusicPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicPort> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusicPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicPort> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusicPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusicPort, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectMusicPort {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -723,21 +596,7 @@ impl IDirectMusicPortDownload {
         (::windows::core::Vtable::vtable(self).Unload)(::windows::core::Vtable::as_raw(self), pidmdownload.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDirectMusicPortDownload> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusicPortDownload) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicPortDownload> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusicPortDownload) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicPortDownload> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusicPortDownload) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusicPortDownload, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectMusicPortDownload {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -849,21 +708,7 @@ impl IDirectMusicSynth {
         (::windows::core::Vtable::vtable(self).GetAppend)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwappend)).ok()
     }
 }
-impl ::core::convert::From<IDirectMusicSynth> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusicSynth) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicSynth> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusicSynth) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicSynth> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusicSynth) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusicSynth, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectMusicSynth {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1015,36 +860,7 @@ impl IDirectMusicSynth8 {
         (::windows::core::Vtable::vtable(self).AssignChannelToBuses)(::windows::core::Vtable::as_raw(self), dwchannelgroup, dwchannel, ::core::mem::transmute(pdwbuses), cbuses).ok()
     }
 }
-impl ::core::convert::From<IDirectMusicSynth8> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusicSynth8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicSynth8> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusicSynth8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicSynth8> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusicSynth8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectMusicSynth8> for IDirectMusicSynth {
-    fn from(value: IDirectMusicSynth8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicSynth8> for &'a IDirectMusicSynth {
-    fn from(value: &'a IDirectMusicSynth8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicSynth8> for IDirectMusicSynth {
-    fn from(value: &IDirectMusicSynth8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusicSynth8, ::windows::core::IUnknown, IDirectMusicSynth);
 impl ::core::clone::Clone for IDirectMusicSynth8 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1127,21 +943,7 @@ impl IDirectMusicSynthSink {
         (::windows::core::Vtable::vtable(self).GetDesiredBufferSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwbuffersizeinsamples)).ok()
     }
 }
-impl ::core::convert::From<IDirectMusicSynthSink> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusicSynthSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicSynthSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusicSynthSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicSynthSink> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusicSynthSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusicSynthSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectMusicSynthSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1194,21 +996,7 @@ impl IDirectMusicThru {
         (::windows::core::Vtable::vtable(self).ThruChannel)(::windows::core::Vtable::as_raw(self), dwsourcechannelgroup, dwsourcechannel, dwdestinationchannelgroup, dwdestinationchannel, pdestinationport.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDirectMusicThru> for ::windows::core::IUnknown {
-    fn from(value: IDirectMusicThru) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectMusicThru> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectMusicThru) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectMusicThru> for ::windows::core::IUnknown {
-    fn from(value: &IDirectMusicThru) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectMusicThru, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectMusicThru {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/mod.rs
@@ -153,21 +153,7 @@ impl IDirectSound {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcguiddevice.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IDirectSound> for ::windows::core::IUnknown {
-    fn from(value: IDirectSound) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSound> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSound) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSound> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSound) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSound, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSound {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -283,21 +269,7 @@ impl IDirectSound3DBuffer {
         (::windows::core::Vtable::vtable(self).SetVelocity)(::windows::core::Vtable::as_raw(self), x, y, z, dwapply).ok()
     }
 }
-impl ::core::convert::From<IDirectSound3DBuffer> for ::windows::core::IUnknown {
-    fn from(value: IDirectSound3DBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSound3DBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSound3DBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSound3DBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSound3DBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSound3DBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSound3DBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -424,21 +396,7 @@ impl IDirectSound3DListener {
         (::windows::core::Vtable::vtable(self).CommitDeferredSettings)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectSound3DListener> for ::windows::core::IUnknown {
-    fn from(value: IDirectSound3DListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSound3DListener> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSound3DListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSound3DListener> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSound3DListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSound3DListener, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSound3DListener {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -543,36 +501,7 @@ impl IDirectSound8 {
         (::windows::core::Vtable::vtable(self).VerifyCertification)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDirectSound8> for ::windows::core::IUnknown {
-    fn from(value: IDirectSound8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSound8> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSound8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSound8> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSound8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectSound8> for IDirectSound {
-    fn from(value: IDirectSound8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSound8> for &'a IDirectSound {
-    fn from(value: &'a IDirectSound8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSound8> for IDirectSound {
-    fn from(value: &IDirectSound8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSound8, ::windows::core::IUnknown, IDirectSound);
 impl ::core::clone::Clone for IDirectSound8 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -668,21 +597,7 @@ impl IDirectSoundBuffer {
         (::windows::core::Vtable::vtable(self).Restore)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectSoundBuffer> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -805,36 +720,7 @@ impl IDirectSoundBuffer8 {
         (::windows::core::Vtable::vtable(self).GetObjectInPath)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rguidobject), dwindex, ::core::mem::transmute(rguidinterface), ::core::mem::transmute(ppobject)).ok()
     }
 }
-impl ::core::convert::From<IDirectSoundBuffer8> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundBuffer8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundBuffer8> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundBuffer8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundBuffer8> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundBuffer8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectSoundBuffer8> for IDirectSoundBuffer {
-    fn from(value: IDirectSoundBuffer8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundBuffer8> for &'a IDirectSoundBuffer {
-    fn from(value: &'a IDirectSoundBuffer8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundBuffer8> for IDirectSoundBuffer {
-    fn from(value: &IDirectSoundBuffer8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundBuffer8, ::windows::core::IUnknown, IDirectSoundBuffer);
 impl ::core::clone::Clone for IDirectSoundBuffer8 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -883,21 +769,7 @@ impl IDirectSoundCapture {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcguiddevice.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IDirectSoundCapture> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundCapture> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundCapture> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundCapture, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundCapture {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -965,21 +837,7 @@ impl IDirectSoundCaptureBuffer {
         (::windows::core::Vtable::vtable(self).Unlock)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvaudioptr1), dwaudiobytes1, ::core::mem::transmute(pvaudioptr2.unwrap_or(::std::ptr::null())), dwaudiobytes2).ok()
     }
 }
-impl ::core::convert::From<IDirectSoundCaptureBuffer> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundCaptureBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundCaptureBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundCaptureBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundCaptureBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundCaptureBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundCaptureBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundCaptureBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1059,36 +917,7 @@ impl IDirectSoundCaptureBuffer8 {
         (::windows::core::Vtable::vtable(self).GetFXStatus)(::windows::core::Vtable::as_raw(self), pdwfxstatus.len() as _, ::core::mem::transmute(pdwfxstatus.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IDirectSoundCaptureBuffer8> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundCaptureBuffer8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundCaptureBuffer8> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundCaptureBuffer8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundCaptureBuffer8> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundCaptureBuffer8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectSoundCaptureBuffer8> for IDirectSoundCaptureBuffer {
-    fn from(value: IDirectSoundCaptureBuffer8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundCaptureBuffer8> for &'a IDirectSoundCaptureBuffer {
-    fn from(value: &'a IDirectSoundCaptureBuffer8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundCaptureBuffer8> for IDirectSoundCaptureBuffer {
-    fn from(value: &IDirectSoundCaptureBuffer8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundCaptureBuffer8, ::windows::core::IUnknown, IDirectSoundCaptureBuffer);
 impl ::core::clone::Clone for IDirectSoundCaptureBuffer8 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1141,21 +970,7 @@ impl IDirectSoundCaptureFXAec {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectSoundCaptureFXAec> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundCaptureFXAec) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundCaptureFXAec> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundCaptureFXAec) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundCaptureFXAec> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundCaptureFXAec) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundCaptureFXAec, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundCaptureFXAec {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1212,21 +1027,7 @@ impl IDirectSoundCaptureFXNoiseSuppress {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectSoundCaptureFXNoiseSuppress> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundCaptureFXNoiseSuppress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundCaptureFXNoiseSuppress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundCaptureFXNoiseSuppress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundCaptureFXNoiseSuppress> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundCaptureFXNoiseSuppress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundCaptureFXNoiseSuppress, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundCaptureFXNoiseSuppress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1275,21 +1076,7 @@ impl IDirectSoundFXChorus {
         (::windows::core::Vtable::vtable(self).GetAllParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DSFXChorus>(result__)
     }
 }
-impl ::core::convert::From<IDirectSoundFXChorus> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundFXChorus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundFXChorus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundFXChorus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundFXChorus> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundFXChorus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundFXChorus, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundFXChorus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1331,21 +1118,7 @@ impl IDirectSoundFXCompressor {
         (::windows::core::Vtable::vtable(self).GetAllParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DSFXCompressor>(result__)
     }
 }
-impl ::core::convert::From<IDirectSoundFXCompressor> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundFXCompressor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundFXCompressor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundFXCompressor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundFXCompressor> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundFXCompressor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundFXCompressor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundFXCompressor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1387,21 +1160,7 @@ impl IDirectSoundFXDistortion {
         (::windows::core::Vtable::vtable(self).GetAllParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DSFXDistortion>(result__)
     }
 }
-impl ::core::convert::From<IDirectSoundFXDistortion> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundFXDistortion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundFXDistortion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundFXDistortion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundFXDistortion> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundFXDistortion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundFXDistortion, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundFXDistortion {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1443,21 +1202,7 @@ impl IDirectSoundFXEcho {
         (::windows::core::Vtable::vtable(self).GetAllParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DSFXEcho>(result__)
     }
 }
-impl ::core::convert::From<IDirectSoundFXEcho> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundFXEcho) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundFXEcho> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundFXEcho) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundFXEcho> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundFXEcho) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundFXEcho, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundFXEcho {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1499,21 +1244,7 @@ impl IDirectSoundFXFlanger {
         (::windows::core::Vtable::vtable(self).GetAllParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DSFXFlanger>(result__)
     }
 }
-impl ::core::convert::From<IDirectSoundFXFlanger> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundFXFlanger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundFXFlanger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundFXFlanger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundFXFlanger> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundFXFlanger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundFXFlanger, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundFXFlanger {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1555,21 +1286,7 @@ impl IDirectSoundFXGargle {
         (::windows::core::Vtable::vtable(self).GetAllParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DSFXGargle>(result__)
     }
 }
-impl ::core::convert::From<IDirectSoundFXGargle> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundFXGargle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundFXGargle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundFXGargle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundFXGargle> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundFXGargle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundFXGargle, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundFXGargle {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1625,21 +1342,7 @@ impl IDirectSoundFXI3DL2Reverb {
         (::windows::core::Vtable::vtable(self).GetQuality)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IDirectSoundFXI3DL2Reverb> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundFXI3DL2Reverb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundFXI3DL2Reverb> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundFXI3DL2Reverb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundFXI3DL2Reverb> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundFXI3DL2Reverb) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundFXI3DL2Reverb, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundFXI3DL2Reverb {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1685,21 +1388,7 @@ impl IDirectSoundFXParamEq {
         (::windows::core::Vtable::vtable(self).GetAllParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DSFXParamEq>(result__)
     }
 }
-impl ::core::convert::From<IDirectSoundFXParamEq> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundFXParamEq) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundFXParamEq> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundFXParamEq) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundFXParamEq> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundFXParamEq) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundFXParamEq, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundFXParamEq {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1741,21 +1430,7 @@ impl IDirectSoundFXWavesReverb {
         (::windows::core::Vtable::vtable(self).GetAllParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DSFXWavesReverb>(result__)
     }
 }
-impl ::core::convert::From<IDirectSoundFXWavesReverb> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundFXWavesReverb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundFXWavesReverb> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundFXWavesReverb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundFXWavesReverb> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundFXWavesReverb) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundFXWavesReverb, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundFXWavesReverb {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1798,21 +1473,7 @@ impl IDirectSoundFullDuplex {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcaptureguid), ::core::mem::transmute(prenderguid), ::core::mem::transmute(lpdscbufferdesc), ::core::mem::transmute(lpdsbufferdesc), hwnd.into(), dwlevel, ::core::mem::transmute(lplpdirectsoundcapturebuffer8), ::core::mem::transmute(lplpdirectsoundbuffer8)).ok()
     }
 }
-impl ::core::convert::From<IDirectSoundFullDuplex> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundFullDuplex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundFullDuplex> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundFullDuplex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundFullDuplex> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundFullDuplex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundFullDuplex, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundFullDuplex {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1854,21 +1515,7 @@ impl IDirectSoundNotify {
         (::windows::core::Vtable::vtable(self).SetNotificationPositions)(::windows::core::Vtable::as_raw(self), pcpositionnotifies.len() as _, ::core::mem::transmute(pcpositionnotifies.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IDirectSoundNotify> for ::windows::core::IUnknown {
-    fn from(value: IDirectSoundNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectSoundNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectSoundNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectSoundNotify> for ::windows::core::IUnknown {
-    fn from(value: &IDirectSoundNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectSoundNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectSoundNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/mod.rs
@@ -6,21 +6,7 @@ impl IAudioEndpointFormatControl {
         (::windows::core::Vtable::vtable(self).ResetToDefault)(::windows::core::Vtable::as_raw(self), resetflags).ok()
     }
 }
-impl ::core::convert::From<IAudioEndpointFormatControl> for ::windows::core::IUnknown {
-    fn from(value: IAudioEndpointFormatControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpointFormatControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEndpointFormatControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpointFormatControl> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEndpointFormatControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEndpointFormatControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEndpointFormatControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -64,21 +50,7 @@ impl IAudioEndpointLastBufferControl {
         (::windows::core::Vtable::vtable(self).ReleaseOutputDataPointerForLastBuffer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pconnectionproperty))
     }
 }
-impl ::core::convert::From<IAudioEndpointLastBufferControl> for ::windows::core::IUnknown {
-    fn from(value: IAudioEndpointLastBufferControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpointLastBufferControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEndpointLastBufferControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpointLastBufferControl> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEndpointLastBufferControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEndpointLastBufferControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEndpointLastBufferControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -127,21 +99,7 @@ impl IAudioEndpointOffloadStreamMeter {
         (::windows::core::Vtable::vtable(self).GetMeteringData)(::windows::core::Vtable::as_raw(self), u32channelcount, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<f32>(result__)
     }
 }
-impl ::core::convert::From<IAudioEndpointOffloadStreamMeter> for ::windows::core::IUnknown {
-    fn from(value: IAudioEndpointOffloadStreamMeter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpointOffloadStreamMeter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEndpointOffloadStreamMeter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpointOffloadStreamMeter> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEndpointOffloadStreamMeter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEndpointOffloadStreamMeter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEndpointOffloadStreamMeter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -183,21 +141,7 @@ impl IAudioEndpointOffloadStreamMute {
         (::windows::core::Vtable::vtable(self).GetMute)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u8>(result__)
     }
 }
-impl ::core::convert::From<IAudioEndpointOffloadStreamMute> for ::windows::core::IUnknown {
-    fn from(value: IAudioEndpointOffloadStreamMute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpointOffloadStreamMute> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEndpointOffloadStreamMute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpointOffloadStreamMute> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEndpointOffloadStreamMute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEndpointOffloadStreamMute, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEndpointOffloadStreamMute {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -245,21 +189,7 @@ impl IAudioEndpointOffloadStreamVolume {
         (::windows::core::Vtable::vtable(self).GetChannelVolumes)(::windows::core::Vtable::as_raw(self), u32channelcount, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<f32>(result__)
     }
 }
-impl ::core::convert::From<IAudioEndpointOffloadStreamVolume> for ::windows::core::IUnknown {
-    fn from(value: IAudioEndpointOffloadStreamVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpointOffloadStreamVolume> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEndpointOffloadStreamVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpointOffloadStreamVolume> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEndpointOffloadStreamVolume) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEndpointOffloadStreamVolume, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEndpointOffloadStreamVolume {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -372,21 +302,7 @@ impl IAudioEndpointVolume {
         (::windows::core::Vtable::vtable(self).GetVolumeRange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pflvolumemindb), ::core::mem::transmute(pflvolumemaxdb), ::core::mem::transmute(pflvolumeincrementdb)).ok()
     }
 }
-impl ::core::convert::From<IAudioEndpointVolume> for ::windows::core::IUnknown {
-    fn from(value: IAudioEndpointVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpointVolume> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEndpointVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpointVolume> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEndpointVolume) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEndpointVolume, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEndpointVolume {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -448,21 +364,7 @@ impl IAudioEndpointVolumeCallback {
         (::windows::core::Vtable::vtable(self).OnNotify)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pnotify)).ok()
     }
 }
-impl ::core::convert::From<IAudioEndpointVolumeCallback> for ::windows::core::IUnknown {
-    fn from(value: IAudioEndpointVolumeCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpointVolumeCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEndpointVolumeCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpointVolumeCallback> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEndpointVolumeCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEndpointVolumeCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEndpointVolumeCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -576,36 +478,7 @@ impl IAudioEndpointVolumeEx {
         (::windows::core::Vtable::vtable(self).GetVolumeRangeChannel)(::windows::core::Vtable::as_raw(self), ichannel, ::core::mem::transmute(pflvolumemindb), ::core::mem::transmute(pflvolumemaxdb), ::core::mem::transmute(pflvolumeincrementdb)).ok()
     }
 }
-impl ::core::convert::From<IAudioEndpointVolumeEx> for ::windows::core::IUnknown {
-    fn from(value: IAudioEndpointVolumeEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpointVolumeEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEndpointVolumeEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpointVolumeEx> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEndpointVolumeEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioEndpointVolumeEx> for IAudioEndpointVolume {
-    fn from(value: IAudioEndpointVolumeEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpointVolumeEx> for &'a IAudioEndpointVolume {
-    fn from(value: &'a IAudioEndpointVolumeEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpointVolumeEx> for IAudioEndpointVolume {
-    fn from(value: &IAudioEndpointVolumeEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEndpointVolumeEx, ::windows::core::IUnknown, IAudioEndpointVolume);
 impl ::core::clone::Clone for IAudioEndpointVolumeEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -653,21 +526,7 @@ impl IAudioLfxControl {
         (::windows::core::Vtable::vtable(self).GetLocalEffectsState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAudioLfxControl> for ::windows::core::IUnknown {
-    fn from(value: IAudioLfxControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioLfxControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioLfxControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioLfxControl> for ::windows::core::IUnknown {
-    fn from(value: &IAudioLfxControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioLfxControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioLfxControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -723,21 +582,7 @@ impl IAudioMeterInformation {
         (::windows::core::Vtable::vtable(self).QueryHardwareSupport)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAudioMeterInformation> for ::windows::core::IUnknown {
-    fn from(value: IAudioMeterInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioMeterInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioMeterInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioMeterInformation> for ::windows::core::IUnknown {
-    fn from(value: &IAudioMeterInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioMeterInformation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioMeterInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -814,21 +659,7 @@ impl IHardwareAudioEngineBase {
         (::windows::core::Vtable::vtable(self).GetGfxState)(::windows::core::Vtable::as_raw(self), pdevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IHardwareAudioEngineBase> for ::windows::core::IUnknown {
-    fn from(value: IHardwareAudioEngineBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHardwareAudioEngineBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHardwareAudioEngineBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHardwareAudioEngineBase> for ::windows::core::IUnknown {
-    fn from(value: &IHardwareAudioEngineBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHardwareAudioEngineBase, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHardwareAudioEngineBase {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
@@ -89,21 +89,7 @@ impl IXAPO {
         (::windows::core::Vtable::vtable(self).CalcOutputFrames)(::windows::core::Vtable::as_raw(self), inputframecount)
     }
 }
-impl ::core::convert::From<IXAPO> for ::windows::core::IUnknown {
-    fn from(value: IXAPO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXAPO> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXAPO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXAPO> for ::windows::core::IUnknown {
-    fn from(value: &IXAPO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXAPO, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXAPO {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -161,21 +147,7 @@ impl IXAPOHrtfParameters {
         (::windows::core::Vtable::vtable(self).SetEnvironment)(::windows::core::Vtable::as_raw(self), environment).ok()
     }
 }
-impl ::core::convert::From<IXAPOHrtfParameters> for ::windows::core::IUnknown {
-    fn from(value: IXAPOHrtfParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXAPOHrtfParameters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXAPOHrtfParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXAPOHrtfParameters> for ::windows::core::IUnknown {
-    fn from(value: &IXAPOHrtfParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXAPOHrtfParameters, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXAPOHrtfParameters {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -218,21 +190,7 @@ impl IXAPOParameters {
         (::windows::core::Vtable::vtable(self).GetParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pparameters), parameterbytesize)
     }
 }
-impl ::core::convert::From<IXAPOParameters> for ::windows::core::IUnknown {
-    fn from(value: IXAPOParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXAPOParameters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXAPOParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXAPOParameters> for ::windows::core::IUnknown {
-    fn from(value: &IXAPOParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXAPOParameters, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXAPOParameters {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -317,21 +275,7 @@ impl IXAudio2 {
         (::windows::core::Vtable::vtable(self).SetDebugConfiguration)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdebugconfiguration.unwrap_or(::std::ptr::null())), ::core::mem::transmute(preserved.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<IXAudio2> for ::windows::core::IUnknown {
-    fn from(value: IXAudio2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXAudio2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXAudio2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXAudio2> for ::windows::core::IUnknown {
-    fn from(value: &IXAudio2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXAudio2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXAudio2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -441,21 +385,7 @@ impl IXAudio2Extension {
         (::windows::core::Vtable::vtable(self).GetProcessor)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(processor))
     }
 }
-impl ::core::convert::From<IXAudio2Extension> for ::windows::core::IUnknown {
-    fn from(value: IXAudio2Extension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXAudio2Extension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXAudio2Extension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXAudio2Extension> for ::windows::core::IUnknown {
-    fn from(value: &IXAudio2Extension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXAudio2Extension, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXAudio2Extension {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -576,21 +506,7 @@ impl IXAudio2MasteringVoice {
         (::windows::core::Vtable::vtable(self).GetChannelMask)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IXAudio2MasteringVoice> for IXAudio2Voice {
-    fn from(value: IXAudio2MasteringVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXAudio2MasteringVoice> for &'a IXAudio2Voice {
-    fn from(value: &'a IXAudio2MasteringVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXAudio2MasteringVoice> for IXAudio2Voice {
-    fn from(value: &IXAudio2MasteringVoice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXAudio2MasteringVoice, IXAudio2Voice);
 impl ::core::clone::Clone for IXAudio2MasteringVoice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -733,21 +649,7 @@ impl IXAudio2SourceVoice {
         (::windows::core::Vtable::vtable(self).SetSourceSampleRate)(::windows::core::Vtable::as_raw(self), newsourcesamplerate).ok()
     }
 }
-impl ::core::convert::From<IXAudio2SourceVoice> for IXAudio2Voice {
-    fn from(value: IXAudio2SourceVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXAudio2SourceVoice> for &'a IXAudio2Voice {
-    fn from(value: &'a IXAudio2SourceVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXAudio2SourceVoice> for IXAudio2Voice {
-    fn from(value: &IXAudio2SourceVoice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXAudio2SourceVoice, IXAudio2Voice);
 impl ::core::clone::Clone for IXAudio2SourceVoice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -869,21 +771,7 @@ impl IXAudio2SubmixVoice {
         (::windows::core::Vtable::vtable(self).base__.DestroyVoice)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IXAudio2SubmixVoice> for IXAudio2Voice {
-    fn from(value: IXAudio2SubmixVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXAudio2SubmixVoice> for &'a IXAudio2Voice {
-    fn from(value: &'a IXAudio2SubmixVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXAudio2SubmixVoice> for IXAudio2Voice {
-    fn from(value: &IXAudio2SubmixVoice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXAudio2SubmixVoice, IXAudio2Voice);
 impl ::core::clone::Clone for IXAudio2SubmixVoice {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
@@ -1831,21 +1831,7 @@ impl IActivateAudioInterfaceAsyncOperation {
         (::windows::core::Vtable::vtable(self).GetActivateResult)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(activateresult), ::core::mem::transmute(activatedinterface.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IActivateAudioInterfaceAsyncOperation> for ::windows::core::IUnknown {
-    fn from(value: IActivateAudioInterfaceAsyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActivateAudioInterfaceAsyncOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActivateAudioInterfaceAsyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActivateAudioInterfaceAsyncOperation> for ::windows::core::IUnknown {
-    fn from(value: &IActivateAudioInterfaceAsyncOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActivateAudioInterfaceAsyncOperation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActivateAudioInterfaceAsyncOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1885,21 +1871,7 @@ impl IActivateAudioInterfaceCompletionHandler {
         (::windows::core::Vtable::vtable(self).ActivateCompleted)(::windows::core::Vtable::as_raw(self), activateoperation.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IActivateAudioInterfaceCompletionHandler> for ::windows::core::IUnknown {
-    fn from(value: IActivateAudioInterfaceCompletionHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActivateAudioInterfaceCompletionHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActivateAudioInterfaceCompletionHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActivateAudioInterfaceCompletionHandler> for ::windows::core::IUnknown {
-    fn from(value: &IActivateAudioInterfaceCompletionHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActivateAudioInterfaceCompletionHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActivateAudioInterfaceCompletionHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1953,21 +1925,7 @@ impl IAudioAmbisonicsControl {
         (::windows::core::Vtable::vtable(self).SetRotation)(::windows::core::Vtable::as_raw(self), x, y, z, w).ok()
     }
 }
-impl ::core::convert::From<IAudioAmbisonicsControl> for ::windows::core::IUnknown {
-    fn from(value: IAudioAmbisonicsControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioAmbisonicsControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioAmbisonicsControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioAmbisonicsControl> for ::windows::core::IUnknown {
-    fn from(value: &IAudioAmbisonicsControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioAmbisonicsControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioAmbisonicsControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2024,21 +1982,7 @@ impl IAudioAutoGainControl {
         (::windows::core::Vtable::vtable(self).SetEnabled)(::windows::core::Vtable::as_raw(self), benable.into(), ::core::mem::transmute(pguideventcontext.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IAudioAutoGainControl> for ::windows::core::IUnknown {
-    fn from(value: IAudioAutoGainControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioAutoGainControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioAutoGainControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioAutoGainControl> for ::windows::core::IUnknown {
-    fn from(value: &IAudioAutoGainControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioAutoGainControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioAutoGainControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2099,36 +2043,7 @@ impl IAudioBass {
         (::windows::core::Vtable::vtable(self).base__.SetLevelAllChannels)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(alevelsdb.as_ptr()), alevelsdb.len() as _, ::core::mem::transmute(pguideventcontext.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IAudioBass> for ::windows::core::IUnknown {
-    fn from(value: IAudioBass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioBass> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioBass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioBass> for ::windows::core::IUnknown {
-    fn from(value: &IAudioBass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioBass> for IPerChannelDbLevel {
-    fn from(value: IAudioBass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioBass> for &'a IPerChannelDbLevel {
-    fn from(value: &'a IAudioBass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioBass> for IPerChannelDbLevel {
-    fn from(value: &IAudioBass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioBass, ::windows::core::IUnknown, IPerChannelDbLevel);
 impl ::core::clone::Clone for IAudioBass {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2171,21 +2086,7 @@ impl IAudioCaptureClient {
         (::windows::core::Vtable::vtable(self).GetNextPacketSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAudioCaptureClient> for ::windows::core::IUnknown {
-    fn from(value: IAudioCaptureClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioCaptureClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioCaptureClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioCaptureClient> for ::windows::core::IUnknown {
-    fn from(value: &IAudioCaptureClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioCaptureClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioCaptureClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2228,21 +2129,7 @@ impl IAudioChannelConfig {
         (::windows::core::Vtable::vtable(self).GetChannelConfig)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAudioChannelConfig> for ::windows::core::IUnknown {
-    fn from(value: IAudioChannelConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioChannelConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioChannelConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioChannelConfig> for ::windows::core::IUnknown {
-    fn from(value: &IAudioChannelConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioChannelConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioChannelConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2326,21 +2213,7 @@ impl IAudioClient {
         (::windows::core::Vtable::vtable(self).GetService)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IAudioClient> for ::windows::core::IUnknown {
-    fn from(value: IAudioClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioClient> for ::windows::core::IUnknown {
-    fn from(value: &IAudioClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2456,36 +2329,7 @@ impl IAudioClient2 {
         (::windows::core::Vtable::vtable(self).GetBufferSizeLimits)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pformat), beventdriven.into(), ::core::mem::transmute(phnsminbufferduration), ::core::mem::transmute(phnsmaxbufferduration)).ok()
     }
 }
-impl ::core::convert::From<IAudioClient2> for ::windows::core::IUnknown {
-    fn from(value: IAudioClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioClient2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioClient2> for ::windows::core::IUnknown {
-    fn from(value: &IAudioClient2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioClient2> for IAudioClient {
-    fn from(value: IAudioClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioClient2> for &'a IAudioClient {
-    fn from(value: &'a IAudioClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioClient2> for IAudioClient {
-    fn from(value: &IAudioClient2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioClient2, ::windows::core::IUnknown, IAudioClient);
 impl ::core::clone::Clone for IAudioClient2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2607,51 +2451,7 @@ impl IAudioClient3 {
         (::windows::core::Vtable::vtable(self).InitializeSharedAudioStream)(::windows::core::Vtable::as_raw(self), streamflags, periodinframes, ::core::mem::transmute(pformat), ::core::mem::transmute(audiosessionguid.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IAudioClient3> for ::windows::core::IUnknown {
-    fn from(value: IAudioClient3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioClient3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioClient3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioClient3> for ::windows::core::IUnknown {
-    fn from(value: &IAudioClient3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioClient3> for IAudioClient {
-    fn from(value: IAudioClient3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioClient3> for &'a IAudioClient {
-    fn from(value: &'a IAudioClient3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioClient3> for IAudioClient {
-    fn from(value: &IAudioClient3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioClient3> for IAudioClient2 {
-    fn from(value: IAudioClient3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioClient3> for &'a IAudioClient2 {
-    fn from(value: &'a IAudioClient3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioClient3> for IAudioClient2 {
-    fn from(value: &IAudioClient3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioClient3, ::windows::core::IUnknown, IAudioClient, IAudioClient2);
 impl ::core::clone::Clone for IAudioClient3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2690,21 +2490,7 @@ impl IAudioClientDuckingControl {
         (::windows::core::Vtable::vtable(self).SetDuckingOptionsForCurrentStream)(::windows::core::Vtable::as_raw(self), options).ok()
     }
 }
-impl ::core::convert::From<IAudioClientDuckingControl> for ::windows::core::IUnknown {
-    fn from(value: IAudioClientDuckingControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioClientDuckingControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioClientDuckingControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioClientDuckingControl> for ::windows::core::IUnknown {
-    fn from(value: &IAudioClientDuckingControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioClientDuckingControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioClientDuckingControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2749,21 +2535,7 @@ impl IAudioClock {
         (::windows::core::Vtable::vtable(self).GetCharacteristics)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAudioClock> for ::windows::core::IUnknown {
-    fn from(value: IAudioClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioClock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioClock> for ::windows::core::IUnknown {
-    fn from(value: &IAudioClock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioClock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioClock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2802,21 +2574,7 @@ impl IAudioClock2 {
         (::windows::core::Vtable::vtable(self).GetDevicePosition)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(deviceposition), ::core::mem::transmute(qpcposition.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IAudioClock2> for ::windows::core::IUnknown {
-    fn from(value: IAudioClock2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioClock2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioClock2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioClock2> for ::windows::core::IUnknown {
-    fn from(value: &IAudioClock2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioClock2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioClock2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2853,21 +2611,7 @@ impl IAudioClockAdjustment {
         (::windows::core::Vtable::vtable(self).SetSampleRate)(::windows::core::Vtable::as_raw(self), flsamplerate).ok()
     }
 }
-impl ::core::convert::From<IAudioClockAdjustment> for ::windows::core::IUnknown {
-    fn from(value: IAudioClockAdjustment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioClockAdjustment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioClockAdjustment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioClockAdjustment> for ::windows::core::IUnknown {
-    fn from(value: &IAudioClockAdjustment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioClockAdjustment, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioClockAdjustment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2904,21 +2648,7 @@ impl IAudioEffectsChangedNotificationClient {
         (::windows::core::Vtable::vtable(self).OnAudioEffectsChanged)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAudioEffectsChangedNotificationClient> for ::windows::core::IUnknown {
-    fn from(value: IAudioEffectsChangedNotificationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEffectsChangedNotificationClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEffectsChangedNotificationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEffectsChangedNotificationClient> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEffectsChangedNotificationClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEffectsChangedNotificationClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEffectsChangedNotificationClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2972,21 +2702,7 @@ impl IAudioEffectsManager {
         (::windows::core::Vtable::vtable(self).SetAudioEffectState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(effectid), state).ok()
     }
 }
-impl ::core::convert::From<IAudioEffectsManager> for ::windows::core::IUnknown {
-    fn from(value: IAudioEffectsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEffectsManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEffectsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEffectsManager> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEffectsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEffectsManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEffectsManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3034,21 +2750,7 @@ impl IAudioFormatEnumerator {
         (::windows::core::Vtable::vtable(self).GetFormat)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut WAVEFORMATEX>(result__)
     }
 }
-impl ::core::convert::From<IAudioFormatEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAudioFormatEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioFormatEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioFormatEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioFormatEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAudioFormatEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioFormatEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioFormatEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3090,21 +2792,7 @@ impl IAudioInputSelector {
         (::windows::core::Vtable::vtable(self).SetSelection)(::windows::core::Vtable::as_raw(self), nidselect, ::core::mem::transmute(pguideventcontext.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IAudioInputSelector> for ::windows::core::IUnknown {
-    fn from(value: IAudioInputSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioInputSelector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioInputSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioInputSelector> for ::windows::core::IUnknown {
-    fn from(value: &IAudioInputSelector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioInputSelector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioInputSelector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3153,21 +2841,7 @@ impl IAudioLoudness {
         (::windows::core::Vtable::vtable(self).SetEnabled)(::windows::core::Vtable::as_raw(self), benable.into(), ::core::mem::transmute(pguideventcontext.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IAudioLoudness> for ::windows::core::IUnknown {
-    fn from(value: IAudioLoudness) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioLoudness> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioLoudness) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioLoudness> for ::windows::core::IUnknown {
-    fn from(value: &IAudioLoudness) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioLoudness, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioLoudness {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3228,36 +2902,7 @@ impl IAudioMidrange {
         (::windows::core::Vtable::vtable(self).base__.SetLevelAllChannels)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(alevelsdb.as_ptr()), alevelsdb.len() as _, ::core::mem::transmute(pguideventcontext.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IAudioMidrange> for ::windows::core::IUnknown {
-    fn from(value: IAudioMidrange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioMidrange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioMidrange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioMidrange> for ::windows::core::IUnknown {
-    fn from(value: &IAudioMidrange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioMidrange> for IPerChannelDbLevel {
-    fn from(value: IAudioMidrange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioMidrange> for &'a IPerChannelDbLevel {
-    fn from(value: &'a IAudioMidrange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioMidrange> for IPerChannelDbLevel {
-    fn from(value: &IAudioMidrange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioMidrange, ::windows::core::IUnknown, IPerChannelDbLevel);
 impl ::core::clone::Clone for IAudioMidrange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3304,21 +2949,7 @@ impl IAudioMute {
         (::windows::core::Vtable::vtable(self).GetMute)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAudioMute> for ::windows::core::IUnknown {
-    fn from(value: IAudioMute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioMute> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioMute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioMute> for ::windows::core::IUnknown {
-    fn from(value: &IAudioMute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioMute, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioMute {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3366,21 +2997,7 @@ impl IAudioOutputSelector {
         (::windows::core::Vtable::vtable(self).SetSelection)(::windows::core::Vtable::as_raw(self), nidselect, ::core::mem::transmute(pguideventcontext.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IAudioOutputSelector> for ::windows::core::IUnknown {
-    fn from(value: IAudioOutputSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioOutputSelector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioOutputSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioOutputSelector> for ::windows::core::IUnknown {
-    fn from(value: &IAudioOutputSelector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioOutputSelector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioOutputSelector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3423,21 +3040,7 @@ impl IAudioPeakMeter {
         (::windows::core::Vtable::vtable(self).GetLevel)(::windows::core::Vtable::as_raw(self), nchannel, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<f32>(result__)
     }
 }
-impl ::core::convert::From<IAudioPeakMeter> for ::windows::core::IUnknown {
-    fn from(value: IAudioPeakMeter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioPeakMeter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioPeakMeter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioPeakMeter> for ::windows::core::IUnknown {
-    fn from(value: &IAudioPeakMeter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioPeakMeter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioPeakMeter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3479,21 +3082,7 @@ impl IAudioRenderClient {
         (::windows::core::Vtable::vtable(self).ReleaseBuffer)(::windows::core::Vtable::as_raw(self), numframeswritten, dwflags).ok()
     }
 }
-impl ::core::convert::From<IAudioRenderClient> for ::windows::core::IUnknown {
-    fn from(value: IAudioRenderClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioRenderClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioRenderClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioRenderClient> for ::windows::core::IUnknown {
-    fn from(value: &IAudioRenderClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioRenderClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioRenderClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3571,21 +3160,7 @@ impl IAudioSessionControl {
         (::windows::core::Vtable::vtable(self).UnregisterAudioSessionNotification)(::windows::core::Vtable::as_raw(self), newnotifications.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAudioSessionControl> for ::windows::core::IUnknown {
-    fn from(value: IAudioSessionControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSessionControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSessionControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSessionControl> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSessionControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSessionControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioSessionControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3693,36 +3268,7 @@ impl IAudioSessionControl2 {
         (::windows::core::Vtable::vtable(self).SetDuckingPreference)(::windows::core::Vtable::as_raw(self), optout.into()).ok()
     }
 }
-impl ::core::convert::From<IAudioSessionControl2> for ::windows::core::IUnknown {
-    fn from(value: IAudioSessionControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSessionControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSessionControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSessionControl2> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSessionControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioSessionControl2> for IAudioSessionControl {
-    fn from(value: IAudioSessionControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSessionControl2> for &'a IAudioSessionControl {
-    fn from(value: &'a IAudioSessionControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSessionControl2> for IAudioSessionControl {
-    fn from(value: &IAudioSessionControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSessionControl2, ::windows::core::IUnknown, IAudioSessionControl);
 impl ::core::clone::Clone for IAudioSessionControl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3771,21 +3317,7 @@ impl IAudioSessionEnumerator {
         (::windows::core::Vtable::vtable(self).GetSession)(::windows::core::Vtable::as_raw(self), sessioncount, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAudioSessionControl>(result__)
     }
 }
-impl ::core::convert::From<IAudioSessionEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAudioSessionEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSessionEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSessionEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSessionEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSessionEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSessionEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioSessionEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3852,21 +3384,7 @@ impl IAudioSessionEvents {
         (::windows::core::Vtable::vtable(self).OnSessionDisconnected)(::windows::core::Vtable::as_raw(self), disconnectreason).ok()
     }
 }
-impl ::core::convert::From<IAudioSessionEvents> for ::windows::core::IUnknown {
-    fn from(value: IAudioSessionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSessionEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSessionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSessionEvents> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSessionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSessionEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioSessionEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3917,21 +3435,7 @@ impl IAudioSessionManager {
         (::windows::core::Vtable::vtable(self).GetSimpleAudioVolume)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(audiosessionguid.unwrap_or(::std::ptr::null())), streamflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISimpleAudioVolume>(result__)
     }
 }
-impl ::core::convert::From<IAudioSessionManager> for ::windows::core::IUnknown {
-    fn from(value: IAudioSessionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSessionManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSessionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSessionManager> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSessionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSessionManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioSessionManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4003,36 +3507,7 @@ impl IAudioSessionManager2 {
         (::windows::core::Vtable::vtable(self).UnregisterDuckNotification)(::windows::core::Vtable::as_raw(self), ducknotification.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAudioSessionManager2> for ::windows::core::IUnknown {
-    fn from(value: IAudioSessionManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSessionManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSessionManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSessionManager2> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSessionManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioSessionManager2> for IAudioSessionManager {
-    fn from(value: IAudioSessionManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSessionManager2> for &'a IAudioSessionManager {
-    fn from(value: &'a IAudioSessionManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSessionManager2> for IAudioSessionManager {
-    fn from(value: &IAudioSessionManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSessionManager2, ::windows::core::IUnknown, IAudioSessionManager);
 impl ::core::clone::Clone for IAudioSessionManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4076,21 +3551,7 @@ impl IAudioSessionNotification {
         (::windows::core::Vtable::vtable(self).OnSessionCreated)(::windows::core::Vtable::as_raw(self), newsession.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAudioSessionNotification> for ::windows::core::IUnknown {
-    fn from(value: IAudioSessionNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSessionNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSessionNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSessionNotification> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSessionNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSessionNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioSessionNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4134,21 +3595,7 @@ impl IAudioStateMonitor {
         (::windows::core::Vtable::vtable(self).GetSoundLevel)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IAudioStateMonitor> for ::windows::core::IUnknown {
-    fn from(value: IAudioStateMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioStateMonitor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioStateMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioStateMonitor> for ::windows::core::IUnknown {
-    fn from(value: &IAudioStateMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioStateMonitor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioStateMonitor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4201,21 +3648,7 @@ impl IAudioStreamVolume {
         (::windows::core::Vtable::vtable(self).GetAllVolumes)(::windows::core::Vtable::as_raw(self), pfvolumes.len() as _, ::core::mem::transmute(pfvolumes.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IAudioStreamVolume> for ::windows::core::IUnknown {
-    fn from(value: IAudioStreamVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioStreamVolume> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioStreamVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioStreamVolume> for ::windows::core::IUnknown {
-    fn from(value: &IAudioStreamVolume) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioStreamVolume, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioStreamVolume {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4258,21 +3691,7 @@ impl IAudioSystemEffectsPropertyChangeNotificationClient {
         (::windows::core::Vtable::vtable(self).OnPropertyChanged)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(key)).ok()
     }
 }
-impl ::core::convert::From<IAudioSystemEffectsPropertyChangeNotificationClient> for ::windows::core::IUnknown {
-    fn from(value: IAudioSystemEffectsPropertyChangeNotificationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSystemEffectsPropertyChangeNotificationClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSystemEffectsPropertyChangeNotificationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSystemEffectsPropertyChangeNotificationClient> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSystemEffectsPropertyChangeNotificationClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSystemEffectsPropertyChangeNotificationClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioSystemEffectsPropertyChangeNotificationClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4345,21 +3764,7 @@ impl IAudioSystemEffectsPropertyStore {
         (::windows::core::Vtable::vtable(self).UnregisterPropertyChangeNotification)(::windows::core::Vtable::as_raw(self), callback.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAudioSystemEffectsPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: IAudioSystemEffectsPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSystemEffectsPropertyStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSystemEffectsPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSystemEffectsPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSystemEffectsPropertyStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSystemEffectsPropertyStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioSystemEffectsPropertyStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4428,36 +3833,7 @@ impl IAudioTreble {
         (::windows::core::Vtable::vtable(self).base__.SetLevelAllChannels)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(alevelsdb.as_ptr()), alevelsdb.len() as _, ::core::mem::transmute(pguideventcontext.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IAudioTreble> for ::windows::core::IUnknown {
-    fn from(value: IAudioTreble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioTreble> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioTreble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioTreble> for ::windows::core::IUnknown {
-    fn from(value: &IAudioTreble) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioTreble> for IPerChannelDbLevel {
-    fn from(value: IAudioTreble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioTreble> for &'a IPerChannelDbLevel {
-    fn from(value: &'a IAudioTreble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioTreble> for IPerChannelDbLevel {
-    fn from(value: &IAudioTreble) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioTreble, ::windows::core::IUnknown, IPerChannelDbLevel);
 impl ::core::clone::Clone for IAudioTreble {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4502,21 +3878,7 @@ impl IAudioVolumeDuckNotification {
         (::windows::core::Vtable::vtable(self).OnVolumeUnduckNotification)(::windows::core::Vtable::as_raw(self), sessionid.into()).ok()
     }
 }
-impl ::core::convert::From<IAudioVolumeDuckNotification> for ::windows::core::IUnknown {
-    fn from(value: IAudioVolumeDuckNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioVolumeDuckNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioVolumeDuckNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioVolumeDuckNotification> for ::windows::core::IUnknown {
-    fn from(value: &IAudioVolumeDuckNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioVolumeDuckNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioVolumeDuckNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4571,36 +3933,7 @@ impl IAudioVolumeLevel {
         (::windows::core::Vtable::vtable(self).base__.SetLevelAllChannels)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(alevelsdb.as_ptr()), alevelsdb.len() as _, ::core::mem::transmute(pguideventcontext.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IAudioVolumeLevel> for ::windows::core::IUnknown {
-    fn from(value: IAudioVolumeLevel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioVolumeLevel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioVolumeLevel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioVolumeLevel> for ::windows::core::IUnknown {
-    fn from(value: &IAudioVolumeLevel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioVolumeLevel> for IPerChannelDbLevel {
-    fn from(value: IAudioVolumeLevel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioVolumeLevel> for &'a IPerChannelDbLevel {
-    fn from(value: &'a IAudioVolumeLevel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioVolumeLevel> for IPerChannelDbLevel {
-    fn from(value: &IAudioVolumeLevel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioVolumeLevel, ::windows::core::IUnknown, IPerChannelDbLevel);
 impl ::core::clone::Clone for IAudioVolumeLevel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4650,21 +3983,7 @@ impl IChannelAudioVolume {
         (::windows::core::Vtable::vtable(self).GetAllVolumes)(::windows::core::Vtable::as_raw(self), pfvolumes.len() as _, ::core::mem::transmute(pfvolumes.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IChannelAudioVolume> for ::windows::core::IUnknown {
-    fn from(value: IChannelAudioVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IChannelAudioVolume> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IChannelAudioVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IChannelAudioVolume> for ::windows::core::IUnknown {
-    fn from(value: &IChannelAudioVolume) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IChannelAudioVolume, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IChannelAudioVolume {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4737,21 +4056,7 @@ impl IConnector {
         (::windows::core::Vtable::vtable(self).GetDeviceIdConnectedTo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IConnector> for ::windows::core::IUnknown {
-    fn from(value: IConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConnector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConnector> for ::windows::core::IUnknown {
-    fn from(value: &IConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConnector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConnector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4798,21 +4103,7 @@ impl IControlChangeNotify {
         (::windows::core::Vtable::vtable(self).OnNotify)(::windows::core::Vtable::as_raw(self), dwsenderprocessid, ::core::mem::transmute(pguideventcontext.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IControlChangeNotify> for ::windows::core::IUnknown {
-    fn from(value: IControlChangeNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IControlChangeNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IControlChangeNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IControlChangeNotify> for ::windows::core::IUnknown {
-    fn from(value: &IControlChangeNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IControlChangeNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IControlChangeNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4854,21 +4145,7 @@ impl IControlInterface {
         (::windows::core::Vtable::vtable(self).GetIID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IControlInterface> for ::windows::core::IUnknown {
-    fn from(value: IControlInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IControlInterface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IControlInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IControlInterface> for ::windows::core::IUnknown {
-    fn from(value: &IControlInterface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IControlInterface, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IControlInterface {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4916,21 +4193,7 @@ impl IDeviceSpecificProperty {
         (::windows::core::Vtable::vtable(self).Get4BRange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(plmin), ::core::mem::transmute(plmax), ::core::mem::transmute(plstepping)).ok()
     }
 }
-impl ::core::convert::From<IDeviceSpecificProperty> for ::windows::core::IUnknown {
-    fn from(value: IDeviceSpecificProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDeviceSpecificProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeviceSpecificProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDeviceSpecificProperty> for ::windows::core::IUnknown {
-    fn from(value: &IDeviceSpecificProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeviceSpecificProperty, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDeviceSpecificProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5002,21 +4265,7 @@ impl IDeviceTopology {
         (::windows::core::Vtable::vtable(self).GetSignalPath)(::windows::core::Vtable::as_raw(self), pipartfrom.into().abi(), pipartto.into().abi(), brejectmixedpaths.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPartsList>(result__)
     }
 }
-impl ::core::convert::From<IDeviceTopology> for ::windows::core::IUnknown {
-    fn from(value: IDeviceTopology) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDeviceTopology> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeviceTopology) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDeviceTopology> for ::windows::core::IUnknown {
-    fn from(value: &IDeviceTopology) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeviceTopology, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDeviceTopology {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5082,21 +4331,7 @@ impl IMMDevice {
         (::windows::core::Vtable::vtable(self).GetState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMMDevice> for ::windows::core::IUnknown {
-    fn from(value: IMMDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMMDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMMDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMMDevice> for ::windows::core::IUnknown {
-    fn from(value: &IMMDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMMDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMMDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5147,21 +4382,7 @@ impl IMMDeviceActivator {
         (::windows::core::Vtable::vtable(self).Activate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(iid), pdevice.into().abi(), ::core::mem::transmute(pactivationparams.unwrap_or(::std::ptr::null())), ::core::mem::transmute(ppinterface)).ok()
     }
 }
-impl ::core::convert::From<IMMDeviceActivator> for ::windows::core::IUnknown {
-    fn from(value: IMMDeviceActivator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMMDeviceActivator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMMDeviceActivator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMMDeviceActivator> for ::windows::core::IUnknown {
-    fn from(value: &IMMDeviceActivator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMMDeviceActivator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMMDeviceActivator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5206,21 +4427,7 @@ impl IMMDeviceCollection {
         (::windows::core::Vtable::vtable(self).Item)(::windows::core::Vtable::as_raw(self), ndevice, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMMDevice>(result__)
     }
 }
-impl ::core::convert::From<IMMDeviceCollection> for ::windows::core::IUnknown {
-    fn from(value: IMMDeviceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMMDeviceCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMMDeviceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMMDeviceCollection> for ::windows::core::IUnknown {
-    fn from(value: &IMMDeviceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMMDeviceCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMMDeviceCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5282,21 +4489,7 @@ impl IMMDeviceEnumerator {
         (::windows::core::Vtable::vtable(self).UnregisterEndpointNotificationCallback)(::windows::core::Vtable::as_raw(self), pclient.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMMDeviceEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IMMDeviceEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMMDeviceEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMMDeviceEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMMDeviceEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IMMDeviceEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMMDeviceEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMMDeviceEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5338,21 +4531,7 @@ impl IMMEndpoint {
         (::windows::core::Vtable::vtable(self).GetDataFlow)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<EDataFlow>(result__)
     }
 }
-impl ::core::convert::From<IMMEndpoint> for ::windows::core::IUnknown {
-    fn from(value: IMMEndpoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMMEndpoint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMMEndpoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMMEndpoint> for ::windows::core::IUnknown {
-    fn from(value: &IMMEndpoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMMEndpoint, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMMEndpoint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5418,21 +4597,7 @@ impl IMMNotificationClient {
         (::windows::core::Vtable::vtable(self).OnPropertyValueChanged)(::windows::core::Vtable::as_raw(self), pwstrdeviceid.into(), ::core::mem::transmute(key)).ok()
     }
 }
-impl ::core::convert::From<IMMNotificationClient> for ::windows::core::IUnknown {
-    fn from(value: IMMNotificationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMMNotificationClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMMNotificationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMMNotificationClient> for ::windows::core::IUnknown {
-    fn from(value: &IMMNotificationClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMMNotificationClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMMNotificationClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5493,21 +4658,7 @@ impl IMessageFilter {
         (::windows::core::Vtable::vtable(self).MessagePending)(::windows::core::Vtable::as_raw(self), htaskcallee.into(), dwtickcount, dwpendingtype)
     }
 }
-impl ::core::convert::From<IMessageFilter> for ::windows::core::IUnknown {
-    fn from(value: IMessageFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMessageFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMessageFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMessageFilter> for ::windows::core::IUnknown {
-    fn from(value: &IMessageFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMessageFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMessageFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5601,21 +4752,7 @@ impl IPart {
         (::windows::core::Vtable::vtable(self).UnregisterControlChangeCallback)(::windows::core::Vtable::as_raw(self), pnotify.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPart> for ::windows::core::IUnknown {
-    fn from(value: IPart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPart> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPart> for ::windows::core::IUnknown {
-    fn from(value: &IPart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPart, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPart {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5669,21 +4806,7 @@ impl IPartsList {
         (::windows::core::Vtable::vtable(self).GetPart)(::windows::core::Vtable::as_raw(self), nindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPart>(result__)
     }
 }
-impl ::core::convert::From<IPartsList> for ::windows::core::IUnknown {
-    fn from(value: IPartsList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPartsList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPartsList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPartsList> for ::windows::core::IUnknown {
-    fn from(value: &IPartsList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPartsList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPartsList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5738,21 +4861,7 @@ impl IPerChannelDbLevel {
         (::windows::core::Vtable::vtable(self).SetLevelAllChannels)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(alevelsdb.as_ptr()), alevelsdb.len() as _, ::core::mem::transmute(pguideventcontext.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IPerChannelDbLevel> for ::windows::core::IUnknown {
-    fn from(value: IPerChannelDbLevel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPerChannelDbLevel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPerChannelDbLevel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPerChannelDbLevel> for ::windows::core::IUnknown {
-    fn from(value: &IPerChannelDbLevel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPerChannelDbLevel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPerChannelDbLevel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5812,21 +4921,7 @@ impl ISimpleAudioVolume {
         (::windows::core::Vtable::vtable(self).GetMute)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ISimpleAudioVolume> for ::windows::core::IUnknown {
-    fn from(value: ISimpleAudioVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISimpleAudioVolume> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISimpleAudioVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISimpleAudioVolume> for ::windows::core::IUnknown {
-    fn from(value: &ISimpleAudioVolume) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISimpleAudioVolume, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISimpleAudioVolume {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5905,21 +5000,7 @@ impl ISpatialAudioClient {
         (::windows::core::Vtable::vtable(self).ActivateSpatialAudioStream)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(activationparams), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ISpatialAudioClient> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioClient> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpatialAudioClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6017,36 +5098,7 @@ impl ISpatialAudioClient2 {
         (::windows::core::Vtable::vtable(self).GetMaxFrameCountForCategory)(::windows::core::Vtable::as_raw(self), category, offloadenabled.into(), ::core::mem::transmute(objectformat), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ISpatialAudioClient2> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioClient2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioClient2> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioClient2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpatialAudioClient2> for ISpatialAudioClient {
-    fn from(value: ISpatialAudioClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioClient2> for &'a ISpatialAudioClient {
-    fn from(value: &'a ISpatialAudioClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioClient2> for ISpatialAudioClient {
-    fn from(value: &ISpatialAudioClient2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioClient2, ::windows::core::IUnknown, ISpatialAudioClient);
 impl ::core::clone::Clone for ISpatialAudioClient2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6106,21 +5158,7 @@ impl ISpatialAudioMetadataClient {
         (::windows::core::Vtable::vtable(self).ActivateSpatialAudioMetadataReader)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISpatialAudioMetadataReader>(result__)
     }
 }
-impl ::core::convert::From<ISpatialAudioMetadataClient> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioMetadataClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioMetadataClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioMetadataClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioMetadataClient> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioMetadataClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioMetadataClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpatialAudioMetadataClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6174,21 +5212,7 @@ impl ISpatialAudioMetadataCopier {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISpatialAudioMetadataCopier> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioMetadataCopier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioMetadataCopier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioMetadataCopier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioMetadataCopier> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioMetadataCopier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioMetadataCopier, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpatialAudioMetadataCopier {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6244,21 +5268,7 @@ impl ISpatialAudioMetadataItems {
         (::windows::core::Vtable::vtable(self).GetInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<SpatialAudioMetadataItemsInfo>(result__)
     }
 }
-impl ::core::convert::From<ISpatialAudioMetadataItems> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioMetadataItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioMetadataItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioMetadataItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioMetadataItems> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioMetadataItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioMetadataItems, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpatialAudioMetadataItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6305,21 +5315,7 @@ impl ISpatialAudioMetadataItemsBuffer {
         (::windows::core::Vtable::vtable(self).DetachBuffer)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISpatialAudioMetadataItemsBuffer> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioMetadataItemsBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioMetadataItemsBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioMetadataItemsBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioMetadataItemsBuffer> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioMetadataItemsBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioMetadataItemsBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpatialAudioMetadataItemsBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6370,21 +5366,7 @@ impl ISpatialAudioMetadataReader {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISpatialAudioMetadataReader> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioMetadataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioMetadataReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioMetadataReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioMetadataReader> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioMetadataReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioMetadataReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpatialAudioMetadataReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6436,21 +5418,7 @@ impl ISpatialAudioMetadataWriter {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISpatialAudioMetadataWriter> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioMetadataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioMetadataWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioMetadataWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioMetadataWriter> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioMetadataWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioMetadataWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpatialAudioMetadataWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6509,36 +5477,7 @@ impl ISpatialAudioObject {
         (::windows::core::Vtable::vtable(self).SetVolume)(::windows::core::Vtable::as_raw(self), volume).ok()
     }
 }
-impl ::core::convert::From<ISpatialAudioObject> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObject> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpatialAudioObject> for ISpatialAudioObjectBase {
-    fn from(value: ISpatialAudioObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObject> for &'a ISpatialAudioObjectBase {
-    fn from(value: &'a ISpatialAudioObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObject> for ISpatialAudioObjectBase {
-    fn from(value: &ISpatialAudioObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioObject, ::windows::core::IUnknown, ISpatialAudioObjectBase);
 impl ::core::clone::Clone for ISpatialAudioObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6589,21 +5528,7 @@ impl ISpatialAudioObjectBase {
         (::windows::core::Vtable::vtable(self).GetAudioObjectType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<AudioObjectType>(result__)
     }
 }
-impl ::core::convert::From<ISpatialAudioObjectBase> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioObjectBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioObjectBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectBase> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioObjectBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioObjectBase, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpatialAudioObjectBase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6677,36 +5602,7 @@ impl ISpatialAudioObjectForHrtf {
         (::windows::core::Vtable::vtable(self).SetDirectivity)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(directivity)).ok()
     }
 }
-impl ::core::convert::From<ISpatialAudioObjectForHrtf> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioObjectForHrtf) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectForHrtf> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioObjectForHrtf) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectForHrtf> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioObjectForHrtf) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpatialAudioObjectForHrtf> for ISpatialAudioObjectBase {
-    fn from(value: ISpatialAudioObjectForHrtf) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectForHrtf> for &'a ISpatialAudioObjectBase {
-    fn from(value: &'a ISpatialAudioObjectForHrtf) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectForHrtf> for ISpatialAudioObjectBase {
-    fn from(value: &ISpatialAudioObjectForHrtf) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioObjectForHrtf, ::windows::core::IUnknown, ISpatialAudioObjectBase);
 impl ::core::clone::Clone for ISpatialAudioObjectForHrtf {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6764,36 +5660,7 @@ impl ISpatialAudioObjectForMetadataCommands {
         (::windows::core::Vtable::vtable(self).WriteNextMetadataCommand)(::windows::core::Vtable::as_raw(self), commandid, ::core::mem::transmute(valuebuffer.unwrap_or(::std::ptr::null())), valuebufferlength).ok()
     }
 }
-impl ::core::convert::From<ISpatialAudioObjectForMetadataCommands> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioObjectForMetadataCommands) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectForMetadataCommands> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioObjectForMetadataCommands) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectForMetadataCommands> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioObjectForMetadataCommands) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpatialAudioObjectForMetadataCommands> for ISpatialAudioObjectBase {
-    fn from(value: ISpatialAudioObjectForMetadataCommands) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectForMetadataCommands> for &'a ISpatialAudioObjectBase {
-    fn from(value: &'a ISpatialAudioObjectForMetadataCommands) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectForMetadataCommands> for ISpatialAudioObjectBase {
-    fn from(value: &ISpatialAudioObjectForMetadataCommands) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioObjectForMetadataCommands, ::windows::core::IUnknown, ISpatialAudioObjectBase);
 impl ::core::clone::Clone for ISpatialAudioObjectForMetadataCommands {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6847,36 +5714,7 @@ impl ISpatialAudioObjectForMetadataItems {
         (::windows::core::Vtable::vtable(self).GetSpatialAudioMetadataItems)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISpatialAudioMetadataItems>(result__)
     }
 }
-impl ::core::convert::From<ISpatialAudioObjectForMetadataItems> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioObjectForMetadataItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectForMetadataItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioObjectForMetadataItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectForMetadataItems> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioObjectForMetadataItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpatialAudioObjectForMetadataItems> for ISpatialAudioObjectBase {
-    fn from(value: ISpatialAudioObjectForMetadataItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectForMetadataItems> for &'a ISpatialAudioObjectBase {
-    fn from(value: &'a ISpatialAudioObjectForMetadataItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectForMetadataItems> for ISpatialAudioObjectBase {
-    fn from(value: &ISpatialAudioObjectForMetadataItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioObjectForMetadataItems, ::windows::core::IUnknown, ISpatialAudioObjectBase);
 impl ::core::clone::Clone for ISpatialAudioObjectForMetadataItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6940,36 +5778,7 @@ impl ISpatialAudioObjectRenderStream {
         (::windows::core::Vtable::vtable(self).ActivateSpatialAudioObject)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISpatialAudioObject>(result__)
     }
 }
-impl ::core::convert::From<ISpatialAudioObjectRenderStream> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioObjectRenderStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectRenderStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioObjectRenderStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectRenderStream> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioObjectRenderStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpatialAudioObjectRenderStream> for ISpatialAudioObjectRenderStreamBase {
-    fn from(value: ISpatialAudioObjectRenderStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectRenderStream> for &'a ISpatialAudioObjectRenderStreamBase {
-    fn from(value: &'a ISpatialAudioObjectRenderStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectRenderStream> for ISpatialAudioObjectRenderStreamBase {
-    fn from(value: &ISpatialAudioObjectRenderStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioObjectRenderStream, ::windows::core::IUnknown, ISpatialAudioObjectRenderStreamBase);
 impl ::core::clone::Clone for ISpatialAudioObjectRenderStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7029,21 +5838,7 @@ impl ISpatialAudioObjectRenderStreamBase {
         (::windows::core::Vtable::vtable(self).EndUpdatingAudioObjects)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISpatialAudioObjectRenderStreamBase> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioObjectRenderStreamBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectRenderStreamBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioObjectRenderStreamBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectRenderStreamBase> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioObjectRenderStreamBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioObjectRenderStreamBase, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpatialAudioObjectRenderStreamBase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7113,36 +5908,7 @@ impl ISpatialAudioObjectRenderStreamForHrtf {
         (::windows::core::Vtable::vtable(self).ActivateSpatialAudioObjectForHrtf)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISpatialAudioObjectForHrtf>(result__)
     }
 }
-impl ::core::convert::From<ISpatialAudioObjectRenderStreamForHrtf> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioObjectRenderStreamForHrtf) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectRenderStreamForHrtf> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioObjectRenderStreamForHrtf) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectRenderStreamForHrtf> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioObjectRenderStreamForHrtf) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpatialAudioObjectRenderStreamForHrtf> for ISpatialAudioObjectRenderStreamBase {
-    fn from(value: ISpatialAudioObjectRenderStreamForHrtf) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectRenderStreamForHrtf> for &'a ISpatialAudioObjectRenderStreamBase {
-    fn from(value: &'a ISpatialAudioObjectRenderStreamForHrtf) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectRenderStreamForHrtf> for ISpatialAudioObjectRenderStreamBase {
-    fn from(value: &ISpatialAudioObjectRenderStreamForHrtf) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioObjectRenderStreamForHrtf, ::windows::core::IUnknown, ISpatialAudioObjectRenderStreamBase);
 impl ::core::clone::Clone for ISpatialAudioObjectRenderStreamForHrtf {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7210,36 +5976,7 @@ impl ISpatialAudioObjectRenderStreamForMetadata {
         (::windows::core::Vtable::vtable(self).ActivateSpatialAudioObjectForMetadataItems)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISpatialAudioObjectForMetadataItems>(result__)
     }
 }
-impl ::core::convert::From<ISpatialAudioObjectRenderStreamForMetadata> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioObjectRenderStreamForMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectRenderStreamForMetadata> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioObjectRenderStreamForMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectRenderStreamForMetadata> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioObjectRenderStreamForMetadata) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpatialAudioObjectRenderStreamForMetadata> for ISpatialAudioObjectRenderStreamBase {
-    fn from(value: ISpatialAudioObjectRenderStreamForMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectRenderStreamForMetadata> for &'a ISpatialAudioObjectRenderStreamBase {
-    fn from(value: &'a ISpatialAudioObjectRenderStreamForMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectRenderStreamForMetadata> for ISpatialAudioObjectRenderStreamBase {
-    fn from(value: &ISpatialAudioObjectRenderStreamForMetadata) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioObjectRenderStreamForMetadata, ::windows::core::IUnknown, ISpatialAudioObjectRenderStreamBase);
 impl ::core::clone::Clone for ISpatialAudioObjectRenderStreamForMetadata {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7280,21 +6017,7 @@ impl ISpatialAudioObjectRenderStreamNotify {
         (::windows::core::Vtable::vtable(self).OnAvailableDynamicObjectCountChange)(::windows::core::Vtable::as_raw(self), sender.into().abi(), hnscompliancedeadlinetime, availabledynamicobjectcountchange).ok()
     }
 }
-impl ::core::convert::From<ISpatialAudioObjectRenderStreamNotify> for ::windows::core::IUnknown {
-    fn from(value: ISpatialAudioObjectRenderStreamNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialAudioObjectRenderStreamNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialAudioObjectRenderStreamNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialAudioObjectRenderStreamNotify> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialAudioObjectRenderStreamNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialAudioObjectRenderStreamNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpatialAudioObjectRenderStreamNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7327,21 +6050,7 @@ pub struct ISpatialAudioObjectRenderStreamNotify_Vtbl {
 #[repr(transparent)]
 pub struct ISubunit(::windows::core::IUnknown);
 impl ISubunit {}
-impl ::core::convert::From<ISubunit> for ::windows::core::IUnknown {
-    fn from(value: ISubunit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISubunit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISubunit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISubunit> for ::windows::core::IUnknown {
-    fn from(value: &ISubunit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISubunit, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISubunit {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/mod.rs
@@ -9,21 +9,7 @@ impl IComponentAuthenticate {
         (::windows::core::Vtable::vtable(self).SACGetProtocols)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppdwprotocols), ::core::mem::transmute(pdwprotocolcount)).ok()
     }
 }
-impl ::core::convert::From<IComponentAuthenticate> for ::windows::core::IUnknown {
-    fn from(value: IComponentAuthenticate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComponentAuthenticate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComponentAuthenticate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComponentAuthenticate> for ::windows::core::IUnknown {
-    fn from(value: &IComponentAuthenticate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComponentAuthenticate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComponentAuthenticate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -98,21 +84,7 @@ impl IMDSPDevice {
         (::windows::core::Vtable::vtable(self).SendOpaqueCommand)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcommand)).ok()
     }
 }
-impl ::core::convert::From<IMDSPDevice> for ::windows::core::IUnknown {
-    fn from(value: IMDSPDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPDevice> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDSPDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -219,36 +191,7 @@ impl IMDSPDevice2 {
         (::windows::core::Vtable::vtable(self).GetCanonicalName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwszpnpname.as_ptr()), pwszpnpname.len() as _).ok()
     }
 }
-impl ::core::convert::From<IMDSPDevice2> for ::windows::core::IUnknown {
-    fn from(value: IMDSPDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPDevice2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPDevice2> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDSPDevice2> for IMDSPDevice {
-    fn from(value: IMDSPDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPDevice2> for &'a IMDSPDevice {
-    fn from(value: &'a IMDSPDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPDevice2> for IMDSPDevice {
-    fn from(value: &IMDSPDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPDevice2, ::windows::core::IUnknown, IMDSPDevice);
 impl ::core::clone::Clone for IMDSPDevice2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -384,51 +327,7 @@ impl IMDSPDevice3 {
         (::windows::core::Vtable::vtable(self).FindStorage)(::windows::core::Vtable::as_raw(self), findscope, pwszuniqueid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMDSPStorage>(result__)
     }
 }
-impl ::core::convert::From<IMDSPDevice3> for ::windows::core::IUnknown {
-    fn from(value: IMDSPDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPDevice3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPDevice3> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDSPDevice3> for IMDSPDevice {
-    fn from(value: IMDSPDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPDevice3> for &'a IMDSPDevice {
-    fn from(value: &'a IMDSPDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPDevice3> for IMDSPDevice {
-    fn from(value: &IMDSPDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDSPDevice3> for IMDSPDevice2 {
-    fn from(value: IMDSPDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPDevice3> for &'a IMDSPDevice2 {
-    fn from(value: &'a IMDSPDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPDevice3> for IMDSPDevice2 {
-    fn from(value: &IMDSPDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPDevice3, ::windows::core::IUnknown, IMDSPDevice, IMDSPDevice2);
 impl ::core::clone::Clone for IMDSPDevice3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -503,21 +402,7 @@ impl IMDSPDeviceControl {
         (::windows::core::Vtable::vtable(self).Seek)(::windows::core::Vtable::as_raw(self), fumode, noffset).ok()
     }
 }
-impl ::core::convert::From<IMDSPDeviceControl> for ::windows::core::IUnknown {
-    fn from(value: IMDSPDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPDeviceControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPDeviceControl> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPDeviceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPDeviceControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDSPDeviceControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -572,21 +457,7 @@ impl IMDSPDirectTransfer {
         (::windows::core::Vtable::vtable(self).TransferToDevice)(::windows::core::Vtable::as_raw(self), pwszsourcefilepath.into(), psourceoperation.into().abi(), fuflags, pwszdestinationname.into(), psourcemetadata.into().abi(), ptransferprogress.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMDSPStorage>(result__)
     }
 }
-impl ::core::convert::From<IMDSPDirectTransfer> for ::windows::core::IUnknown {
-    fn from(value: IMDSPDirectTransfer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPDirectTransfer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPDirectTransfer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPDirectTransfer> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPDirectTransfer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPDirectTransfer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDSPDirectTransfer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -634,21 +505,7 @@ impl IMDSPEnumDevice {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMDSPEnumDevice>(result__)
     }
 }
-impl ::core::convert::From<IMDSPEnumDevice> for ::windows::core::IUnknown {
-    fn from(value: IMDSPEnumDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPEnumDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPEnumDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPEnumDevice> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPEnumDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPEnumDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDSPEnumDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -699,21 +556,7 @@ impl IMDSPEnumStorage {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMDSPEnumStorage>(result__)
     }
 }
-impl ::core::convert::From<IMDSPEnumStorage> for ::windows::core::IUnknown {
-    fn from(value: IMDSPEnumStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPEnumStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPEnumStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPEnumStorage> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPEnumStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPEnumStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDSPEnumStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -785,21 +628,7 @@ impl IMDSPObject {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMDSPObject> for ::windows::core::IUnknown {
-    fn from(value: IMDSPObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPObject> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDSPObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -881,36 +710,7 @@ impl IMDSPObject2 {
         (::windows::core::Vtable::vtable(self).WriteOnClearChannel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdata), ::core::mem::transmute(pdwsize)).ok()
     }
 }
-impl ::core::convert::From<IMDSPObject2> for ::windows::core::IUnknown {
-    fn from(value: IMDSPObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPObject2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPObject2> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPObject2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDSPObject2> for IMDSPObject {
-    fn from(value: IMDSPObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPObject2> for &'a IMDSPObject {
-    fn from(value: &'a IMDSPObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPObject2> for IMDSPObject {
-    fn from(value: &IMDSPObject2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPObject2, ::windows::core::IUnknown, IMDSPObject);
 impl ::core::clone::Clone for IMDSPObject2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -971,21 +771,7 @@ impl IMDSPObjectInfo {
         (::windows::core::Vtable::vtable(self).GetLongestPlayPosition)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMDSPObjectInfo> for ::windows::core::IUnknown {
-    fn from(value: IMDSPObjectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPObjectInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPObjectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPObjectInfo> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPObjectInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPObjectInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDSPObjectInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1028,21 +814,7 @@ impl IMDSPRevoked {
         (::windows::core::Vtable::vtable(self).GetRevocationURL)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppwszrevocationurl), ::core::mem::transmute(pdwbufferlen)).ok()
     }
 }
-impl ::core::convert::From<IMDSPRevoked> for ::windows::core::IUnknown {
-    fn from(value: IMDSPRevoked) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPRevoked> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPRevoked) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPRevoked> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPRevoked) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPRevoked, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDSPRevoked {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1119,21 +891,7 @@ impl IMDSPStorage {
         (::windows::core::Vtable::vtable(self).SendOpaqueCommand)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcommand)).ok()
     }
 }
-impl ::core::convert::From<IMDSPStorage> for ::windows::core::IUnknown {
-    fn from(value: IMDSPStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPStorage> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDSPStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1254,36 +1012,7 @@ impl IMDSPStorage2 {
         (::windows::core::Vtable::vtable(self).GetAttributes2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwattributes), ::core::mem::transmute(pdwattributesex), ::core::mem::transmute(paudioformat.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pvideoformat.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMDSPStorage2> for ::windows::core::IUnknown {
-    fn from(value: IMDSPStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPStorage2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPStorage2> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPStorage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDSPStorage2> for IMDSPStorage {
-    fn from(value: IMDSPStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPStorage2> for &'a IMDSPStorage {
-    fn from(value: &'a IMDSPStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPStorage2> for IMDSPStorage {
-    fn from(value: &IMDSPStorage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPStorage2, ::windows::core::IUnknown, IMDSPStorage);
 impl ::core::clone::Clone for IMDSPStorage2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1410,51 +1139,7 @@ impl IMDSPStorage3 {
         (::windows::core::Vtable::vtable(self).SetMetadata)(::windows::core::Vtable::as_raw(self), pmetadata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMDSPStorage3> for ::windows::core::IUnknown {
-    fn from(value: IMDSPStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPStorage3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPStorage3> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPStorage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDSPStorage3> for IMDSPStorage {
-    fn from(value: IMDSPStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPStorage3> for &'a IMDSPStorage {
-    fn from(value: &'a IMDSPStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPStorage3> for IMDSPStorage {
-    fn from(value: &IMDSPStorage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDSPStorage3> for IMDSPStorage2 {
-    fn from(value: IMDSPStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPStorage3> for &'a IMDSPStorage2 {
-    fn from(value: &'a IMDSPStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPStorage3> for IMDSPStorage2 {
-    fn from(value: &IMDSPStorage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPStorage3, ::windows::core::IUnknown, IMDSPStorage, IMDSPStorage2);
 impl ::core::clone::Clone for IMDSPStorage3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1601,66 +1286,7 @@ impl IMDSPStorage4 {
         (::windows::core::Vtable::vtable(self).GetParent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMDSPStorage>(result__)
     }
 }
-impl ::core::convert::From<IMDSPStorage4> for ::windows::core::IUnknown {
-    fn from(value: IMDSPStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPStorage4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPStorage4> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPStorage4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDSPStorage4> for IMDSPStorage {
-    fn from(value: IMDSPStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPStorage4> for &'a IMDSPStorage {
-    fn from(value: &'a IMDSPStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPStorage4> for IMDSPStorage {
-    fn from(value: &IMDSPStorage4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDSPStorage4> for IMDSPStorage2 {
-    fn from(value: IMDSPStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPStorage4> for &'a IMDSPStorage2 {
-    fn from(value: &'a IMDSPStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPStorage4> for IMDSPStorage2 {
-    fn from(value: &IMDSPStorage4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDSPStorage4> for IMDSPStorage3 {
-    fn from(value: IMDSPStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPStorage4> for &'a IMDSPStorage3 {
-    fn from(value: &'a IMDSPStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPStorage4> for IMDSPStorage3 {
-    fn from(value: &IMDSPStorage4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPStorage4, ::windows::core::IUnknown, IMDSPStorage, IMDSPStorage2, IMDSPStorage3);
 impl ::core::clone::Clone for IMDSPStorage4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1733,21 +1359,7 @@ impl IMDSPStorageGlobals {
         (::windows::core::Vtable::vtable(self).GetRootStorage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMDSPStorage>(result__)
     }
 }
-impl ::core::convert::From<IMDSPStorageGlobals> for ::windows::core::IUnknown {
-    fn from(value: IMDSPStorageGlobals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDSPStorageGlobals> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDSPStorageGlobals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDSPStorageGlobals> for ::windows::core::IUnknown {
-    fn from(value: &IMDSPStorageGlobals) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDSPStorageGlobals, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDSPStorageGlobals {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1797,21 +1409,7 @@ impl IMDServiceProvider {
         (::windows::core::Vtable::vtable(self).EnumDevices)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMDSPEnumDevice>(result__)
     }
 }
-impl ::core::convert::From<IMDServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: IMDServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDServiceProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: &IMDServiceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDServiceProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDServiceProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1860,36 +1458,7 @@ impl IMDServiceProvider2 {
         (::windows::core::Vtable::vtable(self).CreateDevice)(::windows::core::Vtable::as_raw(self), pwszdevicepath.into(), ::core::mem::transmute(pdwcount), ::core::mem::transmute(pppdevicearray)).ok()
     }
 }
-impl ::core::convert::From<IMDServiceProvider2> for ::windows::core::IUnknown {
-    fn from(value: IMDServiceProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDServiceProvider2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDServiceProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDServiceProvider2> for ::windows::core::IUnknown {
-    fn from(value: &IMDServiceProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDServiceProvider2> for IMDServiceProvider {
-    fn from(value: IMDServiceProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDServiceProvider2> for &'a IMDServiceProvider {
-    fn from(value: &'a IMDServiceProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDServiceProvider2> for IMDServiceProvider {
-    fn from(value: &IMDServiceProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDServiceProvider2, ::windows::core::IUnknown, IMDServiceProvider);
 impl ::core::clone::Clone for IMDServiceProvider2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1940,51 +1509,7 @@ impl IMDServiceProvider3 {
         (::windows::core::Vtable::vtable(self).SetDeviceEnumPreference)(::windows::core::Vtable::as_raw(self), dwenumpref).ok()
     }
 }
-impl ::core::convert::From<IMDServiceProvider3> for ::windows::core::IUnknown {
-    fn from(value: IMDServiceProvider3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDServiceProvider3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDServiceProvider3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDServiceProvider3> for ::windows::core::IUnknown {
-    fn from(value: &IMDServiceProvider3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDServiceProvider3> for IMDServiceProvider {
-    fn from(value: IMDServiceProvider3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDServiceProvider3> for &'a IMDServiceProvider {
-    fn from(value: &'a IMDServiceProvider3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDServiceProvider3> for IMDServiceProvider {
-    fn from(value: &IMDServiceProvider3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMDServiceProvider3> for IMDServiceProvider2 {
-    fn from(value: IMDServiceProvider3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDServiceProvider3> for &'a IMDServiceProvider2 {
-    fn from(value: &'a IMDServiceProvider3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDServiceProvider3> for IMDServiceProvider2 {
-    fn from(value: &IMDServiceProvider3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDServiceProvider3, ::windows::core::IUnknown, IMDServiceProvider, IMDServiceProvider2);
 impl ::core::clone::Clone for IMDServiceProvider3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2022,21 +1547,7 @@ impl ISCPSecureAuthenticate {
         (::windows::core::Vtable::vtable(self).GetSecureQuery)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISCPSecureQuery>(result__)
     }
 }
-impl ::core::convert::From<ISCPSecureAuthenticate> for ::windows::core::IUnknown {
-    fn from(value: ISCPSecureAuthenticate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureAuthenticate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISCPSecureAuthenticate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureAuthenticate> for ::windows::core::IUnknown {
-    fn from(value: &ISCPSecureAuthenticate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISCPSecureAuthenticate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISCPSecureAuthenticate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2078,36 +1589,7 @@ impl ISCPSecureAuthenticate2 {
         (::windows::core::Vtable::vtable(self).GetSCPSession)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISCPSession>(result__)
     }
 }
-impl ::core::convert::From<ISCPSecureAuthenticate2> for ::windows::core::IUnknown {
-    fn from(value: ISCPSecureAuthenticate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureAuthenticate2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISCPSecureAuthenticate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureAuthenticate2> for ::windows::core::IUnknown {
-    fn from(value: &ISCPSecureAuthenticate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISCPSecureAuthenticate2> for ISCPSecureAuthenticate {
-    fn from(value: ISCPSecureAuthenticate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureAuthenticate2> for &'a ISCPSecureAuthenticate {
-    fn from(value: &'a ISCPSecureAuthenticate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureAuthenticate2> for ISCPSecureAuthenticate {
-    fn from(value: &ISCPSecureAuthenticate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISCPSecureAuthenticate2, ::windows::core::IUnknown, ISCPSecureAuthenticate);
 impl ::core::clone::Clone for ISCPSecureAuthenticate2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2150,21 +1632,7 @@ impl ISCPSecureExchange {
         (::windows::core::Vtable::vtable(self).TransferComplete)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISCPSecureExchange> for ::windows::core::IUnknown {
-    fn from(value: ISCPSecureExchange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureExchange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISCPSecureExchange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureExchange> for ::windows::core::IUnknown {
-    fn from(value: &ISCPSecureExchange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISCPSecureExchange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISCPSecureExchange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2215,36 +1683,7 @@ impl ISCPSecureExchange2 {
         (::windows::core::Vtable::vtable(self).TransferContainerData2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdata.as_ptr()), pdata.len() as _, pprogresscallback.into().abi(), ::core::mem::transmute(pfureadyflags), ::core::mem::transmute(abmac)).ok()
     }
 }
-impl ::core::convert::From<ISCPSecureExchange2> for ::windows::core::IUnknown {
-    fn from(value: ISCPSecureExchange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureExchange2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISCPSecureExchange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureExchange2> for ::windows::core::IUnknown {
-    fn from(value: &ISCPSecureExchange2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISCPSecureExchange2> for ISCPSecureExchange {
-    fn from(value: ISCPSecureExchange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureExchange2> for &'a ISCPSecureExchange {
-    fn from(value: &'a ISCPSecureExchange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureExchange2> for ISCPSecureExchange {
-    fn from(value: &ISCPSecureExchange2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISCPSecureExchange2, ::windows::core::IUnknown, ISCPSecureExchange);
 impl ::core::clone::Clone for ISCPSecureExchange2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2313,51 +1752,7 @@ impl ISCPSecureExchange3 {
         (::windows::core::Vtable::vtable(self).TransferCompleteForDevice)(::windows::core::Vtable::as_raw(self), pdevice.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISCPSecureExchange3> for ::windows::core::IUnknown {
-    fn from(value: ISCPSecureExchange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureExchange3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISCPSecureExchange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureExchange3> for ::windows::core::IUnknown {
-    fn from(value: &ISCPSecureExchange3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISCPSecureExchange3> for ISCPSecureExchange {
-    fn from(value: ISCPSecureExchange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureExchange3> for &'a ISCPSecureExchange {
-    fn from(value: &'a ISCPSecureExchange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureExchange3> for ISCPSecureExchange {
-    fn from(value: &ISCPSecureExchange3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISCPSecureExchange3> for ISCPSecureExchange2 {
-    fn from(value: ISCPSecureExchange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureExchange3> for &'a ISCPSecureExchange2 {
-    fn from(value: &'a ISCPSecureExchange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureExchange3> for ISCPSecureExchange2 {
-    fn from(value: &ISCPSecureExchange3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISCPSecureExchange3, ::windows::core::IUnknown, ISCPSecureExchange, ISCPSecureExchange2);
 impl ::core::clone::Clone for ISCPSecureExchange3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2414,21 +1809,7 @@ impl ISCPSecureQuery {
         (::windows::core::Vtable::vtable(self).GetRights)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdata.as_ptr()), pdata.len() as _, ::core::mem::transmute(pbspsessionkey.as_ptr()), pbspsessionkey.len() as _, pstgglobals.into().abi(), ::core::mem::transmute(pprights), ::core::mem::transmute(pnrightscount), ::core::mem::transmute(abmac)).ok()
     }
 }
-impl ::core::convert::From<ISCPSecureQuery> for ::windows::core::IUnknown {
-    fn from(value: ISCPSecureQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureQuery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISCPSecureQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureQuery> for ::windows::core::IUnknown {
-    fn from(value: &ISCPSecureQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISCPSecureQuery, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISCPSecureQuery {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2514,36 +1895,7 @@ impl ISCPSecureQuery2 {
         .ok()
     }
 }
-impl ::core::convert::From<ISCPSecureQuery2> for ::windows::core::IUnknown {
-    fn from(value: ISCPSecureQuery2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureQuery2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISCPSecureQuery2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureQuery2> for ::windows::core::IUnknown {
-    fn from(value: &ISCPSecureQuery2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISCPSecureQuery2> for ISCPSecureQuery {
-    fn from(value: ISCPSecureQuery2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureQuery2> for &'a ISCPSecureQuery {
-    fn from(value: &'a ISCPSecureQuery2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureQuery2> for ISCPSecureQuery {
-    fn from(value: &ISCPSecureQuery2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISCPSecureQuery2, ::windows::core::IUnknown, ISCPSecureQuery);
 impl ::core::clone::Clone for ISCPSecureQuery2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2662,51 +2014,7 @@ impl ISCPSecureQuery3 {
         .ok()
     }
 }
-impl ::core::convert::From<ISCPSecureQuery3> for ::windows::core::IUnknown {
-    fn from(value: ISCPSecureQuery3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureQuery3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISCPSecureQuery3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureQuery3> for ::windows::core::IUnknown {
-    fn from(value: &ISCPSecureQuery3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISCPSecureQuery3> for ISCPSecureQuery {
-    fn from(value: ISCPSecureQuery3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureQuery3> for &'a ISCPSecureQuery {
-    fn from(value: &'a ISCPSecureQuery3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureQuery3> for ISCPSecureQuery {
-    fn from(value: &ISCPSecureQuery3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISCPSecureQuery3> for ISCPSecureQuery2 {
-    fn from(value: ISCPSecureQuery3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSecureQuery3> for &'a ISCPSecureQuery2 {
-    fn from(value: &'a ISCPSecureQuery3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSecureQuery3> for ISCPSecureQuery2 {
-    fn from(value: &ISCPSecureQuery3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISCPSecureQuery3, ::windows::core::IUnknown, ISCPSecureQuery, ISCPSecureQuery2);
 impl ::core::clone::Clone for ISCPSecureQuery3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2754,21 +2062,7 @@ impl ISCPSession {
         (::windows::core::Vtable::vtable(self).GetSecureQuery)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISCPSecureQuery>(result__)
     }
 }
-impl ::core::convert::From<ISCPSession> for ::windows::core::IUnknown {
-    fn from(value: ISCPSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISCPSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISCPSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISCPSession> for ::windows::core::IUnknown {
-    fn from(value: &ISCPSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISCPSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISCPSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2844,21 +2138,7 @@ impl IWMDMDevice {
         (::windows::core::Vtable::vtable(self).SendOpaqueCommand)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcommand)).ok()
     }
 }
-impl ::core::convert::From<IWMDMDevice> for ::windows::core::IUnknown {
-    fn from(value: IWMDMDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMDevice> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2965,36 +2245,7 @@ impl IWMDMDevice2 {
         (::windows::core::Vtable::vtable(self).GetCanonicalName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwszpnpname.as_ptr()), pwszpnpname.len() as _).ok()
     }
 }
-impl ::core::convert::From<IWMDMDevice2> for ::windows::core::IUnknown {
-    fn from(value: IWMDMDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMDevice2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMDevice2> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMDevice2> for IWMDMDevice {
-    fn from(value: IWMDMDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMDevice2> for &'a IWMDMDevice {
-    fn from(value: &'a IWMDMDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMDevice2> for IWMDMDevice {
-    fn from(value: &IWMDMDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMDevice2, ::windows::core::IUnknown, IWMDMDevice);
 impl ::core::clone::Clone for IWMDMDevice2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3130,51 +2381,7 @@ impl IWMDMDevice3 {
         (::windows::core::Vtable::vtable(self).FindStorage)(::windows::core::Vtable::as_raw(self), findscope, pwszuniqueid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMDMStorage>(result__)
     }
 }
-impl ::core::convert::From<IWMDMDevice3> for ::windows::core::IUnknown {
-    fn from(value: IWMDMDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMDevice3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMDevice3> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMDevice3> for IWMDMDevice {
-    fn from(value: IWMDMDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMDevice3> for &'a IWMDMDevice {
-    fn from(value: &'a IWMDMDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMDevice3> for IWMDMDevice {
-    fn from(value: &IWMDMDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMDevice3> for IWMDMDevice2 {
-    fn from(value: IWMDMDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMDevice3> for &'a IWMDMDevice2 {
-    fn from(value: &'a IWMDMDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMDevice3> for IWMDMDevice2 {
-    fn from(value: &IWMDMDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMDevice3, ::windows::core::IUnknown, IWMDMDevice, IWMDMDevice2);
 impl ::core::clone::Clone for IWMDMDevice3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3249,21 +2456,7 @@ impl IWMDMDeviceControl {
         (::windows::core::Vtable::vtable(self).Seek)(::windows::core::Vtable::as_raw(self), fumode, noffset).ok()
     }
 }
-impl ::core::convert::From<IWMDMDeviceControl> for ::windows::core::IUnknown {
-    fn from(value: IWMDMDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMDeviceControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMDeviceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMDeviceControl> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMDeviceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMDeviceControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMDeviceControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3313,21 +2506,7 @@ impl IWMDMDeviceSession {
         (::windows::core::Vtable::vtable(self).EndSession)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(pctx.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), pctx.as_deref().map_or(0, |slice| slice.len() as _)).ok()
     }
 }
-impl ::core::convert::From<IWMDMDeviceSession> for ::windows::core::IUnknown {
-    fn from(value: IWMDMDeviceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMDeviceSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMDeviceSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMDeviceSession> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMDeviceSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMDeviceSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMDeviceSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3376,21 +2555,7 @@ impl IWMDMEnumDevice {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMDMEnumDevice>(result__)
     }
 }
-impl ::core::convert::From<IWMDMEnumDevice> for ::windows::core::IUnknown {
-    fn from(value: IWMDMEnumDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMEnumDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMEnumDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMEnumDevice> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMEnumDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMEnumDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMEnumDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3441,21 +2606,7 @@ impl IWMDMEnumStorage {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMDMEnumStorage>(result__)
     }
 }
-impl ::core::convert::From<IWMDMEnumStorage> for ::windows::core::IUnknown {
-    fn from(value: IWMDMEnumStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMEnumStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMEnumStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMEnumStorage> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMEnumStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMEnumStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMEnumStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3538,21 +2689,7 @@ impl IWMDMLogger {
         (::windows::core::Vtable::vtable(self).SetSizeParams)(::windows::core::Vtable::as_raw(self), dwmaxsize, dwshrinktosize).ok()
     }
 }
-impl ::core::convert::From<IWMDMLogger> for ::windows::core::IUnknown {
-    fn from(value: IWMDMLogger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMLogger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMLogger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMLogger> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMLogger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMLogger, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMLogger {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3619,21 +2756,7 @@ impl IWMDMMetaData {
         (::windows::core::Vtable::vtable(self).GetItemCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IWMDMMetaData> for ::windows::core::IUnknown {
-    fn from(value: IWMDMMetaData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMMetaData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMMetaData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMMetaData> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMMetaData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMMetaData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMMetaData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3676,21 +2799,7 @@ impl IWMDMNotification {
         (::windows::core::Vtable::vtable(self).WMDMMessage)(::windows::core::Vtable::as_raw(self), dwmessagetype, pwszcanonicalname.into()).ok()
     }
 }
-impl ::core::convert::From<IWMDMNotification> for ::windows::core::IUnknown {
-    fn from(value: IWMDMNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMNotification> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3750,21 +2859,7 @@ impl IWMDMObjectInfo {
         (::windows::core::Vtable::vtable(self).GetLongestPlayPosition)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IWMDMObjectInfo> for ::windows::core::IUnknown {
-    fn from(value: IWMDMObjectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMObjectInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMObjectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMObjectInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMObjectInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMObjectInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMObjectInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3841,21 +2936,7 @@ impl IWMDMOperation {
         (::windows::core::Vtable::vtable(self).End)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phcompletioncode), pnewobject.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWMDMOperation> for ::windows::core::IUnknown {
-    fn from(value: IWMDMOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMOperation> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMOperation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3951,36 +3032,7 @@ impl IWMDMOperation2 {
         (::windows::core::Vtable::vtable(self).GetObjectAttributes2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwattributes), ::core::mem::transmute(pdwattributesex), ::core::mem::transmute(paudioformat.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pvideoformat.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IWMDMOperation2> for ::windows::core::IUnknown {
-    fn from(value: IWMDMOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMOperation2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMOperation2> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMOperation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMOperation2> for IWMDMOperation {
-    fn from(value: IWMDMOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMOperation2> for &'a IWMDMOperation {
-    fn from(value: &'a IWMDMOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMOperation2> for IWMDMOperation {
-    fn from(value: &IWMDMOperation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMOperation2, ::windows::core::IUnknown, IWMDMOperation);
 impl ::core::clone::Clone for IWMDMOperation2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4061,36 +3113,7 @@ impl IWMDMOperation3 {
         (::windows::core::Vtable::vtable(self).TransferObjectDataOnClearChannel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdata), ::core::mem::transmute(pdwsize)).ok()
     }
 }
-impl ::core::convert::From<IWMDMOperation3> for ::windows::core::IUnknown {
-    fn from(value: IWMDMOperation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMOperation3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMOperation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMOperation3> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMOperation3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMOperation3> for IWMDMOperation {
-    fn from(value: IWMDMOperation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMOperation3> for &'a IWMDMOperation {
-    fn from(value: &'a IWMDMOperation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMOperation3> for IWMDMOperation {
-    fn from(value: &IWMDMOperation3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMOperation3, ::windows::core::IUnknown, IWMDMOperation);
 impl ::core::clone::Clone for IWMDMOperation3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4133,21 +3156,7 @@ impl IWMDMProgress {
         (::windows::core::Vtable::vtable(self).End)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMDMProgress> for ::windows::core::IUnknown {
-    fn from(value: IWMDMProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMProgress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMProgress> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMProgress, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMProgress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4195,36 +3204,7 @@ impl IWMDMProgress2 {
         (::windows::core::Vtable::vtable(self).End2)(::windows::core::Vtable::as_raw(self), hrcompletioncode).ok()
     }
 }
-impl ::core::convert::From<IWMDMProgress2> for ::windows::core::IUnknown {
-    fn from(value: IWMDMProgress2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMProgress2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMProgress2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMProgress2> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMProgress2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMProgress2> for IWMDMProgress {
-    fn from(value: IWMDMProgress2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMProgress2> for &'a IWMDMProgress {
-    fn from(value: &'a IWMDMProgress2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMProgress2> for IWMDMProgress {
-    fn from(value: &IWMDMProgress2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMProgress2, ::windows::core::IUnknown, IWMDMProgress);
 impl ::core::clone::Clone for IWMDMProgress2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4279,51 +3259,7 @@ impl IWMDMProgress3 {
         (::windows::core::Vtable::vtable(self).End3)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(eventid), hrcompletioncode, ::core::mem::transmute(pcontext.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IWMDMProgress3> for ::windows::core::IUnknown {
-    fn from(value: IWMDMProgress3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMProgress3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMProgress3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMProgress3> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMProgress3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMProgress3> for IWMDMProgress {
-    fn from(value: IWMDMProgress3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMProgress3> for &'a IWMDMProgress {
-    fn from(value: &'a IWMDMProgress3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMProgress3> for IWMDMProgress {
-    fn from(value: &IWMDMProgress3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMProgress3> for IWMDMProgress2 {
-    fn from(value: IWMDMProgress3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMProgress3> for &'a IWMDMProgress2 {
-    fn from(value: &'a IWMDMProgress3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMProgress3> for IWMDMProgress2 {
-    fn from(value: &IWMDMProgress3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMProgress3, ::windows::core::IUnknown, IWMDMProgress, IWMDMProgress2);
 impl ::core::clone::Clone for IWMDMProgress3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4362,21 +3298,7 @@ impl IWMDMRevoked {
         (::windows::core::Vtable::vtable(self).GetRevocationURL)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppwszrevocationurl), ::core::mem::transmute(pdwbufferlen), ::core::mem::transmute(pdwrevokedbitflag)).ok()
     }
 }
-impl ::core::convert::From<IWMDMRevoked> for ::windows::core::IUnknown {
-    fn from(value: IWMDMRevoked) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMRevoked> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMRevoked) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMRevoked> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMRevoked) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMRevoked, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMRevoked {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4444,21 +3366,7 @@ impl IWMDMStorage {
         (::windows::core::Vtable::vtable(self).SendOpaqueCommand)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcommand)).ok()
     }
 }
-impl ::core::convert::From<IWMDMStorage> for ::windows::core::IUnknown {
-    fn from(value: IWMDMStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorage> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4557,36 +3465,7 @@ impl IWMDMStorage2 {
         (::windows::core::Vtable::vtable(self).GetAttributes2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwattributes), ::core::mem::transmute(pdwattributesex), ::core::mem::transmute(paudioformat.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pvideoformat.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IWMDMStorage2> for ::windows::core::IUnknown {
-    fn from(value: IWMDMStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorage2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorage2> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMStorage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMStorage2> for IWMDMStorage {
-    fn from(value: IWMDMStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorage2> for &'a IWMDMStorage {
-    fn from(value: &'a IWMDMStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorage2> for IWMDMStorage {
-    fn from(value: &IWMDMStorage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMStorage2, ::windows::core::IUnknown, IWMDMStorage);
 impl ::core::clone::Clone for IWMDMStorage2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4696,51 +3575,7 @@ impl IWMDMStorage3 {
         (::windows::core::Vtable::vtable(self).SetEnumPreference)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmode), pviews.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(pviews.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr()))).ok()
     }
 }
-impl ::core::convert::From<IWMDMStorage3> for ::windows::core::IUnknown {
-    fn from(value: IWMDMStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorage3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorage3> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMStorage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMStorage3> for IWMDMStorage {
-    fn from(value: IWMDMStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorage3> for &'a IWMDMStorage {
-    fn from(value: &'a IWMDMStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorage3> for IWMDMStorage {
-    fn from(value: &IWMDMStorage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMStorage3> for IWMDMStorage2 {
-    fn from(value: IWMDMStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorage3> for &'a IWMDMStorage2 {
-    fn from(value: &'a IWMDMStorage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorage3> for IWMDMStorage2 {
-    fn from(value: &IWMDMStorage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMStorage3, ::windows::core::IUnknown, IWMDMStorage, IWMDMStorage2);
 impl ::core::clone::Clone for IWMDMStorage3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4872,66 +3707,7 @@ impl IWMDMStorage4 {
         (::windows::core::Vtable::vtable(self).GetParent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMDMStorage>(result__)
     }
 }
-impl ::core::convert::From<IWMDMStorage4> for ::windows::core::IUnknown {
-    fn from(value: IWMDMStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorage4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorage4> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMStorage4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMStorage4> for IWMDMStorage {
-    fn from(value: IWMDMStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorage4> for &'a IWMDMStorage {
-    fn from(value: &'a IWMDMStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorage4> for IWMDMStorage {
-    fn from(value: &IWMDMStorage4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMStorage4> for IWMDMStorage2 {
-    fn from(value: IWMDMStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorage4> for &'a IWMDMStorage2 {
-    fn from(value: &'a IWMDMStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorage4> for IWMDMStorage2 {
-    fn from(value: &IWMDMStorage4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMStorage4> for IWMDMStorage3 {
-    fn from(value: IWMDMStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorage4> for &'a IWMDMStorage3 {
-    fn from(value: &'a IWMDMStorage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorage4> for IWMDMStorage3 {
-    fn from(value: &IWMDMStorage4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMStorage4, ::windows::core::IUnknown, IWMDMStorage, IWMDMStorage2, IWMDMStorage3);
 impl ::core::clone::Clone for IWMDMStorage4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5007,21 +3783,7 @@ impl IWMDMStorageControl {
         (::windows::core::Vtable::vtable(self).Move)(::windows::core::Vtable::as_raw(self), fumode, ptargetobject.into().abi(), pprogress.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWMDMStorageControl> for ::windows::core::IUnknown {
-    fn from(value: IWMDMStorageControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorageControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMStorageControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorageControl> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMStorageControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMStorageControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMStorageControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5106,36 +3868,7 @@ impl IWMDMStorageControl2 {
         (::windows::core::Vtable::vtable(self).Insert2)(::windows::core::Vtable::as_raw(self), fumode, pwszfilesource.into(), pwszfiledest.into(), poperation.into().abi(), pprogress.into().abi(), punknown.into().abi(), ::core::mem::transmute(ppnewobject.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IWMDMStorageControl2> for ::windows::core::IUnknown {
-    fn from(value: IWMDMStorageControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorageControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMStorageControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorageControl2> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMStorageControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMStorageControl2> for IWMDMStorageControl {
-    fn from(value: IWMDMStorageControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorageControl2> for &'a IWMDMStorageControl {
-    fn from(value: &'a IWMDMStorageControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorageControl2> for IWMDMStorageControl {
-    fn from(value: &IWMDMStorageControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMStorageControl2, ::windows::core::IUnknown, IWMDMStorageControl);
 impl ::core::clone::Clone for IWMDMStorageControl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5227,51 +3960,7 @@ impl IWMDMStorageControl3 {
         (::windows::core::Vtable::vtable(self).Insert3)(::windows::core::Vtable::as_raw(self), fumode, futype, pwszfilesource.into(), pwszfiledest.into(), poperation.into().abi(), pprogress.into().abi(), pmetadata.into().abi(), punknown.into().abi(), ::core::mem::transmute(ppnewobject.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IWMDMStorageControl3> for ::windows::core::IUnknown {
-    fn from(value: IWMDMStorageControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorageControl3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMStorageControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorageControl3> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMStorageControl3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMStorageControl3> for IWMDMStorageControl {
-    fn from(value: IWMDMStorageControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorageControl3> for &'a IWMDMStorageControl {
-    fn from(value: &'a IWMDMStorageControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorageControl3> for IWMDMStorageControl {
-    fn from(value: &IWMDMStorageControl3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDMStorageControl3> for IWMDMStorageControl2 {
-    fn from(value: IWMDMStorageControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorageControl3> for &'a IWMDMStorageControl2 {
-    fn from(value: &'a IWMDMStorageControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorageControl3> for IWMDMStorageControl2 {
-    fn from(value: &IWMDMStorageControl3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMStorageControl3, ::windows::core::IUnknown, IWMDMStorageControl, IWMDMStorageControl2);
 impl ::core::clone::Clone for IWMDMStorageControl3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5331,21 +4020,7 @@ impl IWMDMStorageGlobals {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), fumode, pprogress.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWMDMStorageGlobals> for ::windows::core::IUnknown {
-    fn from(value: IWMDMStorageGlobals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDMStorageGlobals> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDMStorageGlobals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDMStorageGlobals> for ::windows::core::IUnknown {
-    fn from(value: &IWMDMStorageGlobals) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDMStorageGlobals, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDMStorageGlobals {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5397,21 +4072,7 @@ impl IWMDeviceManager {
         (::windows::core::Vtable::vtable(self).EnumDevices)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMDMEnumDevice>(result__)
     }
 }
-impl ::core::convert::From<IWMDeviceManager> for ::windows::core::IUnknown {
-    fn from(value: IWMDeviceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDeviceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDeviceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDeviceManager> for ::windows::core::IUnknown {
-    fn from(value: &IWMDeviceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDeviceManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDeviceManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5473,36 +4134,7 @@ impl IWMDeviceManager2 {
         (::windows::core::Vtable::vtable(self).Reinitialize)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMDeviceManager2> for ::windows::core::IUnknown {
-    fn from(value: IWMDeviceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDeviceManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDeviceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDeviceManager2> for ::windows::core::IUnknown {
-    fn from(value: &IWMDeviceManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDeviceManager2> for IWMDeviceManager {
-    fn from(value: IWMDeviceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDeviceManager2> for &'a IWMDeviceManager {
-    fn from(value: &'a IWMDeviceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDeviceManager2> for IWMDeviceManager {
-    fn from(value: &IWMDeviceManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDeviceManager2, ::windows::core::IUnknown, IWMDeviceManager);
 impl ::core::clone::Clone for IWMDeviceManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5567,51 +4199,7 @@ impl IWMDeviceManager3 {
         (::windows::core::Vtable::vtable(self).SetDeviceEnumPreference)(::windows::core::Vtable::as_raw(self), dwenumpref).ok()
     }
 }
-impl ::core::convert::From<IWMDeviceManager3> for ::windows::core::IUnknown {
-    fn from(value: IWMDeviceManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDeviceManager3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDeviceManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDeviceManager3> for ::windows::core::IUnknown {
-    fn from(value: &IWMDeviceManager3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDeviceManager3> for IWMDeviceManager {
-    fn from(value: IWMDeviceManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDeviceManager3> for &'a IWMDeviceManager {
-    fn from(value: &'a IWMDeviceManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDeviceManager3> for IWMDeviceManager {
-    fn from(value: &IWMDeviceManager3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDeviceManager3> for IWMDeviceManager2 {
-    fn from(value: IWMDeviceManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDeviceManager3> for &'a IWMDeviceManager2 {
-    fn from(value: &'a IWMDeviceManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDeviceManager3> for IWMDeviceManager2 {
-    fn from(value: &IWMDeviceManager3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDeviceManager3, ::windows::core::IUnknown, IWMDeviceManager, IWMDeviceManager2);
 impl ::core::clone::Clone for IWMDeviceManager3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/mod.rs
@@ -26,21 +26,7 @@ impl IXMLGraphBuilder {
         (::windows::core::Vtable::vtable(self).BuildFromXMLFile)(::windows::core::Vtable::as_raw(self), pgraph.into().abi(), wszfilename.into(), wszbaseurl.into()).ok()
     }
 }
-impl ::core::convert::From<IXMLGraphBuilder> for ::windows::core::IUnknown {
-    fn from(value: IXMLGraphBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXMLGraphBuilder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXMLGraphBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXMLGraphBuilder> for ::windows::core::IUnknown {
-    fn from(value: &IXMLGraphBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXMLGraphBuilder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXMLGraphBuilder {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
@@ -122,21 +122,7 @@ impl IDMOQualityControl {
         (::windows::core::Vtable::vtable(self).GetStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDMOQualityControl> for ::windows::core::IUnknown {
-    fn from(value: IDMOQualityControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMOQualityControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMOQualityControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMOQualityControl> for ::windows::core::IUnknown {
-    fn from(value: &IDMOQualityControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMOQualityControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDMOQualityControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -187,21 +173,7 @@ impl IDMOVideoOutputOptimizations {
         (::windows::core::Vtable::vtable(self).GetCurrentSampleRequirements)(::windows::core::Vtable::as_raw(self), uloutputstreamindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDMOVideoOutputOptimizations> for ::windows::core::IUnknown {
-    fn from(value: IDMOVideoOutputOptimizations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDMOVideoOutputOptimizations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDMOVideoOutputOptimizations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDMOVideoOutputOptimizations> for ::windows::core::IUnknown {
-    fn from(value: &IDMOVideoOutputOptimizations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDMOVideoOutputOptimizations, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDMOVideoOutputOptimizations {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -251,21 +223,7 @@ impl IEnumDMO {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDMO>(result__)
     }
 }
-impl ::core::convert::From<IEnumDMO> for ::windows::core::IUnknown {
-    fn from(value: IEnumDMO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDMO> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDMO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDMO> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDMO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDMO, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDMO {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -312,21 +270,7 @@ impl IMediaBuffer {
         (::windows::core::Vtable::vtable(self).GetBufferAndLength)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppbuffer.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pcblength.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMediaBuffer> for ::windows::core::IUnknown {
-    fn from(value: IMediaBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IMediaBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMediaBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -448,21 +392,7 @@ impl IMediaObject {
         (::windows::core::Vtable::vtable(self).Lock)(::windows::core::Vtable::as_raw(self), block).ok()
     }
 }
-impl ::core::convert::From<IMediaObject> for ::windows::core::IUnknown {
-    fn from(value: IMediaObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaObject> for ::windows::core::IUnknown {
-    fn from(value: &IMediaObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMediaObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -545,21 +475,7 @@ impl IMediaObjectInPlace {
         (::windows::core::Vtable::vtable(self).GetLatency)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i64>(result__)
     }
 }
-impl ::core::convert::From<IMediaObjectInPlace> for ::windows::core::IUnknown {
-    fn from(value: IMediaObjectInPlace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMediaObjectInPlace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMediaObjectInPlace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMediaObjectInPlace> for ::windows::core::IUnknown {
-    fn from(value: &IMediaObjectInPlace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMediaObjectInPlace, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMediaObjectInPlace {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
@@ -117,21 +117,7 @@ impl IKsAggregateControl {
         (::windows::core::Vtable::vtable(self).KsRemoveAggregate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(aggregateclass)).ok()
     }
 }
-impl ::core::convert::From<IKsAggregateControl> for ::windows::core::IUnknown {
-    fn from(value: IKsAggregateControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKsAggregateControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKsAggregateControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKsAggregateControl> for ::windows::core::IUnknown {
-    fn from(value: &IKsAggregateControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKsAggregateControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKsAggregateControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -175,21 +161,7 @@ impl IKsControl {
         (::windows::core::Vtable::vtable(self).KsEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(event), eventlength, ::core::mem::transmute(eventdata), datalength, ::core::mem::transmute(bytesreturned)).ok()
     }
 }
-impl ::core::convert::From<IKsControl> for ::windows::core::IUnknown {
-    fn from(value: IKsControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKsControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKsControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKsControl> for ::windows::core::IUnknown {
-    fn from(value: &IKsControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKsControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKsControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -234,21 +206,7 @@ impl IKsFormatSupport {
         (::windows::core::Vtable::vtable(self).GetDevicePreferredFormat)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut KSDATAFORMAT>(result__)
     }
 }
-impl ::core::convert::From<IKsFormatSupport> for ::windows::core::IUnknown {
-    fn from(value: IKsFormatSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKsFormatSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKsFormatSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKsFormatSupport> for ::windows::core::IUnknown {
-    fn from(value: &IKsFormatSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKsFormatSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKsFormatSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -290,21 +248,7 @@ impl IKsJackContainerId {
         (::windows::core::Vtable::vtable(self).GetJackContainerId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IKsJackContainerId> for ::windows::core::IUnknown {
-    fn from(value: IKsJackContainerId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKsJackContainerId> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKsJackContainerId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKsJackContainerId> for ::windows::core::IUnknown {
-    fn from(value: &IKsJackContainerId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKsJackContainerId, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKsJackContainerId {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -348,21 +292,7 @@ impl IKsJackDescription {
         (::windows::core::Vtable::vtable(self).GetJackDescription)(::windows::core::Vtable::as_raw(self), njack, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<KSJACK_DESCRIPTION>(result__)
     }
 }
-impl ::core::convert::From<IKsJackDescription> for ::windows::core::IUnknown {
-    fn from(value: IKsJackDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKsJackDescription> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKsJackDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKsJackDescription> for ::windows::core::IUnknown {
-    fn from(value: &IKsJackDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKsJackDescription, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKsJackDescription {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -408,21 +338,7 @@ impl IKsJackDescription2 {
         (::windows::core::Vtable::vtable(self).GetJackDescription2)(::windows::core::Vtable::as_raw(self), njack, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<KSJACK_DESCRIPTION2>(result__)
     }
 }
-impl ::core::convert::From<IKsJackDescription2> for ::windows::core::IUnknown {
-    fn from(value: IKsJackDescription2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKsJackDescription2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKsJackDescription2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKsJackDescription2> for ::windows::core::IUnknown {
-    fn from(value: &IKsJackDescription2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKsJackDescription2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKsJackDescription2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -463,21 +379,7 @@ impl IKsJackSinkInformation {
         (::windows::core::Vtable::vtable(self).GetJackSinkInformation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<KSJACK_SINK_INFORMATION>(result__)
     }
 }
-impl ::core::convert::From<IKsJackSinkInformation> for ::windows::core::IUnknown {
-    fn from(value: IKsJackSinkInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKsJackSinkInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKsJackSinkInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKsJackSinkInformation> for ::windows::core::IUnknown {
-    fn from(value: &IKsJackSinkInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKsJackSinkInformation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKsJackSinkInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -524,21 +426,7 @@ impl IKsPropertySet {
         (::windows::core::Vtable::vtable(self).QuerySupported)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(propset), id, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IKsPropertySet> for ::windows::core::IUnknown {
-    fn from(value: IKsPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKsPropertySet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKsPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKsPropertySet> for ::windows::core::IUnknown {
-    fn from(value: &IKsPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKsPropertySet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKsPropertySet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -580,21 +468,7 @@ impl IKsTopology {
         (::windows::core::Vtable::vtable(self).CreateNodeInstance)(::windows::core::Vtable::as_raw(self), nodeid, flags, desiredaccess, unkouter.into().abi(), ::core::mem::transmute(interfaceid), ::core::mem::transmute(interface)).ok()
     }
 }
-impl ::core::convert::From<IKsTopology> for ::windows::core::IUnknown {
-    fn from(value: IKsTopology) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKsTopology> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKsTopology) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKsTopology> for ::windows::core::IUnknown {
-    fn from(value: &IKsTopology) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKsTopology, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKsTopology {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/LibrarySharingServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/LibrarySharingServices/mod.rs
@@ -23,41 +23,7 @@ impl IWindowsMediaLibrarySharingDevice {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsMediaLibrarySharingDevice> for ::windows::core::IUnknown {
-    fn from(value: IWindowsMediaLibrarySharingDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsMediaLibrarySharingDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsMediaLibrarySharingDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsMediaLibrarySharingDevice> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsMediaLibrarySharingDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsMediaLibrarySharingDevice> for super::super::System::Com::IDispatch {
-    fn from(value: IWindowsMediaLibrarySharingDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsMediaLibrarySharingDevice> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWindowsMediaLibrarySharingDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsMediaLibrarySharingDevice> for super::super::System::Com::IDispatch {
-    fn from(value: &IWindowsMediaLibrarySharingDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsMediaLibrarySharingDevice, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsMediaLibrarySharingDevice {
     fn clone(&self) -> Self {
@@ -123,41 +89,7 @@ impl IWindowsMediaLibrarySharingDeviceProperties {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsMediaLibrarySharingDeviceProperties> for ::windows::core::IUnknown {
-    fn from(value: IWindowsMediaLibrarySharingDeviceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsMediaLibrarySharingDeviceProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsMediaLibrarySharingDeviceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsMediaLibrarySharingDeviceProperties> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsMediaLibrarySharingDeviceProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsMediaLibrarySharingDeviceProperties> for super::super::System::Com::IDispatch {
-    fn from(value: IWindowsMediaLibrarySharingDeviceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsMediaLibrarySharingDeviceProperties> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWindowsMediaLibrarySharingDeviceProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsMediaLibrarySharingDeviceProperties> for super::super::System::Com::IDispatch {
-    fn from(value: &IWindowsMediaLibrarySharingDeviceProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsMediaLibrarySharingDeviceProperties, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsMediaLibrarySharingDeviceProperties {
     fn clone(&self) -> Self {
@@ -219,41 +151,7 @@ impl IWindowsMediaLibrarySharingDeviceProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsMediaLibrarySharingDeviceProperty> for ::windows::core::IUnknown {
-    fn from(value: IWindowsMediaLibrarySharingDeviceProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsMediaLibrarySharingDeviceProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsMediaLibrarySharingDeviceProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsMediaLibrarySharingDeviceProperty> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsMediaLibrarySharingDeviceProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsMediaLibrarySharingDeviceProperty> for super::super::System::Com::IDispatch {
-    fn from(value: IWindowsMediaLibrarySharingDeviceProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsMediaLibrarySharingDeviceProperty> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWindowsMediaLibrarySharingDeviceProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsMediaLibrarySharingDeviceProperty> for super::super::System::Com::IDispatch {
-    fn from(value: &IWindowsMediaLibrarySharingDeviceProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsMediaLibrarySharingDeviceProperty, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsMediaLibrarySharingDeviceProperty {
     fn clone(&self) -> Self {
@@ -317,41 +215,7 @@ impl IWindowsMediaLibrarySharingDevices {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsMediaLibrarySharingDevices> for ::windows::core::IUnknown {
-    fn from(value: IWindowsMediaLibrarySharingDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsMediaLibrarySharingDevices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsMediaLibrarySharingDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsMediaLibrarySharingDevices> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsMediaLibrarySharingDevices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsMediaLibrarySharingDevices> for super::super::System::Com::IDispatch {
-    fn from(value: IWindowsMediaLibrarySharingDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsMediaLibrarySharingDevices> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWindowsMediaLibrarySharingDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsMediaLibrarySharingDevices> for super::super::System::Com::IDispatch {
-    fn from(value: &IWindowsMediaLibrarySharingDevices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsMediaLibrarySharingDevices, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsMediaLibrarySharingDevices {
     fn clone(&self) -> Self {
@@ -471,41 +335,7 @@ impl IWindowsMediaLibrarySharingServices {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsMediaLibrarySharingServices> for ::windows::core::IUnknown {
-    fn from(value: IWindowsMediaLibrarySharingServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsMediaLibrarySharingServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsMediaLibrarySharingServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsMediaLibrarySharingServices> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsMediaLibrarySharingServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsMediaLibrarySharingServices> for super::super::System::Com::IDispatch {
-    fn from(value: IWindowsMediaLibrarySharingServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsMediaLibrarySharingServices> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWindowsMediaLibrarySharingServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsMediaLibrarySharingServices> for super::super::System::Com::IDispatch {
-    fn from(value: &IWindowsMediaLibrarySharingServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsMediaLibrarySharingServices, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsMediaLibrarySharingServices {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
@@ -2853,21 +2853,7 @@ impl IAdvancedMediaCapture {
         (::windows::core::Vtable::vtable(self).GetAdvancedMediaCaptureSettings)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAdvancedMediaCaptureSettings>(result__)
     }
 }
-impl ::core::convert::From<IAdvancedMediaCapture> for ::windows::core::IUnknown {
-    fn from(value: IAdvancedMediaCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdvancedMediaCapture> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAdvancedMediaCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdvancedMediaCapture> for ::windows::core::IUnknown {
-    fn from(value: &IAdvancedMediaCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAdvancedMediaCapture, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAdvancedMediaCapture {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2907,21 +2893,7 @@ impl IAdvancedMediaCaptureInitializationSettings {
         (::windows::core::Vtable::vtable(self).SetDirectxDeviceManager)(::windows::core::Vtable::as_raw(self), value.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAdvancedMediaCaptureInitializationSettings> for ::windows::core::IUnknown {
-    fn from(value: IAdvancedMediaCaptureInitializationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdvancedMediaCaptureInitializationSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAdvancedMediaCaptureInitializationSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdvancedMediaCaptureInitializationSettings> for ::windows::core::IUnknown {
-    fn from(value: &IAdvancedMediaCaptureInitializationSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAdvancedMediaCaptureInitializationSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAdvancedMediaCaptureInitializationSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2959,21 +2931,7 @@ impl IAdvancedMediaCaptureSettings {
         (::windows::core::Vtable::vtable(self).GetDirectxDeviceManager)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFDXGIDeviceManager>(result__)
     }
 }
-impl ::core::convert::From<IAdvancedMediaCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: IAdvancedMediaCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdvancedMediaCaptureSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAdvancedMediaCaptureSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdvancedMediaCaptureSettings> for ::windows::core::IUnknown {
-    fn from(value: &IAdvancedMediaCaptureSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAdvancedMediaCaptureSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAdvancedMediaCaptureSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3010,21 +2968,7 @@ impl IAudioSourceProvider {
         (::windows::core::Vtable::vtable(self).ProvideInput)(::windows::core::Vtable::as_raw(self), dwsamplecount, ::core::mem::transmute(pdwchannelcount), ::core::mem::transmute(pinterleavedaudiodata.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IAudioSourceProvider> for ::windows::core::IUnknown {
-    fn from(value: IAudioSourceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioSourceProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioSourceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioSourceProvider> for ::windows::core::IUnknown {
-    fn from(value: &IAudioSourceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioSourceProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioSourceProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3068,21 +3012,7 @@ impl IClusterDetector {
         (::windows::core::Vtable::vtable(self).Detect)(::windows::core::Vtable::as_raw(self), dwmaxnumclusters, fminclusterduration, fmaxclusterduration, psrctoc.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IToc>(result__)
     }
 }
-impl ::core::convert::From<IClusterDetector> for ::windows::core::IUnknown {
-    fn from(value: IClusterDetector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IClusterDetector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IClusterDetector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IClusterDetector> for ::windows::core::IUnknown {
-    fn from(value: &IClusterDetector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IClusterDetector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IClusterDetector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3191,21 +3121,7 @@ impl ICodecAPI {
         (::windows::core::Vtable::vtable(self).SetAllSettingsWithNotify)(::windows::core::Vtable::as_raw(self), __midl__icodecapi0002.into().abi(), ::core::mem::transmute(changedparam), ::core::mem::transmute(changedparamcount)).ok()
     }
 }
-impl ::core::convert::From<ICodecAPI> for ::windows::core::IUnknown {
-    fn from(value: ICodecAPI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICodecAPI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICodecAPI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICodecAPI> for ::windows::core::IUnknown {
-    fn from(value: &ICodecAPI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICodecAPI, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICodecAPI {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3404,77 +3320,7 @@ impl ID3D12VideoDecodeCommandList {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoDecodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoDecodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoDecodeCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoDecodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoDecodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoDecodeCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoDecodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoDecodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoDecodeCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: ID3D12VideoDecodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList> for &'a super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &'a ID3D12VideoDecodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &ID3D12VideoDecodeCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoDecodeCommandList, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12CommandList);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoDecodeCommandList {
     fn clone(&self) -> Self {
@@ -3691,95 +3537,7 @@ impl ID3D12VideoDecodeCommandList1 {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoDecodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoDecodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoDecodeCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoDecodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList1> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoDecodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoDecodeCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoDecodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList1> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoDecodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoDecodeCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: ID3D12VideoDecodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList1> for &'a super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &'a ID3D12VideoDecodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &ID3D12VideoDecodeCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList1> for ID3D12VideoDecodeCommandList {
-    fn from(value: ID3D12VideoDecodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList1> for &'a ID3D12VideoDecodeCommandList {
-    fn from(value: &'a ID3D12VideoDecodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList1> for ID3D12VideoDecodeCommandList {
-    fn from(value: &ID3D12VideoDecodeCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoDecodeCommandList1, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12CommandList, ID3D12VideoDecodeCommandList);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoDecodeCommandList1 {
     fn clone(&self) -> Self {
@@ -3983,113 +3741,7 @@ impl ID3D12VideoDecodeCommandList2 {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList2> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoDecodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList2> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoDecodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList2> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoDecodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList2> for &'a super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &'a ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &ID3D12VideoDecodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList2> for ID3D12VideoDecodeCommandList {
-    fn from(value: ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList2> for &'a ID3D12VideoDecodeCommandList {
-    fn from(value: &'a ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList2> for ID3D12VideoDecodeCommandList {
-    fn from(value: &ID3D12VideoDecodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecodeCommandList2> for ID3D12VideoDecodeCommandList1 {
-    fn from(value: ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecodeCommandList2> for &'a ID3D12VideoDecodeCommandList1 {
-    fn from(value: &'a ID3D12VideoDecodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecodeCommandList2> for ID3D12VideoDecodeCommandList1 {
-    fn from(value: &ID3D12VideoDecodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoDecodeCommandList2, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12CommandList, ID3D12VideoDecodeCommandList, ID3D12VideoDecodeCommandList1);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoDecodeCommandList2 {
     fn clone(&self) -> Self {
@@ -4187,77 +3839,7 @@ impl ID3D12VideoDecoder {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoder> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoder> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoder> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoder> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoder> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoder> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoder> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoder> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoder> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: ID3D12VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoder> for &'a super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &'a ID3D12VideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoder> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &ID3D12VideoDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoDecoder, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12Pageable);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoDecoder {
     fn clone(&self) -> Self {
@@ -4350,95 +3932,7 @@ impl ID3D12VideoDecoder1 {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoder1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoDecoder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoder1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoDecoder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoder1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoDecoder1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoder1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoDecoder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoder1> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoDecoder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoder1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoDecoder1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoder1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoDecoder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoder1> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoDecoder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoder1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoDecoder1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoder1> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: ID3D12VideoDecoder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoder1> for &'a super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &'a ID3D12VideoDecoder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoder1> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &ID3D12VideoDecoder1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoder1> for ID3D12VideoDecoder {
-    fn from(value: ID3D12VideoDecoder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoder1> for &'a ID3D12VideoDecoder {
-    fn from(value: &'a ID3D12VideoDecoder1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoder1> for ID3D12VideoDecoder {
-    fn from(value: &ID3D12VideoDecoder1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoDecoder1, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12Pageable, ID3D12VideoDecoder);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoDecoder1 {
     fn clone(&self) -> Self {
@@ -4527,77 +4021,7 @@ impl ID3D12VideoDecoderHeap {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoderHeap> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoDecoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoderHeap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoDecoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoderHeap> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoDecoderHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoderHeap> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoDecoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoderHeap> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoDecoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoderHeap> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoDecoderHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoderHeap> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoDecoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoderHeap> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoDecoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoderHeap> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoDecoderHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoderHeap> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: ID3D12VideoDecoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoderHeap> for &'a super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &'a ID3D12VideoDecoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoderHeap> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &ID3D12VideoDecoderHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoDecoderHeap, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12Pageable);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoDecoderHeap {
     fn clone(&self) -> Self {
@@ -4695,95 +4119,7 @@ impl ID3D12VideoDecoderHeap1 {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoderHeap1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoDecoderHeap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoderHeap1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoDecoderHeap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoderHeap1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoDecoderHeap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoderHeap1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoDecoderHeap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoderHeap1> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoDecoderHeap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoderHeap1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoDecoderHeap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoderHeap1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoDecoderHeap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoderHeap1> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoDecoderHeap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoderHeap1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoDecoderHeap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoderHeap1> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: ID3D12VideoDecoderHeap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoderHeap1> for &'a super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &'a ID3D12VideoDecoderHeap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoderHeap1> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &ID3D12VideoDecoderHeap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoDecoderHeap1> for ID3D12VideoDecoderHeap {
-    fn from(value: ID3D12VideoDecoderHeap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoDecoderHeap1> for &'a ID3D12VideoDecoderHeap {
-    fn from(value: &'a ID3D12VideoDecoderHeap1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoDecoderHeap1> for ID3D12VideoDecoderHeap {
-    fn from(value: &ID3D12VideoDecoderHeap1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoDecoderHeap1, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12Pageable, ID3D12VideoDecoderHeap);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoDecoderHeap1 {
     fn clone(&self) -> Self {
@@ -4856,21 +4192,7 @@ impl ID3D12VideoDevice {
         (::windows::core::Vtable::vtable(self).CreateVideoProcessor)(::windows::core::Vtable::as_raw(self), nodemask, ::core::mem::transmute(poutputstreamdesc), pinputstreamdescs.len() as _, ::core::mem::transmute(pinputstreamdescs.as_ptr()), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ID3D12VideoDevice> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12VideoDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12VideoDevice> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ID3D12VideoDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4963,36 +4285,7 @@ impl ID3D12VideoDevice1 {
         (::windows::core::Vtable::vtable(self).CreateVideoMotionVectorHeap)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc), pprotectedresourcesession.into().abi(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ID3D12VideoDevice1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12VideoDevice1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12VideoDevice1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoDevice1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12VideoDevice1> for ID3D12VideoDevice {
-    fn from(value: ID3D12VideoDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12VideoDevice1> for &'a ID3D12VideoDevice {
-    fn from(value: &'a ID3D12VideoDevice1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12VideoDevice1> for ID3D12VideoDevice {
-    fn from(value: &ID3D12VideoDevice1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoDevice1, ::windows::core::IUnknown, ID3D12VideoDevice);
 impl ::core::clone::Clone for ID3D12VideoDevice1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5131,51 +4424,7 @@ impl ID3D12VideoDevice2 {
         (::windows::core::Vtable::vtable(self).ExecuteExtensionCommand)(::windows::core::Vtable::as_raw(self), pextensioncommand.into().abi(), ::core::mem::transmute(pexecutionparameters), executionparameterssizeinbytes, ::core::mem::transmute(poutputdata), outputdatasizeinbytes).ok()
     }
 }
-impl ::core::convert::From<ID3D12VideoDevice2> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12VideoDevice2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12VideoDevice2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12VideoDevice2> for ID3D12VideoDevice {
-    fn from(value: ID3D12VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12VideoDevice2> for &'a ID3D12VideoDevice {
-    fn from(value: &'a ID3D12VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12VideoDevice2> for ID3D12VideoDevice {
-    fn from(value: &ID3D12VideoDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12VideoDevice2> for ID3D12VideoDevice1 {
-    fn from(value: ID3D12VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12VideoDevice2> for &'a ID3D12VideoDevice1 {
-    fn from(value: &'a ID3D12VideoDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12VideoDevice2> for ID3D12VideoDevice1 {
-    fn from(value: &ID3D12VideoDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoDevice2, ::windows::core::IUnknown, ID3D12VideoDevice, ID3D12VideoDevice1);
 impl ::core::clone::Clone for ID3D12VideoDevice2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5342,66 +4591,7 @@ impl ID3D12VideoDevice3 {
         (::windows::core::Vtable::vtable(self).CreateVideoEncoderHeap)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdesc), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ID3D12VideoDevice3> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12VideoDevice3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12VideoDevice3> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12VideoDevice3> for ID3D12VideoDevice {
-    fn from(value: ID3D12VideoDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12VideoDevice3> for &'a ID3D12VideoDevice {
-    fn from(value: &'a ID3D12VideoDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12VideoDevice3> for ID3D12VideoDevice {
-    fn from(value: &ID3D12VideoDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12VideoDevice3> for ID3D12VideoDevice1 {
-    fn from(value: ID3D12VideoDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12VideoDevice3> for &'a ID3D12VideoDevice1 {
-    fn from(value: &'a ID3D12VideoDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12VideoDevice3> for ID3D12VideoDevice1 {
-    fn from(value: &ID3D12VideoDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ID3D12VideoDevice3> for ID3D12VideoDevice2 {
-    fn from(value: ID3D12VideoDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ID3D12VideoDevice3> for &'a ID3D12VideoDevice2 {
-    fn from(value: &'a ID3D12VideoDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ID3D12VideoDevice3> for ID3D12VideoDevice2 {
-    fn from(value: &ID3D12VideoDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoDevice3, ::windows::core::IUnknown, ID3D12VideoDevice, ID3D12VideoDevice1, ID3D12VideoDevice2);
 impl ::core::clone::Clone for ID3D12VideoDevice3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5578,77 +4768,7 @@ impl ID3D12VideoEncodeCommandList {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoEncodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoEncodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoEncodeCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoEncodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoEncodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoEncodeCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoEncodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoEncodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoEncodeCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: ID3D12VideoEncodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList> for &'a super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &'a ID3D12VideoEncodeCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &ID3D12VideoEncodeCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoEncodeCommandList, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12CommandList);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoEncodeCommandList {
     fn clone(&self) -> Self {
@@ -5894,95 +5014,7 @@ impl ID3D12VideoEncodeCommandList1 {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoEncodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoEncodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoEncodeCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoEncodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList1> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoEncodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoEncodeCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoEncodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList1> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoEncodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoEncodeCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: ID3D12VideoEncodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList1> for &'a super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &'a ID3D12VideoEncodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList1> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &ID3D12VideoEncodeCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList1> for ID3D12VideoEncodeCommandList {
-    fn from(value: ID3D12VideoEncodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList1> for &'a ID3D12VideoEncodeCommandList {
-    fn from(value: &'a ID3D12VideoEncodeCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList1> for ID3D12VideoEncodeCommandList {
-    fn from(value: &ID3D12VideoEncodeCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoEncodeCommandList1, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12CommandList, ID3D12VideoEncodeCommandList);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoEncodeCommandList1 {
     fn clone(&self) -> Self {
@@ -6201,113 +5233,7 @@ impl ID3D12VideoEncodeCommandList2 {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList2> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoEncodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList2> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoEncodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList2> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoEncodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList2> for &'a super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &'a ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList2> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &ID3D12VideoEncodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList2> for ID3D12VideoEncodeCommandList {
-    fn from(value: ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList2> for &'a ID3D12VideoEncodeCommandList {
-    fn from(value: &'a ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList2> for ID3D12VideoEncodeCommandList {
-    fn from(value: &ID3D12VideoEncodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncodeCommandList2> for ID3D12VideoEncodeCommandList1 {
-    fn from(value: ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncodeCommandList2> for &'a ID3D12VideoEncodeCommandList1 {
-    fn from(value: &'a ID3D12VideoEncodeCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncodeCommandList2> for ID3D12VideoEncodeCommandList1 {
-    fn from(value: &ID3D12VideoEncodeCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoEncodeCommandList2, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12CommandList, ID3D12VideoEncodeCommandList, ID3D12VideoEncodeCommandList1);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoEncodeCommandList2 {
     fn clone(&self) -> Self {
@@ -6419,77 +5345,7 @@ impl ID3D12VideoEncoder {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncoder> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncoder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncoder> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoEncoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncoder> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncoder> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncoder> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoEncoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncoder> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncoder> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncoder> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoEncoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncoder> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: ID3D12VideoEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncoder> for &'a super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &'a ID3D12VideoEncoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncoder> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &ID3D12VideoEncoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoEncoder, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12Pageable);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoEncoder {
     fn clone(&self) -> Self {
@@ -6601,77 +5457,7 @@ impl ID3D12VideoEncoderHeap {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncoderHeap> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoEncoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncoderHeap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoEncoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncoderHeap> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoEncoderHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncoderHeap> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoEncoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncoderHeap> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoEncoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncoderHeap> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoEncoderHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncoderHeap> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoEncoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncoderHeap> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoEncoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncoderHeap> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoEncoderHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoEncoderHeap> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: ID3D12VideoEncoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoEncoderHeap> for &'a super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &'a ID3D12VideoEncoderHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoEncoderHeap> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &ID3D12VideoEncoderHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoEncoderHeap, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12Pageable);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoEncoderHeap {
     fn clone(&self) -> Self {
@@ -6770,77 +5556,7 @@ impl ID3D12VideoExtensionCommand {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoExtensionCommand> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoExtensionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoExtensionCommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoExtensionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoExtensionCommand> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoExtensionCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoExtensionCommand> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoExtensionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoExtensionCommand> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoExtensionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoExtensionCommand> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoExtensionCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoExtensionCommand> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoExtensionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoExtensionCommand> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoExtensionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoExtensionCommand> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoExtensionCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoExtensionCommand> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: ID3D12VideoExtensionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoExtensionCommand> for &'a super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &'a ID3D12VideoExtensionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoExtensionCommand> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &ID3D12VideoExtensionCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoExtensionCommand, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12Pageable);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoExtensionCommand {
     fn clone(&self) -> Self {
@@ -6936,77 +5652,7 @@ impl ID3D12VideoMotionEstimator {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoMotionEstimator> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoMotionEstimator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoMotionEstimator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoMotionEstimator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoMotionEstimator> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoMotionEstimator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoMotionEstimator> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoMotionEstimator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoMotionEstimator> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoMotionEstimator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoMotionEstimator> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoMotionEstimator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoMotionEstimator> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoMotionEstimator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoMotionEstimator> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoMotionEstimator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoMotionEstimator> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoMotionEstimator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoMotionEstimator> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: ID3D12VideoMotionEstimator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoMotionEstimator> for &'a super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &'a ID3D12VideoMotionEstimator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoMotionEstimator> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &ID3D12VideoMotionEstimator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoMotionEstimator, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12Pageable);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoMotionEstimator {
     fn clone(&self) -> Self {
@@ -7105,77 +5751,7 @@ impl ID3D12VideoMotionVectorHeap {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoMotionVectorHeap> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoMotionVectorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoMotionVectorHeap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoMotionVectorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoMotionVectorHeap> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoMotionVectorHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoMotionVectorHeap> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoMotionVectorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoMotionVectorHeap> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoMotionVectorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoMotionVectorHeap> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoMotionVectorHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoMotionVectorHeap> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoMotionVectorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoMotionVectorHeap> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoMotionVectorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoMotionVectorHeap> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoMotionVectorHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoMotionVectorHeap> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: ID3D12VideoMotionVectorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoMotionVectorHeap> for &'a super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &'a ID3D12VideoMotionVectorHeap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoMotionVectorHeap> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &ID3D12VideoMotionVectorHeap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoMotionVectorHeap, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12Pageable);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoMotionVectorHeap {
     fn clone(&self) -> Self {
@@ -7348,77 +5924,7 @@ impl ID3D12VideoProcessCommandList {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoProcessCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoProcessCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoProcessCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoProcessCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoProcessCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoProcessCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoProcessCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoProcessCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoProcessCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: ID3D12VideoProcessCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList> for &'a super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &'a ID3D12VideoProcessCommandList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &ID3D12VideoProcessCommandList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoProcessCommandList, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12CommandList);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoProcessCommandList {
     fn clone(&self) -> Self {
@@ -7635,95 +6141,7 @@ impl ID3D12VideoProcessCommandList1 {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoProcessCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoProcessCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoProcessCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoProcessCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList1> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoProcessCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoProcessCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoProcessCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList1> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoProcessCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoProcessCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList1> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: ID3D12VideoProcessCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList1> for &'a super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &'a ID3D12VideoProcessCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList1> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &ID3D12VideoProcessCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList1> for ID3D12VideoProcessCommandList {
-    fn from(value: ID3D12VideoProcessCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList1> for &'a ID3D12VideoProcessCommandList {
-    fn from(value: &'a ID3D12VideoProcessCommandList1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList1> for ID3D12VideoProcessCommandList {
-    fn from(value: &ID3D12VideoProcessCommandList1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoProcessCommandList1, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12CommandList, ID3D12VideoProcessCommandList);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoProcessCommandList1 {
     fn clone(&self) -> Self {
@@ -7927,113 +6345,7 @@ impl ID3D12VideoProcessCommandList2 {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList2> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList2> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoProcessCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList2> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList2> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList2> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoProcessCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList2> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList2> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList2> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoProcessCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList2> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList2> for &'a super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &'a ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList2> for super::super::Graphics::Direct3D12::ID3D12CommandList {
-    fn from(value: &ID3D12VideoProcessCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList2> for ID3D12VideoProcessCommandList {
-    fn from(value: ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList2> for &'a ID3D12VideoProcessCommandList {
-    fn from(value: &'a ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList2> for ID3D12VideoProcessCommandList {
-    fn from(value: &ID3D12VideoProcessCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessCommandList2> for ID3D12VideoProcessCommandList1 {
-    fn from(value: ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessCommandList2> for &'a ID3D12VideoProcessCommandList1 {
-    fn from(value: &'a ID3D12VideoProcessCommandList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessCommandList2> for ID3D12VideoProcessCommandList1 {
-    fn from(value: &ID3D12VideoProcessCommandList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoProcessCommandList2, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12CommandList, ID3D12VideoProcessCommandList, ID3D12VideoProcessCommandList1);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoProcessCommandList2 {
     fn clone(&self) -> Self {
@@ -8144,77 +6456,7 @@ impl ID3D12VideoProcessor {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessor> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessor> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessor> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessor> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessor> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessor> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessor> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessor> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessor> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: ID3D12VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessor> for &'a super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &'a ID3D12VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessor> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &ID3D12VideoProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoProcessor, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12Pageable);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoProcessor {
     fn clone(&self) -> Self {
@@ -8329,95 +6571,7 @@ impl ID3D12VideoProcessor1 {
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessor1> for ::windows::core::IUnknown {
-    fn from(value: ID3D12VideoProcessor1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessor1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ID3D12VideoProcessor1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessor1> for ::windows::core::IUnknown {
-    fn from(value: &ID3D12VideoProcessor1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessor1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: ID3D12VideoProcessor1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessor1> for &'a super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &'a ID3D12VideoProcessor1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessor1> for super::super::Graphics::Direct3D12::ID3D12Object {
-    fn from(value: &ID3D12VideoProcessor1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessor1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: ID3D12VideoProcessor1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessor1> for &'a super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &'a ID3D12VideoProcessor1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessor1> for super::super::Graphics::Direct3D12::ID3D12DeviceChild {
-    fn from(value: &ID3D12VideoProcessor1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessor1> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: ID3D12VideoProcessor1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessor1> for &'a super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &'a ID3D12VideoProcessor1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessor1> for super::super::Graphics::Direct3D12::ID3D12Pageable {
-    fn from(value: &ID3D12VideoProcessor1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<ID3D12VideoProcessor1> for ID3D12VideoProcessor {
-    fn from(value: ID3D12VideoProcessor1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl<'a> ::core::convert::From<&'a ID3D12VideoProcessor1> for &'a ID3D12VideoProcessor {
-    fn from(value: &'a ID3D12VideoProcessor1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::core::convert::From<&ID3D12VideoProcessor1> for ID3D12VideoProcessor {
-    fn from(value: &ID3D12VideoProcessor1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ID3D12VideoProcessor1, ::windows::core::IUnknown, super::super::Graphics::Direct3D12::ID3D12Object, super::super::Graphics::Direct3D12::ID3D12DeviceChild, super::super::Graphics::Direct3D12::ID3D12Pageable, ID3D12VideoProcessor);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ::core::clone::Clone for ID3D12VideoProcessor1 {
     fn clone(&self) -> Self {
@@ -8499,21 +6653,7 @@ impl IDXVAHD_Device {
         (::windows::core::Vtable::vtable(self).CreateVideoProcessor)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvpguid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDXVAHD_VideoProcessor>(result__)
     }
 }
-impl ::core::convert::From<IDXVAHD_Device> for ::windows::core::IUnknown {
-    fn from(value: IDXVAHD_Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXVAHD_Device> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXVAHD_Device) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXVAHD_Device> for ::windows::core::IUnknown {
-    fn from(value: &IDXVAHD_Device) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXVAHD_Device, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXVAHD_Device {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8589,21 +6729,7 @@ impl IDXVAHD_VideoProcessor {
         (::windows::core::Vtable::vtable(self).VideoProcessBltHD)(::windows::core::Vtable::as_raw(self), poutputsurface.into().abi(), outputframe, pstreams.len() as _, ::core::mem::transmute(pstreams.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IDXVAHD_VideoProcessor> for ::windows::core::IUnknown {
-    fn from(value: IDXVAHD_VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDXVAHD_VideoProcessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDXVAHD_VideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDXVAHD_VideoProcessor> for ::windows::core::IUnknown {
-    fn from(value: &IDXVAHD_VideoProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDXVAHD_VideoProcessor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDXVAHD_VideoProcessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8649,21 +6775,7 @@ impl IDirect3D9ExOverlayExtension {
         (::windows::core::Vtable::vtable(self).CheckDeviceOverlayType)(::windows::core::Vtable::as_raw(self), adapter, devtype, overlaywidth, overlayheight, overlayformat, ::core::mem::transmute(pdisplaymode), displayrotation, ::core::mem::transmute(poverlaycaps)).ok()
     }
 }
-impl ::core::convert::From<IDirect3D9ExOverlayExtension> for ::windows::core::IUnknown {
-    fn from(value: IDirect3D9ExOverlayExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3D9ExOverlayExtension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3D9ExOverlayExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3D9ExOverlayExtension> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3D9ExOverlayExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3D9ExOverlayExtension, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3D9ExOverlayExtension {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8717,21 +6829,7 @@ impl IDirect3DAuthenticatedChannel9 {
         (::windows::core::Vtable::vtable(self).Configure)(::windows::core::Vtable::as_raw(self), inputsize, ::core::mem::transmute(pinput), ::core::mem::transmute(poutput)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DAuthenticatedChannel9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DAuthenticatedChannel9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DAuthenticatedChannel9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DAuthenticatedChannel9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DAuthenticatedChannel9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DAuthenticatedChannel9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DAuthenticatedChannel9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DAuthenticatedChannel9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8816,21 +6914,7 @@ impl IDirect3DCryptoSession9 {
         (::windows::core::Vtable::vtable(self).GetEncryptionBltKey)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(preadbackkey), keysize).ok()
     }
 }
-impl ::core::convert::From<IDirect3DCryptoSession9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DCryptoSession9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DCryptoSession9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DCryptoSession9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DCryptoSession9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DCryptoSession9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DCryptoSession9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DCryptoSession9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8894,21 +6978,7 @@ impl IDirect3DDevice9Video {
         (::windows::core::Vtable::vtable(self).CreateCryptoSession)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcryptotype), ::core::mem::transmute(pdecodeprofile), ::core::mem::transmute(ppcryptosession), ::core::mem::transmute(pcryptohandle)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DDevice9Video> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DDevice9Video) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DDevice9Video> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DDevice9Video) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DDevice9Video> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DDevice9Video) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DDevice9Video, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DDevice9Video {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9006,21 +7076,7 @@ impl IDirect3DDeviceManager9 {
         (::windows::core::Vtable::vtable(self).GetVideoService)(::windows::core::Vtable::as_raw(self), hdevice.into(), ::core::mem::transmute(riid), ::core::mem::transmute(ppservice)).ok()
     }
 }
-impl ::core::convert::From<IDirect3DDeviceManager9> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DDeviceManager9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DDeviceManager9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DDeviceManager9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DDeviceManager9> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DDeviceManager9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DDeviceManager9, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DDeviceManager9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9086,21 +7142,7 @@ impl IDirectXVideoAccelerationService {
         (::windows::core::Vtable::vtable(self).CreateSurface)(::windows::core::Vtable::as_raw(self), width, height, backbuffers, format, pool, usage, dxvatype, ::core::mem::transmute(ppsurface), ::core::mem::transmute(psharedhandle.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDirectXVideoAccelerationService> for ::windows::core::IUnknown {
-    fn from(value: IDirectXVideoAccelerationService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectXVideoAccelerationService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectXVideoAccelerationService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectXVideoAccelerationService> for ::windows::core::IUnknown {
-    fn from(value: &IDirectXVideoAccelerationService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectXVideoAccelerationService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectXVideoAccelerationService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9168,21 +7210,7 @@ impl IDirectXVideoDecoder {
         (::windows::core::Vtable::vtable(self).Execute)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pexecuteparams)).ok()
     }
 }
-impl ::core::convert::From<IDirectXVideoDecoder> for ::windows::core::IUnknown {
-    fn from(value: IDirectXVideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectXVideoDecoder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectXVideoDecoder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectXVideoDecoder> for ::windows::core::IUnknown {
-    fn from(value: &IDirectXVideoDecoder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectXVideoDecoder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectXVideoDecoder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9255,36 +7283,7 @@ impl IDirectXVideoDecoderService {
         (::windows::core::Vtable::vtable(self).CreateVideoDecoder)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), ::core::mem::transmute(pvideodesc), ::core::mem::transmute(pconfig), ::core::mem::transmute(ppdecoderrendertargets.as_ptr()), ppdecoderrendertargets.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDirectXVideoDecoder>(result__)
     }
 }
-impl ::core::convert::From<IDirectXVideoDecoderService> for ::windows::core::IUnknown {
-    fn from(value: IDirectXVideoDecoderService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectXVideoDecoderService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectXVideoDecoderService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectXVideoDecoderService> for ::windows::core::IUnknown {
-    fn from(value: &IDirectXVideoDecoderService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectXVideoDecoderService> for IDirectXVideoAccelerationService {
-    fn from(value: IDirectXVideoDecoderService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectXVideoDecoderService> for &'a IDirectXVideoAccelerationService {
-    fn from(value: &'a IDirectXVideoDecoderService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectXVideoDecoderService> for IDirectXVideoAccelerationService {
-    fn from(value: &IDirectXVideoDecoderService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectXVideoDecoderService, ::windows::core::IUnknown, IDirectXVideoAccelerationService);
 impl ::core::clone::Clone for IDirectXVideoDecoderService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9337,21 +7336,7 @@ impl IDirectXVideoMemoryConfiguration {
         (::windows::core::Vtable::vtable(self).SetSurfaceType)(::windows::core::Vtable::as_raw(self), dwtype).ok()
     }
 }
-impl ::core::convert::From<IDirectXVideoMemoryConfiguration> for ::windows::core::IUnknown {
-    fn from(value: IDirectXVideoMemoryConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectXVideoMemoryConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectXVideoMemoryConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectXVideoMemoryConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &IDirectXVideoMemoryConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectXVideoMemoryConfiguration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectXVideoMemoryConfiguration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9417,21 +7402,7 @@ impl IDirectXVideoProcessor {
         (::windows::core::Vtable::vtable(self).VideoProcessBlt)(::windows::core::Vtable::as_raw(self), prendertarget.into().abi(), ::core::mem::transmute(pbltparams), ::core::mem::transmute(psamples.as_ptr()), psamples.len() as _, ::core::mem::transmute(phandlecomplete.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDirectXVideoProcessor> for ::windows::core::IUnknown {
-    fn from(value: IDirectXVideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectXVideoProcessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectXVideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectXVideoProcessor> for ::windows::core::IUnknown {
-    fn from(value: &IDirectXVideoProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectXVideoProcessor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectXVideoProcessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9526,36 +7497,7 @@ impl IDirectXVideoProcessorService {
         (::windows::core::Vtable::vtable(self).CreateVideoProcessor)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(videoprocdeviceguid), ::core::mem::transmute(pvideodesc), rendertargetformat, maxnumsubstreams, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDirectXVideoProcessor>(result__)
     }
 }
-impl ::core::convert::From<IDirectXVideoProcessorService> for ::windows::core::IUnknown {
-    fn from(value: IDirectXVideoProcessorService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectXVideoProcessorService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectXVideoProcessorService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectXVideoProcessorService> for ::windows::core::IUnknown {
-    fn from(value: &IDirectXVideoProcessorService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDirectXVideoProcessorService> for IDirectXVideoAccelerationService {
-    fn from(value: IDirectXVideoProcessorService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectXVideoProcessorService> for &'a IDirectXVideoAccelerationService {
-    fn from(value: &'a IDirectXVideoProcessorService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectXVideoProcessorService> for IDirectXVideoAccelerationService {
-    fn from(value: &IDirectXVideoProcessorService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectXVideoProcessorService, ::windows::core::IUnknown, IDirectXVideoAccelerationService);
 impl ::core::clone::Clone for IDirectXVideoProcessorService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9624,21 +7566,7 @@ impl IEVRFilterConfig {
         (::windows::core::Vtable::vtable(self).GetNumberOfStreams)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEVRFilterConfig> for ::windows::core::IUnknown {
-    fn from(value: IEVRFilterConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEVRFilterConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEVRFilterConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEVRFilterConfig> for ::windows::core::IUnknown {
-    fn from(value: &IEVRFilterConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEVRFilterConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEVRFilterConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9687,36 +7615,7 @@ impl IEVRFilterConfigEx {
         (::windows::core::Vtable::vtable(self).GetConfigPrefs)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEVRFilterConfigEx> for ::windows::core::IUnknown {
-    fn from(value: IEVRFilterConfigEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEVRFilterConfigEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEVRFilterConfigEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEVRFilterConfigEx> for ::windows::core::IUnknown {
-    fn from(value: &IEVRFilterConfigEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEVRFilterConfigEx> for IEVRFilterConfig {
-    fn from(value: IEVRFilterConfigEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEVRFilterConfigEx> for &'a IEVRFilterConfig {
-    fn from(value: &'a IEVRFilterConfigEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEVRFilterConfigEx> for IEVRFilterConfig {
-    fn from(value: &IEVRFilterConfigEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEVRFilterConfigEx, ::windows::core::IUnknown, IEVRFilterConfig);
 impl ::core::clone::Clone for IEVRFilterConfigEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9774,21 +7673,7 @@ impl IEVRTrustedVideoPlugin {
         (::windows::core::Vtable::vtable(self).DisableImageExport)(::windows::core::Vtable::as_raw(self), bdisable.into()).ok()
     }
 }
-impl ::core::convert::From<IEVRTrustedVideoPlugin> for ::windows::core::IUnknown {
-    fn from(value: IEVRTrustedVideoPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEVRTrustedVideoPlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEVRTrustedVideoPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEVRTrustedVideoPlugin> for ::windows::core::IUnknown {
-    fn from(value: &IEVRTrustedVideoPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEVRTrustedVideoPlugin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEVRTrustedVideoPlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9848,21 +7733,7 @@ impl IEVRVideoStreamControl {
         (::windows::core::Vtable::vtable(self).GetStreamActiveState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IEVRVideoStreamControl> for ::windows::core::IUnknown {
-    fn from(value: IEVRVideoStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEVRVideoStreamControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEVRVideoStreamControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEVRVideoStreamControl> for ::windows::core::IUnknown {
-    fn from(value: &IEVRVideoStreamControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEVRVideoStreamControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEVRVideoStreamControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9918,21 +7789,7 @@ impl IFileClient {
         (::windows::core::Vtable::vtable(self).Read)(::windows::core::Vtable::as_raw(self), pfio.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IFileClient> for ::windows::core::IUnknown {
-    fn from(value: IFileClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileClient> for ::windows::core::IUnknown {
-    fn from(value: &IFileClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFileClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10003,21 +7860,7 @@ impl IFileIo {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IFileIo> for ::windows::core::IUnknown {
-    fn from(value: IFileIo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileIo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileIo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileIo> for ::windows::core::IUnknown {
-    fn from(value: &IFileIo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileIo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFileIo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10088,21 +7931,7 @@ impl IMF2DBuffer {
         (::windows::core::Vtable::vtable(self).ContiguousCopyFrom)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbsrcbuffer.as_ptr()), pbsrcbuffer.len() as _).ok()
     }
 }
-impl ::core::convert::From<IMF2DBuffer> for ::windows::core::IUnknown {
-    fn from(value: IMF2DBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMF2DBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMF2DBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMF2DBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IMF2DBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMF2DBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMF2DBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10179,36 +8008,7 @@ impl IMF2DBuffer2 {
         (::windows::core::Vtable::vtable(self).Copy2DTo)(::windows::core::Vtable::as_raw(self), pdestbuffer.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMF2DBuffer2> for ::windows::core::IUnknown {
-    fn from(value: IMF2DBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMF2DBuffer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMF2DBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMF2DBuffer2> for ::windows::core::IUnknown {
-    fn from(value: &IMF2DBuffer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMF2DBuffer2> for IMF2DBuffer {
-    fn from(value: IMF2DBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMF2DBuffer2> for &'a IMF2DBuffer {
-    fn from(value: &'a IMF2DBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMF2DBuffer2> for IMF2DBuffer {
-    fn from(value: &IMF2DBuffer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMF2DBuffer2, ::windows::core::IUnknown, IMF2DBuffer);
 impl ::core::clone::Clone for IMF2DBuffer2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10283,21 +8083,7 @@ impl IMFASFContentInfo {
         (::windows::core::Vtable::vtable(self).GetEncodingConfigurationPropertyStore)(::windows::core::Vtable::as_raw(self), wstreamnumber, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::UI::Shell::PropertiesSystem::IPropertyStore>(result__)
     }
 }
-impl ::core::convert::From<IMFASFContentInfo> for ::windows::core::IUnknown {
-    fn from(value: IMFASFContentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFASFContentInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFASFContentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFASFContentInfo> for ::windows::core::IUnknown {
-    fn from(value: &IMFASFContentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFASFContentInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFASFContentInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10407,21 +8193,7 @@ impl IMFASFIndexer {
         (::windows::core::Vtable::vtable(self).GetCompletedIndex)(::windows::core::Vtable::as_raw(self), piindexbuffer.into().abi(), cboffsetwithinindex).ok()
     }
 }
-impl ::core::convert::From<IMFASFIndexer> for ::windows::core::IUnknown {
-    fn from(value: IMFASFIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFASFIndexer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFASFIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFASFIndexer> for ::windows::core::IUnknown {
-    fn from(value: &IMFASFIndexer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFASFIndexer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFASFIndexer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10514,21 +8286,7 @@ impl IMFASFMultiplexer {
         (::windows::core::Vtable::vtable(self).SetSyncTolerance)(::windows::core::Vtable::as_raw(self), mssynctolerance).ok()
     }
 }
-impl ::core::convert::From<IMFASFMultiplexer> for ::windows::core::IUnknown {
-    fn from(value: IMFASFMultiplexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFASFMultiplexer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFASFMultiplexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFASFMultiplexer> for ::windows::core::IUnknown {
-    fn from(value: &IMFASFMultiplexer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFASFMultiplexer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFASFMultiplexer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10601,21 +8359,7 @@ impl IMFASFMutualExclusion {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFASFMutualExclusion>(result__)
     }
 }
-impl ::core::convert::From<IMFASFMutualExclusion> for ::windows::core::IUnknown {
-    fn from(value: IMFASFMutualExclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFASFMutualExclusion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFASFMutualExclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFASFMutualExclusion> for ::windows::core::IUnknown {
-    fn from(value: &IMFASFMutualExclusion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFASFMutualExclusion, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFASFMutualExclusion {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10852,36 +8596,7 @@ impl IMFASFProfile {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFASFProfile>(result__)
     }
 }
-impl ::core::convert::From<IMFASFProfile> for ::windows::core::IUnknown {
-    fn from(value: IMFASFProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFASFProfile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFASFProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFASFProfile> for ::windows::core::IUnknown {
-    fn from(value: &IMFASFProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFASFProfile> for IMFAttributes {
-    fn from(value: IMFASFProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFASFProfile> for &'a IMFAttributes {
-    fn from(value: &'a IMFASFProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFASFProfile> for IMFAttributes {
-    fn from(value: &IMFASFProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFASFProfile, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFASFProfile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10965,21 +8680,7 @@ impl IMFASFSplitter {
         (::windows::core::Vtable::vtable(self).GetLastSendTime)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMFASFSplitter> for ::windows::core::IUnknown {
-    fn from(value: IMFASFSplitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFASFSplitter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFASFSplitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFASFSplitter> for ::windows::core::IUnknown {
-    fn from(value: &IMFASFSplitter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFASFSplitter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFASFSplitter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11184,36 +8885,7 @@ impl IMFASFStreamConfig {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFASFStreamConfig>(result__)
     }
 }
-impl ::core::convert::From<IMFASFStreamConfig> for ::windows::core::IUnknown {
-    fn from(value: IMFASFStreamConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFASFStreamConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFASFStreamConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFASFStreamConfig> for ::windows::core::IUnknown {
-    fn from(value: &IMFASFStreamConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFASFStreamConfig> for IMFAttributes {
-    fn from(value: IMFASFStreamConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFASFStreamConfig> for &'a IMFAttributes {
-    fn from(value: &'a IMFASFStreamConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFASFStreamConfig> for IMFAttributes {
-    fn from(value: &IMFASFStreamConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFASFStreamConfig, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFASFStreamConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11273,21 +8945,7 @@ impl IMFASFStreamPrioritization {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFASFStreamPrioritization>(result__)
     }
 }
-impl ::core::convert::From<IMFASFStreamPrioritization> for ::windows::core::IUnknown {
-    fn from(value: IMFASFStreamPrioritization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFASFStreamPrioritization> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFASFStreamPrioritization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFASFStreamPrioritization> for ::windows::core::IUnknown {
-    fn from(value: &IMFASFStreamPrioritization) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFASFStreamPrioritization, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFASFStreamPrioritization {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11377,21 +9035,7 @@ impl IMFASFStreamSelector {
         (::windows::core::Vtable::vtable(self).SetStreamSelectorFlags)(::windows::core::Vtable::as_raw(self), dwstreamselectorflags).ok()
     }
 }
-impl ::core::convert::From<IMFASFStreamSelector> for ::windows::core::IUnknown {
-    fn from(value: IMFASFStreamSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFASFStreamSelector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFASFStreamSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFASFStreamSelector> for ::windows::core::IUnknown {
-    fn from(value: &IMFASFStreamSelector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFASFStreamSelector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFASFStreamSelector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11577,36 +9221,7 @@ impl IMFActivate {
         (::windows::core::Vtable::vtable(self).DetachObject)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFActivate> for ::windows::core::IUnknown {
-    fn from(value: IMFActivate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFActivate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFActivate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFActivate> for ::windows::core::IUnknown {
-    fn from(value: &IMFActivate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFActivate> for IMFAttributes {
-    fn from(value: IMFActivate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFActivate> for &'a IMFAttributes {
-    fn from(value: &'a IMFActivate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFActivate> for IMFAttributes {
-    fn from(value: &IMFActivate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFActivate, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFActivate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11651,21 +9266,7 @@ impl IMFAsyncCallback {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self), pasyncresult.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFAsyncCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFAsyncCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFAsyncCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFAsyncCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFAsyncCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFAsyncCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFAsyncCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFAsyncCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11715,36 +9316,7 @@ impl IMFAsyncCallbackLogging {
         (::windows::core::Vtable::vtable(self).GetObjectTag)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFAsyncCallbackLogging> for ::windows::core::IUnknown {
-    fn from(value: IMFAsyncCallbackLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFAsyncCallbackLogging> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFAsyncCallbackLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFAsyncCallbackLogging> for ::windows::core::IUnknown {
-    fn from(value: &IMFAsyncCallbackLogging) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFAsyncCallbackLogging> for IMFAsyncCallback {
-    fn from(value: IMFAsyncCallbackLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFAsyncCallbackLogging> for &'a IMFAsyncCallback {
-    fn from(value: &'a IMFAsyncCallbackLogging) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFAsyncCallbackLogging> for IMFAsyncCallback {
-    fn from(value: &IMFAsyncCallbackLogging) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFAsyncCallbackLogging, ::windows::core::IUnknown, IMFAsyncCallback);
 impl ::core::clone::Clone for IMFAsyncCallbackLogging {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11796,21 +9368,7 @@ impl IMFAsyncResult {
         (::windows::core::Vtable::vtable(self).GetStateNoAddRef)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFAsyncResult> for ::windows::core::IUnknown {
-    fn from(value: IMFAsyncResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFAsyncResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFAsyncResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFAsyncResult> for ::windows::core::IUnknown {
-    fn from(value: &IMFAsyncResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFAsyncResult, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFAsyncResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11974,21 +9532,7 @@ impl IMFAttributes {
         (::windows::core::Vtable::vtable(self).CopyAllItems)(::windows::core::Vtable::as_raw(self), pdest.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFAttributes> for ::windows::core::IUnknown {
-    fn from(value: IMFAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFAttributes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFAttributes> for ::windows::core::IUnknown {
-    fn from(value: &IMFAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFAttributes, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFAttributes {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12220,51 +9764,7 @@ impl IMFAudioMediaType {
         (::windows::core::Vtable::vtable(self).GetAudioFormat)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFAudioMediaType> for ::windows::core::IUnknown {
-    fn from(value: IMFAudioMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFAudioMediaType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFAudioMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFAudioMediaType> for ::windows::core::IUnknown {
-    fn from(value: &IMFAudioMediaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFAudioMediaType> for IMFAttributes {
-    fn from(value: IMFAudioMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFAudioMediaType> for &'a IMFAttributes {
-    fn from(value: &'a IMFAudioMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFAudioMediaType> for IMFAttributes {
-    fn from(value: &IMFAudioMediaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFAudioMediaType> for IMFMediaType {
-    fn from(value: IMFAudioMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFAudioMediaType> for &'a IMFMediaType {
-    fn from(value: &'a IMFAudioMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFAudioMediaType> for IMFMediaType {
-    fn from(value: &IMFAudioMediaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFAudioMediaType, ::windows::core::IUnknown, IMFAttributes, IMFMediaType);
 impl ::core::clone::Clone for IMFAudioMediaType {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12328,21 +9828,7 @@ impl IMFAudioPolicy {
         (::windows::core::Vtable::vtable(self).GetIconPath)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IMFAudioPolicy> for ::windows::core::IUnknown {
-    fn from(value: IMFAudioPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFAudioPolicy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFAudioPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFAudioPolicy> for ::windows::core::IUnknown {
-    fn from(value: &IMFAudioPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFAudioPolicy, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFAudioPolicy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12398,21 +9884,7 @@ impl IMFAudioStreamVolume {
         (::windows::core::Vtable::vtable(self).GetAllVolumes)(::windows::core::Vtable::as_raw(self), pfvolumes.len() as _, ::core::mem::transmute(pfvolumes.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IMFAudioStreamVolume> for ::windows::core::IUnknown {
-    fn from(value: IMFAudioStreamVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFAudioStreamVolume> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFAudioStreamVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFAudioStreamVolume> for ::windows::core::IUnknown {
-    fn from(value: &IMFAudioStreamVolume) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFAudioStreamVolume, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFAudioStreamVolume {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12456,21 +9928,7 @@ impl IMFBufferListNotify {
         (::windows::core::Vtable::vtable(self).OnRemoveSourceBuffer)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFBufferListNotify> for ::windows::core::IUnknown {
-    fn from(value: IMFBufferListNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFBufferListNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFBufferListNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFBufferListNotify> for ::windows::core::IUnknown {
-    fn from(value: &IMFBufferListNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFBufferListNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFBufferListNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12574,21 +10032,7 @@ impl IMFByteStream {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFByteStream> for ::windows::core::IUnknown {
-    fn from(value: IMFByteStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFByteStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFByteStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFByteStream> for ::windows::core::IUnknown {
-    fn from(value: &IMFByteStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFByteStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFByteStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12653,21 +10097,7 @@ impl IMFByteStreamBuffering {
         (::windows::core::Vtable::vtable(self).StopBuffering)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFByteStreamBuffering> for ::windows::core::IUnknown {
-    fn from(value: IMFByteStreamBuffering) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFByteStreamBuffering> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFByteStreamBuffering) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFByteStreamBuffering> for ::windows::core::IUnknown {
-    fn from(value: &IMFByteStreamBuffering) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFByteStreamBuffering, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFByteStreamBuffering {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12709,21 +10139,7 @@ impl IMFByteStreamCacheControl {
         (::windows::core::Vtable::vtable(self).StopBackgroundTransfer)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFByteStreamCacheControl> for ::windows::core::IUnknown {
-    fn from(value: IMFByteStreamCacheControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFByteStreamCacheControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFByteStreamCacheControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFByteStreamCacheControl> for ::windows::core::IUnknown {
-    fn from(value: &IMFByteStreamCacheControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFByteStreamCacheControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFByteStreamCacheControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12772,36 +10188,7 @@ impl IMFByteStreamCacheControl2 {
         (::windows::core::Vtable::vtable(self).IsBackgroundTransferActive)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IMFByteStreamCacheControl2> for ::windows::core::IUnknown {
-    fn from(value: IMFByteStreamCacheControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFByteStreamCacheControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFByteStreamCacheControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFByteStreamCacheControl2> for ::windows::core::IUnknown {
-    fn from(value: &IMFByteStreamCacheControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFByteStreamCacheControl2> for IMFByteStreamCacheControl {
-    fn from(value: IMFByteStreamCacheControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFByteStreamCacheControl2> for &'a IMFByteStreamCacheControl {
-    fn from(value: &'a IMFByteStreamCacheControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFByteStreamCacheControl2> for IMFByteStreamCacheControl {
-    fn from(value: &IMFByteStreamCacheControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFByteStreamCacheControl2, ::windows::core::IUnknown, IMFByteStreamCacheControl);
 impl ::core::clone::Clone for IMFByteStreamCacheControl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12868,21 +10255,7 @@ impl IMFByteStreamHandler {
         (::windows::core::Vtable::vtable(self).GetMaxNumberOfBytesRequiredForResolution)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IMFByteStreamHandler> for ::windows::core::IUnknown {
-    fn from(value: IMFByteStreamHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFByteStreamHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFByteStreamHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFByteStreamHandler> for ::windows::core::IUnknown {
-    fn from(value: &IMFByteStreamHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFByteStreamHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFByteStreamHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12931,21 +10304,7 @@ impl IMFByteStreamProxyClassFactory {
         (::windows::core::Vtable::vtable(self).CreateByteStreamProxy)(::windows::core::Vtable::as_raw(self), pbytestream.into().abi(), pattributes.into().abi(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IMFByteStreamProxyClassFactory> for ::windows::core::IUnknown {
-    fn from(value: IMFByteStreamProxyClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFByteStreamProxyClassFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFByteStreamProxyClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFByteStreamProxyClassFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMFByteStreamProxyClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFByteStreamProxyClassFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFByteStreamProxyClassFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12991,21 +10350,7 @@ impl IMFByteStreamTimeSeek {
         (::windows::core::Vtable::vtable(self).GetTimeSeekResult)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pqwstarttime), ::core::mem::transmute(pqwstoptime), ::core::mem::transmute(pqwduration)).ok()
     }
 }
-impl ::core::convert::From<IMFByteStreamTimeSeek> for ::windows::core::IUnknown {
-    fn from(value: IMFByteStreamTimeSeek) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFByteStreamTimeSeek> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFByteStreamTimeSeek) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFByteStreamTimeSeek> for ::windows::core::IUnknown {
-    fn from(value: &IMFByteStreamTimeSeek) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFByteStreamTimeSeek, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFByteStreamTimeSeek {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13053,21 +10398,7 @@ impl IMFCameraOcclusionStateMonitor {
         (::windows::core::Vtable::vtable(self).GetSupportedStates)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFCameraOcclusionStateMonitor> for ::windows::core::IUnknown {
-    fn from(value: IMFCameraOcclusionStateMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCameraOcclusionStateMonitor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCameraOcclusionStateMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCameraOcclusionStateMonitor> for ::windows::core::IUnknown {
-    fn from(value: &IMFCameraOcclusionStateMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCameraOcclusionStateMonitor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCameraOcclusionStateMonitor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13107,21 +10438,7 @@ impl IMFCameraOcclusionStateReport {
         (::windows::core::Vtable::vtable(self).GetOcclusionState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMFCameraOcclusionStateReport> for ::windows::core::IUnknown {
-    fn from(value: IMFCameraOcclusionStateReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCameraOcclusionStateReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCameraOcclusionStateReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCameraOcclusionStateReport> for ::windows::core::IUnknown {
-    fn from(value: &IMFCameraOcclusionStateReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCameraOcclusionStateReport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCameraOcclusionStateReport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13161,21 +10478,7 @@ impl IMFCameraOcclusionStateReportCallback {
         (::windows::core::Vtable::vtable(self).OnOcclusionStateReport)(::windows::core::Vtable::as_raw(self), occlusionstatereport.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFCameraOcclusionStateReportCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFCameraOcclusionStateReportCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCameraOcclusionStateReportCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCameraOcclusionStateReportCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCameraOcclusionStateReportCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFCameraOcclusionStateReportCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCameraOcclusionStateReportCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCameraOcclusionStateReportCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13215,21 +10518,7 @@ impl IMFCameraSyncObject {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFCameraSyncObject> for ::windows::core::IUnknown {
-    fn from(value: IMFCameraSyncObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCameraSyncObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCameraSyncObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCameraSyncObject> for ::windows::core::IUnknown {
-    fn from(value: &IMFCameraSyncObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCameraSyncObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCameraSyncObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13302,21 +10591,7 @@ impl IMFCaptureEngine {
         (::windows::core::Vtable::vtable(self).GetSource)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFCaptureSource>(result__)
     }
 }
-impl ::core::convert::From<IMFCaptureEngine> for ::windows::core::IUnknown {
-    fn from(value: IMFCaptureEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureEngine> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCaptureEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureEngine> for ::windows::core::IUnknown {
-    fn from(value: &IMFCaptureEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCaptureEngine, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCaptureEngine {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13367,21 +10642,7 @@ impl IMFCaptureEngineClassFactory {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clsid), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IMFCaptureEngineClassFactory> for ::windows::core::IUnknown {
-    fn from(value: IMFCaptureEngineClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureEngineClassFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCaptureEngineClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureEngineClassFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMFCaptureEngineClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCaptureEngineClassFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCaptureEngineClassFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13421,21 +10682,7 @@ impl IMFCaptureEngineOnEventCallback {
         (::windows::core::Vtable::vtable(self).OnEvent)(::windows::core::Vtable::as_raw(self), pevent.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFCaptureEngineOnEventCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFCaptureEngineOnEventCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureEngineOnEventCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCaptureEngineOnEventCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureEngineOnEventCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFCaptureEngineOnEventCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCaptureEngineOnEventCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCaptureEngineOnEventCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13475,21 +10722,7 @@ impl IMFCaptureEngineOnSampleCallback {
         (::windows::core::Vtable::vtable(self).OnSample)(::windows::core::Vtable::as_raw(self), psample.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFCaptureEngineOnSampleCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFCaptureEngineOnSampleCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureEngineOnSampleCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCaptureEngineOnSampleCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureEngineOnSampleCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFCaptureEngineOnSampleCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCaptureEngineOnSampleCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCaptureEngineOnSampleCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13535,36 +10768,7 @@ impl IMFCaptureEngineOnSampleCallback2 {
         (::windows::core::Vtable::vtable(self).OnSynchronizedEvent)(::windows::core::Vtable::as_raw(self), pevent.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFCaptureEngineOnSampleCallback2> for ::windows::core::IUnknown {
-    fn from(value: IMFCaptureEngineOnSampleCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureEngineOnSampleCallback2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCaptureEngineOnSampleCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureEngineOnSampleCallback2> for ::windows::core::IUnknown {
-    fn from(value: &IMFCaptureEngineOnSampleCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFCaptureEngineOnSampleCallback2> for IMFCaptureEngineOnSampleCallback {
-    fn from(value: IMFCaptureEngineOnSampleCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureEngineOnSampleCallback2> for &'a IMFCaptureEngineOnSampleCallback {
-    fn from(value: &'a IMFCaptureEngineOnSampleCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureEngineOnSampleCallback2> for IMFCaptureEngineOnSampleCallback {
-    fn from(value: &IMFCaptureEngineOnSampleCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCaptureEngineOnSampleCallback2, ::windows::core::IUnknown, IMFCaptureEngineOnSampleCallback);
 impl ::core::clone::Clone for IMFCaptureEngineOnSampleCallback2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13611,21 +10815,7 @@ impl IMFCapturePhotoConfirmation {
         (::windows::core::Vtable::vtable(self).GetPixelFormat)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IMFCapturePhotoConfirmation> for ::windows::core::IUnknown {
-    fn from(value: IMFCapturePhotoConfirmation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCapturePhotoConfirmation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCapturePhotoConfirmation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCapturePhotoConfirmation> for ::windows::core::IUnknown {
-    fn from(value: &IMFCapturePhotoConfirmation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCapturePhotoConfirmation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCapturePhotoConfirmation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13701,36 +10891,7 @@ impl IMFCapturePhotoSink {
         (::windows::core::Vtable::vtable(self).SetOutputByteStream)(::windows::core::Vtable::as_raw(self), pbytestream.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFCapturePhotoSink> for ::windows::core::IUnknown {
-    fn from(value: IMFCapturePhotoSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCapturePhotoSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCapturePhotoSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCapturePhotoSink> for ::windows::core::IUnknown {
-    fn from(value: &IMFCapturePhotoSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFCapturePhotoSink> for IMFCaptureSink {
-    fn from(value: IMFCapturePhotoSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCapturePhotoSink> for &'a IMFCaptureSink {
-    fn from(value: &'a IMFCapturePhotoSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCapturePhotoSink> for IMFCaptureSink {
-    fn from(value: &IMFCapturePhotoSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCapturePhotoSink, ::windows::core::IUnknown, IMFCaptureSink);
 impl ::core::clone::Clone for IMFCapturePhotoSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13840,36 +11001,7 @@ impl IMFCapturePreviewSink {
         (::windows::core::Vtable::vtable(self).SetCustomSink)(::windows::core::Vtable::as_raw(self), pmediasink.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFCapturePreviewSink> for ::windows::core::IUnknown {
-    fn from(value: IMFCapturePreviewSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCapturePreviewSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCapturePreviewSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCapturePreviewSink> for ::windows::core::IUnknown {
-    fn from(value: &IMFCapturePreviewSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFCapturePreviewSink> for IMFCaptureSink {
-    fn from(value: IMFCapturePreviewSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCapturePreviewSink> for &'a IMFCaptureSink {
-    fn from(value: &'a IMFCapturePreviewSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCapturePreviewSink> for IMFCaptureSink {
-    fn from(value: &IMFCapturePreviewSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCapturePreviewSink, ::windows::core::IUnknown, IMFCaptureSink);
 impl ::core::clone::Clone for IMFCapturePreviewSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13976,36 +11108,7 @@ impl IMFCaptureRecordSink {
         (::windows::core::Vtable::vtable(self).SetRotation)(::windows::core::Vtable::as_raw(self), dwstreamindex, dwrotationvalue).ok()
     }
 }
-impl ::core::convert::From<IMFCaptureRecordSink> for ::windows::core::IUnknown {
-    fn from(value: IMFCaptureRecordSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureRecordSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCaptureRecordSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureRecordSink> for ::windows::core::IUnknown {
-    fn from(value: &IMFCaptureRecordSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFCaptureRecordSink> for IMFCaptureSink {
-    fn from(value: IMFCaptureRecordSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureRecordSink> for &'a IMFCaptureSink {
-    fn from(value: &'a IMFCaptureRecordSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureRecordSink> for IMFCaptureSink {
-    fn from(value: &IMFCaptureRecordSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCaptureRecordSink, ::windows::core::IUnknown, IMFCaptureSink);
 impl ::core::clone::Clone for IMFCaptureRecordSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14066,21 +11169,7 @@ impl IMFCaptureSink {
         (::windows::core::Vtable::vtable(self).RemoveAllStreams)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFCaptureSink> for ::windows::core::IUnknown {
-    fn from(value: IMFCaptureSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCaptureSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureSink> for ::windows::core::IUnknown {
-    fn from(value: &IMFCaptureSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCaptureSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCaptureSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14147,36 +11236,7 @@ impl IMFCaptureSink2 {
         (::windows::core::Vtable::vtable(self).SetOutputMediaType)(::windows::core::Vtable::as_raw(self), dwstreamindex, pmediatype.into().abi(), pencodingattributes.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFCaptureSink2> for ::windows::core::IUnknown {
-    fn from(value: IMFCaptureSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureSink2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCaptureSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureSink2> for ::windows::core::IUnknown {
-    fn from(value: &IMFCaptureSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFCaptureSink2> for IMFCaptureSink {
-    fn from(value: IMFCaptureSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureSink2> for &'a IMFCaptureSink {
-    fn from(value: &'a IMFCaptureSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureSink2> for IMFCaptureSink {
-    fn from(value: &IMFCaptureSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCaptureSink2, ::windows::core::IUnknown, IMFCaptureSink);
 impl ::core::clone::Clone for IMFCaptureSink2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14277,21 +11337,7 @@ impl IMFCaptureSource {
         (::windows::core::Vtable::vtable(self).GetStreamIndexFromFriendlyName)(::windows::core::Vtable::as_raw(self), uifriendlyname, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMFCaptureSource> for ::windows::core::IUnknown {
-    fn from(value: IMFCaptureSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCaptureSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCaptureSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCaptureSource> for ::windows::core::IUnknown {
-    fn from(value: &IMFCaptureSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCaptureSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCaptureSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14350,21 +11396,7 @@ impl IMFCdmSuspendNotify {
         (::windows::core::Vtable::vtable(self).End)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFCdmSuspendNotify> for ::windows::core::IUnknown {
-    fn from(value: IMFCdmSuspendNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCdmSuspendNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCdmSuspendNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCdmSuspendNotify> for ::windows::core::IUnknown {
-    fn from(value: &IMFCdmSuspendNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCdmSuspendNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCdmSuspendNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14418,21 +11450,7 @@ impl IMFClock {
         (::windows::core::Vtable::vtable(self).GetProperties)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MFCLOCK_PROPERTIES>(result__)
     }
 }
-impl ::core::convert::From<IMFClock> for ::windows::core::IUnknown {
-    fn from(value: IMFClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFClock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFClock> for ::windows::core::IUnknown {
-    fn from(value: &IMFClock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFClock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFClock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14480,21 +11498,7 @@ impl IMFClockConsumer {
         (::windows::core::Vtable::vtable(self).GetPresentationClock)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFPresentationClock>(result__)
     }
 }
-impl ::core::convert::From<IMFClockConsumer> for ::windows::core::IUnknown {
-    fn from(value: IMFClockConsumer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFClockConsumer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFClockConsumer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFClockConsumer> for ::windows::core::IUnknown {
-    fn from(value: &IMFClockConsumer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFClockConsumer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFClockConsumer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14544,21 +11548,7 @@ impl IMFClockStateSink {
         (::windows::core::Vtable::vtable(self).OnClockSetRate)(::windows::core::Vtable::as_raw(self), hnssystemtime, flrate).ok()
     }
 }
-impl ::core::convert::From<IMFClockStateSink> for ::windows::core::IUnknown {
-    fn from(value: IMFClockStateSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFClockStateSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFClockStateSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFClockStateSink> for ::windows::core::IUnknown {
-    fn from(value: &IMFClockStateSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFClockStateSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFClockStateSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14623,21 +11613,7 @@ impl IMFCollection {
         (::windows::core::Vtable::vtable(self).RemoveAllElements)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFCollection> for ::windows::core::IUnknown {
-    fn from(value: IMFCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFCollection> for ::windows::core::IUnknown {
-    fn from(value: &IMFCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14710,21 +11686,7 @@ impl IMFContentDecryptionModule {
         (::windows::core::Vtable::vtable(self).GetProtectionSystemIds)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(systemids), ::core::mem::transmute(count)).ok()
     }
 }
-impl ::core::convert::From<IMFContentDecryptionModule> for ::windows::core::IUnknown {
-    fn from(value: IMFContentDecryptionModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFContentDecryptionModule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFContentDecryptionModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFContentDecryptionModule> for ::windows::core::IUnknown {
-    fn from(value: &IMFContentDecryptionModule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFContentDecryptionModule, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFContentDecryptionModule {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14783,21 +11745,7 @@ impl IMFContentDecryptionModuleAccess {
         (::windows::core::Vtable::vtable(self).GetKeySystem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IMFContentDecryptionModuleAccess> for ::windows::core::IUnknown {
-    fn from(value: IMFContentDecryptionModuleAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFContentDecryptionModuleAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFContentDecryptionModuleAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFContentDecryptionModuleAccess> for ::windows::core::IUnknown {
-    fn from(value: &IMFContentDecryptionModuleAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFContentDecryptionModuleAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFContentDecryptionModuleAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14857,21 +11805,7 @@ impl IMFContentDecryptionModuleFactory {
         (::windows::core::Vtable::vtable(self).CreateContentDecryptionModuleAccess)(::windows::core::Vtable::as_raw(self), keysystem.into(), ::core::mem::transmute(configurations.as_ptr()), configurations.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFContentDecryptionModuleAccess>(result__)
     }
 }
-impl ::core::convert::From<IMFContentDecryptionModuleFactory> for ::windows::core::IUnknown {
-    fn from(value: IMFContentDecryptionModuleFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFContentDecryptionModuleFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFContentDecryptionModuleFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFContentDecryptionModuleFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMFContentDecryptionModuleFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFContentDecryptionModuleFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFContentDecryptionModuleFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14947,21 +11881,7 @@ impl IMFContentDecryptionModuleSession {
         (::windows::core::Vtable::vtable(self).Remove)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFContentDecryptionModuleSession> for ::windows::core::IUnknown {
-    fn from(value: IMFContentDecryptionModuleSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFContentDecryptionModuleSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFContentDecryptionModuleSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFContentDecryptionModuleSession> for ::windows::core::IUnknown {
-    fn from(value: &IMFContentDecryptionModuleSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFContentDecryptionModuleSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFContentDecryptionModuleSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15014,21 +11934,7 @@ impl IMFContentDecryptionModuleSessionCallbacks {
         (::windows::core::Vtable::vtable(self).KeyStatusChanged)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFContentDecryptionModuleSessionCallbacks> for ::windows::core::IUnknown {
-    fn from(value: IMFContentDecryptionModuleSessionCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFContentDecryptionModuleSessionCallbacks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFContentDecryptionModuleSessionCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFContentDecryptionModuleSessionCallbacks> for ::windows::core::IUnknown {
-    fn from(value: &IMFContentDecryptionModuleSessionCallbacks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFContentDecryptionModuleSessionCallbacks, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFContentDecryptionModuleSessionCallbacks {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15067,21 +11973,7 @@ impl IMFContentDecryptorContext {
         (::windows::core::Vtable::vtable(self).InitializeHardwareKey)(::windows::core::Vtable::as_raw(self), inputprivatedata.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(inputprivatedata.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IMFContentDecryptorContext> for ::windows::core::IUnknown {
-    fn from(value: IMFContentDecryptorContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFContentDecryptorContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFContentDecryptorContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFContentDecryptorContext> for ::windows::core::IUnknown {
-    fn from(value: &IMFContentDecryptorContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFContentDecryptorContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFContentDecryptorContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15140,21 +12032,7 @@ impl IMFContentEnabler {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFContentEnabler> for ::windows::core::IUnknown {
-    fn from(value: IMFContentEnabler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFContentEnabler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFContentEnabler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFContentEnabler> for ::windows::core::IUnknown {
-    fn from(value: &IMFContentEnabler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFContentEnabler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFContentEnabler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15203,21 +12081,7 @@ impl IMFContentProtectionDevice {
         (::windows::core::Vtable::vtable(self).GetPrivateDataByteCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(privateinputbytecount), ::core::mem::transmute(privateoutputbytecount)).ok()
     }
 }
-impl ::core::convert::From<IMFContentProtectionDevice> for ::windows::core::IUnknown {
-    fn from(value: IMFContentProtectionDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFContentProtectionDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFContentProtectionDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFContentProtectionDevice> for ::windows::core::IUnknown {
-    fn from(value: &IMFContentProtectionDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFContentProtectionDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFContentProtectionDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15267,21 +12131,7 @@ impl IMFContentProtectionManager {
         (::windows::core::Vtable::vtable(self).EndEnableContent)(::windows::core::Vtable::as_raw(self), presult.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFContentProtectionManager> for ::windows::core::IUnknown {
-    fn from(value: IMFContentProtectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFContentProtectionManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFContentProtectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFContentProtectionManager> for ::windows::core::IUnknown {
-    fn from(value: &IMFContentProtectionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFContentProtectionManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFContentProtectionManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15327,21 +12177,7 @@ impl IMFD3D12SynchronizationObject {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFD3D12SynchronizationObject> for ::windows::core::IUnknown {
-    fn from(value: IMFD3D12SynchronizationObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFD3D12SynchronizationObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFD3D12SynchronizationObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFD3D12SynchronizationObject> for ::windows::core::IUnknown {
-    fn from(value: &IMFD3D12SynchronizationObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFD3D12SynchronizationObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFD3D12SynchronizationObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15411,21 +12247,7 @@ impl IMFD3D12SynchronizationObjectCommands {
         (::windows::core::Vtable::vtable(self).EnqueueResourceRelease)(::windows::core::Vtable::as_raw(self), pconsumercommandqueue.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFD3D12SynchronizationObjectCommands> for ::windows::core::IUnknown {
-    fn from(value: IMFD3D12SynchronizationObjectCommands) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFD3D12SynchronizationObjectCommands> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFD3D12SynchronizationObjectCommands) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFD3D12SynchronizationObjectCommands> for ::windows::core::IUnknown {
-    fn from(value: &IMFD3D12SynchronizationObjectCommands) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFD3D12SynchronizationObjectCommands, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFD3D12SynchronizationObjectCommands {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15483,21 +12305,7 @@ impl IMFDLNASinkInit {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pbytestream.into().abi(), fpal.into()).ok()
     }
 }
-impl ::core::convert::From<IMFDLNASinkInit> for ::windows::core::IUnknown {
-    fn from(value: IMFDLNASinkInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFDLNASinkInit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFDLNASinkInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFDLNASinkInit> for ::windows::core::IUnknown {
-    fn from(value: &IMFDLNASinkInit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFDLNASinkInit, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFDLNASinkInit {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15540,21 +12348,7 @@ impl IMFDRMNetHelper {
         (::windows::core::Vtable::vtable(self).GetChainedLicenseResponse)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pplicenseresponse), ::core::mem::transmute(pcblicenseresponse)).ok()
     }
 }
-impl ::core::convert::From<IMFDRMNetHelper> for ::windows::core::IUnknown {
-    fn from(value: IMFDRMNetHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFDRMNetHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFDRMNetHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFDRMNetHelper> for ::windows::core::IUnknown {
-    fn from(value: &IMFDRMNetHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFDRMNetHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFDRMNetHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15605,21 +12399,7 @@ impl IMFDXGIBuffer {
         (::windows::core::Vtable::vtable(self).SetUnknown)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), punkdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFDXGIBuffer> for ::windows::core::IUnknown {
-    fn from(value: IMFDXGIBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFDXGIBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFDXGIBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFDXGIBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IMFDXGIBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFDXGIBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFDXGIBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15710,21 +12490,7 @@ impl IMFDXGIDeviceManager {
         (::windows::core::Vtable::vtable(self).UnlockDevice)(::windows::core::Vtable::as_raw(self), hdevice.into(), fsavestate.into()).ok()
     }
 }
-impl ::core::convert::From<IMFDXGIDeviceManager> for ::windows::core::IUnknown {
-    fn from(value: IMFDXGIDeviceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFDXGIDeviceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFDXGIDeviceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFDXGIDeviceManager> for ::windows::core::IUnknown {
-    fn from(value: &IMFDXGIDeviceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFDXGIDeviceManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFDXGIDeviceManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15786,21 +12552,7 @@ impl IMFDXGIDeviceManagerSource {
         (::windows::core::Vtable::vtable(self).GetManager)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFDXGIDeviceManager>(result__)
     }
 }
-impl ::core::convert::From<IMFDXGIDeviceManagerSource> for ::windows::core::IUnknown {
-    fn from(value: IMFDXGIDeviceManagerSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFDXGIDeviceManagerSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFDXGIDeviceManagerSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFDXGIDeviceManagerSource> for ::windows::core::IUnknown {
-    fn from(value: &IMFDXGIDeviceManagerSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFDXGIDeviceManagerSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFDXGIDeviceManagerSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15843,21 +12595,7 @@ impl IMFDesiredSample {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFDesiredSample> for ::windows::core::IUnknown {
-    fn from(value: IMFDesiredSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFDesiredSample> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFDesiredSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFDesiredSample> for ::windows::core::IUnknown {
-    fn from(value: &IMFDesiredSample) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFDesiredSample, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFDesiredSample {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15976,21 +12714,7 @@ impl IMFDeviceTransform {
         (::windows::core::Vtable::vtable(self).FlushOutputStream)(::windows::core::Vtable::as_raw(self), dwstreamindex, dwflags).ok()
     }
 }
-impl ::core::convert::From<IMFDeviceTransform> for ::windows::core::IUnknown {
-    fn from(value: IMFDeviceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFDeviceTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFDeviceTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFDeviceTransform> for ::windows::core::IUnknown {
-    fn from(value: &IMFDeviceTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFDeviceTransform, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFDeviceTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16049,21 +12773,7 @@ impl IMFDeviceTransformCallback {
         (::windows::core::Vtable::vtable(self).OnBufferSent)(::windows::core::Vtable::as_raw(self), pcallbackattributes.into().abi(), pinid).ok()
     }
 }
-impl ::core::convert::From<IMFDeviceTransformCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFDeviceTransformCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFDeviceTransformCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFDeviceTransformCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFDeviceTransformCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFDeviceTransformCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFDeviceTransformCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFDeviceTransformCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16115,21 +12825,7 @@ impl IMFExtendedCameraControl {
         (::windows::core::Vtable::vtable(self).CommitSettings)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFExtendedCameraControl> for ::windows::core::IUnknown {
-    fn from(value: IMFExtendedCameraControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFExtendedCameraControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFExtendedCameraControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFExtendedCameraControl> for ::windows::core::IUnknown {
-    fn from(value: &IMFExtendedCameraControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFExtendedCameraControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFExtendedCameraControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16172,21 +12868,7 @@ impl IMFExtendedCameraController {
         (::windows::core::Vtable::vtable(self).GetExtendedCameraControl)(::windows::core::Vtable::as_raw(self), dwstreamindex, ulpropertyid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFExtendedCameraControl>(result__)
     }
 }
-impl ::core::convert::From<IMFExtendedCameraController> for ::windows::core::IUnknown {
-    fn from(value: IMFExtendedCameraController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFExtendedCameraController> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFExtendedCameraController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFExtendedCameraController> for ::windows::core::IUnknown {
-    fn from(value: &IMFExtendedCameraController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFExtendedCameraController, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFExtendedCameraController {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16231,21 +12913,7 @@ impl IMFExtendedCameraIntrinsicModel {
         (::windows::core::Vtable::vtable(self).GetDistortionModelType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MFCameraIntrinsic_DistortionModelType>(result__)
     }
 }
-impl ::core::convert::From<IMFExtendedCameraIntrinsicModel> for ::windows::core::IUnknown {
-    fn from(value: IMFExtendedCameraIntrinsicModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFExtendedCameraIntrinsicModel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFExtendedCameraIntrinsicModel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFExtendedCameraIntrinsicModel> for ::windows::core::IUnknown {
-    fn from(value: &IMFExtendedCameraIntrinsicModel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFExtendedCameraIntrinsicModel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFExtendedCameraIntrinsicModel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16305,21 +12973,7 @@ impl IMFExtendedCameraIntrinsics {
         (::windows::core::Vtable::vtable(self).AddIntrinsicModel)(::windows::core::Vtable::as_raw(self), pintrinsicmodel.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFExtendedCameraIntrinsics> for ::windows::core::IUnknown {
-    fn from(value: IMFExtendedCameraIntrinsics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFExtendedCameraIntrinsics> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFExtendedCameraIntrinsics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFExtendedCameraIntrinsics> for ::windows::core::IUnknown {
-    fn from(value: &IMFExtendedCameraIntrinsics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFExtendedCameraIntrinsics, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFExtendedCameraIntrinsics {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16365,21 +13019,7 @@ impl IMFExtendedCameraIntrinsicsDistortionModel6KT {
         (::windows::core::Vtable::vtable(self).SetDistortionModel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdistortionmodel)).ok()
     }
 }
-impl ::core::convert::From<IMFExtendedCameraIntrinsicsDistortionModel6KT> for ::windows::core::IUnknown {
-    fn from(value: IMFExtendedCameraIntrinsicsDistortionModel6KT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFExtendedCameraIntrinsicsDistortionModel6KT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFExtendedCameraIntrinsicsDistortionModel6KT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFExtendedCameraIntrinsicsDistortionModel6KT> for ::windows::core::IUnknown {
-    fn from(value: &IMFExtendedCameraIntrinsicsDistortionModel6KT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFExtendedCameraIntrinsicsDistortionModel6KT, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFExtendedCameraIntrinsicsDistortionModel6KT {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16421,21 +13061,7 @@ impl IMFExtendedCameraIntrinsicsDistortionModelArcTan {
         (::windows::core::Vtable::vtable(self).SetDistortionModel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdistortionmodel)).ok()
     }
 }
-impl ::core::convert::From<IMFExtendedCameraIntrinsicsDistortionModelArcTan> for ::windows::core::IUnknown {
-    fn from(value: IMFExtendedCameraIntrinsicsDistortionModelArcTan) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFExtendedCameraIntrinsicsDistortionModelArcTan> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFExtendedCameraIntrinsicsDistortionModelArcTan) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFExtendedCameraIntrinsicsDistortionModelArcTan> for ::windows::core::IUnknown {
-    fn from(value: &IMFExtendedCameraIntrinsicsDistortionModelArcTan) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFExtendedCameraIntrinsicsDistortionModelArcTan, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFExtendedCameraIntrinsicsDistortionModelArcTan {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16474,21 +13100,7 @@ impl IMFExtendedDRMTypeSupport {
         (::windows::core::Vtable::vtable(self).IsTypeSupportedEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(r#type), ::core::mem::transmute_copy(keysystem), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MF_MEDIA_ENGINE_CANPLAY>(result__)
     }
 }
-impl ::core::convert::From<IMFExtendedDRMTypeSupport> for ::windows::core::IUnknown {
-    fn from(value: IMFExtendedDRMTypeSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFExtendedDRMTypeSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFExtendedDRMTypeSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFExtendedDRMTypeSupport> for ::windows::core::IUnknown {
-    fn from(value: &IMFExtendedDRMTypeSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFExtendedDRMTypeSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFExtendedDRMTypeSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16528,21 +13140,7 @@ impl IMFFieldOfUseMFTUnlock {
         (::windows::core::Vtable::vtable(self).Unlock)(::windows::core::Vtable::as_raw(self), punkmft.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFFieldOfUseMFTUnlock> for ::windows::core::IUnknown {
-    fn from(value: IMFFieldOfUseMFTUnlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFFieldOfUseMFTUnlock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFFieldOfUseMFTUnlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFFieldOfUseMFTUnlock> for ::windows::core::IUnknown {
-    fn from(value: &IMFFieldOfUseMFTUnlock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFFieldOfUseMFTUnlock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFFieldOfUseMFTUnlock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16628,36 +13226,7 @@ impl IMFFinalizableMediaSink {
         (::windows::core::Vtable::vtable(self).EndFinalize)(::windows::core::Vtable::as_raw(self), presult.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFFinalizableMediaSink> for ::windows::core::IUnknown {
-    fn from(value: IMFFinalizableMediaSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFFinalizableMediaSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFFinalizableMediaSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFFinalizableMediaSink> for ::windows::core::IUnknown {
-    fn from(value: &IMFFinalizableMediaSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFFinalizableMediaSink> for IMFMediaSink {
-    fn from(value: IMFFinalizableMediaSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFFinalizableMediaSink> for &'a IMFMediaSink {
-    fn from(value: &'a IMFFinalizableMediaSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFFinalizableMediaSink> for IMFMediaSink {
-    fn from(value: &IMFFinalizableMediaSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFFinalizableMediaSink, ::windows::core::IUnknown, IMFMediaSink);
 impl ::core::clone::Clone for IMFFinalizableMediaSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16699,21 +13268,7 @@ impl IMFGetService {
         (::windows::core::Vtable::vtable(self).GetService)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidservice), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IMFGetService> for ::windows::core::IUnknown {
-    fn from(value: IMFGetService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFGetService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFGetService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFGetService> for ::windows::core::IUnknown {
-    fn from(value: &IMFGetService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFGetService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFGetService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16755,21 +13310,7 @@ impl IMFHDCPStatus {
         (::windows::core::Vtable::vtable(self).Set)(::windows::core::Vtable::as_raw(self), status).ok()
     }
 }
-impl ::core::convert::From<IMFHDCPStatus> for ::windows::core::IUnknown {
-    fn from(value: IMFHDCPStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFHDCPStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFHDCPStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFHDCPStatus> for ::windows::core::IUnknown {
-    fn from(value: &IMFHDCPStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFHDCPStatus, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFHDCPStatus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16893,21 +13434,7 @@ impl IMFHttpDownloadRequest {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFHttpDownloadRequest> for ::windows::core::IUnknown {
-    fn from(value: IMFHttpDownloadRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFHttpDownloadRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFHttpDownloadRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFHttpDownloadRequest> for ::windows::core::IUnknown {
-    fn from(value: &IMFHttpDownloadRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFHttpDownloadRequest, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFHttpDownloadRequest {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16984,21 +13511,7 @@ impl IMFHttpDownloadSession {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFHttpDownloadSession> for ::windows::core::IUnknown {
-    fn from(value: IMFHttpDownloadSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFHttpDownloadSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFHttpDownloadSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFHttpDownloadSession> for ::windows::core::IUnknown {
-    fn from(value: &IMFHttpDownloadSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFHttpDownloadSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFHttpDownloadSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17044,21 +13557,7 @@ impl IMFHttpDownloadSessionProvider {
         (::windows::core::Vtable::vtable(self).CreateHttpDownloadSession)(::windows::core::Vtable::as_raw(self), wszscheme.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFHttpDownloadSession>(result__)
     }
 }
-impl ::core::convert::From<IMFHttpDownloadSessionProvider> for ::windows::core::IUnknown {
-    fn from(value: IMFHttpDownloadSessionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFHttpDownloadSessionProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFHttpDownloadSessionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFHttpDownloadSessionProvider> for ::windows::core::IUnknown {
-    fn from(value: &IMFHttpDownloadSessionProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFHttpDownloadSessionProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFHttpDownloadSessionProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17105,21 +13604,7 @@ impl IMFImageSharingEngine {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFImageSharingEngine> for ::windows::core::IUnknown {
-    fn from(value: IMFImageSharingEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFImageSharingEngine> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFImageSharingEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFImageSharingEngine> for ::windows::core::IUnknown {
-    fn from(value: &IMFImageSharingEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFImageSharingEngine, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFImageSharingEngine {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17159,21 +13644,7 @@ impl IMFImageSharingEngineClassFactory {
         (::windows::core::Vtable::vtable(self).CreateInstanceFromUDN)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(puniquedevicename), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFImageSharingEngine>(result__)
     }
 }
-impl ::core::convert::From<IMFImageSharingEngineClassFactory> for ::windows::core::IUnknown {
-    fn from(value: IMFImageSharingEngineClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFImageSharingEngineClassFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFImageSharingEngineClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFImageSharingEngineClassFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMFImageSharingEngineClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFImageSharingEngineClassFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFImageSharingEngineClassFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17227,21 +13698,7 @@ impl IMFInputTrustAuthority {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFInputTrustAuthority> for ::windows::core::IUnknown {
-    fn from(value: IMFInputTrustAuthority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFInputTrustAuthority> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFInputTrustAuthority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFInputTrustAuthority> for ::windows::core::IUnknown {
-    fn from(value: &IMFInputTrustAuthority) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFInputTrustAuthority, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFInputTrustAuthority {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17283,21 +13740,7 @@ impl IMFLocalMFTRegistration {
         (::windows::core::Vtable::vtable(self).RegisterMFTs)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmfts.as_ptr()), pmfts.len() as _).ok()
     }
 }
-impl ::core::convert::From<IMFLocalMFTRegistration> for ::windows::core::IUnknown {
-    fn from(value: IMFLocalMFTRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFLocalMFTRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFLocalMFTRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFLocalMFTRegistration> for ::windows::core::IUnknown {
-    fn from(value: &IMFLocalMFTRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFLocalMFTRegistration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFLocalMFTRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17348,21 +13791,7 @@ impl IMFMediaBuffer {
         (::windows::core::Vtable::vtable(self).GetMaxLength)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaBuffer> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17572,21 +14001,7 @@ impl IMFMediaEngine {
         (::windows::core::Vtable::vtable(self).OnVideoStreamTick)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i64>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaEngine> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngine> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngine> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngine, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngine {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17707,21 +14122,7 @@ impl IMFMediaEngineAudioEndpointId {
         (::windows::core::Vtable::vtable(self).GetAudioEndpointId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaEngineAudioEndpointId> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineAudioEndpointId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineAudioEndpointId> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineAudioEndpointId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineAudioEndpointId> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineAudioEndpointId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineAudioEndpointId, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineAudioEndpointId {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17771,21 +14172,7 @@ impl IMFMediaEngineClassFactory {
         (::windows::core::Vtable::vtable(self).CreateError)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFMediaError>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaEngineClassFactory> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineClassFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineClassFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineClassFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineClassFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17825,21 +14212,7 @@ impl IMFMediaEngineClassFactory2 {
         (::windows::core::Vtable::vtable(self).CreateMediaKeys2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(keysystem), ::core::mem::transmute_copy(defaultcdmstorepath), ::core::mem::transmute_copy(inprivatecdmstorepath), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFMediaKeys>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaEngineClassFactory2> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineClassFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineClassFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineClassFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineClassFactory2> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineClassFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineClassFactory2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineClassFactory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17879,21 +14252,7 @@ impl IMFMediaEngineClassFactory3 {
         (::windows::core::Vtable::vtable(self).CreateMediaKeySystemAccess)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(keysystem), ::core::mem::transmute(ppsupportedconfigurationsarray.as_ptr()), ppsupportedconfigurationsarray.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFMediaKeySystemAccess>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaEngineClassFactory3> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineClassFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineClassFactory3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineClassFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineClassFactory3> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineClassFactory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineClassFactory3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineClassFactory3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17936,21 +14295,7 @@ impl IMFMediaEngineClassFactory4 {
         (::windows::core::Vtable::vtable(self).CreateContentDecryptionModuleFactory)(::windows::core::Vtable::as_raw(self), keysystem.into(), ::core::mem::transmute(riid), ::core::mem::transmute(ppvobject)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEngineClassFactory4> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineClassFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineClassFactory4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineClassFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineClassFactory4> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineClassFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineClassFactory4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineClassFactory4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18016,36 +14361,7 @@ impl IMFMediaEngineClassFactoryEx {
         (::windows::core::Vtable::vtable(self).IsTypeSupported)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(r#type), ::core::mem::transmute_copy(keysystem), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaEngineClassFactoryEx> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineClassFactoryEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineClassFactoryEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineClassFactoryEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineClassFactoryEx> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineClassFactoryEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaEngineClassFactoryEx> for IMFMediaEngineClassFactory {
-    fn from(value: IMFMediaEngineClassFactoryEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineClassFactoryEx> for &'a IMFMediaEngineClassFactory {
-    fn from(value: &'a IMFMediaEngineClassFactoryEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineClassFactoryEx> for IMFMediaEngineClassFactory {
-    fn from(value: &IMFMediaEngineClassFactoryEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineClassFactoryEx, ::windows::core::IUnknown, IMFMediaEngineClassFactory);
 impl ::core::clone::Clone for IMFMediaEngineClassFactoryEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18094,21 +14410,7 @@ impl IMFMediaEngineEME {
         (::windows::core::Vtable::vtable(self).SetMediaKeys)(::windows::core::Vtable::as_raw(self), keys.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEngineEME> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineEME) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineEME> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineEME) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineEME> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineEME) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineEME, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineEME {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18149,21 +14451,7 @@ impl IMFMediaEngineEMENotify {
         (::windows::core::Vtable::vtable(self).WaitingForKey)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFMediaEngineEMENotify> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineEMENotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineEMENotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineEMENotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineEMENotify> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineEMENotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineEMENotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineEMENotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18560,36 +14848,7 @@ impl IMFMediaEngineEx {
         (::windows::core::Vtable::vtable(self).EnableTimeUpdateTimer)(::windows::core::Vtable::as_raw(self), fenabletimer.into()).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEngineEx> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineEx> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaEngineEx> for IMFMediaEngine {
-    fn from(value: IMFMediaEngineEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineEx> for &'a IMFMediaEngine {
-    fn from(value: &'a IMFMediaEngineEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineEx> for IMFMediaEngine {
-    fn from(value: &IMFMediaEngineEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineEx, ::windows::core::IUnknown, IMFMediaEngine);
 impl ::core::clone::Clone for IMFMediaEngineEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18743,21 +15002,7 @@ impl IMFMediaEngineExtension {
         (::windows::core::Vtable::vtable(self).EndCreateObject)(::windows::core::Vtable::as_raw(self), presult.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaEngineExtension> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineExtension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineExtension> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineExtension, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineExtension {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18800,21 +15045,7 @@ impl IMFMediaEngineNeedKeyNotify {
         (::windows::core::Vtable::vtable(self).NeedKey)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(initdata.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), initdata.as_deref().map_or(0, |slice| slice.len() as _))
     }
 }
-impl ::core::convert::From<IMFMediaEngineNeedKeyNotify> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineNeedKeyNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineNeedKeyNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineNeedKeyNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineNeedKeyNotify> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineNeedKeyNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineNeedKeyNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineNeedKeyNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18851,21 +15082,7 @@ impl IMFMediaEngineNotify {
         (::windows::core::Vtable::vtable(self).EventNotify)(::windows::core::Vtable::as_raw(self), event, param1, param2).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEngineNotify> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineNotify> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18904,21 +15121,7 @@ impl IMFMediaEngineOPMInfo {
         (::windows::core::Vtable::vtable(self).GetOPMInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pstatus), ::core::mem::transmute(pconstricted)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEngineOPMInfo> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineOPMInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineOPMInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineOPMInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineOPMInfo> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineOPMInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineOPMInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineOPMInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18991,21 +15194,7 @@ impl IMFMediaEngineProtectedContent {
         (::windows::core::Vtable::vtable(self).SetApplicationCertificate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbblob.as_ptr()), pbblob.len() as _).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEngineProtectedContent> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineProtectedContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineProtectedContent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineProtectedContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineProtectedContent> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineProtectedContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineProtectedContent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineProtectedContent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19071,21 +15260,7 @@ impl IMFMediaEngineSrcElements {
         (::windows::core::Vtable::vtable(self).RemoveAllElements)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEngineSrcElements> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineSrcElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineSrcElements> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineSrcElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineSrcElements> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineSrcElements) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineSrcElements, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineSrcElements {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19152,36 +15327,7 @@ impl IMFMediaEngineSrcElementsEx {
         (::windows::core::Vtable::vtable(self).GetKeySystem)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaEngineSrcElementsEx> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineSrcElementsEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineSrcElementsEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineSrcElementsEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineSrcElementsEx> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineSrcElementsEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaEngineSrcElementsEx> for IMFMediaEngineSrcElements {
-    fn from(value: IMFMediaEngineSrcElementsEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineSrcElementsEx> for &'a IMFMediaEngineSrcElements {
-    fn from(value: &'a IMFMediaEngineSrcElementsEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineSrcElementsEx> for IMFMediaEngineSrcElements {
-    fn from(value: &IMFMediaEngineSrcElementsEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineSrcElementsEx, ::windows::core::IUnknown, IMFMediaEngineSrcElements);
 impl ::core::clone::Clone for IMFMediaEngineSrcElementsEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19233,21 +15379,7 @@ impl IMFMediaEngineSupportsSourceTransfer {
         (::windows::core::Vtable::vtable(self).AttachMediaSource)(::windows::core::Vtable::as_raw(self), pbytestream.into().abi(), pmediasource.into().abi(), pmse.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEngineSupportsSourceTransfer> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineSupportsSourceTransfer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineSupportsSourceTransfer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineSupportsSourceTransfer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineSupportsSourceTransfer> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineSupportsSourceTransfer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineSupportsSourceTransfer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineSupportsSourceTransfer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19292,21 +15424,7 @@ impl IMFMediaEngineTransferSource {
         (::windows::core::Vtable::vtable(self).TransferSourceToMediaEngine)(::windows::core::Vtable::as_raw(self), destination.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEngineTransferSource> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineTransferSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineTransferSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineTransferSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineTransferSource> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineTransferSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineTransferSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineTransferSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19352,21 +15470,7 @@ impl IMFMediaEngineWebSupport {
         (::windows::core::Vtable::vtable(self).DisconnectWebAudio)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEngineWebSupport> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEngineWebSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEngineWebSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEngineWebSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEngineWebSupport> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEngineWebSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEngineWebSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEngineWebSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19417,21 +15521,7 @@ impl IMFMediaError {
         (::windows::core::Vtable::vtable(self).SetExtendedErrorCode)(::windows::core::Vtable::as_raw(self), error).ok()
     }
 }
-impl ::core::convert::From<IMFMediaError> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaError> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaError, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaError {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19612,36 +15702,7 @@ impl IMFMediaEvent {
         (::windows::core::Vtable::vtable(self).GetValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::StructuredStorage::PROPVARIANT>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaEvent> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEvent> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaEvent> for IMFAttributes {
-    fn from(value: IMFMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEvent> for &'a IMFAttributes {
-    fn from(value: &'a IMFMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEvent> for IMFAttributes {
-    fn from(value: &IMFMediaEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEvent, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFMediaEvent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19704,21 +15765,7 @@ impl IMFMediaEventGenerator {
         (::windows::core::Vtable::vtable(self).QueueEvent)(::windows::core::Vtable::as_raw(self), met, ::core::mem::transmute(guidextendedtype), hrstatus, ::core::mem::transmute(pvvalue)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEventGenerator> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEventGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEventGenerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEventGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEventGenerator> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEventGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEventGenerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEventGenerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19796,21 +15843,7 @@ impl IMFMediaEventQueue {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaEventQueue> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaEventQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaEventQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaEventQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaEventQueue> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaEventQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaEventQueue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaEventQueue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19870,21 +15903,7 @@ impl IMFMediaKeySession {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaKeySession> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaKeySession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaKeySession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaKeySession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaKeySession> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaKeySession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaKeySession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaKeySession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19961,36 +15980,7 @@ impl IMFMediaKeySession2 {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaKeySession2> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaKeySession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaKeySession2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaKeySession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaKeySession2> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaKeySession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaKeySession2> for IMFMediaKeySession {
-    fn from(value: IMFMediaKeySession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaKeySession2> for &'a IMFMediaKeySession {
-    fn from(value: &'a IMFMediaKeySession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaKeySession2> for IMFMediaKeySession {
-    fn from(value: &IMFMediaKeySession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaKeySession2, ::windows::core::IUnknown, IMFMediaKeySession);
 impl ::core::clone::Clone for IMFMediaKeySession2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20041,21 +16031,7 @@ impl IMFMediaKeySessionNotify {
         (::windows::core::Vtable::vtable(self).KeyError)(::windows::core::Vtable::as_raw(self), code, systemcode)
     }
 }
-impl ::core::convert::From<IMFMediaKeySessionNotify> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaKeySessionNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaKeySessionNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaKeySessionNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaKeySessionNotify> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaKeySessionNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaKeySessionNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaKeySessionNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20106,36 +16082,7 @@ impl IMFMediaKeySessionNotify2 {
         (::windows::core::Vtable::vtable(self).KeyStatusChange)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFMediaKeySessionNotify2> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaKeySessionNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaKeySessionNotify2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaKeySessionNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaKeySessionNotify2> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaKeySessionNotify2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaKeySessionNotify2> for IMFMediaKeySessionNotify {
-    fn from(value: IMFMediaKeySessionNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaKeySessionNotify2> for &'a IMFMediaKeySessionNotify {
-    fn from(value: &'a IMFMediaKeySessionNotify2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaKeySessionNotify2> for IMFMediaKeySessionNotify {
-    fn from(value: &IMFMediaKeySessionNotify2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaKeySessionNotify2, ::windows::core::IUnknown, IMFMediaKeySessionNotify);
 impl ::core::clone::Clone for IMFMediaKeySessionNotify2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20189,21 +16136,7 @@ impl IMFMediaKeySystemAccess {
         (::windows::core::Vtable::vtable(self).KeySystem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaKeySystemAccess> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaKeySystemAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaKeySystemAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaKeySystemAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaKeySystemAccess> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaKeySystemAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaKeySystemAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaKeySystemAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20263,21 +16196,7 @@ impl IMFMediaKeys {
         (::windows::core::Vtable::vtable(self).GetSuspendNotify)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFCdmSuspendNotify>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaKeys> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaKeys> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaKeys> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaKeys, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaKeys {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20346,36 +16265,7 @@ impl IMFMediaKeys2 {
         (::windows::core::Vtable::vtable(self).GetDOMException)(::windows::core::Vtable::as_raw(self), systemcode, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::HRESULT>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaKeys2> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaKeys2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaKeys2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaKeys2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaKeys2> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaKeys2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaKeys2> for IMFMediaKeys {
-    fn from(value: IMFMediaKeys2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaKeys2> for &'a IMFMediaKeys {
-    fn from(value: &'a IMFMediaKeys2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaKeys2> for IMFMediaKeys {
-    fn from(value: &IMFMediaKeys2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaKeys2, ::windows::core::IUnknown, IMFMediaKeys);
 impl ::core::clone::Clone for IMFMediaKeys2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20472,36 +16362,7 @@ impl IMFMediaSession {
         (::windows::core::Vtable::vtable(self).GetFullTopology)(::windows::core::Vtable::as_raw(self), dwgetfulltopologyflags, topoid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFTopology>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaSession> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSession> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaSession> for IMFMediaEventGenerator {
-    fn from(value: IMFMediaSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSession> for &'a IMFMediaEventGenerator {
-    fn from(value: &'a IMFMediaSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSession> for IMFMediaEventGenerator {
-    fn from(value: &IMFMediaSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSession, ::windows::core::IUnknown, IMFMediaEventGenerator);
 impl ::core::clone::Clone for IMFMediaSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20723,36 +16584,7 @@ impl IMFMediaSharingEngine {
         (::windows::core::Vtable::vtable(self).GetDevice)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DEVICE_INFO>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaSharingEngine> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSharingEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSharingEngine> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSharingEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSharingEngine> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSharingEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaSharingEngine> for IMFMediaEngine {
-    fn from(value: IMFMediaSharingEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSharingEngine> for &'a IMFMediaEngine {
-    fn from(value: &'a IMFMediaSharingEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSharingEngine> for IMFMediaEngine {
-    fn from(value: &IMFMediaSharingEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSharingEngine, ::windows::core::IUnknown, IMFMediaEngine);
 impl ::core::clone::Clone for IMFMediaSharingEngine {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20793,21 +16625,7 @@ impl IMFMediaSharingEngineClassFactory {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), dwflags, pattr.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFMediaSharingEngine>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaSharingEngineClassFactory> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSharingEngineClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSharingEngineClassFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSharingEngineClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSharingEngineClassFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSharingEngineClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSharingEngineClassFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaSharingEngineClassFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20880,21 +16698,7 @@ impl IMFMediaSink {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaSink> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSink> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20939,21 +16743,7 @@ impl IMFMediaSinkPreroll {
         (::windows::core::Vtable::vtable(self).NotifyPreroll)(::windows::core::Vtable::as_raw(self), hnsupcomingstarttime).ok()
     }
 }
-impl ::core::convert::From<IMFMediaSinkPreroll> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSinkPreroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSinkPreroll> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSinkPreroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSinkPreroll> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSinkPreroll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSinkPreroll, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaSinkPreroll {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21035,36 +16825,7 @@ impl IMFMediaSource {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaSource> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSource> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaSource> for IMFMediaEventGenerator {
-    fn from(value: IMFMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSource> for &'a IMFMediaEventGenerator {
-    fn from(value: &'a IMFMediaSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSource> for IMFMediaEventGenerator {
-    fn from(value: &IMFMediaSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSource, ::windows::core::IUnknown, IMFMediaEventGenerator);
 impl ::core::clone::Clone for IMFMediaSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21174,66 +16935,7 @@ impl IMFMediaSource2 {
         (::windows::core::Vtable::vtable(self).SetMediaType)(::windows::core::Vtable::as_raw(self), dwstreamid, pmediatype.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFMediaSource2> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSource2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSource2> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaSource2> for IMFMediaEventGenerator {
-    fn from(value: IMFMediaSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSource2> for &'a IMFMediaEventGenerator {
-    fn from(value: &'a IMFMediaSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSource2> for IMFMediaEventGenerator {
-    fn from(value: &IMFMediaSource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaSource2> for IMFMediaSource {
-    fn from(value: IMFMediaSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSource2> for &'a IMFMediaSource {
-    fn from(value: &'a IMFMediaSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSource2> for IMFMediaSource {
-    fn from(value: &IMFMediaSource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaSource2> for IMFMediaSourceEx {
-    fn from(value: IMFMediaSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSource2> for &'a IMFMediaSourceEx {
-    fn from(value: &'a IMFMediaSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSource2> for IMFMediaSourceEx {
-    fn from(value: &IMFMediaSource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSource2, ::windows::core::IUnknown, IMFMediaEventGenerator, IMFMediaSource, IMFMediaSourceEx);
 impl ::core::clone::Clone for IMFMediaSource2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21329,51 +17031,7 @@ impl IMFMediaSourceEx {
         (::windows::core::Vtable::vtable(self).SetD3DManager)(::windows::core::Vtable::as_raw(self), pmanager.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFMediaSourceEx> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSourceEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSourceEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSourceEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSourceEx> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSourceEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaSourceEx> for IMFMediaEventGenerator {
-    fn from(value: IMFMediaSourceEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSourceEx> for &'a IMFMediaEventGenerator {
-    fn from(value: &'a IMFMediaSourceEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSourceEx> for IMFMediaEventGenerator {
-    fn from(value: &IMFMediaSourceEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaSourceEx> for IMFMediaSource {
-    fn from(value: IMFMediaSourceEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSourceEx> for &'a IMFMediaSource {
-    fn from(value: &'a IMFMediaSourceEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSourceEx> for IMFMediaSource {
-    fn from(value: &IMFMediaSourceEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSourceEx, ::windows::core::IUnknown, IMFMediaEventGenerator, IMFMediaSource);
 impl ::core::clone::Clone for IMFMediaSourceEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21448,21 +17106,7 @@ impl IMFMediaSourceExtension {
         (::windows::core::Vtable::vtable(self).GetSourceBuffer)(::windows::core::Vtable::as_raw(self), dwstreamindex)
     }
 }
-impl ::core::convert::From<IMFMediaSourceExtension> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSourceExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSourceExtension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSourceExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSourceExtension> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSourceExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSourceExtension, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaSourceExtension {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21514,21 +17158,7 @@ impl IMFMediaSourceExtensionLiveSeekableRange {
         (::windows::core::Vtable::vtable(self).ClearLiveSeekableRange)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaSourceExtensionLiveSeekableRange> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSourceExtensionLiveSeekableRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSourceExtensionLiveSeekableRange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSourceExtensionLiveSeekableRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSourceExtensionLiveSeekableRange> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSourceExtensionLiveSeekableRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSourceExtensionLiveSeekableRange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaSourceExtensionLiveSeekableRange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21572,21 +17202,7 @@ impl IMFMediaSourceExtensionNotify {
         (::windows::core::Vtable::vtable(self).OnSourceClose)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFMediaSourceExtensionNotify> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSourceExtensionNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSourceExtensionNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSourceExtensionNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSourceExtensionNotify> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSourceExtensionNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSourceExtensionNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaSourceExtensionNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21628,21 +17244,7 @@ impl IMFMediaSourcePresentationProvider {
         (::windows::core::Vtable::vtable(self).ForceEndOfPresentation)(::windows::core::Vtable::as_raw(self), ppresentationdescriptor.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFMediaSourcePresentationProvider> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSourcePresentationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSourcePresentationProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSourcePresentationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSourcePresentationProvider> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSourcePresentationProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSourcePresentationProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaSourcePresentationProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21683,21 +17285,7 @@ impl IMFMediaSourceTopologyProvider {
         (::windows::core::Vtable::vtable(self).GetMediaSourceTopology)(::windows::core::Vtable::as_raw(self), ppresentationdescriptor.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFTopology>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaSourceTopologyProvider> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaSourceTopologyProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaSourceTopologyProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaSourceTopologyProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaSourceTopologyProvider> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaSourceTopologyProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaSourceTopologyProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaSourceTopologyProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21768,36 +17356,7 @@ impl IMFMediaStream {
         (::windows::core::Vtable::vtable(self).RequestSample)(::windows::core::Vtable::as_raw(self), ptoken.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFMediaStream> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaStream> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaStream> for IMFMediaEventGenerator {
-    fn from(value: IMFMediaStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaStream> for &'a IMFMediaEventGenerator {
-    fn from(value: &'a IMFMediaStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaStream> for IMFMediaEventGenerator {
-    fn from(value: &IMFMediaStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaStream, ::windows::core::IUnknown, IMFMediaEventGenerator);
 impl ::core::clone::Clone for IMFMediaStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21877,51 +17436,7 @@ impl IMFMediaStream2 {
         (::windows::core::Vtable::vtable(self).GetStreamState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MF_STREAM_STATE>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaStream2> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaStream2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaStream2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaStream2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaStream2> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaStream2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaStream2> for IMFMediaEventGenerator {
-    fn from(value: IMFMediaStream2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaStream2> for &'a IMFMediaEventGenerator {
-    fn from(value: &'a IMFMediaStream2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaStream2> for IMFMediaEventGenerator {
-    fn from(value: &IMFMediaStream2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaStream2> for IMFMediaStream {
-    fn from(value: IMFMediaStream2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaStream2> for &'a IMFMediaStream {
-    fn from(value: &'a IMFMediaStream2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaStream2> for IMFMediaStream {
-    fn from(value: &IMFMediaStream2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaStream2, ::windows::core::IUnknown, IMFMediaEventGenerator, IMFMediaStream);
 impl ::core::clone::Clone for IMFMediaStream2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21962,21 +17477,7 @@ impl IMFMediaStreamSourceSampleRequest {
         (::windows::core::Vtable::vtable(self).SetSample)(::windows::core::Vtable::as_raw(self), value.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFMediaStreamSourceSampleRequest> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaStreamSourceSampleRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaStreamSourceSampleRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaStreamSourceSampleRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaStreamSourceSampleRequest> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaStreamSourceSampleRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaStreamSourceSampleRequest, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaStreamSourceSampleRequest {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22032,21 +17533,7 @@ impl IMFMediaTimeRange {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaTimeRange> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaTimeRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaTimeRange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaTimeRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaTimeRange> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaTimeRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaTimeRange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaTimeRange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22237,36 +17724,7 @@ impl IMFMediaType {
         (::windows::core::Vtable::vtable(self).FreeRepresentation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidrepresentation), ::core::mem::transmute(pvrepresentation)).ok()
     }
 }
-impl ::core::convert::From<IMFMediaType> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaType> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFMediaType> for IMFAttributes {
-    fn from(value: IMFMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaType> for &'a IMFAttributes {
-    fn from(value: &'a IMFMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaType> for IMFAttributes {
-    fn from(value: &IMFMediaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaType, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFMediaType {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22336,21 +17794,7 @@ impl IMFMediaTypeHandler {
         (::windows::core::Vtable::vtable(self).GetMajorType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IMFMediaTypeHandler> for ::windows::core::IUnknown {
-    fn from(value: IMFMediaTypeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMediaTypeHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMediaTypeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMediaTypeHandler> for ::windows::core::IUnknown {
-    fn from(value: &IMFMediaTypeHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMediaTypeHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMediaTypeHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22434,21 +17878,7 @@ impl IMFMetadata {
         (::windows::core::Vtable::vtable(self).GetAllPropertyNames)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::StructuredStorage::PROPVARIANT>(result__)
     }
 }
-impl ::core::convert::From<IMFMetadata> for ::windows::core::IUnknown {
-    fn from(value: IMFMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMetadata> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMetadata> for ::windows::core::IUnknown {
-    fn from(value: &IMFMetadata) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMetadata, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMetadata {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22507,21 +17937,7 @@ impl IMFMetadataProvider {
         (::windows::core::Vtable::vtable(self).GetMFMetadata)(::windows::core::Vtable::as_raw(self), ppresentationdescriptor.into().abi(), dwstreamidentifier, dwflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFMetadata>(result__)
     }
 }
-impl ::core::convert::From<IMFMetadataProvider> for ::windows::core::IUnknown {
-    fn from(value: IMFMetadataProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMetadataProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMetadataProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMetadataProvider> for ::windows::core::IUnknown {
-    fn from(value: &IMFMetadataProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMetadataProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMetadataProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22563,21 +17979,7 @@ impl IMFMuxStreamAttributesManager {
         (::windows::core::Vtable::vtable(self).GetAttributes)(::windows::core::Vtable::as_raw(self), dwmuxstreamindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFAttributes>(result__)
     }
 }
-impl ::core::convert::From<IMFMuxStreamAttributesManager> for ::windows::core::IUnknown {
-    fn from(value: IMFMuxStreamAttributesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMuxStreamAttributesManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMuxStreamAttributesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMuxStreamAttributesManager> for ::windows::core::IUnknown {
-    fn from(value: &IMFMuxStreamAttributesManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMuxStreamAttributesManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMuxStreamAttributesManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22634,21 +18036,7 @@ impl IMFMuxStreamMediaTypeManager {
         (::windows::core::Vtable::vtable(self).GetStreamConfiguration)(::windows::core::Vtable::as_raw(self), ulindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IMFMuxStreamMediaTypeManager> for ::windows::core::IUnknown {
-    fn from(value: IMFMuxStreamMediaTypeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMuxStreamMediaTypeManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMuxStreamMediaTypeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMuxStreamMediaTypeManager> for ::windows::core::IUnknown {
-    fn from(value: &IMFMuxStreamMediaTypeManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMuxStreamMediaTypeManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMuxStreamMediaTypeManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22698,21 +18086,7 @@ impl IMFMuxStreamSampleManager {
         (::windows::core::Vtable::vtable(self).GetStreamConfiguration)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFMuxStreamSampleManager> for ::windows::core::IUnknown {
-    fn from(value: IMFMuxStreamSampleManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFMuxStreamSampleManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFMuxStreamSampleManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFMuxStreamSampleManager> for ::windows::core::IUnknown {
-    fn from(value: &IMFMuxStreamSampleManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFMuxStreamSampleManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFMuxStreamSampleManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22786,21 +18160,7 @@ impl IMFNetCredential {
         (::windows::core::Vtable::vtable(self).LoggedOnUser)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IMFNetCredential> for ::windows::core::IUnknown {
-    fn from(value: IMFNetCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFNetCredential> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFNetCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFNetCredential> for ::windows::core::IUnknown {
-    fn from(value: &IMFNetCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFNetCredential, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFNetCredential {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22875,21 +18235,7 @@ impl IMFNetCredentialCache {
         (::windows::core::Vtable::vtable(self).SetUserOptions)(::windows::core::Vtable::as_raw(self), pcred.into().abi(), dwoptionsflags).ok()
     }
 }
-impl ::core::convert::From<IMFNetCredentialCache> for ::windows::core::IUnknown {
-    fn from(value: IMFNetCredentialCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFNetCredentialCache> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFNetCredentialCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFNetCredentialCache> for ::windows::core::IUnknown {
-    fn from(value: &IMFNetCredentialCache) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFNetCredentialCache, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFNetCredentialCache {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22953,21 +18299,7 @@ impl IMFNetCredentialManager {
         (::windows::core::Vtable::vtable(self).SetGood)(::windows::core::Vtable::as_raw(self), pcred.into().abi(), fgood.into()).ok()
     }
 }
-impl ::core::convert::From<IMFNetCredentialManager> for ::windows::core::IUnknown {
-    fn from(value: IMFNetCredentialManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFNetCredentialManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFNetCredentialManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFNetCredentialManager> for ::windows::core::IUnknown {
-    fn from(value: &IMFNetCredentialManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFNetCredentialManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFNetCredentialManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23026,21 +18358,7 @@ impl IMFNetCrossOriginSupport {
         (::windows::core::Vtable::vtable(self).IsSameOrigin)(::windows::core::Vtable::as_raw(self), wszurl.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IMFNetCrossOriginSupport> for ::windows::core::IUnknown {
-    fn from(value: IMFNetCrossOriginSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFNetCrossOriginSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFNetCrossOriginSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFNetCrossOriginSupport> for ::windows::core::IUnknown {
-    fn from(value: &IMFNetCrossOriginSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFNetCrossOriginSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFNetCrossOriginSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23102,21 +18420,7 @@ impl IMFNetProxyLocator {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFNetProxyLocator>(result__)
     }
 }
-impl ::core::convert::From<IMFNetProxyLocator> for ::windows::core::IUnknown {
-    fn from(value: IMFNetProxyLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFNetProxyLocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFNetProxyLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFNetProxyLocator> for ::windows::core::IUnknown {
-    fn from(value: &IMFNetProxyLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFNetProxyLocator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFNetProxyLocator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23164,21 +18468,7 @@ impl IMFNetProxyLocatorFactory {
         (::windows::core::Vtable::vtable(self).CreateProxyLocator)(::windows::core::Vtable::as_raw(self), pszprotocol.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFNetProxyLocator>(result__)
     }
 }
-impl ::core::convert::From<IMFNetProxyLocatorFactory> for ::windows::core::IUnknown {
-    fn from(value: IMFNetProxyLocatorFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFNetProxyLocatorFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFNetProxyLocatorFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFNetProxyLocatorFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMFNetProxyLocatorFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFNetProxyLocatorFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFNetProxyLocatorFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23225,21 +18515,7 @@ impl IMFNetResourceFilter {
         (::windows::core::Vtable::vtable(self).OnSendingRequest)(::windows::core::Vtable::as_raw(self), pszurl.into()).ok()
     }
 }
-impl ::core::convert::From<IMFNetResourceFilter> for ::windows::core::IUnknown {
-    fn from(value: IMFNetResourceFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFNetResourceFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFNetResourceFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFNetResourceFilter> for ::windows::core::IUnknown {
-    fn from(value: &IMFNetResourceFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFNetResourceFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFNetResourceFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23285,21 +18561,7 @@ impl IMFNetSchemeHandlerConfig {
         (::windows::core::Vtable::vtable(self).ResetProtocolRolloverSettings)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFNetSchemeHandlerConfig> for ::windows::core::IUnknown {
-    fn from(value: IMFNetSchemeHandlerConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFNetSchemeHandlerConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFNetSchemeHandlerConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFNetSchemeHandlerConfig> for ::windows::core::IUnknown {
-    fn from(value: &IMFNetSchemeHandlerConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFNetSchemeHandlerConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFNetSchemeHandlerConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23344,21 +18606,7 @@ impl IMFObjectReferenceStream {
         (::windows::core::Vtable::vtable(self).LoadReference)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(ppv)).ok()
     }
 }
-impl ::core::convert::From<IMFObjectReferenceStream> for ::windows::core::IUnknown {
-    fn from(value: IMFObjectReferenceStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFObjectReferenceStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFObjectReferenceStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFObjectReferenceStream> for ::windows::core::IUnknown {
-    fn from(value: &IMFObjectReferenceStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFObjectReferenceStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFObjectReferenceStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23531,36 +18779,7 @@ impl IMFOutputPolicy {
         (::windows::core::Vtable::vtable(self).GetMinimumGRLVersion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMFOutputPolicy> for ::windows::core::IUnknown {
-    fn from(value: IMFOutputPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFOutputPolicy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFOutputPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFOutputPolicy> for ::windows::core::IUnknown {
-    fn from(value: &IMFOutputPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFOutputPolicy> for IMFAttributes {
-    fn from(value: IMFOutputPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFOutputPolicy> for &'a IMFAttributes {
-    fn from(value: &'a IMFOutputPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFOutputPolicy> for IMFAttributes {
-    fn from(value: &IMFOutputPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFOutputPolicy, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFOutputPolicy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23734,36 +18953,7 @@ impl IMFOutputSchema {
         (::windows::core::Vtable::vtable(self).GetOriginatorID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IMFOutputSchema> for ::windows::core::IUnknown {
-    fn from(value: IMFOutputSchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFOutputSchema> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFOutputSchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFOutputSchema> for ::windows::core::IUnknown {
-    fn from(value: &IMFOutputSchema) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFOutputSchema> for IMFAttributes {
-    fn from(value: IMFOutputSchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFOutputSchema> for &'a IMFAttributes {
-    fn from(value: &'a IMFOutputSchema) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFOutputSchema> for IMFAttributes {
-    fn from(value: &IMFOutputSchema) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFOutputSchema, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFOutputSchema {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23806,21 +18996,7 @@ impl IMFOutputTrustAuthority {
         (::windows::core::Vtable::vtable(self).SetPolicy)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pppolicy.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), pppolicy.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(ppbticket.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pcbticket.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMFOutputTrustAuthority> for ::windows::core::IUnknown {
-    fn from(value: IMFOutputTrustAuthority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFOutputTrustAuthority> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFOutputTrustAuthority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFOutputTrustAuthority> for ::windows::core::IUnknown {
-    fn from(value: &IMFOutputTrustAuthority) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFOutputTrustAuthority, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFOutputTrustAuthority {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23861,21 +19037,7 @@ impl IMFPMPClient {
         (::windows::core::Vtable::vtable(self).SetPMPHost)(::windows::core::Vtable::as_raw(self), ppmphost.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFPMPClient> for ::windows::core::IUnknown {
-    fn from(value: IMFPMPClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPMPClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPMPClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPMPClient> for ::windows::core::IUnknown {
-    fn from(value: &IMFPMPClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPMPClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFPMPClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23915,21 +19077,7 @@ impl IMFPMPClientApp {
         (::windows::core::Vtable::vtable(self).SetPMPHost)(::windows::core::Vtable::as_raw(self), ppmphost.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFPMPClientApp> for ::windows::core::IUnknown {
-    fn from(value: IMFPMPClientApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPMPClientApp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPMPClientApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPMPClientApp> for ::windows::core::IUnknown {
-    fn from(value: &IMFPMPClientApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPMPClientApp, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFPMPClientApp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23979,21 +19127,7 @@ impl IMFPMPHost {
         (::windows::core::Vtable::vtable(self).CreateObjectByCLSID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clsid), pstream.into().abi(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IMFPMPHost> for ::windows::core::IUnknown {
-    fn from(value: IMFPMPHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPMPHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPMPHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPMPHost> for ::windows::core::IUnknown {
-    fn from(value: &IMFPMPHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPMPHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFPMPHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24049,21 +19183,7 @@ impl IMFPMPHostApp {
         (::windows::core::Vtable::vtable(self).ActivateClassById)(::windows::core::Vtable::as_raw(self), id.into(), pstream.into().abi(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IMFPMPHostApp> for ::windows::core::IUnknown {
-    fn from(value: IMFPMPHostApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPMPHostApp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPMPHostApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPMPHostApp> for ::windows::core::IUnknown {
-    fn from(value: &IMFPMPHostApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPMPHostApp, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFPMPHostApp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24115,21 +19235,7 @@ impl IMFPMPServer {
         (::windows::core::Vtable::vtable(self).CreateObjectByCLSID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clsid), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IMFPMPServer> for ::windows::core::IUnknown {
-    fn from(value: IMFPMPServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPMPServer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPMPServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPMPServer> for ::windows::core::IUnknown {
-    fn from(value: &IMFPMPServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPMPServer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFPMPServer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24262,21 +19368,7 @@ impl IMFPMediaItem {
         (::windows::core::Vtable::vtable(self).GetMetadata)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::UI::Shell::PropertiesSystem::IPropertyStore>(result__)
     }
 }
-impl ::core::convert::From<IMFPMediaItem> for ::windows::core::IUnknown {
-    fn from(value: IMFPMediaItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPMediaItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPMediaItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPMediaItem> for ::windows::core::IUnknown {
-    fn from(value: &IMFPMediaItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPMediaItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFPMediaItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24538,21 +19630,7 @@ impl IMFPMediaPlayer {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFPMediaPlayer> for ::windows::core::IUnknown {
-    fn from(value: IMFPMediaPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPMediaPlayer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPMediaPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPMediaPlayer> for ::windows::core::IUnknown {
-    fn from(value: &IMFPMediaPlayer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPMediaPlayer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFPMediaPlayer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24668,21 +19746,7 @@ impl IMFPMediaPlayerCallback {
         (::windows::core::Vtable::vtable(self).OnMediaPlayerEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(peventheader))
     }
 }
-impl ::core::convert::From<IMFPMediaPlayerCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFPMediaPlayerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPMediaPlayerCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPMediaPlayerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPMediaPlayerCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFPMediaPlayerCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPMediaPlayerCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFPMediaPlayerCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24750,21 +19814,7 @@ impl IMFPluginControl {
         (::windows::core::Vtable::vtable(self).SetDisabled)(::windows::core::Vtable::as_raw(self), plugintype, ::core::mem::transmute(clsid), disabled.into()).ok()
     }
 }
-impl ::core::convert::From<IMFPluginControl> for ::windows::core::IUnknown {
-    fn from(value: IMFPluginControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPluginControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPluginControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPluginControl> for ::windows::core::IUnknown {
-    fn from(value: &IMFPluginControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPluginControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFPluginControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24840,36 +19890,7 @@ impl IMFPluginControl2 {
         (::windows::core::Vtable::vtable(self).SetPolicy)(::windows::core::Vtable::as_raw(self), policy).ok()
     }
 }
-impl ::core::convert::From<IMFPluginControl2> for ::windows::core::IUnknown {
-    fn from(value: IMFPluginControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPluginControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPluginControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPluginControl2> for ::windows::core::IUnknown {
-    fn from(value: &IMFPluginControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFPluginControl2> for IMFPluginControl {
-    fn from(value: IMFPluginControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPluginControl2> for &'a IMFPluginControl {
-    fn from(value: &'a IMFPluginControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPluginControl2> for IMFPluginControl {
-    fn from(value: &IMFPluginControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPluginControl2, ::windows::core::IUnknown, IMFPluginControl);
 impl ::core::clone::Clone for IMFPluginControl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24957,36 +19978,7 @@ impl IMFPresentationClock {
         (::windows::core::Vtable::vtable(self).Pause)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFPresentationClock> for ::windows::core::IUnknown {
-    fn from(value: IMFPresentationClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPresentationClock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPresentationClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPresentationClock> for ::windows::core::IUnknown {
-    fn from(value: &IMFPresentationClock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFPresentationClock> for IMFClock {
-    fn from(value: IMFPresentationClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPresentationClock> for &'a IMFClock {
-    fn from(value: &'a IMFPresentationClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPresentationClock> for IMFClock {
-    fn from(value: &IMFPresentationClock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPresentationClock, ::windows::core::IUnknown, IMFClock);
 impl ::core::clone::Clone for IMFPresentationClock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25172,36 +20164,7 @@ impl IMFPresentationDescriptor {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFPresentationDescriptor>(result__)
     }
 }
-impl ::core::convert::From<IMFPresentationDescriptor> for ::windows::core::IUnknown {
-    fn from(value: IMFPresentationDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPresentationDescriptor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPresentationDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPresentationDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &IMFPresentationDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFPresentationDescriptor> for IMFAttributes {
-    fn from(value: IMFPresentationDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPresentationDescriptor> for &'a IMFAttributes {
-    fn from(value: &'a IMFPresentationDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPresentationDescriptor> for IMFAttributes {
-    fn from(value: &IMFPresentationDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPresentationDescriptor, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFPresentationDescriptor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25265,36 +20228,7 @@ impl IMFPresentationTimeSource {
         (::windows::core::Vtable::vtable(self).GetUnderlyingClock)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFClock>(result__)
     }
 }
-impl ::core::convert::From<IMFPresentationTimeSource> for ::windows::core::IUnknown {
-    fn from(value: IMFPresentationTimeSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPresentationTimeSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFPresentationTimeSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPresentationTimeSource> for ::windows::core::IUnknown {
-    fn from(value: &IMFPresentationTimeSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFPresentationTimeSource> for IMFClock {
-    fn from(value: IMFPresentationTimeSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFPresentationTimeSource> for &'a IMFClock {
-    fn from(value: &'a IMFPresentationTimeSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFPresentationTimeSource> for IMFClock {
-    fn from(value: &IMFPresentationTimeSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFPresentationTimeSource, ::windows::core::IUnknown, IMFClock);
 impl ::core::clone::Clone for IMFPresentationTimeSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25334,21 +20268,7 @@ impl IMFProtectedEnvironmentAccess {
         (::windows::core::Vtable::vtable(self).ReadGRL)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(outputlength), ::core::mem::transmute(output)).ok()
     }
 }
-impl ::core::convert::From<IMFProtectedEnvironmentAccess> for ::windows::core::IUnknown {
-    fn from(value: IMFProtectedEnvironmentAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFProtectedEnvironmentAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFProtectedEnvironmentAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFProtectedEnvironmentAccess> for ::windows::core::IUnknown {
-    fn from(value: &IMFProtectedEnvironmentAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFProtectedEnvironmentAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFProtectedEnvironmentAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25400,21 +20320,7 @@ impl IMFQualityAdvise {
         (::windows::core::Vtable::vtable(self).DropTime)(::windows::core::Vtable::as_raw(self), hnsamounttodrop).ok()
     }
 }
-impl ::core::convert::From<IMFQualityAdvise> for ::windows::core::IUnknown {
-    fn from(value: IMFQualityAdvise) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFQualityAdvise> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFQualityAdvise) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFQualityAdvise> for ::windows::core::IUnknown {
-    fn from(value: &IMFQualityAdvise) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFQualityAdvise, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFQualityAdvise {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25476,36 +20382,7 @@ impl IMFQualityAdvise2 {
         (::windows::core::Vtable::vtable(self).NotifyQualityEvent)(::windows::core::Vtable::as_raw(self), pevent.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMFQualityAdvise2> for ::windows::core::IUnknown {
-    fn from(value: IMFQualityAdvise2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFQualityAdvise2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFQualityAdvise2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFQualityAdvise2> for ::windows::core::IUnknown {
-    fn from(value: &IMFQualityAdvise2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFQualityAdvise2> for IMFQualityAdvise {
-    fn from(value: IMFQualityAdvise2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFQualityAdvise2> for &'a IMFQualityAdvise {
-    fn from(value: &'a IMFQualityAdvise2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFQualityAdvise2> for IMFQualityAdvise {
-    fn from(value: &IMFQualityAdvise2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFQualityAdvise2, ::windows::core::IUnknown, IMFQualityAdvise);
 impl ::core::clone::Clone for IMFQualityAdvise2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25547,21 +20424,7 @@ impl IMFQualityAdviseLimits {
         (::windows::core::Vtable::vtable(self).GetMinimumQualityLevel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MF_QUALITY_LEVEL>(result__)
     }
 }
-impl ::core::convert::From<IMFQualityAdviseLimits> for ::windows::core::IUnknown {
-    fn from(value: IMFQualityAdviseLimits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFQualityAdviseLimits> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFQualityAdviseLimits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFQualityAdviseLimits> for ::windows::core::IUnknown {
-    fn from(value: &IMFQualityAdviseLimits) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFQualityAdviseLimits, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFQualityAdviseLimits {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25632,21 +20495,7 @@ impl IMFQualityManager {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFQualityManager> for ::windows::core::IUnknown {
-    fn from(value: IMFQualityManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFQualityManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFQualityManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFQualityManager> for ::windows::core::IUnknown {
-    fn from(value: &IMFQualityManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFQualityManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFQualityManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25698,21 +20547,7 @@ impl IMFRateControl {
         (::windows::core::Vtable::vtable(self).GetRate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfthin), ::core::mem::transmute(pflrate)).ok()
     }
 }
-impl ::core::convert::From<IMFRateControl> for ::windows::core::IUnknown {
-    fn from(value: IMFRateControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFRateControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFRateControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFRateControl> for ::windows::core::IUnknown {
-    fn from(value: &IMFRateControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFRateControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFRateControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25779,21 +20614,7 @@ impl IMFRateSupport {
         (::windows::core::Vtable::vtable(self).IsRateSupported)(::windows::core::Vtable::as_raw(self), fthin.into(), flrate, ::core::mem::transmute(pflnearestsupportedrate)).ok()
     }
 }
-impl ::core::convert::From<IMFRateSupport> for ::windows::core::IUnknown {
-    fn from(value: IMFRateSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFRateSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFRateSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFRateSupport> for ::windows::core::IUnknown {
-    fn from(value: &IMFRateSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFRateSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFRateSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25856,21 +20677,7 @@ impl IMFReadWriteClassFactory {
         (::windows::core::Vtable::vtable(self).CreateInstanceFromObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clsid), punkobject.into().abi(), pattributes.into().abi(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IMFReadWriteClassFactory> for ::windows::core::IUnknown {
-    fn from(value: IMFReadWriteClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFReadWriteClassFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFReadWriteClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFReadWriteClassFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMFReadWriteClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFReadWriteClassFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFReadWriteClassFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25917,21 +20724,7 @@ impl IMFRealTimeClient {
         (::windows::core::Vtable::vtable(self).SetWorkQueue)(::windows::core::Vtable::as_raw(self), dwworkqueueid).ok()
     }
 }
-impl ::core::convert::From<IMFRealTimeClient> for ::windows::core::IUnknown {
-    fn from(value: IMFRealTimeClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFRealTimeClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFRealTimeClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFRealTimeClient> for ::windows::core::IUnknown {
-    fn from(value: &IMFRealTimeClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFRealTimeClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFRealTimeClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25979,21 +20772,7 @@ impl IMFRealTimeClientEx {
         (::windows::core::Vtable::vtable(self).SetWorkQueueEx)(::windows::core::Vtable::as_raw(self), dwmultithreadedworkqueueid, lworkitembasepriority).ok()
     }
 }
-impl ::core::convert::From<IMFRealTimeClientEx> for ::windows::core::IUnknown {
-    fn from(value: IMFRealTimeClientEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFRealTimeClientEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFRealTimeClientEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFRealTimeClientEx> for ::windows::core::IUnknown {
-    fn from(value: &IMFRealTimeClientEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFRealTimeClientEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFRealTimeClientEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26033,21 +20812,7 @@ impl IMFRelativePanelReport {
         (::windows::core::Vtable::vtable(self).GetRelativePanel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMFRelativePanelReport> for ::windows::core::IUnknown {
-    fn from(value: IMFRelativePanelReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFRelativePanelReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFRelativePanelReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFRelativePanelReport> for ::windows::core::IUnknown {
-    fn from(value: &IMFRelativePanelReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFRelativePanelReport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFRelativePanelReport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26106,36 +20871,7 @@ impl IMFRelativePanelWatcher {
         (::windows::core::Vtable::vtable(self).GetReport)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFRelativePanelReport>(result__)
     }
 }
-impl ::core::convert::From<IMFRelativePanelWatcher> for ::windows::core::IUnknown {
-    fn from(value: IMFRelativePanelWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFRelativePanelWatcher> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFRelativePanelWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFRelativePanelWatcher> for ::windows::core::IUnknown {
-    fn from(value: &IMFRelativePanelWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFRelativePanelWatcher> for IMFShutdown {
-    fn from(value: IMFRelativePanelWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFRelativePanelWatcher> for &'a IMFShutdown {
-    fn from(value: &'a IMFRelativePanelWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFRelativePanelWatcher> for IMFShutdown {
-    fn from(value: &IMFRelativePanelWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFRelativePanelWatcher, ::windows::core::IUnknown, IMFShutdown);
 impl ::core::clone::Clone for IMFRelativePanelWatcher {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26177,21 +20913,7 @@ impl IMFRemoteAsyncCallback {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self), hr, premoteresult.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFRemoteAsyncCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFRemoteAsyncCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFRemoteAsyncCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFRemoteAsyncCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFRemoteAsyncCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFRemoteAsyncCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFRemoteAsyncCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFRemoteAsyncCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26231,21 +20953,7 @@ impl IMFRemoteDesktopPlugin {
         (::windows::core::Vtable::vtable(self).UpdateTopology)(::windows::core::Vtable::as_raw(self), ptopology.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFRemoteDesktopPlugin> for ::windows::core::IUnknown {
-    fn from(value: IMFRemoteDesktopPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFRemoteDesktopPlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFRemoteDesktopPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFRemoteDesktopPlugin> for ::windows::core::IUnknown {
-    fn from(value: &IMFRemoteDesktopPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFRemoteDesktopPlugin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFRemoteDesktopPlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26285,21 +20993,7 @@ impl IMFRemoteProxy {
         (::windows::core::Vtable::vtable(self).GetRemoteHost)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(ppv)).ok()
     }
 }
-impl ::core::convert::From<IMFRemoteProxy> for ::windows::core::IUnknown {
-    fn from(value: IMFRemoteProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFRemoteProxy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFRemoteProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFRemoteProxy> for ::windows::core::IUnknown {
-    fn from(value: &IMFRemoteProxy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFRemoteProxy, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFRemoteProxy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26354,21 +21048,7 @@ impl IMFSAMIStyle {
         (::windows::core::Vtable::vtable(self).GetSelectedStyle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IMFSAMIStyle> for ::windows::core::IUnknown {
-    fn from(value: IMFSAMIStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSAMIStyle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSAMIStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSAMIStyle> for ::windows::core::IUnknown {
-    fn from(value: &IMFSAMIStyle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSAMIStyle, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSAMIStyle {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26445,21 +21125,7 @@ impl IMFSSLCertificateManager {
         (::windows::core::Vtable::vtable(self).OnServerCertificate)(::windows::core::Vtable::as_raw(self), pszurl.into(), ::core::mem::transmute(pbdata.as_ptr()), pbdata.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IMFSSLCertificateManager> for ::windows::core::IUnknown {
-    fn from(value: IMFSSLCertificateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSSLCertificateManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSSLCertificateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSSLCertificateManager> for ::windows::core::IUnknown {
-    fn from(value: &IMFSSLCertificateManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSSLCertificateManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSSLCertificateManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26684,36 +21350,7 @@ impl IMFSample {
         (::windows::core::Vtable::vtable(self).CopyToBuffer)(::windows::core::Vtable::as_raw(self), pbuffer.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFSample> for ::windows::core::IUnknown {
-    fn from(value: IMFSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSample> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSample> for ::windows::core::IUnknown {
-    fn from(value: &IMFSample) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSample> for IMFAttributes {
-    fn from(value: IMFSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSample> for &'a IMFAttributes {
-    fn from(value: &'a IMFSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSample> for IMFAttributes {
-    fn from(value: &IMFSample) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSample, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFSample {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26769,21 +21406,7 @@ impl IMFSampleAllocatorControl {
         (::windows::core::Vtable::vtable(self).GetAllocatorUsage)(::windows::core::Vtable::as_raw(self), dwoutputstreamid, ::core::mem::transmute(pdwinputstreamid), ::core::mem::transmute(peusage)).ok()
     }
 }
-impl ::core::convert::From<IMFSampleAllocatorControl> for ::windows::core::IUnknown {
-    fn from(value: IMFSampleAllocatorControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSampleAllocatorControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSampleAllocatorControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSampleAllocatorControl> for ::windows::core::IUnknown {
-    fn from(value: &IMFSampleAllocatorControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSampleAllocatorControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSampleAllocatorControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26845,36 +21468,7 @@ impl IMFSampleGrabberSinkCallback {
         (::windows::core::Vtable::vtable(self).OnShutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFSampleGrabberSinkCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFSampleGrabberSinkCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSampleGrabberSinkCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSampleGrabberSinkCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSampleGrabberSinkCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFSampleGrabberSinkCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSampleGrabberSinkCallback> for IMFClockStateSink {
-    fn from(value: IMFSampleGrabberSinkCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSampleGrabberSinkCallback> for &'a IMFClockStateSink {
-    fn from(value: &'a IMFSampleGrabberSinkCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSampleGrabberSinkCallback> for IMFClockStateSink {
-    fn from(value: &IMFSampleGrabberSinkCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSampleGrabberSinkCallback, ::windows::core::IUnknown, IMFClockStateSink);
 impl ::core::clone::Clone for IMFSampleGrabberSinkCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26943,51 +21537,7 @@ impl IMFSampleGrabberSinkCallback2 {
         (::windows::core::Vtable::vtable(self).OnProcessSampleEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidmajormediatype), dwsampleflags, llsampletime, llsampleduration, ::core::mem::transmute(psamplebuffer.as_ptr()), psamplebuffer.len() as _, pattributes.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFSampleGrabberSinkCallback2> for ::windows::core::IUnknown {
-    fn from(value: IMFSampleGrabberSinkCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSampleGrabberSinkCallback2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSampleGrabberSinkCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSampleGrabberSinkCallback2> for ::windows::core::IUnknown {
-    fn from(value: &IMFSampleGrabberSinkCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSampleGrabberSinkCallback2> for IMFClockStateSink {
-    fn from(value: IMFSampleGrabberSinkCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSampleGrabberSinkCallback2> for &'a IMFClockStateSink {
-    fn from(value: &'a IMFSampleGrabberSinkCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSampleGrabberSinkCallback2> for IMFClockStateSink {
-    fn from(value: &IMFSampleGrabberSinkCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSampleGrabberSinkCallback2> for IMFSampleGrabberSinkCallback {
-    fn from(value: IMFSampleGrabberSinkCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSampleGrabberSinkCallback2> for &'a IMFSampleGrabberSinkCallback {
-    fn from(value: &'a IMFSampleGrabberSinkCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSampleGrabberSinkCallback2> for IMFSampleGrabberSinkCallback {
-    fn from(value: &IMFSampleGrabberSinkCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSampleGrabberSinkCallback2, ::windows::core::IUnknown, IMFClockStateSink, IMFSampleGrabberSinkCallback);
 impl ::core::clone::Clone for IMFSampleGrabberSinkCallback2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27038,21 +21588,7 @@ impl IMFSampleOutputStream {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFSampleOutputStream> for ::windows::core::IUnknown {
-    fn from(value: IMFSampleOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSampleOutputStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSampleOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSampleOutputStream> for ::windows::core::IUnknown {
-    fn from(value: &IMFSampleOutputStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSampleOutputStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSampleOutputStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27105,21 +21641,7 @@ impl IMFSampleProtection {
         (::windows::core::Vtable::vtable(self).InitInputProtection)(::windows::core::Vtable::as_raw(self), dwversion, dwinputid, ::core::mem::transmute(pbseed), cbseed).ok()
     }
 }
-impl ::core::convert::From<IMFSampleProtection> for ::windows::core::IUnknown {
-    fn from(value: IMFSampleProtection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSampleProtection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSampleProtection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSampleProtection> for ::windows::core::IUnknown {
-    fn from(value: &IMFSampleProtection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSampleProtection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSampleProtection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27178,21 +21700,7 @@ impl IMFSaveJob {
         (::windows::core::Vtable::vtable(self).GetProgress)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMFSaveJob> for ::windows::core::IUnknown {
-    fn from(value: IMFSaveJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSaveJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSaveJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSaveJob> for ::windows::core::IUnknown {
-    fn from(value: &IMFSaveJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSaveJob, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSaveJob {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27252,21 +21760,7 @@ impl IMFSchemeHandler {
         (::windows::core::Vtable::vtable(self).CancelObjectCreation)(::windows::core::Vtable::as_raw(self), piunknowncancelcookie.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFSchemeHandler> for ::windows::core::IUnknown {
-    fn from(value: IMFSchemeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSchemeHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSchemeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSchemeHandler> for ::windows::core::IUnknown {
-    fn from(value: &IMFSchemeHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSchemeHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSchemeHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27309,21 +21803,7 @@ impl IMFSecureBuffer {
         (::windows::core::Vtable::vtable(self).GetIdentifier)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IMFSecureBuffer> for ::windows::core::IUnknown {
-    fn from(value: IMFSecureBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSecureBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSecureBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSecureBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IMFSecureBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSecureBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSecureBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27363,21 +21843,7 @@ impl IMFSecureChannel {
         (::windows::core::Vtable::vtable(self).SetupSession)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbencryptedsessionkey.as_ptr()), pbencryptedsessionkey.len() as _).ok()
     }
 }
-impl ::core::convert::From<IMFSecureChannel> for ::windows::core::IUnknown {
-    fn from(value: IMFSecureChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSecureChannel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSecureChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSecureChannel> for ::windows::core::IUnknown {
-    fn from(value: &IMFSecureChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSecureChannel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSecureChannel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27417,21 +21883,7 @@ impl IMFSeekInfo {
         (::windows::core::Vtable::vtable(self).GetNearestKeyFrames)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguidtimeformat), ::core::mem::transmute(pvarstartposition), ::core::mem::transmute(pvarpreviouskeyframe), ::core::mem::transmute(pvarnextkeyframe)).ok()
     }
 }
-impl ::core::convert::From<IMFSeekInfo> for ::windows::core::IUnknown {
-    fn from(value: IMFSeekInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSeekInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSeekInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSeekInfo> for ::windows::core::IUnknown {
-    fn from(value: &IMFSeekInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSeekInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSeekInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27483,21 +21935,7 @@ impl IMFSensorActivitiesReport {
         (::windows::core::Vtable::vtable(self).GetActivityReportByDeviceName)(::windows::core::Vtable::as_raw(self), symbolicname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFSensorActivityReport>(result__)
     }
 }
-impl ::core::convert::From<IMFSensorActivitiesReport> for ::windows::core::IUnknown {
-    fn from(value: IMFSensorActivitiesReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorActivitiesReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSensorActivitiesReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorActivitiesReport> for ::windows::core::IUnknown {
-    fn from(value: &IMFSensorActivitiesReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSensorActivitiesReport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSensorActivitiesReport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27539,21 +21977,7 @@ impl IMFSensorActivitiesReportCallback {
         (::windows::core::Vtable::vtable(self).OnActivitiesReport)(::windows::core::Vtable::as_raw(self), sensoractivitiesreport.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFSensorActivitiesReportCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFSensorActivitiesReportCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorActivitiesReportCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSensorActivitiesReportCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorActivitiesReportCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFSensorActivitiesReportCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSensorActivitiesReportCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSensorActivitiesReportCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27593,21 +22017,7 @@ impl IMFSensorActivityMonitor {
         (::windows::core::Vtable::vtable(self).Stop)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFSensorActivityMonitor> for ::windows::core::IUnknown {
-    fn from(value: IMFSensorActivityMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorActivityMonitor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSensorActivityMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorActivityMonitor> for ::windows::core::IUnknown {
-    fn from(value: &IMFSensorActivityMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSensorActivityMonitor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSensorActivityMonitor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27656,21 +22066,7 @@ impl IMFSensorActivityReport {
         (::windows::core::Vtable::vtable(self).GetProcessActivity)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFSensorProcessActivity>(result__)
     }
 }
-impl ::core::convert::From<IMFSensorActivityReport> for ::windows::core::IUnknown {
-    fn from(value: IMFSensorActivityReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorActivityReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSensorActivityReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorActivityReport> for ::windows::core::IUnknown {
-    fn from(value: &IMFSensorActivityReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSensorActivityReport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSensorActivityReport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27741,21 +22137,7 @@ impl IMFSensorDevice {
         (::windows::core::Vtable::vtable(self).GetSensorDeviceMode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MFSensorDeviceMode>(result__)
     }
 }
-impl ::core::convert::From<IMFSensorDevice> for ::windows::core::IUnknown {
-    fn from(value: IMFSensorDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSensorDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorDevice> for ::windows::core::IUnknown {
-    fn from(value: &IMFSensorDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSensorDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSensorDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27827,21 +22209,7 @@ impl IMFSensorGroup {
         (::windows::core::Vtable::vtable(self).CreateMediaSource)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFMediaSource>(result__)
     }
 }
-impl ::core::convert::From<IMFSensorGroup> for ::windows::core::IUnknown {
-    fn from(value: IMFSensorGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSensorGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorGroup> for ::windows::core::IUnknown {
-    fn from(value: &IMFSensorGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSensorGroup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSensorGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27902,21 +22270,7 @@ impl IMFSensorProcessActivity {
         (::windows::core::Vtable::vtable(self).GetReportTime)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::FILETIME>(result__)
     }
 }
-impl ::core::convert::From<IMFSensorProcessActivity> for ::windows::core::IUnknown {
-    fn from(value: IMFSensorProcessActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorProcessActivity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSensorProcessActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorProcessActivity> for ::windows::core::IUnknown {
-    fn from(value: &IMFSensorProcessActivity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSensorProcessActivity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSensorProcessActivity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27984,21 +22338,7 @@ impl IMFSensorProfile {
         (::windows::core::Vtable::vtable(self).AddBlockedControl)(::windows::core::Vtable::as_raw(self), wzblockedcontrol.into()).ok()
     }
 }
-impl ::core::convert::From<IMFSensorProfile> for ::windows::core::IUnknown {
-    fn from(value: IMFSensorProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorProfile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSensorProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorProfile> for ::windows::core::IUnknown {
-    fn from(value: &IMFSensorProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSensorProfile, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSensorProfile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28061,21 +22401,7 @@ impl IMFSensorProfileCollection {
         (::windows::core::Vtable::vtable(self).RemoveProfile)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(profileid))
     }
 }
-impl ::core::convert::From<IMFSensorProfileCollection> for ::windows::core::IUnknown {
-    fn from(value: IMFSensorProfileCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorProfileCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSensorProfileCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorProfileCollection> for ::windows::core::IUnknown {
-    fn from(value: &IMFSensorProfileCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSensorProfileCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSensorProfileCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28252,36 +22578,7 @@ impl IMFSensorStream {
         (::windows::core::Vtable::vtable(self).CloneSensorStream)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFSensorStream>(result__)
     }
 }
-impl ::core::convert::From<IMFSensorStream> for ::windows::core::IUnknown {
-    fn from(value: IMFSensorStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSensorStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorStream> for ::windows::core::IUnknown {
-    fn from(value: &IMFSensorStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSensorStream> for IMFAttributes {
-    fn from(value: IMFSensorStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorStream> for &'a IMFAttributes {
-    fn from(value: &'a IMFSensorStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorStream> for IMFAttributes {
-    fn from(value: &IMFSensorStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSensorStream, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFSensorStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28342,21 +22639,7 @@ impl IMFSensorTransformFactory {
         (::windows::core::Vtable::vtable(self).CreateTransform)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidsensortransformid), pattributes.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFDeviceTransform>(result__)
     }
 }
-impl ::core::convert::From<IMFSensorTransformFactory> for ::windows::core::IUnknown {
-    fn from(value: IMFSensorTransformFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSensorTransformFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSensorTransformFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSensorTransformFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMFSensorTransformFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSensorTransformFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSensorTransformFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28419,21 +22702,7 @@ impl IMFSequencerSource {
         (::windows::core::Vtable::vtable(self).UpdateTopologyFlags)(::windows::core::Vtable::as_raw(self), dwid, dwflags).ok()
     }
 }
-impl ::core::convert::From<IMFSequencerSource> for ::windows::core::IUnknown {
-    fn from(value: IMFSequencerSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSequencerSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSequencerSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSequencerSource> for ::windows::core::IUnknown {
-    fn from(value: &IMFSequencerSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSequencerSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSequencerSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28478,21 +22747,7 @@ impl IMFSharingEngineClassFactory {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), dwflags, pattr.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IMFSharingEngineClassFactory> for ::windows::core::IUnknown {
-    fn from(value: IMFSharingEngineClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSharingEngineClassFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSharingEngineClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSharingEngineClassFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMFSharingEngineClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSharingEngineClassFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSharingEngineClassFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28533,21 +22788,7 @@ impl IMFShutdown {
         (::windows::core::Vtable::vtable(self).GetShutdownStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MFSHUTDOWN_STATUS>(result__)
     }
 }
-impl ::core::convert::From<IMFShutdown> for ::windows::core::IUnknown {
-    fn from(value: IMFShutdown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFShutdown> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFShutdown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFShutdown> for ::windows::core::IUnknown {
-    fn from(value: &IMFShutdown) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFShutdown, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFShutdown {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28588,21 +22829,7 @@ impl IMFSignedLibrary {
         (::windows::core::Vtable::vtable(self).GetProcedureAddress)(::windows::core::Vtable::as_raw(self), name.into(), ::core::mem::transmute(address)).ok()
     }
 }
-impl ::core::convert::From<IMFSignedLibrary> for ::windows::core::IUnknown {
-    fn from(value: IMFSignedLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSignedLibrary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSignedLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSignedLibrary> for ::windows::core::IUnknown {
-    fn from(value: &IMFSignedLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSignedLibrary, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSignedLibrary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28657,21 +22884,7 @@ impl IMFSimpleAudioVolume {
         (::windows::core::Vtable::vtable(self).GetMute)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IMFSimpleAudioVolume> for ::windows::core::IUnknown {
-    fn from(value: IMFSimpleAudioVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSimpleAudioVolume> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSimpleAudioVolume) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSimpleAudioVolume> for ::windows::core::IUnknown {
-    fn from(value: &IMFSimpleAudioVolume) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSimpleAudioVolume, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSimpleAudioVolume {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28759,21 +22972,7 @@ impl IMFSinkWriter {
         (::windows::core::Vtable::vtable(self).GetStatistics)(::windows::core::Vtable::as_raw(self), dwstreamindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MF_SINK_WRITER_STATISTICS>(result__)
     }
 }
-impl ::core::convert::From<IMFSinkWriter> for ::windows::core::IUnknown {
-    fn from(value: IMFSinkWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSinkWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSinkWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSinkWriter> for ::windows::core::IUnknown {
-    fn from(value: &IMFSinkWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSinkWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSinkWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28823,21 +23022,7 @@ impl IMFSinkWriterCallback {
         (::windows::core::Vtable::vtable(self).OnMarker)(::windows::core::Vtable::as_raw(self), dwstreamindex, ::core::mem::transmute(pvcontext)).ok()
     }
 }
-impl ::core::convert::From<IMFSinkWriterCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFSinkWriterCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSinkWriterCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSinkWriterCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSinkWriterCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFSinkWriterCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSinkWriterCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSinkWriterCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28884,36 +23069,7 @@ impl IMFSinkWriterCallback2 {
         (::windows::core::Vtable::vtable(self).OnStreamError)(::windows::core::Vtable::as_raw(self), dwstreamindex, hrstatus).ok()
     }
 }
-impl ::core::convert::From<IMFSinkWriterCallback2> for ::windows::core::IUnknown {
-    fn from(value: IMFSinkWriterCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSinkWriterCallback2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSinkWriterCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSinkWriterCallback2> for ::windows::core::IUnknown {
-    fn from(value: &IMFSinkWriterCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSinkWriterCallback2> for IMFSinkWriterCallback {
-    fn from(value: IMFSinkWriterCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSinkWriterCallback2> for &'a IMFSinkWriterCallback {
-    fn from(value: &'a IMFSinkWriterCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSinkWriterCallback2> for IMFSinkWriterCallback {
-    fn from(value: &IMFSinkWriterCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSinkWriterCallback2, ::windows::core::IUnknown, IMFSinkWriterCallback);
 impl ::core::clone::Clone for IMFSinkWriterCallback2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28961,21 +23117,7 @@ impl IMFSinkWriterEncoderConfig {
         (::windows::core::Vtable::vtable(self).PlaceEncodingParameters)(::windows::core::Vtable::as_raw(self), dwstreamindex, pencodingparameters.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFSinkWriterEncoderConfig> for ::windows::core::IUnknown {
-    fn from(value: IMFSinkWriterEncoderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSinkWriterEncoderConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSinkWriterEncoderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSinkWriterEncoderConfig> for ::windows::core::IUnknown {
-    fn from(value: &IMFSinkWriterEncoderConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSinkWriterEncoderConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSinkWriterEncoderConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29058,36 +23200,7 @@ impl IMFSinkWriterEx {
         (::windows::core::Vtable::vtable(self).GetTransformForStream)(::windows::core::Vtable::as_raw(self), dwstreamindex, dwtransformindex, ::core::mem::transmute(pguidcategory.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pptransform)).ok()
     }
 }
-impl ::core::convert::From<IMFSinkWriterEx> for ::windows::core::IUnknown {
-    fn from(value: IMFSinkWriterEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSinkWriterEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSinkWriterEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSinkWriterEx> for ::windows::core::IUnknown {
-    fn from(value: &IMFSinkWriterEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSinkWriterEx> for IMFSinkWriter {
-    fn from(value: IMFSinkWriterEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSinkWriterEx> for &'a IMFSinkWriter {
-    fn from(value: &'a IMFSinkWriterEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSinkWriterEx> for IMFSinkWriter {
-    fn from(value: &IMFSinkWriterEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSinkWriterEx, ::windows::core::IUnknown, IMFSinkWriter);
 impl ::core::clone::Clone for IMFSinkWriterEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29163,21 +23276,7 @@ impl IMFSourceBuffer {
         (::windows::core::Vtable::vtable(self).Remove)(::windows::core::Vtable::as_raw(self), start, end).ok()
     }
 }
-impl ::core::convert::From<IMFSourceBuffer> for ::windows::core::IUnknown {
-    fn from(value: IMFSourceBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSourceBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IMFSourceBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSourceBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSourceBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29231,21 +23330,7 @@ impl IMFSourceBufferAppendMode {
         (::windows::core::Vtable::vtable(self).SetAppendMode)(::windows::core::Vtable::as_raw(self), mode).ok()
     }
 }
-impl ::core::convert::From<IMFSourceBufferAppendMode> for ::windows::core::IUnknown {
-    fn from(value: IMFSourceBufferAppendMode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceBufferAppendMode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSourceBufferAppendMode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceBufferAppendMode> for ::windows::core::IUnknown {
-    fn from(value: &IMFSourceBufferAppendMode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSourceBufferAppendMode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSourceBufferAppendMode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29286,21 +23371,7 @@ impl IMFSourceBufferList {
         (::windows::core::Vtable::vtable(self).GetSourceBuffer)(::windows::core::Vtable::as_raw(self), index)
     }
 }
-impl ::core::convert::From<IMFSourceBufferList> for ::windows::core::IUnknown {
-    fn from(value: IMFSourceBufferList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceBufferList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSourceBufferList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceBufferList> for ::windows::core::IUnknown {
-    fn from(value: &IMFSourceBufferList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSourceBufferList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSourceBufferList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29350,21 +23421,7 @@ impl IMFSourceBufferNotify {
         (::windows::core::Vtable::vtable(self).OnUpdateEnd)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFSourceBufferNotify> for ::windows::core::IUnknown {
-    fn from(value: IMFSourceBufferNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceBufferNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSourceBufferNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceBufferNotify> for ::windows::core::IUnknown {
-    fn from(value: &IMFSourceBufferNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSourceBufferNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSourceBufferNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29408,21 +23465,7 @@ impl IMFSourceOpenMonitor {
         (::windows::core::Vtable::vtable(self).OnSourceEvent)(::windows::core::Vtable::as_raw(self), pevent.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFSourceOpenMonitor> for ::windows::core::IUnknown {
-    fn from(value: IMFSourceOpenMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceOpenMonitor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSourceOpenMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceOpenMonitor> for ::windows::core::IUnknown {
-    fn from(value: &IMFSourceOpenMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSourceOpenMonitor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSourceOpenMonitor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29504,21 +23547,7 @@ impl IMFSourceReader {
         (::windows::core::Vtable::vtable(self).GetPresentationAttribute)(::windows::core::Vtable::as_raw(self), dwstreamindex, ::core::mem::transmute(guidattribute), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::StructuredStorage::PROPVARIANT>(result__)
     }
 }
-impl ::core::convert::From<IMFSourceReader> for ::windows::core::IUnknown {
-    fn from(value: IMFSourceReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSourceReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceReader> for ::windows::core::IUnknown {
-    fn from(value: &IMFSourceReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSourceReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSourceReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29588,21 +23617,7 @@ impl IMFSourceReaderCallback {
         (::windows::core::Vtable::vtable(self).OnEvent)(::windows::core::Vtable::as_raw(self), dwstreamindex, pevent.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFSourceReaderCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFSourceReaderCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceReaderCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSourceReaderCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceReaderCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFSourceReaderCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSourceReaderCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSourceReaderCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29659,36 +23674,7 @@ impl IMFSourceReaderCallback2 {
         (::windows::core::Vtable::vtable(self).OnStreamError)(::windows::core::Vtable::as_raw(self), dwstreamindex, hrstatus).ok()
     }
 }
-impl ::core::convert::From<IMFSourceReaderCallback2> for ::windows::core::IUnknown {
-    fn from(value: IMFSourceReaderCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceReaderCallback2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSourceReaderCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceReaderCallback2> for ::windows::core::IUnknown {
-    fn from(value: &IMFSourceReaderCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSourceReaderCallback2> for IMFSourceReaderCallback {
-    fn from(value: IMFSourceReaderCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceReaderCallback2> for &'a IMFSourceReaderCallback {
-    fn from(value: &'a IMFSourceReaderCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceReaderCallback2> for IMFSourceReaderCallback {
-    fn from(value: &IMFSourceReaderCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSourceReaderCallback2, ::windows::core::IUnknown, IMFSourceReaderCallback);
 impl ::core::clone::Clone for IMFSourceReaderCallback2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29790,36 +23776,7 @@ impl IMFSourceReaderEx {
         (::windows::core::Vtable::vtable(self).GetTransformForStream)(::windows::core::Vtable::as_raw(self), dwstreamindex, dwtransformindex, ::core::mem::transmute(pguidcategory.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pptransform)).ok()
     }
 }
-impl ::core::convert::From<IMFSourceReaderEx> for ::windows::core::IUnknown {
-    fn from(value: IMFSourceReaderEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceReaderEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSourceReaderEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceReaderEx> for ::windows::core::IUnknown {
-    fn from(value: &IMFSourceReaderEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSourceReaderEx> for IMFSourceReader {
-    fn from(value: IMFSourceReaderEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceReaderEx> for &'a IMFSourceReader {
-    fn from(value: &'a IMFSourceReaderEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceReaderEx> for IMFSourceReader {
-    fn from(value: &IMFSourceReaderEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSourceReaderEx, ::windows::core::IUnknown, IMFSourceReader);
 impl ::core::clone::Clone for IMFSourceReaderEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29916,21 +23873,7 @@ impl IMFSourceResolver {
         (::windows::core::Vtable::vtable(self).CancelObjectCreation)(::windows::core::Vtable::as_raw(self), piunknowncancelcookie.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFSourceResolver> for ::windows::core::IUnknown {
-    fn from(value: IMFSourceResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSourceResolver> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSourceResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSourceResolver> for ::windows::core::IUnknown {
-    fn from(value: &IMFSourceResolver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSourceResolver, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSourceResolver {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30023,36 +23966,7 @@ impl IMFSpatialAudioObjectBuffer {
         (::windows::core::Vtable::vtable(self).GetMetadataItems)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Audio::ISpatialAudioMetadataItems>(result__)
     }
 }
-impl ::core::convert::From<IMFSpatialAudioObjectBuffer> for ::windows::core::IUnknown {
-    fn from(value: IMFSpatialAudioObjectBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSpatialAudioObjectBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSpatialAudioObjectBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSpatialAudioObjectBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IMFSpatialAudioObjectBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSpatialAudioObjectBuffer> for IMFMediaBuffer {
-    fn from(value: IMFSpatialAudioObjectBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSpatialAudioObjectBuffer> for &'a IMFMediaBuffer {
-    fn from(value: &'a IMFSpatialAudioObjectBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSpatialAudioObjectBuffer> for IMFMediaBuffer {
-    fn from(value: &IMFSpatialAudioObjectBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSpatialAudioObjectBuffer, ::windows::core::IUnknown, IMFMediaBuffer);
 impl ::core::clone::Clone for IMFSpatialAudioObjectBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30294,51 +24208,7 @@ impl IMFSpatialAudioSample {
         (::windows::core::Vtable::vtable(self).GetSpatialAudioObjectByIndex)(::windows::core::Vtable::as_raw(self), dwindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFSpatialAudioObjectBuffer>(result__)
     }
 }
-impl ::core::convert::From<IMFSpatialAudioSample> for ::windows::core::IUnknown {
-    fn from(value: IMFSpatialAudioSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSpatialAudioSample> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSpatialAudioSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSpatialAudioSample> for ::windows::core::IUnknown {
-    fn from(value: &IMFSpatialAudioSample) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSpatialAudioSample> for IMFAttributes {
-    fn from(value: IMFSpatialAudioSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSpatialAudioSample> for &'a IMFAttributes {
-    fn from(value: &'a IMFSpatialAudioSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSpatialAudioSample> for IMFAttributes {
-    fn from(value: &IMFSpatialAudioSample) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFSpatialAudioSample> for IMFSample {
-    fn from(value: IMFSpatialAudioSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSpatialAudioSample> for &'a IMFSample {
-    fn from(value: &'a IMFSpatialAudioSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSpatialAudioSample> for IMFSample {
-    fn from(value: &IMFSpatialAudioSample) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSpatialAudioSample, ::windows::core::IUnknown, IMFAttributes, IMFSample);
 impl ::core::clone::Clone for IMFSpatialAudioSample {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30508,36 +24378,7 @@ impl IMFStreamDescriptor {
         (::windows::core::Vtable::vtable(self).GetMediaTypeHandler)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFMediaTypeHandler>(result__)
     }
 }
-impl ::core::convert::From<IMFStreamDescriptor> for ::windows::core::IUnknown {
-    fn from(value: IMFStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFStreamDescriptor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFStreamDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &IMFStreamDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFStreamDescriptor> for IMFAttributes {
-    fn from(value: IMFStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFStreamDescriptor> for &'a IMFAttributes {
-    fn from(value: &'a IMFStreamDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFStreamDescriptor> for IMFAttributes {
-    fn from(value: &IMFStreamDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFStreamDescriptor, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFStreamDescriptor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30621,36 +24462,7 @@ impl IMFStreamSink {
         (::windows::core::Vtable::vtable(self).Flush)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFStreamSink> for ::windows::core::IUnknown {
-    fn from(value: IMFStreamSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFStreamSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFStreamSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFStreamSink> for ::windows::core::IUnknown {
-    fn from(value: &IMFStreamSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFStreamSink> for IMFMediaEventGenerator {
-    fn from(value: IMFStreamSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFStreamSink> for &'a IMFMediaEventGenerator {
-    fn from(value: &'a IMFStreamSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFStreamSink> for IMFMediaEventGenerator {
-    fn from(value: &IMFStreamSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFStreamSink, ::windows::core::IUnknown, IMFMediaEventGenerator);
 impl ::core::clone::Clone for IMFStreamSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30700,21 +24512,7 @@ impl IMFStreamingSinkConfig {
         (::windows::core::Vtable::vtable(self).StartStreaming)(::windows::core::Vtable::as_raw(self), fseekoffsetisbyteoffset.into(), qwseekoffset).ok()
     }
 }
-impl ::core::convert::From<IMFStreamingSinkConfig> for ::windows::core::IUnknown {
-    fn from(value: IMFStreamingSinkConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFStreamingSinkConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFStreamingSinkConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFStreamingSinkConfig> for ::windows::core::IUnknown {
-    fn from(value: &IMFStreamingSinkConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFStreamingSinkConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFStreamingSinkConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30757,21 +24555,7 @@ impl IMFSystemId {
         (::windows::core::Vtable::vtable(self).Setup)(::windows::core::Vtable::as_raw(self), stage, pbin.len() as _, ::core::mem::transmute(pbin.as_ptr()), ::core::mem::transmute(pcbout), ::core::mem::transmute(ppbout)).ok()
     }
 }
-impl ::core::convert::From<IMFSystemId> for ::windows::core::IUnknown {
-    fn from(value: IMFSystemId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFSystemId> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFSystemId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFSystemId> for ::windows::core::IUnknown {
-    fn from(value: &IMFSystemId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFSystemId, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFSystemId {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30838,21 +24622,7 @@ impl IMFTimecodeTranslate {
         (::windows::core::Vtable::vtable(self).EndConvertHNSToTimecode)(::windows::core::Vtable::as_raw(self), presult.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::StructuredStorage::PROPVARIANT>(result__)
     }
 }
-impl ::core::convert::From<IMFTimecodeTranslate> for ::windows::core::IUnknown {
-    fn from(value: IMFTimecodeTranslate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimecodeTranslate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimecodeTranslate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimecodeTranslate> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimecodeTranslate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimecodeTranslate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimecodeTranslate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30983,21 +24753,7 @@ impl IMFTimedText {
         (::windows::core::Vtable::vtable(self).IsInBandEnabled)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFTimedText> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedText> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedText> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedText, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedText {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31062,21 +24818,7 @@ impl IMFTimedTextBinary {
         (::windows::core::Vtable::vtable(self).GetData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(data), ::core::mem::transmute(length)).ok()
     }
 }
-impl ::core::convert::From<IMFTimedTextBinary> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextBinary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextBinary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextBinary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextBinary> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextBinary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextBinary, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextBinary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31122,21 +24864,7 @@ impl IMFTimedTextBouten {
         (::windows::core::Vtable::vtable(self).GetBoutenPosition)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MF_TIMED_TEXT_BOUTEN_POSITION>(result__)
     }
 }
-impl ::core::convert::From<IMFTimedTextBouten> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextBouten) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextBouten> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextBouten) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextBouten> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextBouten) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextBouten, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextBouten {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31210,21 +24938,7 @@ impl IMFTimedTextCue {
         (::windows::core::Vtable::vtable(self).GetLine)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFTimedTextFormattedText>(result__)
     }
 }
-impl ::core::convert::From<IMFTimedTextCue> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextCue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextCue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextCue> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextCue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextCue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextCue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31303,21 +25017,7 @@ impl IMFTimedTextCueList {
         (::windows::core::Vtable::vtable(self).RemoveCue)(::windows::core::Vtable::as_raw(self), cue.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFTimedTextCueList> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextCueList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextCueList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextCueList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextCueList> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextCueList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextCueList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextCueList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31367,21 +25067,7 @@ impl IMFTimedTextFormattedText {
         (::windows::core::Vtable::vtable(self).GetSubformatting)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(firstchar), ::core::mem::transmute(charlength), ::core::mem::transmute(style.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMFTimedTextFormattedText> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextFormattedText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextFormattedText> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextFormattedText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextFormattedText> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextFormattedText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextFormattedText, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextFormattedText {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31446,21 +25132,7 @@ impl IMFTimedTextNotify {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMFTimedTextNotify> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextNotify> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31551,21 +25223,7 @@ impl IMFTimedTextRegion {
         (::windows::core::Vtable::vtable(self).GetScrollMode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MF_TIMED_TEXT_SCROLL_MODE>(result__)
     }
 }
-impl ::core::convert::From<IMFTimedTextRegion> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextRegion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextRegion> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextRegion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextRegion, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextRegion {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31632,21 +25290,7 @@ impl IMFTimedTextRuby {
         (::windows::core::Vtable::vtable(self).GetRubyReserve)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MF_TIMED_TEXT_RUBY_RESERVE>(result__)
     }
 }
-impl ::core::convert::From<IMFTimedTextRuby> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextRuby) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextRuby> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextRuby) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextRuby> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextRuby) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextRuby, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextRuby {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31740,21 +25384,7 @@ impl IMFTimedTextStyle {
         (::windows::core::Vtable::vtable(self).GetTextOutline)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(color), ::core::mem::transmute(thickness), ::core::mem::transmute(blurradius), ::core::mem::transmute(unittype)).ok()
     }
 }
-impl ::core::convert::From<IMFTimedTextStyle> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextStyle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextStyle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextStyle> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextStyle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextStyle, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextStyle {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31830,21 +25460,7 @@ impl IMFTimedTextStyle2 {
         (::windows::core::Vtable::vtable(self).GetFontAngleInDegrees)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<f64>(result__)
     }
 }
-impl ::core::convert::From<IMFTimedTextStyle2> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextStyle2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextStyle2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextStyle2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextStyle2> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextStyle2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextStyle2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextStyle2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31935,21 +25551,7 @@ impl IMFTimedTextTrack {
         (::windows::core::Vtable::vtable(self).GetCueList)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFTimedTextCueList>(result__)
     }
 }
-impl ::core::convert::From<IMFTimedTextTrack> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextTrack> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextTrack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextTrack> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextTrack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextTrack, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextTrack {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32012,21 +25614,7 @@ impl IMFTimedTextTrackList {
         (::windows::core::Vtable::vtable(self).GetTrackById)(::windows::core::Vtable::as_raw(self), trackid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFTimedTextTrack>(result__)
     }
 }
-impl ::core::convert::From<IMFTimedTextTrackList> for ::windows::core::IUnknown {
-    fn from(value: IMFTimedTextTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimedTextTrackList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimedTextTrackList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimedTextTrackList> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimedTextTrackList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimedTextTrackList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimedTextTrackList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32076,21 +25664,7 @@ impl IMFTimer {
         (::windows::core::Vtable::vtable(self).CancelTimer)(::windows::core::Vtable::as_raw(self), punkkey.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFTimer> for ::windows::core::IUnknown {
-    fn from(value: IMFTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTimer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTimer> for ::windows::core::IUnknown {
-    fn from(value: &IMFTimer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTimer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTimer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32132,21 +25706,7 @@ impl IMFTopoLoader {
         (::windows::core::Vtable::vtable(self).Load)(::windows::core::Vtable::as_raw(self), pinputtopo.into().abi(), ::core::mem::transmute(ppoutputtopo), pcurrenttopo.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFTopoLoader> for ::windows::core::IUnknown {
-    fn from(value: IMFTopoLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTopoLoader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTopoLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTopoLoader> for ::windows::core::IUnknown {
-    fn from(value: &IMFTopoLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTopoLoader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTopoLoader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32351,36 +25911,7 @@ impl IMFTopology {
         (::windows::core::Vtable::vtable(self).GetOutputNodeCollection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFCollection>(result__)
     }
 }
-impl ::core::convert::From<IMFTopology> for ::windows::core::IUnknown {
-    fn from(value: IMFTopology) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTopology> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTopology) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTopology> for ::windows::core::IUnknown {
-    fn from(value: &IMFTopology) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFTopology> for IMFAttributes {
-    fn from(value: IMFTopology) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTopology> for &'a IMFAttributes {
-    fn from(value: &'a IMFTopology) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTopology> for IMFAttributes {
-    fn from(value: &IMFTopology) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTopology, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFTopology {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32619,36 +26150,7 @@ impl IMFTopologyNode {
         (::windows::core::Vtable::vtable(self).CloneFrom)(::windows::core::Vtable::as_raw(self), pnode.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFTopologyNode> for ::windows::core::IUnknown {
-    fn from(value: IMFTopologyNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTopologyNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTopologyNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTopologyNode> for ::windows::core::IUnknown {
-    fn from(value: &IMFTopologyNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFTopologyNode> for IMFAttributes {
-    fn from(value: IMFTopologyNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTopologyNode> for &'a IMFAttributes {
-    fn from(value: &'a IMFTopologyNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTopologyNode> for IMFAttributes {
-    fn from(value: &IMFTopologyNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTopologyNode, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFTopologyNode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32700,21 +26202,7 @@ impl IMFTopologyNodeAttributeEditor {
         (::windows::core::Vtable::vtable(self).UpdateNodeAttributes)(::windows::core::Vtable::as_raw(self), topoid, pupdates.len() as _, ::core::mem::transmute(pupdates.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IMFTopologyNodeAttributeEditor> for ::windows::core::IUnknown {
-    fn from(value: IMFTopologyNodeAttributeEditor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTopologyNodeAttributeEditor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTopologyNodeAttributeEditor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTopologyNodeAttributeEditor> for ::windows::core::IUnknown {
-    fn from(value: &IMFTopologyNodeAttributeEditor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTopologyNodeAttributeEditor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTopologyNodeAttributeEditor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32751,21 +26239,7 @@ impl IMFTopologyServiceLookup {
         (::windows::core::Vtable::vtable(self).LookupService)(::windows::core::Vtable::as_raw(self), r#type, dwindex, ::core::mem::transmute(guidservice), ::core::mem::transmute(riid), ::core::mem::transmute(ppvobjects), ::core::mem::transmute(pnobjects)).ok()
     }
 }
-impl ::core::convert::From<IMFTopologyServiceLookup> for ::windows::core::IUnknown {
-    fn from(value: IMFTopologyServiceLookup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTopologyServiceLookup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTopologyServiceLookup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTopologyServiceLookup> for ::windows::core::IUnknown {
-    fn from(value: &IMFTopologyServiceLookup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTopologyServiceLookup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTopologyServiceLookup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32808,21 +26282,7 @@ impl IMFTopologyServiceLookupClient {
         (::windows::core::Vtable::vtable(self).ReleaseServicePointers)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFTopologyServiceLookupClient> for ::windows::core::IUnknown {
-    fn from(value: IMFTopologyServiceLookupClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTopologyServiceLookupClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTopologyServiceLookupClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTopologyServiceLookupClient> for ::windows::core::IUnknown {
-    fn from(value: &IMFTopologyServiceLookupClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTopologyServiceLookupClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTopologyServiceLookupClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32864,21 +26324,7 @@ impl IMFTrackedSample {
         (::windows::core::Vtable::vtable(self).SetAllocator)(::windows::core::Vtable::as_raw(self), psampleallocator.into().abi(), punkstate.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFTrackedSample> for ::windows::core::IUnknown {
-    fn from(value: IMFTrackedSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTrackedSample> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTrackedSample) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTrackedSample> for ::windows::core::IUnknown {
-    fn from(value: &IMFTrackedSample) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTrackedSample, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTrackedSample {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32942,21 +26388,7 @@ impl IMFTranscodeProfile {
         (::windows::core::Vtable::vtable(self).GetContainerAttributes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFAttributes>(result__)
     }
 }
-impl ::core::convert::From<IMFTranscodeProfile> for ::windows::core::IUnknown {
-    fn from(value: IMFTranscodeProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTranscodeProfile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTranscodeProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTranscodeProfile> for ::windows::core::IUnknown {
-    fn from(value: &IMFTranscodeProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTranscodeProfile, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTranscodeProfile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33017,21 +26449,7 @@ impl IMFTranscodeSinkInfoProvider {
         (::windows::core::Vtable::vtable(self).GetSinkInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MF_TRANSCODE_SINK_INFO>(result__)
     }
 }
-impl ::core::convert::From<IMFTranscodeSinkInfoProvider> for ::windows::core::IUnknown {
-    fn from(value: IMFTranscodeSinkInfoProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTranscodeSinkInfoProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTranscodeSinkInfoProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTranscodeSinkInfoProvider> for ::windows::core::IUnknown {
-    fn from(value: &IMFTranscodeSinkInfoProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTranscodeSinkInfoProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTranscodeSinkInfoProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33160,21 +26578,7 @@ impl IMFTransform {
         (::windows::core::Vtable::vtable(self).ProcessOutput)(::windows::core::Vtable::as_raw(self), dwflags, poutputsamples.len() as _, ::core::mem::transmute(poutputsamples.as_ptr()), ::core::mem::transmute(pdwstatus)).ok()
     }
 }
-impl ::core::convert::From<IMFTransform> for ::windows::core::IUnknown {
-    fn from(value: IMFTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTransform> for ::windows::core::IUnknown {
-    fn from(value: &IMFTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTransform, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33234,21 +26638,7 @@ impl IMFTrustedInput {
         (::windows::core::Vtable::vtable(self).GetInputTrustAuthority)(::windows::core::Vtable::as_raw(self), dwstreamid, ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IMFTrustedInput> for ::windows::core::IUnknown {
-    fn from(value: IMFTrustedInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTrustedInput> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTrustedInput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTrustedInput> for ::windows::core::IUnknown {
-    fn from(value: &IMFTrustedInput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTrustedInput, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTrustedInput {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33296,21 +26686,7 @@ impl IMFTrustedOutput {
         (::windows::core::Vtable::vtable(self).IsFinal)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IMFTrustedOutput> for ::windows::core::IUnknown {
-    fn from(value: IMFTrustedOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFTrustedOutput> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFTrustedOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFTrustedOutput> for ::windows::core::IUnknown {
-    fn from(value: &IMFTrustedOutput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFTrustedOutput, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFTrustedOutput {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33375,36 +26751,7 @@ impl IMFVideoCaptureSampleAllocator {
         (::windows::core::Vtable::vtable(self).InitializeCaptureSampleAllocator)(::windows::core::Vtable::as_raw(self), cbsamplesize, cbcapturemetadatasize, cbalignment, cminimumsamples, pattributes.into().abi(), pmediatype.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFVideoCaptureSampleAllocator> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoCaptureSampleAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoCaptureSampleAllocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoCaptureSampleAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoCaptureSampleAllocator> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoCaptureSampleAllocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFVideoCaptureSampleAllocator> for IMFVideoSampleAllocator {
-    fn from(value: IMFVideoCaptureSampleAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoCaptureSampleAllocator> for &'a IMFVideoSampleAllocator {
-    fn from(value: &'a IMFVideoCaptureSampleAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoCaptureSampleAllocator> for IMFVideoSampleAllocator {
-    fn from(value: &IMFVideoCaptureSampleAllocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoCaptureSampleAllocator, ::windows::core::IUnknown, IMFVideoSampleAllocator);
 impl ::core::clone::Clone for IMFVideoCaptureSampleAllocator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33442,21 +26789,7 @@ impl IMFVideoDeviceID {
         (::windows::core::Vtable::vtable(self).GetDeviceID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IMFVideoDeviceID> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoDeviceID) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoDeviceID> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoDeviceID) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoDeviceID> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoDeviceID) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoDeviceID, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoDeviceID {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33574,21 +26907,7 @@ impl IMFVideoDisplayControl {
         (::windows::core::Vtable::vtable(self).GetFullscreen)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IMFVideoDisplayControl> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoDisplayControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoDisplayControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoDisplayControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoDisplayControl> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoDisplayControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoDisplayControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoDisplayControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33827,51 +27146,7 @@ impl IMFVideoMediaType {
         (::windows::core::Vtable::vtable(self).GetVideoRepresentation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidrepresentation), ::core::mem::transmute(ppvrepresentation), lstride).ok()
     }
 }
-impl ::core::convert::From<IMFVideoMediaType> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoMediaType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoMediaType> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoMediaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFVideoMediaType> for IMFAttributes {
-    fn from(value: IMFVideoMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoMediaType> for &'a IMFAttributes {
-    fn from(value: &'a IMFVideoMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoMediaType> for IMFAttributes {
-    fn from(value: &IMFVideoMediaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFVideoMediaType> for IMFMediaType {
-    fn from(value: IMFVideoMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoMediaType> for &'a IMFMediaType {
-    fn from(value: &'a IMFVideoMediaType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoMediaType> for IMFMediaType {
-    fn from(value: &IMFVideoMediaType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoMediaType, ::windows::core::IUnknown, IMFAttributes, IMFMediaType);
 impl ::core::clone::Clone for IMFVideoMediaType {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33928,21 +27203,7 @@ impl IMFVideoMixerBitmap {
         (::windows::core::Vtable::vtable(self).GetAlphaBitmapParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MFVideoAlphaBitmapParams>(result__)
     }
 }
-impl ::core::convert::From<IMFVideoMixerBitmap> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoMixerBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoMixerBitmap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoMixerBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoMixerBitmap> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoMixerBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoMixerBitmap, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoMixerBitmap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34002,21 +27263,7 @@ impl IMFVideoMixerControl {
         (::windows::core::Vtable::vtable(self).GetStreamOutputRect)(::windows::core::Vtable::as_raw(self), dwstreamid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MFVideoNormalizedRect>(result__)
     }
 }
-impl ::core::convert::From<IMFVideoMixerControl> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoMixerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoMixerControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoMixerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoMixerControl> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoMixerControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoMixerControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoMixerControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34074,36 +27321,7 @@ impl IMFVideoMixerControl2 {
         (::windows::core::Vtable::vtable(self).GetMixingPrefs)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMFVideoMixerControl2> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoMixerControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoMixerControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoMixerControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoMixerControl2> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoMixerControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFVideoMixerControl2> for IMFVideoMixerControl {
-    fn from(value: IMFVideoMixerControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoMixerControl2> for &'a IMFVideoMixerControl {
-    fn from(value: &'a IMFVideoMixerControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoMixerControl2> for IMFVideoMixerControl {
-    fn from(value: &IMFVideoMixerControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoMixerControl2, ::windows::core::IUnknown, IMFVideoMixerControl);
 impl ::core::clone::Clone for IMFVideoMixerControl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34141,21 +27359,7 @@ impl IMFVideoPositionMapper {
         (::windows::core::Vtable::vtable(self).MapOutputCoordinateToInputStream)(::windows::core::Vtable::as_raw(self), xout, yout, dwoutputstreamindex, dwinputstreamindex, ::core::mem::transmute(pxin), ::core::mem::transmute(pyin)).ok()
     }
 }
-impl ::core::convert::From<IMFVideoPositionMapper> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoPositionMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoPositionMapper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoPositionMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoPositionMapper> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoPositionMapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoPositionMapper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoPositionMapper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34211,36 +27415,7 @@ impl IMFVideoPresenter {
         (::windows::core::Vtable::vtable(self).GetCurrentMediaType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFVideoMediaType>(result__)
     }
 }
-impl ::core::convert::From<IMFVideoPresenter> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoPresenter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoPresenter> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoPresenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFVideoPresenter> for IMFClockStateSink {
-    fn from(value: IMFVideoPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoPresenter> for &'a IMFClockStateSink {
-    fn from(value: &'a IMFVideoPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoPresenter> for IMFClockStateSink {
-    fn from(value: &IMFVideoPresenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoPresenter, ::windows::core::IUnknown, IMFClockStateSink);
 impl ::core::clone::Clone for IMFVideoPresenter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34327,21 +27502,7 @@ impl IMFVideoProcessor {
         (::windows::core::Vtable::vtable(self).SetBackgroundColor)(::windows::core::Vtable::as_raw(self), clrbkg.into()).ok()
     }
 }
-impl ::core::convert::From<IMFVideoProcessor> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoProcessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoProcessor> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoProcessor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoProcessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34419,21 +27580,7 @@ impl IMFVideoProcessorControl {
         (::windows::core::Vtable::vtable(self).SetConstrictionSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pconstrictionsize.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IMFVideoProcessorControl> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoProcessorControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoProcessorControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoProcessorControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoProcessorControl> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoProcessorControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoProcessorControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoProcessorControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34520,36 +27667,7 @@ impl IMFVideoProcessorControl2 {
         (::windows::core::Vtable::vtable(self).GetSupportedHardwareEffects)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMFVideoProcessorControl2> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoProcessorControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoProcessorControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoProcessorControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoProcessorControl2> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoProcessorControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFVideoProcessorControl2> for IMFVideoProcessorControl {
-    fn from(value: IMFVideoProcessorControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoProcessorControl2> for &'a IMFVideoProcessorControl {
-    fn from(value: &'a IMFVideoProcessorControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoProcessorControl2> for IMFVideoProcessorControl {
-    fn from(value: &IMFVideoProcessorControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoProcessorControl2, ::windows::core::IUnknown, IMFVideoProcessorControl);
 impl ::core::clone::Clone for IMFVideoProcessorControl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34648,51 +27766,7 @@ impl IMFVideoProcessorControl3 {
         (::windows::core::Vtable::vtable(self).SetOutputDevice)(::windows::core::Vtable::as_raw(self), poutputdevice.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFVideoProcessorControl3> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoProcessorControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoProcessorControl3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoProcessorControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoProcessorControl3> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoProcessorControl3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFVideoProcessorControl3> for IMFVideoProcessorControl {
-    fn from(value: IMFVideoProcessorControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoProcessorControl3> for &'a IMFVideoProcessorControl {
-    fn from(value: &'a IMFVideoProcessorControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoProcessorControl3> for IMFVideoProcessorControl {
-    fn from(value: &IMFVideoProcessorControl3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFVideoProcessorControl3> for IMFVideoProcessorControl2 {
-    fn from(value: IMFVideoProcessorControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoProcessorControl3> for &'a IMFVideoProcessorControl2 {
-    fn from(value: &'a IMFVideoProcessorControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoProcessorControl3> for IMFVideoProcessorControl2 {
-    fn from(value: &IMFVideoProcessorControl3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoProcessorControl3, ::windows::core::IUnknown, IMFVideoProcessorControl, IMFVideoProcessorControl2);
 impl ::core::clone::Clone for IMFVideoProcessorControl3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34739,21 +27813,7 @@ impl IMFVideoRenderer {
         (::windows::core::Vtable::vtable(self).InitializeRenderer)(::windows::core::Vtable::as_raw(self), pvideomixer.into().abi(), pvideopresenter.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFVideoRenderer> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoRenderer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoRenderer> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoRenderer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoRenderer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoRenderer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34793,21 +27853,7 @@ impl IMFVideoRendererEffectControl {
         (::windows::core::Vtable::vtable(self).OnAppServiceConnectionEstablished)(::windows::core::Vtable::as_raw(self), pappserviceconnection.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFVideoRendererEffectControl> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoRendererEffectControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoRendererEffectControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoRendererEffectControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoRendererEffectControl> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoRendererEffectControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoRendererEffectControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoRendererEffectControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34860,21 +27906,7 @@ impl IMFVideoSampleAllocator {
         (::windows::core::Vtable::vtable(self).AllocateSample)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMFSample>(result__)
     }
 }
-impl ::core::convert::From<IMFVideoSampleAllocator> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoSampleAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoSampleAllocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoSampleAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoSampleAllocator> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoSampleAllocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoSampleAllocator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoSampleAllocator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34921,21 +27953,7 @@ impl IMFVideoSampleAllocatorCallback {
         (::windows::core::Vtable::vtable(self).GetFreeSampleCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IMFVideoSampleAllocatorCallback> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoSampleAllocatorCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoSampleAllocatorCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoSampleAllocatorCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoSampleAllocatorCallback> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoSampleAllocatorCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoSampleAllocatorCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoSampleAllocatorCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34996,36 +28014,7 @@ impl IMFVideoSampleAllocatorEx {
         (::windows::core::Vtable::vtable(self).InitializeSampleAllocatorEx)(::windows::core::Vtable::as_raw(self), cinitialsamples, cmaximumsamples, pattributes.into().abi(), pmediatype.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFVideoSampleAllocatorEx> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoSampleAllocatorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoSampleAllocatorEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoSampleAllocatorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoSampleAllocatorEx> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoSampleAllocatorEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFVideoSampleAllocatorEx> for IMFVideoSampleAllocator {
-    fn from(value: IMFVideoSampleAllocatorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoSampleAllocatorEx> for &'a IMFVideoSampleAllocator {
-    fn from(value: &'a IMFVideoSampleAllocatorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoSampleAllocatorEx> for IMFVideoSampleAllocator {
-    fn from(value: &IMFVideoSampleAllocatorEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoSampleAllocatorEx, ::windows::core::IUnknown, IMFVideoSampleAllocator);
 impl ::core::clone::Clone for IMFVideoSampleAllocatorEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35062,21 +28051,7 @@ impl IMFVideoSampleAllocatorNotify {
         (::windows::core::Vtable::vtable(self).NotifyRelease)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFVideoSampleAllocatorNotify> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoSampleAllocatorNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoSampleAllocatorNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoSampleAllocatorNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoSampleAllocatorNotify> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoSampleAllocatorNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoSampleAllocatorNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFVideoSampleAllocatorNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35119,36 +28094,7 @@ impl IMFVideoSampleAllocatorNotifyEx {
         (::windows::core::Vtable::vtable(self).NotifyPrune)(::windows::core::Vtable::as_raw(self), __midl__imfvideosampleallocatornotifyex0000.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMFVideoSampleAllocatorNotifyEx> for ::windows::core::IUnknown {
-    fn from(value: IMFVideoSampleAllocatorNotifyEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoSampleAllocatorNotifyEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVideoSampleAllocatorNotifyEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoSampleAllocatorNotifyEx> for ::windows::core::IUnknown {
-    fn from(value: &IMFVideoSampleAllocatorNotifyEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFVideoSampleAllocatorNotifyEx> for IMFVideoSampleAllocatorNotify {
-    fn from(value: IMFVideoSampleAllocatorNotifyEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVideoSampleAllocatorNotifyEx> for &'a IMFVideoSampleAllocatorNotify {
-    fn from(value: &'a IMFVideoSampleAllocatorNotifyEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVideoSampleAllocatorNotifyEx> for IMFVideoSampleAllocatorNotify {
-    fn from(value: &IMFVideoSampleAllocatorNotifyEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVideoSampleAllocatorNotifyEx, ::windows::core::IUnknown, IMFVideoSampleAllocatorNotify);
 impl ::core::clone::Clone for IMFVideoSampleAllocatorNotifyEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35366,36 +28312,7 @@ impl IMFVirtualCamera {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMFVirtualCamera> for ::windows::core::IUnknown {
-    fn from(value: IMFVirtualCamera) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVirtualCamera> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFVirtualCamera) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVirtualCamera> for ::windows::core::IUnknown {
-    fn from(value: &IMFVirtualCamera) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFVirtualCamera> for IMFAttributes {
-    fn from(value: IMFVirtualCamera) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFVirtualCamera> for &'a IMFAttributes {
-    fn from(value: &'a IMFVirtualCamera) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFVirtualCamera> for IMFAttributes {
-    fn from(value: &IMFVirtualCamera) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFVirtualCamera, ::windows::core::IUnknown, IMFAttributes);
 impl ::core::clone::Clone for IMFVirtualCamera {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35516,21 +28433,7 @@ impl IMFWorkQueueServices {
         (::windows::core::Vtable::vtable(self).GetPlatformWorkQueueMMCSSTaskId)(::windows::core::Vtable::as_raw(self), dwplatformworkqueueid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMFWorkQueueServices> for ::windows::core::IUnknown {
-    fn from(value: IMFWorkQueueServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFWorkQueueServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFWorkQueueServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFWorkQueueServices> for ::windows::core::IUnknown {
-    fn from(value: &IMFWorkQueueServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFWorkQueueServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMFWorkQueueServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35659,36 +28562,7 @@ impl IMFWorkQueueServicesEx {
         (::windows::core::Vtable::vtable(self).GetPlatformWorkQueueMMCSSPriority)(::windows::core::Vtable::as_raw(self), dwplatformworkqueueid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IMFWorkQueueServicesEx> for ::windows::core::IUnknown {
-    fn from(value: IMFWorkQueueServicesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFWorkQueueServicesEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMFWorkQueueServicesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFWorkQueueServicesEx> for ::windows::core::IUnknown {
-    fn from(value: &IMFWorkQueueServicesEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMFWorkQueueServicesEx> for IMFWorkQueueServices {
-    fn from(value: IMFWorkQueueServicesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMFWorkQueueServicesEx> for &'a IMFWorkQueueServices {
-    fn from(value: &'a IMFWorkQueueServicesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMFWorkQueueServicesEx> for IMFWorkQueueServices {
-    fn from(value: &IMFWorkQueueServicesEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMFWorkQueueServicesEx, ::windows::core::IUnknown, IMFWorkQueueServices);
 impl ::core::clone::Clone for IMFWorkQueueServicesEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35741,21 +28615,7 @@ impl IOPMVideoOutput {
         (::windows::core::Vtable::vtable(self).Configure)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pparameters), pbadditionalparameters.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(pbadditionalparameters.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr()))).ok()
     }
 }
-impl ::core::convert::From<IOPMVideoOutput> for ::windows::core::IUnknown {
-    fn from(value: IOPMVideoOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOPMVideoOutput> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOPMVideoOutput) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOPMVideoOutput> for ::windows::core::IUnknown {
-    fn from(value: &IOPMVideoOutput) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOPMVideoOutput, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOPMVideoOutput {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35802,21 +28662,7 @@ impl IPlayToControl {
         (::windows::core::Vtable::vtable(self).Disconnect)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPlayToControl> for ::windows::core::IUnknown {
-    fn from(value: IPlayToControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayToControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlayToControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayToControl> for ::windows::core::IUnknown {
-    fn from(value: &IPlayToControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlayToControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPlayToControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35864,36 +28710,7 @@ impl IPlayToControlWithCapabilities {
         (::windows::core::Vtable::vtable(self).GetCapabilities)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<PLAYTO_SOURCE_CREATEFLAGS>(result__)
     }
 }
-impl ::core::convert::From<IPlayToControlWithCapabilities> for ::windows::core::IUnknown {
-    fn from(value: IPlayToControlWithCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayToControlWithCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlayToControlWithCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayToControlWithCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &IPlayToControlWithCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPlayToControlWithCapabilities> for IPlayToControl {
-    fn from(value: IPlayToControlWithCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayToControlWithCapabilities> for &'a IPlayToControl {
-    fn from(value: &'a IPlayToControlWithCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayToControlWithCapabilities> for IPlayToControl {
-    fn from(value: &IPlayToControlWithCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlayToControlWithCapabilities, ::windows::core::IUnknown, IPlayToControl);
 impl ::core::clone::Clone for IPlayToControlWithCapabilities {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35934,21 +28751,7 @@ impl IPlayToSourceClassFactory {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), dwflags, pcontrol.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IInspectable>(result__)
     }
 }
-impl ::core::convert::From<IPlayToSourceClassFactory> for ::windows::core::IUnknown {
-    fn from(value: IPlayToSourceClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayToSourceClassFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlayToSourceClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayToSourceClassFactory> for ::windows::core::IUnknown {
-    fn from(value: &IPlayToSourceClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlayToSourceClassFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPlayToSourceClassFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36025,21 +28828,7 @@ impl IToc {
         (::windows::core::Vtable::vtable(self).RemoveEntryListByIndex)(::windows::core::Vtable::as_raw(self), wentrylistindex).ok()
     }
 }
-impl ::core::convert::From<IToc> for ::windows::core::IUnknown {
-    fn from(value: IToc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IToc> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IToc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IToc> for ::windows::core::IUnknown {
-    fn from(value: &IToc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IToc, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IToc {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36105,21 +28894,7 @@ impl ITocCollection {
         (::windows::core::Vtable::vtable(self).RemoveEntryByIndex)(::windows::core::Vtable::as_raw(self), dwentryindex).ok()
     }
 }
-impl ::core::convert::From<ITocCollection> for ::windows::core::IUnknown {
-    fn from(value: ITocCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITocCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITocCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITocCollection> for ::windows::core::IUnknown {
-    fn from(value: &ITocCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITocCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITocCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36184,21 +28959,7 @@ impl ITocEntry {
         (::windows::core::Vtable::vtable(self).GetDescriptionData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwdescriptiondatasize), ::core::mem::transmute(pbtdescriptiondata), ::core::mem::transmute(pguidtype)).ok()
     }
 }
-impl ::core::convert::From<ITocEntry> for ::windows::core::IUnknown {
-    fn from(value: ITocEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITocEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITocEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITocEntry> for ::windows::core::IUnknown {
-    fn from(value: &ITocEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITocEntry, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITocEntry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36261,21 +29022,7 @@ impl ITocEntryList {
         (::windows::core::Vtable::vtable(self).RemoveEntryByIndex)(::windows::core::Vtable::as_raw(self), dwentryindex).ok()
     }
 }
-impl ::core::convert::From<ITocEntryList> for ::windows::core::IUnknown {
-    fn from(value: ITocEntryList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITocEntryList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITocEntryList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITocEntryList> for ::windows::core::IUnknown {
-    fn from(value: &ITocEntryList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITocEntryList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITocEntryList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36345,21 +29092,7 @@ impl ITocParser {
         (::windows::core::Vtable::vtable(self).Commit)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITocParser> for ::windows::core::IUnknown {
-    fn from(value: ITocParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITocParser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITocParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITocParser> for ::windows::core::IUnknown {
-    fn from(value: &ITocParser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITocParser, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITocParser {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36403,21 +29136,7 @@ impl IValidateBinding {
         (::windows::core::Vtable::vtable(self).GetIdentifier)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidlicensorid), ::core::mem::transmute(pbephemeron.as_ptr()), pbephemeron.len() as _, ::core::mem::transmute(ppbblobvalidationid), ::core::mem::transmute(pcbblobsize)).ok()
     }
 }
-impl ::core::convert::From<IValidateBinding> for ::windows::core::IUnknown {
-    fn from(value: IValidateBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IValidateBinding> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IValidateBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IValidateBinding> for ::windows::core::IUnknown {
-    fn from(value: &IValidateBinding) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IValidateBinding, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IValidateBinding {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36463,21 +29182,7 @@ impl IWMCodecLeakyBucket {
         (::windows::core::Vtable::vtable(self).GetBufferFullnessBits)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pulbufferfullness)).ok()
     }
 }
-impl ::core::convert::From<IWMCodecLeakyBucket> for ::windows::core::IUnknown {
-    fn from(value: IWMCodecLeakyBucket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCodecLeakyBucket> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMCodecLeakyBucket) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCodecLeakyBucket> for ::windows::core::IUnknown {
-    fn from(value: &IWMCodecLeakyBucket) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMCodecLeakyBucket, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMCodecLeakyBucket {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36517,21 +29222,7 @@ impl IWMCodecOutputTimestamp {
         (::windows::core::Vtable::vtable(self).GetNextOutputTime)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prttime)).ok()
     }
 }
-impl ::core::convert::From<IWMCodecOutputTimestamp> for ::windows::core::IUnknown {
-    fn from(value: IWMCodecOutputTimestamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCodecOutputTimestamp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMCodecOutputTimestamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCodecOutputTimestamp> for ::windows::core::IUnknown {
-    fn from(value: &IWMCodecOutputTimestamp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMCodecOutputTimestamp, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMCodecOutputTimestamp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36573,21 +29264,7 @@ impl IWMCodecPrivateData {
         (::windows::core::Vtable::vtable(self).GetPrivateData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbdata), ::core::mem::transmute(pcbdata)).ok()
     }
 }
-impl ::core::convert::From<IWMCodecPrivateData> for ::windows::core::IUnknown {
-    fn from(value: IWMCodecPrivateData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCodecPrivateData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMCodecPrivateData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCodecPrivateData> for ::windows::core::IUnknown {
-    fn from(value: &IWMCodecPrivateData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMCodecPrivateData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMCodecPrivateData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36639,21 +29316,7 @@ impl IWMCodecProps {
         (::windows::core::Vtable::vtable(self).GetCodecProp)(::windows::core::Vtable::as_raw(self), dwformat, pszname.into(), ::core::mem::transmute(ptype), ::core::mem::transmute(pvalue), ::core::mem::transmute(pdwsize)).ok()
     }
 }
-impl ::core::convert::From<IWMCodecProps> for ::windows::core::IUnknown {
-    fn from(value: IWMCodecProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCodecProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMCodecProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCodecProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMCodecProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMCodecProps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMCodecProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36701,21 +29364,7 @@ impl IWMCodecStrings {
         (::windows::core::Vtable::vtable(self).GetDescription)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmt), szdescription.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(szdescription.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ::core::mem::transmute(pcchlength)).ok()
     }
 }
-impl ::core::convert::From<IWMCodecStrings> for ::windows::core::IUnknown {
-    fn from(value: IWMCodecStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCodecStrings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMCodecStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCodecStrings> for ::windows::core::IUnknown {
-    fn from(value: &IWMCodecStrings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMCodecStrings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMCodecStrings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36762,21 +29411,7 @@ impl IWMColorConvProps {
         (::windows::core::Vtable::vtable(self).SetFullCroppingParam)(::windows::core::Vtable::as_raw(self), lsrccropleft, lsrccroptop, ldstcropleft, ldstcroptop, lcropwidth, lcropheight).ok()
     }
 }
-impl ::core::convert::From<IWMColorConvProps> for ::windows::core::IUnknown {
-    fn from(value: IWMColorConvProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMColorConvProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMColorConvProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMColorConvProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMColorConvProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMColorConvProps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMColorConvProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36814,21 +29449,7 @@ impl IWMColorLegalizerProps {
         (::windows::core::Vtable::vtable(self).SetColorLegalizerQuality)(::windows::core::Vtable::as_raw(self), lquality).ok()
     }
 }
-impl ::core::convert::From<IWMColorLegalizerProps> for ::windows::core::IUnknown {
-    fn from(value: IWMColorLegalizerProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMColorLegalizerProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMColorLegalizerProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMColorLegalizerProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMColorLegalizerProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMColorLegalizerProps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMColorLegalizerProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36879,21 +29500,7 @@ impl IWMFrameInterpProps {
         (::windows::core::Vtable::vtable(self).SetComplexityLevel)(::windows::core::Vtable::as_raw(self), icomplexity).ok()
     }
 }
-impl ::core::convert::From<IWMFrameInterpProps> for ::windows::core::IUnknown {
-    fn from(value: IWMFrameInterpProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMFrameInterpProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMFrameInterpProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMFrameInterpProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMFrameInterpProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMFrameInterpProps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMFrameInterpProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36942,21 +29549,7 @@ impl IWMInterlaceProps {
         (::windows::core::Vtable::vtable(self).SetLastFrame)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMInterlaceProps> for ::windows::core::IUnknown {
-    fn from(value: IWMInterlaceProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMInterlaceProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMInterlaceProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMInterlaceProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMInterlaceProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMInterlaceProps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMInterlaceProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36998,21 +29591,7 @@ impl IWMResamplerProps {
         (::windows::core::Vtable::vtable(self).SetUserChannelMtx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(userchannelmtx)).ok()
     }
 }
-impl ::core::convert::From<IWMResamplerProps> for ::windows::core::IUnknown {
-    fn from(value: IWMResamplerProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMResamplerProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMResamplerProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMResamplerProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMResamplerProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMResamplerProps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMResamplerProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37062,21 +29641,7 @@ impl IWMResizerProps {
         (::windows::core::Vtable::vtable(self).GetFullCropRegion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lcliporixsrc), ::core::mem::transmute(lcliporiysrc), ::core::mem::transmute(lclipwidthsrc), ::core::mem::transmute(lclipheightsrc), ::core::mem::transmute(lcliporixdst), ::core::mem::transmute(lcliporiydst), ::core::mem::transmute(lclipwidthdst), ::core::mem::transmute(lclipheightdst)).ok()
     }
 }
-impl ::core::convert::From<IWMResizerProps> for ::windows::core::IUnknown {
-    fn from(value: IWMResizerProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMResizerProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMResizerProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMResizerProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMResizerProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMResizerProps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMResizerProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37122,21 +29687,7 @@ impl IWMSampleExtensionSupport {
         (::windows::core::Vtable::vtable(self).SetUseSampleExtensions)(::windows::core::Vtable::as_raw(self), fuseextensions.into()).ok()
     }
 }
-impl ::core::convert::From<IWMSampleExtensionSupport> for ::windows::core::IUnknown {
-    fn from(value: IWMSampleExtensionSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMSampleExtensionSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMSampleExtensionSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMSampleExtensionSupport> for ::windows::core::IUnknown {
-    fn from(value: &IWMSampleExtensionSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMSampleExtensionSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMSampleExtensionSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37176,21 +29727,7 @@ impl IWMValidate {
         (::windows::core::Vtable::vtable(self).SetIdentifier)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidvalidationid)).ok()
     }
 }
-impl ::core::convert::From<IWMValidate> for ::windows::core::IUnknown {
-    fn from(value: IWMValidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMValidate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMValidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMValidate> for ::windows::core::IUnknown {
-    fn from(value: &IWMValidate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMValidate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMValidate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37230,21 +29767,7 @@ impl IWMVideoDecoderHurryup {
         (::windows::core::Vtable::vtable(self).GetHurryup)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(plhurryup)).ok()
     }
 }
-impl ::core::convert::From<IWMVideoDecoderHurryup> for ::windows::core::IUnknown {
-    fn from(value: IWMVideoDecoderHurryup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMVideoDecoderHurryup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMVideoDecoderHurryup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMVideoDecoderHurryup> for ::windows::core::IUnknown {
-    fn from(value: &IWMVideoDecoderHurryup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMVideoDecoderHurryup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMVideoDecoderHurryup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37298,21 +29821,7 @@ impl IWMVideoDecoderReconBuffer {
         (::windows::core::Vtable::vtable(self).SetReconstructedVideoFrame)(::windows::core::Vtable::as_raw(self), pbuf.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWMVideoDecoderReconBuffer> for ::windows::core::IUnknown {
-    fn from(value: IWMVideoDecoderReconBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMVideoDecoderReconBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMVideoDecoderReconBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMVideoDecoderReconBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IWMVideoDecoderReconBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMVideoDecoderReconBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMVideoDecoderReconBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37357,21 +29866,7 @@ impl IWMVideoForceKeyFrame {
         (::windows::core::Vtable::vtable(self).SetKeyFrame)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMVideoForceKeyFrame> for ::windows::core::IUnknown {
-    fn from(value: IWMVideoForceKeyFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMVideoForceKeyFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMVideoForceKeyFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMVideoForceKeyFrame> for ::windows::core::IUnknown {
-    fn from(value: &IWMVideoForceKeyFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMVideoForceKeyFrame, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMVideoForceKeyFrame {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37422,36 +29917,7 @@ impl MFASYNCRESULT {
         (::windows::core::Vtable::vtable(self).base__.GetStateNoAddRef)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<MFASYNCRESULT> for ::windows::core::IUnknown {
-    fn from(value: MFASYNCRESULT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a MFASYNCRESULT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a MFASYNCRESULT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MFASYNCRESULT> for ::windows::core::IUnknown {
-    fn from(value: &MFASYNCRESULT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<MFASYNCRESULT> for IMFAsyncResult {
-    fn from(value: MFASYNCRESULT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a MFASYNCRESULT> for &'a IMFAsyncResult {
-    fn from(value: &'a MFASYNCRESULT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&MFASYNCRESULT> for IMFAsyncResult {
-    fn from(value: &MFASYNCRESULT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(MFASYNCRESULT, ::windows::core::IUnknown, IMFAsyncResult);
 impl ::core::clone::Clone for MFASYNCRESULT {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/mod.rs
@@ -177,41 +177,7 @@ impl IFeed {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeed> for ::windows::core::IUnknown {
-    fn from(value: IFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeed> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeed> for ::windows::core::IUnknown {
-    fn from(value: &IFeed) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeed> for super::super::System::Com::IDispatch {
-    fn from(value: IFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeed> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeed> for super::super::System::Com::IDispatch {
-    fn from(value: &IFeed) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeed, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFeed {
     fn clone(&self) -> Self {
@@ -505,59 +471,7 @@ impl IFeed2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeed2> for ::windows::core::IUnknown {
-    fn from(value: IFeed2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeed2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeed2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeed2> for ::windows::core::IUnknown {
-    fn from(value: &IFeed2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeed2> for super::super::System::Com::IDispatch {
-    fn from(value: IFeed2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeed2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFeed2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeed2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFeed2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeed2> for IFeed {
-    fn from(value: IFeed2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeed2> for &'a IFeed {
-    fn from(value: &'a IFeed2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeed2> for IFeed {
-    fn from(value: &IFeed2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeed2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFeed);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFeed2 {
     fn clone(&self) -> Self {
@@ -659,41 +573,7 @@ impl IFeedEnclosure {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedEnclosure> for ::windows::core::IUnknown {
-    fn from(value: IFeedEnclosure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedEnclosure> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeedEnclosure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedEnclosure> for ::windows::core::IUnknown {
-    fn from(value: &IFeedEnclosure) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedEnclosure> for super::super::System::Com::IDispatch {
-    fn from(value: IFeedEnclosure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedEnclosure> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFeedEnclosure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedEnclosure> for super::super::System::Com::IDispatch {
-    fn from(value: &IFeedEnclosure) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeedEnclosure, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFeedEnclosure {
     fn clone(&self) -> Self {
@@ -776,41 +656,7 @@ impl IFeedEvents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedEvents> for ::windows::core::IUnknown {
-    fn from(value: IFeedEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeedEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedEvents> for ::windows::core::IUnknown {
-    fn from(value: &IFeedEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedEvents> for super::super::System::Com::IDispatch {
-    fn from(value: IFeedEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFeedEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &IFeedEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeedEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFeedEvents {
     fn clone(&self) -> Self {
@@ -946,41 +792,7 @@ impl IFeedFolder {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedFolder> for ::windows::core::IUnknown {
-    fn from(value: IFeedFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeedFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedFolder> for ::windows::core::IUnknown {
-    fn from(value: &IFeedFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedFolder> for super::super::System::Com::IDispatch {
-    fn from(value: IFeedFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedFolder> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFeedFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedFolder> for super::super::System::Com::IDispatch {
-    fn from(value: &IFeedFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeedFolder, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFeedFolder {
     fn clone(&self) -> Self {
@@ -1113,41 +925,7 @@ impl IFeedFolderEvents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedFolderEvents> for ::windows::core::IUnknown {
-    fn from(value: IFeedFolderEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedFolderEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeedFolderEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedFolderEvents> for ::windows::core::IUnknown {
-    fn from(value: &IFeedFolderEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedFolderEvents> for super::super::System::Com::IDispatch {
-    fn from(value: IFeedFolderEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedFolderEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFeedFolderEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedFolderEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &IFeedFolderEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeedFolderEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFeedFolderEvents {
     fn clone(&self) -> Self {
@@ -1276,41 +1054,7 @@ impl IFeedItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedItem> for ::windows::core::IUnknown {
-    fn from(value: IFeedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedItem> for ::windows::core::IUnknown {
-    fn from(value: &IFeedItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedItem> for super::super::System::Com::IDispatch {
-    fn from(value: IFeedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedItem> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFeedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedItem> for super::super::System::Com::IDispatch {
-    fn from(value: &IFeedItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeedItem, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFeedItem {
     fn clone(&self) -> Self {
@@ -1450,59 +1194,7 @@ impl IFeedItem2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedItem2> for ::windows::core::IUnknown {
-    fn from(value: IFeedItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeedItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedItem2> for ::windows::core::IUnknown {
-    fn from(value: &IFeedItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedItem2> for super::super::System::Com::IDispatch {
-    fn from(value: IFeedItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedItem2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFeedItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedItem2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFeedItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedItem2> for IFeedItem {
-    fn from(value: IFeedItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedItem2> for &'a IFeedItem {
-    fn from(value: &'a IFeedItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedItem2> for IFeedItem {
-    fn from(value: &IFeedItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeedItem2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFeedItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFeedItem2 {
     fn clone(&self) -> Self {
@@ -1562,41 +1254,7 @@ impl IFeedsEnum {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedsEnum> for ::windows::core::IUnknown {
-    fn from(value: IFeedsEnum) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedsEnum> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeedsEnum) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedsEnum> for ::windows::core::IUnknown {
-    fn from(value: &IFeedsEnum) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedsEnum> for super::super::System::Com::IDispatch {
-    fn from(value: IFeedsEnum) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedsEnum> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFeedsEnum) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedsEnum> for super::super::System::Com::IDispatch {
-    fn from(value: &IFeedsEnum) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeedsEnum, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFeedsEnum {
     fn clone(&self) -> Self {
@@ -1715,41 +1373,7 @@ impl IFeedsManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedsManager> for ::windows::core::IUnknown {
-    fn from(value: IFeedsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedsManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeedsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedsManager> for ::windows::core::IUnknown {
-    fn from(value: &IFeedsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFeedsManager> for super::super::System::Com::IDispatch {
-    fn from(value: IFeedsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFeedsManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFeedsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFeedsManager> for super::super::System::Com::IDispatch {
-    fn from(value: &IFeedsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeedsManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFeedsManager {
     fn clone(&self) -> Self {
@@ -1823,21 +1447,7 @@ impl IWMPAudioRenderConfig {
         (::windows::core::Vtable::vtable(self).SetaudioOutputDevice)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstroutputdevice)).ok()
     }
 }
-impl ::core::convert::From<IWMPAudioRenderConfig> for ::windows::core::IUnknown {
-    fn from(value: IWMPAudioRenderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPAudioRenderConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPAudioRenderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPAudioRenderConfig> for ::windows::core::IUnknown {
-    fn from(value: &IWMPAudioRenderConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPAudioRenderConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPAudioRenderConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1887,41 +1497,7 @@ impl IWMPCdrom {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCdrom> for ::windows::core::IUnknown {
-    fn from(value: IWMPCdrom) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCdrom> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPCdrom) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCdrom> for ::windows::core::IUnknown {
-    fn from(value: &IWMPCdrom) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCdrom> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPCdrom) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCdrom> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPCdrom) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCdrom> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPCdrom) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPCdrom, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPCdrom {
     fn clone(&self) -> Self {
@@ -2017,21 +1593,7 @@ impl IWMPCdromBurn {
         (::windows::core::Vtable::vtable(self).erase)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMPCdromBurn> for ::windows::core::IUnknown {
-    fn from(value: IWMPCdromBurn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPCdromBurn> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPCdromBurn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPCdromBurn> for ::windows::core::IUnknown {
-    fn from(value: &IWMPCdromBurn) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPCdromBurn, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPCdromBurn {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2102,41 +1664,7 @@ impl IWMPCdromCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCdromCollection> for ::windows::core::IUnknown {
-    fn from(value: IWMPCdromCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCdromCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPCdromCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCdromCollection> for ::windows::core::IUnknown {
-    fn from(value: &IWMPCdromCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCdromCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPCdromCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCdromCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPCdromCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCdromCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPCdromCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPCdromCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPCdromCollection {
     fn clone(&self) -> Self {
@@ -2197,21 +1725,7 @@ impl IWMPCdromRip {
         (::windows::core::Vtable::vtable(self).stopRip)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMPCdromRip> for ::windows::core::IUnknown {
-    fn from(value: IWMPCdromRip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPCdromRip> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPCdromRip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPCdromRip> for ::windows::core::IUnknown {
-    fn from(value: &IWMPCdromRip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPCdromRip, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPCdromRip {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2275,41 +1789,7 @@ impl IWMPClosedCaption {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPClosedCaption> for ::windows::core::IUnknown {
-    fn from(value: IWMPClosedCaption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPClosedCaption> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPClosedCaption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPClosedCaption> for ::windows::core::IUnknown {
-    fn from(value: &IWMPClosedCaption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPClosedCaption> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPClosedCaption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPClosedCaption> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPClosedCaption) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPClosedCaption> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPClosedCaption) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPClosedCaption, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPClosedCaption {
     fn clone(&self) -> Self {
@@ -2399,59 +1879,7 @@ impl IWMPClosedCaption2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPClosedCaption2> for ::windows::core::IUnknown {
-    fn from(value: IWMPClosedCaption2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPClosedCaption2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPClosedCaption2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPClosedCaption2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPClosedCaption2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPClosedCaption2> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPClosedCaption2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPClosedCaption2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPClosedCaption2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPClosedCaption2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPClosedCaption2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPClosedCaption2> for IWMPClosedCaption {
-    fn from(value: IWMPClosedCaption2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPClosedCaption2> for &'a IWMPClosedCaption {
-    fn from(value: &'a IWMPClosedCaption2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPClosedCaption2> for IWMPClosedCaption {
-    fn from(value: &IWMPClosedCaption2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPClosedCaption2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPClosedCaption);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPClosedCaption2 {
     fn clone(&self) -> Self {
@@ -2520,21 +1948,7 @@ impl IWMPContentContainer {
         (::windows::core::Vtable::vtable(self).GetContentID)(::windows::core::Vtable::as_raw(self), idxcontent, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IWMPContentContainer> for ::windows::core::IUnknown {
-    fn from(value: IWMPContentContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPContentContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPContentContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPContentContainer> for ::windows::core::IUnknown {
-    fn from(value: &IWMPContentContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPContentContainer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPContentContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2585,21 +1999,7 @@ impl IWMPContentContainerList {
         (::windows::core::Vtable::vtable(self).GetContainer)(::windows::core::Vtable::as_raw(self), idxcontainer, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMPContentContainer>(result__)
     }
 }
-impl ::core::convert::From<IWMPContentContainerList> for ::windows::core::IUnknown {
-    fn from(value: IWMPContentContainerList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPContentContainerList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPContentContainerList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPContentContainerList> for ::windows::core::IUnknown {
-    fn from(value: &IWMPContentContainerList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPContentContainerList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPContentContainerList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2750,21 +2150,7 @@ impl IWMPContentPartner {
         (::windows::core::Vtable::vtable(self).VerifyPermission)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrpermission), ::core::mem::transmute(pcontext)).ok()
     }
 }
-impl ::core::convert::From<IWMPContentPartner> for ::windows::core::IUnknown {
-    fn from(value: IWMPContentPartner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPContentPartner> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPContentPartner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPContentPartner> for ::windows::core::IUnknown {
-    fn from(value: &IWMPContentPartner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPContentPartner, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPContentPartner {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2902,21 +2288,7 @@ impl IWMPContentPartnerCallback {
         (::windows::core::Vtable::vtable(self).VerifyPermissionComplete)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrpermission), ::core::mem::transmute(pcontext), hrpermission).ok()
     }
 }
-impl ::core::convert::From<IWMPContentPartnerCallback> for ::windows::core::IUnknown {
-    fn from(value: IWMPContentPartnerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPContentPartnerCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPContentPartnerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPContentPartnerCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWMPContentPartnerCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPContentPartnerCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPContentPartnerCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3032,41 +2404,7 @@ impl IWMPControls {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPControls> for ::windows::core::IUnknown {
-    fn from(value: IWMPControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPControls> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPControls> for ::windows::core::IUnknown {
-    fn from(value: &IWMPControls) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPControls> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPControls> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPControls> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPControls) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPControls, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPControls {
     fn clone(&self) -> Self {
@@ -3198,59 +2536,7 @@ impl IWMPControls2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPControls2> for ::windows::core::IUnknown {
-    fn from(value: IWMPControls2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPControls2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPControls2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPControls2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPControls2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPControls2> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPControls2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPControls2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPControls2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPControls2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPControls2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPControls2> for IWMPControls {
-    fn from(value: IWMPControls2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPControls2> for &'a IWMPControls {
-    fn from(value: &'a IWMPControls2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPControls2> for IWMPControls {
-    fn from(value: &IWMPControls2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPControls2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPControls);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPControls2 {
     fn clone(&self) -> Self {
@@ -3388,77 +2674,7 @@ impl IWMPControls3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPControls3> for ::windows::core::IUnknown {
-    fn from(value: IWMPControls3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPControls3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPControls3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPControls3> for ::windows::core::IUnknown {
-    fn from(value: &IWMPControls3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPControls3> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPControls3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPControls3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPControls3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPControls3> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPControls3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPControls3> for IWMPControls {
-    fn from(value: IWMPControls3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPControls3> for &'a IWMPControls {
-    fn from(value: &'a IWMPControls3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPControls3> for IWMPControls {
-    fn from(value: &IWMPControls3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPControls3> for IWMPControls2 {
-    fn from(value: IWMPControls3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPControls3> for &'a IWMPControls2 {
-    fn from(value: &'a IWMPControls3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPControls3> for IWMPControls2 {
-    fn from(value: &IWMPControls3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPControls3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPControls, IWMPControls2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPControls3 {
     fn clone(&self) -> Self {
@@ -3514,21 +2730,7 @@ impl IWMPConvert {
         (::windows::core::Vtable::vtable(self).GetErrorURL)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbstrurl)).ok()
     }
 }
-impl ::core::convert::From<IWMPConvert> for ::windows::core::IUnknown {
-    fn from(value: IWMPConvert) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPConvert> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPConvert) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPConvert> for ::windows::core::IUnknown {
-    fn from(value: &IWMPConvert) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPConvert, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPConvert {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3669,41 +2871,7 @@ impl IWMPCore {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCore> for ::windows::core::IUnknown {
-    fn from(value: IWMPCore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPCore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCore> for ::windows::core::IUnknown {
-    fn from(value: &IWMPCore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCore> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPCore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCore> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPCore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCore> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPCore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPCore, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPCore {
     fn clone(&self) -> Self {
@@ -3912,59 +3080,7 @@ impl IWMPCore2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCore2> for ::windows::core::IUnknown {
-    fn from(value: IWMPCore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCore2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPCore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCore2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPCore2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCore2> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPCore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCore2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPCore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCore2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPCore2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCore2> for IWMPCore {
-    fn from(value: IWMPCore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCore2> for &'a IWMPCore {
-    fn from(value: &'a IWMPCore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCore2> for IWMPCore {
-    fn from(value: &IWMPCore2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPCore2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPCore);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPCore2 {
     fn clone(&self) -> Self {
@@ -4132,77 +3248,7 @@ impl IWMPCore3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCore3> for ::windows::core::IUnknown {
-    fn from(value: IWMPCore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCore3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPCore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCore3> for ::windows::core::IUnknown {
-    fn from(value: &IWMPCore3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCore3> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPCore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCore3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPCore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCore3> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPCore3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCore3> for IWMPCore {
-    fn from(value: IWMPCore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCore3> for &'a IWMPCore {
-    fn from(value: &'a IWMPCore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCore3> for IWMPCore {
-    fn from(value: &IWMPCore3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPCore3> for IWMPCore2 {
-    fn from(value: IWMPCore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPCore3> for &'a IWMPCore2 {
-    fn from(value: &'a IWMPCore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPCore3> for IWMPCore2 {
-    fn from(value: &IWMPCore3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPCore3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPCore, IWMPCore2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPCore3 {
     fn clone(&self) -> Self {
@@ -4271,41 +3317,7 @@ impl IWMPDVD {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPDVD> for ::windows::core::IUnknown {
-    fn from(value: IWMPDVD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPDVD> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPDVD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPDVD> for ::windows::core::IUnknown {
-    fn from(value: &IWMPDVD) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPDVD> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPDVD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPDVD> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPDVD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPDVD> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPDVD) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPDVD, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPDVD {
     fn clone(&self) -> Self {
@@ -4378,41 +3390,7 @@ impl IWMPDownloadCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPDownloadCollection> for ::windows::core::IUnknown {
-    fn from(value: IWMPDownloadCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPDownloadCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPDownloadCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPDownloadCollection> for ::windows::core::IUnknown {
-    fn from(value: &IWMPDownloadCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPDownloadCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPDownloadCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPDownloadCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPDownloadCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPDownloadCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPDownloadCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPDownloadCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPDownloadCollection {
     fn clone(&self) -> Self {
@@ -4491,41 +3469,7 @@ impl IWMPDownloadItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPDownloadItem> for ::windows::core::IUnknown {
-    fn from(value: IWMPDownloadItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPDownloadItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPDownloadItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPDownloadItem> for ::windows::core::IUnknown {
-    fn from(value: &IWMPDownloadItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPDownloadItem> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPDownloadItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPDownloadItem> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPDownloadItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPDownloadItem> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPDownloadItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPDownloadItem, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPDownloadItem {
     fn clone(&self) -> Self {
@@ -4603,59 +3547,7 @@ impl IWMPDownloadItem2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPDownloadItem2> for ::windows::core::IUnknown {
-    fn from(value: IWMPDownloadItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPDownloadItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPDownloadItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPDownloadItem2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPDownloadItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPDownloadItem2> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPDownloadItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPDownloadItem2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPDownloadItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPDownloadItem2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPDownloadItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPDownloadItem2> for IWMPDownloadItem {
-    fn from(value: IWMPDownloadItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPDownloadItem2> for &'a IWMPDownloadItem {
-    fn from(value: &'a IWMPDownloadItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPDownloadItem2> for IWMPDownloadItem {
-    fn from(value: &IWMPDownloadItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPDownloadItem2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPDownloadItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPDownloadItem2 {
     fn clone(&self) -> Self {
@@ -4711,41 +3603,7 @@ impl IWMPDownloadManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPDownloadManager> for ::windows::core::IUnknown {
-    fn from(value: IWMPDownloadManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPDownloadManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPDownloadManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPDownloadManager> for ::windows::core::IUnknown {
-    fn from(value: &IWMPDownloadManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPDownloadManager> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPDownloadManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPDownloadManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPDownloadManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPDownloadManager> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPDownloadManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPDownloadManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPDownloadManager {
     fn clone(&self) -> Self {
@@ -4841,21 +3699,7 @@ impl IWMPEffects {
         (::windows::core::Vtable::vtable(self).RenderFullScreen)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(plevels)).ok()
     }
 }
-impl ::core::convert::From<IWMPEffects> for ::windows::core::IUnknown {
-    fn from(value: IWMPEffects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEffects> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPEffects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEffects> for ::windows::core::IUnknown {
-    fn from(value: &IWMPEffects) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPEffects, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPEffects {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5000,36 +3844,7 @@ impl IWMPEffects2 {
         (::windows::core::Vtable::vtable(self).RenderWindowed)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdata), frequiredrender.into()).ok()
     }
 }
-impl ::core::convert::From<IWMPEffects2> for ::windows::core::IUnknown {
-    fn from(value: IWMPEffects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEffects2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPEffects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEffects2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPEffects2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPEffects2> for IWMPEffects {
-    fn from(value: IWMPEffects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEffects2> for &'a IWMPEffects {
-    fn from(value: &'a IWMPEffects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEffects2> for IWMPEffects {
-    fn from(value: &IWMPEffects2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPEffects2, ::windows::core::IUnknown, IWMPEffects);
 impl ::core::clone::Clone for IWMPEffects2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5101,41 +3916,7 @@ impl IWMPError {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPError> for ::windows::core::IUnknown {
-    fn from(value: IWMPError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPError> for ::windows::core::IUnknown {
-    fn from(value: &IWMPError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPError> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPError> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPError> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPError, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPError {
     fn clone(&self) -> Self {
@@ -5202,41 +3983,7 @@ impl IWMPErrorItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPErrorItem> for ::windows::core::IUnknown {
-    fn from(value: IWMPErrorItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPErrorItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPErrorItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPErrorItem> for ::windows::core::IUnknown {
-    fn from(value: &IWMPErrorItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPErrorItem> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPErrorItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPErrorItem> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPErrorItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPErrorItem> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPErrorItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPErrorItem, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPErrorItem {
     fn clone(&self) -> Self {
@@ -5307,59 +4054,7 @@ impl IWMPErrorItem2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPErrorItem2> for ::windows::core::IUnknown {
-    fn from(value: IWMPErrorItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPErrorItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPErrorItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPErrorItem2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPErrorItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPErrorItem2> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPErrorItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPErrorItem2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPErrorItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPErrorItem2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPErrorItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPErrorItem2> for IWMPErrorItem {
-    fn from(value: IWMPErrorItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPErrorItem2> for &'a IWMPErrorItem {
-    fn from(value: &'a IWMPErrorItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPErrorItem2> for IWMPErrorItem {
-    fn from(value: &IWMPErrorItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPErrorItem2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPErrorItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPErrorItem2 {
     fn clone(&self) -> Self {
@@ -5560,21 +4255,7 @@ impl IWMPEvents {
         (::windows::core::Vtable::vtable(self).MouseUp)(::windows::core::Vtable::as_raw(self), nbutton, nshiftstate, fx, fy)
     }
 }
-impl ::core::convert::From<IWMPEvents> for ::windows::core::IUnknown {
-    fn from(value: IWMPEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEvents> for ::windows::core::IUnknown {
-    fn from(value: &IWMPEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5866,36 +4547,7 @@ impl IWMPEvents2 {
         (::windows::core::Vtable::vtable(self).CreatePartnershipComplete)(::windows::core::Vtable::as_raw(self), pdevice.into().abi(), hrresult)
     }
 }
-impl ::core::convert::From<IWMPEvents2> for ::windows::core::IUnknown {
-    fn from(value: IWMPEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEvents2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEvents2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPEvents2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPEvents2> for IWMPEvents {
-    fn from(value: IWMPEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEvents2> for &'a IWMPEvents {
-    fn from(value: &'a IWMPEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEvents2> for IWMPEvents {
-    fn from(value: &IWMPEvents2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPEvents2, ::windows::core::IUnknown, IWMPEvents);
 impl ::core::clone::Clone for IWMPEvents2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6211,51 +4863,7 @@ impl IWMPEvents3 {
         (::windows::core::Vtable::vtable(self).MediaCollectionMediaRemoved)(::windows::core::Vtable::as_raw(self), pdispmedia.into().abi())
     }
 }
-impl ::core::convert::From<IWMPEvents3> for ::windows::core::IUnknown {
-    fn from(value: IWMPEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEvents3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEvents3> for ::windows::core::IUnknown {
-    fn from(value: &IWMPEvents3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPEvents3> for IWMPEvents {
-    fn from(value: IWMPEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEvents3> for &'a IWMPEvents {
-    fn from(value: &'a IWMPEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEvents3> for IWMPEvents {
-    fn from(value: &IWMPEvents3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPEvents3> for IWMPEvents2 {
-    fn from(value: IWMPEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEvents3> for &'a IWMPEvents2 {
-    fn from(value: &'a IWMPEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEvents3> for IWMPEvents2 {
-    fn from(value: &IWMPEvents3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPEvents3, ::windows::core::IUnknown, IWMPEvents, IWMPEvents2);
 impl ::core::clone::Clone for IWMPEvents3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6594,66 +5202,7 @@ impl IWMPEvents4 {
         (::windows::core::Vtable::vtable(self).DeviceEstimation)(::windows::core::Vtable::as_raw(self), pdevice.into().abi(), hrresult, qwestimatedusedspace, qwestimatedspace)
     }
 }
-impl ::core::convert::From<IWMPEvents4> for ::windows::core::IUnknown {
-    fn from(value: IWMPEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEvents4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEvents4> for ::windows::core::IUnknown {
-    fn from(value: &IWMPEvents4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPEvents4> for IWMPEvents {
-    fn from(value: IWMPEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEvents4> for &'a IWMPEvents {
-    fn from(value: &'a IWMPEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEvents4> for IWMPEvents {
-    fn from(value: &IWMPEvents4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPEvents4> for IWMPEvents2 {
-    fn from(value: IWMPEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEvents4> for &'a IWMPEvents2 {
-    fn from(value: &'a IWMPEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEvents4> for IWMPEvents2 {
-    fn from(value: &IWMPEvents4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPEvents4> for IWMPEvents3 {
-    fn from(value: IWMPEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPEvents4> for &'a IWMPEvents3 {
-    fn from(value: &'a IWMPEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPEvents4> for IWMPEvents3 {
-    fn from(value: &IWMPEvents4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPEvents4, ::windows::core::IUnknown, IWMPEvents, IWMPEvents2, IWMPEvents3);
 impl ::core::clone::Clone for IWMPEvents4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6720,21 +5269,7 @@ impl IWMPFolderMonitorServices {
         (::windows::core::Vtable::vtable(self).stopScan)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMPFolderMonitorServices> for ::windows::core::IUnknown {
-    fn from(value: IWMPFolderMonitorServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPFolderMonitorServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPFolderMonitorServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPFolderMonitorServices> for ::windows::core::IUnknown {
-    fn from(value: &IWMPFolderMonitorServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPFolderMonitorServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPFolderMonitorServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6794,21 +5329,7 @@ impl IWMPGraphCreation {
         (::windows::core::Vtable::vtable(self).GetGraphCreationFlags)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwflags)).ok()
     }
 }
-impl ::core::convert::From<IWMPGraphCreation> for ::windows::core::IUnknown {
-    fn from(value: IWMPGraphCreation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPGraphCreation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPGraphCreation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPGraphCreation> for ::windows::core::IUnknown {
-    fn from(value: &IWMPGraphCreation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPGraphCreation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPGraphCreation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6862,21 +5383,7 @@ impl IWMPLibrary {
         (::windows::core::Vtable::vtable(self).isIdentical)(::windows::core::Vtable::as_raw(self), piwmplibrary.into().abi(), ::core::mem::transmute(pvbool)).ok()
     }
 }
-impl ::core::convert::From<IWMPLibrary> for ::windows::core::IUnknown {
-    fn from(value: IWMPLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPLibrary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPLibrary> for ::windows::core::IUnknown {
-    fn from(value: &IWMPLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPLibrary, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPLibrary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6937,36 +5444,7 @@ impl IWMPLibrary2 {
         (::windows::core::Vtable::vtable(self).getItemInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstritemname), ::core::mem::transmute(pbstrval)).ok()
     }
 }
-impl ::core::convert::From<IWMPLibrary2> for ::windows::core::IUnknown {
-    fn from(value: IWMPLibrary2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPLibrary2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPLibrary2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPLibrary2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPLibrary2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPLibrary2> for IWMPLibrary {
-    fn from(value: IWMPLibrary2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPLibrary2> for &'a IWMPLibrary {
-    fn from(value: &'a IWMPLibrary2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPLibrary2> for IWMPLibrary {
-    fn from(value: &IWMPLibrary2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPLibrary2, ::windows::core::IUnknown, IWMPLibrary);
 impl ::core::clone::Clone for IWMPLibrary2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7007,21 +5485,7 @@ impl IWMPLibraryServices {
         (::windows::core::Vtable::vtable(self).getLibraryByType)(::windows::core::Vtable::as_raw(self), wmplt, lindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMPLibrary>(result__)
     }
 }
-impl ::core::convert::From<IWMPLibraryServices> for ::windows::core::IUnknown {
-    fn from(value: IWMPLibraryServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPLibraryServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPLibraryServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPLibraryServices> for ::windows::core::IUnknown {
-    fn from(value: &IWMPLibraryServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPLibraryServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPLibraryServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7065,21 +5529,7 @@ impl IWMPLibrarySharingServices {
         (::windows::core::Vtable::vtable(self).showLibrarySharing)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMPLibrarySharingServices> for ::windows::core::IUnknown {
-    fn from(value: IWMPLibrarySharingServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPLibrarySharingServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPLibrarySharingServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPLibrarySharingServices> for ::windows::core::IUnknown {
-    fn from(value: &IWMPLibrarySharingServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPLibrarySharingServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPLibrarySharingServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7182,41 +5632,7 @@ impl IWMPMedia {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMedia> for ::windows::core::IUnknown {
-    fn from(value: IWMPMedia) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMedia> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPMedia) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMedia> for ::windows::core::IUnknown {
-    fn from(value: &IWMPMedia) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMedia> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPMedia) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMedia> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPMedia) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMedia> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPMedia) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPMedia, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPMedia {
     fn clone(&self) -> Self {
@@ -7353,59 +5769,7 @@ impl IWMPMedia2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMedia2> for ::windows::core::IUnknown {
-    fn from(value: IWMPMedia2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMedia2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPMedia2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMedia2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPMedia2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMedia2> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPMedia2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMedia2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPMedia2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMedia2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPMedia2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMedia2> for IWMPMedia {
-    fn from(value: IWMPMedia2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMedia2> for &'a IWMPMedia {
-    fn from(value: &'a IWMPMedia2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMedia2> for IWMPMedia {
-    fn from(value: &IWMPMedia2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPMedia2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPMedia);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPMedia2 {
     fn clone(&self) -> Self {
@@ -7530,77 +5894,7 @@ impl IWMPMedia3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMedia3> for ::windows::core::IUnknown {
-    fn from(value: IWMPMedia3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMedia3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPMedia3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMedia3> for ::windows::core::IUnknown {
-    fn from(value: &IWMPMedia3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMedia3> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPMedia3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMedia3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPMedia3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMedia3> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPMedia3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMedia3> for IWMPMedia {
-    fn from(value: IWMPMedia3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMedia3> for &'a IWMPMedia {
-    fn from(value: &'a IWMPMedia3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMedia3> for IWMPMedia {
-    fn from(value: &IWMPMedia3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMedia3> for IWMPMedia2 {
-    fn from(value: IWMPMedia3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMedia3> for &'a IWMPMedia2 {
-    fn from(value: &'a IWMPMedia3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMedia3> for IWMPMedia2 {
-    fn from(value: &IWMPMedia3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPMedia3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPMedia, IWMPMedia2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPMedia3 {
     fn clone(&self) -> Self {
@@ -7723,41 +6017,7 @@ impl IWMPMediaCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMediaCollection> for ::windows::core::IUnknown {
-    fn from(value: IWMPMediaCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMediaCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPMediaCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMediaCollection> for ::windows::core::IUnknown {
-    fn from(value: &IWMPMediaCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMediaCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPMediaCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMediaCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPMediaCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMediaCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPMediaCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPMediaCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPMediaCollection {
     fn clone(&self) -> Self {
@@ -7950,59 +6210,7 @@ impl IWMPMediaCollection2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMediaCollection2> for ::windows::core::IUnknown {
-    fn from(value: IWMPMediaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMediaCollection2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPMediaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMediaCollection2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPMediaCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMediaCollection2> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPMediaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMediaCollection2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPMediaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMediaCollection2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPMediaCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMediaCollection2> for IWMPMediaCollection {
-    fn from(value: IWMPMediaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMediaCollection2> for &'a IWMPMediaCollection {
-    fn from(value: &'a IWMPMediaCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMediaCollection2> for IWMPMediaCollection {
-    fn from(value: &IWMPMediaCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPMediaCollection2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPMediaCollection);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPMediaCollection2 {
     fn clone(&self) -> Self {
@@ -8069,21 +6277,7 @@ impl IWMPMediaPluginRegistrar {
         (::windows::core::Vtable::vtable(self).WMPUnRegisterPlayerPlugin)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidplugintype), ::core::mem::transmute(clsid)).ok()
     }
 }
-impl ::core::convert::From<IWMPMediaPluginRegistrar> for ::windows::core::IUnknown {
-    fn from(value: IWMPMediaPluginRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPMediaPluginRegistrar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPMediaPluginRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPMediaPluginRegistrar> for ::windows::core::IUnknown {
-    fn from(value: &IWMPMediaPluginRegistrar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPMediaPluginRegistrar, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPMediaPluginRegistrar {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8133,41 +6327,7 @@ impl IWMPMetadataPicture {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMetadataPicture> for ::windows::core::IUnknown {
-    fn from(value: IWMPMetadataPicture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMetadataPicture> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPMetadataPicture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMetadataPicture> for ::windows::core::IUnknown {
-    fn from(value: &IWMPMetadataPicture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMetadataPicture> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPMetadataPicture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMetadataPicture> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPMetadataPicture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMetadataPicture> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPMetadataPicture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPMetadataPicture, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPMetadataPicture {
     fn clone(&self) -> Self {
@@ -8220,41 +6380,7 @@ impl IWMPMetadataText {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMetadataText> for ::windows::core::IUnknown {
-    fn from(value: IWMPMetadataText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMetadataText> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPMetadataText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMetadataText> for ::windows::core::IUnknown {
-    fn from(value: &IWMPMetadataText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPMetadataText> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPMetadataText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPMetadataText> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPMetadataText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPMetadataText> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPMetadataText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPMetadataText, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPMetadataText {
     fn clone(&self) -> Self {
@@ -8383,41 +6509,7 @@ impl IWMPNetwork {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPNetwork> for ::windows::core::IUnknown {
-    fn from(value: IWMPNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPNetwork> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPNetwork> for ::windows::core::IUnknown {
-    fn from(value: &IWMPNetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPNetwork> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPNetwork> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPNetwork> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPNetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPNetwork, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPNetwork {
     fn clone(&self) -> Self {
@@ -8526,21 +6618,7 @@ impl IWMPNodeRealEstate {
         (::windows::core::Vtable::vtable(self).GetFullScreen)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pffullscreen)).ok()
     }
 }
-impl ::core::convert::From<IWMPNodeRealEstate> for ::windows::core::IUnknown {
-    fn from(value: IWMPNodeRealEstate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPNodeRealEstate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPNodeRealEstate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPNodeRealEstate> for ::windows::core::IUnknown {
-    fn from(value: &IWMPNodeRealEstate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPNodeRealEstate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPNodeRealEstate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8614,21 +6692,7 @@ impl IWMPNodeRealEstateHost {
         (::windows::core::Vtable::vtable(self).OnFullScreenTransition)(::windows::core::Vtable::as_raw(self), ffullscreen.into()).ok()
     }
 }
-impl ::core::convert::From<IWMPNodeRealEstateHost> for ::windows::core::IUnknown {
-    fn from(value: IWMPNodeRealEstateHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPNodeRealEstateHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPNodeRealEstateHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPNodeRealEstateHost> for ::windows::core::IUnknown {
-    fn from(value: &IWMPNodeRealEstateHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPNodeRealEstateHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPNodeRealEstateHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8675,21 +6739,7 @@ impl IWMPNodeWindowed {
         (::windows::core::Vtable::vtable(self).GetOwnerWindow)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phwnd)).ok()
     }
 }
-impl ::core::convert::From<IWMPNodeWindowed> for ::windows::core::IUnknown {
-    fn from(value: IWMPNodeWindowed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPNodeWindowed> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPNodeWindowed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPNodeWindowed> for ::windows::core::IUnknown {
-    fn from(value: &IWMPNodeWindowed) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPNodeWindowed, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPNodeWindowed {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8733,21 +6783,7 @@ impl IWMPNodeWindowedHost {
         (::windows::core::Vtable::vtable(self).OnWindowMessageFromRenderer)(::windows::core::Vtable::as_raw(self), umsg, wparam.into(), lparam.into(), ::core::mem::transmute(plret), ::core::mem::transmute(pfhandled)).ok()
     }
 }
-impl ::core::convert::From<IWMPNodeWindowedHost> for ::windows::core::IUnknown {
-    fn from(value: IWMPNodeWindowedHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPNodeWindowedHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPNodeWindowedHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPNodeWindowedHost> for ::windows::core::IUnknown {
-    fn from(value: &IWMPNodeWindowedHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPNodeWindowedHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPNodeWindowedHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8798,36 +6834,7 @@ impl IWMPNodeWindowless {
         (::windows::core::Vtable::vtable(self).OnDraw)(::windows::core::Vtable::as_raw(self), hdc, ::core::mem::transmute(prcdraw)).ok()
     }
 }
-impl ::core::convert::From<IWMPNodeWindowless> for ::windows::core::IUnknown {
-    fn from(value: IWMPNodeWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPNodeWindowless> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPNodeWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPNodeWindowless> for ::windows::core::IUnknown {
-    fn from(value: &IWMPNodeWindowless) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPNodeWindowless> for IWMPWindowMessageSink {
-    fn from(value: IWMPNodeWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPNodeWindowless> for &'a IWMPWindowMessageSink {
-    fn from(value: &'a IWMPNodeWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPNodeWindowless> for IWMPWindowMessageSink {
-    fn from(value: &IWMPNodeWindowless) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPNodeWindowless, ::windows::core::IUnknown, IWMPWindowMessageSink);
 impl ::core::clone::Clone for IWMPNodeWindowless {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8872,21 +6879,7 @@ impl IWMPNodeWindowlessHost {
         (::windows::core::Vtable::vtable(self).InvalidateRect)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prc), ferase.into()).ok()
     }
 }
-impl ::core::convert::From<IWMPNodeWindowlessHost> for ::windows::core::IUnknown {
-    fn from(value: IWMPNodeWindowlessHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPNodeWindowlessHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPNodeWindowlessHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPNodeWindowlessHost> for ::windows::core::IUnknown {
-    fn from(value: &IWMPNodeWindowlessHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPNodeWindowlessHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPNodeWindowlessHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9053,59 +7046,7 @@ impl IWMPPlayer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer> for ::windows::core::IUnknown {
-    fn from(value: IWMPPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPlayer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPPlayer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer> for IWMPCore {
-    fn from(value: IWMPPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer> for &'a IWMPCore {
-    fn from(value: &'a IWMPPlayer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer> for IWMPCore {
-    fn from(value: &IWMPPlayer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPlayer, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPCore);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPPlayer {
     fn clone(&self) -> Self {
@@ -9295,59 +7236,7 @@ impl IWMPPlayer2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer2> for ::windows::core::IUnknown {
-    fn from(value: IWMPPlayer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPlayer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPlayer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer2> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPPlayer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPPlayer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPPlayer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer2> for IWMPCore {
-    fn from(value: IWMPPlayer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer2> for &'a IWMPCore {
-    fn from(value: &'a IWMPPlayer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer2> for IWMPCore {
-    fn from(value: &IWMPPlayer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPlayer2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPCore);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPPlayer2 {
     fn clone(&self) -> Self {
@@ -9547,77 +7436,7 @@ impl IWMPPlayer3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer3> for ::windows::core::IUnknown {
-    fn from(value: IWMPPlayer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPlayer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer3> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPlayer3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer3> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPPlayer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPPlayer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer3> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPPlayer3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer3> for IWMPCore {
-    fn from(value: IWMPPlayer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer3> for &'a IWMPCore {
-    fn from(value: &'a IWMPPlayer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer3> for IWMPCore {
-    fn from(value: &IWMPPlayer3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer3> for IWMPCore2 {
-    fn from(value: IWMPPlayer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer3> for &'a IWMPCore2 {
-    fn from(value: &'a IWMPPlayer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer3> for IWMPCore2 {
-    fn from(value: &IWMPPlayer3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPlayer3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPCore, IWMPCore2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPPlayer3 {
     fn clone(&self) -> Self {
@@ -9841,95 +7660,7 @@ impl IWMPPlayer4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer4> for ::windows::core::IUnknown {
-    fn from(value: IWMPPlayer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPlayer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer4> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPlayer4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer4> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPPlayer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer4> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPPlayer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer4> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPPlayer4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer4> for IWMPCore {
-    fn from(value: IWMPPlayer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer4> for &'a IWMPCore {
-    fn from(value: &'a IWMPPlayer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer4> for IWMPCore {
-    fn from(value: &IWMPPlayer4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer4> for IWMPCore2 {
-    fn from(value: IWMPPlayer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer4> for &'a IWMPCore2 {
-    fn from(value: &'a IWMPPlayer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer4> for IWMPCore2 {
-    fn from(value: &IWMPPlayer4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayer4> for IWMPCore3 {
-    fn from(value: IWMPPlayer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayer4> for &'a IWMPCore3 {
-    fn from(value: &'a IWMPPlayer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayer4> for IWMPCore3 {
-    fn from(value: &IWMPPlayer4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPlayer4, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPCore, IWMPCore2, IWMPCore3);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPPlayer4 {
     fn clone(&self) -> Self {
@@ -10002,41 +7733,7 @@ impl IWMPPlayerApplication {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayerApplication> for ::windows::core::IUnknown {
-    fn from(value: IWMPPlayerApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayerApplication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPlayerApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayerApplication> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPlayerApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlayerApplication> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPPlayerApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlayerApplication> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPPlayerApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlayerApplication> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPPlayerApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPlayerApplication, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPPlayerApplication {
     fn clone(&self) -> Self {
@@ -10089,21 +7786,7 @@ impl IWMPPlayerServices {
         (::windows::core::Vtable::vtable(self).setTaskPaneURL)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrtaskpane), ::core::mem::transmute_copy(bstrurl), ::core::mem::transmute_copy(bstrfriendlyname)).ok()
     }
 }
-impl ::core::convert::From<IWMPPlayerServices> for ::windows::core::IUnknown {
-    fn from(value: IWMPPlayerServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPPlayerServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPlayerServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPPlayerServices> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPlayerServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPlayerServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPPlayerServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10151,36 +7834,7 @@ impl IWMPPlayerServices2 {
         (::windows::core::Vtable::vtable(self).setBackgroundProcessingPriority)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrpriority)).ok()
     }
 }
-impl ::core::convert::From<IWMPPlayerServices2> for ::windows::core::IUnknown {
-    fn from(value: IWMPPlayerServices2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPPlayerServices2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPlayerServices2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPPlayerServices2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPlayerServices2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPPlayerServices2> for IWMPPlayerServices {
-    fn from(value: IWMPPlayerServices2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPPlayerServices2> for &'a IWMPPlayerServices {
-    fn from(value: &'a IWMPPlayerServices2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPPlayerServices2> for IWMPPlayerServices {
-    fn from(value: &IWMPPlayerServices2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPlayerServices2, ::windows::core::IUnknown, IWMPPlayerServices);
 impl ::core::clone::Clone for IWMPPlayerServices2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10282,41 +7936,7 @@ impl IWMPPlaylist {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlaylist> for ::windows::core::IUnknown {
-    fn from(value: IWMPPlaylist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlaylist> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPlaylist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlaylist> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPlaylist) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlaylist> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPPlaylist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlaylist> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPPlaylist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlaylist> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPPlaylist) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPlaylist, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPPlaylist {
     fn clone(&self) -> Self {
@@ -10397,41 +8017,7 @@ impl IWMPPlaylistArray {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlaylistArray> for ::windows::core::IUnknown {
-    fn from(value: IWMPPlaylistArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlaylistArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPlaylistArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlaylistArray> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPlaylistArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlaylistArray> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPPlaylistArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlaylistArray> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPPlaylistArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlaylistArray> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPPlaylistArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPlaylistArray, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPPlaylistArray {
     fn clone(&self) -> Self {
@@ -10530,41 +8116,7 @@ impl IWMPPlaylistCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlaylistCollection> for ::windows::core::IUnknown {
-    fn from(value: IWMPPlaylistCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlaylistCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPlaylistCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlaylistCollection> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPlaylistCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPPlaylistCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPPlaylistCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPPlaylistCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPPlaylistCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPPlaylistCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPPlaylistCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPlaylistCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPPlaylistCollection {
     fn clone(&self) -> Self {
@@ -10653,21 +8205,7 @@ impl IWMPPlugin {
         (::windows::core::Vtable::vtable(self).UnAdviseWMPServices)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMPPlugin> for ::windows::core::IUnknown {
-    fn from(value: IWMPPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPPlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPPlugin> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPlugin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPPlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10719,21 +8257,7 @@ impl IWMPPluginEnable {
         (::windows::core::Vtable::vtable(self).GetEnable)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfenable)).ok()
     }
 }
-impl ::core::convert::From<IWMPPluginEnable> for ::windows::core::IUnknown {
-    fn from(value: IWMPPluginEnable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPPluginEnable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPluginEnable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPPluginEnable> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPluginEnable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPluginEnable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPPluginEnable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10822,21 +8346,7 @@ impl IWMPPluginUI {
         (::windows::core::Vtable::vtable(self).TranslateAccelerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpmsg)).ok()
     }
 }
-impl ::core::convert::From<IWMPPluginUI> for ::windows::core::IUnknown {
-    fn from(value: IWMPPluginUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPPluginUI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPPluginUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPPluginUI> for ::windows::core::IUnknown {
-    fn from(value: &IWMPPluginUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPPluginUI, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPPluginUI {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10903,41 +8413,7 @@ impl IWMPQuery {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPQuery> for ::windows::core::IUnknown {
-    fn from(value: IWMPQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPQuery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPQuery> for ::windows::core::IUnknown {
-    fn from(value: &IWMPQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPQuery> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPQuery> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPQuery> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPQuery, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPQuery {
     fn clone(&self) -> Self {
@@ -10993,21 +8469,7 @@ impl IWMPRemoteMediaServices {
         (::windows::core::Vtable::vtable(self).GetCustomUIMode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbstrfile)).ok()
     }
 }
-impl ::core::convert::From<IWMPRemoteMediaServices> for ::windows::core::IUnknown {
-    fn from(value: IWMPRemoteMediaServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPRemoteMediaServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPRemoteMediaServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPRemoteMediaServices> for ::windows::core::IUnknown {
-    fn from(value: &IWMPRemoteMediaServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPRemoteMediaServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPRemoteMediaServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11060,21 +8522,7 @@ impl IWMPRenderConfig {
         (::windows::core::Vtable::vtable(self).inProcOnly)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfinproc)).ok()
     }
 }
-impl ::core::convert::From<IWMPRenderConfig> for ::windows::core::IUnknown {
-    fn from(value: IWMPRenderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPRenderConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPRenderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPRenderConfig> for ::windows::core::IUnknown {
-    fn from(value: &IWMPRenderConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPRenderConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPRenderConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11121,21 +8569,7 @@ impl IWMPServices {
         (::windows::core::Vtable::vtable(self).GetStreamState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pstate)).ok()
     }
 }
-impl ::core::convert::From<IWMPServices> for ::windows::core::IUnknown {
-    fn from(value: IWMPServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPServices> for ::windows::core::IUnknown {
-    fn from(value: &IWMPServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11242,41 +8676,7 @@ impl IWMPSettings {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPSettings> for ::windows::core::IUnknown {
-    fn from(value: IWMPSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPSettings> for ::windows::core::IUnknown {
-    fn from(value: &IWMPSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPSettings> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPSettings> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPSettings> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPSettings, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPSettings {
     fn clone(&self) -> Self {
@@ -11420,59 +8820,7 @@ impl IWMPSettings2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPSettings2> for ::windows::core::IUnknown {
-    fn from(value: IWMPSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPSettings2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPSettings2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPSettings2> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPSettings2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPSettings2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPSettings2> for IWMPSettings {
-    fn from(value: IWMPSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPSettings2> for &'a IWMPSettings {
-    fn from(value: &'a IWMPSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPSettings2> for IWMPSettings {
-    fn from(value: &IWMPSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPSettings2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPSettings);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPSettings2 {
     fn clone(&self) -> Self {
@@ -11518,21 +8866,7 @@ impl IWMPSkinManager {
         (::windows::core::Vtable::vtable(self).SetVisualStyle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrpath)).ok()
     }
 }
-impl ::core::convert::From<IWMPSkinManager> for ::windows::core::IUnknown {
-    fn from(value: IWMPSkinManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSkinManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPSkinManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSkinManager> for ::windows::core::IUnknown {
-    fn from(value: &IWMPSkinManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPSkinManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPSkinManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11575,41 +8909,7 @@ impl IWMPStringCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPStringCollection> for ::windows::core::IUnknown {
-    fn from(value: IWMPStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPStringCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPStringCollection> for ::windows::core::IUnknown {
-    fn from(value: &IWMPStringCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPStringCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPStringCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPStringCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPStringCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPStringCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPStringCollection {
     fn clone(&self) -> Self {
@@ -11679,59 +8979,7 @@ impl IWMPStringCollection2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPStringCollection2> for ::windows::core::IUnknown {
-    fn from(value: IWMPStringCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPStringCollection2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPStringCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPStringCollection2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPStringCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPStringCollection2> for super::super::System::Com::IDispatch {
-    fn from(value: IWMPStringCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPStringCollection2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWMPStringCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPStringCollection2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWMPStringCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMPStringCollection2> for IWMPStringCollection {
-    fn from(value: IWMPStringCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMPStringCollection2> for &'a IWMPStringCollection {
-    fn from(value: &'a IWMPStringCollection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMPStringCollection2> for IWMPStringCollection {
-    fn from(value: &IWMPStringCollection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPStringCollection2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWMPStringCollection);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMPStringCollection2 {
     fn clone(&self) -> Self {
@@ -11816,21 +9064,7 @@ impl IWMPSubscriptionService {
         (::windows::core::Vtable::vtable(self).startBackgroundProcessing)(::windows::core::Vtable::as_raw(self), hwnd.into()).ok()
     }
 }
-impl ::core::convert::From<IWMPSubscriptionService> for ::windows::core::IUnknown {
-    fn from(value: IWMPSubscriptionService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSubscriptionService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPSubscriptionService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSubscriptionService> for ::windows::core::IUnknown {
-    fn from(value: &IWMPSubscriptionService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPSubscriptionService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPSubscriptionService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11932,36 +9166,7 @@ impl IWMPSubscriptionService2 {
         (::windows::core::Vtable::vtable(self).prepareForSync)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrfilename), ::core::mem::transmute_copy(bstrdevicename), pcb.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWMPSubscriptionService2> for ::windows::core::IUnknown {
-    fn from(value: IWMPSubscriptionService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSubscriptionService2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPSubscriptionService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSubscriptionService2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPSubscriptionService2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPSubscriptionService2> for IWMPSubscriptionService {
-    fn from(value: IWMPSubscriptionService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSubscriptionService2> for &'a IWMPSubscriptionService {
-    fn from(value: &'a IWMPSubscriptionService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSubscriptionService2> for IWMPSubscriptionService {
-    fn from(value: &IWMPSubscriptionService2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPSubscriptionService2, ::windows::core::IUnknown, IWMPSubscriptionService);
 impl ::core::clone::Clone for IWMPSubscriptionService2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12001,21 +9206,7 @@ impl IWMPSubscriptionServiceCallback {
         (::windows::core::Vtable::vtable(self).onComplete)(::windows::core::Vtable::as_raw(self), hrresult).ok()
     }
 }
-impl ::core::convert::From<IWMPSubscriptionServiceCallback> for ::windows::core::IUnknown {
-    fn from(value: IWMPSubscriptionServiceCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSubscriptionServiceCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPSubscriptionServiceCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSubscriptionServiceCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWMPSubscriptionServiceCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPSubscriptionServiceCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPSubscriptionServiceCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12100,21 +9291,7 @@ impl IWMPSyncDevice {
         (::windows::core::Vtable::vtable(self).isIdentical)(::windows::core::Vtable::as_raw(self), pdevice.into().abi(), ::core::mem::transmute(pvbool)).ok()
     }
 }
-impl ::core::convert::From<IWMPSyncDevice> for ::windows::core::IUnknown {
-    fn from(value: IWMPSyncDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSyncDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPSyncDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSyncDevice> for ::windows::core::IUnknown {
-    fn from(value: &IWMPSyncDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPSyncDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPSyncDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12217,36 +9394,7 @@ impl IWMPSyncDevice2 {
         (::windows::core::Vtable::vtable(self).setItemInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstritemname), ::core::mem::transmute_copy(bstrval)).ok()
     }
 }
-impl ::core::convert::From<IWMPSyncDevice2> for ::windows::core::IUnknown {
-    fn from(value: IWMPSyncDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSyncDevice2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPSyncDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSyncDevice2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPSyncDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPSyncDevice2> for IWMPSyncDevice {
-    fn from(value: IWMPSyncDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSyncDevice2> for &'a IWMPSyncDevice {
-    fn from(value: &'a IWMPSyncDevice2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSyncDevice2> for IWMPSyncDevice {
-    fn from(value: &IWMPSyncDevice2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPSyncDevice2, ::windows::core::IUnknown, IWMPSyncDevice);
 impl ::core::clone::Clone for IWMPSyncDevice2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12346,51 +9494,7 @@ impl IWMPSyncDevice3 {
         (::windows::core::Vtable::vtable(self).cancelEstimation)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMPSyncDevice3> for ::windows::core::IUnknown {
-    fn from(value: IWMPSyncDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSyncDevice3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPSyncDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSyncDevice3> for ::windows::core::IUnknown {
-    fn from(value: &IWMPSyncDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPSyncDevice3> for IWMPSyncDevice {
-    fn from(value: IWMPSyncDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSyncDevice3> for &'a IWMPSyncDevice {
-    fn from(value: &'a IWMPSyncDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSyncDevice3> for IWMPSyncDevice {
-    fn from(value: &IWMPSyncDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPSyncDevice3> for IWMPSyncDevice2 {
-    fn from(value: IWMPSyncDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSyncDevice3> for &'a IWMPSyncDevice2 {
-    fn from(value: &'a IWMPSyncDevice3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSyncDevice3> for IWMPSyncDevice2 {
-    fn from(value: &IWMPSyncDevice3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPSyncDevice3, ::windows::core::IUnknown, IWMPSyncDevice, IWMPSyncDevice2);
 impl ::core::clone::Clone for IWMPSyncDevice3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12435,21 +9539,7 @@ impl IWMPSyncServices {
         (::windows::core::Vtable::vtable(self).getDevice)(::windows::core::Vtable::as_raw(self), lindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMPSyncDevice>(result__)
     }
 }
-impl ::core::convert::From<IWMPSyncServices> for ::windows::core::IUnknown {
-    fn from(value: IWMPSyncServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPSyncServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPSyncServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPSyncServices> for ::windows::core::IUnknown {
-    fn from(value: &IWMPSyncServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPSyncServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPSyncServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12487,21 +9577,7 @@ impl IWMPTranscodePolicy {
         (::windows::core::Vtable::vtable(self).allowTranscode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvballow)).ok()
     }
 }
-impl ::core::convert::From<IWMPTranscodePolicy> for ::windows::core::IUnknown {
-    fn from(value: IWMPTranscodePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPTranscodePolicy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPTranscodePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPTranscodePolicy> for ::windows::core::IUnknown {
-    fn from(value: &IWMPTranscodePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPTranscodePolicy, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPTranscodePolicy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12538,21 +9614,7 @@ impl IWMPUserEventSink {
         (::windows::core::Vtable::vtable(self).NotifyUserEvent)(::windows::core::Vtable::as_raw(self), eventcode).ok()
     }
 }
-impl ::core::convert::From<IWMPUserEventSink> for ::windows::core::IUnknown {
-    fn from(value: IWMPUserEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPUserEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPUserEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPUserEventSink> for ::windows::core::IUnknown {
-    fn from(value: &IWMPUserEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPUserEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPUserEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12594,21 +9656,7 @@ impl IWMPVideoRenderConfig {
         (::windows::core::Vtable::vtable(self).SetpresenterActivate)(::windows::core::Vtable::as_raw(self), pactivate.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWMPVideoRenderConfig> for ::windows::core::IUnknown {
-    fn from(value: IWMPVideoRenderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPVideoRenderConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPVideoRenderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPVideoRenderConfig> for ::windows::core::IUnknown {
-    fn from(value: &IWMPVideoRenderConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPVideoRenderConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPVideoRenderConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12654,21 +9702,7 @@ impl IWMPWindowMessageSink {
         (::windows::core::Vtable::vtable(self).OnWindowMessage)(::windows::core::Vtable::as_raw(self), umsg, wparam.into(), lparam.into(), ::core::mem::transmute(plret), ::core::mem::transmute(pfhandled)).ok()
     }
 }
-impl ::core::convert::From<IWMPWindowMessageSink> for ::windows::core::IUnknown {
-    fn from(value: IWMPWindowMessageSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPWindowMessageSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPWindowMessageSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPWindowMessageSink> for ::windows::core::IUnknown {
-    fn from(value: &IWMPWindowMessageSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPWindowMessageSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPWindowMessageSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12911,21 +9945,7 @@ impl IXFeed {
         (::windows::core::Vtable::vtable(self).ItemCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IXFeed> for ::windows::core::IUnknown {
-    fn from(value: IXFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeed> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeed> for ::windows::core::IUnknown {
-    fn from(value: &IXFeed) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXFeed, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXFeed {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13266,36 +10286,7 @@ impl IXFeed2 {
         (::windows::core::Vtable::vtable(self).ClearCredentials)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IXFeed2> for ::windows::core::IUnknown {
-    fn from(value: IXFeed2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeed2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXFeed2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeed2> for ::windows::core::IUnknown {
-    fn from(value: &IXFeed2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXFeed2> for IXFeed {
-    fn from(value: IXFeed2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeed2> for &'a IXFeed {
-    fn from(value: &'a IXFeed2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeed2> for IXFeed {
-    fn from(value: &IXFeed2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXFeed2, ::windows::core::IUnknown, IXFeed);
 impl ::core::clone::Clone for IXFeed2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13394,21 +10385,7 @@ impl IXFeedEnclosure {
         (::windows::core::Vtable::vtable(self).SetFile)(::windows::core::Vtable::as_raw(self), pszdownloadurl.into(), pszdownloadfilepath.into(), pszdownloadmimetype.into(), pszenclosurefilename.into()).ok()
     }
 }
-impl ::core::convert::From<IXFeedEnclosure> for ::windows::core::IUnknown {
-    fn from(value: IXFeedEnclosure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeedEnclosure> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXFeedEnclosure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeedEnclosure> for ::windows::core::IUnknown {
-    fn from(value: &IXFeedEnclosure) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXFeedEnclosure, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXFeedEnclosure {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13501,21 +10478,7 @@ impl IXFeedEvents {
         (::windows::core::Vtable::vtable(self).FeedItemCountChanged)(::windows::core::Vtable::as_raw(self), pszpath.into(), feicfflags).ok()
     }
 }
-impl ::core::convert::From<IXFeedEvents> for ::windows::core::IUnknown {
-    fn from(value: IXFeedEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeedEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXFeedEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeedEvents> for ::windows::core::IUnknown {
-    fn from(value: &IXFeedEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXFeedEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXFeedEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13664,21 +10627,7 @@ impl IXFeedFolder {
         (::windows::core::Vtable::vtable(self).TotalItemCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IXFeedFolder> for ::windows::core::IUnknown {
-    fn from(value: IXFeedFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeedFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXFeedFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeedFolder> for ::windows::core::IUnknown {
-    fn from(value: &IXFeedFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXFeedFolder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXFeedFolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13837,21 +10786,7 @@ impl IXFeedFolderEvents {
         (::windows::core::Vtable::vtable(self).FeedItemCountChanged)(::windows::core::Vtable::as_raw(self), pszpath.into(), feicfflags).ok()
     }
 }
-impl ::core::convert::From<IXFeedFolderEvents> for ::windows::core::IUnknown {
-    fn from(value: IXFeedFolderEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeedFolderEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXFeedFolderEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeedFolderEvents> for ::windows::core::IUnknown {
-    fn from(value: &IXFeedFolderEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXFeedFolderEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXFeedFolderEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13987,21 +10922,7 @@ impl IXFeedItem {
         (::windows::core::Vtable::vtable(self).Modified)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::SYSTEMTIME>(result__)
     }
 }
-impl ::core::convert::From<IXFeedItem> for ::windows::core::IUnknown {
-    fn from(value: IXFeedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeedItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXFeedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeedItem> for ::windows::core::IUnknown {
-    fn from(value: &IXFeedItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXFeedItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXFeedItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14160,36 +11081,7 @@ impl IXFeedItem2 {
         (::windows::core::Vtable::vtable(self).EffectiveId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IXFeedItem2> for ::windows::core::IUnknown {
-    fn from(value: IXFeedItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeedItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXFeedItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeedItem2> for ::windows::core::IUnknown {
-    fn from(value: &IXFeedItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXFeedItem2> for IXFeedItem {
-    fn from(value: IXFeedItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeedItem2> for &'a IXFeedItem {
-    fn from(value: &'a IXFeedItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeedItem2> for IXFeedItem {
-    fn from(value: &IXFeedItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXFeedItem2, ::windows::core::IUnknown, IXFeedItem);
 impl ::core::clone::Clone for IXFeedItem2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14234,21 +11126,7 @@ impl IXFeedsEnum {
         (::windows::core::Vtable::vtable(self).Item)(::windows::core::Vtable::as_raw(self), uiindex, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IXFeedsEnum> for ::windows::core::IUnknown {
-    fn from(value: IXFeedsEnum) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeedsEnum> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXFeedsEnum) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeedsEnum> for ::windows::core::IUnknown {
-    fn from(value: &IXFeedsEnum) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXFeedsEnum, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXFeedsEnum {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14383,21 +11261,7 @@ impl IXFeedsManager {
         (::windows::core::Vtable::vtable(self).ItemCountLimit)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IXFeedsManager> for ::windows::core::IUnknown {
-    fn from(value: IXFeedsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXFeedsManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXFeedsManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXFeedsManager> for ::windows::core::IUnknown {
-    fn from(value: &IXFeedsManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXFeedsManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXFeedsManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14460,41 +11324,7 @@ pub struct _WMPOCXEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _WMPOCXEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_WMPOCXEvents> for ::windows::core::IUnknown {
-    fn from(value: _WMPOCXEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _WMPOCXEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _WMPOCXEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_WMPOCXEvents> for ::windows::core::IUnknown {
-    fn from(value: &_WMPOCXEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_WMPOCXEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _WMPOCXEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _WMPOCXEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _WMPOCXEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_WMPOCXEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_WMPOCXEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_WMPOCXEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _WMPOCXEvents {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
@@ -2006,21 +2006,7 @@ impl IAVIEditStream {
         (::windows::core::Vtable::vtable(self).SetInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpinfo), cbinfo).ok()
     }
 }
-impl ::core::convert::From<IAVIEditStream> for ::windows::core::IUnknown {
-    fn from(value: IAVIEditStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAVIEditStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAVIEditStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAVIEditStream> for ::windows::core::IUnknown {
-    fn from(value: &IAVIEditStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAVIEditStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAVIEditStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2084,21 +2070,7 @@ impl IAVIFile {
         (::windows::core::Vtable::vtable(self).DeleteStream)(::windows::core::Vtable::as_raw(self), fcctype, lparam).ok()
     }
 }
-impl ::core::convert::From<IAVIFile> for ::windows::core::IUnknown {
-    fn from(value: IAVIFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAVIFile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAVIFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAVIFile> for ::windows::core::IUnknown {
-    fn from(value: &IAVIFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAVIFile, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAVIFile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2189,59 +2161,7 @@ impl IAVIPersistFile {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAVIPersistFile> for ::windows::core::IUnknown {
-    fn from(value: IAVIPersistFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAVIPersistFile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAVIPersistFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAVIPersistFile> for ::windows::core::IUnknown {
-    fn from(value: &IAVIPersistFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAVIPersistFile> for super::super::System::Com::IPersist {
-    fn from(value: IAVIPersistFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAVIPersistFile> for &'a super::super::System::Com::IPersist {
-    fn from(value: &'a IAVIPersistFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAVIPersistFile> for super::super::System::Com::IPersist {
-    fn from(value: &IAVIPersistFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAVIPersistFile> for super::super::System::Com::IPersistFile {
-    fn from(value: IAVIPersistFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAVIPersistFile> for &'a super::super::System::Com::IPersistFile {
-    fn from(value: &'a IAVIPersistFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAVIPersistFile> for super::super::System::Com::IPersistFile {
-    fn from(value: &IAVIPersistFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAVIPersistFile, ::windows::core::IUnknown, super::super::System::Com::IPersist, super::super::System::Com::IPersistFile);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAVIPersistFile {
     fn clone(&self) -> Self {
@@ -2325,21 +2245,7 @@ impl IAVIStream {
         (::windows::core::Vtable::vtable(self).SetInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpinfo), cbinfo).ok()
     }
 }
-impl ::core::convert::From<IAVIStream> for ::windows::core::IUnknown {
-    fn from(value: IAVIStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAVIStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAVIStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAVIStream> for ::windows::core::IUnknown {
-    fn from(value: &IAVIStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAVIStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAVIStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2398,21 +2304,7 @@ impl IAVIStreaming {
         (::windows::core::Vtable::vtable(self).End)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAVIStreaming> for ::windows::core::IUnknown {
-    fn from(value: IAVIStreaming) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAVIStreaming> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAVIStreaming) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAVIStreaming> for ::windows::core::IUnknown {
-    fn from(value: &IAVIStreaming) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAVIStreaming, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAVIStreaming {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2461,21 +2353,7 @@ impl IGetFrame {
         (::windows::core::Vtable::vtable(self).SetFormat)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpbi), ::core::mem::transmute(lpbits.unwrap_or(::std::ptr::null())), x, y, dx, dy).ok()
     }
 }
-impl ::core::convert::From<IGetFrame> for ::windows::core::IUnknown {
-    fn from(value: IGetFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetFrame> for ::windows::core::IUnknown {
-    fn from(value: &IGetFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetFrame, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetFrame {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/mod.rs
@@ -28,21 +28,7 @@ impl IPhotoAcquire {
         (::windows::core::Vtable::vtable(self).EnumResults)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IEnumString>(result__)
     }
 }
-impl ::core::convert::From<IPhotoAcquire> for ::windows::core::IUnknown {
-    fn from(value: IPhotoAcquire) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhotoAcquire> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhotoAcquire) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhotoAcquire> for ::windows::core::IUnknown {
-    fn from(value: &IPhotoAcquire) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhotoAcquire, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPhotoAcquire {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -104,21 +90,7 @@ impl IPhotoAcquireDeviceSelectionDialog {
         (::windows::core::Vtable::vtable(self).DoModal)(::windows::core::Vtable::as_raw(self), hwndparent.into(), dwdeviceflags, ::core::mem::transmute(pbstrdeviceid.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pndevicetype.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IPhotoAcquireDeviceSelectionDialog> for ::windows::core::IUnknown {
-    fn from(value: IPhotoAcquireDeviceSelectionDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhotoAcquireDeviceSelectionDialog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhotoAcquireDeviceSelectionDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhotoAcquireDeviceSelectionDialog> for ::windows::core::IUnknown {
-    fn from(value: &IPhotoAcquireDeviceSelectionDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhotoAcquireDeviceSelectionDialog, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPhotoAcquireDeviceSelectionDialog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -201,21 +173,7 @@ impl IPhotoAcquireItem {
         (::windows::core::Vtable::vtable(self).GetSubItemAt)(::windows::core::Vtable::as_raw(self), nitemindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPhotoAcquireItem>(result__)
     }
 }
-impl ::core::convert::From<IPhotoAcquireItem> for ::windows::core::IUnknown {
-    fn from(value: IPhotoAcquireItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhotoAcquireItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhotoAcquireItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhotoAcquireItem> for ::windows::core::IUnknown {
-    fn from(value: &IPhotoAcquireItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhotoAcquireItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPhotoAcquireItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -301,21 +259,7 @@ impl IPhotoAcquireOptionsDialog {
         (::windows::core::Vtable::vtable(self).SaveData)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPhotoAcquireOptionsDialog> for ::windows::core::IUnknown {
-    fn from(value: IPhotoAcquireOptionsDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhotoAcquireOptionsDialog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhotoAcquireOptionsDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhotoAcquireOptionsDialog> for ::windows::core::IUnknown {
-    fn from(value: &IPhotoAcquireOptionsDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhotoAcquireOptionsDialog, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPhotoAcquireOptionsDialog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -388,21 +332,7 @@ impl IPhotoAcquirePlugin {
         (::windows::core::Vtable::vtable(self).DisplayConfigureDialog)(::windows::core::Vtable::as_raw(self), hwndparent.into()).ok()
     }
 }
-impl ::core::convert::From<IPhotoAcquirePlugin> for ::windows::core::IUnknown {
-    fn from(value: IPhotoAcquirePlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhotoAcquirePlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhotoAcquirePlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhotoAcquirePlugin> for ::windows::core::IUnknown {
-    fn from(value: &IPhotoAcquirePlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhotoAcquirePlugin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPhotoAcquirePlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -549,21 +479,7 @@ impl IPhotoAcquireProgressCB {
         (::windows::core::Vtable::vtable(self).GetUserInput)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riidtype), punknown.into().abi(), ::core::mem::transmute(ppropvarresult), ::core::mem::transmute(ppropvardefault.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IPhotoAcquireProgressCB> for ::windows::core::IUnknown {
-    fn from(value: IPhotoAcquireProgressCB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhotoAcquireProgressCB> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhotoAcquireProgressCB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhotoAcquireProgressCB> for ::windows::core::IUnknown {
-    fn from(value: &IPhotoAcquireProgressCB) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhotoAcquireProgressCB, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPhotoAcquireProgressCB {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -692,21 +608,7 @@ impl IPhotoAcquireSettings {
         (::windows::core::Vtable::vtable(self).GetAcquisitionTime)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::FILETIME>(result__)
     }
 }
-impl ::core::convert::From<IPhotoAcquireSettings> for ::windows::core::IUnknown {
-    fn from(value: IPhotoAcquireSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhotoAcquireSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhotoAcquireSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhotoAcquireSettings> for ::windows::core::IUnknown {
-    fn from(value: &IPhotoAcquireSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhotoAcquireSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPhotoAcquireSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -801,21 +703,7 @@ impl IPhotoAcquireSource {
         (::windows::core::Vtable::vtable(self).BindToObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(ppv)).ok()
     }
 }
-impl ::core::convert::From<IPhotoAcquireSource> for ::windows::core::IUnknown {
-    fn from(value: IPhotoAcquireSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhotoAcquireSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhotoAcquireSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhotoAcquireSource> for ::windows::core::IUnknown {
-    fn from(value: &IPhotoAcquireSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhotoAcquireSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPhotoAcquireSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -870,21 +758,7 @@ impl IPhotoProgressActionCB {
         (::windows::core::Vtable::vtable(self).DoAction)(::windows::core::Vtable::as_raw(self), hwndparent.into()).ok()
     }
 }
-impl ::core::convert::From<IPhotoProgressActionCB> for ::windows::core::IUnknown {
-    fn from(value: IPhotoProgressActionCB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhotoProgressActionCB> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhotoProgressActionCB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhotoProgressActionCB> for ::windows::core::IUnknown {
-    fn from(value: &IPhotoProgressActionCB) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhotoProgressActionCB, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPhotoProgressActionCB {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1036,21 +910,7 @@ impl IPhotoProgressDialog {
         (::windows::core::Vtable::vtable(self).GetUserInput)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riidtype), punknown.into().abi(), ::core::mem::transmute(ppropvarresult), ::core::mem::transmute(ppropvardefault.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IPhotoProgressDialog> for ::windows::core::IUnknown {
-    fn from(value: IPhotoProgressDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhotoProgressDialog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhotoProgressDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhotoProgressDialog> for ::windows::core::IUnknown {
-    fn from(value: &IPhotoProgressDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhotoProgressDialog, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPhotoProgressDialog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1169,21 +1029,7 @@ impl IUserInputString {
         (::windows::core::Vtable::vtable(self).GetImage)(::windows::core::Vtable::as_raw(self), nsize, ::core::mem::transmute(phbitmap.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(phicon.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IUserInputString> for ::windows::core::IUnknown {
-    fn from(value: IUserInputString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserInputString> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserInputString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserInputString> for ::windows::core::IUnknown {
-    fn from(value: &IUserInputString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserInputString, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUserInputString {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
@@ -23,21 +23,7 @@ impl IEnumSpObjectTokens {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcount)).ok()
     }
 }
-impl ::core::convert::From<IEnumSpObjectTokens> for ::windows::core::IUnknown {
-    fn from(value: IEnumSpObjectTokens) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSpObjectTokens> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSpObjectTokens) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSpObjectTokens> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSpObjectTokens) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSpObjectTokens, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSpObjectTokens {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -184,77 +170,7 @@ impl ISpAudio {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpAudio> for ::windows::core::IUnknown {
-    fn from(value: ISpAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpAudio> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpAudio> for ::windows::core::IUnknown {
-    fn from(value: &ISpAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpAudio> for super::super::System::Com::ISequentialStream {
-    fn from(value: ISpAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpAudio> for &'a super::super::System::Com::ISequentialStream {
-    fn from(value: &'a ISpAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpAudio> for super::super::System::Com::ISequentialStream {
-    fn from(value: &ISpAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpAudio> for super::super::System::Com::IStream {
-    fn from(value: ISpAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpAudio> for &'a super::super::System::Com::IStream {
-    fn from(value: &'a ISpAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpAudio> for super::super::System::Com::IStream {
-    fn from(value: &ISpAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpAudio> for ISpStreamFormat {
-    fn from(value: ISpAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpAudio> for &'a ISpStreamFormat {
-    fn from(value: &'a ISpAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpAudio> for ISpStreamFormat {
-    fn from(value: &ISpAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpAudio, ::windows::core::IUnknown, super::super::System::Com::ISequentialStream, super::super::System::Com::IStream, ISpStreamFormat);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpAudio {
     fn clone(&self) -> Self {
@@ -347,36 +263,7 @@ impl ISpContainerLexicon {
         (::windows::core::Vtable::vtable(self).AddLexicon)(::windows::core::Vtable::as_raw(self), paddlexicon.into().abi(), dwflags).ok()
     }
 }
-impl ::core::convert::From<ISpContainerLexicon> for ::windows::core::IUnknown {
-    fn from(value: ISpContainerLexicon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpContainerLexicon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpContainerLexicon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpContainerLexicon> for ::windows::core::IUnknown {
-    fn from(value: &ISpContainerLexicon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpContainerLexicon> for ISpLexicon {
-    fn from(value: ISpContainerLexicon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpContainerLexicon> for &'a ISpLexicon {
-    fn from(value: &'a ISpContainerLexicon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpContainerLexicon> for ISpLexicon {
-    fn from(value: &ISpContainerLexicon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpContainerLexicon, ::windows::core::IUnknown, ISpLexicon);
 impl ::core::clone::Clone for ISpContainerLexicon {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -482,21 +369,7 @@ impl ISpDataKey {
         (::windows::core::Vtable::vtable(self).EnumValues)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ISpDataKey> for ::windows::core::IUnknown {
-    fn from(value: ISpDataKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpDataKey> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpDataKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpDataKey> for ::windows::core::IUnknown {
-    fn from(value: &ISpDataKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpDataKey, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpDataKey {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -547,21 +420,7 @@ impl ISpDisplayAlternates {
         (::windows::core::Vtable::vtable(self).SetFullStopTrailSpace)(::windows::core::Vtable::as_raw(self), ultrailspace).ok()
     }
 }
-impl ::core::convert::From<ISpDisplayAlternates> for ::windows::core::IUnknown {
-    fn from(value: ISpDisplayAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpDisplayAlternates> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpDisplayAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpDisplayAlternates> for ::windows::core::IUnknown {
-    fn from(value: &ISpDisplayAlternates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpDisplayAlternates, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpDisplayAlternates {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -612,21 +471,7 @@ impl ISpEnginePronunciation {
         (::windows::core::Vtable::vtable(self).GetPronunciations)(::windows::core::Vtable::as_raw(self), pszword.into(), pszleftcontext.into(), pszrightcontext.into(), langid, ::core::mem::transmute(penginepronunciationlist)).ok()
     }
 }
-impl ::core::convert::From<ISpEnginePronunciation> for ::windows::core::IUnknown {
-    fn from(value: ISpEnginePronunciation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpEnginePronunciation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpEnginePronunciation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpEnginePronunciation> for ::windows::core::IUnknown {
-    fn from(value: &ISpEnginePronunciation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpEnginePronunciation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpEnginePronunciation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -669,21 +514,7 @@ impl ISpEventSink {
         (::windows::core::Vtable::vtable(self).GetEventInterest)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pulleventinterest)).ok()
     }
 }
-impl ::core::convert::From<ISpEventSink> for ::windows::core::IUnknown {
-    fn from(value: ISpEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpEventSink> for ::windows::core::IUnknown {
-    fn from(value: &ISpEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -778,36 +609,7 @@ impl ISpEventSource {
         (::windows::core::Vtable::vtable(self).GetInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo)).ok()
     }
 }
-impl ::core::convert::From<ISpEventSource> for ::windows::core::IUnknown {
-    fn from(value: ISpEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpEventSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpEventSource> for ::windows::core::IUnknown {
-    fn from(value: &ISpEventSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpEventSource> for ISpNotifySource {
-    fn from(value: ISpEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpEventSource> for &'a ISpNotifySource {
-    fn from(value: &'a ISpEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpEventSource> for ISpNotifySource {
-    fn from(value: &ISpEventSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpEventSource, ::windows::core::IUnknown, ISpNotifySource);
 impl ::core::clone::Clone for ISpEventSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -908,51 +710,7 @@ impl ISpEventSource2 {
         (::windows::core::Vtable::vtable(self).GetEventsEx)(::windows::core::Vtable::as_raw(self), ulcount, ::core::mem::transmute(peventarray), ::core::mem::transmute(pulfetched)).ok()
     }
 }
-impl ::core::convert::From<ISpEventSource2> for ::windows::core::IUnknown {
-    fn from(value: ISpEventSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpEventSource2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpEventSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpEventSource2> for ::windows::core::IUnknown {
-    fn from(value: &ISpEventSource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpEventSource2> for ISpNotifySource {
-    fn from(value: ISpEventSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpEventSource2> for &'a ISpNotifySource {
-    fn from(value: &'a ISpEventSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpEventSource2> for ISpNotifySource {
-    fn from(value: &ISpEventSource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpEventSource2> for ISpEventSource {
-    fn from(value: ISpEventSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpEventSource2> for &'a ISpEventSource {
-    fn from(value: &'a ISpEventSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpEventSource2> for ISpEventSource {
-    fn from(value: &ISpEventSource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpEventSource2, ::windows::core::IUnknown, ISpNotifySource, ISpEventSource);
 impl ::core::clone::Clone for ISpEventSource2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1031,21 +789,7 @@ impl ISpGrammarBuilder {
         (::windows::core::Vtable::vtable(self).Commit)(::windows::core::Vtable::as_raw(self), dwreserved).ok()
     }
 }
-impl ::core::convert::From<ISpGrammarBuilder> for ::windows::core::IUnknown {
-    fn from(value: ISpGrammarBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpGrammarBuilder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpGrammarBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpGrammarBuilder> for ::windows::core::IUnknown {
-    fn from(value: &ISpGrammarBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpGrammarBuilder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpGrammarBuilder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1104,21 +848,7 @@ impl ISpGrammarBuilder2 {
         (::windows::core::Vtable::vtable(self).SetPhoneticAlphabet)(::windows::core::Vtable::as_raw(self), phoneticalphabet).ok()
     }
 }
-impl ::core::convert::From<ISpGrammarBuilder2> for ::windows::core::IUnknown {
-    fn from(value: ISpGrammarBuilder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpGrammarBuilder2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpGrammarBuilder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpGrammarBuilder2> for ::windows::core::IUnknown {
-    fn from(value: &ISpGrammarBuilder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpGrammarBuilder2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpGrammarBuilder2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1180,21 +910,7 @@ impl ISpLexicon {
         (::windows::core::Vtable::vtable(self).GetWords)(::windows::core::Vtable::as_raw(self), dwflags, ::core::mem::transmute(pdwgeneration), ::core::mem::transmute(pdwcookie.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pwordlist)).ok()
     }
 }
-impl ::core::convert::From<ISpLexicon> for ::windows::core::IUnknown {
-    fn from(value: ISpLexicon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpLexicon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpLexicon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpLexicon> for ::windows::core::IUnknown {
-    fn from(value: &ISpLexicon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpLexicon, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpLexicon {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1356,95 +1072,7 @@ impl ISpMMSysAudio {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpMMSysAudio> for ::windows::core::IUnknown {
-    fn from(value: ISpMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpMMSysAudio> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpMMSysAudio> for ::windows::core::IUnknown {
-    fn from(value: &ISpMMSysAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpMMSysAudio> for super::super::System::Com::ISequentialStream {
-    fn from(value: ISpMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpMMSysAudio> for &'a super::super::System::Com::ISequentialStream {
-    fn from(value: &'a ISpMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpMMSysAudio> for super::super::System::Com::ISequentialStream {
-    fn from(value: &ISpMMSysAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpMMSysAudio> for super::super::System::Com::IStream {
-    fn from(value: ISpMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpMMSysAudio> for &'a super::super::System::Com::IStream {
-    fn from(value: &'a ISpMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpMMSysAudio> for super::super::System::Com::IStream {
-    fn from(value: &ISpMMSysAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpMMSysAudio> for ISpStreamFormat {
-    fn from(value: ISpMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpMMSysAudio> for &'a ISpStreamFormat {
-    fn from(value: &'a ISpMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpMMSysAudio> for ISpStreamFormat {
-    fn from(value: &ISpMMSysAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpMMSysAudio> for ISpAudio {
-    fn from(value: ISpMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpMMSysAudio> for &'a ISpAudio {
-    fn from(value: &'a ISpMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpMMSysAudio> for ISpAudio {
-    fn from(value: &ISpMMSysAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpMMSysAudio, ::windows::core::IUnknown, super::super::System::Com::ISequentialStream, super::super::System::Com::IStream, ISpStreamFormat, ISpAudio);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpMMSysAudio {
     fn clone(&self) -> Self {
@@ -1542,21 +1170,7 @@ impl ISpNotifySink {
         (::windows::core::Vtable::vtable(self).Notify)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISpNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ISpNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ISpNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpNotifySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1636,21 +1250,7 @@ impl ISpNotifySource {
         (::windows::core::Vtable::vtable(self).GetNotifyEventHandle)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ISpNotifySource> for ::windows::core::IUnknown {
-    fn from(value: ISpNotifySource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpNotifySource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpNotifySource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpNotifySource> for ::windows::core::IUnknown {
-    fn from(value: &ISpNotifySource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpNotifySource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpNotifySource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1751,36 +1351,7 @@ impl ISpNotifyTranslator {
         (::windows::core::Vtable::vtable(self).GetEventHandle)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ISpNotifyTranslator> for ::windows::core::IUnknown {
-    fn from(value: ISpNotifyTranslator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpNotifyTranslator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpNotifyTranslator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpNotifyTranslator> for ::windows::core::IUnknown {
-    fn from(value: &ISpNotifyTranslator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpNotifyTranslator> for ISpNotifySink {
-    fn from(value: ISpNotifyTranslator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpNotifyTranslator> for &'a ISpNotifySink {
-    fn from(value: &'a ISpNotifyTranslator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpNotifyTranslator> for ISpNotifySink {
-    fn from(value: &ISpNotifyTranslator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpNotifyTranslator, ::windows::core::IUnknown, ISpNotifySink);
 impl ::core::clone::Clone for ISpNotifyTranslator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1978,36 +1549,7 @@ impl ISpObjectToken {
         (::windows::core::Vtable::vtable(self).MatchesAttributes)(::windows::core::Vtable::as_raw(self), pszattributes.into(), ::core::mem::transmute(pfmatches)).ok()
     }
 }
-impl ::core::convert::From<ISpObjectToken> for ::windows::core::IUnknown {
-    fn from(value: ISpObjectToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpObjectToken> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpObjectToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpObjectToken> for ::windows::core::IUnknown {
-    fn from(value: &ISpObjectToken) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpObjectToken> for ISpDataKey {
-    fn from(value: ISpObjectToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpObjectToken> for &'a ISpDataKey {
-    fn from(value: &'a ISpObjectToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpObjectToken> for ISpDataKey {
-    fn from(value: &ISpObjectToken) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpObjectToken, ::windows::core::IUnknown, ISpDataKey);
 impl ::core::clone::Clone for ISpObjectToken {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2172,36 +1714,7 @@ impl ISpObjectTokenCategory {
         (::windows::core::Vtable::vtable(self).GetDefaultTokenId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ISpObjectTokenCategory> for ::windows::core::IUnknown {
-    fn from(value: ISpObjectTokenCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpObjectTokenCategory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpObjectTokenCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpObjectTokenCategory> for ::windows::core::IUnknown {
-    fn from(value: &ISpObjectTokenCategory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpObjectTokenCategory> for ISpDataKey {
-    fn from(value: ISpObjectTokenCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpObjectTokenCategory> for &'a ISpDataKey {
-    fn from(value: &'a ISpObjectTokenCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpObjectTokenCategory> for ISpDataKey {
-    fn from(value: &ISpObjectTokenCategory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpObjectTokenCategory, ::windows::core::IUnknown, ISpDataKey);
 impl ::core::clone::Clone for ISpObjectTokenCategory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2395,51 +1908,7 @@ impl ISpObjectTokenInit {
         (::windows::core::Vtable::vtable(self).InitFromDataKey)(::windows::core::Vtable::as_raw(self), pszcategoryid.into(), psztokenid.into(), pdatakey.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISpObjectTokenInit> for ::windows::core::IUnknown {
-    fn from(value: ISpObjectTokenInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpObjectTokenInit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpObjectTokenInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpObjectTokenInit> for ::windows::core::IUnknown {
-    fn from(value: &ISpObjectTokenInit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpObjectTokenInit> for ISpDataKey {
-    fn from(value: ISpObjectTokenInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpObjectTokenInit> for &'a ISpDataKey {
-    fn from(value: &'a ISpObjectTokenInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpObjectTokenInit> for ISpDataKey {
-    fn from(value: &ISpObjectTokenInit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpObjectTokenInit> for ISpObjectToken {
-    fn from(value: ISpObjectTokenInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpObjectTokenInit> for &'a ISpObjectToken {
-    fn from(value: &'a ISpObjectTokenInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpObjectTokenInit> for ISpObjectToken {
-    fn from(value: &ISpObjectTokenInit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpObjectTokenInit, ::windows::core::IUnknown, ISpDataKey, ISpObjectToken);
 impl ::core::clone::Clone for ISpObjectTokenInit {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2483,21 +1952,7 @@ impl ISpObjectWithToken {
         (::windows::core::Vtable::vtable(self).GetObjectToken)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISpObjectToken>(result__)
     }
 }
-impl ::core::convert::From<ISpObjectWithToken> for ::windows::core::IUnknown {
-    fn from(value: ISpObjectWithToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpObjectWithToken> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpObjectWithToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpObjectWithToken> for ::windows::core::IUnknown {
-    fn from(value: &ISpObjectWithToken) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpObjectWithToken, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpObjectWithToken {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2552,36 +2007,7 @@ impl ISpPhoneConverter {
         (::windows::core::Vtable::vtable(self).IdToPhone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pid), ::core::mem::transmute(pszphone)).ok()
     }
 }
-impl ::core::convert::From<ISpPhoneConverter> for ::windows::core::IUnknown {
-    fn from(value: ISpPhoneConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpPhoneConverter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpPhoneConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpPhoneConverter> for ::windows::core::IUnknown {
-    fn from(value: &ISpPhoneConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpPhoneConverter> for ISpObjectWithToken {
-    fn from(value: ISpPhoneConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpPhoneConverter> for &'a ISpObjectWithToken {
-    fn from(value: &'a ISpPhoneConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpPhoneConverter> for ISpObjectWithToken {
-    fn from(value: &ISpPhoneConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpPhoneConverter, ::windows::core::IUnknown, ISpObjectWithToken);
 impl ::core::clone::Clone for ISpPhoneConverter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2638,21 +2064,7 @@ impl ISpPhoneticAlphabetConverter {
         (::windows::core::Vtable::vtable(self).GetMaxConvertLength)(::windows::core::Vtable::as_raw(self), csrclength, bsapi2ups.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ISpPhoneticAlphabetConverter> for ::windows::core::IUnknown {
-    fn from(value: ISpPhoneticAlphabetConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpPhoneticAlphabetConverter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpPhoneticAlphabetConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpPhoneticAlphabetConverter> for ::windows::core::IUnknown {
-    fn from(value: &ISpPhoneticAlphabetConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpPhoneticAlphabetConverter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpPhoneticAlphabetConverter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2707,21 +2119,7 @@ impl ISpPhoneticAlphabetSelection {
         (::windows::core::Vtable::vtable(self).SetAlphabetToUPS)(::windows::core::Vtable::as_raw(self), fforceups.into()).ok()
     }
 }
-impl ::core::convert::From<ISpPhoneticAlphabetSelection> for ::windows::core::IUnknown {
-    fn from(value: ISpPhoneticAlphabetSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpPhoneticAlphabetSelection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpPhoneticAlphabetSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpPhoneticAlphabetSelection> for ::windows::core::IUnknown {
-    fn from(value: &ISpPhoneticAlphabetSelection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpPhoneticAlphabetSelection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpPhoneticAlphabetSelection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2783,21 +2181,7 @@ impl ISpPhrase {
         (::windows::core::Vtable::vtable(self).Discard)(::windows::core::Vtable::as_raw(self), dwvaluetypes).ok()
     }
 }
-impl ::core::convert::From<ISpPhrase> for ::windows::core::IUnknown {
-    fn from(value: ISpPhrase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpPhrase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpPhrase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpPhrase> for ::windows::core::IUnknown {
-    fn from(value: &ISpPhrase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpPhrase, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpPhrase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2873,36 +2257,7 @@ impl ISpPhrase2 {
         (::windows::core::Vtable::vtable(self).GetAudio)(::windows::core::Vtable::as_raw(self), ulstartelement, celements, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISpStreamFormat>(result__)
     }
 }
-impl ::core::convert::From<ISpPhrase2> for ::windows::core::IUnknown {
-    fn from(value: ISpPhrase2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpPhrase2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpPhrase2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpPhrase2> for ::windows::core::IUnknown {
-    fn from(value: &ISpPhrase2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpPhrase2> for ISpPhrase {
-    fn from(value: ISpPhrase2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpPhrase2> for &'a ISpPhrase {
-    fn from(value: &'a ISpPhrase2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpPhrase2> for ISpPhrase {
-    fn from(value: &ISpPhrase2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpPhrase2, ::windows::core::IUnknown, ISpPhrase);
 impl ::core::clone::Clone for ISpPhrase2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2968,36 +2323,7 @@ impl ISpPhraseAlt {
         (::windows::core::Vtable::vtable(self).Commit)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISpPhraseAlt> for ::windows::core::IUnknown {
-    fn from(value: ISpPhraseAlt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpPhraseAlt> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpPhraseAlt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpPhraseAlt> for ::windows::core::IUnknown {
-    fn from(value: &ISpPhraseAlt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpPhraseAlt> for ISpPhrase {
-    fn from(value: ISpPhraseAlt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpPhraseAlt> for &'a ISpPhrase {
-    fn from(value: &'a ISpPhraseAlt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpPhraseAlt> for ISpPhrase {
-    fn from(value: &ISpPhraseAlt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpPhraseAlt, ::windows::core::IUnknown, ISpPhrase);
 impl ::core::clone::Clone for ISpPhraseAlt {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3058,21 +2384,7 @@ impl ISpProperties {
         (::windows::core::Vtable::vtable(self).GetPropertyString)(::windows::core::Vtable::as_raw(self), pname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ISpProperties> for ::windows::core::IUnknown {
-    fn from(value: ISpProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpProperties> for ::windows::core::IUnknown {
-    fn from(value: &ISpProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3242,51 +2554,7 @@ impl ISpRecoContext {
         (::windows::core::Vtable::vtable(self).GetContextState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pecontextstate)).ok()
     }
 }
-impl ::core::convert::From<ISpRecoContext> for ::windows::core::IUnknown {
-    fn from(value: ISpRecoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpRecoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoContext> for ::windows::core::IUnknown {
-    fn from(value: &ISpRecoContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpRecoContext> for ISpNotifySource {
-    fn from(value: ISpRecoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoContext> for &'a ISpNotifySource {
-    fn from(value: &'a ISpRecoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoContext> for ISpNotifySource {
-    fn from(value: &ISpRecoContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpRecoContext> for ISpEventSource {
-    fn from(value: ISpRecoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoContext> for &'a ISpEventSource {
-    fn from(value: &'a ISpRecoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoContext> for ISpEventSource {
-    fn from(value: &ISpRecoContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpRecoContext, ::windows::core::IUnknown, ISpNotifySource, ISpEventSource);
 impl ::core::clone::Clone for ISpRecoContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3362,21 +2630,7 @@ impl ISpRecoContext2 {
         (::windows::core::Vtable::vtable(self).SetAdaptationData2)(::windows::core::Vtable::as_raw(self), padaptationdata.into(), cch, ptopicname.into(), eadaptationsettings, erelevance).ok()
     }
 }
-impl ::core::convert::From<ISpRecoContext2> for ::windows::core::IUnknown {
-    fn from(value: ISpRecoContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoContext2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpRecoContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoContext2> for ::windows::core::IUnknown {
-    fn from(value: &ISpRecoContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpRecoContext2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpRecoContext2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3540,36 +2794,7 @@ impl ISpRecoGrammar {
         (::windows::core::Vtable::vtable(self).GetGrammarState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pegrammarstate)).ok()
     }
 }
-impl ::core::convert::From<ISpRecoGrammar> for ::windows::core::IUnknown {
-    fn from(value: ISpRecoGrammar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoGrammar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpRecoGrammar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoGrammar> for ::windows::core::IUnknown {
-    fn from(value: &ISpRecoGrammar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpRecoGrammar> for ISpGrammarBuilder {
-    fn from(value: ISpRecoGrammar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoGrammar> for &'a ISpGrammarBuilder {
-    fn from(value: &'a ISpRecoGrammar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoGrammar> for ISpGrammarBuilder {
-    fn from(value: &ISpRecoGrammar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpRecoGrammar, ::windows::core::IUnknown, ISpGrammarBuilder);
 impl ::core::clone::Clone for ISpRecoGrammar {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3675,21 +2900,7 @@ impl ISpRecoGrammar2 {
         (::windows::core::Vtable::vtable(self).SetSMLSecurityManager)(::windows::core::Vtable::as_raw(self), psmlsecuritymanager.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISpRecoGrammar2> for ::windows::core::IUnknown {
-    fn from(value: ISpRecoGrammar2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoGrammar2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpRecoGrammar2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoGrammar2> for ::windows::core::IUnknown {
-    fn from(value: &ISpRecoGrammar2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpRecoGrammar2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpRecoGrammar2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3786,36 +2997,7 @@ impl ISpRecoResult {
         (::windows::core::Vtable::vtable(self).GetRecoContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISpRecoContext>(result__)
     }
 }
-impl ::core::convert::From<ISpRecoResult> for ::windows::core::IUnknown {
-    fn from(value: ISpRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoResult> for ::windows::core::IUnknown {
-    fn from(value: &ISpRecoResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpRecoResult> for ISpPhrase {
-    fn from(value: ISpRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoResult> for &'a ISpPhrase {
-    fn from(value: &'a ISpRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoResult> for ISpPhrase {
-    fn from(value: &ISpRecoResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpRecoResult, ::windows::core::IUnknown, ISpPhrase);
 impl ::core::clone::Clone for ISpRecoResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3936,51 +3118,7 @@ impl ISpRecoResult2 {
         (::windows::core::Vtable::vtable(self).SetTextFeedback)(::windows::core::Vtable::as_raw(self), pszfeedback.into(), fsuccessful.into()).ok()
     }
 }
-impl ::core::convert::From<ISpRecoResult2> for ::windows::core::IUnknown {
-    fn from(value: ISpRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoResult2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoResult2> for ::windows::core::IUnknown {
-    fn from(value: &ISpRecoResult2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpRecoResult2> for ISpPhrase {
-    fn from(value: ISpRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoResult2> for &'a ISpPhrase {
-    fn from(value: &'a ISpRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoResult2> for ISpPhrase {
-    fn from(value: &ISpRecoResult2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpRecoResult2> for ISpRecoResult {
-    fn from(value: ISpRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecoResult2> for &'a ISpRecoResult {
-    fn from(value: &'a ISpRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecoResult2> for ISpRecoResult {
-    fn from(value: &ISpRecoResult2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpRecoResult2, ::windows::core::IUnknown, ISpPhrase, ISpRecoResult);
 impl ::core::clone::Clone for ISpRecoResult2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4129,36 +3267,7 @@ impl ISpRecognizer {
         (::windows::core::Vtable::vtable(self).EmulateRecognition)(::windows::core::Vtable::as_raw(self), pphrase.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISpRecognizer> for ::windows::core::IUnknown {
-    fn from(value: ISpRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecognizer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecognizer> for ::windows::core::IUnknown {
-    fn from(value: &ISpRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpRecognizer> for ISpProperties {
-    fn from(value: ISpRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecognizer> for &'a ISpProperties {
-    fn from(value: &'a ISpRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecognizer> for ISpProperties {
-    fn from(value: &ISpRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpRecognizer, ::windows::core::IUnknown, ISpProperties);
 impl ::core::clone::Clone for ISpRecognizer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4240,21 +3349,7 @@ impl ISpRecognizer2 {
         (::windows::core::Vtable::vtable(self).ResetAcousticModelAdaptation)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISpRecognizer2> for ::windows::core::IUnknown {
-    fn from(value: ISpRecognizer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRecognizer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpRecognizer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRecognizer2> for ::windows::core::IUnknown {
-    fn from(value: &ISpRecognizer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpRecognizer2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpRecognizer2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4374,36 +3469,7 @@ impl ISpRegDataKey {
         (::windows::core::Vtable::vtable(self).SetKey)(::windows::core::Vtable::as_raw(self), hkey.into(), freadonly.into()).ok()
     }
 }
-impl ::core::convert::From<ISpRegDataKey> for ::windows::core::IUnknown {
-    fn from(value: ISpRegDataKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRegDataKey> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpRegDataKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRegDataKey> for ::windows::core::IUnknown {
-    fn from(value: &ISpRegDataKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpRegDataKey> for ISpDataKey {
-    fn from(value: ISpRegDataKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpRegDataKey> for &'a ISpDataKey {
-    fn from(value: &'a ISpRegDataKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpRegDataKey> for ISpDataKey {
-    fn from(value: &ISpRegDataKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpRegDataKey, ::windows::core::IUnknown, ISpDataKey);
 impl ::core::clone::Clone for ISpRegDataKey {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4462,41 +3528,7 @@ impl ISpResourceManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpResourceManager> for ::windows::core::IUnknown {
-    fn from(value: ISpResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpResourceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpResourceManager> for ::windows::core::IUnknown {
-    fn from(value: &ISpResourceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpResourceManager> for super::super::System::Com::IServiceProvider {
-    fn from(value: ISpResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpResourceManager> for &'a super::super::System::Com::IServiceProvider {
-    fn from(value: &'a ISpResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpResourceManager> for super::super::System::Com::IServiceProvider {
-    fn from(value: &ISpResourceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpResourceManager, ::windows::core::IUnknown, super::super::System::Com::IServiceProvider);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpResourceManager {
     fn clone(&self) -> Self {
@@ -4547,21 +3579,7 @@ impl ISpSerializeState {
         (::windows::core::Vtable::vtable(self).SetSerializedState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbdata), ulsize, dwreserved).ok()
     }
 }
-impl ::core::convert::From<ISpSerializeState> for ::windows::core::IUnknown {
-    fn from(value: ISpSerializeState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpSerializeState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpSerializeState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpSerializeState> for ::windows::core::IUnknown {
-    fn from(value: &ISpSerializeState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpSerializeState, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpSerializeState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4629,21 +3647,7 @@ impl ISpShortcut {
         (::windows::core::Vtable::vtable(self).GetGenerationChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwgeneration), ::core::mem::transmute(pshortcutpairlist)).ok()
     }
 }
-impl ::core::convert::From<ISpShortcut> for ::windows::core::IUnknown {
-    fn from(value: ISpShortcut) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpShortcut> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpShortcut) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpShortcut> for ::windows::core::IUnknown {
-    fn from(value: &ISpShortcut) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpShortcut, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpShortcut {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4778,77 +3782,7 @@ impl ISpStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpStream> for ::windows::core::IUnknown {
-    fn from(value: ISpStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpStream> for ::windows::core::IUnknown {
-    fn from(value: &ISpStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpStream> for super::super::System::Com::ISequentialStream {
-    fn from(value: ISpStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpStream> for &'a super::super::System::Com::ISequentialStream {
-    fn from(value: &'a ISpStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpStream> for super::super::System::Com::ISequentialStream {
-    fn from(value: &ISpStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpStream> for super::super::System::Com::IStream {
-    fn from(value: ISpStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpStream> for &'a super::super::System::Com::IStream {
-    fn from(value: &'a ISpStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpStream> for super::super::System::Com::IStream {
-    fn from(value: &ISpStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpStream> for ISpStreamFormat {
-    fn from(value: ISpStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpStream> for &'a ISpStreamFormat {
-    fn from(value: &'a ISpStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpStream> for ISpStreamFormat {
-    fn from(value: &ISpStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpStream, ::windows::core::IUnknown, super::super::System::Com::ISequentialStream, super::super::System::Com::IStream, ISpStreamFormat);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpStream {
     fn clone(&self) -> Self {
@@ -4970,59 +3904,7 @@ impl ISpStreamFormat {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpStreamFormat> for ::windows::core::IUnknown {
-    fn from(value: ISpStreamFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpStreamFormat> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpStreamFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpStreamFormat> for ::windows::core::IUnknown {
-    fn from(value: &ISpStreamFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpStreamFormat> for super::super::System::Com::ISequentialStream {
-    fn from(value: ISpStreamFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpStreamFormat> for &'a super::super::System::Com::ISequentialStream {
-    fn from(value: &'a ISpStreamFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpStreamFormat> for super::super::System::Com::ISequentialStream {
-    fn from(value: &ISpStreamFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpStreamFormat> for super::super::System::Com::IStream {
-    fn from(value: ISpStreamFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpStreamFormat> for &'a super::super::System::Com::IStream {
-    fn from(value: &'a ISpStreamFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpStreamFormat> for super::super::System::Com::IStream {
-    fn from(value: &ISpStreamFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpStreamFormat, ::windows::core::IUnknown, super::super::System::Com::ISequentialStream, super::super::System::Com::IStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpStreamFormat {
     fn clone(&self) -> Self {
@@ -5167,77 +4049,7 @@ impl ISpStreamFormatConverter {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpStreamFormatConverter> for ::windows::core::IUnknown {
-    fn from(value: ISpStreamFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpStreamFormatConverter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpStreamFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpStreamFormatConverter> for ::windows::core::IUnknown {
-    fn from(value: &ISpStreamFormatConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpStreamFormatConverter> for super::super::System::Com::ISequentialStream {
-    fn from(value: ISpStreamFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpStreamFormatConverter> for &'a super::super::System::Com::ISequentialStream {
-    fn from(value: &'a ISpStreamFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpStreamFormatConverter> for super::super::System::Com::ISequentialStream {
-    fn from(value: &ISpStreamFormatConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpStreamFormatConverter> for super::super::System::Com::IStream {
-    fn from(value: ISpStreamFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpStreamFormatConverter> for &'a super::super::System::Com::IStream {
-    fn from(value: &'a ISpStreamFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpStreamFormatConverter> for super::super::System::Com::IStream {
-    fn from(value: &ISpStreamFormatConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpStreamFormatConverter> for ISpStreamFormat {
-    fn from(value: ISpStreamFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpStreamFormatConverter> for &'a ISpStreamFormat {
-    fn from(value: &'a ISpStreamFormatConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpStreamFormatConverter> for ISpStreamFormat {
-    fn from(value: &ISpStreamFormatConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpStreamFormatConverter, ::windows::core::IUnknown, super::super::System::Com::ISequentialStream, super::super::System::Com::IStream, ISpStreamFormat);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpStreamFormatConverter {
     fn clone(&self) -> Self {
@@ -5302,21 +4114,7 @@ impl ISpTranscript {
         (::windows::core::Vtable::vtable(self).AppendTranscript)(::windows::core::Vtable::as_raw(self), psztranscript.into()).ok()
     }
 }
-impl ::core::convert::From<ISpTranscript> for ::windows::core::IUnknown {
-    fn from(value: ISpTranscript) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpTranscript> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpTranscript) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpTranscript> for ::windows::core::IUnknown {
-    fn from(value: &ISpTranscript) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpTranscript, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpTranscript {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5524,51 +4322,7 @@ impl ISpVoice {
         (::windows::core::Vtable::vtable(self).DisplayUI)(::windows::core::Vtable::as_raw(self), hwndparent.into(), psztitle.into(), psztypeofui.into(), ::core::mem::transmute(pvextradata), cbextradata).ok()
     }
 }
-impl ::core::convert::From<ISpVoice> for ::windows::core::IUnknown {
-    fn from(value: ISpVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpVoice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpVoice> for ::windows::core::IUnknown {
-    fn from(value: &ISpVoice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpVoice> for ISpNotifySource {
-    fn from(value: ISpVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpVoice> for &'a ISpNotifySource {
-    fn from(value: &'a ISpVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpVoice> for ISpNotifySource {
-    fn from(value: &ISpVoice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpVoice> for ISpEventSource {
-    fn from(value: ISpVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpVoice> for &'a ISpEventSource {
-    fn from(value: &'a ISpVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpVoice> for ISpEventSource {
-    fn from(value: &ISpVoice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpVoice, ::windows::core::IUnknown, ISpNotifySource, ISpEventSource);
 impl ::core::clone::Clone for ISpVoice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5700,51 +4454,7 @@ impl ISpXMLRecoResult {
         (::windows::core::Vtable::vtable(self).GetXMLErrorInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(psemanticerrorinfo)).ok()
     }
 }
-impl ::core::convert::From<ISpXMLRecoResult> for ::windows::core::IUnknown {
-    fn from(value: ISpXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpXMLRecoResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpXMLRecoResult> for ::windows::core::IUnknown {
-    fn from(value: &ISpXMLRecoResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpXMLRecoResult> for ISpPhrase {
-    fn from(value: ISpXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpXMLRecoResult> for &'a ISpPhrase {
-    fn from(value: &'a ISpXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpXMLRecoResult> for ISpPhrase {
-    fn from(value: &ISpXMLRecoResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpXMLRecoResult> for ISpRecoResult {
-    fn from(value: ISpXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpXMLRecoResult> for &'a ISpRecoResult {
-    fn from(value: &'a ISpXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpXMLRecoResult> for ISpRecoResult {
-    fn from(value: &ISpXMLRecoResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpXMLRecoResult, ::windows::core::IUnknown, ISpPhrase, ISpRecoResult);
 impl ::core::clone::Clone for ISpXMLRecoResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5858,59 +4568,7 @@ impl ISpeechAudio {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechAudio> for ::windows::core::IUnknown {
-    fn from(value: ISpeechAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechAudio> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechAudio> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechAudio> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechAudio> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechAudio> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechAudio> for ISpeechBaseStream {
-    fn from(value: ISpeechAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechAudio> for &'a ISpeechBaseStream {
-    fn from(value: &'a ISpeechAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechAudio> for ISpeechBaseStream {
-    fn from(value: &ISpeechAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechAudio, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ISpeechBaseStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechAudio {
     fn clone(&self) -> Self {
@@ -5992,41 +4650,7 @@ impl ISpeechAudioBufferInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechAudioBufferInfo> for ::windows::core::IUnknown {
-    fn from(value: ISpeechAudioBufferInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechAudioBufferInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechAudioBufferInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechAudioBufferInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechAudioBufferInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechAudioBufferInfo> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechAudioBufferInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechAudioBufferInfo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechAudioBufferInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechAudioBufferInfo> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechAudioBufferInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechAudioBufferInfo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechAudioBufferInfo {
     fn clone(&self) -> Self {
@@ -6103,41 +4727,7 @@ impl ISpeechAudioFormat {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechAudioFormat> for ::windows::core::IUnknown {
-    fn from(value: ISpeechAudioFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechAudioFormat> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechAudioFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechAudioFormat> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechAudioFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechAudioFormat> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechAudioFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechAudioFormat> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechAudioFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechAudioFormat> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechAudioFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechAudioFormat, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechAudioFormat {
     fn clone(&self) -> Self {
@@ -6216,41 +4806,7 @@ impl ISpeechAudioStatus {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechAudioStatus> for ::windows::core::IUnknown {
-    fn from(value: ISpeechAudioStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechAudioStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechAudioStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechAudioStatus> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechAudioStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechAudioStatus> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechAudioStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechAudioStatus> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechAudioStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechAudioStatus> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechAudioStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechAudioStatus, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechAudioStatus {
     fn clone(&self) -> Self {
@@ -6341,41 +4897,7 @@ impl ISpeechBaseStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechBaseStream> for ::windows::core::IUnknown {
-    fn from(value: ISpeechBaseStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechBaseStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechBaseStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechBaseStream> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechBaseStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechBaseStream> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechBaseStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechBaseStream> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechBaseStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechBaseStream> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechBaseStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechBaseStream, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechBaseStream {
     fn clone(&self) -> Self {
@@ -6485,59 +5007,7 @@ impl ISpeechCustomStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechCustomStream> for ::windows::core::IUnknown {
-    fn from(value: ISpeechCustomStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechCustomStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechCustomStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechCustomStream> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechCustomStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechCustomStream> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechCustomStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechCustomStream> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechCustomStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechCustomStream> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechCustomStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechCustomStream> for ISpeechBaseStream {
-    fn from(value: ISpeechCustomStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechCustomStream> for &'a ISpeechBaseStream {
-    fn from(value: &'a ISpeechCustomStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechCustomStream> for ISpeechBaseStream {
-    fn from(value: &ISpeechCustomStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechCustomStream, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ISpeechBaseStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechCustomStream {
     fn clone(&self) -> Self {
@@ -6636,41 +5106,7 @@ impl ISpeechDataKey {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechDataKey> for ::windows::core::IUnknown {
-    fn from(value: ISpeechDataKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechDataKey> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechDataKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechDataKey> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechDataKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechDataKey> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechDataKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechDataKey> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechDataKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechDataKey> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechDataKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechDataKey, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechDataKey {
     fn clone(&self) -> Self {
@@ -6780,59 +5216,7 @@ impl ISpeechFileStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechFileStream> for ::windows::core::IUnknown {
-    fn from(value: ISpeechFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechFileStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechFileStream> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechFileStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechFileStream> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechFileStream> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechFileStream> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechFileStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechFileStream> for ISpeechBaseStream {
-    fn from(value: ISpeechFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechFileStream> for &'a ISpeechBaseStream {
-    fn from(value: &'a ISpeechFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechFileStream> for ISpeechBaseStream {
-    fn from(value: &ISpeechFileStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechFileStream, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ISpeechBaseStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechFileStream {
     fn clone(&self) -> Self {
@@ -6907,41 +5291,7 @@ impl ISpeechGrammarRule {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechGrammarRule> for ::windows::core::IUnknown {
-    fn from(value: ISpeechGrammarRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechGrammarRule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechGrammarRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechGrammarRule> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechGrammarRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechGrammarRule> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechGrammarRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechGrammarRule> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechGrammarRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechGrammarRule> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechGrammarRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechGrammarRule, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechGrammarRule {
     fn clone(&self) -> Self {
@@ -7034,41 +5384,7 @@ impl ISpeechGrammarRuleState {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechGrammarRuleState> for ::windows::core::IUnknown {
-    fn from(value: ISpeechGrammarRuleState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechGrammarRuleState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechGrammarRuleState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechGrammarRuleState> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechGrammarRuleState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechGrammarRuleState> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechGrammarRuleState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechGrammarRuleState> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechGrammarRuleState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechGrammarRuleState> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechGrammarRuleState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechGrammarRuleState, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechGrammarRuleState {
     fn clone(&self) -> Self {
@@ -7171,41 +5487,7 @@ impl ISpeechGrammarRuleStateTransition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechGrammarRuleStateTransition> for ::windows::core::IUnknown {
-    fn from(value: ISpeechGrammarRuleStateTransition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechGrammarRuleStateTransition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechGrammarRuleStateTransition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechGrammarRuleStateTransition> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechGrammarRuleStateTransition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechGrammarRuleStateTransition> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechGrammarRuleStateTransition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechGrammarRuleStateTransition> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechGrammarRuleStateTransition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechGrammarRuleStateTransition> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechGrammarRuleStateTransition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechGrammarRuleStateTransition, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechGrammarRuleStateTransition {
     fn clone(&self) -> Self {
@@ -7282,41 +5564,7 @@ impl ISpeechGrammarRuleStateTransitions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechGrammarRuleStateTransitions> for ::windows::core::IUnknown {
-    fn from(value: ISpeechGrammarRuleStateTransitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechGrammarRuleStateTransitions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechGrammarRuleStateTransitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechGrammarRuleStateTransitions> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechGrammarRuleStateTransitions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechGrammarRuleStateTransitions> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechGrammarRuleStateTransitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechGrammarRuleStateTransitions> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechGrammarRuleStateTransitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechGrammarRuleStateTransitions> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechGrammarRuleStateTransitions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechGrammarRuleStateTransitions, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechGrammarRuleStateTransitions {
     fn clone(&self) -> Self {
@@ -7406,41 +5654,7 @@ impl ISpeechGrammarRules {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechGrammarRules> for ::windows::core::IUnknown {
-    fn from(value: ISpeechGrammarRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechGrammarRules> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechGrammarRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechGrammarRules> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechGrammarRules) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechGrammarRules> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechGrammarRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechGrammarRules> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechGrammarRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechGrammarRules> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechGrammarRules) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechGrammarRules, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechGrammarRules {
     fn clone(&self) -> Self {
@@ -7539,41 +5753,7 @@ impl ISpeechLexicon {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechLexicon> for ::windows::core::IUnknown {
-    fn from(value: ISpeechLexicon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechLexicon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechLexicon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechLexicon> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechLexicon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechLexicon> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechLexicon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechLexicon> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechLexicon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechLexicon> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechLexicon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechLexicon, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechLexicon {
     fn clone(&self) -> Self {
@@ -7661,41 +5841,7 @@ impl ISpeechLexiconPronunciation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechLexiconPronunciation> for ::windows::core::IUnknown {
-    fn from(value: ISpeechLexiconPronunciation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechLexiconPronunciation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechLexiconPronunciation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechLexiconPronunciation> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechLexiconPronunciation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechLexiconPronunciation> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechLexiconPronunciation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechLexiconPronunciation> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechLexiconPronunciation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechLexiconPronunciation> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechLexiconPronunciation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechLexiconPronunciation, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechLexiconPronunciation {
     fn clone(&self) -> Self {
@@ -7760,41 +5906,7 @@ impl ISpeechLexiconPronunciations {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechLexiconPronunciations> for ::windows::core::IUnknown {
-    fn from(value: ISpeechLexiconPronunciations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechLexiconPronunciations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechLexiconPronunciations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechLexiconPronunciations> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechLexiconPronunciations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechLexiconPronunciations> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechLexiconPronunciations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechLexiconPronunciations> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechLexiconPronunciations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechLexiconPronunciations> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechLexiconPronunciations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechLexiconPronunciations, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechLexiconPronunciations {
     fn clone(&self) -> Self {
@@ -7861,41 +5973,7 @@ impl ISpeechLexiconWord {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechLexiconWord> for ::windows::core::IUnknown {
-    fn from(value: ISpeechLexiconWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechLexiconWord> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechLexiconWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechLexiconWord> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechLexiconWord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechLexiconWord> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechLexiconWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechLexiconWord> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechLexiconWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechLexiconWord> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechLexiconWord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechLexiconWord, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechLexiconWord {
     fn clone(&self) -> Self {
@@ -7959,41 +6037,7 @@ impl ISpeechLexiconWords {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechLexiconWords> for ::windows::core::IUnknown {
-    fn from(value: ISpeechLexiconWords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechLexiconWords> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechLexiconWords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechLexiconWords> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechLexiconWords) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechLexiconWords> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechLexiconWords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechLexiconWords> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechLexiconWords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechLexiconWords> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechLexiconWords) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechLexiconWords, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechLexiconWords {
     fn clone(&self) -> Self {
@@ -8136,77 +6180,7 @@ impl ISpeechMMSysAudio {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechMMSysAudio> for ::windows::core::IUnknown {
-    fn from(value: ISpeechMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechMMSysAudio> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechMMSysAudio> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechMMSysAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechMMSysAudio> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechMMSysAudio> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechMMSysAudio> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechMMSysAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechMMSysAudio> for ISpeechBaseStream {
-    fn from(value: ISpeechMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechMMSysAudio> for &'a ISpeechBaseStream {
-    fn from(value: &'a ISpeechMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechMMSysAudio> for ISpeechBaseStream {
-    fn from(value: &ISpeechMMSysAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechMMSysAudio> for ISpeechAudio {
-    fn from(value: ISpeechMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechMMSysAudio> for &'a ISpeechAudio {
-    fn from(value: &'a ISpeechMMSysAudio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechMMSysAudio> for ISpeechAudio {
-    fn from(value: &ISpeechMMSysAudio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechMMSysAudio, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ISpeechBaseStream, ISpeechAudio);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechMMSysAudio {
     fn clone(&self) -> Self {
@@ -8305,59 +6279,7 @@ impl ISpeechMemoryStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechMemoryStream> for ::windows::core::IUnknown {
-    fn from(value: ISpeechMemoryStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechMemoryStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechMemoryStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechMemoryStream> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechMemoryStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechMemoryStream> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechMemoryStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechMemoryStream> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechMemoryStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechMemoryStream> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechMemoryStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechMemoryStream> for ISpeechBaseStream {
-    fn from(value: ISpeechMemoryStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechMemoryStream> for &'a ISpeechBaseStream {
-    fn from(value: &'a ISpeechMemoryStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechMemoryStream> for ISpeechBaseStream {
-    fn from(value: &ISpeechMemoryStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechMemoryStream, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ISpeechBaseStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechMemoryStream {
     fn clone(&self) -> Self {
@@ -8473,41 +6395,7 @@ impl ISpeechObjectToken {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechObjectToken> for ::windows::core::IUnknown {
-    fn from(value: ISpeechObjectToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechObjectToken> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechObjectToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechObjectToken> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechObjectToken) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechObjectToken> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechObjectToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechObjectToken> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechObjectToken) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechObjectToken> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechObjectToken) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechObjectToken, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechObjectToken {
     fn clone(&self) -> Self {
@@ -8601,41 +6489,7 @@ impl ISpeechObjectTokenCategory {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechObjectTokenCategory> for ::windows::core::IUnknown {
-    fn from(value: ISpeechObjectTokenCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechObjectTokenCategory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechObjectTokenCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechObjectTokenCategory> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechObjectTokenCategory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechObjectTokenCategory> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechObjectTokenCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechObjectTokenCategory> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechObjectTokenCategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechObjectTokenCategory> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechObjectTokenCategory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechObjectTokenCategory, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechObjectTokenCategory {
     fn clone(&self) -> Self {
@@ -8704,41 +6558,7 @@ impl ISpeechObjectTokens {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechObjectTokens> for ::windows::core::IUnknown {
-    fn from(value: ISpeechObjectTokens) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechObjectTokens> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechObjectTokens) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechObjectTokens> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechObjectTokens) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechObjectTokens> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechObjectTokens) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechObjectTokens> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechObjectTokens) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechObjectTokens> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechObjectTokens) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechObjectTokens, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechObjectTokens {
     fn clone(&self) -> Self {
@@ -8809,41 +6629,7 @@ impl ISpeechPhoneConverter {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhoneConverter> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhoneConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhoneConverter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhoneConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhoneConverter> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhoneConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhoneConverter> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhoneConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhoneConverter> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhoneConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhoneConverter> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhoneConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhoneConverter, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhoneConverter {
     fn clone(&self) -> Self {
@@ -8919,41 +6705,7 @@ impl ISpeechPhraseAlternate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseAlternate> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseAlternate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseAlternate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseAlternate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseAlternate> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseAlternate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseAlternate> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseAlternate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseAlternate> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseAlternate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseAlternate> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseAlternate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseAlternate, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseAlternate {
     fn clone(&self) -> Self {
@@ -9021,41 +6773,7 @@ impl ISpeechPhraseAlternates {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseAlternates> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseAlternates> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseAlternates> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseAlternates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseAlternates> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseAlternates> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseAlternates> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseAlternates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseAlternates, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseAlternates {
     fn clone(&self) -> Self {
@@ -9158,41 +6876,7 @@ impl ISpeechPhraseElement {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseElement> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseElement> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseElement> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseElement> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseElement> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseElement, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseElement {
     fn clone(&self) -> Self {
@@ -9265,41 +6949,7 @@ impl ISpeechPhraseElements {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseElements> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseElements> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseElements> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseElements) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseElements> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseElements> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseElements> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseElements) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseElements, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseElements {
     fn clone(&self) -> Self {
@@ -9430,41 +7080,7 @@ impl ISpeechPhraseInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseInfo> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseInfo> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseInfo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseInfo> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseInfo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseInfo {
     fn clone(&self) -> Self {
@@ -9556,41 +7172,7 @@ impl ISpeechPhraseInfoBuilder {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseInfoBuilder> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseInfoBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseInfoBuilder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseInfoBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseInfoBuilder> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseInfoBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseInfoBuilder> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseInfoBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseInfoBuilder> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseInfoBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseInfoBuilder> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseInfoBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseInfoBuilder, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseInfoBuilder {
     fn clone(&self) -> Self {
@@ -9651,41 +7233,7 @@ impl ISpeechPhraseProperties {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseProperties> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseProperties> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseProperties> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseProperties> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseProperties> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseProperties, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseProperties {
     fn clone(&self) -> Self {
@@ -9776,41 +7324,7 @@ impl ISpeechPhraseProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseProperty> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseProperty> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseProperty> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseProperty> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseProperty> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseProperty, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseProperty {
     fn clone(&self) -> Self {
@@ -9887,41 +7401,7 @@ impl ISpeechPhraseReplacement {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseReplacement> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseReplacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseReplacement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseReplacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseReplacement> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseReplacement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseReplacement> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseReplacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseReplacement> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseReplacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseReplacement> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseReplacement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseReplacement, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseReplacement {
     fn clone(&self) -> Self {
@@ -9982,41 +7462,7 @@ impl ISpeechPhraseReplacements {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseReplacements> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseReplacements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseReplacements> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseReplacements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseReplacements> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseReplacements) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseReplacements> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseReplacements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseReplacements> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseReplacements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseReplacements> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseReplacements) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseReplacements, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseReplacements {
     fn clone(&self) -> Self {
@@ -10101,41 +7547,7 @@ impl ISpeechPhraseRule {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseRule> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseRule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseRule> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseRule> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseRule> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseRule> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseRule, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseRule {
     fn clone(&self) -> Self {
@@ -10206,41 +7618,7 @@ impl ISpeechPhraseRules {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseRules> for ::windows::core::IUnknown {
-    fn from(value: ISpeechPhraseRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseRules> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechPhraseRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseRules> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechPhraseRules) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechPhraseRules> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechPhraseRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechPhraseRules> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechPhraseRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechPhraseRules> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechPhraseRules) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechPhraseRules, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechPhraseRules {
     fn clone(&self) -> Self {
@@ -10406,41 +7784,7 @@ impl ISpeechRecoContext {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoContext> for ::windows::core::IUnknown {
-    fn from(value: ISpeechRecoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechRecoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoContext> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechRecoContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoContext> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechRecoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoContext> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechRecoContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoContext> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechRecoContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechRecoContext, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechRecoContext {
     fn clone(&self) -> Self {
@@ -10626,41 +7970,7 @@ impl ISpeechRecoGrammar {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoGrammar> for ::windows::core::IUnknown {
-    fn from(value: ISpeechRecoGrammar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoGrammar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechRecoGrammar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoGrammar> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechRecoGrammar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoGrammar> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechRecoGrammar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoGrammar> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechRecoGrammar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoGrammar> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechRecoGrammar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechRecoGrammar, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechRecoGrammar {
     fn clone(&self) -> Self {
@@ -10803,41 +8113,7 @@ impl ISpeechRecoResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoResult> for ::windows::core::IUnknown {
-    fn from(value: ISpeechRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoResult> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechRecoResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoResult> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoResult> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoResult> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechRecoResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechRecoResult, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechRecoResult {
     fn clone(&self) -> Self {
@@ -10974,59 +8250,7 @@ impl ISpeechRecoResult2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoResult2> for ::windows::core::IUnknown {
-    fn from(value: ISpeechRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoResult2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoResult2> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechRecoResult2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoResult2> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoResult2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoResult2> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechRecoResult2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoResult2> for ISpeechRecoResult {
-    fn from(value: ISpeechRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoResult2> for &'a ISpeechRecoResult {
-    fn from(value: &'a ISpeechRecoResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoResult2> for ISpeechRecoResult {
-    fn from(value: &ISpeechRecoResult2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechRecoResult2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ISpeechRecoResult);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechRecoResult2 {
     fn clone(&self) -> Self {
@@ -11137,41 +8361,7 @@ impl ISpeechRecoResultDispatch {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoResultDispatch> for ::windows::core::IUnknown {
-    fn from(value: ISpeechRecoResultDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoResultDispatch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechRecoResultDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoResultDispatch> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechRecoResultDispatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoResultDispatch> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechRecoResultDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoResultDispatch> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechRecoResultDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoResultDispatch> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechRecoResultDispatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechRecoResultDispatch, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechRecoResultDispatch {
     fn clone(&self) -> Self {
@@ -11273,41 +8463,7 @@ impl ISpeechRecoResultTimes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoResultTimes> for ::windows::core::IUnknown {
-    fn from(value: ISpeechRecoResultTimes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoResultTimes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechRecoResultTimes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoResultTimes> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechRecoResultTimes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecoResultTimes> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechRecoResultTimes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecoResultTimes> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechRecoResultTimes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecoResultTimes> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechRecoResultTimes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechRecoResultTimes, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechRecoResultTimes {
     fn clone(&self) -> Self {
@@ -11506,41 +8662,7 @@ impl ISpeechRecognizer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecognizer> for ::windows::core::IUnknown {
-    fn from(value: ISpeechRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecognizer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecognizer> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecognizer> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecognizer> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecognizer> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechRecognizer, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechRecognizer {
     fn clone(&self) -> Self {
@@ -11690,41 +8812,7 @@ impl ISpeechRecognizerStatus {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecognizerStatus> for ::windows::core::IUnknown {
-    fn from(value: ISpeechRecognizerStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecognizerStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechRecognizerStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecognizerStatus> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechRecognizerStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechRecognizerStatus> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechRecognizerStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechRecognizerStatus> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechRecognizerStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechRecognizerStatus> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechRecognizerStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechRecognizerStatus, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechRecognizerStatus {
     fn clone(&self) -> Self {
@@ -11791,41 +8879,7 @@ impl ISpeechResourceLoader {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechResourceLoader> for ::windows::core::IUnknown {
-    fn from(value: ISpeechResourceLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechResourceLoader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechResourceLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechResourceLoader> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechResourceLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechResourceLoader> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechResourceLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechResourceLoader> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechResourceLoader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechResourceLoader> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechResourceLoader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechResourceLoader, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechResourceLoader {
     fn clone(&self) -> Self {
@@ -11899,41 +8953,7 @@ impl ISpeechTextSelectionInformation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechTextSelectionInformation> for ::windows::core::IUnknown {
-    fn from(value: ISpeechTextSelectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechTextSelectionInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechTextSelectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechTextSelectionInformation> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechTextSelectionInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechTextSelectionInformation> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechTextSelectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechTextSelectionInformation> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechTextSelectionInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechTextSelectionInformation> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechTextSelectionInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechTextSelectionInformation, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechTextSelectionInformation {
     fn clone(&self) -> Self {
@@ -12135,41 +9155,7 @@ impl ISpeechVoice {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechVoice> for ::windows::core::IUnknown {
-    fn from(value: ISpeechVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechVoice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechVoice> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechVoice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechVoice> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechVoice> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechVoice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechVoice> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechVoice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechVoice, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechVoice {
     fn clone(&self) -> Self {
@@ -12328,41 +9314,7 @@ impl ISpeechVoiceStatus {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechVoiceStatus> for ::windows::core::IUnknown {
-    fn from(value: ISpeechVoiceStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechVoiceStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechVoiceStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechVoiceStatus> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechVoiceStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechVoiceStatus> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechVoiceStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechVoiceStatus> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechVoiceStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechVoiceStatus> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechVoiceStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechVoiceStatus, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechVoiceStatus {
     fn clone(&self) -> Self {
@@ -12473,41 +9425,7 @@ impl ISpeechWaveFormatEx {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechWaveFormatEx> for ::windows::core::IUnknown {
-    fn from(value: ISpeechWaveFormatEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechWaveFormatEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechWaveFormatEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechWaveFormatEx> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechWaveFormatEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechWaveFormatEx> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechWaveFormatEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechWaveFormatEx> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechWaveFormatEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechWaveFormatEx> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechWaveFormatEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechWaveFormatEx, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechWaveFormatEx {
     fn clone(&self) -> Self {
@@ -12634,59 +9552,7 @@ impl ISpeechXMLRecoResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechXMLRecoResult> for ::windows::core::IUnknown {
-    fn from(value: ISpeechXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechXMLRecoResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechXMLRecoResult> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechXMLRecoResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechXMLRecoResult> for super::super::System::Com::IDispatch {
-    fn from(value: ISpeechXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechXMLRecoResult> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISpeechXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechXMLRecoResult> for super::super::System::Com::IDispatch {
-    fn from(value: &ISpeechXMLRecoResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISpeechXMLRecoResult> for ISpeechRecoResult {
-    fn from(value: ISpeechXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISpeechXMLRecoResult> for &'a ISpeechRecoResult {
-    fn from(value: &'a ISpeechXMLRecoResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISpeechXMLRecoResult> for ISpeechRecoResult {
-    fn from(value: &ISpeechXMLRecoResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechXMLRecoResult, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ISpeechRecoResult);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISpeechXMLRecoResult {
     fn clone(&self) -> Self {
@@ -12730,41 +9596,7 @@ pub struct _ISpeechRecoContextEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _ISpeechRecoContextEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_ISpeechRecoContextEvents> for ::windows::core::IUnknown {
-    fn from(value: _ISpeechRecoContextEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _ISpeechRecoContextEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _ISpeechRecoContextEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_ISpeechRecoContextEvents> for ::windows::core::IUnknown {
-    fn from(value: &_ISpeechRecoContextEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_ISpeechRecoContextEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _ISpeechRecoContextEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _ISpeechRecoContextEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _ISpeechRecoContextEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_ISpeechRecoContextEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_ISpeechRecoContextEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_ISpeechRecoContextEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _ISpeechRecoContextEvents {
     fn clone(&self) -> Self {
@@ -12806,41 +9638,7 @@ pub struct _ISpeechVoiceEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _ISpeechVoiceEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_ISpeechVoiceEvents> for ::windows::core::IUnknown {
-    fn from(value: _ISpeechVoiceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _ISpeechVoiceEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _ISpeechVoiceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_ISpeechVoiceEvents> for ::windows::core::IUnknown {
-    fn from(value: &_ISpeechVoiceEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_ISpeechVoiceEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _ISpeechVoiceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _ISpeechVoiceEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _ISpeechVoiceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_ISpeechVoiceEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_ISpeechVoiceEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_ISpeechVoiceEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _ISpeechVoiceEvents {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/mod.rs
@@ -170,21 +170,7 @@ impl INSNetSourceCreator {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<INSNetSourceCreator> for ::windows::core::IUnknown {
-    fn from(value: INSNetSourceCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INSNetSourceCreator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INSNetSourceCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INSNetSourceCreator> for ::windows::core::IUnknown {
-    fn from(value: &INSNetSourceCreator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INSNetSourceCreator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INSNetSourceCreator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -246,21 +232,7 @@ impl INSSBuffer {
         (::windows::core::Vtable::vtable(self).GetBufferAndLength)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppdwbuffer), ::core::mem::transmute(pdwlength)).ok()
     }
 }
-impl ::core::convert::From<INSSBuffer> for ::windows::core::IUnknown {
-    fn from(value: INSSBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INSSBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INSSBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INSSBuffer> for ::windows::core::IUnknown {
-    fn from(value: &INSSBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INSSBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INSSBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -323,36 +295,7 @@ impl INSSBuffer2 {
         (::windows::core::Vtable::vtable(self).SetSampleProperties)(::windows::core::Vtable::as_raw(self), cbproperties, ::core::mem::transmute(pbproperties)).ok()
     }
 }
-impl ::core::convert::From<INSSBuffer2> for ::windows::core::IUnknown {
-    fn from(value: INSSBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INSSBuffer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INSSBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INSSBuffer2> for ::windows::core::IUnknown {
-    fn from(value: &INSSBuffer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INSSBuffer2> for INSSBuffer {
-    fn from(value: INSSBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INSSBuffer2> for &'a INSSBuffer {
-    fn from(value: &'a INSSBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INSSBuffer2> for INSSBuffer {
-    fn from(value: &INSSBuffer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INSSBuffer2, ::windows::core::IUnknown, INSSBuffer);
 impl ::core::clone::Clone for INSSBuffer2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -418,51 +361,7 @@ impl INSSBuffer3 {
         (::windows::core::Vtable::vtable(self).GetProperty)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidbufferproperty), ::core::mem::transmute(pvbufferproperty), ::core::mem::transmute(pdwbufferpropertysize)).ok()
     }
 }
-impl ::core::convert::From<INSSBuffer3> for ::windows::core::IUnknown {
-    fn from(value: INSSBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INSSBuffer3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INSSBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INSSBuffer3> for ::windows::core::IUnknown {
-    fn from(value: &INSSBuffer3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INSSBuffer3> for INSSBuffer {
-    fn from(value: INSSBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INSSBuffer3> for &'a INSSBuffer {
-    fn from(value: &'a INSSBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INSSBuffer3> for INSSBuffer {
-    fn from(value: &INSSBuffer3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INSSBuffer3> for INSSBuffer2 {
-    fn from(value: INSSBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INSSBuffer3> for &'a INSSBuffer2 {
-    fn from(value: &'a INSSBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INSSBuffer3> for INSSBuffer2 {
-    fn from(value: &INSSBuffer3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INSSBuffer3, ::windows::core::IUnknown, INSSBuffer, INSSBuffer2);
 impl ::core::clone::Clone for INSSBuffer3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -535,66 +434,7 @@ impl INSSBuffer4 {
         (::windows::core::Vtable::vtable(self).GetPropertyByIndex)(::windows::core::Vtable::as_raw(self), dwbufferpropertyindex, ::core::mem::transmute(pguidbufferproperty), ::core::mem::transmute(pvbufferproperty), ::core::mem::transmute(pdwbufferpropertysize)).ok()
     }
 }
-impl ::core::convert::From<INSSBuffer4> for ::windows::core::IUnknown {
-    fn from(value: INSSBuffer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INSSBuffer4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INSSBuffer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INSSBuffer4> for ::windows::core::IUnknown {
-    fn from(value: &INSSBuffer4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INSSBuffer4> for INSSBuffer {
-    fn from(value: INSSBuffer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INSSBuffer4> for &'a INSSBuffer {
-    fn from(value: &'a INSSBuffer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INSSBuffer4> for INSSBuffer {
-    fn from(value: &INSSBuffer4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INSSBuffer4> for INSSBuffer2 {
-    fn from(value: INSSBuffer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INSSBuffer4> for &'a INSSBuffer2 {
-    fn from(value: &'a INSSBuffer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INSSBuffer4> for INSSBuffer2 {
-    fn from(value: &INSSBuffer4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INSSBuffer4> for INSSBuffer3 {
-    fn from(value: INSSBuffer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INSSBuffer4> for &'a INSSBuffer3 {
-    fn from(value: &'a INSSBuffer4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INSSBuffer4> for INSSBuffer3 {
-    fn from(value: &INSSBuffer4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INSSBuffer4, ::windows::core::IUnknown, INSSBuffer, INSSBuffer2, INSSBuffer3);
 impl ::core::clone::Clone for INSSBuffer4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -643,21 +483,7 @@ impl IWMAddressAccess {
         (::windows::core::Vtable::vtable(self).RemoveAccessEntry)(::windows::core::Vtable::as_raw(self), aetype, dwentrynum).ok()
     }
 }
-impl ::core::convert::From<IWMAddressAccess> for ::windows::core::IUnknown {
-    fn from(value: IWMAddressAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMAddressAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMAddressAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMAddressAccess> for ::windows::core::IUnknown {
-    fn from(value: &IWMAddressAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMAddressAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMAddressAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -714,36 +540,7 @@ impl IWMAddressAccess2 {
         (::windows::core::Vtable::vtable(self).AddAccessEntryEx)(::windows::core::Vtable::as_raw(self), aetype, ::core::mem::transmute_copy(bstraddress), ::core::mem::transmute_copy(bstrmask)).ok()
     }
 }
-impl ::core::convert::From<IWMAddressAccess2> for ::windows::core::IUnknown {
-    fn from(value: IWMAddressAccess2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMAddressAccess2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMAddressAccess2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMAddressAccess2> for ::windows::core::IUnknown {
-    fn from(value: &IWMAddressAccess2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMAddressAccess2> for IWMAddressAccess {
-    fn from(value: IWMAddressAccess2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMAddressAccess2> for &'a IWMAddressAccess {
-    fn from(value: &'a IWMAddressAccess2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMAddressAccess2> for IWMAddressAccess {
-    fn from(value: &IWMAddressAccess2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMAddressAccess2, ::windows::core::IUnknown, IWMAddressAccess);
 impl ::core::clone::Clone for IWMAddressAccess2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -790,21 +587,7 @@ impl IWMAuthorizer {
         (::windows::core::Vtable::vtable(self).GetSharedData)(::windows::core::Vtable::as_raw(self), dwcertindex, ::core::mem::transmute(pbshareddata), ::core::mem::transmute(pbcert), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut u8>(result__)
     }
 }
-impl ::core::convert::From<IWMAuthorizer> for ::windows::core::IUnknown {
-    fn from(value: IWMAuthorizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMAuthorizer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMAuthorizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMAuthorizer> for ::windows::core::IUnknown {
-    fn from(value: &IWMAuthorizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMAuthorizer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMAuthorizer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -868,21 +651,7 @@ impl IWMBackupRestoreProps {
         (::windows::core::Vtable::vtable(self).RemoveAllProps)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMBackupRestoreProps> for ::windows::core::IUnknown {
-    fn from(value: IWMBackupRestoreProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMBackupRestoreProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMBackupRestoreProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMBackupRestoreProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMBackupRestoreProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMBackupRestoreProps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMBackupRestoreProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -943,36 +712,7 @@ impl IWMBandwidthSharing {
         (::windows::core::Vtable::vtable(self).SetBandwidth)(::windows::core::Vtable::as_raw(self), dwbitrate, msbufferwindow).ok()
     }
 }
-impl ::core::convert::From<IWMBandwidthSharing> for ::windows::core::IUnknown {
-    fn from(value: IWMBandwidthSharing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMBandwidthSharing> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMBandwidthSharing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMBandwidthSharing> for ::windows::core::IUnknown {
-    fn from(value: &IWMBandwidthSharing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMBandwidthSharing> for IWMStreamList {
-    fn from(value: IWMBandwidthSharing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMBandwidthSharing> for &'a IWMStreamList {
-    fn from(value: &'a IWMBandwidthSharing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMBandwidthSharing> for IWMStreamList {
-    fn from(value: &IWMBandwidthSharing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMBandwidthSharing, ::windows::core::IUnknown, IWMStreamList);
 impl ::core::clone::Clone for IWMBandwidthSharing {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1017,21 +757,7 @@ impl IWMClientConnections {
         (::windows::core::Vtable::vtable(self).GetClientProperties)(::windows::core::Vtable::as_raw(self), dwclientnum, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WM_CLIENT_PROPERTIES>(result__)
     }
 }
-impl ::core::convert::From<IWMClientConnections> for ::windows::core::IUnknown {
-    fn from(value: IWMClientConnections) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMClientConnections> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMClientConnections) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMClientConnections> for ::windows::core::IUnknown {
-    fn from(value: &IWMClientConnections) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMClientConnections, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMClientConnections {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1077,36 +803,7 @@ impl IWMClientConnections2 {
         (::windows::core::Vtable::vtable(self).GetClientInfo)(::windows::core::Vtable::as_raw(self), dwclientnum, ::core::mem::transmute(pwsznetworkaddress), ::core::mem::transmute(pcchnetworkaddress), ::core::mem::transmute(pwszport), ::core::mem::transmute(pcchport), ::core::mem::transmute(pwszdnsname), ::core::mem::transmute(pcchdnsname)).ok()
     }
 }
-impl ::core::convert::From<IWMClientConnections2> for ::windows::core::IUnknown {
-    fn from(value: IWMClientConnections2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMClientConnections2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMClientConnections2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMClientConnections2> for ::windows::core::IUnknown {
-    fn from(value: &IWMClientConnections2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMClientConnections2> for IWMClientConnections {
-    fn from(value: IWMClientConnections2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMClientConnections2> for &'a IWMClientConnections {
-    fn from(value: &'a IWMClientConnections2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMClientConnections2> for IWMClientConnections {
-    fn from(value: &IWMClientConnections2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMClientConnections2, ::windows::core::IUnknown, IWMClientConnections);
 impl ::core::clone::Clone for IWMClientConnections2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1152,21 +849,7 @@ impl IWMCodecInfo {
         (::windows::core::Vtable::vtable(self).GetCodecFormat)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidtype), dwcodecindex, dwformatindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMStreamConfig>(result__)
     }
 }
-impl ::core::convert::From<IWMCodecInfo> for ::windows::core::IUnknown {
-    fn from(value: IWMCodecInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCodecInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMCodecInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCodecInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWMCodecInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMCodecInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMCodecInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1220,36 +903,7 @@ impl IWMCodecInfo2 {
         (::windows::core::Vtable::vtable(self).GetCodecFormatDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidtype), dwcodecindex, dwformatindex, ::core::mem::transmute(ppistreamconfig), ::core::mem::transmute(wszdesc), ::core::mem::transmute(pcchdesc)).ok()
     }
 }
-impl ::core::convert::From<IWMCodecInfo2> for ::windows::core::IUnknown {
-    fn from(value: IWMCodecInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCodecInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMCodecInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCodecInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IWMCodecInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMCodecInfo2> for IWMCodecInfo {
-    fn from(value: IWMCodecInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCodecInfo2> for &'a IWMCodecInfo {
-    fn from(value: &'a IWMCodecInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCodecInfo2> for IWMCodecInfo {
-    fn from(value: &IWMCodecInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMCodecInfo2, ::windows::core::IUnknown, IWMCodecInfo);
 impl ::core::clone::Clone for IWMCodecInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1326,51 +980,7 @@ impl IWMCodecInfo3 {
         (::windows::core::Vtable::vtable(self).GetCodecEnumerationSetting)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidtype), dwcodecindex, pszname.into(), ::core::mem::transmute(ptype), ::core::mem::transmute(pvalue), ::core::mem::transmute(pdwsize)).ok()
     }
 }
-impl ::core::convert::From<IWMCodecInfo3> for ::windows::core::IUnknown {
-    fn from(value: IWMCodecInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCodecInfo3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMCodecInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCodecInfo3> for ::windows::core::IUnknown {
-    fn from(value: &IWMCodecInfo3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMCodecInfo3> for IWMCodecInfo {
-    fn from(value: IWMCodecInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCodecInfo3> for &'a IWMCodecInfo {
-    fn from(value: &'a IWMCodecInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCodecInfo3> for IWMCodecInfo {
-    fn from(value: &IWMCodecInfo3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMCodecInfo3> for IWMCodecInfo2 {
-    fn from(value: IWMCodecInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCodecInfo3> for &'a IWMCodecInfo2 {
-    fn from(value: &'a IWMCodecInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCodecInfo3> for IWMCodecInfo2 {
-    fn from(value: &IWMCodecInfo3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMCodecInfo3, ::windows::core::IUnknown, IWMCodecInfo, IWMCodecInfo2);
 impl ::core::clone::Clone for IWMCodecInfo3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1414,21 +1024,7 @@ impl IWMCredentialCallback {
         (::windows::core::Vtable::vtable(self).AcquireCredentials)(::windows::core::Vtable::as_raw(self), pwszrealm.into(), pwszsite.into(), ::core::mem::transmute(pwszuser.as_ptr()), pwszuser.len() as _, ::core::mem::transmute(pwszpassword.as_ptr()), pwszpassword.len() as _, hrstatus, ::core::mem::transmute(pdwflags)).ok()
     }
 }
-impl ::core::convert::From<IWMCredentialCallback> for ::windows::core::IUnknown {
-    fn from(value: IWMCredentialCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMCredentialCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMCredentialCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMCredentialCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWMCredentialCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMCredentialCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMCredentialCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1468,21 +1064,7 @@ impl IWMDRMEditor {
         (::windows::core::Vtable::vtable(self).GetDRMProperty)(::windows::core::Vtable::as_raw(self), pwstrname.into(), ::core::mem::transmute(pdwtype), ::core::mem::transmute(pvalue), ::core::mem::transmute(pcblength)).ok()
     }
 }
-impl ::core::convert::From<IWMDRMEditor> for ::windows::core::IUnknown {
-    fn from(value: IWMDRMEditor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMEditor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDRMEditor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMEditor> for ::windows::core::IUnknown {
-    fn from(value: &IWMDRMEditor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDRMEditor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDRMEditor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1522,21 +1104,7 @@ impl IWMDRMMessageParser {
         (::windows::core::Vtable::vtable(self).ParseLicenseRequestMsg)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pblicenserequestmsg.as_ptr()), pblicenserequestmsg.len() as _, ::core::mem::transmute(ppdevicecert), ::core::mem::transmute(pdeviceserialnumber), ::core::mem::transmute(pbstraction)).ok()
     }
 }
-impl ::core::convert::From<IWMDRMMessageParser> for ::windows::core::IUnknown {
-    fn from(value: IWMDRMMessageParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMMessageParser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDRMMessageParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMMessageParser> for ::windows::core::IUnknown {
-    fn from(value: &IWMDRMMessageParser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDRMMessageParser, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDRMMessageParser {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1601,21 +1169,7 @@ impl IWMDRMReader {
         (::windows::core::Vtable::vtable(self).GetDRMProperty)(::windows::core::Vtable::as_raw(self), pwstrname.into(), ::core::mem::transmute(pdwtype), ::core::mem::transmute(pvalue), ::core::mem::transmute(pcblength)).ok()
     }
 }
-impl ::core::convert::From<IWMDRMReader> for ::windows::core::IUnknown {
-    fn from(value: IWMDRMReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDRMReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMReader> for ::windows::core::IUnknown {
-    fn from(value: &IWMDRMReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDRMReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDRMReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1703,36 +1257,7 @@ impl IWMDRMReader2 {
         (::windows::core::Vtable::vtable(self).TryNextLicense)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMDRMReader2> for ::windows::core::IUnknown {
-    fn from(value: IWMDRMReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMReader2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDRMReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMReader2> for ::windows::core::IUnknown {
-    fn from(value: &IWMDRMReader2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDRMReader2> for IWMDRMReader {
-    fn from(value: IWMDRMReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMReader2> for &'a IWMDRMReader {
-    fn from(value: &'a IWMDRMReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMReader2> for IWMDRMReader {
-    fn from(value: &IWMDRMReader2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDRMReader2, ::windows::core::IUnknown, IWMDRMReader);
 impl ::core::clone::Clone for IWMDRMReader2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1822,51 +1347,7 @@ impl IWMDRMReader3 {
         (::windows::core::Vtable::vtable(self).GetInclusionList)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppguids), ::core::mem::transmute(pcguids)).ok()
     }
 }
-impl ::core::convert::From<IWMDRMReader3> for ::windows::core::IUnknown {
-    fn from(value: IWMDRMReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMReader3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDRMReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMReader3> for ::windows::core::IUnknown {
-    fn from(value: &IWMDRMReader3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDRMReader3> for IWMDRMReader {
-    fn from(value: IWMDRMReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMReader3> for &'a IWMDRMReader {
-    fn from(value: &'a IWMDRMReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMReader3> for IWMDRMReader {
-    fn from(value: &IWMDRMReader3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDRMReader3> for IWMDRMReader2 {
-    fn from(value: IWMDRMReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMReader3> for &'a IWMDRMReader2 {
-    fn from(value: &'a IWMDRMReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMReader3> for IWMDRMReader2 {
-    fn from(value: &IWMDRMReader3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDRMReader3, ::windows::core::IUnknown, IWMDRMReader, IWMDRMReader2);
 impl ::core::clone::Clone for IWMDRMReader3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1904,21 +1385,7 @@ impl IWMDRMTranscryptionManager {
         (::windows::core::Vtable::vtable(self).CreateTranscryptor)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMDRMTranscryptor>(result__)
     }
 }
-impl ::core::convert::From<IWMDRMTranscryptionManager> for ::windows::core::IUnknown {
-    fn from(value: IWMDRMTranscryptionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMTranscryptionManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDRMTranscryptionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMTranscryptionManager> for ::windows::core::IUnknown {
-    fn from(value: &IWMDRMTranscryptionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDRMTranscryptionManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDRMTranscryptionManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1967,21 +1434,7 @@ impl IWMDRMTranscryptor {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMDRMTranscryptor> for ::windows::core::IUnknown {
-    fn from(value: IWMDRMTranscryptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMTranscryptor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDRMTranscryptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMTranscryptor> for ::windows::core::IUnknown {
-    fn from(value: &IWMDRMTranscryptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDRMTranscryptor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDRMTranscryptor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2057,36 +1510,7 @@ impl IWMDRMTranscryptor2 {
         (::windows::core::Vtable::vtable(self).GetDuration)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IWMDRMTranscryptor2> for ::windows::core::IUnknown {
-    fn from(value: IWMDRMTranscryptor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMTranscryptor2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDRMTranscryptor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMTranscryptor2> for ::windows::core::IUnknown {
-    fn from(value: &IWMDRMTranscryptor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDRMTranscryptor2> for IWMDRMTranscryptor {
-    fn from(value: IWMDRMTranscryptor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMTranscryptor2> for &'a IWMDRMTranscryptor {
-    fn from(value: &'a IWMDRMTranscryptor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMTranscryptor2> for IWMDRMTranscryptor {
-    fn from(value: &IWMDRMTranscryptor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDRMTranscryptor2, ::windows::core::IUnknown, IWMDRMTranscryptor);
 impl ::core::clone::Clone for IWMDRMTranscryptor2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2144,21 +1568,7 @@ impl IWMDRMWriter {
         (::windows::core::Vtable::vtable(self).SetDRMAttribute)(::windows::core::Vtable::as_raw(self), wstreamnum, pszname.into(), r#type, ::core::mem::transmute(pvalue.as_ptr()), pvalue.len() as _).ok()
     }
 }
-impl ::core::convert::From<IWMDRMWriter> for ::windows::core::IUnknown {
-    fn from(value: IWMDRMWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDRMWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMWriter> for ::windows::core::IUnknown {
-    fn from(value: &IWMDRMWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDRMWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDRMWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2218,36 +1628,7 @@ impl IWMDRMWriter2 {
         (::windows::core::Vtable::vtable(self).SetWMDRMNetEncryption)(::windows::core::Vtable::as_raw(self), fsamplesencrypted.into(), ::core::mem::transmute(pbkeyid), cbkeyid).ok()
     }
 }
-impl ::core::convert::From<IWMDRMWriter2> for ::windows::core::IUnknown {
-    fn from(value: IWMDRMWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMWriter2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDRMWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMWriter2> for ::windows::core::IUnknown {
-    fn from(value: &IWMDRMWriter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDRMWriter2> for IWMDRMWriter {
-    fn from(value: IWMDRMWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMWriter2> for &'a IWMDRMWriter {
-    fn from(value: &'a IWMDRMWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMWriter2> for IWMDRMWriter {
-    fn from(value: &IWMDRMWriter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDRMWriter2, ::windows::core::IUnknown, IWMDRMWriter);
 impl ::core::clone::Clone for IWMDRMWriter2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2310,51 +1691,7 @@ impl IWMDRMWriter3 {
         (::windows::core::Vtable::vtable(self).SetProtectStreamSamples)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pimportinitstruct)).ok()
     }
 }
-impl ::core::convert::From<IWMDRMWriter3> for ::windows::core::IUnknown {
-    fn from(value: IWMDRMWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMWriter3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDRMWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMWriter3> for ::windows::core::IUnknown {
-    fn from(value: &IWMDRMWriter3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDRMWriter3> for IWMDRMWriter {
-    fn from(value: IWMDRMWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMWriter3> for &'a IWMDRMWriter {
-    fn from(value: &'a IWMDRMWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMWriter3> for IWMDRMWriter {
-    fn from(value: &IWMDRMWriter3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMDRMWriter3> for IWMDRMWriter2 {
-    fn from(value: IWMDRMWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDRMWriter3> for &'a IWMDRMWriter2 {
-    fn from(value: &'a IWMDRMWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDRMWriter3> for IWMDRMWriter2 {
-    fn from(value: &IWMDRMWriter3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDRMWriter3, ::windows::core::IUnknown, IWMDRMWriter, IWMDRMWriter2);
 impl ::core::clone::Clone for IWMDRMWriter3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2411,21 +1748,7 @@ impl IWMDeviceRegistration {
         (::windows::core::Vtable::vtable(self).GetRegisteredDeviceByID)(::windows::core::Vtable::as_raw(self), dwregistertype, ::core::mem::transmute(pbcertificate.as_ptr()), pbcertificate.len() as _, ::core::mem::transmute(serialnumber), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMRegisteredDevice>(result__)
     }
 }
-impl ::core::convert::From<IWMDeviceRegistration> for ::windows::core::IUnknown {
-    fn from(value: IWMDeviceRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMDeviceRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMDeviceRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMDeviceRegistration> for ::windows::core::IUnknown {
-    fn from(value: &IWMDeviceRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMDeviceRegistration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMDeviceRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2468,21 +1791,7 @@ impl IWMGetSecureChannel {
         (::windows::core::Vtable::vtable(self).GetPeerSecureChannelInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMSecureChannel>(result__)
     }
 }
-impl ::core::convert::From<IWMGetSecureChannel> for ::windows::core::IUnknown {
-    fn from(value: IWMGetSecureChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMGetSecureChannel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMGetSecureChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMGetSecureChannel> for ::windows::core::IUnknown {
-    fn from(value: &IWMGetSecureChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMGetSecureChannel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMGetSecureChannel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2568,21 +1877,7 @@ impl IWMHeaderInfo {
         (::windows::core::Vtable::vtable(self).RemoveScript)(::windows::core::Vtable::as_raw(self), windex).ok()
     }
 }
-impl ::core::convert::From<IWMHeaderInfo> for ::windows::core::IUnknown {
-    fn from(value: IWMHeaderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMHeaderInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMHeaderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMHeaderInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWMHeaderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMHeaderInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMHeaderInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2686,36 +1981,7 @@ impl IWMHeaderInfo2 {
         (::windows::core::Vtable::vtable(self).GetCodecInfo)(::windows::core::Vtable::as_raw(self), windex, ::core::mem::transmute(pcchname), ::core::mem::transmute(pwszname), ::core::mem::transmute(pcchdescription), ::core::mem::transmute(pwszdescription), ::core::mem::transmute(pcodectype), ::core::mem::transmute(pcbcodecinfo), ::core::mem::transmute(pbcodecinfo)).ok()
     }
 }
-impl ::core::convert::From<IWMHeaderInfo2> for ::windows::core::IUnknown {
-    fn from(value: IWMHeaderInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMHeaderInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMHeaderInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMHeaderInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IWMHeaderInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMHeaderInfo2> for IWMHeaderInfo {
-    fn from(value: IWMHeaderInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMHeaderInfo2> for &'a IWMHeaderInfo {
-    fn from(value: &'a IWMHeaderInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMHeaderInfo2> for IWMHeaderInfo {
-    fn from(value: &IWMHeaderInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMHeaderInfo2, ::windows::core::IUnknown, IWMHeaderInfo);
 impl ::core::clone::Clone for IWMHeaderInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2841,51 +2107,7 @@ impl IWMHeaderInfo3 {
         (::windows::core::Vtable::vtable(self).AddCodecInfo)(::windows::core::Vtable::as_raw(self), pwszname.into(), pwszdescription.into(), codectype, pbcodecinfo.len() as _, ::core::mem::transmute(pbcodecinfo.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IWMHeaderInfo3> for ::windows::core::IUnknown {
-    fn from(value: IWMHeaderInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMHeaderInfo3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMHeaderInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMHeaderInfo3> for ::windows::core::IUnknown {
-    fn from(value: &IWMHeaderInfo3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMHeaderInfo3> for IWMHeaderInfo {
-    fn from(value: IWMHeaderInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMHeaderInfo3> for &'a IWMHeaderInfo {
-    fn from(value: &'a IWMHeaderInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMHeaderInfo3> for IWMHeaderInfo {
-    fn from(value: &IWMHeaderInfo3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMHeaderInfo3> for IWMHeaderInfo2 {
-    fn from(value: IWMHeaderInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMHeaderInfo3> for &'a IWMHeaderInfo2 {
-    fn from(value: &'a IWMHeaderInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMHeaderInfo3> for IWMHeaderInfo2 {
-    fn from(value: &IWMHeaderInfo3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMHeaderInfo3, ::windows::core::IUnknown, IWMHeaderInfo, IWMHeaderInfo2);
 impl ::core::clone::Clone for IWMHeaderInfo3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2931,21 +2153,7 @@ impl IWMIStreamProps {
         (::windows::core::Vtable::vtable(self).GetProperty)(::windows::core::Vtable::as_raw(self), pszname.into(), ::core::mem::transmute(ptype), ::core::mem::transmute(pvalue), ::core::mem::transmute(pdwsize)).ok()
     }
 }
-impl ::core::convert::From<IWMIStreamProps> for ::windows::core::IUnknown {
-    fn from(value: IWMIStreamProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMIStreamProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMIStreamProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMIStreamProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMIStreamProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMIStreamProps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMIStreamProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2986,21 +2194,7 @@ impl IWMImageInfo {
         (::windows::core::Vtable::vtable(self).GetImage)(::windows::core::Vtable::as_raw(self), windex, ::core::mem::transmute(pcchmimetype), ::core::mem::transmute(pwszmimetype), ::core::mem::transmute(pcchdescription), ::core::mem::transmute(pwszdescription), ::core::mem::transmute(pimagetype), ::core::mem::transmute(pcbimagedata), ::core::mem::transmute(pbimagedata)).ok()
     }
 }
-impl ::core::convert::From<IWMImageInfo> for ::windows::core::IUnknown {
-    fn from(value: IWMImageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMImageInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMImageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMImageInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWMImageInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMImageInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMImageInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3045,21 +2239,7 @@ impl IWMIndexer {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMIndexer> for ::windows::core::IUnknown {
-    fn from(value: IWMIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMIndexer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMIndexer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMIndexer> for ::windows::core::IUnknown {
-    fn from(value: &IWMIndexer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMIndexer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMIndexer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3107,36 +2287,7 @@ impl IWMIndexer2 {
         (::windows::core::Vtable::vtable(self).Configure)(::windows::core::Vtable::as_raw(self), wstreamnum, nindexertype, ::core::mem::transmute(pvinterval), ::core::mem::transmute(pvindextype)).ok()
     }
 }
-impl ::core::convert::From<IWMIndexer2> for ::windows::core::IUnknown {
-    fn from(value: IWMIndexer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMIndexer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMIndexer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMIndexer2> for ::windows::core::IUnknown {
-    fn from(value: &IWMIndexer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMIndexer2> for IWMIndexer {
-    fn from(value: IWMIndexer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMIndexer2> for &'a IWMIndexer {
-    fn from(value: &'a IWMIndexer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMIndexer2> for IWMIndexer {
-    fn from(value: &IWMIndexer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMIndexer2, ::windows::core::IUnknown, IWMIndexer);
 impl ::core::clone::Clone for IWMIndexer2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3190,36 +2341,7 @@ impl IWMInputMediaProps {
         (::windows::core::Vtable::vtable(self).GetGroupName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwszname), ::core::mem::transmute(pcchname)).ok()
     }
 }
-impl ::core::convert::From<IWMInputMediaProps> for ::windows::core::IUnknown {
-    fn from(value: IWMInputMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMInputMediaProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMInputMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMInputMediaProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMInputMediaProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMInputMediaProps> for IWMMediaProps {
-    fn from(value: IWMInputMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMInputMediaProps> for &'a IWMMediaProps {
-    fn from(value: &'a IWMInputMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMInputMediaProps> for IWMMediaProps {
-    fn from(value: &IWMInputMediaProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMInputMediaProps, ::windows::core::IUnknown, IWMMediaProps);
 impl ::core::clone::Clone for IWMInputMediaProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3268,21 +2390,7 @@ impl IWMLanguageList {
         (::windows::core::Vtable::vtable(self).AddLanguageByRFC1766String)(::windows::core::Vtable::as_raw(self), pwszlanguagestring.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u16>(result__)
     }
 }
-impl ::core::convert::From<IWMLanguageList> for ::windows::core::IUnknown {
-    fn from(value: IWMLanguageList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMLanguageList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMLanguageList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMLanguageList> for ::windows::core::IUnknown {
-    fn from(value: &IWMLanguageList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMLanguageList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMLanguageList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3327,21 +2435,7 @@ impl IWMLicenseBackup {
         (::windows::core::Vtable::vtable(self).CancelLicenseBackup)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMLicenseBackup> for ::windows::core::IUnknown {
-    fn from(value: IWMLicenseBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMLicenseBackup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMLicenseBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMLicenseBackup> for ::windows::core::IUnknown {
-    fn from(value: &IWMLicenseBackup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMLicenseBackup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMLicenseBackup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3385,21 +2479,7 @@ impl IWMLicenseRestore {
         (::windows::core::Vtable::vtable(self).CancelLicenseRestore)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMLicenseRestore> for ::windows::core::IUnknown {
-    fn from(value: IWMLicenseRestore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMLicenseRestore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMLicenseRestore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMLicenseRestore> for ::windows::core::IUnknown {
-    fn from(value: &IWMLicenseRestore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMLicenseRestore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMLicenseRestore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3440,21 +2520,7 @@ impl IWMLicenseRevocationAgent {
         (::windows::core::Vtable::vtable(self).ProcessLRB)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(psignedlrb), dwsignedlrblength, ::core::mem::transmute(psignedack), ::core::mem::transmute(pdwsignedacklength)).ok()
     }
 }
-impl ::core::convert::From<IWMLicenseRevocationAgent> for ::windows::core::IUnknown {
-    fn from(value: IWMLicenseRevocationAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMLicenseRevocationAgent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMLicenseRevocationAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMLicenseRevocationAgent> for ::windows::core::IUnknown {
-    fn from(value: &IWMLicenseRevocationAgent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMLicenseRevocationAgent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMLicenseRevocationAgent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3503,21 +2569,7 @@ impl IWMMediaProps {
         (::windows::core::Vtable::vtable(self).SetMediaType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptype)).ok()
     }
 }
-impl ::core::convert::From<IWMMediaProps> for ::windows::core::IUnknown {
-    fn from(value: IWMMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMMediaProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMMediaProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMMediaProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMMediaProps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMMediaProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3571,21 +2623,7 @@ impl IWMMetadataEditor {
         (::windows::core::Vtable::vtable(self).Flush)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMMetadataEditor> for ::windows::core::IUnknown {
-    fn from(value: IWMMetadataEditor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMMetadataEditor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMMetadataEditor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMMetadataEditor> for ::windows::core::IUnknown {
-    fn from(value: &IWMMetadataEditor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMMetadataEditor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMMetadataEditor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3639,36 +2677,7 @@ impl IWMMetadataEditor2 {
         (::windows::core::Vtable::vtable(self).OpenEx)(::windows::core::Vtable::as_raw(self), pwszfilename.into(), dwdesiredaccess, dwsharemode).ok()
     }
 }
-impl ::core::convert::From<IWMMetadataEditor2> for ::windows::core::IUnknown {
-    fn from(value: IWMMetadataEditor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMMetadataEditor2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMMetadataEditor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMMetadataEditor2> for ::windows::core::IUnknown {
-    fn from(value: &IWMMetadataEditor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMMetadataEditor2> for IWMMetadataEditor {
-    fn from(value: IWMMetadataEditor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMMetadataEditor2> for &'a IWMMetadataEditor {
-    fn from(value: &'a IWMMetadataEditor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMMetadataEditor2> for IWMMetadataEditor {
-    fn from(value: &IWMMetadataEditor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMMetadataEditor2, ::windows::core::IUnknown, IWMMetadataEditor);
 impl ::core::clone::Clone for IWMMetadataEditor2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3718,36 +2727,7 @@ impl IWMMutualExclusion {
         (::windows::core::Vtable::vtable(self).SetType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidtype)).ok()
     }
 }
-impl ::core::convert::From<IWMMutualExclusion> for ::windows::core::IUnknown {
-    fn from(value: IWMMutualExclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMMutualExclusion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMMutualExclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMMutualExclusion> for ::windows::core::IUnknown {
-    fn from(value: &IWMMutualExclusion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMMutualExclusion> for IWMStreamList {
-    fn from(value: IWMMutualExclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMMutualExclusion> for &'a IWMStreamList {
-    fn from(value: &'a IWMMutualExclusion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMMutualExclusion> for IWMStreamList {
-    fn from(value: &IWMMutualExclusion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMMutualExclusion, ::windows::core::IUnknown, IWMStreamList);
 impl ::core::clone::Clone for IWMMutualExclusion {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3835,51 +2815,7 @@ impl IWMMutualExclusion2 {
         (::windows::core::Vtable::vtable(self).RemoveStreamForRecord)(::windows::core::Vtable::as_raw(self), wrecordnumber, wstreamnumber).ok()
     }
 }
-impl ::core::convert::From<IWMMutualExclusion2> for ::windows::core::IUnknown {
-    fn from(value: IWMMutualExclusion2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMMutualExclusion2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMMutualExclusion2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMMutualExclusion2> for ::windows::core::IUnknown {
-    fn from(value: &IWMMutualExclusion2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMMutualExclusion2> for IWMStreamList {
-    fn from(value: IWMMutualExclusion2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMMutualExclusion2> for &'a IWMStreamList {
-    fn from(value: &'a IWMMutualExclusion2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMMutualExclusion2> for IWMStreamList {
-    fn from(value: &IWMMutualExclusion2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMMutualExclusion2> for IWMMutualExclusion {
-    fn from(value: IWMMutualExclusion2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMMutualExclusion2> for &'a IWMMutualExclusion {
-    fn from(value: &'a IWMMutualExclusion2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMMutualExclusion2> for IWMMutualExclusion {
-    fn from(value: &IWMMutualExclusion2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMMutualExclusion2, ::windows::core::IUnknown, IWMStreamList, IWMMutualExclusion);
 impl ::core::clone::Clone for IWMMutualExclusion2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3942,36 +2878,7 @@ impl IWMOutputMediaProps {
         (::windows::core::Vtable::vtable(self).GetConnectionName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwszname), ::core::mem::transmute(pcchname)).ok()
     }
 }
-impl ::core::convert::From<IWMOutputMediaProps> for ::windows::core::IUnknown {
-    fn from(value: IWMOutputMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMOutputMediaProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMOutputMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMOutputMediaProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMOutputMediaProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMOutputMediaProps> for IWMMediaProps {
-    fn from(value: IWMOutputMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMOutputMediaProps> for &'a IWMMediaProps {
-    fn from(value: &'a IWMOutputMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMOutputMediaProps> for IWMMediaProps {
-    fn from(value: &IWMOutputMediaProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMOutputMediaProps, ::windows::core::IUnknown, IWMMediaProps);
 impl ::core::clone::Clone for IWMOutputMediaProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4013,21 +2920,7 @@ impl IWMPacketSize {
         (::windows::core::Vtable::vtable(self).SetMaxPacketSize)(::windows::core::Vtable::as_raw(self), dwmaxpacketsize).ok()
     }
 }
-impl ::core::convert::From<IWMPacketSize> for ::windows::core::IUnknown {
-    fn from(value: IWMPacketSize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPacketSize> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPacketSize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPacketSize> for ::windows::core::IUnknown {
-    fn from(value: &IWMPacketSize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPacketSize, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPacketSize {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4076,36 +2969,7 @@ impl IWMPacketSize2 {
         (::windows::core::Vtable::vtable(self).SetMinPacketSize)(::windows::core::Vtable::as_raw(self), dwminpacketsize).ok()
     }
 }
-impl ::core::convert::From<IWMPacketSize2> for ::windows::core::IUnknown {
-    fn from(value: IWMPacketSize2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPacketSize2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPacketSize2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPacketSize2> for ::windows::core::IUnknown {
-    fn from(value: &IWMPacketSize2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMPacketSize2> for IWMPacketSize {
-    fn from(value: IWMPacketSize2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPacketSize2> for &'a IWMPacketSize {
-    fn from(value: &'a IWMPacketSize2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPacketSize2> for IWMPacketSize {
-    fn from(value: &IWMPacketSize2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPacketSize2, ::windows::core::IUnknown, IWMPacketSize);
 impl ::core::clone::Clone for IWMPacketSize2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4143,21 +3007,7 @@ impl IWMPlayerHook {
         (::windows::core::Vtable::vtable(self).PreDecode)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMPlayerHook> for ::windows::core::IUnknown {
-    fn from(value: IWMPlayerHook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPlayerHook> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPlayerHook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPlayerHook> for ::windows::core::IUnknown {
-    fn from(value: &IWMPlayerHook) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPlayerHook, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPlayerHook {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4195,21 +3045,7 @@ impl IWMPlayerTimestampHook {
         (::windows::core::Vtable::vtable(self).MapTimestamp)(::windows::core::Vtable::as_raw(self), rtin, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i64>(result__)
     }
 }
-impl ::core::convert::From<IWMPlayerTimestampHook> for ::windows::core::IUnknown {
-    fn from(value: IWMPlayerTimestampHook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPlayerTimestampHook> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPlayerTimestampHook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPlayerTimestampHook> for ::windows::core::IUnknown {
-    fn from(value: &IWMPlayerTimestampHook) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPlayerTimestampHook, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPlayerTimestampHook {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4326,21 +3162,7 @@ impl IWMProfile {
         (::windows::core::Vtable::vtable(self).CreateNewMutualExclusion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMMutualExclusion>(result__)
     }
 }
-impl ::core::convert::From<IWMProfile> for ::windows::core::IUnknown {
-    fn from(value: IWMProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMProfile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMProfile> for ::windows::core::IUnknown {
-    fn from(value: &IWMProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMProfile, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMProfile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4478,36 +3300,7 @@ impl IWMProfile2 {
         (::windows::core::Vtable::vtable(self).GetProfileID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IWMProfile2> for ::windows::core::IUnknown {
-    fn from(value: IWMProfile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMProfile2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMProfile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMProfile2> for ::windows::core::IUnknown {
-    fn from(value: &IWMProfile2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMProfile2> for IWMProfile {
-    fn from(value: IWMProfile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMProfile2> for &'a IWMProfile {
-    fn from(value: &'a IWMProfile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMProfile2> for IWMProfile {
-    fn from(value: &IWMProfile2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMProfile2, ::windows::core::IUnknown, IWMProfile);
 impl ::core::clone::Clone for IWMProfile2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4680,51 +3473,7 @@ impl IWMProfile3 {
         (::windows::core::Vtable::vtable(self).GetExpectedPacketCount)(::windows::core::Vtable::as_raw(self), msduration, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IWMProfile3> for ::windows::core::IUnknown {
-    fn from(value: IWMProfile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMProfile3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMProfile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMProfile3> for ::windows::core::IUnknown {
-    fn from(value: &IWMProfile3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMProfile3> for IWMProfile {
-    fn from(value: IWMProfile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMProfile3> for &'a IWMProfile {
-    fn from(value: &'a IWMProfile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMProfile3> for IWMProfile {
-    fn from(value: &IWMProfile3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMProfile3> for IWMProfile2 {
-    fn from(value: IWMProfile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMProfile3> for &'a IWMProfile2 {
-    fn from(value: &'a IWMProfile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMProfile3> for IWMProfile2 {
-    fn from(value: &IWMProfile3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMProfile3, ::windows::core::IUnknown, IWMProfile, IWMProfile2);
 impl ::core::clone::Clone for IWMProfile3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4799,21 +3548,7 @@ impl IWMProfileManager {
         (::windows::core::Vtable::vtable(self).LoadSystemProfile)(::windows::core::Vtable::as_raw(self), dwprofileindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMProfile>(result__)
     }
 }
-impl ::core::convert::From<IWMProfileManager> for ::windows::core::IUnknown {
-    fn from(value: IWMProfileManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMProfileManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMProfileManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMProfileManager> for ::windows::core::IUnknown {
-    fn from(value: &IWMProfileManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMProfileManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMProfileManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4888,36 +3623,7 @@ impl IWMProfileManager2 {
         (::windows::core::Vtable::vtable(self).SetSystemProfileVersion)(::windows::core::Vtable::as_raw(self), dwversion).ok()
     }
 }
-impl ::core::convert::From<IWMProfileManager2> for ::windows::core::IUnknown {
-    fn from(value: IWMProfileManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMProfileManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMProfileManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMProfileManager2> for ::windows::core::IUnknown {
-    fn from(value: &IWMProfileManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMProfileManager2> for IWMProfileManager {
-    fn from(value: IWMProfileManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMProfileManager2> for &'a IWMProfileManager {
-    fn from(value: &'a IWMProfileManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMProfileManager2> for IWMProfileManager {
-    fn from(value: &IWMProfileManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMProfileManager2, ::windows::core::IUnknown, IWMProfileManager);
 impl ::core::clone::Clone for IWMProfileManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4958,21 +3664,7 @@ impl IWMProfileManagerLanguage {
         (::windows::core::Vtable::vtable(self).SetUserLanguageID)(::windows::core::Vtable::as_raw(self), wlangid).ok()
     }
 }
-impl ::core::convert::From<IWMProfileManagerLanguage> for ::windows::core::IUnknown {
-    fn from(value: IWMProfileManagerLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMProfileManagerLanguage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMProfileManagerLanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMProfileManagerLanguage> for ::windows::core::IUnknown {
-    fn from(value: &IWMProfileManagerLanguage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMProfileManagerLanguage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMProfileManagerLanguage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5034,21 +3726,7 @@ impl IWMPropertyVault {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMPropertyVault> for ::windows::core::IUnknown {
-    fn from(value: IWMPropertyVault) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMPropertyVault> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMPropertyVault) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMPropertyVault> for ::windows::core::IUnknown {
-    fn from(value: &IWMPropertyVault) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMPropertyVault, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMPropertyVault {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5093,21 +3771,7 @@ impl IWMProximityDetection {
         (::windows::core::Vtable::vtable(self).StartDetection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbregistrationmsg.as_ptr()), pbregistrationmsg.len() as _, ::core::mem::transmute(pblocaladdress.as_ptr()), pblocaladdress.len() as _, dwextraportsallowed, ::core::mem::transmute(ppregistrationresponsemsg), pcallback.into().abi(), ::core::mem::transmute(pvcontext)).ok()
     }
 }
-impl ::core::convert::From<IWMProximityDetection> for ::windows::core::IUnknown {
-    fn from(value: IWMProximityDetection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMProximityDetection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMProximityDetection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMProximityDetection> for ::windows::core::IUnknown {
-    fn from(value: &IWMProximityDetection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMProximityDetection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMProximityDetection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5185,21 +3849,7 @@ impl IWMReader {
         (::windows::core::Vtable::vtable(self).Resume)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMReader> for ::windows::core::IUnknown {
-    fn from(value: IWMReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReader> for ::windows::core::IUnknown {
-    fn from(value: &IWMReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5251,21 +3901,7 @@ impl IWMReaderAccelerator {
         (::windows::core::Vtable::vtable(self).Notify)(::windows::core::Vtable::as_raw(self), dwoutputnum, ::core::mem::transmute(psubtype)).ok()
     }
 }
-impl ::core::convert::From<IWMReaderAccelerator> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderAccelerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAccelerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderAccelerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAccelerator> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderAccelerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderAccelerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMReaderAccelerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5416,21 +4052,7 @@ impl IWMReaderAdvanced {
         (::windows::core::Vtable::vtable(self).NotifyLateDelivery)(::windows::core::Vtable::as_raw(self), cnslateness).ok()
     }
 }
-impl ::core::convert::From<IWMReaderAdvanced> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderAdvanced) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderAdvanced) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderAdvanced) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderAdvanced, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMReaderAdvanced {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5705,36 +4327,7 @@ impl IWMReaderAdvanced2 {
         (::windows::core::Vtable::vtable(self).OpenStream)(::windows::core::Vtable::as_raw(self), pstream.into().abi(), pcallback.into().abi(), ::core::mem::transmute(pvcontext)).ok()
     }
 }
-impl ::core::convert::From<IWMReaderAdvanced2> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderAdvanced2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderAdvanced2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced2> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderAdvanced2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced2> for IWMReaderAdvanced {
-    fn from(value: IWMReaderAdvanced2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced2> for &'a IWMReaderAdvanced {
-    fn from(value: &'a IWMReaderAdvanced2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced2> for IWMReaderAdvanced {
-    fn from(value: &IWMReaderAdvanced2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderAdvanced2, ::windows::core::IUnknown, IWMReaderAdvanced);
 impl ::core::clone::Clone for IWMReaderAdvanced2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5980,51 +4573,7 @@ impl IWMReaderAdvanced3 {
         (::windows::core::Vtable::vtable(self).StartAtPosition)(::windows::core::Vtable::as_raw(self), wstreamnum, ::core::mem::transmute(pvoffsetstart), ::core::mem::transmute(pvduration), dwoffsetformat, frate, ::core::mem::transmute(pvcontext)).ok()
     }
 }
-impl ::core::convert::From<IWMReaderAdvanced3> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced3> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderAdvanced3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced3> for IWMReaderAdvanced {
-    fn from(value: IWMReaderAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced3> for &'a IWMReaderAdvanced {
-    fn from(value: &'a IWMReaderAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced3> for IWMReaderAdvanced {
-    fn from(value: &IWMReaderAdvanced3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced3> for IWMReaderAdvanced2 {
-    fn from(value: IWMReaderAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced3> for &'a IWMReaderAdvanced2 {
-    fn from(value: &'a IWMReaderAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced3> for IWMReaderAdvanced2 {
-    fn from(value: &IWMReaderAdvanced3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderAdvanced3, ::windows::core::IUnknown, IWMReaderAdvanced, IWMReaderAdvanced2);
 impl ::core::clone::Clone for IWMReaderAdvanced3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6288,66 +4837,7 @@ impl IWMReaderAdvanced4 {
         (::windows::core::Vtable::vtable(self).GetURL)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwszurl), ::core::mem::transmute(pcchurl)).ok()
     }
 }
-impl ::core::convert::From<IWMReaderAdvanced4> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderAdvanced4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderAdvanced4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced4> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderAdvanced4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced4> for IWMReaderAdvanced {
-    fn from(value: IWMReaderAdvanced4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced4> for &'a IWMReaderAdvanced {
-    fn from(value: &'a IWMReaderAdvanced4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced4> for IWMReaderAdvanced {
-    fn from(value: &IWMReaderAdvanced4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced4> for IWMReaderAdvanced2 {
-    fn from(value: IWMReaderAdvanced4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced4> for &'a IWMReaderAdvanced2 {
-    fn from(value: &'a IWMReaderAdvanced4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced4> for IWMReaderAdvanced2 {
-    fn from(value: &IWMReaderAdvanced4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced4> for IWMReaderAdvanced3 {
-    fn from(value: IWMReaderAdvanced4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced4> for &'a IWMReaderAdvanced3 {
-    fn from(value: &'a IWMReaderAdvanced4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced4> for IWMReaderAdvanced3 {
-    fn from(value: &IWMReaderAdvanced4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderAdvanced4, ::windows::core::IUnknown, IWMReaderAdvanced, IWMReaderAdvanced2, IWMReaderAdvanced3);
 impl ::core::clone::Clone for IWMReaderAdvanced4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6630,81 +5120,7 @@ impl IWMReaderAdvanced5 {
         (::windows::core::Vtable::vtable(self).SetPlayerHook)(::windows::core::Vtable::as_raw(self), dwoutputnum, phook.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWMReaderAdvanced5> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderAdvanced5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderAdvanced5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced5> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderAdvanced5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced5> for IWMReaderAdvanced {
-    fn from(value: IWMReaderAdvanced5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced5> for &'a IWMReaderAdvanced {
-    fn from(value: &'a IWMReaderAdvanced5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced5> for IWMReaderAdvanced {
-    fn from(value: &IWMReaderAdvanced5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced5> for IWMReaderAdvanced2 {
-    fn from(value: IWMReaderAdvanced5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced5> for &'a IWMReaderAdvanced2 {
-    fn from(value: &'a IWMReaderAdvanced5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced5> for IWMReaderAdvanced2 {
-    fn from(value: &IWMReaderAdvanced5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced5> for IWMReaderAdvanced3 {
-    fn from(value: IWMReaderAdvanced5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced5> for &'a IWMReaderAdvanced3 {
-    fn from(value: &'a IWMReaderAdvanced5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced5> for IWMReaderAdvanced3 {
-    fn from(value: &IWMReaderAdvanced5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced5> for IWMReaderAdvanced4 {
-    fn from(value: IWMReaderAdvanced5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced5> for &'a IWMReaderAdvanced4 {
-    fn from(value: &'a IWMReaderAdvanced5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced5> for IWMReaderAdvanced4 {
-    fn from(value: &IWMReaderAdvanced5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderAdvanced5, ::windows::core::IUnknown, IWMReaderAdvanced, IWMReaderAdvanced2, IWMReaderAdvanced3, IWMReaderAdvanced4);
 impl ::core::clone::Clone for IWMReaderAdvanced5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6976,96 +5392,7 @@ impl IWMReaderAdvanced6 {
         (::windows::core::Vtable::vtable(self).SetProtectStreamSamples)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbcertificate.as_ptr()), pbcertificate.len() as _, dwcertificatetype, dwflags, ::core::mem::transmute(pbinitializationvector), ::core::mem::transmute(pcbinitializationvector)).ok()
     }
 }
-impl ::core::convert::From<IWMReaderAdvanced6> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced6> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderAdvanced6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced6> for IWMReaderAdvanced {
-    fn from(value: IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced6> for &'a IWMReaderAdvanced {
-    fn from(value: &'a IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced6> for IWMReaderAdvanced {
-    fn from(value: &IWMReaderAdvanced6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced6> for IWMReaderAdvanced2 {
-    fn from(value: IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced6> for &'a IWMReaderAdvanced2 {
-    fn from(value: &'a IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced6> for IWMReaderAdvanced2 {
-    fn from(value: &IWMReaderAdvanced6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced6> for IWMReaderAdvanced3 {
-    fn from(value: IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced6> for &'a IWMReaderAdvanced3 {
-    fn from(value: &'a IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced6> for IWMReaderAdvanced3 {
-    fn from(value: &IWMReaderAdvanced6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced6> for IWMReaderAdvanced4 {
-    fn from(value: IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced6> for &'a IWMReaderAdvanced4 {
-    fn from(value: &'a IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced6> for IWMReaderAdvanced4 {
-    fn from(value: &IWMReaderAdvanced6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderAdvanced6> for IWMReaderAdvanced5 {
-    fn from(value: IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAdvanced6> for &'a IWMReaderAdvanced5 {
-    fn from(value: &'a IWMReaderAdvanced6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAdvanced6> for IWMReaderAdvanced5 {
-    fn from(value: &IWMReaderAdvanced6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderAdvanced6, ::windows::core::IUnknown, IWMReaderAdvanced, IWMReaderAdvanced2, IWMReaderAdvanced3, IWMReaderAdvanced4, IWMReaderAdvanced5);
 impl ::core::clone::Clone for IWMReaderAdvanced6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7105,21 +5432,7 @@ impl IWMReaderAllocatorEx {
         (::windows::core::Vtable::vtable(self).AllocateForOutputEx)(::windows::core::Vtable::as_raw(self), dwoutputnum, cbbuffer, ::core::mem::transmute(ppbuffer), dwflags, cnssampletime, cnssampleduration, ::core::mem::transmute(pvcontext)).ok()
     }
 }
-impl ::core::convert::From<IWMReaderAllocatorEx> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderAllocatorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderAllocatorEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderAllocatorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderAllocatorEx> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderAllocatorEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderAllocatorEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMReaderAllocatorEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7163,36 +5476,7 @@ impl IWMReaderCallback {
         (::windows::core::Vtable::vtable(self).OnSample)(::windows::core::Vtable::as_raw(self), dwoutputnum, cnssampletime, cnssampleduration, dwflags, psample.into().abi(), ::core::mem::transmute(pvcontext)).ok()
     }
 }
-impl ::core::convert::From<IWMReaderCallback> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderCallback> for IWMStatusCallback {
-    fn from(value: IWMReaderCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderCallback> for &'a IWMStatusCallback {
-    fn from(value: &'a IWMReaderCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderCallback> for IWMStatusCallback {
-    fn from(value: &IWMReaderCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderCallback, ::windows::core::IUnknown, IWMStatusCallback);
 impl ::core::clone::Clone for IWMReaderCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7249,21 +5533,7 @@ impl IWMReaderCallbackAdvanced {
         (::windows::core::Vtable::vtable(self).AllocateForOutput)(::windows::core::Vtable::as_raw(self), dwoutputnum, cbbuffer, ::core::mem::transmute(ppbuffer), ::core::mem::transmute(pvcontext)).ok()
     }
 }
-impl ::core::convert::From<IWMReaderCallbackAdvanced> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderCallbackAdvanced) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderCallbackAdvanced> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderCallbackAdvanced) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderCallbackAdvanced> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderCallbackAdvanced) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderCallbackAdvanced, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMReaderCallbackAdvanced {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7491,21 +5761,7 @@ impl IWMReaderNetworkConfig {
         (::windows::core::Vtable::vtable(self).ResetLoggingUrlList)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMReaderNetworkConfig> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderNetworkConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderNetworkConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderNetworkConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderNetworkConfig> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderNetworkConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderNetworkConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMReaderNetworkConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7867,36 +6123,7 @@ impl IWMReaderNetworkConfig2 {
         (::windows::core::Vtable::vtable(self).GetMaxNetPacketSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IWMReaderNetworkConfig2> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderNetworkConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderNetworkConfig2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderNetworkConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderNetworkConfig2> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderNetworkConfig2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMReaderNetworkConfig2> for IWMReaderNetworkConfig {
-    fn from(value: IWMReaderNetworkConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderNetworkConfig2> for &'a IWMReaderNetworkConfig {
-    fn from(value: &'a IWMReaderNetworkConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderNetworkConfig2> for IWMReaderNetworkConfig {
-    fn from(value: &IWMReaderNetworkConfig2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderNetworkConfig2, ::windows::core::IUnknown, IWMReaderNetworkConfig);
 impl ::core::clone::Clone for IWMReaderNetworkConfig2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7982,21 +6209,7 @@ impl IWMReaderPlaylistBurn {
         (::windows::core::Vtable::vtable(self).EndPlaylistBurn)(::windows::core::Vtable::as_raw(self), hrburnresult).ok()
     }
 }
-impl ::core::convert::From<IWMReaderPlaylistBurn> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderPlaylistBurn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderPlaylistBurn> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderPlaylistBurn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderPlaylistBurn> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderPlaylistBurn) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderPlaylistBurn, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMReaderPlaylistBurn {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8043,21 +6256,7 @@ impl IWMReaderStreamClock {
         (::windows::core::Vtable::vtable(self).KillTimer)(::windows::core::Vtable::as_raw(self), dwtimerid).ok()
     }
 }
-impl ::core::convert::From<IWMReaderStreamClock> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderStreamClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderStreamClock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderStreamClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderStreamClock> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderStreamClock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderStreamClock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMReaderStreamClock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8100,21 +6299,7 @@ impl IWMReaderTimecode {
         (::windows::core::Vtable::vtable(self).GetTimecodeRangeBounds)(::windows::core::Vtable::as_raw(self), wstreamnum, wrangenum, ::core::mem::transmute(pstarttimecode), ::core::mem::transmute(pendtimecode)).ok()
     }
 }
-impl ::core::convert::From<IWMReaderTimecode> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderTimecode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderTimecode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderTimecode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderTimecode> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderTimecode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderTimecode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMReaderTimecode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8155,21 +6340,7 @@ impl IWMReaderTypeNegotiation {
         (::windows::core::Vtable::vtable(self).TryOutputProps)(::windows::core::Vtable::as_raw(self), dwoutputnum, poutput.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWMReaderTypeNegotiation> for ::windows::core::IUnknown {
-    fn from(value: IWMReaderTypeNegotiation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMReaderTypeNegotiation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMReaderTypeNegotiation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMReaderTypeNegotiation> for ::windows::core::IUnknown {
-    fn from(value: &IWMReaderTypeNegotiation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMReaderTypeNegotiation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMReaderTypeNegotiation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8215,21 +6386,7 @@ impl IWMRegisterCallback {
         (::windows::core::Vtable::vtable(self).Unadvise)(::windows::core::Vtable::as_raw(self), pcallback.into().abi(), ::core::mem::transmute(pvcontext)).ok()
     }
 }
-impl ::core::convert::From<IWMRegisterCallback> for ::windows::core::IUnknown {
-    fn from(value: IWMRegisterCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMRegisterCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMRegisterCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMRegisterCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWMRegisterCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMRegisterCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMRegisterCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8328,21 +6485,7 @@ impl IWMRegisteredDevice {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMRegisteredDevice> for ::windows::core::IUnknown {
-    fn from(value: IWMRegisteredDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMRegisteredDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMRegisteredDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMRegisteredDevice> for ::windows::core::IUnknown {
-    fn from(value: &IWMRegisteredDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMRegisteredDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMRegisteredDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8412,21 +6555,7 @@ impl IWMSBufferAllocator {
         (::windows::core::Vtable::vtable(self).AllocatePageSizeBuffer)(::windows::core::Vtable::as_raw(self), dwmaxbuffersize, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<INSSBuffer>(result__)
     }
 }
-impl ::core::convert::From<IWMSBufferAllocator> for ::windows::core::IUnknown {
-    fn from(value: IWMSBufferAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMSBufferAllocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMSBufferAllocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMSBufferAllocator> for ::windows::core::IUnknown {
-    fn from(value: &IWMSBufferAllocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMSBufferAllocator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMSBufferAllocator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8517,21 +6646,7 @@ impl IWMSInternalAdminNetSource {
         (::windows::core::Vtable::vtable(self).IsUsingIE)(::windows::core::Vtable::as_raw(self), dwproxycontext, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWMSInternalAdminNetSource> for ::windows::core::IUnknown {
-    fn from(value: IWMSInternalAdminNetSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMSInternalAdminNetSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMSInternalAdminNetSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMSInternalAdminNetSource> for ::windows::core::IUnknown {
-    fn from(value: &IWMSInternalAdminNetSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMSInternalAdminNetSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMSInternalAdminNetSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8621,21 +6736,7 @@ impl IWMSInternalAdminNetSource2 {
         (::windows::core::Vtable::vtable(self).FindProxyForURLEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrprotocol), ::core::mem::transmute_copy(bstrhost), ::core::mem::transmute_copy(bstrurl), ::core::mem::transmute(pfproxyenabled), ::core::mem::transmute(pbstrproxyserver), ::core::mem::transmute(pdwproxyport), ::core::mem::transmute(pdwproxycontext)).ok()
     }
 }
-impl ::core::convert::From<IWMSInternalAdminNetSource2> for ::windows::core::IUnknown {
-    fn from(value: IWMSInternalAdminNetSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMSInternalAdminNetSource2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMSInternalAdminNetSource2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMSInternalAdminNetSource2> for ::windows::core::IUnknown {
-    fn from(value: &IWMSInternalAdminNetSource2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMSInternalAdminNetSource2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMSInternalAdminNetSource2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8756,36 +6857,7 @@ impl IWMSInternalAdminNetSource3 {
         (::windows::core::Vtable::vtable(self).GetCredentialsEx2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrrealm), ::core::mem::transmute_copy(bstrurl), fproxy.into(), fcleartextauthentication.into(), ::core::mem::transmute(pdwurlpolicy), ::core::mem::transmute(pbstrname), ::core::mem::transmute(pbstrpassword), ::core::mem::transmute(pfconfirmedgood)).ok()
     }
 }
-impl ::core::convert::From<IWMSInternalAdminNetSource3> for ::windows::core::IUnknown {
-    fn from(value: IWMSInternalAdminNetSource3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMSInternalAdminNetSource3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMSInternalAdminNetSource3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMSInternalAdminNetSource3> for ::windows::core::IUnknown {
-    fn from(value: &IWMSInternalAdminNetSource3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMSInternalAdminNetSource3> for IWMSInternalAdminNetSource2 {
-    fn from(value: IWMSInternalAdminNetSource3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMSInternalAdminNetSource3> for &'a IWMSInternalAdminNetSource2 {
-    fn from(value: &'a IWMSInternalAdminNetSource3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMSInternalAdminNetSource3> for IWMSInternalAdminNetSource2 {
-    fn from(value: &IWMSInternalAdminNetSource3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMSInternalAdminNetSource3, ::windows::core::IUnknown, IWMSInternalAdminNetSource2);
 impl ::core::clone::Clone for IWMSInternalAdminNetSource3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8891,36 +6963,7 @@ impl IWMSecureChannel {
         (::windows::core::Vtable::vtable(self).WMSC_SetSharedData)(::windows::core::Vtable::as_raw(self), dwcertindex, ::core::mem::transmute(pbshareddata)).ok()
     }
 }
-impl ::core::convert::From<IWMSecureChannel> for ::windows::core::IUnknown {
-    fn from(value: IWMSecureChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMSecureChannel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMSecureChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMSecureChannel> for ::windows::core::IUnknown {
-    fn from(value: &IWMSecureChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMSecureChannel> for IWMAuthorizer {
-    fn from(value: IWMSecureChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMSecureChannel> for &'a IWMAuthorizer {
-    fn from(value: &'a IWMSecureChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMSecureChannel> for IWMAuthorizer {
-    fn from(value: &IWMSecureChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMSecureChannel, ::windows::core::IUnknown, IWMAuthorizer);
 impl ::core::clone::Clone for IWMSecureChannel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8970,21 +7013,7 @@ impl IWMStatusCallback {
         (::windows::core::Vtable::vtable(self).OnStatus)(::windows::core::Vtable::as_raw(self), status, hr, dwtype, ::core::mem::transmute(pvalue), ::core::mem::transmute(pvcontext)).ok()
     }
 }
-impl ::core::convert::From<IWMStatusCallback> for ::windows::core::IUnknown {
-    fn from(value: IWMStatusCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMStatusCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMStatusCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMStatusCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWMStatusCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMStatusCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMStatusCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9061,21 +7090,7 @@ impl IWMStreamConfig {
         (::windows::core::Vtable::vtable(self).SetBufferWindow)(::windows::core::Vtable::as_raw(self), msbufferwindow).ok()
     }
 }
-impl ::core::convert::From<IWMStreamConfig> for ::windows::core::IUnknown {
-    fn from(value: IWMStreamConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMStreamConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMStreamConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMStreamConfig> for ::windows::core::IUnknown {
-    fn from(value: &IWMStreamConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMStreamConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMStreamConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9182,36 +7197,7 @@ impl IWMStreamConfig2 {
         (::windows::core::Vtable::vtable(self).RemoveAllDataUnitExtensions)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMStreamConfig2> for ::windows::core::IUnknown {
-    fn from(value: IWMStreamConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMStreamConfig2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMStreamConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMStreamConfig2> for ::windows::core::IUnknown {
-    fn from(value: &IWMStreamConfig2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMStreamConfig2> for IWMStreamConfig {
-    fn from(value: IWMStreamConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMStreamConfig2> for &'a IWMStreamConfig {
-    fn from(value: &'a IWMStreamConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMStreamConfig2> for IWMStreamConfig {
-    fn from(value: &IWMStreamConfig2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMStreamConfig2, ::windows::core::IUnknown, IWMStreamConfig);
 impl ::core::clone::Clone for IWMStreamConfig2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9322,51 +7308,7 @@ impl IWMStreamConfig3 {
         (::windows::core::Vtable::vtable(self).SetLanguage)(::windows::core::Vtable::as_raw(self), pwszlanguagestring.into()).ok()
     }
 }
-impl ::core::convert::From<IWMStreamConfig3> for ::windows::core::IUnknown {
-    fn from(value: IWMStreamConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMStreamConfig3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMStreamConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMStreamConfig3> for ::windows::core::IUnknown {
-    fn from(value: &IWMStreamConfig3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMStreamConfig3> for IWMStreamConfig {
-    fn from(value: IWMStreamConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMStreamConfig3> for &'a IWMStreamConfig {
-    fn from(value: &'a IWMStreamConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMStreamConfig3> for IWMStreamConfig {
-    fn from(value: &IWMStreamConfig3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMStreamConfig3> for IWMStreamConfig2 {
-    fn from(value: IWMStreamConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMStreamConfig3> for &'a IWMStreamConfig2 {
-    fn from(value: &'a IWMStreamConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMStreamConfig3> for IWMStreamConfig2 {
-    fn from(value: &IWMStreamConfig3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMStreamConfig3, ::windows::core::IUnknown, IWMStreamConfig, IWMStreamConfig2);
 impl ::core::clone::Clone for IWMStreamConfig3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9410,21 +7352,7 @@ impl IWMStreamList {
         (::windows::core::Vtable::vtable(self).RemoveStream)(::windows::core::Vtable::as_raw(self), wstreamnum).ok()
     }
 }
-impl ::core::convert::From<IWMStreamList> for ::windows::core::IUnknown {
-    fn from(value: IWMStreamList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMStreamList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMStreamList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMStreamList> for ::windows::core::IUnknown {
-    fn from(value: &IWMStreamList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMStreamList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMStreamList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9470,21 +7398,7 @@ impl IWMStreamPrioritization {
         (::windows::core::Vtable::vtable(self).SetPriorityRecords)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(precordarray), crecords).ok()
     }
 }
-impl ::core::convert::From<IWMStreamPrioritization> for ::windows::core::IUnknown {
-    fn from(value: IWMStreamPrioritization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMStreamPrioritization> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMStreamPrioritization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMStreamPrioritization> for ::windows::core::IUnknown {
-    fn from(value: &IWMStreamPrioritization) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMStreamPrioritization, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMStreamPrioritization {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9622,21 +7536,7 @@ impl IWMSyncReader {
         (::windows::core::Vtable::vtable(self).OpenStream)(::windows::core::Vtable::as_raw(self), pstream.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWMSyncReader> for ::windows::core::IUnknown {
-    fn from(value: IWMSyncReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMSyncReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMSyncReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMSyncReader> for ::windows::core::IUnknown {
-    fn from(value: &IWMSyncReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMSyncReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMSyncReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9823,36 +7723,7 @@ impl IWMSyncReader2 {
         (::windows::core::Vtable::vtable(self).GetAllocateForStream)(::windows::core::Vtable::as_raw(self), dwsreamnum, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWMReaderAllocatorEx>(result__)
     }
 }
-impl ::core::convert::From<IWMSyncReader2> for ::windows::core::IUnknown {
-    fn from(value: IWMSyncReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMSyncReader2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMSyncReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMSyncReader2> for ::windows::core::IUnknown {
-    fn from(value: &IWMSyncReader2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMSyncReader2> for IWMSyncReader {
-    fn from(value: IWMSyncReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMSyncReader2> for &'a IWMSyncReader {
-    fn from(value: &'a IWMSyncReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMSyncReader2> for IWMSyncReader {
-    fn from(value: &IWMSyncReader2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMSyncReader2, ::windows::core::IUnknown, IWMSyncReader);
 impl ::core::clone::Clone for IWMSyncReader2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9919,36 +7790,7 @@ impl IWMVideoMediaProps {
         (::windows::core::Vtable::vtable(self).SetQuality)(::windows::core::Vtable::as_raw(self), dwquality).ok()
     }
 }
-impl ::core::convert::From<IWMVideoMediaProps> for ::windows::core::IUnknown {
-    fn from(value: IWMVideoMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMVideoMediaProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMVideoMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMVideoMediaProps> for ::windows::core::IUnknown {
-    fn from(value: &IWMVideoMediaProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMVideoMediaProps> for IWMMediaProps {
-    fn from(value: IWMVideoMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMVideoMediaProps> for &'a IWMMediaProps {
-    fn from(value: &'a IWMVideoMediaProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMVideoMediaProps> for IWMMediaProps {
-    fn from(value: &IWMVideoMediaProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMVideoMediaProps, ::windows::core::IUnknown, IWMMediaProps);
 impl ::core::clone::Clone for IWMVideoMediaProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9993,21 +7835,7 @@ impl IWMWatermarkInfo {
         (::windows::core::Vtable::vtable(self).GetWatermarkEntry)(::windows::core::Vtable::as_raw(self), wmettype, dwentrynum, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WMT_WATERMARK_ENTRY>(result__)
     }
 }
-impl ::core::convert::From<IWMWatermarkInfo> for ::windows::core::IUnknown {
-    fn from(value: IWMWatermarkInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWatermarkInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWatermarkInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWatermarkInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWMWatermarkInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWatermarkInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMWatermarkInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10098,21 +7926,7 @@ impl IWMWriter {
         (::windows::core::Vtable::vtable(self).Flush)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMWriter> for ::windows::core::IUnknown {
-    fn from(value: IWMWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriter> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10213,21 +8027,7 @@ impl IWMWriterAdvanced {
         (::windows::core::Vtable::vtable(self).GetSyncTolerance)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IWMWriterAdvanced> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterAdvanced) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterAdvanced> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterAdvanced) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterAdvanced> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterAdvanced) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterAdvanced, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMWriterAdvanced {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10344,36 +8144,7 @@ impl IWMWriterAdvanced2 {
         (::windows::core::Vtable::vtable(self).SetInputSetting)(::windows::core::Vtable::as_raw(self), dwinputnum, pszname.into(), r#type, ::core::mem::transmute(pvalue.as_ptr()), pvalue.len() as _).ok()
     }
 }
-impl ::core::convert::From<IWMWriterAdvanced2> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterAdvanced2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterAdvanced2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterAdvanced2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterAdvanced2> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterAdvanced2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterAdvanced2> for IWMWriterAdvanced {
-    fn from(value: IWMWriterAdvanced2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterAdvanced2> for &'a IWMWriterAdvanced {
-    fn from(value: &'a IWMWriterAdvanced2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterAdvanced2> for IWMWriterAdvanced {
-    fn from(value: &IWMWriterAdvanced2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterAdvanced2, ::windows::core::IUnknown, IWMWriterAdvanced);
 impl ::core::clone::Clone for IWMWriterAdvanced2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10482,51 +8253,7 @@ impl IWMWriterAdvanced3 {
         (::windows::core::Vtable::vtable(self).SetNonBlocking)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMWriterAdvanced3> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterAdvanced3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterAdvanced3> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterAdvanced3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterAdvanced3> for IWMWriterAdvanced {
-    fn from(value: IWMWriterAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterAdvanced3> for &'a IWMWriterAdvanced {
-    fn from(value: &'a IWMWriterAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterAdvanced3> for IWMWriterAdvanced {
-    fn from(value: &IWMWriterAdvanced3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterAdvanced3> for IWMWriterAdvanced2 {
-    fn from(value: IWMWriterAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterAdvanced3> for &'a IWMWriterAdvanced2 {
-    fn from(value: &'a IWMWriterAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterAdvanced3> for IWMWriterAdvanced2 {
-    fn from(value: &IWMWriterAdvanced3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterAdvanced3, ::windows::core::IUnknown, IWMWriterAdvanced, IWMWriterAdvanced2);
 impl ::core::clone::Clone for IWMWriterAdvanced3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10592,36 +8319,7 @@ impl IWMWriterFileSink {
         (::windows::core::Vtable::vtable(self).Open)(::windows::core::Vtable::as_raw(self), pwszfilename.into()).ok()
     }
 }
-impl ::core::convert::From<IWMWriterFileSink> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterFileSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterFileSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterFileSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterFileSink> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterFileSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterFileSink> for IWMWriterSink {
-    fn from(value: IWMWriterFileSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterFileSink> for &'a IWMWriterSink {
-    fn from(value: &'a IWMWriterFileSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterFileSink> for IWMWriterSink {
-    fn from(value: &IWMWriterFileSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterFileSink, ::windows::core::IUnknown, IWMWriterSink);
 impl ::core::clone::Clone for IWMWriterFileSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10715,51 +8413,7 @@ impl IWMWriterFileSink2 {
         (::windows::core::Vtable::vtable(self).IsClosed)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWMWriterFileSink2> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterFileSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterFileSink2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterFileSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterFileSink2> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterFileSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterFileSink2> for IWMWriterSink {
-    fn from(value: IWMWriterFileSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterFileSink2> for &'a IWMWriterSink {
-    fn from(value: &'a IWMWriterFileSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterFileSink2> for IWMWriterSink {
-    fn from(value: &IWMWriterFileSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterFileSink2> for IWMWriterFileSink {
-    fn from(value: IWMWriterFileSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterFileSink2> for &'a IWMWriterFileSink {
-    fn from(value: &'a IWMWriterFileSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterFileSink2> for IWMWriterFileSink {
-    fn from(value: &IWMWriterFileSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterFileSink2, ::windows::core::IUnknown, IWMWriterSink, IWMWriterFileSink);
 impl ::core::clone::Clone for IWMWriterFileSink2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10912,66 +8566,7 @@ impl IWMWriterFileSink3 {
         (::windows::core::Vtable::vtable(self).CompleteOperations)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMWriterFileSink3> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterFileSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterFileSink3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterFileSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterFileSink3> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterFileSink3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterFileSink3> for IWMWriterSink {
-    fn from(value: IWMWriterFileSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterFileSink3> for &'a IWMWriterSink {
-    fn from(value: &'a IWMWriterFileSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterFileSink3> for IWMWriterSink {
-    fn from(value: &IWMWriterFileSink3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterFileSink3> for IWMWriterFileSink {
-    fn from(value: IWMWriterFileSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterFileSink3> for &'a IWMWriterFileSink {
-    fn from(value: &'a IWMWriterFileSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterFileSink3> for IWMWriterFileSink {
-    fn from(value: &IWMWriterFileSink3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterFileSink3> for IWMWriterFileSink2 {
-    fn from(value: IWMWriterFileSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterFileSink3> for &'a IWMWriterFileSink2 {
-    fn from(value: &'a IWMWriterFileSink3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterFileSink3> for IWMWriterFileSink2 {
-    fn from(value: &IWMWriterFileSink3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterFileSink3, ::windows::core::IUnknown, IWMWriterSink, IWMWriterFileSink, IWMWriterFileSink2);
 impl ::core::clone::Clone for IWMWriterFileSink3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11078,36 +8673,7 @@ impl IWMWriterNetworkSink {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMWriterNetworkSink> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterNetworkSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterNetworkSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterNetworkSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterNetworkSink> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterNetworkSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterNetworkSink> for IWMWriterSink {
-    fn from(value: IWMWriterNetworkSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterNetworkSink> for &'a IWMWriterSink {
-    fn from(value: &'a IWMWriterNetworkSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterNetworkSink> for IWMWriterSink {
-    fn from(value: &IWMWriterNetworkSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterNetworkSink, ::windows::core::IUnknown, IWMWriterSink);
 impl ::core::clone::Clone for IWMWriterNetworkSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11200,21 +8766,7 @@ impl IWMWriterPostView {
         (::windows::core::Vtable::vtable(self).GetAllocateForPostView)(::windows::core::Vtable::as_raw(self), wstreamnumber, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWMWriterPostView> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterPostView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterPostView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterPostView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterPostView> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterPostView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterPostView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMWriterPostView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11280,36 +8832,7 @@ impl IWMWriterPostViewCallback {
         (::windows::core::Vtable::vtable(self).AllocateForPostView)(::windows::core::Vtable::as_raw(self), wstreamnum, cbbuffer, ::core::mem::transmute(ppbuffer), ::core::mem::transmute(pvcontext)).ok()
     }
 }
-impl ::core::convert::From<IWMWriterPostViewCallback> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterPostViewCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterPostViewCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterPostViewCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterPostViewCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterPostViewCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterPostViewCallback> for IWMStatusCallback {
-    fn from(value: IWMWriterPostViewCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterPostViewCallback> for &'a IWMStatusCallback {
-    fn from(value: &'a IWMWriterPostViewCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterPostViewCallback> for IWMStatusCallback {
-    fn from(value: &IWMWriterPostViewCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterPostViewCallback, ::windows::core::IUnknown, IWMStatusCallback);
 impl ::core::clone::Clone for IWMWriterPostViewCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11363,21 +8886,7 @@ impl IWMWriterPreprocess {
         (::windows::core::Vtable::vtable(self).EndPreprocessingPass)(::windows::core::Vtable::as_raw(self), dwinputnum, dwflags).ok()
     }
 }
-impl ::core::convert::From<IWMWriterPreprocess> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterPreprocess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterPreprocess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterPreprocess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterPreprocess> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterPreprocess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterPreprocess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMWriterPreprocess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11456,36 +8965,7 @@ impl IWMWriterPushSink {
         (::windows::core::Vtable::vtable(self).EndSession)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMWriterPushSink> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterPushSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterPushSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterPushSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterPushSink> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterPushSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWMWriterPushSink> for IWMWriterSink {
-    fn from(value: IWMWriterPushSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterPushSink> for &'a IWMWriterSink {
-    fn from(value: &'a IWMWriterPushSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterPushSink> for IWMWriterSink {
-    fn from(value: &IWMWriterPushSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterPushSink, ::windows::core::IUnknown, IWMWriterSink);
 impl ::core::clone::Clone for IWMWriterPushSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11549,21 +9029,7 @@ impl IWMWriterSink {
         (::windows::core::Vtable::vtable(self).OnEndWriting)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWMWriterSink> for ::windows::core::IUnknown {
-    fn from(value: IWMWriterSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWMWriterSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMWriterSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWMWriterSink> for ::windows::core::IUnknown {
-    fn from(value: &IWMWriterSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMWriterSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWMWriterSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/mod.rs
@@ -117,21 +117,7 @@ impl IReferenceClock {
         (::windows::core::Vtable::vtable(self).Unadvise)(::windows::core::Vtable::as_raw(self), dwadvisecookie).ok()
     }
 }
-impl ::core::convert::From<IReferenceClock> for ::windows::core::IUnknown {
-    fn from(value: IReferenceClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IReferenceClock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IReferenceClock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IReferenceClock> for ::windows::core::IUnknown {
-    fn from(value: &IReferenceClock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IReferenceClock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IReferenceClock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -199,36 +185,7 @@ impl IReferenceClock2 {
         (::windows::core::Vtable::vtable(self).base__.Unadvise)(::windows::core::Vtable::as_raw(self), dwadvisecookie).ok()
     }
 }
-impl ::core::convert::From<IReferenceClock2> for ::windows::core::IUnknown {
-    fn from(value: IReferenceClock2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IReferenceClock2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IReferenceClock2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IReferenceClock2> for ::windows::core::IUnknown {
-    fn from(value: &IReferenceClock2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IReferenceClock2> for IReferenceClock {
-    fn from(value: IReferenceClock2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IReferenceClock2> for &'a IReferenceClock {
-    fn from(value: &'a IReferenceClock2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IReferenceClock2> for IReferenceClock {
-    fn from(value: &IReferenceClock2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IReferenceClock2, ::windows::core::IUnknown, IReferenceClock);
 impl ::core::clone::Clone for IReferenceClock2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -268,21 +225,7 @@ impl IReferenceClockTimerControl {
         (::windows::core::Vtable::vtable(self).GetDefaultTimerResolution)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i64>(result__)
     }
 }
-impl ::core::convert::From<IReferenceClockTimerControl> for ::windows::core::IUnknown {
-    fn from(value: IReferenceClockTimerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IReferenceClockTimerControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IReferenceClockTimerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IReferenceClockTimerControl> for ::windows::core::IUnknown {
-    fn from(value: &IReferenceClockTimerControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IReferenceClockTimerControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IReferenceClockTimerControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/mod.rs
@@ -5,41 +5,7 @@ pub struct IDummyMBNUCMExt(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IDummyMBNUCMExt {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDummyMBNUCMExt> for ::windows::core::IUnknown {
-    fn from(value: IDummyMBNUCMExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDummyMBNUCMExt> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDummyMBNUCMExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDummyMBNUCMExt> for ::windows::core::IUnknown {
-    fn from(value: &IDummyMBNUCMExt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDummyMBNUCMExt> for super::super::System::Com::IDispatch {
-    fn from(value: IDummyMBNUCMExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDummyMBNUCMExt> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDummyMBNUCMExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDummyMBNUCMExt> for super::super::System::Com::IDispatch {
-    fn from(value: &IDummyMBNUCMExt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDummyMBNUCMExt, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDummyMBNUCMExt {
     fn clone(&self) -> Self {
@@ -109,21 +75,7 @@ impl IMbnConnection {
         (::windows::core::Vtable::vtable(self).GetActivationNetworkError)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMbnConnection> for ::windows::core::IUnknown {
-    fn from(value: IMbnConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnConnection> for ::windows::core::IUnknown {
-    fn from(value: &IMbnConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -177,21 +129,7 @@ impl IMbnConnectionContext {
         (::windows::core::Vtable::vtable(self).SetProvisionedContext)(::windows::core::Vtable::as_raw(self), provisionedcontexts.into().abi(), providerid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMbnConnectionContext> for ::windows::core::IUnknown {
-    fn from(value: IMbnConnectionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnConnectionContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnConnectionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnConnectionContext> for ::windows::core::IUnknown {
-    fn from(value: &IMbnConnectionContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnConnectionContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnConnectionContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -241,21 +179,7 @@ impl IMbnConnectionContextEvents {
         (::windows::core::Vtable::vtable(self).OnSetProvisionedContextComplete)(::windows::core::Vtable::as_raw(self), newinterface.into().abi(), requestid, status).ok()
     }
 }
-impl ::core::convert::From<IMbnConnectionContextEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnConnectionContextEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnConnectionContextEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnConnectionContextEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnConnectionContextEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnConnectionContextEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnConnectionContextEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnConnectionContextEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -314,21 +238,7 @@ impl IMbnConnectionEvents {
         (::windows::core::Vtable::vtable(self).OnVoiceCallStateChange)(::windows::core::Vtable::as_raw(self), newconnection.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMbnConnectionEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnConnectionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnConnectionEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnConnectionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnConnectionEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnConnectionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnConnectionEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnConnectionEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -378,21 +288,7 @@ impl IMbnConnectionManager {
         (::windows::core::Vtable::vtable(self).GetConnections)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IMbnConnectionManager> for ::windows::core::IUnknown {
-    fn from(value: IMbnConnectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnConnectionManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnConnectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnConnectionManager> for ::windows::core::IUnknown {
-    fn from(value: &IMbnConnectionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnConnectionManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnConnectionManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -442,21 +338,7 @@ impl IMbnConnectionManagerEvents {
         (::windows::core::Vtable::vtable(self).OnConnectionRemoval)(::windows::core::Vtable::as_raw(self), oldconnection.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMbnConnectionManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnConnectionManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnConnectionManagerEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnConnectionManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnConnectionManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnConnectionManagerEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnConnectionManagerEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnConnectionManagerEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -504,21 +386,7 @@ impl IMbnConnectionProfile {
         (::windows::core::Vtable::vtable(self).Delete)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMbnConnectionProfile> for ::windows::core::IUnknown {
-    fn from(value: IMbnConnectionProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnConnectionProfile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnConnectionProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnConnectionProfile> for ::windows::core::IUnknown {
-    fn from(value: &IMbnConnectionProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnConnectionProfile, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnConnectionProfile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -560,21 +428,7 @@ impl IMbnConnectionProfileEvents {
         (::windows::core::Vtable::vtable(self).OnProfileUpdate)(::windows::core::Vtable::as_raw(self), newprofile.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMbnConnectionProfileEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnConnectionProfileEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnConnectionProfileEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnConnectionProfileEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnConnectionProfileEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnConnectionProfileEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnConnectionProfileEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnConnectionProfileEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -631,21 +485,7 @@ impl IMbnConnectionProfileManager {
         (::windows::core::Vtable::vtable(self).CreateConnectionProfile)(::windows::core::Vtable::as_raw(self), xmlprofile.into()).ok()
     }
 }
-impl ::core::convert::From<IMbnConnectionProfileManager> for ::windows::core::IUnknown {
-    fn from(value: IMbnConnectionProfileManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnConnectionProfileManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnConnectionProfileManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnConnectionProfileManager> for ::windows::core::IUnknown {
-    fn from(value: &IMbnConnectionProfileManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnConnectionProfileManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnConnectionProfileManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -696,21 +536,7 @@ impl IMbnConnectionProfileManagerEvents {
         (::windows::core::Vtable::vtable(self).OnConnectionProfileRemoval)(::windows::core::Vtable::as_raw(self), oldconnectionprofile.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMbnConnectionProfileManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnConnectionProfileManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnConnectionProfileManagerEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnConnectionProfileManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnConnectionProfileManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnConnectionProfileManagerEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnConnectionProfileManagerEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnConnectionProfileManagerEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -803,21 +629,7 @@ impl IMbnDeviceService {
         (::windows::core::Vtable::vtable(self).IsDataSessionOpen)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IMbnDeviceService> for ::windows::core::IUnknown {
-    fn from(value: IMbnDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnDeviceService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnDeviceService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnDeviceService> for ::windows::core::IUnknown {
-    fn from(value: &IMbnDeviceService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnDeviceService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnDeviceService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -880,21 +692,7 @@ impl IMbnDeviceServiceStateEvents {
         (::windows::core::Vtable::vtable(self).OnSessionsStateChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(interfaceid), statechange).ok()
     }
 }
-impl ::core::convert::From<IMbnDeviceServiceStateEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnDeviceServiceStateEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnDeviceServiceStateEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnDeviceServiceStateEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnDeviceServiceStateEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnDeviceServiceStateEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnDeviceServiceStateEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnDeviceServiceStateEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -946,21 +744,7 @@ impl IMbnDeviceServicesContext {
         (::windows::core::Vtable::vtable(self).MaxDataSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMbnDeviceServicesContext> for ::windows::core::IUnknown {
-    fn from(value: IMbnDeviceServicesContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnDeviceServicesContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnDeviceServicesContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnDeviceServicesContext> for ::windows::core::IUnknown {
-    fn from(value: &IMbnDeviceServicesContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnDeviceServicesContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnDeviceServicesContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1073,21 +857,7 @@ impl IMbnDeviceServicesEvents {
         (::windows::core::Vtable::vtable(self).OnInterfaceStateChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(interfaceid), statechange).ok()
     }
 }
-impl ::core::convert::From<IMbnDeviceServicesEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnDeviceServicesEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnDeviceServicesEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnDeviceServicesEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnDeviceServicesEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnDeviceServicesEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnDeviceServicesEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnDeviceServicesEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1150,21 +920,7 @@ impl IMbnDeviceServicesManager {
         (::windows::core::Vtable::vtable(self).GetDeviceServicesContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(networkinterfaceid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMbnDeviceServicesContext>(result__)
     }
 }
-impl ::core::convert::From<IMbnDeviceServicesManager> for ::windows::core::IUnknown {
-    fn from(value: IMbnDeviceServicesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnDeviceServicesManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnDeviceServicesManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnDeviceServicesManager> for ::windows::core::IUnknown {
-    fn from(value: &IMbnDeviceServicesManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnDeviceServicesManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnDeviceServicesManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1247,21 +1003,7 @@ impl IMbnInterface {
         (::windows::core::Vtable::vtable(self).GetConnection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMbnConnection>(result__)
     }
 }
-impl ::core::convert::From<IMbnInterface> for ::windows::core::IUnknown {
-    fn from(value: IMbnInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnInterface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnInterface> for ::windows::core::IUnknown {
-    fn from(value: &IMbnInterface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnInterface, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnInterface {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1362,21 +1104,7 @@ impl IMbnInterfaceEvents {
         (::windows::core::Vtable::vtable(self).OnScanNetworkComplete)(::windows::core::Vtable::as_raw(self), newinterface.into().abi(), requestid, status).ok()
     }
 }
-impl ::core::convert::From<IMbnInterfaceEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnInterfaceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnInterfaceEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnInterfaceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnInterfaceEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnInterfaceEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnInterfaceEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnInterfaceEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1430,21 +1158,7 @@ impl IMbnInterfaceManager {
         (::windows::core::Vtable::vtable(self).GetInterfaces)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IMbnInterfaceManager> for ::windows::core::IUnknown {
-    fn from(value: IMbnInterfaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnInterfaceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnInterfaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnInterfaceManager> for ::windows::core::IUnknown {
-    fn from(value: &IMbnInterfaceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnInterfaceManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnInterfaceManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1494,21 +1208,7 @@ impl IMbnInterfaceManagerEvents {
         (::windows::core::Vtable::vtable(self).OnInterfaceRemoval)(::windows::core::Vtable::as_raw(self), oldinterface.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMbnInterfaceManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnInterfaceManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnInterfaceManagerEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnInterfaceManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnInterfaceManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnInterfaceManagerEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnInterfaceManagerEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnInterfaceManagerEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1572,21 +1272,7 @@ impl IMbnMultiCarrier {
         (::windows::core::Vtable::vtable(self).ScanNetwork)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMbnMultiCarrier> for ::windows::core::IUnknown {
-    fn from(value: IMbnMultiCarrier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnMultiCarrier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnMultiCarrier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnMultiCarrier> for ::windows::core::IUnknown {
-    fn from(value: &IMbnMultiCarrier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnMultiCarrier, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnMultiCarrier {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1664,21 +1350,7 @@ impl IMbnMultiCarrierEvents {
         (::windows::core::Vtable::vtable(self).OnInterfaceCapabilityChange)(::windows::core::Vtable::as_raw(self), mbninterface.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMbnMultiCarrierEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnMultiCarrierEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnMultiCarrierEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnMultiCarrierEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnMultiCarrierEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnMultiCarrierEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnMultiCarrierEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnMultiCarrierEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1777,21 +1449,7 @@ impl IMbnPin {
         (::windows::core::Vtable::vtable(self).GetPinManager)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMbnPinManager>(result__)
     }
 }
-impl ::core::convert::From<IMbnPin> for ::windows::core::IUnknown {
-    fn from(value: IMbnPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnPin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnPin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnPin> for ::windows::core::IUnknown {
-    fn from(value: &IMbnPin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnPin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnPin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1865,21 +1523,7 @@ impl IMbnPinEvents {
         (::windows::core::Vtable::vtable(self).OnUnblockComplete)(::windows::core::Vtable::as_raw(self), pin.into().abi(), ::core::mem::transmute(pininfo), requestid, status).ok()
     }
 }
-impl ::core::convert::From<IMbnPinEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnPinEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnPinEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnPinEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnPinEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnPinEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnPinEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnPinEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1931,21 +1575,7 @@ impl IMbnPinManager {
         (::windows::core::Vtable::vtable(self).GetPinState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMbnPinManager> for ::windows::core::IUnknown {
-    fn from(value: IMbnPinManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnPinManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnPinManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnPinManager> for ::windows::core::IUnknown {
-    fn from(value: &IMbnPinManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnPinManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnPinManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1996,21 +1626,7 @@ impl IMbnPinManagerEvents {
         (::windows::core::Vtable::vtable(self).OnGetPinStateComplete)(::windows::core::Vtable::as_raw(self), pinmanager.into().abi(), ::core::mem::transmute(pininfo), requestid, status).ok()
     }
 }
-impl ::core::convert::From<IMbnPinManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnPinManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnPinManagerEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnPinManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnPinManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnPinManagerEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnPinManagerEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnPinManagerEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2057,21 +1673,7 @@ impl IMbnRadio {
         (::windows::core::Vtable::vtable(self).SetSoftwareRadioState)(::windows::core::Vtable::as_raw(self), radiostate, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMbnRadio> for ::windows::core::IUnknown {
-    fn from(value: IMbnRadio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnRadio> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnRadio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnRadio> for ::windows::core::IUnknown {
-    fn from(value: &IMbnRadio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnRadio, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnRadio {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2119,21 +1721,7 @@ impl IMbnRadioEvents {
         (::windows::core::Vtable::vtable(self).OnSetSoftwareRadioStateComplete)(::windows::core::Vtable::as_raw(self), newinterface.into().abi(), requestid, status).ok()
     }
 }
-impl ::core::convert::From<IMbnRadioEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnRadioEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnRadioEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnRadioEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnRadioEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnRadioEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnRadioEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnRadioEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2211,21 +1799,7 @@ impl IMbnRegistration {
         (::windows::core::Vtable::vtable(self).SetRegisterMode)(::windows::core::Vtable::as_raw(self), registermode, providerid.into(), dataclass, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMbnRegistration> for ::windows::core::IUnknown {
-    fn from(value: IMbnRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnRegistration> for ::windows::core::IUnknown {
-    fn from(value: &IMbnRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnRegistration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2292,21 +1866,7 @@ impl IMbnRegistrationEvents {
         (::windows::core::Vtable::vtable(self).OnSetRegisterModeComplete)(::windows::core::Vtable::as_raw(self), newinterface.into().abi(), requestid, status).ok()
     }
 }
-impl ::core::convert::From<IMbnRegistrationEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnRegistrationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnRegistrationEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnRegistrationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnRegistrationEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnRegistrationEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnRegistrationEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnRegistrationEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2349,21 +1909,7 @@ impl IMbnServiceActivation {
         (::windows::core::Vtable::vtable(self).Activate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(vendorspecificdata), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMbnServiceActivation> for ::windows::core::IUnknown {
-    fn from(value: IMbnServiceActivation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnServiceActivation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnServiceActivation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnServiceActivation> for ::windows::core::IUnknown {
-    fn from(value: &IMbnServiceActivation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnServiceActivation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnServiceActivation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2408,21 +1954,7 @@ impl IMbnServiceActivationEvents {
         (::windows::core::Vtable::vtable(self).OnActivationComplete)(::windows::core::Vtable::as_raw(self), serviceactivation.into().abi(), ::core::mem::transmute(vendorspecificdata), requestid, status, networkerror).ok()
     }
 }
-impl ::core::convert::From<IMbnServiceActivationEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnServiceActivationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnServiceActivationEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnServiceActivationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnServiceActivationEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnServiceActivationEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnServiceActivationEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnServiceActivationEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2467,21 +1999,7 @@ impl IMbnSignal {
         (::windows::core::Vtable::vtable(self).GetSignalError)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMbnSignal> for ::windows::core::IUnknown {
-    fn from(value: IMbnSignal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnSignal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnSignal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnSignal> for ::windows::core::IUnknown {
-    fn from(value: &IMbnSignal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnSignal, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnSignal {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2522,21 +2040,7 @@ impl IMbnSignalEvents {
         (::windows::core::Vtable::vtable(self).OnSignalStateChange)(::windows::core::Vtable::as_raw(self), newinterface.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMbnSignalEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnSignalEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnSignalEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnSignalEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnSignalEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnSignalEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnSignalEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnSignalEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2615,21 +2119,7 @@ impl IMbnSms {
         (::windows::core::Vtable::vtable(self).GetSmsStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MBN_SMS_STATUS_INFO>(result__)
     }
 }
-impl ::core::convert::From<IMbnSms> for ::windows::core::IUnknown {
-    fn from(value: IMbnSms) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnSms> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnSms) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnSms> for ::windows::core::IUnknown {
-    fn from(value: &IMbnSms) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnSms, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnSms {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2701,21 +2191,7 @@ impl IMbnSmsConfiguration {
         (::windows::core::Vtable::vtable(self).SetSmsFormat)(::windows::core::Vtable::as_raw(self), smsformat).ok()
     }
 }
-impl ::core::convert::From<IMbnSmsConfiguration> for ::windows::core::IUnknown {
-    fn from(value: IMbnSmsConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnSmsConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnSmsConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnSmsConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &IMbnSmsConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnSmsConfiguration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnSmsConfiguration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2800,21 +2276,7 @@ impl IMbnSmsEvents {
         (::windows::core::Vtable::vtable(self).OnSmsStatusChange)(::windows::core::Vtable::as_raw(self), sms.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMbnSmsEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnSmsEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnSmsEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnSmsEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnSmsEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnSmsEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnSmsEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnSmsEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2878,21 +2340,7 @@ impl IMbnSmsReadMsgPdu {
         (::windows::core::Vtable::vtable(self).Message)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IMbnSmsReadMsgPdu> for ::windows::core::IUnknown {
-    fn from(value: IMbnSmsReadMsgPdu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnSmsReadMsgPdu> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnSmsReadMsgPdu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnSmsReadMsgPdu> for ::windows::core::IUnknown {
-    fn from(value: &IMbnSmsReadMsgPdu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnSmsReadMsgPdu, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnSmsReadMsgPdu {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2966,21 +2414,7 @@ impl IMbnSmsReadMsgTextCdma {
         (::windows::core::Vtable::vtable(self).Message)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IMbnSmsReadMsgTextCdma> for ::windows::core::IUnknown {
-    fn from(value: IMbnSmsReadMsgTextCdma) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnSmsReadMsgTextCdma> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnSmsReadMsgTextCdma) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnSmsReadMsgTextCdma> for ::windows::core::IUnknown {
-    fn from(value: &IMbnSmsReadMsgTextCdma) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnSmsReadMsgTextCdma, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnSmsReadMsgTextCdma {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3038,21 +2472,7 @@ impl IMbnSubscriberInformation {
         (::windows::core::Vtable::vtable(self).TelephoneNumbers)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IMbnSubscriberInformation> for ::windows::core::IUnknown {
-    fn from(value: IMbnSubscriberInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnSubscriberInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnSubscriberInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnSubscriberInformation> for ::windows::core::IUnknown {
-    fn from(value: &IMbnSubscriberInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnSubscriberInformation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnSubscriberInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3107,21 +2527,7 @@ impl IMbnVendorSpecificEvents {
         (::windows::core::Vtable::vtable(self).OnSetVendorSpecificComplete)(::windows::core::Vtable::as_raw(self), vendoroperation.into().abi(), ::core::mem::transmute(vendorspecificdata), requestid).ok()
     }
 }
-impl ::core::convert::From<IMbnVendorSpecificEvents> for ::windows::core::IUnknown {
-    fn from(value: IMbnVendorSpecificEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnVendorSpecificEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnVendorSpecificEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnVendorSpecificEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMbnVendorSpecificEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnVendorSpecificEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnVendorSpecificEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3168,21 +2574,7 @@ impl IMbnVendorSpecificOperation {
         (::windows::core::Vtable::vtable(self).SetVendorSpecific)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(vendorspecificdata), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMbnVendorSpecificOperation> for ::windows::core::IUnknown {
-    fn from(value: IMbnVendorSpecificOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMbnVendorSpecificOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMbnVendorSpecificOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMbnVendorSpecificOperation> for ::windows::core::IUnknown {
-    fn from(value: &IMbnVendorSpecificOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMbnVendorSpecificOperation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMbnVendorSpecificOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
@@ -2187,21 +2187,7 @@ impl IEnumNetCfgBindingInterface {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNetCfgBindingInterface>(result__)
     }
 }
-impl ::core::convert::From<IEnumNetCfgBindingInterface> for ::windows::core::IUnknown {
-    fn from(value: IEnumNetCfgBindingInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumNetCfgBindingInterface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumNetCfgBindingInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumNetCfgBindingInterface> for ::windows::core::IUnknown {
-    fn from(value: &IEnumNetCfgBindingInterface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumNetCfgBindingInterface, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumNetCfgBindingInterface {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2251,21 +2237,7 @@ impl IEnumNetCfgBindingPath {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNetCfgBindingPath>(result__)
     }
 }
-impl ::core::convert::From<IEnumNetCfgBindingPath> for ::windows::core::IUnknown {
-    fn from(value: IEnumNetCfgBindingPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumNetCfgBindingPath> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumNetCfgBindingPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumNetCfgBindingPath> for ::windows::core::IUnknown {
-    fn from(value: &IEnumNetCfgBindingPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumNetCfgBindingPath, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumNetCfgBindingPath {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2315,21 +2287,7 @@ impl IEnumNetCfgComponent {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNetCfgComponent>(result__)
     }
 }
-impl ::core::convert::From<IEnumNetCfgComponent> for ::windows::core::IUnknown {
-    fn from(value: IEnumNetCfgComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumNetCfgComponent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumNetCfgComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumNetCfgComponent> for ::windows::core::IUnknown {
-    fn from(value: &IEnumNetCfgComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumNetCfgComponent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumNetCfgComponent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2392,21 +2350,7 @@ impl INetCfg {
         (::windows::core::Vtable::vtable(self).QueryNetCfgClass)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguidclass), ::core::mem::transmute(riid), ::core::mem::transmute(ppvobject.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<INetCfg> for ::windows::core::IUnknown {
-    fn from(value: INetCfg) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfg> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfg) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfg> for ::windows::core::IUnknown {
-    fn from(value: &INetCfg) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfg, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfg {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2458,21 +2402,7 @@ impl INetCfgBindingInterface {
         (::windows::core::Vtable::vtable(self).GetLowerComponent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<INetCfgComponent>(result__)
     }
 }
-impl ::core::convert::From<INetCfgBindingInterface> for ::windows::core::IUnknown {
-    fn from(value: INetCfgBindingInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgBindingInterface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgBindingInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgBindingInterface> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgBindingInterface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgBindingInterface, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgBindingInterface {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2547,21 +2477,7 @@ impl INetCfgBindingPath {
         (::windows::core::Vtable::vtable(self).EnumBindingInterfaces)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNetCfgBindingInterface>(result__)
     }
 }
-impl ::core::convert::From<INetCfgBindingPath> for ::windows::core::IUnknown {
-    fn from(value: INetCfgBindingPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgBindingPath> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgBindingPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgBindingPath> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgBindingPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgBindingPath, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgBindingPath {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2616,21 +2532,7 @@ impl INetCfgClass {
         (::windows::core::Vtable::vtable(self).EnumComponents)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNetCfgComponent>(result__)
     }
 }
-impl ::core::convert::From<INetCfgClass> for ::windows::core::IUnknown {
-    fn from(value: INetCfgClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgClass> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgClass> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgClass, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgClass {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2693,21 +2595,7 @@ impl INetCfgClassSetup {
         (::windows::core::Vtable::vtable(self).DeInstall)(::windows::core::Vtable::as_raw(self), pcomponent.into().abi(), ::core::mem::transmute(pobotoken.unwrap_or(::std::ptr::null())), ::core::mem::transmute(pmszwrefs.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<INetCfgClassSetup> for ::windows::core::IUnknown {
-    fn from(value: INetCfgClassSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgClassSetup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgClassSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgClassSetup> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgClassSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgClassSetup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgClassSetup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2786,36 +2674,7 @@ impl INetCfgClassSetup2 {
         (::windows::core::Vtable::vtable(self).UpdateNonEnumeratedComponent)(::windows::core::Vtable::as_raw(self), picomp.into().abi(), dwsetupflags, dwupgradefrombuildno).ok()
     }
 }
-impl ::core::convert::From<INetCfgClassSetup2> for ::windows::core::IUnknown {
-    fn from(value: INetCfgClassSetup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgClassSetup2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgClassSetup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgClassSetup2> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgClassSetup2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INetCfgClassSetup2> for INetCfgClassSetup {
-    fn from(value: INetCfgClassSetup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgClassSetup2> for &'a INetCfgClassSetup {
-    fn from(value: &'a INetCfgClassSetup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgClassSetup2> for INetCfgClassSetup {
-    fn from(value: &INetCfgClassSetup2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgClassSetup2, ::windows::core::IUnknown, INetCfgClassSetup);
 impl ::core::clone::Clone for INetCfgClassSetup2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2906,21 +2765,7 @@ impl INetCfgComponent {
         (::windows::core::Vtable::vtable(self).RaisePropertyUi)(::windows::core::Vtable::as_raw(self), hwndparent.into(), dwflags, punkcontext.into().abi()).ok()
     }
 }
-impl ::core::convert::From<INetCfgComponent> for ::windows::core::IUnknown {
-    fn from(value: INetCfgComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgComponent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgComponent> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgComponent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgComponent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3019,21 +2864,7 @@ impl INetCfgComponentBindings {
         (::windows::core::Vtable::vtable(self).MoveAfter)(::windows::core::Vtable::as_raw(self), pncbitemsrc.into().abi(), pncbitemdest.into().abi()).ok()
     }
 }
-impl ::core::convert::From<INetCfgComponentBindings> for ::windows::core::IUnknown {
-    fn from(value: INetCfgComponentBindings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgComponentBindings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgComponentBindings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgComponentBindings> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgComponentBindings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgComponentBindings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgComponentBindings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3096,21 +2927,7 @@ impl INetCfgComponentControl {
         (::windows::core::Vtable::vtable(self).CancelChanges)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<INetCfgComponentControl> for ::windows::core::IUnknown {
-    fn from(value: INetCfgComponentControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgComponentControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgComponentControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgComponentControl> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgComponentControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgComponentControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgComponentControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3162,21 +2979,7 @@ impl INetCfgComponentNotifyBinding {
         (::windows::core::Vtable::vtable(self).NotifyBindingPath)(::windows::core::Vtable::as_raw(self), dwchangeflag, pipath.into().abi()).ok()
     }
 }
-impl ::core::convert::From<INetCfgComponentNotifyBinding> for ::windows::core::IUnknown {
-    fn from(value: INetCfgComponentNotifyBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgComponentNotifyBinding> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgComponentNotifyBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgComponentNotifyBinding> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgComponentNotifyBinding) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgComponentNotifyBinding, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgComponentNotifyBinding {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3233,21 +3036,7 @@ impl INetCfgComponentNotifyGlobal {
         (::windows::core::Vtable::vtable(self).SysNotifyComponent)(::windows::core::Vtable::as_raw(self), dwchangeflag, picomp.into().abi()).ok()
     }
 }
-impl ::core::convert::From<INetCfgComponentNotifyGlobal> for ::windows::core::IUnknown {
-    fn from(value: INetCfgComponentNotifyGlobal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgComponentNotifyGlobal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgComponentNotifyGlobal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgComponentNotifyGlobal> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgComponentNotifyGlobal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgComponentNotifyGlobal, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgComponentNotifyGlobal {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3318,21 +3107,7 @@ impl INetCfgComponentPropertyUi {
         (::windows::core::Vtable::vtable(self).CancelProperties)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<INetCfgComponentPropertyUi> for ::windows::core::IUnknown {
-    fn from(value: INetCfgComponentPropertyUi) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgComponentPropertyUi> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgComponentPropertyUi) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgComponentPropertyUi> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgComponentPropertyUi) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgComponentPropertyUi, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgComponentPropertyUi {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3393,21 +3168,7 @@ impl INetCfgComponentSetup {
         (::windows::core::Vtable::vtable(self).Removing)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<INetCfgComponentSetup> for ::windows::core::IUnknown {
-    fn from(value: INetCfgComponentSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgComponentSetup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgComponentSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgComponentSetup> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgComponentSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgComponentSetup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgComponentSetup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3458,21 +3219,7 @@ impl INetCfgComponentSysPrep {
         (::windows::core::Vtable::vtable(self).RestoreAdapterParameters)(::windows::core::Vtable::as_raw(self), pszwanswerfile.into(), pszwanswersection.into(), ::core::mem::transmute(padapterinstanceguid)).ok()
     }
 }
-impl ::core::convert::From<INetCfgComponentSysPrep> for ::windows::core::IUnknown {
-    fn from(value: INetCfgComponentSysPrep) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgComponentSysPrep> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgComponentSysPrep) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgComponentSysPrep> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgComponentSysPrep) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgComponentSysPrep, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgComponentSysPrep {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3525,21 +3272,7 @@ impl INetCfgComponentUpperEdge {
         (::windows::core::Vtable::vtable(self).RemoveInterfacesFromAdapter)(::windows::core::Vtable::as_raw(self), padapter.into().abi(), pguidinterfaceids.len() as _, ::core::mem::transmute(pguidinterfaceids.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<INetCfgComponentUpperEdge> for ::windows::core::IUnknown {
-    fn from(value: INetCfgComponentUpperEdge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgComponentUpperEdge> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgComponentUpperEdge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgComponentUpperEdge> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgComponentUpperEdge) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgComponentUpperEdge, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgComponentUpperEdge {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3589,21 +3322,7 @@ impl INetCfgLock {
         (::windows::core::Vtable::vtable(self).IsWriteLocked)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<INetCfgLock> for ::windows::core::IUnknown {
-    fn from(value: INetCfgLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgLock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgLock> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgLock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgLock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgLock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3646,21 +3365,7 @@ impl INetCfgPnpReconfigCallback {
         (::windows::core::Vtable::vtable(self).SendPnpReconfig)(::windows::core::Vtable::as_raw(self), layer, pszwupper.into(), pszwlower.into(), ::core::mem::transmute(pvdata), dwsizeofdata).ok()
     }
 }
-impl ::core::convert::From<INetCfgPnpReconfigCallback> for ::windows::core::IUnknown {
-    fn from(value: INetCfgPnpReconfigCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgPnpReconfigCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgPnpReconfigCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgPnpReconfigCallback> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgPnpReconfigCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgPnpReconfigCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgPnpReconfigCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3727,21 +3432,7 @@ impl INetCfgSysPrep {
         (::windows::core::Vtable::vtable(self).HrSetupSetFirstMultiSzField)(::windows::core::Vtable::as_raw(self), pwszsection.into(), pwszkey.into(), pmszvalue.into()).ok()
     }
 }
-impl ::core::convert::From<INetCfgSysPrep> for ::windows::core::IUnknown {
-    fn from(value: INetCfgSysPrep) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetCfgSysPrep> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetCfgSysPrep) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetCfgSysPrep> for ::windows::core::IUnknown {
-    fn from(value: &INetCfgSysPrep) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetCfgSysPrep, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetCfgSysPrep {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3785,21 +3476,7 @@ impl INetLanConnectionUiInfo {
         (::windows::core::Vtable::vtable(self).GetDeviceGuid)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<INetLanConnectionUiInfo> for ::windows::core::IUnknown {
-    fn from(value: INetLanConnectionUiInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetLanConnectionUiInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetLanConnectionUiInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetLanConnectionUiInfo> for ::windows::core::IUnknown {
-    fn from(value: &INetLanConnectionUiInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetLanConnectionUiInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetLanConnectionUiInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3839,21 +3516,7 @@ impl INetRasConnectionIpUiInfo {
         (::windows::core::Vtable::vtable(self).GetUiInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<RASCON_IPUI>(result__)
     }
 }
-impl ::core::convert::From<INetRasConnectionIpUiInfo> for ::windows::core::IUnknown {
-    fn from(value: INetRasConnectionIpUiInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetRasConnectionIpUiInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetRasConnectionIpUiInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetRasConnectionIpUiInfo> for ::windows::core::IUnknown {
-    fn from(value: &INetRasConnectionIpUiInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetRasConnectionIpUiInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetRasConnectionIpUiInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3907,21 +3570,7 @@ impl IProvisioningDomain {
         (::windows::core::Vtable::vtable(self).Query)(::windows::core::Vtable::as_raw(self), pszwdomain.into(), pszwlanguage.into(), pszwxpathquery.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Data::Xml::MsXml::IXMLDOMNodeList>(result__)
     }
 }
-impl ::core::convert::From<IProvisioningDomain> for ::windows::core::IUnknown {
-    fn from(value: IProvisioningDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvisioningDomain> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvisioningDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvisioningDomain> for ::windows::core::IUnknown {
-    fn from(value: &IProvisioningDomain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvisioningDomain, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProvisioningDomain {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3963,21 +3612,7 @@ impl IProvisioningProfileWireless {
         (::windows::core::Vtable::vtable(self).CreateProfile)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrxmlwirelessconfigprofile), ::core::mem::transmute_copy(bstrxmlconnectionconfigprofile), ::core::mem::transmute(padapterinstanceguid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IProvisioningProfileWireless> for ::windows::core::IUnknown {
-    fn from(value: IProvisioningProfileWireless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvisioningProfileWireless> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvisioningProfileWireless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvisioningProfileWireless> for ::windows::core::IUnknown {
-    fn from(value: &IProvisioningProfileWireless) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvisioningProfileWireless, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProvisioningProfileWireless {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/mod.rs
@@ -197,21 +197,7 @@ impl INetDiagExtensibleHelper {
         (::windows::core::Vtable::vtable(self).ResolveAttributes)(::windows::core::Vtable::as_raw(self), rgkeyattributes.len() as _, ::core::mem::transmute(rgkeyattributes.as_ptr()), ::core::mem::transmute(pcelt), ::core::mem::transmute(prgmatchvalues)).ok()
     }
 }
-impl ::core::convert::From<INetDiagExtensibleHelper> for ::windows::core::IUnknown {
-    fn from(value: INetDiagExtensibleHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetDiagExtensibleHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetDiagExtensibleHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetDiagExtensibleHelper> for ::windows::core::IUnknown {
-    fn from(value: &INetDiagExtensibleHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetDiagExtensibleHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetDiagExtensibleHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -331,21 +317,7 @@ impl INetDiagHelper {
         (::windows::core::Vtable::vtable(self).Cleanup)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<INetDiagHelper> for ::windows::core::IUnknown {
-    fn from(value: INetDiagHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetDiagHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetDiagHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetDiagHelper> for ::windows::core::IUnknown {
-    fn from(value: &INetDiagHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetDiagHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetDiagHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -440,21 +412,7 @@ impl INetDiagHelperEx {
         (::windows::core::Vtable::vtable(self).ReproduceFailure)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<INetDiagHelperEx> for ::windows::core::IUnknown {
-    fn from(value: INetDiagHelperEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetDiagHelperEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetDiagHelperEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetDiagHelperEx> for ::windows::core::IUnknown {
-    fn from(value: &INetDiagHelperEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetDiagHelperEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetDiagHelperEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -496,21 +454,7 @@ impl INetDiagHelperInfo {
         (::windows::core::Vtable::vtable(self).GetAttributeInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcelt), ::core::mem::transmute(pprgattributeinfos)).ok()
     }
 }
-impl ::core::convert::From<INetDiagHelperInfo> for ::windows::core::IUnknown {
-    fn from(value: INetDiagHelperInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetDiagHelperInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetDiagHelperInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetDiagHelperInfo> for ::windows::core::IUnknown {
-    fn from(value: &INetDiagHelperInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetDiagHelperInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetDiagHelperInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -551,21 +495,7 @@ impl INetDiagHelperUtilFactory {
         (::windows::core::Vtable::vtable(self).CreateUtilityInstance)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<INetDiagHelperUtilFactory> for ::windows::core::IUnknown {
-    fn from(value: INetDiagHelperUtilFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetDiagHelperUtilFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetDiagHelperUtilFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetDiagHelperUtilFactory> for ::windows::core::IUnknown {
-    fn from(value: &INetDiagHelperUtilFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetDiagHelperUtilFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetDiagHelperUtilFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/mod.rs
@@ -34,41 +34,7 @@ impl ISdo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdo> for ::windows::core::IUnknown {
-    fn from(value: ISdo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISdo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdo> for ::windows::core::IUnknown {
-    fn from(value: &ISdo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdo> for super::super::System::Com::IDispatch {
-    fn from(value: ISdo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISdo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdo> for super::super::System::Com::IDispatch {
-    fn from(value: &ISdo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISdo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISdo {
     fn clone(&self) -> Self {
@@ -161,41 +127,7 @@ impl ISdoCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdoCollection> for ::windows::core::IUnknown {
-    fn from(value: ISdoCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdoCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISdoCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdoCollection> for ::windows::core::IUnknown {
-    fn from(value: &ISdoCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdoCollection> for super::super::System::Com::IDispatch {
-    fn from(value: ISdoCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdoCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISdoCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdoCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &ISdoCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISdoCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISdoCollection {
     fn clone(&self) -> Self {
@@ -281,41 +213,7 @@ impl ISdoDictionaryOld {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdoDictionaryOld> for ::windows::core::IUnknown {
-    fn from(value: ISdoDictionaryOld) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdoDictionaryOld> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISdoDictionaryOld) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdoDictionaryOld> for ::windows::core::IUnknown {
-    fn from(value: &ISdoDictionaryOld) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdoDictionaryOld> for super::super::System::Com::IDispatch {
-    fn from(value: ISdoDictionaryOld) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdoDictionaryOld> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISdoDictionaryOld) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdoDictionaryOld> for super::super::System::Com::IDispatch {
-    fn from(value: &ISdoDictionaryOld) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISdoDictionaryOld, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISdoDictionaryOld {
     fn clone(&self) -> Self {
@@ -410,41 +308,7 @@ impl ISdoMachine {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdoMachine> for ::windows::core::IUnknown {
-    fn from(value: ISdoMachine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdoMachine> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISdoMachine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdoMachine> for ::windows::core::IUnknown {
-    fn from(value: &ISdoMachine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdoMachine> for super::super::System::Com::IDispatch {
-    fn from(value: ISdoMachine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdoMachine> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISdoMachine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdoMachine> for super::super::System::Com::IDispatch {
-    fn from(value: &ISdoMachine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISdoMachine, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISdoMachine {
     fn clone(&self) -> Self {
@@ -550,59 +414,7 @@ impl ISdoMachine2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdoMachine2> for ::windows::core::IUnknown {
-    fn from(value: ISdoMachine2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdoMachine2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISdoMachine2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdoMachine2> for ::windows::core::IUnknown {
-    fn from(value: &ISdoMachine2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdoMachine2> for super::super::System::Com::IDispatch {
-    fn from(value: ISdoMachine2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdoMachine2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISdoMachine2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdoMachine2> for super::super::System::Com::IDispatch {
-    fn from(value: &ISdoMachine2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdoMachine2> for ISdoMachine {
-    fn from(value: ISdoMachine2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdoMachine2> for &'a ISdoMachine {
-    fn from(value: &'a ISdoMachine2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdoMachine2> for ISdoMachine {
-    fn from(value: &ISdoMachine2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISdoMachine2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ISdoMachine);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISdoMachine2 {
     fn clone(&self) -> Self {
@@ -663,41 +475,7 @@ impl ISdoServiceControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdoServiceControl> for ::windows::core::IUnknown {
-    fn from(value: ISdoServiceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdoServiceControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISdoServiceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdoServiceControl> for ::windows::core::IUnknown {
-    fn from(value: &ISdoServiceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISdoServiceControl> for super::super::System::Com::IDispatch {
-    fn from(value: ISdoServiceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISdoServiceControl> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISdoServiceControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISdoServiceControl> for super::super::System::Com::IDispatch {
-    fn from(value: &ISdoServiceControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISdoServiceControl, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISdoServiceControl {
     fn clone(&self) -> Self {
@@ -796,59 +574,7 @@ impl ITemplateSdo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITemplateSdo> for ::windows::core::IUnknown {
-    fn from(value: ITemplateSdo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITemplateSdo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITemplateSdo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITemplateSdo> for ::windows::core::IUnknown {
-    fn from(value: &ITemplateSdo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITemplateSdo> for super::super::System::Com::IDispatch {
-    fn from(value: ITemplateSdo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITemplateSdo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ITemplateSdo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITemplateSdo> for super::super::System::Com::IDispatch {
-    fn from(value: &ITemplateSdo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITemplateSdo> for ISdo {
-    fn from(value: ITemplateSdo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITemplateSdo> for &'a ISdo {
-    fn from(value: &'a ITemplateSdo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITemplateSdo> for ISdo {
-    fn from(value: &ITemplateSdo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITemplateSdo, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ISdo);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITemplateSdo {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
@@ -830,21 +830,7 @@ impl IDot11AdHocInterface {
         (::windows::core::Vtable::vtable(self).GetStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pstate)).ok()
     }
 }
-impl ::core::convert::From<IDot11AdHocInterface> for ::windows::core::IUnknown {
-    fn from(value: IDot11AdHocInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDot11AdHocInterface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDot11AdHocInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDot11AdHocInterface> for ::windows::core::IUnknown {
-    fn from(value: &IDot11AdHocInterface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDot11AdHocInterface, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDot11AdHocInterface {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -889,21 +875,7 @@ impl IDot11AdHocInterfaceNotificationSink {
         (::windows::core::Vtable::vtable(self).OnConnectionStatusChange)(::windows::core::Vtable::as_raw(self), estatus).ok()
     }
 }
-impl ::core::convert::From<IDot11AdHocInterfaceNotificationSink> for ::windows::core::IUnknown {
-    fn from(value: IDot11AdHocInterfaceNotificationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDot11AdHocInterfaceNotificationSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDot11AdHocInterfaceNotificationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDot11AdHocInterfaceNotificationSink> for ::windows::core::IUnknown {
-    fn from(value: &IDot11AdHocInterfaceNotificationSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDot11AdHocInterfaceNotificationSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDot11AdHocInterfaceNotificationSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -969,21 +941,7 @@ impl IDot11AdHocManager {
         (::windows::core::Vtable::vtable(self).GetNetwork)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(networksignature), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDot11AdHocNetwork>(result__)
     }
 }
-impl ::core::convert::From<IDot11AdHocManager> for ::windows::core::IUnknown {
-    fn from(value: IDot11AdHocManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDot11AdHocManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDot11AdHocManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDot11AdHocManager> for ::windows::core::IUnknown {
-    fn from(value: &IDot11AdHocManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDot11AdHocManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDot11AdHocManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1042,21 +1000,7 @@ impl IDot11AdHocManagerNotificationSink {
         (::windows::core::Vtable::vtable(self).OnInterfaceRemove)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(signature)).ok()
     }
 }
-impl ::core::convert::From<IDot11AdHocManagerNotificationSink> for ::windows::core::IUnknown {
-    fn from(value: IDot11AdHocManagerNotificationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDot11AdHocManagerNotificationSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDot11AdHocManagerNotificationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDot11AdHocManagerNotificationSink> for ::windows::core::IUnknown {
-    fn from(value: &IDot11AdHocManagerNotificationSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDot11AdHocManagerNotificationSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDot11AdHocManagerNotificationSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1140,21 +1084,7 @@ impl IDot11AdHocNetwork {
         (::windows::core::Vtable::vtable(self).Disconnect)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDot11AdHocNetwork> for ::windows::core::IUnknown {
-    fn from(value: IDot11AdHocNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDot11AdHocNetwork> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDot11AdHocNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDot11AdHocNetwork> for ::windows::core::IUnknown {
-    fn from(value: &IDot11AdHocNetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDot11AdHocNetwork, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDot11AdHocNetwork {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1208,21 +1138,7 @@ impl IDot11AdHocNetworkNotificationSink {
         (::windows::core::Vtable::vtable(self).OnConnectFail)(::windows::core::Vtable::as_raw(self), efailreason).ok()
     }
 }
-impl ::core::convert::From<IDot11AdHocNetworkNotificationSink> for ::windows::core::IUnknown {
-    fn from(value: IDot11AdHocNetworkNotificationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDot11AdHocNetworkNotificationSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDot11AdHocNetworkNotificationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDot11AdHocNetworkNotificationSink> for ::windows::core::IUnknown {
-    fn from(value: &IDot11AdHocNetworkNotificationSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDot11AdHocNetworkNotificationSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDot11AdHocNetworkNotificationSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1263,21 +1179,7 @@ impl IDot11AdHocSecuritySettings {
         (::windows::core::Vtable::vtable(self).GetDot11CipherAlgorithm)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcipher)).ok()
     }
 }
-impl ::core::convert::From<IDot11AdHocSecuritySettings> for ::windows::core::IUnknown {
-    fn from(value: IDot11AdHocSecuritySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDot11AdHocSecuritySettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDot11AdHocSecuritySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDot11AdHocSecuritySettings> for ::windows::core::IUnknown {
-    fn from(value: &IDot11AdHocSecuritySettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDot11AdHocSecuritySettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDot11AdHocSecuritySettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1325,21 +1227,7 @@ impl IEnumDot11AdHocInterfaces {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDot11AdHocInterfaces>(result__)
     }
 }
-impl ::core::convert::From<IEnumDot11AdHocInterfaces> for ::windows::core::IUnknown {
-    fn from(value: IEnumDot11AdHocInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDot11AdHocInterfaces> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDot11AdHocInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDot11AdHocInterfaces> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDot11AdHocInterfaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDot11AdHocInterfaces, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDot11AdHocInterfaces {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1389,21 +1277,7 @@ impl IEnumDot11AdHocNetworks {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDot11AdHocNetworks>(result__)
     }
 }
-impl ::core::convert::From<IEnumDot11AdHocNetworks> for ::windows::core::IUnknown {
-    fn from(value: IEnumDot11AdHocNetworks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDot11AdHocNetworks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDot11AdHocNetworks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDot11AdHocNetworks> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDot11AdHocNetworks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDot11AdHocNetworks, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDot11AdHocNetworks {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1453,21 +1327,7 @@ impl IEnumDot11AdHocSecuritySettings {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDot11AdHocSecuritySettings>(result__)
     }
 }
-impl ::core::convert::From<IEnumDot11AdHocSecuritySettings> for ::windows::core::IUnknown {
-    fn from(value: IEnumDot11AdHocSecuritySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDot11AdHocSecuritySettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDot11AdHocSecuritySettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDot11AdHocSecuritySettings> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDot11AdHocSecuritySettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDot11AdHocSecuritySettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDot11AdHocSecuritySettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/mod.rs
@@ -9,21 +9,7 @@ impl IWCNConnectNotify {
         (::windows::core::Vtable::vtable(self).ConnectFailed)(::windows::core::Vtable::as_raw(self), hrfailure).ok()
     }
 }
-impl ::core::convert::From<IWCNConnectNotify> for ::windows::core::IUnknown {
-    fn from(value: IWCNConnectNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWCNConnectNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWCNConnectNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWCNConnectNotify> for ::windows::core::IUnknown {
-    fn from(value: &IWCNConnectNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWCNConnectNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWCNConnectNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -109,21 +95,7 @@ impl IWCNDevice {
         .ok()
     }
 }
-impl ::core::convert::From<IWCNDevice> for ::windows::core::IUnknown {
-    fn from(value: IWCNDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWCNDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWCNDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWCNDevice> for ::windows::core::IUnknown {
-    fn from(value: &IWCNDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWCNDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWCNDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
@@ -150,41 +150,7 @@ impl IDynamicPortMapping {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDynamicPortMapping> for ::windows::core::IUnknown {
-    fn from(value: IDynamicPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDynamicPortMapping> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDynamicPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDynamicPortMapping> for ::windows::core::IUnknown {
-    fn from(value: &IDynamicPortMapping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDynamicPortMapping> for super::super::System::Com::IDispatch {
-    fn from(value: IDynamicPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDynamicPortMapping> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDynamicPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDynamicPortMapping> for super::super::System::Com::IDispatch {
-    fn from(value: &IDynamicPortMapping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDynamicPortMapping, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDynamicPortMapping {
     fn clone(&self) -> Self {
@@ -264,41 +230,7 @@ impl IDynamicPortMappingCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDynamicPortMappingCollection> for ::windows::core::IUnknown {
-    fn from(value: IDynamicPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDynamicPortMappingCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDynamicPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDynamicPortMappingCollection> for ::windows::core::IUnknown {
-    fn from(value: &IDynamicPortMappingCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDynamicPortMappingCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IDynamicPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDynamicPortMappingCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDynamicPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDynamicPortMappingCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IDynamicPortMappingCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDynamicPortMappingCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDynamicPortMappingCollection {
     fn clone(&self) -> Self {
@@ -362,21 +294,7 @@ impl IEnumNetConnection {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNetConnection>(result__)
     }
 }
-impl ::core::convert::From<IEnumNetConnection> for ::windows::core::IUnknown {
-    fn from(value: IEnumNetConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumNetConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumNetConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumNetConnection> for ::windows::core::IUnknown {
-    fn from(value: &IEnumNetConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumNetConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumNetConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -428,21 +346,7 @@ impl IEnumNetSharingEveryConnection {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNetSharingEveryConnection>(result__)
     }
 }
-impl ::core::convert::From<IEnumNetSharingEveryConnection> for ::windows::core::IUnknown {
-    fn from(value: IEnumNetSharingEveryConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumNetSharingEveryConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumNetSharingEveryConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumNetSharingEveryConnection> for ::windows::core::IUnknown {
-    fn from(value: &IEnumNetSharingEveryConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumNetSharingEveryConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumNetSharingEveryConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -497,21 +401,7 @@ impl IEnumNetSharingPortMapping {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNetSharingPortMapping>(result__)
     }
 }
-impl ::core::convert::From<IEnumNetSharingPortMapping> for ::windows::core::IUnknown {
-    fn from(value: IEnumNetSharingPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumNetSharingPortMapping> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumNetSharingPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumNetSharingPortMapping> for ::windows::core::IUnknown {
-    fn from(value: &IEnumNetSharingPortMapping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumNetSharingPortMapping, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumNetSharingPortMapping {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -566,21 +456,7 @@ impl IEnumNetSharingPrivateConnection {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNetSharingPrivateConnection>(result__)
     }
 }
-impl ::core::convert::From<IEnumNetSharingPrivateConnection> for ::windows::core::IUnknown {
-    fn from(value: IEnumNetSharingPrivateConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumNetSharingPrivateConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumNetSharingPrivateConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumNetSharingPrivateConnection> for ::windows::core::IUnknown {
-    fn from(value: &IEnumNetSharingPrivateConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumNetSharingPrivateConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumNetSharingPrivateConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -635,21 +511,7 @@ impl IEnumNetSharingPublicConnection {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNetSharingPublicConnection>(result__)
     }
 }
-impl ::core::convert::From<IEnumNetSharingPublicConnection> for ::windows::core::IUnknown {
-    fn from(value: IEnumNetSharingPublicConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumNetSharingPublicConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumNetSharingPublicConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumNetSharingPublicConnection> for ::windows::core::IUnknown {
-    fn from(value: &IEnumNetSharingPublicConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumNetSharingPublicConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumNetSharingPublicConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -704,41 +566,7 @@ impl INATEventManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INATEventManager> for ::windows::core::IUnknown {
-    fn from(value: INATEventManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INATEventManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INATEventManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INATEventManager> for ::windows::core::IUnknown {
-    fn from(value: &INATEventManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INATEventManager> for super::super::System::Com::IDispatch {
-    fn from(value: INATEventManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INATEventManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INATEventManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INATEventManager> for super::super::System::Com::IDispatch {
-    fn from(value: &INATEventManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INATEventManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INATEventManager {
     fn clone(&self) -> Self {
@@ -783,21 +611,7 @@ impl INATExternalIPAddressCallback {
         (::windows::core::Vtable::vtable(self).NewExternalIPAddress)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrnewexternalipaddress)).ok()
     }
 }
-impl ::core::convert::From<INATExternalIPAddressCallback> for ::windows::core::IUnknown {
-    fn from(value: INATExternalIPAddressCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INATExternalIPAddressCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INATExternalIPAddressCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INATExternalIPAddressCallback> for ::windows::core::IUnknown {
-    fn from(value: &INATExternalIPAddressCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INATExternalIPAddressCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INATExternalIPAddressCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -834,21 +648,7 @@ impl INATNumberOfEntriesCallback {
         (::windows::core::Vtable::vtable(self).NewNumberOfEntries)(::windows::core::Vtable::as_raw(self), lnewnumberofentries).ok()
     }
 }
-impl ::core::convert::From<INATNumberOfEntriesCallback> for ::windows::core::IUnknown {
-    fn from(value: INATNumberOfEntriesCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INATNumberOfEntriesCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INATNumberOfEntriesCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INATNumberOfEntriesCallback> for ::windows::core::IUnknown {
-    fn from(value: &INATNumberOfEntriesCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INATNumberOfEntriesCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INATNumberOfEntriesCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -912,21 +712,7 @@ impl INetConnection {
         (::windows::core::Vtable::vtable(self).Rename)(::windows::core::Vtable::as_raw(self), pszwnewname.into()).ok()
     }
 }
-impl ::core::convert::From<INetConnection> for ::windows::core::IUnknown {
-    fn from(value: INetConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetConnection> for ::windows::core::IUnknown {
-    fn from(value: &INetConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -988,21 +774,7 @@ impl INetConnectionConnectUi {
         (::windows::core::Vtable::vtable(self).Disconnect)(::windows::core::Vtable::as_raw(self), hwndparent.into(), dwflags).ok()
     }
 }
-impl ::core::convert::From<INetConnectionConnectUi> for ::windows::core::IUnknown {
-    fn from(value: INetConnectionConnectUi) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetConnectionConnectUi> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetConnectionConnectUi) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetConnectionConnectUi> for ::windows::core::IUnknown {
-    fn from(value: &INetConnectionConnectUi) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetConnectionConnectUi, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetConnectionConnectUi {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1048,21 +820,7 @@ impl INetConnectionManager {
         (::windows::core::Vtable::vtable(self).EnumConnections)(::windows::core::Vtable::as_raw(self), flags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNetConnection>(result__)
     }
 }
-impl ::core::convert::From<INetConnectionManager> for ::windows::core::IUnknown {
-    fn from(value: INetConnectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetConnectionManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetConnectionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetConnectionManager> for ::windows::core::IUnknown {
-    fn from(value: &INetConnectionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetConnectionManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetConnectionManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1123,41 +881,7 @@ impl INetConnectionProps {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetConnectionProps> for ::windows::core::IUnknown {
-    fn from(value: INetConnectionProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetConnectionProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetConnectionProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetConnectionProps> for ::windows::core::IUnknown {
-    fn from(value: &INetConnectionProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetConnectionProps> for super::super::System::Com::IDispatch {
-    fn from(value: INetConnectionProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetConnectionProps> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetConnectionProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetConnectionProps> for super::super::System::Com::IDispatch {
-    fn from(value: &INetConnectionProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetConnectionProps, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetConnectionProps {
     fn clone(&self) -> Self {
@@ -1248,41 +972,7 @@ impl INetFwAuthorizedApplication {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwAuthorizedApplication> for ::windows::core::IUnknown {
-    fn from(value: INetFwAuthorizedApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwAuthorizedApplication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwAuthorizedApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwAuthorizedApplication> for ::windows::core::IUnknown {
-    fn from(value: &INetFwAuthorizedApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwAuthorizedApplication> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwAuthorizedApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwAuthorizedApplication> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwAuthorizedApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwAuthorizedApplication> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwAuthorizedApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwAuthorizedApplication, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwAuthorizedApplication {
     fn clone(&self) -> Self {
@@ -1362,41 +1052,7 @@ impl INetFwAuthorizedApplications {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwAuthorizedApplications> for ::windows::core::IUnknown {
-    fn from(value: INetFwAuthorizedApplications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwAuthorizedApplications> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwAuthorizedApplications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwAuthorizedApplications> for ::windows::core::IUnknown {
-    fn from(value: &INetFwAuthorizedApplications) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwAuthorizedApplications> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwAuthorizedApplications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwAuthorizedApplications> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwAuthorizedApplications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwAuthorizedApplications> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwAuthorizedApplications) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwAuthorizedApplications, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwAuthorizedApplications {
     fn clone(&self) -> Self {
@@ -1520,41 +1176,7 @@ impl INetFwIcmpSettings {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwIcmpSettings> for ::windows::core::IUnknown {
-    fn from(value: INetFwIcmpSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwIcmpSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwIcmpSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwIcmpSettings> for ::windows::core::IUnknown {
-    fn from(value: &INetFwIcmpSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwIcmpSettings> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwIcmpSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwIcmpSettings> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwIcmpSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwIcmpSettings> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwIcmpSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwIcmpSettings, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwIcmpSettings {
     fn clone(&self) -> Self {
@@ -1640,41 +1262,7 @@ impl INetFwMgr {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwMgr> for ::windows::core::IUnknown {
-    fn from(value: INetFwMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwMgr> for ::windows::core::IUnknown {
-    fn from(value: &INetFwMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwMgr> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwMgr> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwMgr> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwMgr, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwMgr {
     fn clone(&self) -> Self {
@@ -1784,41 +1372,7 @@ impl INetFwOpenPort {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwOpenPort> for ::windows::core::IUnknown {
-    fn from(value: INetFwOpenPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwOpenPort> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwOpenPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwOpenPort> for ::windows::core::IUnknown {
-    fn from(value: &INetFwOpenPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwOpenPort> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwOpenPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwOpenPort> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwOpenPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwOpenPort> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwOpenPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwOpenPort, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwOpenPort {
     fn clone(&self) -> Self {
@@ -1901,41 +1455,7 @@ impl INetFwOpenPorts {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwOpenPorts> for ::windows::core::IUnknown {
-    fn from(value: INetFwOpenPorts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwOpenPorts> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwOpenPorts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwOpenPorts> for ::windows::core::IUnknown {
-    fn from(value: &INetFwOpenPorts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwOpenPorts> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwOpenPorts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwOpenPorts> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwOpenPorts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwOpenPorts> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwOpenPorts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwOpenPorts, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwOpenPorts {
     fn clone(&self) -> Self {
@@ -2001,41 +1521,7 @@ impl INetFwPolicy {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwPolicy> for ::windows::core::IUnknown {
-    fn from(value: INetFwPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwPolicy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwPolicy> for ::windows::core::IUnknown {
-    fn from(value: &INetFwPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwPolicy> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwPolicy> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwPolicy> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwPolicy, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwPolicy {
     fn clone(&self) -> Self {
@@ -2176,41 +1662,7 @@ impl INetFwPolicy2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwPolicy2> for ::windows::core::IUnknown {
-    fn from(value: INetFwPolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwPolicy2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwPolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwPolicy2> for ::windows::core::IUnknown {
-    fn from(value: &INetFwPolicy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwPolicy2> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwPolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwPolicy2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwPolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwPolicy2> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwPolicy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwPolicy2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwPolicy2 {
     fn clone(&self) -> Self {
@@ -2312,41 +1764,7 @@ impl INetFwProduct {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwProduct> for ::windows::core::IUnknown {
-    fn from(value: INetFwProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwProduct> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwProduct> for ::windows::core::IUnknown {
-    fn from(value: &INetFwProduct) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwProduct> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwProduct> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwProduct> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwProduct) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwProduct, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwProduct {
     fn clone(&self) -> Self {
@@ -2423,41 +1841,7 @@ impl INetFwProducts {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwProducts> for ::windows::core::IUnknown {
-    fn from(value: INetFwProducts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwProducts> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwProducts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwProducts> for ::windows::core::IUnknown {
-    fn from(value: &INetFwProducts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwProducts> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwProducts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwProducts> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwProducts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwProducts> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwProducts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwProducts, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwProducts {
     fn clone(&self) -> Self {
@@ -2572,41 +1956,7 @@ impl INetFwProfile {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwProfile> for ::windows::core::IUnknown {
-    fn from(value: INetFwProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwProfile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwProfile> for ::windows::core::IUnknown {
-    fn from(value: &INetFwProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwProfile> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwProfile> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwProfile> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwProfile, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwProfile {
     fn clone(&self) -> Self {
@@ -2706,41 +2056,7 @@ impl INetFwRemoteAdminSettings {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRemoteAdminSettings> for ::windows::core::IUnknown {
-    fn from(value: INetFwRemoteAdminSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRemoteAdminSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwRemoteAdminSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRemoteAdminSettings> for ::windows::core::IUnknown {
-    fn from(value: &INetFwRemoteAdminSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRemoteAdminSettings> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwRemoteAdminSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRemoteAdminSettings> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwRemoteAdminSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRemoteAdminSettings> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwRemoteAdminSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwRemoteAdminSettings, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwRemoteAdminSettings {
     fn clone(&self) -> Self {
@@ -2924,41 +2240,7 @@ impl INetFwRule {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRule> for ::windows::core::IUnknown {
-    fn from(value: INetFwRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRule> for ::windows::core::IUnknown {
-    fn from(value: &INetFwRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRule> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRule> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRule> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwRule, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwRule {
     fn clone(&self) -> Self {
@@ -3183,59 +2465,7 @@ impl INetFwRule2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRule2> for ::windows::core::IUnknown {
-    fn from(value: INetFwRule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRule2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwRule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRule2> for ::windows::core::IUnknown {
-    fn from(value: &INetFwRule2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRule2> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwRule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRule2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwRule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRule2> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwRule2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRule2> for INetFwRule {
-    fn from(value: INetFwRule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRule2> for &'a INetFwRule {
-    fn from(value: &'a INetFwRule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRule2> for INetFwRule {
-    fn from(value: &INetFwRule2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwRule2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, INetFwRule);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwRule2 {
     fn clone(&self) -> Self {
@@ -3462,77 +2692,7 @@ impl INetFwRule3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRule3> for ::windows::core::IUnknown {
-    fn from(value: INetFwRule3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRule3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwRule3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRule3> for ::windows::core::IUnknown {
-    fn from(value: &INetFwRule3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRule3> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwRule3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRule3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwRule3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRule3> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwRule3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRule3> for INetFwRule {
-    fn from(value: INetFwRule3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRule3> for &'a INetFwRule {
-    fn from(value: &'a INetFwRule3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRule3> for INetFwRule {
-    fn from(value: &INetFwRule3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRule3> for INetFwRule2 {
-    fn from(value: INetFwRule3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRule3> for &'a INetFwRule2 {
-    fn from(value: &'a INetFwRule3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRule3> for INetFwRule2 {
-    fn from(value: &INetFwRule3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwRule3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, INetFwRule, INetFwRule2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwRule3 {
     fn clone(&self) -> Self {
@@ -3612,41 +2772,7 @@ impl INetFwRules {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRules> for ::windows::core::IUnknown {
-    fn from(value: INetFwRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRules> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRules> for ::windows::core::IUnknown {
-    fn from(value: &INetFwRules) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwRules> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwRules> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwRules> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwRules) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwRules, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwRules {
     fn clone(&self) -> Self {
@@ -3746,41 +2872,7 @@ impl INetFwService {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwService> for ::windows::core::IUnknown {
-    fn from(value: INetFwService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwService> for ::windows::core::IUnknown {
-    fn from(value: &INetFwService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwService> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwService> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwService> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwService, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwService {
     fn clone(&self) -> Self {
@@ -3851,41 +2943,7 @@ impl INetFwServiceRestriction {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwServiceRestriction> for ::windows::core::IUnknown {
-    fn from(value: INetFwServiceRestriction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwServiceRestriction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwServiceRestriction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwServiceRestriction> for ::windows::core::IUnknown {
-    fn from(value: &INetFwServiceRestriction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwServiceRestriction> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwServiceRestriction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwServiceRestriction> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwServiceRestriction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwServiceRestriction> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwServiceRestriction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwServiceRestriction, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwServiceRestriction {
     fn clone(&self) -> Self {
@@ -3948,41 +3006,7 @@ impl INetFwServices {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwServices> for ::windows::core::IUnknown {
-    fn from(value: INetFwServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetFwServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwServices> for ::windows::core::IUnknown {
-    fn from(value: &INetFwServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetFwServices> for super::super::System::Com::IDispatch {
-    fn from(value: INetFwServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetFwServices> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetFwServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetFwServices> for super::super::System::Com::IDispatch {
-    fn from(value: &INetFwServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetFwServices, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetFwServices {
     fn clone(&self) -> Self {
@@ -4075,41 +3099,7 @@ impl INetSharingConfiguration {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingConfiguration> for ::windows::core::IUnknown {
-    fn from(value: INetSharingConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetSharingConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &INetSharingConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingConfiguration> for super::super::System::Com::IDispatch {
-    fn from(value: INetSharingConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingConfiguration> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetSharingConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingConfiguration> for super::super::System::Com::IDispatch {
-    fn from(value: &INetSharingConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetSharingConfiguration, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetSharingConfiguration {
     fn clone(&self) -> Self {
@@ -4179,41 +3169,7 @@ impl INetSharingEveryConnectionCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingEveryConnectionCollection> for ::windows::core::IUnknown {
-    fn from(value: INetSharingEveryConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingEveryConnectionCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetSharingEveryConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingEveryConnectionCollection> for ::windows::core::IUnknown {
-    fn from(value: &INetSharingEveryConnectionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingEveryConnectionCollection> for super::super::System::Com::IDispatch {
-    fn from(value: INetSharingEveryConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingEveryConnectionCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetSharingEveryConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingEveryConnectionCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &INetSharingEveryConnectionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetSharingEveryConnectionCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetSharingEveryConnectionCollection {
     fn clone(&self) -> Self {
@@ -4298,41 +3254,7 @@ impl INetSharingManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingManager> for ::windows::core::IUnknown {
-    fn from(value: INetSharingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetSharingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingManager> for ::windows::core::IUnknown {
-    fn from(value: &INetSharingManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingManager> for super::super::System::Com::IDispatch {
-    fn from(value: INetSharingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetSharingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingManager> for super::super::System::Com::IDispatch {
-    fn from(value: &INetSharingManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetSharingManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetSharingManager {
     fn clone(&self) -> Self {
@@ -4411,41 +3333,7 @@ impl INetSharingPortMapping {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingPortMapping> for ::windows::core::IUnknown {
-    fn from(value: INetSharingPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingPortMapping> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetSharingPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingPortMapping> for ::windows::core::IUnknown {
-    fn from(value: &INetSharingPortMapping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingPortMapping> for super::super::System::Com::IDispatch {
-    fn from(value: INetSharingPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingPortMapping> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetSharingPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingPortMapping> for super::super::System::Com::IDispatch {
-    fn from(value: &INetSharingPortMapping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetSharingPortMapping, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetSharingPortMapping {
     fn clone(&self) -> Self {
@@ -4503,41 +3391,7 @@ impl INetSharingPortMappingCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingPortMappingCollection> for ::windows::core::IUnknown {
-    fn from(value: INetSharingPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingPortMappingCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetSharingPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingPortMappingCollection> for ::windows::core::IUnknown {
-    fn from(value: &INetSharingPortMappingCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingPortMappingCollection> for super::super::System::Com::IDispatch {
-    fn from(value: INetSharingPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingPortMappingCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetSharingPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingPortMappingCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &INetSharingPortMappingCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetSharingPortMappingCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetSharingPortMappingCollection {
     fn clone(&self) -> Self {
@@ -4614,41 +3468,7 @@ impl INetSharingPortMappingProps {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingPortMappingProps> for ::windows::core::IUnknown {
-    fn from(value: INetSharingPortMappingProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingPortMappingProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetSharingPortMappingProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingPortMappingProps> for ::windows::core::IUnknown {
-    fn from(value: &INetSharingPortMappingProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingPortMappingProps> for super::super::System::Com::IDispatch {
-    fn from(value: INetSharingPortMappingProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingPortMappingProps> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetSharingPortMappingProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingPortMappingProps> for super::super::System::Com::IDispatch {
-    fn from(value: &INetSharingPortMappingProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetSharingPortMappingProps, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetSharingPortMappingProps {
     fn clone(&self) -> Self {
@@ -4707,41 +3527,7 @@ impl INetSharingPrivateConnectionCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingPrivateConnectionCollection> for ::windows::core::IUnknown {
-    fn from(value: INetSharingPrivateConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingPrivateConnectionCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetSharingPrivateConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingPrivateConnectionCollection> for ::windows::core::IUnknown {
-    fn from(value: &INetSharingPrivateConnectionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingPrivateConnectionCollection> for super::super::System::Com::IDispatch {
-    fn from(value: INetSharingPrivateConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingPrivateConnectionCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetSharingPrivateConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingPrivateConnectionCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &INetSharingPrivateConnectionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetSharingPrivateConnectionCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetSharingPrivateConnectionCollection {
     fn clone(&self) -> Self {
@@ -4794,41 +3580,7 @@ impl INetSharingPublicConnectionCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingPublicConnectionCollection> for ::windows::core::IUnknown {
-    fn from(value: INetSharingPublicConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingPublicConnectionCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetSharingPublicConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingPublicConnectionCollection> for ::windows::core::IUnknown {
-    fn from(value: &INetSharingPublicConnectionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetSharingPublicConnectionCollection> for super::super::System::Com::IDispatch {
-    fn from(value: INetSharingPublicConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetSharingPublicConnectionCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetSharingPublicConnectionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetSharingPublicConnectionCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &INetSharingPublicConnectionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetSharingPublicConnectionCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetSharingPublicConnectionCollection {
     fn clone(&self) -> Self {
@@ -4913,41 +3665,7 @@ impl IStaticPortMapping {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStaticPortMapping> for ::windows::core::IUnknown {
-    fn from(value: IStaticPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStaticPortMapping> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStaticPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStaticPortMapping> for ::windows::core::IUnknown {
-    fn from(value: &IStaticPortMapping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStaticPortMapping> for super::super::System::Com::IDispatch {
-    fn from(value: IStaticPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStaticPortMapping> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IStaticPortMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStaticPortMapping> for super::super::System::Com::IDispatch {
-    fn from(value: &IStaticPortMapping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStaticPortMapping, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IStaticPortMapping {
     fn clone(&self) -> Self {
@@ -5024,41 +3742,7 @@ impl IStaticPortMappingCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStaticPortMappingCollection> for ::windows::core::IUnknown {
-    fn from(value: IStaticPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStaticPortMappingCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStaticPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStaticPortMappingCollection> for ::windows::core::IUnknown {
-    fn from(value: &IStaticPortMappingCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStaticPortMappingCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IStaticPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStaticPortMappingCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IStaticPortMappingCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStaticPortMappingCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IStaticPortMappingCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStaticPortMappingCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IStaticPortMappingCollection {
     fn clone(&self) -> Self {
@@ -5130,41 +3814,7 @@ impl IUPnPNAT {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPNAT> for ::windows::core::IUnknown {
-    fn from(value: IUPnPNAT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPNAT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUPnPNAT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPNAT> for ::windows::core::IUnknown {
-    fn from(value: &IUPnPNAT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUPnPNAT> for super::super::System::Com::IDispatch {
-    fn from(value: IUPnPNAT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUPnPNAT> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IUPnPNAT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUPnPNAT> for super::super::System::Com::IDispatch {
-    fn from(value: &IUPnPNAT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUPnPNAT, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUPnPNAT {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
@@ -2089,41 +2089,7 @@ impl IADs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADs> for ::windows::core::IUnknown {
-    fn from(value: IADs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADs> for ::windows::core::IUnknown {
-    fn from(value: &IADs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADs> for super::super::System::Com::IDispatch {
-    fn from(value: IADs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADs> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADs> for super::super::System::Com::IDispatch {
-    fn from(value: &IADs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADs, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADs {
     fn clone(&self) -> Self {
@@ -2247,41 +2213,7 @@ impl IADsADSystemInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsADSystemInfo> for ::windows::core::IUnknown {
-    fn from(value: IADsADSystemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsADSystemInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsADSystemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsADSystemInfo> for ::windows::core::IUnknown {
-    fn from(value: &IADsADSystemInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsADSystemInfo> for super::super::System::Com::IDispatch {
-    fn from(value: IADsADSystemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsADSystemInfo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsADSystemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsADSystemInfo> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsADSystemInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsADSystemInfo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsADSystemInfo {
     fn clone(&self) -> Self {
@@ -2389,41 +2321,7 @@ impl IADsAccessControlEntry {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsAccessControlEntry> for ::windows::core::IUnknown {
-    fn from(value: IADsAccessControlEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsAccessControlEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsAccessControlEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsAccessControlEntry> for ::windows::core::IUnknown {
-    fn from(value: &IADsAccessControlEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsAccessControlEntry> for super::super::System::Com::IDispatch {
-    fn from(value: IADsAccessControlEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsAccessControlEntry> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsAccessControlEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsAccessControlEntry> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsAccessControlEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsAccessControlEntry, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsAccessControlEntry {
     fn clone(&self) -> Self {
@@ -2520,41 +2418,7 @@ impl IADsAccessControlList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsAccessControlList> for ::windows::core::IUnknown {
-    fn from(value: IADsAccessControlList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsAccessControlList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsAccessControlList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsAccessControlList> for ::windows::core::IUnknown {
-    fn from(value: &IADsAccessControlList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsAccessControlList> for super::super::System::Com::IDispatch {
-    fn from(value: IADsAccessControlList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsAccessControlList> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsAccessControlList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsAccessControlList> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsAccessControlList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsAccessControlList, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsAccessControlList {
     fn clone(&self) -> Self {
@@ -2641,41 +2505,7 @@ impl IADsAcl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsAcl> for ::windows::core::IUnknown {
-    fn from(value: IADsAcl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsAcl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsAcl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsAcl> for ::windows::core::IUnknown {
-    fn from(value: &IADsAcl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsAcl> for super::super::System::Com::IDispatch {
-    fn from(value: IADsAcl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsAcl> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsAcl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsAcl> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsAcl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsAcl, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsAcl {
     fn clone(&self) -> Self {
@@ -2740,21 +2570,7 @@ impl IADsAggregatee {
         (::windows::core::Vtable::vtable(self).RestoreInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid)).ok()
     }
 }
-impl ::core::convert::From<IADsAggregatee> for ::windows::core::IUnknown {
-    fn from(value: IADsAggregatee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IADsAggregatee> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsAggregatee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IADsAggregatee> for ::windows::core::IUnknown {
-    fn from(value: &IADsAggregatee) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsAggregatee, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IADsAggregatee {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2800,21 +2616,7 @@ impl IADsAggregator {
         (::windows::core::Vtable::vtable(self).DisconnectAsAggregator)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IADsAggregator> for ::windows::core::IUnknown {
-    fn from(value: IADsAggregator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IADsAggregator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsAggregator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IADsAggregator> for ::windows::core::IUnknown {
-    fn from(value: &IADsAggregator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsAggregator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IADsAggregator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2866,41 +2668,7 @@ impl IADsBackLink {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsBackLink> for ::windows::core::IUnknown {
-    fn from(value: IADsBackLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsBackLink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsBackLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsBackLink> for ::windows::core::IUnknown {
-    fn from(value: &IADsBackLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsBackLink> for super::super::System::Com::IDispatch {
-    fn from(value: IADsBackLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsBackLink> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsBackLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsBackLink> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsBackLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsBackLink, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsBackLink {
     fn clone(&self) -> Self {
@@ -2961,41 +2729,7 @@ impl IADsCaseIgnoreList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsCaseIgnoreList> for ::windows::core::IUnknown {
-    fn from(value: IADsCaseIgnoreList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsCaseIgnoreList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsCaseIgnoreList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsCaseIgnoreList> for ::windows::core::IUnknown {
-    fn from(value: &IADsCaseIgnoreList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsCaseIgnoreList> for super::super::System::Com::IDispatch {
-    fn from(value: IADsCaseIgnoreList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsCaseIgnoreList> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsCaseIgnoreList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsCaseIgnoreList> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsCaseIgnoreList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsCaseIgnoreList, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsCaseIgnoreList {
     fn clone(&self) -> Self {
@@ -3269,59 +3003,7 @@ impl IADsClass {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsClass> for ::windows::core::IUnknown {
-    fn from(value: IADsClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsClass> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsClass> for ::windows::core::IUnknown {
-    fn from(value: &IADsClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsClass> for super::super::System::Com::IDispatch {
-    fn from(value: IADsClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsClass> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsClass> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsClass> for IADs {
-    fn from(value: IADsClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsClass> for &'a IADs {
-    fn from(value: &'a IADsClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsClass> for IADs {
-    fn from(value: &IADsClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsClass, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsClass {
     fn clone(&self) -> Self {
@@ -3460,41 +3142,7 @@ impl IADsCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsCollection> for ::windows::core::IUnknown {
-    fn from(value: IADsCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsCollection> for ::windows::core::IUnknown {
-    fn from(value: &IADsCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IADsCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsCollection {
     fn clone(&self) -> Self {
@@ -3733,59 +3381,7 @@ impl IADsComputer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsComputer> for ::windows::core::IUnknown {
-    fn from(value: IADsComputer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsComputer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsComputer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsComputer> for ::windows::core::IUnknown {
-    fn from(value: &IADsComputer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsComputer> for super::super::System::Com::IDispatch {
-    fn from(value: IADsComputer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsComputer> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsComputer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsComputer> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsComputer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsComputer> for IADs {
-    fn from(value: IADsComputer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsComputer> for &'a IADs {
-    fn from(value: &'a IADsComputer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsComputer> for IADs {
-    fn from(value: &IADsComputer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsComputer, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsComputer {
     fn clone(&self) -> Self {
@@ -3941,59 +3537,7 @@ impl IADsComputerOperations {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsComputerOperations> for ::windows::core::IUnknown {
-    fn from(value: IADsComputerOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsComputerOperations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsComputerOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsComputerOperations> for ::windows::core::IUnknown {
-    fn from(value: &IADsComputerOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsComputerOperations> for super::super::System::Com::IDispatch {
-    fn from(value: IADsComputerOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsComputerOperations> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsComputerOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsComputerOperations> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsComputerOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsComputerOperations> for IADs {
-    fn from(value: IADsComputerOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsComputerOperations> for &'a IADs {
-    fn from(value: &'a IADsComputerOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsComputerOperations> for IADs {
-    fn from(value: &IADsComputerOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsComputerOperations, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsComputerOperations {
     fn clone(&self) -> Self {
@@ -4104,41 +3648,7 @@ impl IADsContainer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsContainer> for ::windows::core::IUnknown {
-    fn from(value: IADsContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsContainer> for ::windows::core::IUnknown {
-    fn from(value: &IADsContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsContainer> for super::super::System::Com::IDispatch {
-    fn from(value: IADsContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsContainer> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsContainer> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsContainer, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsContainer {
     fn clone(&self) -> Self {
@@ -4237,41 +3747,7 @@ impl IADsDNWithBinary {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsDNWithBinary> for ::windows::core::IUnknown {
-    fn from(value: IADsDNWithBinary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsDNWithBinary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsDNWithBinary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsDNWithBinary> for ::windows::core::IUnknown {
-    fn from(value: &IADsDNWithBinary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsDNWithBinary> for super::super::System::Com::IDispatch {
-    fn from(value: IADsDNWithBinary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsDNWithBinary> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsDNWithBinary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsDNWithBinary> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsDNWithBinary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsDNWithBinary, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsDNWithBinary {
     fn clone(&self) -> Self {
@@ -4338,41 +3814,7 @@ impl IADsDNWithString {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsDNWithString> for ::windows::core::IUnknown {
-    fn from(value: IADsDNWithString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsDNWithString> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsDNWithString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsDNWithString> for ::windows::core::IUnknown {
-    fn from(value: &IADsDNWithString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsDNWithString> for super::super::System::Com::IDispatch {
-    fn from(value: IADsDNWithString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsDNWithString> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsDNWithString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsDNWithString> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsDNWithString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsDNWithString, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsDNWithString {
     fn clone(&self) -> Self {
@@ -4422,41 +3864,7 @@ impl IADsDeleteOps {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsDeleteOps> for ::windows::core::IUnknown {
-    fn from(value: IADsDeleteOps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsDeleteOps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsDeleteOps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsDeleteOps> for ::windows::core::IUnknown {
-    fn from(value: &IADsDeleteOps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsDeleteOps> for super::super::System::Com::IDispatch {
-    fn from(value: IADsDeleteOps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsDeleteOps> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsDeleteOps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsDeleteOps> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsDeleteOps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsDeleteOps, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsDeleteOps {
     fn clone(&self) -> Self {
@@ -4626,59 +4034,7 @@ impl IADsDomain {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsDomain> for ::windows::core::IUnknown {
-    fn from(value: IADsDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsDomain> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsDomain> for ::windows::core::IUnknown {
-    fn from(value: &IADsDomain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsDomain> for super::super::System::Com::IDispatch {
-    fn from(value: IADsDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsDomain> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsDomain> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsDomain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsDomain> for IADs {
-    fn from(value: IADsDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsDomain> for &'a IADs {
-    fn from(value: &'a IADsDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsDomain> for IADs {
-    fn from(value: &IADsDomain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsDomain, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsDomain {
     fn clone(&self) -> Self {
@@ -4752,41 +4108,7 @@ impl IADsEmail {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsEmail> for ::windows::core::IUnknown {
-    fn from(value: IADsEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsEmail> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsEmail> for ::windows::core::IUnknown {
-    fn from(value: &IADsEmail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsEmail> for super::super::System::Com::IDispatch {
-    fn from(value: IADsEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsEmail> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsEmail> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsEmail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsEmail, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsEmail {
     fn clone(&self) -> Self {
@@ -4849,21 +4171,7 @@ impl IADsExtension {
         (::windows::core::Vtable::vtable(self).PrivateInvoke)(::windows::core::Vtable::as_raw(self), dispidmember, ::core::mem::transmute(riid), lcid, wflags, ::core::mem::transmute(pdispparams), ::core::mem::transmute(pvarresult), ::core::mem::transmute(pexcepinfo), ::core::mem::transmute(puargerr)).ok()
     }
 }
-impl ::core::convert::From<IADsExtension> for ::windows::core::IUnknown {
-    fn from(value: IADsExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IADsExtension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IADsExtension> for ::windows::core::IUnknown {
-    fn from(value: &IADsExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsExtension, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IADsExtension {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4929,41 +4237,7 @@ impl IADsFaxNumber {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFaxNumber> for ::windows::core::IUnknown {
-    fn from(value: IADsFaxNumber) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFaxNumber> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsFaxNumber) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFaxNumber> for ::windows::core::IUnknown {
-    fn from(value: &IADsFaxNumber) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFaxNumber> for super::super::System::Com::IDispatch {
-    fn from(value: IADsFaxNumber) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFaxNumber> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsFaxNumber) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFaxNumber> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsFaxNumber) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsFaxNumber, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsFaxNumber {
     fn clone(&self) -> Self {
@@ -5187,77 +4461,7 @@ impl IADsFileService {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFileService> for ::windows::core::IUnknown {
-    fn from(value: IADsFileService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFileService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsFileService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFileService> for ::windows::core::IUnknown {
-    fn from(value: &IADsFileService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFileService> for super::super::System::Com::IDispatch {
-    fn from(value: IADsFileService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFileService> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsFileService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFileService> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsFileService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFileService> for IADs {
-    fn from(value: IADsFileService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFileService> for &'a IADs {
-    fn from(value: &'a IADsFileService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFileService> for IADs {
-    fn from(value: &IADsFileService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFileService> for IADsService {
-    fn from(value: IADsFileService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFileService> for &'a IADsService {
-    fn from(value: &'a IADsFileService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFileService> for IADsService {
-    fn from(value: &IADsFileService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsFileService, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs, IADsService);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsFileService {
     fn clone(&self) -> Self {
@@ -5401,77 +4605,7 @@ impl IADsFileServiceOperations {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFileServiceOperations> for ::windows::core::IUnknown {
-    fn from(value: IADsFileServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFileServiceOperations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsFileServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFileServiceOperations> for ::windows::core::IUnknown {
-    fn from(value: &IADsFileServiceOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFileServiceOperations> for super::super::System::Com::IDispatch {
-    fn from(value: IADsFileServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFileServiceOperations> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsFileServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFileServiceOperations> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsFileServiceOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFileServiceOperations> for IADs {
-    fn from(value: IADsFileServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFileServiceOperations> for &'a IADs {
-    fn from(value: &'a IADsFileServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFileServiceOperations> for IADs {
-    fn from(value: &IADsFileServiceOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFileServiceOperations> for IADsServiceOperations {
-    fn from(value: IADsFileServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFileServiceOperations> for &'a IADsServiceOperations {
-    fn from(value: &'a IADsFileServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFileServiceOperations> for IADsServiceOperations {
-    fn from(value: &IADsFileServiceOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsFileServiceOperations, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs, IADsServiceOperations);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsFileServiceOperations {
     fn clone(&self) -> Self {
@@ -5620,59 +4754,7 @@ impl IADsFileShare {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFileShare> for ::windows::core::IUnknown {
-    fn from(value: IADsFileShare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFileShare> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsFileShare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFileShare> for ::windows::core::IUnknown {
-    fn from(value: &IADsFileShare) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFileShare> for super::super::System::Com::IDispatch {
-    fn from(value: IADsFileShare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFileShare> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsFileShare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFileShare> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsFileShare) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsFileShare> for IADs {
-    fn from(value: IADsFileShare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsFileShare> for &'a IADs {
-    fn from(value: &'a IADsFileShare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsFileShare> for IADs {
-    fn from(value: &IADsFileShare) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsFileShare, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsFileShare {
     fn clone(&self) -> Self {
@@ -5813,59 +4895,7 @@ impl IADsGroup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsGroup> for ::windows::core::IUnknown {
-    fn from(value: IADsGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsGroup> for ::windows::core::IUnknown {
-    fn from(value: &IADsGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsGroup> for super::super::System::Com::IDispatch {
-    fn from(value: IADsGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsGroup> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsGroup> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsGroup> for IADs {
-    fn from(value: IADsGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsGroup> for &'a IADs {
-    fn from(value: &'a IADsGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsGroup> for IADs {
-    fn from(value: &IADsGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsGroup, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsGroup {
     fn clone(&self) -> Self {
@@ -5931,41 +4961,7 @@ impl IADsHold {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsHold> for ::windows::core::IUnknown {
-    fn from(value: IADsHold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsHold> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsHold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsHold> for ::windows::core::IUnknown {
-    fn from(value: &IADsHold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsHold> for super::super::System::Com::IDispatch {
-    fn from(value: IADsHold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsHold> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsHold) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsHold> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsHold) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsHold, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsHold {
     fn clone(&self) -> Self {
@@ -6026,41 +5022,7 @@ impl IADsLargeInteger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsLargeInteger> for ::windows::core::IUnknown {
-    fn from(value: IADsLargeInteger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsLargeInteger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsLargeInteger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsLargeInteger> for ::windows::core::IUnknown {
-    fn from(value: &IADsLargeInteger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsLargeInteger> for super::super::System::Com::IDispatch {
-    fn from(value: IADsLargeInteger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsLargeInteger> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsLargeInteger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsLargeInteger> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsLargeInteger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsLargeInteger, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsLargeInteger {
     fn clone(&self) -> Self {
@@ -6208,59 +5170,7 @@ impl IADsLocality {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsLocality> for ::windows::core::IUnknown {
-    fn from(value: IADsLocality) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsLocality> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsLocality) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsLocality> for ::windows::core::IUnknown {
-    fn from(value: &IADsLocality) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsLocality> for super::super::System::Com::IDispatch {
-    fn from(value: IADsLocality) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsLocality> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsLocality) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsLocality> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsLocality) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsLocality> for IADs {
-    fn from(value: IADsLocality) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsLocality> for &'a IADs {
-    fn from(value: &'a IADsLocality) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsLocality> for IADs {
-    fn from(value: &IADsLocality) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsLocality, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsLocality {
     fn clone(&self) -> Self {
@@ -6339,41 +5249,7 @@ impl IADsMembers {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsMembers> for ::windows::core::IUnknown {
-    fn from(value: IADsMembers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsMembers> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsMembers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsMembers> for ::windows::core::IUnknown {
-    fn from(value: &IADsMembers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsMembers> for super::super::System::Com::IDispatch {
-    fn from(value: IADsMembers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsMembers> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsMembers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsMembers> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsMembers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsMembers, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsMembers {
     fn clone(&self) -> Self {
@@ -6456,41 +5332,7 @@ impl IADsNameTranslate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsNameTranslate> for ::windows::core::IUnknown {
-    fn from(value: IADsNameTranslate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsNameTranslate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsNameTranslate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsNameTranslate> for ::windows::core::IUnknown {
-    fn from(value: &IADsNameTranslate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsNameTranslate> for super::super::System::Com::IDispatch {
-    fn from(value: IADsNameTranslate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsNameTranslate> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsNameTranslate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsNameTranslate> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsNameTranslate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsNameTranslate, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsNameTranslate {
     fn clone(&self) -> Self {
@@ -6619,59 +5461,7 @@ impl IADsNamespaces {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsNamespaces> for ::windows::core::IUnknown {
-    fn from(value: IADsNamespaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsNamespaces> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsNamespaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsNamespaces> for ::windows::core::IUnknown {
-    fn from(value: &IADsNamespaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsNamespaces> for super::super::System::Com::IDispatch {
-    fn from(value: IADsNamespaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsNamespaces> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsNamespaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsNamespaces> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsNamespaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsNamespaces> for IADs {
-    fn from(value: IADsNamespaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsNamespaces> for &'a IADs {
-    fn from(value: &'a IADsNamespaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsNamespaces> for IADs {
-    fn from(value: &IADsNamespaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsNamespaces, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsNamespaces {
     fn clone(&self) -> Self {
@@ -6737,41 +5527,7 @@ impl IADsNetAddress {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsNetAddress> for ::windows::core::IUnknown {
-    fn from(value: IADsNetAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsNetAddress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsNetAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsNetAddress> for ::windows::core::IUnknown {
-    fn from(value: &IADsNetAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsNetAddress> for super::super::System::Com::IDispatch {
-    fn from(value: IADsNetAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsNetAddress> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsNetAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsNetAddress> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsNetAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsNetAddress, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsNetAddress {
     fn clone(&self) -> Self {
@@ -6939,59 +5695,7 @@ impl IADsO {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsO> for ::windows::core::IUnknown {
-    fn from(value: IADsO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsO> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsO> for ::windows::core::IUnknown {
-    fn from(value: &IADsO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsO> for super::super::System::Com::IDispatch {
-    fn from(value: IADsO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsO> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsO> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsO> for IADs {
-    fn from(value: IADsO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsO> for &'a IADs {
-    fn from(value: &'a IADsO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsO> for IADs {
-    fn from(value: &IADsO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsO, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsO {
     fn clone(&self) -> Self {
@@ -7174,59 +5878,7 @@ impl IADsOU {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsOU> for ::windows::core::IUnknown {
-    fn from(value: IADsOU) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsOU> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsOU) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsOU> for ::windows::core::IUnknown {
-    fn from(value: &IADsOU) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsOU> for super::super::System::Com::IDispatch {
-    fn from(value: IADsOU) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsOU> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsOU) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsOU> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsOU) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsOU> for IADs {
-    fn from(value: IADsOU) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsOU> for &'a IADs {
-    fn from(value: &'a IADsOU) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsOU> for IADs {
-    fn from(value: &IADsOU) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsOU, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsOU {
     fn clone(&self) -> Self {
@@ -7303,41 +5955,7 @@ impl IADsObjectOptions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsObjectOptions> for ::windows::core::IUnknown {
-    fn from(value: IADsObjectOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsObjectOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsObjectOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsObjectOptions> for ::windows::core::IUnknown {
-    fn from(value: &IADsObjectOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsObjectOptions> for super::super::System::Com::IDispatch {
-    fn from(value: IADsObjectOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsObjectOptions> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsObjectOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsObjectOptions> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsObjectOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsObjectOptions, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsObjectOptions {
     fn clone(&self) -> Self {
@@ -7402,41 +6020,7 @@ impl IADsOctetList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsOctetList> for ::windows::core::IUnknown {
-    fn from(value: IADsOctetList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsOctetList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsOctetList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsOctetList> for ::windows::core::IUnknown {
-    fn from(value: &IADsOctetList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsOctetList> for super::super::System::Com::IDispatch {
-    fn from(value: IADsOctetList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsOctetList> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsOctetList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsOctetList> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsOctetList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsOctetList, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsOctetList {
     fn clone(&self) -> Self {
@@ -7493,41 +6077,7 @@ impl IADsOpenDSObject {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsOpenDSObject> for ::windows::core::IUnknown {
-    fn from(value: IADsOpenDSObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsOpenDSObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsOpenDSObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsOpenDSObject> for ::windows::core::IUnknown {
-    fn from(value: &IADsOpenDSObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsOpenDSObject> for super::super::System::Com::IDispatch {
-    fn from(value: IADsOpenDSObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsOpenDSObject> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsOpenDSObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsOpenDSObject> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsOpenDSObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsOpenDSObject, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsOpenDSObject {
     fn clone(&self) -> Self {
@@ -7595,41 +6145,7 @@ impl IADsPath {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPath> for ::windows::core::IUnknown {
-    fn from(value: IADsPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPath> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPath> for ::windows::core::IUnknown {
-    fn from(value: &IADsPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPath> for super::super::System::Com::IDispatch {
-    fn from(value: IADsPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPath> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPath> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsPath, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsPath {
     fn clone(&self) -> Self {
@@ -7719,41 +6235,7 @@ impl IADsPathname {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPathname> for ::windows::core::IUnknown {
-    fn from(value: IADsPathname) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPathname> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsPathname) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPathname> for ::windows::core::IUnknown {
-    fn from(value: &IADsPathname) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPathname> for super::super::System::Com::IDispatch {
-    fn from(value: IADsPathname) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPathname> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsPathname) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPathname> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsPathname) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsPathname, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsPathname {
     fn clone(&self) -> Self {
@@ -7824,41 +6306,7 @@ impl IADsPostalAddress {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPostalAddress> for ::windows::core::IUnknown {
-    fn from(value: IADsPostalAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPostalAddress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsPostalAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPostalAddress> for ::windows::core::IUnknown {
-    fn from(value: &IADsPostalAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPostalAddress> for super::super::System::Com::IDispatch {
-    fn from(value: IADsPostalAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPostalAddress> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsPostalAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPostalAddress> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsPostalAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsPostalAddress, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsPostalAddress {
     fn clone(&self) -> Self {
@@ -8041,59 +6489,7 @@ impl IADsPrintJob {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintJob> for ::windows::core::IUnknown {
-    fn from(value: IADsPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintJob> for ::windows::core::IUnknown {
-    fn from(value: &IADsPrintJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintJob> for super::super::System::Com::IDispatch {
-    fn from(value: IADsPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintJob> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintJob> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsPrintJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintJob> for IADs {
-    fn from(value: IADsPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintJob> for &'a IADs {
-    fn from(value: &'a IADsPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintJob> for IADs {
-    fn from(value: &IADsPrintJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsPrintJob, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsPrintJob {
     fn clone(&self) -> Self {
@@ -8245,59 +6641,7 @@ impl IADsPrintJobOperations {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintJobOperations> for ::windows::core::IUnknown {
-    fn from(value: IADsPrintJobOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintJobOperations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsPrintJobOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintJobOperations> for ::windows::core::IUnknown {
-    fn from(value: &IADsPrintJobOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintJobOperations> for super::super::System::Com::IDispatch {
-    fn from(value: IADsPrintJobOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintJobOperations> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsPrintJobOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintJobOperations> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsPrintJobOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintJobOperations> for IADs {
-    fn from(value: IADsPrintJobOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintJobOperations> for &'a IADs {
-    fn from(value: &'a IADsPrintJobOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintJobOperations> for IADs {
-    fn from(value: &IADsPrintJobOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsPrintJobOperations, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsPrintJobOperations {
     fn clone(&self) -> Self {
@@ -8518,59 +6862,7 @@ impl IADsPrintQueue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintQueue> for ::windows::core::IUnknown {
-    fn from(value: IADsPrintQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsPrintQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintQueue> for ::windows::core::IUnknown {
-    fn from(value: &IADsPrintQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintQueue> for super::super::System::Com::IDispatch {
-    fn from(value: IADsPrintQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintQueue> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsPrintQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintQueue> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsPrintQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintQueue> for IADs {
-    fn from(value: IADsPrintQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintQueue> for &'a IADs {
-    fn from(value: &'a IADsPrintQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintQueue> for IADs {
-    fn from(value: &IADsPrintQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsPrintQueue, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsPrintQueue {
     fn clone(&self) -> Self {
@@ -8736,59 +7028,7 @@ impl IADsPrintQueueOperations {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintQueueOperations> for ::windows::core::IUnknown {
-    fn from(value: IADsPrintQueueOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintQueueOperations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsPrintQueueOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintQueueOperations> for ::windows::core::IUnknown {
-    fn from(value: &IADsPrintQueueOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintQueueOperations> for super::super::System::Com::IDispatch {
-    fn from(value: IADsPrintQueueOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintQueueOperations> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsPrintQueueOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintQueueOperations> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsPrintQueueOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPrintQueueOperations> for IADs {
-    fn from(value: IADsPrintQueueOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPrintQueueOperations> for &'a IADs {
-    fn from(value: &'a IADsPrintQueueOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPrintQueueOperations> for IADs {
-    fn from(value: &IADsPrintQueueOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsPrintQueueOperations, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsPrintQueueOperations {
     fn clone(&self) -> Self {
@@ -8946,59 +7186,7 @@ impl IADsProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsProperty> for ::windows::core::IUnknown {
-    fn from(value: IADsProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsProperty> for ::windows::core::IUnknown {
-    fn from(value: &IADsProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsProperty> for super::super::System::Com::IDispatch {
-    fn from(value: IADsProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsProperty> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsProperty> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsProperty> for IADs {
-    fn from(value: IADsProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsProperty> for &'a IADs {
-    fn from(value: &'a IADsProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsProperty> for IADs {
-    fn from(value: &IADsProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsProperty, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsProperty {
     fn clone(&self) -> Self {
@@ -9093,41 +7281,7 @@ impl IADsPropertyEntry {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPropertyEntry> for ::windows::core::IUnknown {
-    fn from(value: IADsPropertyEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPropertyEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsPropertyEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPropertyEntry> for ::windows::core::IUnknown {
-    fn from(value: &IADsPropertyEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPropertyEntry> for super::super::System::Com::IDispatch {
-    fn from(value: IADsPropertyEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPropertyEntry> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsPropertyEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPropertyEntry> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsPropertyEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsPropertyEntry, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsPropertyEntry {
     fn clone(&self) -> Self {
@@ -9234,41 +7388,7 @@ impl IADsPropertyList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPropertyList> for ::windows::core::IUnknown {
-    fn from(value: IADsPropertyList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPropertyList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsPropertyList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPropertyList> for ::windows::core::IUnknown {
-    fn from(value: &IADsPropertyList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPropertyList> for super::super::System::Com::IDispatch {
-    fn from(value: IADsPropertyList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPropertyList> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsPropertyList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPropertyList> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsPropertyList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsPropertyList, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsPropertyList {
     fn clone(&self) -> Self {
@@ -9443,41 +7563,7 @@ impl IADsPropertyValue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPropertyValue> for ::windows::core::IUnknown {
-    fn from(value: IADsPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPropertyValue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPropertyValue> for ::windows::core::IUnknown {
-    fn from(value: &IADsPropertyValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPropertyValue> for super::super::System::Com::IDispatch {
-    fn from(value: IADsPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPropertyValue> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPropertyValue> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsPropertyValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsPropertyValue, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsPropertyValue {
     fn clone(&self) -> Self {
@@ -9576,41 +7662,7 @@ impl IADsPropertyValue2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPropertyValue2> for ::windows::core::IUnknown {
-    fn from(value: IADsPropertyValue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPropertyValue2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsPropertyValue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPropertyValue2> for ::windows::core::IUnknown {
-    fn from(value: &IADsPropertyValue2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsPropertyValue2> for super::super::System::Com::IDispatch {
-    fn from(value: IADsPropertyValue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsPropertyValue2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsPropertyValue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsPropertyValue2> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsPropertyValue2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsPropertyValue2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsPropertyValue2 {
     fn clone(&self) -> Self {
@@ -9703,41 +7755,7 @@ impl IADsReplicaPointer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsReplicaPointer> for ::windows::core::IUnknown {
-    fn from(value: IADsReplicaPointer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsReplicaPointer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsReplicaPointer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsReplicaPointer> for ::windows::core::IUnknown {
-    fn from(value: &IADsReplicaPointer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsReplicaPointer> for super::super::System::Com::IDispatch {
-    fn from(value: IADsReplicaPointer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsReplicaPointer> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsReplicaPointer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsReplicaPointer> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsReplicaPointer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsReplicaPointer, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsReplicaPointer {
     fn clone(&self) -> Self {
@@ -9878,59 +7896,7 @@ impl IADsResource {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsResource> for ::windows::core::IUnknown {
-    fn from(value: IADsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsResource> for ::windows::core::IUnknown {
-    fn from(value: &IADsResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsResource> for super::super::System::Com::IDispatch {
-    fn from(value: IADsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsResource> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsResource> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsResource> for IADs {
-    fn from(value: IADsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsResource> for &'a IADs {
-    fn from(value: &'a IADsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsResource> for IADs {
-    fn from(value: &IADsResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsResource, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsResource {
     fn clone(&self) -> Self {
@@ -10067,41 +8033,7 @@ impl IADsSecurityDescriptor {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsSecurityDescriptor> for ::windows::core::IUnknown {
-    fn from(value: IADsSecurityDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsSecurityDescriptor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsSecurityDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsSecurityDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &IADsSecurityDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsSecurityDescriptor> for super::super::System::Com::IDispatch {
-    fn from(value: IADsSecurityDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsSecurityDescriptor> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsSecurityDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsSecurityDescriptor> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsSecurityDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsSecurityDescriptor, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsSecurityDescriptor {
     fn clone(&self) -> Self {
@@ -10214,41 +8146,7 @@ impl IADsSecurityUtility {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsSecurityUtility> for ::windows::core::IUnknown {
-    fn from(value: IADsSecurityUtility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsSecurityUtility> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsSecurityUtility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsSecurityUtility> for ::windows::core::IUnknown {
-    fn from(value: &IADsSecurityUtility) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsSecurityUtility> for super::super::System::Com::IDispatch {
-    fn from(value: IADsSecurityUtility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsSecurityUtility> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsSecurityUtility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsSecurityUtility> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsSecurityUtility) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsSecurityUtility, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsSecurityUtility {
     fn clone(&self) -> Self {
@@ -10462,59 +8360,7 @@ impl IADsService {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsService> for ::windows::core::IUnknown {
-    fn from(value: IADsService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsService> for ::windows::core::IUnknown {
-    fn from(value: &IADsService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsService> for super::super::System::Com::IDispatch {
-    fn from(value: IADsService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsService> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsService> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsService> for IADs {
-    fn from(value: IADsService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsService> for &'a IADs {
-    fn from(value: &'a IADsService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsService> for IADs {
-    fn from(value: &IADsService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsService, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsService {
     fn clone(&self) -> Self {
@@ -10672,59 +8518,7 @@ impl IADsServiceOperations {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsServiceOperations> for ::windows::core::IUnknown {
-    fn from(value: IADsServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsServiceOperations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsServiceOperations> for ::windows::core::IUnknown {
-    fn from(value: &IADsServiceOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsServiceOperations> for super::super::System::Com::IDispatch {
-    fn from(value: IADsServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsServiceOperations> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsServiceOperations> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsServiceOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsServiceOperations> for IADs {
-    fn from(value: IADsServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsServiceOperations> for &'a IADs {
-    fn from(value: &'a IADsServiceOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsServiceOperations> for IADs {
-    fn from(value: &IADsServiceOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsServiceOperations, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsServiceOperations {
     fn clone(&self) -> Self {
@@ -10863,59 +8657,7 @@ impl IADsSession {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsSession> for ::windows::core::IUnknown {
-    fn from(value: IADsSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsSession> for ::windows::core::IUnknown {
-    fn from(value: &IADsSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsSession> for super::super::System::Com::IDispatch {
-    fn from(value: IADsSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsSession> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsSession> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsSession> for IADs {
-    fn from(value: IADsSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsSession> for &'a IADs {
-    fn from(value: &'a IADsSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsSession> for IADs {
-    fn from(value: &IADsSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsSession, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsSession {
     fn clone(&self) -> Self {
@@ -11037,59 +8779,7 @@ impl IADsSyntax {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsSyntax> for ::windows::core::IUnknown {
-    fn from(value: IADsSyntax) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsSyntax> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsSyntax) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsSyntax> for ::windows::core::IUnknown {
-    fn from(value: &IADsSyntax) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsSyntax> for super::super::System::Com::IDispatch {
-    fn from(value: IADsSyntax) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsSyntax> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsSyntax) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsSyntax> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsSyntax) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsSyntax> for IADs {
-    fn from(value: IADsSyntax) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsSyntax> for &'a IADs {
-    fn from(value: &'a IADsSyntax) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsSyntax> for IADs {
-    fn from(value: &IADsSyntax) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsSyntax, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsSyntax {
     fn clone(&self) -> Self {
@@ -11148,41 +8838,7 @@ impl IADsTimestamp {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsTimestamp> for ::windows::core::IUnknown {
-    fn from(value: IADsTimestamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsTimestamp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsTimestamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsTimestamp> for ::windows::core::IUnknown {
-    fn from(value: &IADsTimestamp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsTimestamp> for super::super::System::Com::IDispatch {
-    fn from(value: IADsTimestamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsTimestamp> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsTimestamp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsTimestamp> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsTimestamp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsTimestamp, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsTimestamp {
     fn clone(&self) -> Self {
@@ -11250,41 +8906,7 @@ impl IADsTypedName {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsTypedName> for ::windows::core::IUnknown {
-    fn from(value: IADsTypedName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsTypedName> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsTypedName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsTypedName> for ::windows::core::IUnknown {
-    fn from(value: &IADsTypedName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsTypedName> for super::super::System::Com::IDispatch {
-    fn from(value: IADsTypedName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsTypedName> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsTypedName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsTypedName> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsTypedName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsTypedName, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsTypedName {
     fn clone(&self) -> Self {
@@ -11813,59 +9435,7 @@ impl IADsUser {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsUser> for ::windows::core::IUnknown {
-    fn from(value: IADsUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsUser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsUser> for ::windows::core::IUnknown {
-    fn from(value: &IADsUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsUser> for super::super::System::Com::IDispatch {
-    fn from(value: IADsUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsUser> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsUser> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsUser> for IADs {
-    fn from(value: IADsUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsUser> for &'a IADs {
-    fn from(value: &'a IADsUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsUser> for IADs {
-    fn from(value: &IADsUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsUser, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IADs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsUser {
     fn clone(&self) -> Self {
@@ -12096,41 +9666,7 @@ impl IADsWinNTSystemInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsWinNTSystemInfo> for ::windows::core::IUnknown {
-    fn from(value: IADsWinNTSystemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsWinNTSystemInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsWinNTSystemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsWinNTSystemInfo> for ::windows::core::IUnknown {
-    fn from(value: &IADsWinNTSystemInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsWinNTSystemInfo> for super::super::System::Com::IDispatch {
-    fn from(value: IADsWinNTSystemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsWinNTSystemInfo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IADsWinNTSystemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsWinNTSystemInfo> for super::super::System::Com::IDispatch {
-    fn from(value: &IADsWinNTSystemInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsWinNTSystemInfo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsWinNTSystemInfo {
     fn clone(&self) -> Self {
@@ -12182,21 +9718,7 @@ impl ICommonQuery {
         (::windows::core::Vtable::vtable(self).OpenQueryWindow)(::windows::core::Vtable::as_raw(self), hwndparent.into(), ::core::mem::transmute(pquerywnd), ::core::mem::transmute(ppdataobject)).ok()
     }
 }
-impl ::core::convert::From<ICommonQuery> for ::windows::core::IUnknown {
-    fn from(value: ICommonQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommonQuery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommonQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommonQuery> for ::windows::core::IUnknown {
-    fn from(value: &ICommonQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommonQuery, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICommonQuery {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12263,21 +9785,7 @@ impl IDirectoryObject {
         (::windows::core::Vtable::vtable(self).DeleteDSObject)(::windows::core::Vtable::as_raw(self), pszrdnname.into()).ok()
     }
 }
-impl ::core::convert::From<IDirectoryObject> for ::windows::core::IUnknown {
-    fn from(value: IDirectoryObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectoryObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectoryObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectoryObject> for ::windows::core::IUnknown {
-    fn from(value: &IDirectoryObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectoryObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectoryObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12378,21 +9886,7 @@ impl IDirectorySchemaMgmt {
         (::windows::core::Vtable::vtable(self).DeleteClassDefinition)(::windows::core::Vtable::as_raw(self), pszclassname.into()).ok()
     }
 }
-impl ::core::convert::From<IDirectorySchemaMgmt> for ::windows::core::IUnknown {
-    fn from(value: IDirectorySchemaMgmt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectorySchemaMgmt> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectorySchemaMgmt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectorySchemaMgmt> for ::windows::core::IUnknown {
-    fn from(value: &IDirectorySchemaMgmt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectorySchemaMgmt, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectorySchemaMgmt {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12514,21 +10008,7 @@ impl IDirectorySearch {
         (::windows::core::Vtable::vtable(self).CloseSearchHandle)(::windows::core::Vtable::as_raw(self), hsearchresult.into()).ok()
     }
 }
-impl ::core::convert::From<IDirectorySearch> for ::windows::core::IUnknown {
-    fn from(value: IDirectorySearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectorySearch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectorySearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectorySearch> for ::windows::core::IUnknown {
-    fn from(value: &IDirectorySearch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectorySearch, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectorySearch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12599,21 +10079,7 @@ impl IDsAdminCreateObj {
         (::windows::core::Vtable::vtable(self).CreateModal)(::windows::core::Vtable::as_raw(self), hwndparent.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IADs>(result__)
     }
 }
-impl ::core::convert::From<IDsAdminCreateObj> for ::windows::core::IUnknown {
-    fn from(value: IDsAdminCreateObj) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDsAdminCreateObj> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDsAdminCreateObj) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDsAdminCreateObj> for ::windows::core::IUnknown {
-    fn from(value: &IDsAdminCreateObj) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDsAdminCreateObj, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDsAdminCreateObj {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12665,21 +10131,7 @@ impl IDsAdminNewObj {
         (::windows::core::Vtable::vtable(self).GetPageCounts)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pntotal), ::core::mem::transmute(pnstartindex)).ok()
     }
 }
-impl ::core::convert::From<IDsAdminNewObj> for ::windows::core::IUnknown {
-    fn from(value: IDsAdminNewObj) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDsAdminNewObj> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDsAdminNewObj) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDsAdminNewObj> for ::windows::core::IUnknown {
-    fn from(value: &IDsAdminNewObj) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDsAdminNewObj, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDsAdminNewObj {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12763,21 +10215,7 @@ impl IDsAdminNewObjExt {
         (::windows::core::Vtable::vtable(self).GetSummaryInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbstrtext)).ok()
     }
 }
-impl ::core::convert::From<IDsAdminNewObjExt> for ::windows::core::IUnknown {
-    fn from(value: IDsAdminNewObjExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDsAdminNewObjExt> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDsAdminNewObjExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDsAdminNewObjExt> for ::windows::core::IUnknown {
-    fn from(value: &IDsAdminNewObjExt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDsAdminNewObjExt, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDsAdminNewObjExt {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12840,21 +10278,7 @@ impl IDsAdminNewObjPrimarySite {
         (::windows::core::Vtable::vtable(self).Commit)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDsAdminNewObjPrimarySite> for ::windows::core::IUnknown {
-    fn from(value: IDsAdminNewObjPrimarySite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDsAdminNewObjPrimarySite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDsAdminNewObjPrimarySite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDsAdminNewObjPrimarySite> for ::windows::core::IUnknown {
-    fn from(value: &IDsAdminNewObjPrimarySite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDsAdminNewObjPrimarySite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDsAdminNewObjPrimarySite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12912,21 +10336,7 @@ impl IDsAdminNotifyHandler {
         (::windows::core::Vtable::vtable(self).End)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDsAdminNotifyHandler> for ::windows::core::IUnknown {
-    fn from(value: IDsAdminNotifyHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDsAdminNotifyHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDsAdminNotifyHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDsAdminNotifyHandler> for ::windows::core::IUnknown {
-    fn from(value: &IDsAdminNotifyHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDsAdminNotifyHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDsAdminNotifyHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12998,21 +10408,7 @@ impl IDsBrowseDomainTree {
         (::windows::core::Vtable::vtable(self).SetComputer)(::windows::core::Vtable::as_raw(self), pszcomputername.into(), pszusername.into(), pszpassword.into()).ok()
     }
 }
-impl ::core::convert::From<IDsBrowseDomainTree> for ::windows::core::IUnknown {
-    fn from(value: IDsBrowseDomainTree) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDsBrowseDomainTree> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDsBrowseDomainTree) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDsBrowseDomainTree> for ::windows::core::IUnknown {
-    fn from(value: &IDsBrowseDomainTree) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDsBrowseDomainTree, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDsBrowseDomainTree {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13133,21 +10529,7 @@ impl IDsDisplaySpecifier {
         (::windows::core::Vtable::vtable(self).GetAttributeADsType)(::windows::core::Vtable::as_raw(self), pszattributename.into())
     }
 }
-impl ::core::convert::From<IDsDisplaySpecifier> for ::windows::core::IUnknown {
-    fn from(value: IDsDisplaySpecifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDsDisplaySpecifier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDsDisplaySpecifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDsDisplaySpecifier> for ::windows::core::IUnknown {
-    fn from(value: &IDsDisplaySpecifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDsDisplaySpecifier, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDsDisplaySpecifier {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13212,21 +10594,7 @@ impl IDsObjectPicker {
         (::windows::core::Vtable::vtable(self).InvokeDialog)(::windows::core::Vtable::as_raw(self), hwndparent.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IDataObject>(result__)
     }
 }
-impl ::core::convert::From<IDsObjectPicker> for ::windows::core::IUnknown {
-    fn from(value: IDsObjectPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDsObjectPicker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDsObjectPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDsObjectPicker> for ::windows::core::IUnknown {
-    fn from(value: &IDsObjectPicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDsObjectPicker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDsObjectPicker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13283,36 +10651,7 @@ impl IDsObjectPickerCredentials {
         (::windows::core::Vtable::vtable(self).SetCredentials)(::windows::core::Vtable::as_raw(self), szusername.into(), szpassword.into()).ok()
     }
 }
-impl ::core::convert::From<IDsObjectPickerCredentials> for ::windows::core::IUnknown {
-    fn from(value: IDsObjectPickerCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDsObjectPickerCredentials> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDsObjectPickerCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDsObjectPickerCredentials> for ::windows::core::IUnknown {
-    fn from(value: &IDsObjectPickerCredentials) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDsObjectPickerCredentials> for IDsObjectPicker {
-    fn from(value: IDsObjectPickerCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDsObjectPickerCredentials> for &'a IDsObjectPicker {
-    fn from(value: &'a IDsObjectPickerCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDsObjectPickerCredentials> for IDsObjectPicker {
-    fn from(value: &IDsObjectPickerCredentials) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDsObjectPickerCredentials, ::windows::core::IUnknown, IDsObjectPicker);
 impl ::core::clone::Clone for IDsObjectPickerCredentials {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13401,41 +10740,7 @@ impl IPersistQuery {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistQuery> for ::windows::core::IUnknown {
-    fn from(value: IPersistQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistQuery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistQuery> for ::windows::core::IUnknown {
-    fn from(value: &IPersistQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistQuery> for super::super::System::Com::IPersist {
-    fn from(value: IPersistQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistQuery> for &'a super::super::System::Com::IPersist {
-    fn from(value: &'a IPersistQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistQuery> for super::super::System::Com::IPersist {
-    fn from(value: &IPersistQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistQuery, ::windows::core::IUnknown, super::super::System::Com::IPersist);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPersistQuery {
     fn clone(&self) -> Self {
@@ -13504,21 +10809,7 @@ impl IPrivateDispatch {
         (::windows::core::Vtable::vtable(self).ADSIInvoke)(::windows::core::Vtable::as_raw(self), dispidmember, ::core::mem::transmute(riid), lcid, wflags, ::core::mem::transmute(pdispparams), ::core::mem::transmute(pvarresult), ::core::mem::transmute(pexcepinfo), ::core::mem::transmute(puargerr)).ok()
     }
 }
-impl ::core::convert::From<IPrivateDispatch> for ::windows::core::IUnknown {
-    fn from(value: IPrivateDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrivateDispatch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrivateDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrivateDispatch> for ::windows::core::IUnknown {
-    fn from(value: &IPrivateDispatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrivateDispatch, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrivateDispatch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13568,21 +10859,7 @@ impl IPrivateUnknown {
         (::windows::core::Vtable::vtable(self).ADSIReleaseObject)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrivateUnknown> for ::windows::core::IUnknown {
-    fn from(value: IPrivateUnknown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrivateUnknown> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrivateUnknown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrivateUnknown> for ::windows::core::IUnknown {
-    fn from(value: &IPrivateUnknown) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrivateUnknown, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrivateUnknown {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13641,21 +10918,7 @@ impl IQueryForm {
         (::windows::core::Vtable::vtable(self).AddPages)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(paddpagesproc), lparam.into()).ok()
     }
 }
-impl ::core::convert::From<IQueryForm> for ::windows::core::IUnknown {
-    fn from(value: IQueryForm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQueryForm> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryForm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQueryForm> for ::windows::core::IUnknown {
-    fn from(value: &IQueryForm) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryForm, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IQueryForm {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/mod.rs
@@ -31,21 +31,7 @@ impl AsyncIBackgroundCopyCallback {
         (::windows::core::Vtable::vtable(self).Finish_JobModification)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIBackgroundCopyCallback> for ::windows::core::IUnknown {
-    fn from(value: AsyncIBackgroundCopyCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIBackgroundCopyCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIBackgroundCopyCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIBackgroundCopyCallback> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIBackgroundCopyCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIBackgroundCopyCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIBackgroundCopyCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -101,41 +87,7 @@ impl IBITSExtensionSetup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBITSExtensionSetup> for ::windows::core::IUnknown {
-    fn from(value: IBITSExtensionSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBITSExtensionSetup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBITSExtensionSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBITSExtensionSetup> for ::windows::core::IUnknown {
-    fn from(value: &IBITSExtensionSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBITSExtensionSetup> for super::super::System::Com::IDispatch {
-    fn from(value: IBITSExtensionSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBITSExtensionSetup> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IBITSExtensionSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBITSExtensionSetup> for super::super::System::Com::IDispatch {
-    fn from(value: &IBITSExtensionSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBITSExtensionSetup, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IBITSExtensionSetup {
     fn clone(&self) -> Self {
@@ -188,41 +140,7 @@ impl IBITSExtensionSetupFactory {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBITSExtensionSetupFactory> for ::windows::core::IUnknown {
-    fn from(value: IBITSExtensionSetupFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBITSExtensionSetupFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBITSExtensionSetupFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBITSExtensionSetupFactory> for ::windows::core::IUnknown {
-    fn from(value: &IBITSExtensionSetupFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBITSExtensionSetupFactory> for super::super::System::Com::IDispatch {
-    fn from(value: IBITSExtensionSetupFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBITSExtensionSetupFactory> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IBITSExtensionSetupFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBITSExtensionSetupFactory> for super::super::System::Com::IDispatch {
-    fn from(value: &IBITSExtensionSetupFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBITSExtensionSetupFactory, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IBITSExtensionSetupFactory {
     fn clone(&self) -> Self {
@@ -285,21 +203,7 @@ impl IBackgroundCopyCallback {
         (::windows::core::Vtable::vtable(self).JobModification)(::windows::core::Vtable::as_raw(self), pjob.into().abi(), dwreserved).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyCallback> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyCallback> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBackgroundCopyCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -356,21 +260,7 @@ impl IBackgroundCopyCallback1 {
         (::windows::core::Vtable::vtable(self).OnProgressEx)(::windows::core::Vtable::as_raw(self), progresstype, pgroup.into().abi(), pjob.into().abi(), dwfileindex, dwprogressvalue, pbyte.len() as _, ::core::mem::transmute(pbyte.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyCallback1> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyCallback1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyCallback1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyCallback1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyCallback1> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyCallback1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyCallback1, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBackgroundCopyCallback1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -432,36 +322,7 @@ impl IBackgroundCopyCallback2 {
         (::windows::core::Vtable::vtable(self).FileTransferred)(::windows::core::Vtable::as_raw(self), pjob.into().abi(), pfile.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyCallback2> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyCallback2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyCallback2> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyCallback2> for IBackgroundCopyCallback {
-    fn from(value: IBackgroundCopyCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyCallback2> for &'a IBackgroundCopyCallback {
-    fn from(value: &'a IBackgroundCopyCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyCallback2> for IBackgroundCopyCallback {
-    fn from(value: &IBackgroundCopyCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyCallback2, ::windows::core::IUnknown, IBackgroundCopyCallback);
 impl ::core::clone::Clone for IBackgroundCopyCallback2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -528,51 +389,7 @@ impl IBackgroundCopyCallback3 {
         (::windows::core::Vtable::vtable(self).FileRangesTransferred)(::windows::core::Vtable::as_raw(self), job.into().abi(), file.into().abi(), ranges.len() as _, ::core::mem::transmute(ranges.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyCallback3> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyCallback3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyCallback3> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyCallback3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyCallback3> for IBackgroundCopyCallback {
-    fn from(value: IBackgroundCopyCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyCallback3> for &'a IBackgroundCopyCallback {
-    fn from(value: &'a IBackgroundCopyCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyCallback3> for IBackgroundCopyCallback {
-    fn from(value: &IBackgroundCopyCallback3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyCallback3> for IBackgroundCopyCallback2 {
-    fn from(value: IBackgroundCopyCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyCallback3> for &'a IBackgroundCopyCallback2 {
-    fn from(value: &'a IBackgroundCopyCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyCallback3> for IBackgroundCopyCallback2 {
-    fn from(value: &IBackgroundCopyCallback3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyCallback3, ::windows::core::IUnknown, IBackgroundCopyCallback, IBackgroundCopyCallback2);
 impl ::core::clone::Clone for IBackgroundCopyCallback3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -625,21 +442,7 @@ impl IBackgroundCopyError {
         (::windows::core::Vtable::vtable(self).GetProtocol)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyError> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyError> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyError, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBackgroundCopyError {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -691,21 +494,7 @@ impl IBackgroundCopyFile {
         (::windows::core::Vtable::vtable(self).GetProgress)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<BG_FILE_PROGRESS>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyFile> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyFile, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBackgroundCopyFile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -767,36 +556,7 @@ impl IBackgroundCopyFile2 {
         (::windows::core::Vtable::vtable(self).SetRemoteName)(::windows::core::Vtable::as_raw(self), val.into()).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyFile2> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyFile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyFile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile2> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyFile2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile2> for IBackgroundCopyFile {
-    fn from(value: IBackgroundCopyFile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile2> for &'a IBackgroundCopyFile {
-    fn from(value: &'a IBackgroundCopyFile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile2> for IBackgroundCopyFile {
-    fn from(value: &IBackgroundCopyFile2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyFile2, ::windows::core::IUnknown, IBackgroundCopyFile);
 impl ::core::clone::Clone for IBackgroundCopyFile2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -878,51 +638,7 @@ impl IBackgroundCopyFile3 {
         (::windows::core::Vtable::vtable(self).IsDownloadedFromPeer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyFile3> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyFile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyFile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile3> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyFile3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile3> for IBackgroundCopyFile {
-    fn from(value: IBackgroundCopyFile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile3> for &'a IBackgroundCopyFile {
-    fn from(value: &'a IBackgroundCopyFile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile3> for IBackgroundCopyFile {
-    fn from(value: &IBackgroundCopyFile3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile3> for IBackgroundCopyFile2 {
-    fn from(value: IBackgroundCopyFile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile3> for &'a IBackgroundCopyFile2 {
-    fn from(value: &'a IBackgroundCopyFile3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile3> for IBackgroundCopyFile2 {
-    fn from(value: &IBackgroundCopyFile3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyFile3, ::windows::core::IUnknown, IBackgroundCopyFile, IBackgroundCopyFile2);
 impl ::core::clone::Clone for IBackgroundCopyFile3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1018,66 +734,7 @@ impl IBackgroundCopyFile4 {
         (::windows::core::Vtable::vtable(self).GetPeerDownloadStats)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfromorigin), ::core::mem::transmute(pfrompeers)).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyFile4> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyFile4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyFile4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile4> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyFile4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile4> for IBackgroundCopyFile {
-    fn from(value: IBackgroundCopyFile4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile4> for &'a IBackgroundCopyFile {
-    fn from(value: &'a IBackgroundCopyFile4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile4> for IBackgroundCopyFile {
-    fn from(value: &IBackgroundCopyFile4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile4> for IBackgroundCopyFile2 {
-    fn from(value: IBackgroundCopyFile4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile4> for &'a IBackgroundCopyFile2 {
-    fn from(value: &'a IBackgroundCopyFile4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile4> for IBackgroundCopyFile2 {
-    fn from(value: &IBackgroundCopyFile4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile4> for IBackgroundCopyFile3 {
-    fn from(value: IBackgroundCopyFile4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile4> for &'a IBackgroundCopyFile3 {
-    fn from(value: &'a IBackgroundCopyFile4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile4> for IBackgroundCopyFile3 {
-    fn from(value: &IBackgroundCopyFile4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyFile4, ::windows::core::IUnknown, IBackgroundCopyFile, IBackgroundCopyFile2, IBackgroundCopyFile3);
 impl ::core::clone::Clone for IBackgroundCopyFile4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1168,81 +825,7 @@ impl IBackgroundCopyFile5 {
         (::windows::core::Vtable::vtable(self).GetProperty)(::windows::core::Vtable::as_raw(self), propertyid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<BITS_FILE_PROPERTY_VALUE>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyFile5> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyFile5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyFile5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile5> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyFile5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile5> for IBackgroundCopyFile {
-    fn from(value: IBackgroundCopyFile5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile5> for &'a IBackgroundCopyFile {
-    fn from(value: &'a IBackgroundCopyFile5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile5> for IBackgroundCopyFile {
-    fn from(value: &IBackgroundCopyFile5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile5> for IBackgroundCopyFile2 {
-    fn from(value: IBackgroundCopyFile5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile5> for &'a IBackgroundCopyFile2 {
-    fn from(value: &'a IBackgroundCopyFile5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile5> for IBackgroundCopyFile2 {
-    fn from(value: &IBackgroundCopyFile5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile5> for IBackgroundCopyFile3 {
-    fn from(value: IBackgroundCopyFile5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile5> for &'a IBackgroundCopyFile3 {
-    fn from(value: &'a IBackgroundCopyFile5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile5> for IBackgroundCopyFile3 {
-    fn from(value: &IBackgroundCopyFile5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile5> for IBackgroundCopyFile4 {
-    fn from(value: IBackgroundCopyFile5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile5> for &'a IBackgroundCopyFile4 {
-    fn from(value: &'a IBackgroundCopyFile5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile5> for IBackgroundCopyFile4 {
-    fn from(value: &IBackgroundCopyFile5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyFile5, ::windows::core::IUnknown, IBackgroundCopyFile, IBackgroundCopyFile2, IBackgroundCopyFile3, IBackgroundCopyFile4);
 impl ::core::clone::Clone for IBackgroundCopyFile5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1343,96 +926,7 @@ impl IBackgroundCopyFile6 {
         (::windows::core::Vtable::vtable(self).GetFilledFileRanges)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rangecount), ::core::mem::transmute(ranges)).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyFile6> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile6> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyFile6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile6> for IBackgroundCopyFile {
-    fn from(value: IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile6> for &'a IBackgroundCopyFile {
-    fn from(value: &'a IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile6> for IBackgroundCopyFile {
-    fn from(value: &IBackgroundCopyFile6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile6> for IBackgroundCopyFile2 {
-    fn from(value: IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile6> for &'a IBackgroundCopyFile2 {
-    fn from(value: &'a IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile6> for IBackgroundCopyFile2 {
-    fn from(value: &IBackgroundCopyFile6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile6> for IBackgroundCopyFile3 {
-    fn from(value: IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile6> for &'a IBackgroundCopyFile3 {
-    fn from(value: &'a IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile6> for IBackgroundCopyFile3 {
-    fn from(value: &IBackgroundCopyFile6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile6> for IBackgroundCopyFile4 {
-    fn from(value: IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile6> for &'a IBackgroundCopyFile4 {
-    fn from(value: &'a IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile6> for IBackgroundCopyFile4 {
-    fn from(value: &IBackgroundCopyFile6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyFile6> for IBackgroundCopyFile5 {
-    fn from(value: IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyFile6> for &'a IBackgroundCopyFile5 {
-    fn from(value: &'a IBackgroundCopyFile6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyFile6> for IBackgroundCopyFile5 {
-    fn from(value: &IBackgroundCopyFile6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyFile6, ::windows::core::IUnknown, IBackgroundCopyFile, IBackgroundCopyFile2, IBackgroundCopyFile3, IBackgroundCopyFile4, IBackgroundCopyFile5);
 impl ::core::clone::Clone for IBackgroundCopyFile6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1528,21 +1022,7 @@ impl IBackgroundCopyGroup {
         (::windows::core::Vtable::vtable(self).SetNotificationPointer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(iid), punk.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyGroup> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyGroup> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyGroup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBackgroundCopyGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1727,21 +1207,7 @@ impl IBackgroundCopyJob {
         (::windows::core::Vtable::vtable(self).TakeOwnership)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyJob> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyJob, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBackgroundCopyJob {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1837,21 +1303,7 @@ impl IBackgroundCopyJob1 {
         (::windows::core::Vtable::vtable(self).JobID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyJob1> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyJob1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyJob1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob1> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyJob1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyJob1, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBackgroundCopyJob1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2055,36 +1507,7 @@ impl IBackgroundCopyJob2 {
         (::windows::core::Vtable::vtable(self).RemoveCredentials)(::windows::core::Vtable::as_raw(self), target, scheme).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyJob2> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyJob2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyJob2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob2> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyJob2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJob2> for IBackgroundCopyJob {
-    fn from(value: IBackgroundCopyJob2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob2> for &'a IBackgroundCopyJob {
-    fn from(value: &'a IBackgroundCopyJob2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob2> for IBackgroundCopyJob {
-    fn from(value: &IBackgroundCopyJob2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyJob2, ::windows::core::IUnknown, IBackgroundCopyJob);
 impl ::core::clone::Clone for IBackgroundCopyJob2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2309,51 +1732,7 @@ impl IBackgroundCopyJob3 {
         (::windows::core::Vtable::vtable(self).GetFileACLFlags)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyJob3> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyJob3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyJob3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob3> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyJob3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJob3> for IBackgroundCopyJob {
-    fn from(value: IBackgroundCopyJob3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob3> for &'a IBackgroundCopyJob {
-    fn from(value: &'a IBackgroundCopyJob3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob3> for IBackgroundCopyJob {
-    fn from(value: &IBackgroundCopyJob3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJob3> for IBackgroundCopyJob2 {
-    fn from(value: IBackgroundCopyJob3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob3> for &'a IBackgroundCopyJob2 {
-    fn from(value: &'a IBackgroundCopyJob3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob3> for IBackgroundCopyJob2 {
-    fn from(value: &IBackgroundCopyJob3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyJob3, ::windows::core::IUnknown, IBackgroundCopyJob, IBackgroundCopyJob2);
 impl ::core::clone::Clone for IBackgroundCopyJob3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2598,66 +1977,7 @@ impl IBackgroundCopyJob4 {
         (::windows::core::Vtable::vtable(self).GetMaximumDownloadTime)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyJob4> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyJob4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyJob4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob4> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyJob4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJob4> for IBackgroundCopyJob {
-    fn from(value: IBackgroundCopyJob4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob4> for &'a IBackgroundCopyJob {
-    fn from(value: &'a IBackgroundCopyJob4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob4> for IBackgroundCopyJob {
-    fn from(value: &IBackgroundCopyJob4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJob4> for IBackgroundCopyJob2 {
-    fn from(value: IBackgroundCopyJob4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob4> for &'a IBackgroundCopyJob2 {
-    fn from(value: &'a IBackgroundCopyJob4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob4> for IBackgroundCopyJob2 {
-    fn from(value: &IBackgroundCopyJob4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJob4> for IBackgroundCopyJob3 {
-    fn from(value: IBackgroundCopyJob4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob4> for &'a IBackgroundCopyJob3 {
-    fn from(value: &'a IBackgroundCopyJob4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob4> for IBackgroundCopyJob3 {
-    fn from(value: &IBackgroundCopyJob4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyJob4, ::windows::core::IUnknown, IBackgroundCopyJob, IBackgroundCopyJob2, IBackgroundCopyJob3);
 impl ::core::clone::Clone for IBackgroundCopyJob4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2918,81 +2238,7 @@ impl IBackgroundCopyJob5 {
         (::windows::core::Vtable::vtable(self).GetProperty)(::windows::core::Vtable::as_raw(self), propertyid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<BITS_JOB_PROPERTY_VALUE>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyJob5> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyJob5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyJob5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob5> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyJob5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJob5> for IBackgroundCopyJob {
-    fn from(value: IBackgroundCopyJob5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob5> for &'a IBackgroundCopyJob {
-    fn from(value: &'a IBackgroundCopyJob5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob5> for IBackgroundCopyJob {
-    fn from(value: &IBackgroundCopyJob5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJob5> for IBackgroundCopyJob2 {
-    fn from(value: IBackgroundCopyJob5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob5> for &'a IBackgroundCopyJob2 {
-    fn from(value: &'a IBackgroundCopyJob5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob5> for IBackgroundCopyJob2 {
-    fn from(value: &IBackgroundCopyJob5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJob5> for IBackgroundCopyJob3 {
-    fn from(value: IBackgroundCopyJob5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob5> for &'a IBackgroundCopyJob3 {
-    fn from(value: &'a IBackgroundCopyJob5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob5> for IBackgroundCopyJob3 {
-    fn from(value: &IBackgroundCopyJob5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJob5> for IBackgroundCopyJob4 {
-    fn from(value: IBackgroundCopyJob5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJob5> for &'a IBackgroundCopyJob4 {
-    fn from(value: &'a IBackgroundCopyJob5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJob5> for IBackgroundCopyJob4 {
-    fn from(value: &IBackgroundCopyJob5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyJob5, ::windows::core::IUnknown, IBackgroundCopyJob, IBackgroundCopyJob2, IBackgroundCopyJob3, IBackgroundCopyJob4);
 impl ::core::clone::Clone for IBackgroundCopyJob5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3069,21 +2315,7 @@ impl IBackgroundCopyJobHttpOptions {
         (::windows::core::Vtable::vtable(self).GetSecurityFlags)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyJobHttpOptions> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyJobHttpOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJobHttpOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyJobHttpOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJobHttpOptions> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyJobHttpOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyJobHttpOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBackgroundCopyJobHttpOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3170,36 +2402,7 @@ impl IBackgroundCopyJobHttpOptions2 {
         (::windows::core::Vtable::vtable(self).GetHttpMethod)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyJobHttpOptions2> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyJobHttpOptions2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJobHttpOptions2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyJobHttpOptions2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJobHttpOptions2> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyJobHttpOptions2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJobHttpOptions2> for IBackgroundCopyJobHttpOptions {
-    fn from(value: IBackgroundCopyJobHttpOptions2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJobHttpOptions2> for &'a IBackgroundCopyJobHttpOptions {
-    fn from(value: &'a IBackgroundCopyJobHttpOptions2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJobHttpOptions2> for IBackgroundCopyJobHttpOptions {
-    fn from(value: &IBackgroundCopyJobHttpOptions2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyJobHttpOptions2, ::windows::core::IUnknown, IBackgroundCopyJobHttpOptions);
 impl ::core::clone::Clone for IBackgroundCopyJobHttpOptions2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3289,51 +2492,7 @@ impl IBackgroundCopyJobHttpOptions3 {
         (::windows::core::Vtable::vtable(self).MakeCustomHeadersWriteOnly)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyJobHttpOptions3> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyJobHttpOptions3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJobHttpOptions3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyJobHttpOptions3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJobHttpOptions3> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyJobHttpOptions3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJobHttpOptions3> for IBackgroundCopyJobHttpOptions {
-    fn from(value: IBackgroundCopyJobHttpOptions3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJobHttpOptions3> for &'a IBackgroundCopyJobHttpOptions {
-    fn from(value: &'a IBackgroundCopyJobHttpOptions3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJobHttpOptions3> for IBackgroundCopyJobHttpOptions {
-    fn from(value: &IBackgroundCopyJobHttpOptions3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBackgroundCopyJobHttpOptions3> for IBackgroundCopyJobHttpOptions2 {
-    fn from(value: IBackgroundCopyJobHttpOptions3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyJobHttpOptions3> for &'a IBackgroundCopyJobHttpOptions2 {
-    fn from(value: &'a IBackgroundCopyJobHttpOptions3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyJobHttpOptions3> for IBackgroundCopyJobHttpOptions2 {
-    fn from(value: &IBackgroundCopyJobHttpOptions3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyJobHttpOptions3, ::windows::core::IUnknown, IBackgroundCopyJobHttpOptions, IBackgroundCopyJobHttpOptions2);
 impl ::core::clone::Clone for IBackgroundCopyJobHttpOptions3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3386,21 +2545,7 @@ impl IBackgroundCopyManager {
         (::windows::core::Vtable::vtable(self).GetErrorDescription)(::windows::core::Vtable::as_raw(self), hresult, languageid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyManager> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyManager> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBackgroundCopyManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3449,21 +2594,7 @@ impl IBackgroundCopyQMgr {
         (::windows::core::Vtable::vtable(self).EnumGroups)(::windows::core::Vtable::as_raw(self), dwflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumBackgroundCopyGroups>(result__)
     }
 }
-impl ::core::convert::From<IBackgroundCopyQMgr> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyQMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyQMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyQMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyQMgr> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyQMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyQMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBackgroundCopyQMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3506,21 +2637,7 @@ impl IBackgroundCopyServerCertificateValidationCallback {
         (::windows::core::Vtable::vtable(self).ValidateServerCertificate)(::windows::core::Vtable::as_raw(self), job.into().abi(), file.into().abi(), certdata.len() as _, ::core::mem::transmute(certdata.as_ptr()), certencodingtype, certstoredata.len() as _, ::core::mem::transmute(certstoredata.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IBackgroundCopyServerCertificateValidationCallback> for ::windows::core::IUnknown {
-    fn from(value: IBackgroundCopyServerCertificateValidationCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBackgroundCopyServerCertificateValidationCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBackgroundCopyServerCertificateValidationCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBackgroundCopyServerCertificateValidationCallback> for ::windows::core::IUnknown {
-    fn from(value: &IBackgroundCopyServerCertificateValidationCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBackgroundCopyServerCertificateValidationCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBackgroundCopyServerCertificateValidationCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3570,21 +2687,7 @@ impl IBitsPeer {
         (::windows::core::Vtable::vtable(self).IsAvailable)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IBitsPeer> for ::windows::core::IUnknown {
-    fn from(value: IBitsPeer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBitsPeer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBitsPeer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBitsPeer> for ::windows::core::IUnknown {
-    fn from(value: &IBitsPeer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBitsPeer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBitsPeer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3677,21 +2780,7 @@ impl IBitsPeerCacheAdministration {
         (::windows::core::Vtable::vtable(self).DiscoverPeers)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IBitsPeerCacheAdministration> for ::windows::core::IUnknown {
-    fn from(value: IBitsPeerCacheAdministration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBitsPeerCacheAdministration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBitsPeerCacheAdministration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBitsPeerCacheAdministration> for ::windows::core::IUnknown {
-    fn from(value: &IBitsPeerCacheAdministration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBitsPeerCacheAdministration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBitsPeerCacheAdministration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3768,21 +2857,7 @@ impl IBitsPeerCacheRecord {
         (::windows::core::Vtable::vtable(self).GetFileRanges)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prangecount), ::core::mem::transmute(ppranges)).ok()
     }
 }
-impl ::core::convert::From<IBitsPeerCacheRecord> for ::windows::core::IUnknown {
-    fn from(value: IBitsPeerCacheRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBitsPeerCacheRecord> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBitsPeerCacheRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBitsPeerCacheRecord> for ::windows::core::IUnknown {
-    fn from(value: &IBitsPeerCacheRecord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBitsPeerCacheRecord, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBitsPeerCacheRecord {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3845,21 +2920,7 @@ impl IBitsTokenOptions {
         (::windows::core::Vtable::vtable(self).GetHelperTokenSid)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IBitsTokenOptions> for ::windows::core::IUnknown {
-    fn from(value: IBitsTokenOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBitsTokenOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBitsTokenOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBitsTokenOptions> for ::windows::core::IUnknown {
-    fn from(value: &IBitsTokenOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBitsTokenOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBitsTokenOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3914,21 +2975,7 @@ impl IEnumBackgroundCopyFiles {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumBackgroundCopyFiles> for ::windows::core::IUnknown {
-    fn from(value: IEnumBackgroundCopyFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumBackgroundCopyFiles> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumBackgroundCopyFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumBackgroundCopyFiles> for ::windows::core::IUnknown {
-    fn from(value: &IEnumBackgroundCopyFiles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumBackgroundCopyFiles, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumBackgroundCopyFiles {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3983,21 +3030,7 @@ impl IEnumBackgroundCopyGroups {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumBackgroundCopyGroups> for ::windows::core::IUnknown {
-    fn from(value: IEnumBackgroundCopyGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumBackgroundCopyGroups> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumBackgroundCopyGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumBackgroundCopyGroups> for ::windows::core::IUnknown {
-    fn from(value: &IEnumBackgroundCopyGroups) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumBackgroundCopyGroups, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumBackgroundCopyGroups {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4052,21 +3085,7 @@ impl IEnumBackgroundCopyJobs {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumBackgroundCopyJobs> for ::windows::core::IUnknown {
-    fn from(value: IEnumBackgroundCopyJobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumBackgroundCopyJobs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumBackgroundCopyJobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumBackgroundCopyJobs> for ::windows::core::IUnknown {
-    fn from(value: &IEnumBackgroundCopyJobs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumBackgroundCopyJobs, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumBackgroundCopyJobs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4121,21 +3140,7 @@ impl IEnumBackgroundCopyJobs1 {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumBackgroundCopyJobs1> for ::windows::core::IUnknown {
-    fn from(value: IEnumBackgroundCopyJobs1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumBackgroundCopyJobs1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumBackgroundCopyJobs1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumBackgroundCopyJobs1> for ::windows::core::IUnknown {
-    fn from(value: &IEnumBackgroundCopyJobs1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumBackgroundCopyJobs1, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumBackgroundCopyJobs1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4190,21 +3195,7 @@ impl IEnumBitsPeerCacheRecords {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumBitsPeerCacheRecords> for ::windows::core::IUnknown {
-    fn from(value: IEnumBitsPeerCacheRecords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumBitsPeerCacheRecords> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumBitsPeerCacheRecords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumBitsPeerCacheRecords> for ::windows::core::IUnknown {
-    fn from(value: &IEnumBitsPeerCacheRecords) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumBitsPeerCacheRecords, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumBitsPeerCacheRecords {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4259,21 +3250,7 @@ impl IEnumBitsPeers {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumBitsPeers> for ::windows::core::IUnknown {
-    fn from(value: IEnumBitsPeers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumBitsPeers> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumBitsPeers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumBitsPeers> for ::windows::core::IUnknown {
-    fn from(value: &IEnumBitsPeers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumBitsPeers, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumBitsPeers {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
@@ -3834,21 +3834,7 @@ impl IGetClusterDataInfo {
         (::windows::core::Vtable::vtable(self).GetObjectCount)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IGetClusterDataInfo> for ::windows::core::IUnknown {
-    fn from(value: IGetClusterDataInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetClusterDataInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetClusterDataInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetClusterDataInfo> for ::windows::core::IUnknown {
-    fn from(value: &IGetClusterDataInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetClusterDataInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetClusterDataInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3887,21 +3873,7 @@ impl IGetClusterGroupInfo {
         (::windows::core::Vtable::vtable(self).GetGroupHandle)(::windows::core::Vtable::as_raw(self), lobjindex)
     }
 }
-impl ::core::convert::From<IGetClusterGroupInfo> for ::windows::core::IUnknown {
-    fn from(value: IGetClusterGroupInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetClusterGroupInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetClusterGroupInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetClusterGroupInfo> for ::windows::core::IUnknown {
-    fn from(value: &IGetClusterGroupInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetClusterGroupInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetClusterGroupInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3938,21 +3910,7 @@ impl IGetClusterNetInterfaceInfo {
         (::windows::core::Vtable::vtable(self).GetNetInterfaceHandle)(::windows::core::Vtable::as_raw(self), lobjindex)
     }
 }
-impl ::core::convert::From<IGetClusterNetInterfaceInfo> for ::windows::core::IUnknown {
-    fn from(value: IGetClusterNetInterfaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetClusterNetInterfaceInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetClusterNetInterfaceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetClusterNetInterfaceInfo> for ::windows::core::IUnknown {
-    fn from(value: &IGetClusterNetInterfaceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetClusterNetInterfaceInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetClusterNetInterfaceInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3989,21 +3947,7 @@ impl IGetClusterNetworkInfo {
         (::windows::core::Vtable::vtable(self).GetNetworkHandle)(::windows::core::Vtable::as_raw(self), lobjindex)
     }
 }
-impl ::core::convert::From<IGetClusterNetworkInfo> for ::windows::core::IUnknown {
-    fn from(value: IGetClusterNetworkInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetClusterNetworkInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetClusterNetworkInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetClusterNetworkInfo> for ::windows::core::IUnknown {
-    fn from(value: &IGetClusterNetworkInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetClusterNetworkInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetClusterNetworkInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4040,21 +3984,7 @@ impl IGetClusterNodeInfo {
         (::windows::core::Vtable::vtable(self).GetNodeHandle)(::windows::core::Vtable::as_raw(self), lobjindex)
     }
 }
-impl ::core::convert::From<IGetClusterNodeInfo> for ::windows::core::IUnknown {
-    fn from(value: IGetClusterNodeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetClusterNodeInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetClusterNodeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetClusterNodeInfo> for ::windows::core::IUnknown {
-    fn from(value: &IGetClusterNodeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetClusterNodeInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetClusterNodeInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4094,21 +4024,7 @@ impl IGetClusterObjectInfo {
         (::windows::core::Vtable::vtable(self).GetObjectType)(::windows::core::Vtable::as_raw(self), lobjindex)
     }
 }
-impl ::core::convert::From<IGetClusterObjectInfo> for ::windows::core::IUnknown {
-    fn from(value: IGetClusterObjectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetClusterObjectInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetClusterObjectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetClusterObjectInfo> for ::windows::core::IUnknown {
-    fn from(value: &IGetClusterObjectInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetClusterObjectInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetClusterObjectInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4154,21 +4070,7 @@ impl IGetClusterResourceInfo {
         (::windows::core::Vtable::vtable(self).GetResourceNetworkName)(::windows::core::Vtable::as_raw(self), lobjindex, ::core::mem::transmute(lpsznetname), ::core::mem::transmute(pcchnetname))
     }
 }
-impl ::core::convert::From<IGetClusterResourceInfo> for ::windows::core::IUnknown {
-    fn from(value: IGetClusterResourceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetClusterResourceInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetClusterResourceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetClusterResourceInfo> for ::windows::core::IUnknown {
-    fn from(value: &IGetClusterResourceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetClusterResourceInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetClusterResourceInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4223,21 +4125,7 @@ impl IGetClusterUIInfo {
         (::windows::core::Vtable::vtable(self).GetIcon)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IGetClusterUIInfo> for ::windows::core::IUnknown {
-    fn from(value: IGetClusterUIInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetClusterUIInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetClusterUIInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetClusterUIInfo> for ::windows::core::IUnknown {
-    fn from(value: &IGetClusterUIInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetClusterUIInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetClusterUIInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4301,41 +4189,7 @@ impl ISClusApplication {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusApplication> for ::windows::core::IUnknown {
-    fn from(value: ISClusApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusApplication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusApplication> for ::windows::core::IUnknown {
-    fn from(value: &ISClusApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusApplication> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusApplication> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusApplication> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusApplication, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusApplication {
     fn clone(&self) -> Self {
@@ -4421,41 +4275,7 @@ impl ISClusCryptoKeys {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusCryptoKeys> for ::windows::core::IUnknown {
-    fn from(value: ISClusCryptoKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusCryptoKeys> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusCryptoKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusCryptoKeys> for ::windows::core::IUnknown {
-    fn from(value: &ISClusCryptoKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusCryptoKeys> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusCryptoKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusCryptoKeys> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusCryptoKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusCryptoKeys> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusCryptoKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusCryptoKeys, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusCryptoKeys {
     fn clone(&self) -> Self {
@@ -4530,41 +4350,7 @@ impl ISClusDisk {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusDisk> for ::windows::core::IUnknown {
-    fn from(value: ISClusDisk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusDisk> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusDisk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusDisk> for ::windows::core::IUnknown {
-    fn from(value: &ISClusDisk) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusDisk> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusDisk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusDisk> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusDisk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusDisk> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusDisk) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusDisk, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusDisk {
     fn clone(&self) -> Self {
@@ -4634,41 +4420,7 @@ impl ISClusDisks {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusDisks> for ::windows::core::IUnknown {
-    fn from(value: ISClusDisks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusDisks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusDisks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusDisks> for ::windows::core::IUnknown {
-    fn from(value: &ISClusDisks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusDisks> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusDisks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusDisks> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusDisks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusDisks> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusDisks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusDisks, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusDisks {
     fn clone(&self) -> Self {
@@ -4759,41 +4511,7 @@ impl ISClusNetInterface {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNetInterface> for ::windows::core::IUnknown {
-    fn from(value: ISClusNetInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNetInterface> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusNetInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNetInterface> for ::windows::core::IUnknown {
-    fn from(value: &ISClusNetInterface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNetInterface> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusNetInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNetInterface> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusNetInterface) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNetInterface> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusNetInterface) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusNetInterface, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusNetInterface {
     fn clone(&self) -> Self {
@@ -4879,41 +4597,7 @@ impl ISClusNetInterfaces {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNetInterfaces> for ::windows::core::IUnknown {
-    fn from(value: ISClusNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNetInterfaces> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNetInterfaces> for ::windows::core::IUnknown {
-    fn from(value: &ISClusNetInterfaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNetInterfaces> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNetInterfaces> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNetInterfaces> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusNetInterfaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusNetInterfaces, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusNetInterfaces {
     fn clone(&self) -> Self {
@@ -5018,41 +4702,7 @@ impl ISClusNetwork {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNetwork> for ::windows::core::IUnknown {
-    fn from(value: ISClusNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNetwork> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNetwork> for ::windows::core::IUnknown {
-    fn from(value: &ISClusNetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNetwork> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNetwork> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNetwork> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusNetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusNetwork, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusNetwork {
     fn clone(&self) -> Self {
@@ -5144,41 +4794,7 @@ impl ISClusNetworkNetInterfaces {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNetworkNetInterfaces> for ::windows::core::IUnknown {
-    fn from(value: ISClusNetworkNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNetworkNetInterfaces> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusNetworkNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNetworkNetInterfaces> for ::windows::core::IUnknown {
-    fn from(value: &ISClusNetworkNetInterfaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNetworkNetInterfaces> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusNetworkNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNetworkNetInterfaces> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusNetworkNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNetworkNetInterfaces> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusNetworkNetInterfaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusNetworkNetInterfaces, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusNetworkNetInterfaces {
     fn clone(&self) -> Self {
@@ -5248,41 +4864,7 @@ impl ISClusNetworks {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNetworks> for ::windows::core::IUnknown {
-    fn from(value: ISClusNetworks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNetworks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusNetworks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNetworks> for ::windows::core::IUnknown {
-    fn from(value: &ISClusNetworks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNetworks> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusNetworks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNetworks> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusNetworks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNetworks> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusNetworks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusNetworks, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusNetworks {
     fn clone(&self) -> Self {
@@ -5399,41 +4981,7 @@ impl ISClusNode {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNode> for ::windows::core::IUnknown {
-    fn from(value: ISClusNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNode> for ::windows::core::IUnknown {
-    fn from(value: &ISClusNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNode> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNode> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNode> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusNode, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusNode {
     fn clone(&self) -> Self {
@@ -5531,41 +5079,7 @@ impl ISClusNodeNetInterfaces {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNodeNetInterfaces> for ::windows::core::IUnknown {
-    fn from(value: ISClusNodeNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNodeNetInterfaces> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusNodeNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNodeNetInterfaces> for ::windows::core::IUnknown {
-    fn from(value: &ISClusNodeNetInterfaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNodeNetInterfaces> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusNodeNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNodeNetInterfaces> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusNodeNetInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNodeNetInterfaces> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusNodeNetInterfaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusNodeNetInterfaces, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusNodeNetInterfaces {
     fn clone(&self) -> Self {
@@ -5635,41 +5149,7 @@ impl ISClusNodes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNodes> for ::windows::core::IUnknown {
-    fn from(value: ISClusNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNodes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNodes> for ::windows::core::IUnknown {
-    fn from(value: &ISClusNodes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusNodes> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusNodes> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusNodes> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusNodes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusNodes, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusNodes {
     fn clone(&self) -> Self {
@@ -5747,41 +5227,7 @@ impl ISClusPartition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPartition> for ::windows::core::IUnknown {
-    fn from(value: ISClusPartition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPartition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusPartition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPartition> for ::windows::core::IUnknown {
-    fn from(value: &ISClusPartition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPartition> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusPartition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPartition> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusPartition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPartition> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusPartition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusPartition, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusPartition {
     fn clone(&self) -> Self {
@@ -5879,59 +5325,7 @@ impl ISClusPartitionEx {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPartitionEx> for ::windows::core::IUnknown {
-    fn from(value: ISClusPartitionEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPartitionEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusPartitionEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPartitionEx> for ::windows::core::IUnknown {
-    fn from(value: &ISClusPartitionEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPartitionEx> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusPartitionEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPartitionEx> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusPartitionEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPartitionEx> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusPartitionEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPartitionEx> for ISClusPartition {
-    fn from(value: ISClusPartitionEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPartitionEx> for &'a ISClusPartition {
-    fn from(value: &'a ISClusPartitionEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPartitionEx> for ISClusPartition {
-    fn from(value: &ISClusPartitionEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusPartitionEx, ::windows::core::IUnknown, super::super::System::Com::IDispatch, ISClusPartition);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusPartitionEx {
     fn clone(&self) -> Self {
@@ -5996,41 +5390,7 @@ impl ISClusPartitions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPartitions> for ::windows::core::IUnknown {
-    fn from(value: ISClusPartitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPartitions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusPartitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPartitions> for ::windows::core::IUnknown {
-    fn from(value: &ISClusPartitions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPartitions> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusPartitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPartitions> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusPartitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPartitions> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusPartitions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusPartitions, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusPartitions {
     fn clone(&self) -> Self {
@@ -6146,41 +5506,7 @@ impl ISClusProperties {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusProperties> for ::windows::core::IUnknown {
-    fn from(value: ISClusProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusProperties> for ::windows::core::IUnknown {
-    fn from(value: &ISClusProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusProperties> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusProperties> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusProperties> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusProperties, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusProperties {
     fn clone(&self) -> Self {
@@ -6331,41 +5657,7 @@ impl ISClusProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusProperty> for ::windows::core::IUnknown {
-    fn from(value: ISClusProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusProperty> for ::windows::core::IUnknown {
-    fn from(value: &ISClusProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusProperty> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusProperty> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusProperty> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusProperty, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusProperty {
     fn clone(&self) -> Self {
@@ -6486,41 +5778,7 @@ impl ISClusPropertyValue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPropertyValue> for ::windows::core::IUnknown {
-    fn from(value: ISClusPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPropertyValue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPropertyValue> for ::windows::core::IUnknown {
-    fn from(value: &ISClusPropertyValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPropertyValue> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPropertyValue> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPropertyValue> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusPropertyValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusPropertyValue, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusPropertyValue {
     fn clone(&self) -> Self {
@@ -6615,41 +5873,7 @@ impl ISClusPropertyValueData {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPropertyValueData> for ::windows::core::IUnknown {
-    fn from(value: ISClusPropertyValueData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPropertyValueData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusPropertyValueData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPropertyValueData> for ::windows::core::IUnknown {
-    fn from(value: &ISClusPropertyValueData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPropertyValueData> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusPropertyValueData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPropertyValueData> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusPropertyValueData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPropertyValueData> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusPropertyValueData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusPropertyValueData, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusPropertyValueData {
     fn clone(&self) -> Self {
@@ -6740,41 +5964,7 @@ impl ISClusPropertyValues {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPropertyValues> for ::windows::core::IUnknown {
-    fn from(value: ISClusPropertyValues) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPropertyValues> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusPropertyValues) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPropertyValues> for ::windows::core::IUnknown {
-    fn from(value: &ISClusPropertyValues) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusPropertyValues> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusPropertyValues) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusPropertyValues> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusPropertyValues) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusPropertyValues> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusPropertyValues) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusPropertyValues, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusPropertyValues {
     fn clone(&self) -> Self {
@@ -6835,41 +6025,7 @@ impl ISClusRefObject {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusRefObject> for ::windows::core::IUnknown {
-    fn from(value: ISClusRefObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusRefObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusRefObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusRefObject> for ::windows::core::IUnknown {
-    fn from(value: &ISClusRefObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusRefObject> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusRefObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusRefObject> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusRefObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusRefObject> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusRefObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusRefObject, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusRefObject {
     fn clone(&self) -> Self {
@@ -6944,41 +6100,7 @@ impl ISClusRegistryKeys {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusRegistryKeys> for ::windows::core::IUnknown {
-    fn from(value: ISClusRegistryKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusRegistryKeys> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusRegistryKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusRegistryKeys> for ::windows::core::IUnknown {
-    fn from(value: &ISClusRegistryKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusRegistryKeys> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusRegistryKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusRegistryKeys> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusRegistryKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusRegistryKeys> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusRegistryKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusRegistryKeys, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusRegistryKeys {
     fn clone(&self) -> Self {
@@ -7083,41 +6205,7 @@ impl ISClusResDependencies {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResDependencies> for ::windows::core::IUnknown {
-    fn from(value: ISClusResDependencies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResDependencies> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResDependencies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResDependencies> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResDependencies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResDependencies> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResDependencies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResDependencies> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResDependencies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResDependencies> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResDependencies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResDependencies, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResDependencies {
     fn clone(&self) -> Self {
@@ -7233,41 +6321,7 @@ impl ISClusResDependents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResDependents> for ::windows::core::IUnknown {
-    fn from(value: ISClusResDependents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResDependents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResDependents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResDependents> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResDependents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResDependents> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResDependents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResDependents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResDependents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResDependents> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResDependents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResDependents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResDependents {
     fn clone(&self) -> Self {
@@ -7428,41 +6482,7 @@ impl ISClusResGroup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResGroup> for ::windows::core::IUnknown {
-    fn from(value: ISClusResGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResGroup> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResGroup> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResGroup> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResGroup> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResGroup, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResGroup {
     fn clone(&self) -> Self {
@@ -7607,41 +6627,7 @@ impl ISClusResGroupPreferredOwnerNodes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResGroupPreferredOwnerNodes> for ::windows::core::IUnknown {
-    fn from(value: ISClusResGroupPreferredOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResGroupPreferredOwnerNodes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResGroupPreferredOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResGroupPreferredOwnerNodes> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResGroupPreferredOwnerNodes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResGroupPreferredOwnerNodes> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResGroupPreferredOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResGroupPreferredOwnerNodes> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResGroupPreferredOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResGroupPreferredOwnerNodes> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResGroupPreferredOwnerNodes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResGroupPreferredOwnerNodes, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResGroupPreferredOwnerNodes {
     fn clone(&self) -> Self {
@@ -7742,41 +6728,7 @@ impl ISClusResGroupResources {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResGroupResources> for ::windows::core::IUnknown {
-    fn from(value: ISClusResGroupResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResGroupResources> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResGroupResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResGroupResources> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResGroupResources) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResGroupResources> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResGroupResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResGroupResources> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResGroupResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResGroupResources> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResGroupResources) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResGroupResources, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResGroupResources {
     fn clone(&self) -> Self {
@@ -7868,41 +6820,7 @@ impl ISClusResGroups {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResGroups> for ::windows::core::IUnknown {
-    fn from(value: ISClusResGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResGroups> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResGroups> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResGroups) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResGroups> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResGroups> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResGroups> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResGroups) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResGroups, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResGroups {
     fn clone(&self) -> Self {
@@ -8002,41 +6920,7 @@ impl ISClusResPossibleOwnerNodes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResPossibleOwnerNodes> for ::windows::core::IUnknown {
-    fn from(value: ISClusResPossibleOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResPossibleOwnerNodes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResPossibleOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResPossibleOwnerNodes> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResPossibleOwnerNodes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResPossibleOwnerNodes> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResPossibleOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResPossibleOwnerNodes> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResPossibleOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResPossibleOwnerNodes> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResPossibleOwnerNodes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResPossibleOwnerNodes, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResPossibleOwnerNodes {
     fn clone(&self) -> Self {
@@ -8153,41 +7037,7 @@ impl ISClusResType {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResType> for ::windows::core::IUnknown {
-    fn from(value: ISClusResType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResType> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResType> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResType> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResType> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResType, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResType {
     fn clone(&self) -> Self {
@@ -8284,41 +7134,7 @@ impl ISClusResTypePossibleOwnerNodes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResTypePossibleOwnerNodes> for ::windows::core::IUnknown {
-    fn from(value: ISClusResTypePossibleOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResTypePossibleOwnerNodes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResTypePossibleOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResTypePossibleOwnerNodes> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResTypePossibleOwnerNodes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResTypePossibleOwnerNodes> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResTypePossibleOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResTypePossibleOwnerNodes> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResTypePossibleOwnerNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResTypePossibleOwnerNodes> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResTypePossibleOwnerNodes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResTypePossibleOwnerNodes, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResTypePossibleOwnerNodes {
     fn clone(&self) -> Self {
@@ -8402,41 +7218,7 @@ impl ISClusResTypeResources {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResTypeResources> for ::windows::core::IUnknown {
-    fn from(value: ISClusResTypeResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResTypeResources> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResTypeResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResTypeResources> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResTypeResources) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResTypeResources> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResTypeResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResTypeResources> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResTypeResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResTypeResources> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResTypeResources) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResTypeResources, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResTypeResources {
     fn clone(&self) -> Self {
@@ -8528,41 +7310,7 @@ impl ISClusResTypes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResTypes> for ::windows::core::IUnknown {
-    fn from(value: ISClusResTypes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResTypes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResTypes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResTypes> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResTypes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResTypes> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResTypes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResTypes> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResTypes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResTypes> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResTypes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResTypes, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResTypes {
     fn clone(&self) -> Self {
@@ -8799,41 +7547,7 @@ impl ISClusResource {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResource> for ::windows::core::IUnknown {
-    fn from(value: ISClusResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResource> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResource> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResource> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResource> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResource, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResource {
     fn clone(&self) -> Self {
@@ -9008,41 +7722,7 @@ impl ISClusResources {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResources> for ::windows::core::IUnknown {
-    fn from(value: ISClusResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResources> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResources> for ::windows::core::IUnknown {
-    fn from(value: &ISClusResources) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusResources> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusResources> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusResources> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusResources) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusResources, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusResources {
     fn clone(&self) -> Self {
@@ -9124,41 +7804,7 @@ impl ISClusScsiAddress {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusScsiAddress> for ::windows::core::IUnknown {
-    fn from(value: ISClusScsiAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusScsiAddress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusScsiAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusScsiAddress> for ::windows::core::IUnknown {
-    fn from(value: &ISClusScsiAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusScsiAddress> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusScsiAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusScsiAddress> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusScsiAddress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusScsiAddress> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusScsiAddress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusScsiAddress, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusScsiAddress {
     fn clone(&self) -> Self {
@@ -9259,41 +7905,7 @@ impl ISClusVersion {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusVersion> for ::windows::core::IUnknown {
-    fn from(value: ISClusVersion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusVersion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusVersion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusVersion> for ::windows::core::IUnknown {
-    fn from(value: &ISClusVersion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusVersion> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusVersion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusVersion> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusVersion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusVersion> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusVersion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusVersion, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusVersion {
     fn clone(&self) -> Self {
@@ -9457,41 +8069,7 @@ impl ISCluster {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISCluster> for ::windows::core::IUnknown {
-    fn from(value: ISCluster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISCluster> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISCluster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISCluster> for ::windows::core::IUnknown {
-    fn from(value: &ISCluster) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISCluster> for super::super::System::Com::IDispatch {
-    fn from(value: ISCluster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISCluster> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISCluster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISCluster> for super::super::System::Com::IDispatch {
-    fn from(value: &ISCluster) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISCluster, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISCluster {
     fn clone(&self) -> Self {
@@ -9618,41 +8196,7 @@ impl ISClusterNames {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusterNames> for ::windows::core::IUnknown {
-    fn from(value: ISClusterNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusterNames> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISClusterNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusterNames> for ::windows::core::IUnknown {
-    fn from(value: &ISClusterNames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISClusterNames> for super::super::System::Com::IDispatch {
-    fn from(value: ISClusterNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISClusterNames> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISClusterNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISClusterNames> for super::super::System::Com::IDispatch {
-    fn from(value: &ISClusterNames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISClusterNames, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISClusterNames {
     fn clone(&self) -> Self {
@@ -9723,41 +8267,7 @@ impl ISDomainNames {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISDomainNames> for ::windows::core::IUnknown {
-    fn from(value: ISDomainNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISDomainNames> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISDomainNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISDomainNames> for ::windows::core::IUnknown {
-    fn from(value: &ISDomainNames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISDomainNames> for super::super::System::Com::IDispatch {
-    fn from(value: ISDomainNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISDomainNames> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISDomainNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISDomainNames> for super::super::System::Com::IDispatch {
-    fn from(value: &ISDomainNames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISDomainNames, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISDomainNames {
     fn clone(&self) -> Self {
@@ -9807,21 +8317,7 @@ impl IWCContextMenuCallback {
         (::windows::core::Vtable::vtable(self).AddExtensionMenuItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(lpszname), ::core::mem::transmute_copy(lpszstatusbartext), ncommandid, nsubmenucommandid, uflags).ok()
     }
 }
-impl ::core::convert::From<IWCContextMenuCallback> for ::windows::core::IUnknown {
-    fn from(value: IWCContextMenuCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWCContextMenuCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWCContextMenuCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWCContextMenuCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWCContextMenuCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWCContextMenuCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWCContextMenuCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9858,21 +8354,7 @@ impl IWCPropertySheetCallback {
         (::windows::core::Vtable::vtable(self).AddPropertySheetPage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(hpage)).ok()
     }
 }
-impl ::core::convert::From<IWCPropertySheetCallback> for ::windows::core::IUnknown {
-    fn from(value: IWCPropertySheetCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWCPropertySheetCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWCPropertySheetCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWCPropertySheetCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWCPropertySheetCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWCPropertySheetCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWCPropertySheetCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9917,21 +8399,7 @@ impl IWCWizard97Callback {
         (::windows::core::Vtable::vtable(self).EnableNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(hpage), benable.into()).ok()
     }
 }
-impl ::core::convert::From<IWCWizard97Callback> for ::windows::core::IUnknown {
-    fn from(value: IWCWizard97Callback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWCWizard97Callback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWCWizard97Callback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWCWizard97Callback> for ::windows::core::IUnknown {
-    fn from(value: &IWCWizard97Callback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWCWizard97Callback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWCWizard97Callback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9980,21 +8448,7 @@ impl IWCWizardCallback {
         (::windows::core::Vtable::vtable(self).EnableNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(hpage), benable.into()).ok()
     }
 }
-impl ::core::convert::From<IWCWizardCallback> for ::windows::core::IUnknown {
-    fn from(value: IWCWizardCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWCWizardCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWCWizardCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWCWizardCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWCWizardCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWCWizardCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWCWizardCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10039,21 +8493,7 @@ impl IWEExtendContextMenu {
         (::windows::core::Vtable::vtable(self).AddContextMenuItems)(::windows::core::Vtable::as_raw(self), pidata.into().abi(), picallback.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWEExtendContextMenu> for ::windows::core::IUnknown {
-    fn from(value: IWEExtendContextMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWEExtendContextMenu> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWEExtendContextMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWEExtendContextMenu> for ::windows::core::IUnknown {
-    fn from(value: &IWEExtendContextMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWEExtendContextMenu, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWEExtendContextMenu {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10094,21 +8534,7 @@ impl IWEExtendPropertySheet {
         (::windows::core::Vtable::vtable(self).CreatePropertySheetPages)(::windows::core::Vtable::as_raw(self), pidata.into().abi(), picallback.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWEExtendPropertySheet> for ::windows::core::IUnknown {
-    fn from(value: IWEExtendPropertySheet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWEExtendPropertySheet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWEExtendPropertySheet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWEExtendPropertySheet> for ::windows::core::IUnknown {
-    fn from(value: &IWEExtendPropertySheet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWEExtendPropertySheet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWEExtendPropertySheet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10149,21 +8575,7 @@ impl IWEExtendWizard {
         (::windows::core::Vtable::vtable(self).CreateWizardPages)(::windows::core::Vtable::as_raw(self), pidata.into().abi(), picallback.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWEExtendWizard> for ::windows::core::IUnknown {
-    fn from(value: IWEExtendWizard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWEExtendWizard> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWEExtendWizard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWEExtendWizard> for ::windows::core::IUnknown {
-    fn from(value: &IWEExtendWizard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWEExtendWizard, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWEExtendWizard {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10204,21 +8616,7 @@ impl IWEExtendWizard97 {
         (::windows::core::Vtable::vtable(self).CreateWizard97Pages)(::windows::core::Vtable::as_raw(self), pidata.into().abi(), picallback.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWEExtendWizard97> for ::windows::core::IUnknown {
-    fn from(value: IWEExtendWizard97) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWEExtendWizard97> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWEExtendWizard97) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWEExtendWizard97> for ::windows::core::IUnknown {
-    fn from(value: &IWEExtendWizard97) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWEExtendWizard97, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWEExtendWizard97 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10258,21 +8656,7 @@ impl IWEInvokeCommand {
         (::windows::core::Vtable::vtable(self).InvokeCommand)(::windows::core::Vtable::as_raw(self), ncommandid, pidata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWEInvokeCommand> for ::windows::core::IUnknown {
-    fn from(value: IWEInvokeCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWEInvokeCommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWEInvokeCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWEInvokeCommand> for ::windows::core::IUnknown {
-    fn from(value: &IWEInvokeCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWEInvokeCommand, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWEInvokeCommand {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/mod.rs
@@ -29,41 +29,7 @@ impl IEnumNetworkConnections {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumNetworkConnections> for ::windows::core::IUnknown {
-    fn from(value: IEnumNetworkConnections) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumNetworkConnections> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumNetworkConnections) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumNetworkConnections> for ::windows::core::IUnknown {
-    fn from(value: &IEnumNetworkConnections) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumNetworkConnections> for super::super::System::Com::IDispatch {
-    fn from(value: IEnumNetworkConnections) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumNetworkConnections> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IEnumNetworkConnections) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumNetworkConnections> for super::super::System::Com::IDispatch {
-    fn from(value: &IEnumNetworkConnections) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumNetworkConnections, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IEnumNetworkConnections {
     fn clone(&self) -> Self {
@@ -143,41 +109,7 @@ impl IEnumNetworks {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumNetworks> for ::windows::core::IUnknown {
-    fn from(value: IEnumNetworks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumNetworks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumNetworks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumNetworks> for ::windows::core::IUnknown {
-    fn from(value: &IEnumNetworks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumNetworks> for super::super::System::Com::IDispatch {
-    fn from(value: IEnumNetworks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumNetworks> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IEnumNetworks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumNetworks> for super::super::System::Com::IDispatch {
-    fn from(value: &IEnumNetworks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumNetworks, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IEnumNetworks {
     fn clone(&self) -> Self {
@@ -284,41 +216,7 @@ impl INetwork {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetwork> for ::windows::core::IUnknown {
-    fn from(value: INetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetwork> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetwork> for ::windows::core::IUnknown {
-    fn from(value: &INetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetwork> for super::super::System::Com::IDispatch {
-    fn from(value: INetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetwork> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetwork> for super::super::System::Com::IDispatch {
-    fn from(value: &INetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetwork, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetwork {
     fn clone(&self) -> Self {
@@ -407,41 +305,7 @@ impl INetworkConnection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetworkConnection> for ::windows::core::IUnknown {
-    fn from(value: INetworkConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetworkConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetworkConnection> for ::windows::core::IUnknown {
-    fn from(value: &INetworkConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetworkConnection> for super::super::System::Com::IDispatch {
-    fn from(value: INetworkConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetworkConnection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetworkConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetworkConnection> for super::super::System::Com::IDispatch {
-    fn from(value: &INetworkConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkConnection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetworkConnection {
     fn clone(&self) -> Self {
@@ -501,21 +365,7 @@ impl INetworkConnectionCost {
         (::windows::core::Vtable::vtable(self).GetDataPlanStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<NLM_DATAPLAN_STATUS>(result__)
     }
 }
-impl ::core::convert::From<INetworkConnectionCost> for ::windows::core::IUnknown {
-    fn from(value: INetworkConnectionCost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetworkConnectionCost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkConnectionCost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetworkConnectionCost> for ::windows::core::IUnknown {
-    fn from(value: &INetworkConnectionCost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkConnectionCost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetworkConnectionCost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -559,21 +409,7 @@ impl INetworkConnectionCostEvents {
         (::windows::core::Vtable::vtable(self).ConnectionDataPlanStatusChanged)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(connectionid)).ok()
     }
 }
-impl ::core::convert::From<INetworkConnectionCostEvents> for ::windows::core::IUnknown {
-    fn from(value: INetworkConnectionCostEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetworkConnectionCostEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkConnectionCostEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetworkConnectionCostEvents> for ::windows::core::IUnknown {
-    fn from(value: &INetworkConnectionCostEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkConnectionCostEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetworkConnectionCostEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -614,21 +450,7 @@ impl INetworkConnectionEvents {
         (::windows::core::Vtable::vtable(self).NetworkConnectionPropertyChanged)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(connectionid), flags).ok()
     }
 }
-impl ::core::convert::From<INetworkConnectionEvents> for ::windows::core::IUnknown {
-    fn from(value: INetworkConnectionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetworkConnectionEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkConnectionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetworkConnectionEvents> for ::windows::core::IUnknown {
-    fn from(value: &INetworkConnectionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkConnectionEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetworkConnectionEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -674,21 +496,7 @@ impl INetworkCostManager {
         (::windows::core::Vtable::vtable(self).SetDestinationAddresses)(::windows::core::Vtable::as_raw(self), pdestipaddrlist.len() as _, ::core::mem::transmute(pdestipaddrlist.as_ptr()), bappend).ok()
     }
 }
-impl ::core::convert::From<INetworkCostManager> for ::windows::core::IUnknown {
-    fn from(value: INetworkCostManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetworkCostManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkCostManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetworkCostManager> for ::windows::core::IUnknown {
-    fn from(value: &INetworkCostManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkCostManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetworkCostManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -733,21 +541,7 @@ impl INetworkCostManagerEvents {
         (::windows::core::Vtable::vtable(self).DataPlanStatusChanged)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdestaddr)).ok()
     }
 }
-impl ::core::convert::From<INetworkCostManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: INetworkCostManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetworkCostManagerEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkCostManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetworkCostManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: &INetworkCostManagerEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkCostManagerEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetworkCostManagerEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -794,21 +588,7 @@ impl INetworkEvents {
         (::windows::core::Vtable::vtable(self).NetworkPropertyChanged)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(networkid), flags).ok()
     }
 }
-impl ::core::convert::From<INetworkEvents> for ::windows::core::IUnknown {
-    fn from(value: INetworkEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetworkEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetworkEvents> for ::windows::core::IUnknown {
-    fn from(value: &INetworkEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetworkEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -890,41 +670,7 @@ impl INetworkListManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetworkListManager> for ::windows::core::IUnknown {
-    fn from(value: INetworkListManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetworkListManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkListManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetworkListManager> for ::windows::core::IUnknown {
-    fn from(value: &INetworkListManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetworkListManager> for super::super::System::Com::IDispatch {
-    fn from(value: INetworkListManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetworkListManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INetworkListManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetworkListManager> for super::super::System::Com::IDispatch {
-    fn from(value: &INetworkListManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkListManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetworkListManager {
     fn clone(&self) -> Self {
@@ -988,21 +734,7 @@ impl INetworkListManagerEvents {
         (::windows::core::Vtable::vtable(self).ConnectivityChanged)(::windows::core::Vtable::as_raw(self), newconnectivity).ok()
     }
 }
-impl ::core::convert::From<INetworkListManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: INetworkListManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetworkListManagerEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkListManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetworkListManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: &INetworkListManagerEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkListManagerEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetworkListManagerEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/mod.rs
@@ -10,21 +10,7 @@ impl IFindSimilarResults {
         (::windows::core::Vtable::vtable(self).GetNextFileId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(numtraitsmatched), ::core::mem::transmute(similarityfileid)).ok()
     }
 }
-impl ::core::convert::From<IFindSimilarResults> for ::windows::core::IUnknown {
-    fn from(value: IFindSimilarResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFindSimilarResults> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFindSimilarResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFindSimilarResults> for ::windows::core::IUnknown {
-    fn from(value: &IFindSimilarResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFindSimilarResults, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFindSimilarResults {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -67,21 +53,7 @@ impl IRdcComparator {
         (::windows::core::Vtable::vtable(self).Process)(::windows::core::Vtable::as_raw(self), endofinput.into(), ::core::mem::transmute(endofoutput), ::core::mem::transmute(inputbuffer), ::core::mem::transmute(outputbuffer), ::core::mem::transmute(rdc_errorcode)).ok()
     }
 }
-impl ::core::convert::From<IRdcComparator> for ::windows::core::IUnknown {
-    fn from(value: IRdcComparator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRdcComparator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRdcComparator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRdcComparator> for ::windows::core::IUnknown {
-    fn from(value: &IRdcComparator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRdcComparator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRdcComparator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -131,21 +103,7 @@ impl IRdcFileReader {
         (::windows::core::Vtable::vtable(self).GetFilePosition)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IRdcFileReader> for ::windows::core::IUnknown {
-    fn from(value: IRdcFileReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRdcFileReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRdcFileReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRdcFileReader> for ::windows::core::IUnknown {
-    fn from(value: &IRdcFileReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRdcFileReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRdcFileReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -207,36 +165,7 @@ impl IRdcFileWriter {
         (::windows::core::Vtable::vtable(self).DeleteOnClose)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IRdcFileWriter> for ::windows::core::IUnknown {
-    fn from(value: IRdcFileWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRdcFileWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRdcFileWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRdcFileWriter> for ::windows::core::IUnknown {
-    fn from(value: &IRdcFileWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRdcFileWriter> for IRdcFileReader {
-    fn from(value: IRdcFileWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRdcFileWriter> for &'a IRdcFileReader {
-    fn from(value: &'a IRdcFileWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRdcFileWriter> for IRdcFileReader {
-    fn from(value: &IRdcFileWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRdcFileWriter, ::windows::core::IUnknown, IRdcFileReader);
 impl ::core::clone::Clone for IRdcFileWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -284,21 +213,7 @@ impl IRdcGenerator {
         (::windows::core::Vtable::vtable(self).Process)(::windows::core::Vtable::as_raw(self), endofinput.into(), ::core::mem::transmute(endofoutput), ::core::mem::transmute(inputbuffer), outputbuffers.len() as _, ::core::mem::transmute(outputbuffers.as_ptr()), ::core::mem::transmute(rdc_errorcode)).ok()
     }
 }
-impl ::core::convert::From<IRdcGenerator> for ::windows::core::IUnknown {
-    fn from(value: IRdcGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRdcGenerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRdcGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRdcGenerator> for ::windows::core::IUnknown {
-    fn from(value: &IRdcGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRdcGenerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRdcGenerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -350,21 +265,7 @@ impl IRdcGeneratorFilterMaxParameters {
         (::windows::core::Vtable::vtable(self).SetHashWindowSize)(::windows::core::Vtable::as_raw(self), hashwindowsize).ok()
     }
 }
-impl ::core::convert::From<IRdcGeneratorFilterMaxParameters> for ::windows::core::IUnknown {
-    fn from(value: IRdcGeneratorFilterMaxParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRdcGeneratorFilterMaxParameters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRdcGeneratorFilterMaxParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRdcGeneratorFilterMaxParameters> for ::windows::core::IUnknown {
-    fn from(value: &IRdcGeneratorFilterMaxParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRdcGeneratorFilterMaxParameters, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRdcGeneratorFilterMaxParameters {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -415,21 +316,7 @@ impl IRdcGeneratorParameters {
         (::windows::core::Vtable::vtable(self).Serialize)(::windows::core::Vtable::as_raw(self), size, ::core::mem::transmute(parametersblob), ::core::mem::transmute(byteswritten)).ok()
     }
 }
-impl ::core::convert::From<IRdcGeneratorParameters> for ::windows::core::IUnknown {
-    fn from(value: IRdcGeneratorParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRdcGeneratorParameters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRdcGeneratorParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRdcGeneratorParameters> for ::windows::core::IUnknown {
-    fn from(value: &IRdcGeneratorParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRdcGeneratorParameters, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRdcGeneratorParameters {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -499,21 +386,7 @@ impl IRdcLibrary {
         (::windows::core::Vtable::vtable(self).GetRDCVersion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(currentversion), ::core::mem::transmute(minimumcompatibleappversion)).ok()
     }
 }
-impl ::core::convert::From<IRdcLibrary> for ::windows::core::IUnknown {
-    fn from(value: IRdcLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRdcLibrary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRdcLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRdcLibrary> for ::windows::core::IUnknown {
-    fn from(value: &IRdcLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRdcLibrary, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRdcLibrary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -562,21 +435,7 @@ impl IRdcSignatureReader {
         (::windows::core::Vtable::vtable(self).ReadSignatures)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rdcsignaturepointer), ::core::mem::transmute(endofoutput)).ok()
     }
 }
-impl ::core::convert::From<IRdcSignatureReader> for ::windows::core::IUnknown {
-    fn from(value: IRdcSignatureReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRdcSignatureReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRdcSignatureReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRdcSignatureReader> for ::windows::core::IUnknown {
-    fn from(value: &IRdcSignatureReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRdcSignatureReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRdcSignatureReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -621,21 +480,7 @@ impl IRdcSimilarityGenerator {
         (::windows::core::Vtable::vtable(self).Results)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<SimilarityData>(result__)
     }
 }
-impl ::core::convert::From<IRdcSimilarityGenerator> for ::windows::core::IUnknown {
-    fn from(value: IRdcSimilarityGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRdcSimilarityGenerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRdcSimilarityGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRdcSimilarityGenerator> for ::windows::core::IUnknown {
-    fn from(value: &IRdcSimilarityGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRdcSimilarityGenerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRdcSimilarityGenerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -717,21 +562,7 @@ impl ISimilarity {
         (::windows::core::Vtable::vtable(self).GetRecordCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ISimilarity> for ::windows::core::IUnknown {
-    fn from(value: ISimilarity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISimilarity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISimilarity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISimilarity> for ::windows::core::IUnknown {
-    fn from(value: &ISimilarity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISimilarity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISimilarity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -823,21 +654,7 @@ impl ISimilarityFileIdTable {
         (::windows::core::Vtable::vtable(self).GetRecordCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ISimilarityFileIdTable> for ::windows::core::IUnknown {
-    fn from(value: ISimilarityFileIdTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISimilarityFileIdTable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISimilarityFileIdTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISimilarityFileIdTable> for ::windows::core::IUnknown {
-    fn from(value: &ISimilarityFileIdTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISimilarityFileIdTable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISimilarityFileIdTable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -889,21 +706,7 @@ impl ISimilarityReportProgress {
         (::windows::core::Vtable::vtable(self).ReportProgress)(::windows::core::Vtable::as_raw(self), percentcompleted).ok()
     }
 }
-impl ::core::convert::From<ISimilarityReportProgress> for ::windows::core::IUnknown {
-    fn from(value: ISimilarityReportProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISimilarityReportProgress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISimilarityReportProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISimilarityReportProgress> for ::windows::core::IUnknown {
-    fn from(value: &ISimilarityReportProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISimilarityReportProgress, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISimilarityReportProgress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -942,21 +745,7 @@ impl ISimilarityTableDumpState {
         (::windows::core::Vtable::vtable(self).GetNextData)(::windows::core::Vtable::as_raw(self), resultssize, ::core::mem::transmute(resultsused), ::core::mem::transmute(eof), ::core::mem::transmute(results)).ok()
     }
 }
-impl ::core::convert::From<ISimilarityTableDumpState> for ::windows::core::IUnknown {
-    fn from(value: ISimilarityTableDumpState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISimilarityTableDumpState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISimilarityTableDumpState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISimilarityTableDumpState> for ::windows::core::IUnknown {
-    fn from(value: &ISimilarityTableDumpState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISimilarityTableDumpState, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISimilarityTableDumpState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1011,21 +800,7 @@ impl ISimilarityTraitsMappedView {
         (::windows::core::Vtable::vtable(self).GetView)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(mappedpagebegin), ::core::mem::transmute(mappedpageend))
     }
 }
-impl ::core::convert::From<ISimilarityTraitsMappedView> for ::windows::core::IUnknown {
-    fn from(value: ISimilarityTraitsMappedView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISimilarityTraitsMappedView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISimilarityTraitsMappedView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISimilarityTraitsMappedView> for ::windows::core::IUnknown {
-    fn from(value: &ISimilarityTraitsMappedView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISimilarityTraitsMappedView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISimilarityTraitsMappedView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1090,21 +865,7 @@ impl ISimilarityTraitsMapping {
         (::windows::core::Vtable::vtable(self).CreateView)(::windows::core::Vtable::as_raw(self), minimummappedpages, accessmode, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISimilarityTraitsMappedView>(result__)
     }
 }
-impl ::core::convert::From<ISimilarityTraitsMapping> for ::windows::core::IUnknown {
-    fn from(value: ISimilarityTraitsMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISimilarityTraitsMapping> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISimilarityTraitsMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISimilarityTraitsMapping> for ::windows::core::IUnknown {
-    fn from(value: &ISimilarityTraitsMapping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISimilarityTraitsMapping, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISimilarityTraitsMapping {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1186,21 +947,7 @@ impl ISimilarityTraitsTable {
         (::windows::core::Vtable::vtable(self).GetLastIndex)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ISimilarityTraitsTable> for ::windows::core::IUnknown {
-    fn from(value: ISimilarityTraitsTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISimilarityTraitsTable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISimilarityTraitsTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISimilarityTraitsTable> for ::windows::core::IUnknown {
-    fn from(value: &ISimilarityTraitsTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISimilarityTraitsTable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISimilarityTraitsTable {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
@@ -3563,21 +3563,7 @@ impl IDialBranding {
         (::windows::core::Vtable::vtable(self).GetBitmap)(::windows::core::Vtable::as_raw(self), dwindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Graphics::Gdi::HBITMAP>(result__)
     }
 }
-impl ::core::convert::From<IDialBranding> for ::windows::core::IUnknown {
-    fn from(value: IDialBranding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDialBranding> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDialBranding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDialBranding> for ::windows::core::IUnknown {
-    fn from(value: &IDialBranding) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDialBranding, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDialBranding {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3650,21 +3636,7 @@ impl IDialEngine {
         (::windows::core::Vtable::vtable(self).GetConnectHandle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<usize>(result__)
     }
 }
-impl ::core::convert::From<IDialEngine> for ::windows::core::IUnknown {
-    fn from(value: IDialEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDialEngine> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDialEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDialEngine> for ::windows::core::IUnknown {
-    fn from(value: &IDialEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDialEngine, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDialEngine {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3707,21 +3679,7 @@ impl IDialEventSink {
         (::windows::core::Vtable::vtable(self).OnEvent)(::windows::core::Vtable::as_raw(self), dwevent, dwstatus).ok()
     }
 }
-impl ::core::convert::From<IDialEventSink> for ::windows::core::IUnknown {
-    fn from(value: IDialEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDialEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDialEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDialEventSink> for ::windows::core::IUnknown {
-    fn from(value: &IDialEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDialEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDialEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3761,21 +3719,7 @@ impl IProofOfPossessionCookieInfoManager {
         (::windows::core::Vtable::vtable(self).GetCookieInfoForUri)(::windows::core::Vtable::as_raw(self), uri.into(), ::core::mem::transmute(cookieinfocount), ::core::mem::transmute(cookieinfo)).ok()
     }
 }
-impl ::core::convert::From<IProofOfPossessionCookieInfoManager> for ::windows::core::IUnknown {
-    fn from(value: IProofOfPossessionCookieInfoManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProofOfPossessionCookieInfoManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProofOfPossessionCookieInfoManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProofOfPossessionCookieInfoManager> for ::windows::core::IUnknown {
-    fn from(value: &IProofOfPossessionCookieInfoManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProofOfPossessionCookieInfoManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProofOfPossessionCookieInfoManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3816,21 +3760,7 @@ impl IProofOfPossessionCookieInfoManager2 {
         (::windows::core::Vtable::vtable(self).GetCookieInfoWithUriForAccount)(::windows::core::Vtable::as_raw(self), webaccount.into().abi(), uri.into(), ::core::mem::transmute(cookieinfocount), ::core::mem::transmute(cookieinfo)).ok()
     }
 }
-impl ::core::convert::From<IProofOfPossessionCookieInfoManager2> for ::windows::core::IUnknown {
-    fn from(value: IProofOfPossessionCookieInfoManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProofOfPossessionCookieInfoManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProofOfPossessionCookieInfoManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProofOfPossessionCookieInfoManager2> for ::windows::core::IUnknown {
-    fn from(value: &IProofOfPossessionCookieInfoManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProofOfPossessionCookieInfoManager2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProofOfPossessionCookieInfoManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
@@ -1964,36 +1964,7 @@ impl IContentPrefetcherTaskTrigger {
         (::windows::core::Vtable::vtable(self).IsRegisteredForContentPrefetch)(::windows::core::Vtable::as_raw(self), packagefullname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u8>(result__)
     }
 }
-impl ::core::convert::From<IContentPrefetcherTaskTrigger> for ::windows::core::IUnknown {
-    fn from(value: IContentPrefetcherTaskTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContentPrefetcherTaskTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContentPrefetcherTaskTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContentPrefetcherTaskTrigger> for ::windows::core::IUnknown {
-    fn from(value: &IContentPrefetcherTaskTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContentPrefetcherTaskTrigger> for ::windows::core::IInspectable {
-    fn from(value: IContentPrefetcherTaskTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContentPrefetcherTaskTrigger> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IContentPrefetcherTaskTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContentPrefetcherTaskTrigger> for ::windows::core::IInspectable {
-    fn from(value: &IContentPrefetcherTaskTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContentPrefetcherTaskTrigger, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IContentPrefetcherTaskTrigger {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/mod.rs
@@ -41,21 +41,7 @@ impl AsyncIAssociatedIdentityProvider {
         (::windows::core::Vtable::vtable(self).Finish_ChangeCredential)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIAssociatedIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: AsyncIAssociatedIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIAssociatedIdentityProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIAssociatedIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIAssociatedIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIAssociatedIdentityProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIAssociatedIdentityProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIAssociatedIdentityProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -147,21 +133,7 @@ impl AsyncIConnectedIdentityProvider {
         (::windows::core::Vtable::vtable(self).Finish_GetAccountState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ACCOUNT_STATE>(result__)
     }
 }
-impl ::core::convert::From<AsyncIConnectedIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: AsyncIConnectedIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIConnectedIdentityProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIConnectedIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIConnectedIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIConnectedIdentityProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIConnectedIdentityProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIConnectedIdentityProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -222,21 +194,7 @@ impl AsyncIIdentityAdvise {
         (::windows::core::Vtable::vtable(self).Finish_IdentityUpdated)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIIdentityAdvise> for ::windows::core::IUnknown {
-    fn from(value: AsyncIIdentityAdvise) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIIdentityAdvise> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIIdentityAdvise) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIIdentityAdvise> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIIdentityAdvise) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIIdentityAdvise, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIIdentityAdvise {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -287,21 +245,7 @@ impl AsyncIIdentityAuthentication {
         (::windows::core::Vtable::vtable(self).Finish_ValidateIdentityCredential)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppidentityproperties.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<AsyncIIdentityAuthentication> for ::windows::core::IUnknown {
-    fn from(value: AsyncIIdentityAuthentication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIIdentityAuthentication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIIdentityAuthentication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIIdentityAuthentication> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIIdentityAuthentication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIIdentityAuthentication, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIIdentityAuthentication {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -428,21 +372,7 @@ impl AsyncIIdentityProvider {
         (::windows::core::Vtable::vtable(self).Finish_UnAdvise)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: AsyncIIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIIdentityProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIIdentityProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIIdentityProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIIdentityProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -563,21 +493,7 @@ impl AsyncIIdentityStore {
         (::windows::core::Vtable::vtable(self).Finish_Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIIdentityStore> for ::windows::core::IUnknown {
-    fn from(value: AsyncIIdentityStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIIdentityStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIIdentityStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIIdentityStore> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIIdentityStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIIdentityStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIIdentityStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -647,21 +563,7 @@ impl AsyncIIdentityStoreEx {
         (::windows::core::Vtable::vtable(self).Finish_DeleteConnectedIdentity)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIIdentityStoreEx> for ::windows::core::IUnknown {
-    fn from(value: AsyncIIdentityStoreEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIIdentityStoreEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIIdentityStoreEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIIdentityStoreEx> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIIdentityStoreEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIIdentityStoreEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIIdentityStoreEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -725,21 +627,7 @@ impl IAssociatedIdentityProvider {
         (::windows::core::Vtable::vtable(self).ChangeCredential)(::windows::core::Vtable::as_raw(self), hwndparent.into(), lpszuniqueid.into()).ok()
     }
 }
-impl ::core::convert::From<IAssociatedIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: IAssociatedIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAssociatedIdentityProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAssociatedIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAssociatedIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: &IAssociatedIdentityProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAssociatedIdentityProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAssociatedIdentityProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -808,21 +696,7 @@ impl IConnectedIdentityProvider {
         (::windows::core::Vtable::vtable(self).GetAccountState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ACCOUNT_STATE>(result__)
     }
 }
-impl ::core::convert::From<IConnectedIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: IConnectedIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConnectedIdentityProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConnectedIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConnectedIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: &IConnectedIdentityProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConnectedIdentityProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConnectedIdentityProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -872,21 +746,7 @@ impl IIdentityAdvise {
         (::windows::core::Vtable::vtable(self).IdentityUpdated)(::windows::core::Vtable::as_raw(self), dwidentityupdateevents, lpszuniqueid.into()).ok()
     }
 }
-impl ::core::convert::From<IIdentityAdvise> for ::windows::core::IUnknown {
-    fn from(value: IIdentityAdvise) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIdentityAdvise> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIdentityAdvise) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIdentityAdvise> for ::windows::core::IUnknown {
-    fn from(value: &IIdentityAdvise) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIdentityAdvise, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IIdentityAdvise {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -928,21 +788,7 @@ impl IIdentityAuthentication {
         (::windows::core::Vtable::vtable(self).ValidateIdentityCredential)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(credbuffer.as_ptr()), credbuffer.len() as _, ::core::mem::transmute(ppidentityproperties.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IIdentityAuthentication> for ::windows::core::IUnknown {
-    fn from(value: IIdentityAuthentication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIdentityAuthentication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIdentityAuthentication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIdentityAuthentication> for ::windows::core::IUnknown {
-    fn from(value: &IIdentityAuthentication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIdentityAuthentication, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IIdentityAuthentication {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1035,21 +881,7 @@ impl IIdentityProvider {
         (::windows::core::Vtable::vtable(self).UnAdvise)(::windows::core::Vtable::as_raw(self), dwcookie).ok()
     }
 }
-impl ::core::convert::From<IIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: IIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIdentityProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIdentityProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIdentityProvider> for ::windows::core::IUnknown {
-    fn from(value: &IIdentityProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIdentityProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IIdentityProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1136,21 +968,7 @@ impl IIdentityStore {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IIdentityStore> for ::windows::core::IUnknown {
-    fn from(value: IIdentityStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIdentityStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIdentityStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIdentityStore> for ::windows::core::IUnknown {
-    fn from(value: &IIdentityStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIdentityStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IIdentityStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1205,21 +1023,7 @@ impl IIdentityStoreEx {
         (::windows::core::Vtable::vtable(self).DeleteConnectedIdentity)(::windows::core::Vtable::as_raw(self), connectedname.into(), ::core::mem::transmute(providerguid)).ok()
     }
 }
-impl ::core::convert::From<IIdentityStoreEx> for ::windows::core::IUnknown {
-    fn from(value: IIdentityStoreEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIdentityStoreEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIdentityStoreEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIdentityStoreEx> for ::windows::core::IUnknown {
-    fn from(value: &IIdentityStoreEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIdentityStoreEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IIdentityStoreEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -2393,21 +2393,7 @@ impl ICcgDomainAuthCredentials {
         (::windows::core::Vtable::vtable(self).GetPasswordCredentials)(::windows::core::Vtable::as_raw(self), plugininput.into(), ::core::mem::transmute(domainname), ::core::mem::transmute(username), ::core::mem::transmute(password)).ok()
     }
 }
-impl ::core::convert::From<ICcgDomainAuthCredentials> for ::windows::core::IUnknown {
-    fn from(value: ICcgDomainAuthCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICcgDomainAuthCredentials> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICcgDomainAuthCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICcgDomainAuthCredentials> for ::windows::core::IUnknown {
-    fn from(value: &ICcgDomainAuthCredentials) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICcgDomainAuthCredentials, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICcgDomainAuthCredentials {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
@@ -55,21 +55,7 @@ impl IEffectivePermission {
         (::windows::core::Vtable::vtable(self).GetEffectivePermission)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguidobjecttype), pusersid.into(), pszservername.into(), psd.into(), ::core::mem::transmute(ppobjecttypelist), ::core::mem::transmute(pcobjecttypelistlength), ::core::mem::transmute(ppgrantedaccesslist), ::core::mem::transmute(pcgrantedaccesslistlength)).ok()
     }
 }
-impl ::core::convert::From<IEffectivePermission> for ::windows::core::IUnknown {
-    fn from(value: IEffectivePermission) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEffectivePermission> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEffectivePermission) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEffectivePermission> for ::windows::core::IUnknown {
-    fn from(value: &IEffectivePermission) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEffectivePermission, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEffectivePermission {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -149,21 +135,7 @@ impl IEffectivePermission2 {
         .ok()
     }
 }
-impl ::core::convert::From<IEffectivePermission2> for ::windows::core::IUnknown {
-    fn from(value: IEffectivePermission2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEffectivePermission2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEffectivePermission2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEffectivePermission2> for ::windows::core::IUnknown {
-    fn from(value: &IEffectivePermission2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEffectivePermission2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEffectivePermission2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -252,21 +224,7 @@ impl ISecurityInformation {
         (::windows::core::Vtable::vtable(self).PropertySheetPageCallback)(::windows::core::Vtable::as_raw(self), hwnd.into(), umsg, upage).ok()
     }
 }
-impl ::core::convert::From<ISecurityInformation> for ::windows::core::IUnknown {
-    fn from(value: ISecurityInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISecurityInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISecurityInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISecurityInformation> for ::windows::core::IUnknown {
-    fn from(value: &ISecurityInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISecurityInformation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISecurityInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -325,21 +283,7 @@ impl ISecurityInformation2 {
         (::windows::core::Vtable::vtable(self).LookupSids)(::windows::core::Vtable::as_raw(self), csids, ::core::mem::transmute(rgpsids), ::core::mem::transmute(ppdo)).ok()
     }
 }
-impl ::core::convert::From<ISecurityInformation2> for ::windows::core::IUnknown {
-    fn from(value: ISecurityInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISecurityInformation2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISecurityInformation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISecurityInformation2> for ::windows::core::IUnknown {
-    fn from(value: &ISecurityInformation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISecurityInformation2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISecurityInformation2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -392,21 +336,7 @@ impl ISecurityInformation3 {
         (::windows::core::Vtable::vtable(self).OpenElevatedEditor)(::windows::core::Vtable::as_raw(self), hwnd.into(), upage).ok()
     }
 }
-impl ::core::convert::From<ISecurityInformation3> for ::windows::core::IUnknown {
-    fn from(value: ISecurityInformation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISecurityInformation3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISecurityInformation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISecurityInformation3> for ::windows::core::IUnknown {
-    fn from(value: &ISecurityInformation3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISecurityInformation3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISecurityInformation3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -449,21 +379,7 @@ impl ISecurityInformation4 {
         (::windows::core::Vtable::vtable(self).GetSecondarySecurity)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(psecurityobjects), ::core::mem::transmute(psecurityobjectcount)).ok()
     }
 }
-impl ::core::convert::From<ISecurityInformation4> for ::windows::core::IUnknown {
-    fn from(value: ISecurityInformation4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISecurityInformation4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISecurityInformation4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISecurityInformation4> for ::windows::core::IUnknown {
-    fn from(value: &ISecurityInformation4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISecurityInformation4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISecurityInformation4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -503,21 +419,7 @@ impl ISecurityObjectTypeInfo {
         (::windows::core::Vtable::vtable(self).GetInheritSource)(::windows::core::Vtable::as_raw(self), si, ::core::mem::transmute(pacl), ::core::mem::transmute(ppinheritarray)).ok()
     }
 }
-impl ::core::convert::From<ISecurityObjectTypeInfo> for ::windows::core::IUnknown {
-    fn from(value: ISecurityObjectTypeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISecurityObjectTypeInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISecurityObjectTypeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISecurityObjectTypeInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISecurityObjectTypeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISecurityObjectTypeInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISecurityObjectTypeInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
@@ -1553,41 +1553,7 @@ impl IAzApplication {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplication> for ::windows::core::IUnknown {
-    fn from(value: IAzApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplication> for ::windows::core::IUnknown {
-    fn from(value: &IAzApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplication> for super::super::System::Com::IDispatch {
-    fn from(value: IAzApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplication> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplication> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzApplication, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzApplication {
     fn clone(&self) -> Self {
@@ -2294,59 +2260,7 @@ impl IAzApplication2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplication2> for ::windows::core::IUnknown {
-    fn from(value: IAzApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplication2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplication2> for ::windows::core::IUnknown {
-    fn from(value: &IAzApplication2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplication2> for super::super::System::Com::IDispatch {
-    fn from(value: IAzApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplication2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplication2> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzApplication2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplication2> for IAzApplication {
-    fn from(value: IAzApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplication2> for &'a IAzApplication {
-    fn from(value: &'a IAzApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplication2> for IAzApplication {
-    fn from(value: &IAzApplication2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzApplication2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzApplication);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzApplication2 {
     fn clone(&self) -> Self {
@@ -2915,77 +2829,7 @@ impl IAzApplication3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplication3> for ::windows::core::IUnknown {
-    fn from(value: IAzApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplication3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplication3> for ::windows::core::IUnknown {
-    fn from(value: &IAzApplication3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplication3> for super::super::System::Com::IDispatch {
-    fn from(value: IAzApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplication3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplication3> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzApplication3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplication3> for IAzApplication {
-    fn from(value: IAzApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplication3> for &'a IAzApplication {
-    fn from(value: &'a IAzApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplication3> for IAzApplication {
-    fn from(value: &IAzApplication3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplication3> for IAzApplication2 {
-    fn from(value: IAzApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplication3> for &'a IAzApplication2 {
-    fn from(value: &'a IAzApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplication3> for IAzApplication2 {
-    fn from(value: &IAzApplication3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzApplication3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzApplication, IAzApplication2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzApplication3 {
     fn clone(&self) -> Self {
@@ -3276,41 +3120,7 @@ impl IAzApplicationGroup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplicationGroup> for ::windows::core::IUnknown {
-    fn from(value: IAzApplicationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplicationGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzApplicationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplicationGroup> for ::windows::core::IUnknown {
-    fn from(value: &IAzApplicationGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplicationGroup> for super::super::System::Com::IDispatch {
-    fn from(value: IAzApplicationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplicationGroup> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzApplicationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplicationGroup> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzApplicationGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzApplicationGroup, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzApplicationGroup {
     fn clone(&self) -> Self {
@@ -3694,59 +3504,7 @@ impl IAzApplicationGroup2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplicationGroup2> for ::windows::core::IUnknown {
-    fn from(value: IAzApplicationGroup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplicationGroup2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzApplicationGroup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplicationGroup2> for ::windows::core::IUnknown {
-    fn from(value: &IAzApplicationGroup2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplicationGroup2> for super::super::System::Com::IDispatch {
-    fn from(value: IAzApplicationGroup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplicationGroup2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzApplicationGroup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplicationGroup2> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzApplicationGroup2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplicationGroup2> for IAzApplicationGroup {
-    fn from(value: IAzApplicationGroup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplicationGroup2> for &'a IAzApplicationGroup {
-    fn from(value: &'a IAzApplicationGroup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplicationGroup2> for IAzApplicationGroup {
-    fn from(value: &IAzApplicationGroup2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzApplicationGroup2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzApplicationGroup);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzApplicationGroup2 {
     fn clone(&self) -> Self {
@@ -3813,41 +3571,7 @@ impl IAzApplicationGroups {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplicationGroups> for ::windows::core::IUnknown {
-    fn from(value: IAzApplicationGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplicationGroups> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzApplicationGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplicationGroups> for ::windows::core::IUnknown {
-    fn from(value: &IAzApplicationGroups) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplicationGroups> for super::super::System::Com::IDispatch {
-    fn from(value: IAzApplicationGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplicationGroups> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzApplicationGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplicationGroups> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzApplicationGroups) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzApplicationGroups, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzApplicationGroups {
     fn clone(&self) -> Self {
@@ -3910,41 +3634,7 @@ impl IAzApplications {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplications> for ::windows::core::IUnknown {
-    fn from(value: IAzApplications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplications> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzApplications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplications> for ::windows::core::IUnknown {
-    fn from(value: &IAzApplications) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzApplications> for super::super::System::Com::IDispatch {
-    fn from(value: IAzApplications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzApplications> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzApplications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzApplications> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzApplications) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzApplications, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzApplications {
     fn clone(&self) -> Self {
@@ -4333,41 +4023,7 @@ impl IAzAuthorizationStore {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzAuthorizationStore> for ::windows::core::IUnknown {
-    fn from(value: IAzAuthorizationStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzAuthorizationStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzAuthorizationStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzAuthorizationStore> for ::windows::core::IUnknown {
-    fn from(value: &IAzAuthorizationStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzAuthorizationStore> for super::super::System::Com::IDispatch {
-    fn from(value: IAzAuthorizationStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzAuthorizationStore> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzAuthorizationStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzAuthorizationStore> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzAuthorizationStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzAuthorizationStore, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzAuthorizationStore {
     fn clone(&self) -> Self {
@@ -4936,59 +4592,7 @@ impl IAzAuthorizationStore2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzAuthorizationStore2> for ::windows::core::IUnknown {
-    fn from(value: IAzAuthorizationStore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzAuthorizationStore2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzAuthorizationStore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzAuthorizationStore2> for ::windows::core::IUnknown {
-    fn from(value: &IAzAuthorizationStore2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzAuthorizationStore2> for super::super::System::Com::IDispatch {
-    fn from(value: IAzAuthorizationStore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzAuthorizationStore2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzAuthorizationStore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzAuthorizationStore2> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzAuthorizationStore2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzAuthorizationStore2> for IAzAuthorizationStore {
-    fn from(value: IAzAuthorizationStore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzAuthorizationStore2> for &'a IAzAuthorizationStore {
-    fn from(value: &'a IAzAuthorizationStore2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzAuthorizationStore2> for IAzAuthorizationStore {
-    fn from(value: &IAzAuthorizationStore2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzAuthorizationStore2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzAuthorizationStore);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzAuthorizationStore2 {
     fn clone(&self) -> Self {
@@ -5415,77 +5019,7 @@ impl IAzAuthorizationStore3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzAuthorizationStore3> for ::windows::core::IUnknown {
-    fn from(value: IAzAuthorizationStore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzAuthorizationStore3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzAuthorizationStore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzAuthorizationStore3> for ::windows::core::IUnknown {
-    fn from(value: &IAzAuthorizationStore3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzAuthorizationStore3> for super::super::System::Com::IDispatch {
-    fn from(value: IAzAuthorizationStore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzAuthorizationStore3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzAuthorizationStore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzAuthorizationStore3> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzAuthorizationStore3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzAuthorizationStore3> for IAzAuthorizationStore {
-    fn from(value: IAzAuthorizationStore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzAuthorizationStore3> for &'a IAzAuthorizationStore {
-    fn from(value: &'a IAzAuthorizationStore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzAuthorizationStore3> for IAzAuthorizationStore {
-    fn from(value: &IAzAuthorizationStore3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzAuthorizationStore3> for IAzAuthorizationStore2 {
-    fn from(value: IAzAuthorizationStore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzAuthorizationStore3> for &'a IAzAuthorizationStore2 {
-    fn from(value: &'a IAzAuthorizationStore3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzAuthorizationStore3> for IAzAuthorizationStore2 {
-    fn from(value: &IAzAuthorizationStore3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzAuthorizationStore3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzAuthorizationStore, IAzAuthorizationStore2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzAuthorizationStore3 {
     fn clone(&self) -> Self {
@@ -5554,41 +5088,7 @@ impl IAzBizRuleContext {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzBizRuleContext> for ::windows::core::IUnknown {
-    fn from(value: IAzBizRuleContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzBizRuleContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzBizRuleContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzBizRuleContext> for ::windows::core::IUnknown {
-    fn from(value: &IAzBizRuleContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzBizRuleContext> for super::super::System::Com::IDispatch {
-    fn from(value: IAzBizRuleContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzBizRuleContext> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzBizRuleContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzBizRuleContext> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzBizRuleContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzBizRuleContext, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzBizRuleContext {
     fn clone(&self) -> Self {
@@ -5674,41 +5174,7 @@ impl IAzBizRuleInterfaces {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzBizRuleInterfaces> for ::windows::core::IUnknown {
-    fn from(value: IAzBizRuleInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzBizRuleInterfaces> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzBizRuleInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzBizRuleInterfaces> for ::windows::core::IUnknown {
-    fn from(value: &IAzBizRuleInterfaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzBizRuleInterfaces> for super::super::System::Com::IDispatch {
-    fn from(value: IAzBizRuleInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzBizRuleInterfaces> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzBizRuleInterfaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzBizRuleInterfaces> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzBizRuleInterfaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzBizRuleInterfaces, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzBizRuleInterfaces {
     fn clone(&self) -> Self {
@@ -5799,41 +5265,7 @@ impl IAzBizRuleParameters {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzBizRuleParameters> for ::windows::core::IUnknown {
-    fn from(value: IAzBizRuleParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzBizRuleParameters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzBizRuleParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzBizRuleParameters> for ::windows::core::IUnknown {
-    fn from(value: &IAzBizRuleParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzBizRuleParameters> for super::super::System::Com::IDispatch {
-    fn from(value: IAzBizRuleParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzBizRuleParameters> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzBizRuleParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzBizRuleParameters> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzBizRuleParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzBizRuleParameters, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzBizRuleParameters {
     fn clone(&self) -> Self {
@@ -5960,41 +5392,7 @@ impl IAzClientContext {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzClientContext> for ::windows::core::IUnknown {
-    fn from(value: IAzClientContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzClientContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzClientContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzClientContext> for ::windows::core::IUnknown {
-    fn from(value: &IAzClientContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzClientContext> for super::super::System::Com::IDispatch {
-    fn from(value: IAzClientContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzClientContext> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzClientContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzClientContext> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzClientContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzClientContext, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzClientContext {
     fn clone(&self) -> Self {
@@ -6164,59 +5562,7 @@ impl IAzClientContext2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzClientContext2> for ::windows::core::IUnknown {
-    fn from(value: IAzClientContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzClientContext2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzClientContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzClientContext2> for ::windows::core::IUnknown {
-    fn from(value: &IAzClientContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzClientContext2> for super::super::System::Com::IDispatch {
-    fn from(value: IAzClientContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzClientContext2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzClientContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzClientContext2> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzClientContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzClientContext2> for IAzClientContext {
-    fn from(value: IAzClientContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzClientContext2> for &'a IAzClientContext {
-    fn from(value: &'a IAzClientContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzClientContext2> for IAzClientContext {
-    fn from(value: &IAzClientContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzClientContext2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzClientContext);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzClientContext2 {
     fn clone(&self) -> Self {
@@ -6426,77 +5772,7 @@ impl IAzClientContext3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzClientContext3> for ::windows::core::IUnknown {
-    fn from(value: IAzClientContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzClientContext3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzClientContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzClientContext3> for ::windows::core::IUnknown {
-    fn from(value: &IAzClientContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzClientContext3> for super::super::System::Com::IDispatch {
-    fn from(value: IAzClientContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzClientContext3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzClientContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzClientContext3> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzClientContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzClientContext3> for IAzClientContext {
-    fn from(value: IAzClientContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzClientContext3> for &'a IAzClientContext {
-    fn from(value: &'a IAzClientContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzClientContext3> for IAzClientContext {
-    fn from(value: &IAzClientContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzClientContext3> for IAzClientContext2 {
-    fn from(value: IAzClientContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzClientContext3> for &'a IAzClientContext2 {
-    fn from(value: &'a IAzClientContext3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzClientContext3> for IAzClientContext2 {
-    fn from(value: &IAzClientContext3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzClientContext3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzClientContext, IAzClientContext2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzClientContext3 {
     fn clone(&self) -> Self {
@@ -6576,41 +5852,7 @@ impl IAzNameResolver {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzNameResolver> for ::windows::core::IUnknown {
-    fn from(value: IAzNameResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzNameResolver> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzNameResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzNameResolver> for ::windows::core::IUnknown {
-    fn from(value: &IAzNameResolver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzNameResolver> for super::super::System::Com::IDispatch {
-    fn from(value: IAzNameResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzNameResolver> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzNameResolver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzNameResolver> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzNameResolver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzNameResolver, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzNameResolver {
     fn clone(&self) -> Self {
@@ -6670,41 +5912,7 @@ impl IAzObjectPicker {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzObjectPicker> for ::windows::core::IUnknown {
-    fn from(value: IAzObjectPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzObjectPicker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzObjectPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzObjectPicker> for ::windows::core::IUnknown {
-    fn from(value: &IAzObjectPicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzObjectPicker> for super::super::System::Com::IDispatch {
-    fn from(value: IAzObjectPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzObjectPicker> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzObjectPicker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzObjectPicker> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzObjectPicker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzObjectPicker, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzObjectPicker {
     fn clone(&self) -> Self {
@@ -6812,41 +6020,7 @@ impl IAzOperation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzOperation> for ::windows::core::IUnknown {
-    fn from(value: IAzOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzOperation> for ::windows::core::IUnknown {
-    fn from(value: &IAzOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzOperation> for super::super::System::Com::IDispatch {
-    fn from(value: IAzOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzOperation> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzOperation> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzOperation, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzOperation {
     fn clone(&self) -> Self {
@@ -6979,59 +6153,7 @@ impl IAzOperation2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzOperation2> for ::windows::core::IUnknown {
-    fn from(value: IAzOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzOperation2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzOperation2> for ::windows::core::IUnknown {
-    fn from(value: &IAzOperation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzOperation2> for super::super::System::Com::IDispatch {
-    fn from(value: IAzOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzOperation2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzOperation2> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzOperation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzOperation2> for IAzOperation {
-    fn from(value: IAzOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzOperation2> for &'a IAzOperation {
-    fn from(value: &'a IAzOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzOperation2> for IAzOperation {
-    fn from(value: &IAzOperation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzOperation2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzOperation);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzOperation2 {
     fn clone(&self) -> Self {
@@ -7092,41 +6214,7 @@ impl IAzOperations {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzOperations> for ::windows::core::IUnknown {
-    fn from(value: IAzOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzOperations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzOperations> for ::windows::core::IUnknown {
-    fn from(value: &IAzOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzOperations> for super::super::System::Com::IDispatch {
-    fn from(value: IAzOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzOperations> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzOperations> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzOperations, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzOperations {
     fn clone(&self) -> Self {
@@ -7187,41 +6275,7 @@ impl IAzPrincipalLocator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzPrincipalLocator> for ::windows::core::IUnknown {
-    fn from(value: IAzPrincipalLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzPrincipalLocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzPrincipalLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzPrincipalLocator> for ::windows::core::IUnknown {
-    fn from(value: &IAzPrincipalLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzPrincipalLocator> for super::super::System::Com::IDispatch {
-    fn from(value: IAzPrincipalLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzPrincipalLocator> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzPrincipalLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzPrincipalLocator> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzPrincipalLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzPrincipalLocator, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzPrincipalLocator {
     fn clone(&self) -> Self {
@@ -7453,41 +6507,7 @@ impl IAzRole {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRole> for ::windows::core::IUnknown {
-    fn from(value: IAzRole) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRole> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzRole) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRole> for ::windows::core::IUnknown {
-    fn from(value: &IAzRole) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRole> for super::super::System::Com::IDispatch {
-    fn from(value: IAzRole) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRole> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzRole) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRole> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzRole) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzRole, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzRole {
     fn clone(&self) -> Self {
@@ -7819,59 +6839,7 @@ impl IAzRoleAssignment {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoleAssignment> for ::windows::core::IUnknown {
-    fn from(value: IAzRoleAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoleAssignment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzRoleAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoleAssignment> for ::windows::core::IUnknown {
-    fn from(value: &IAzRoleAssignment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoleAssignment> for super::super::System::Com::IDispatch {
-    fn from(value: IAzRoleAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoleAssignment> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzRoleAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoleAssignment> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzRoleAssignment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoleAssignment> for IAzRole {
-    fn from(value: IAzRoleAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoleAssignment> for &'a IAzRole {
-    fn from(value: &'a IAzRoleAssignment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoleAssignment> for IAzRole {
-    fn from(value: &IAzRoleAssignment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzRoleAssignment, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzRole);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzRoleAssignment {
     fn clone(&self) -> Self {
@@ -7938,41 +6906,7 @@ impl IAzRoleAssignments {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoleAssignments> for ::windows::core::IUnknown {
-    fn from(value: IAzRoleAssignments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoleAssignments> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzRoleAssignments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoleAssignments> for ::windows::core::IUnknown {
-    fn from(value: &IAzRoleAssignments) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoleAssignments> for super::super::System::Com::IDispatch {
-    fn from(value: IAzRoleAssignments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoleAssignments> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzRoleAssignments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoleAssignments> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzRoleAssignments) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzRoleAssignments, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzRoleAssignments {
     fn clone(&self) -> Self {
@@ -8189,59 +7123,7 @@ impl IAzRoleDefinition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoleDefinition> for ::windows::core::IUnknown {
-    fn from(value: IAzRoleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoleDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzRoleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoleDefinition> for ::windows::core::IUnknown {
-    fn from(value: &IAzRoleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoleDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: IAzRoleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoleDefinition> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzRoleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoleDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzRoleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoleDefinition> for IAzTask {
-    fn from(value: IAzRoleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoleDefinition> for &'a IAzTask {
-    fn from(value: &'a IAzRoleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoleDefinition> for IAzTask {
-    fn from(value: &IAzRoleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzRoleDefinition, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzTask);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzRoleDefinition {
     fn clone(&self) -> Self {
@@ -8308,41 +7190,7 @@ impl IAzRoleDefinitions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoleDefinitions> for ::windows::core::IUnknown {
-    fn from(value: IAzRoleDefinitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoleDefinitions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzRoleDefinitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoleDefinitions> for ::windows::core::IUnknown {
-    fn from(value: &IAzRoleDefinitions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoleDefinitions> for super::super::System::Com::IDispatch {
-    fn from(value: IAzRoleDefinitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoleDefinitions> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzRoleDefinitions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoleDefinitions> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzRoleDefinitions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzRoleDefinitions, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzRoleDefinitions {
     fn clone(&self) -> Self {
@@ -8405,41 +7253,7 @@ impl IAzRoles {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoles> for ::windows::core::IUnknown {
-    fn from(value: IAzRoles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoles> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzRoles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoles> for ::windows::core::IUnknown {
-    fn from(value: &IAzRoles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzRoles> for super::super::System::Com::IDispatch {
-    fn from(value: IAzRoles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzRoles> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzRoles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzRoles> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzRoles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzRoles, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzRoles {
     fn clone(&self) -> Self {
@@ -8755,41 +7569,7 @@ impl IAzScope {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzScope> for ::windows::core::IUnknown {
-    fn from(value: IAzScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzScope> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzScope> for ::windows::core::IUnknown {
-    fn from(value: &IAzScope) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzScope> for super::super::System::Com::IDispatch {
-    fn from(value: IAzScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzScope> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzScope> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzScope) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzScope, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzScope {
     fn clone(&self) -> Self {
@@ -9275,59 +8055,7 @@ impl IAzScope2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzScope2> for ::windows::core::IUnknown {
-    fn from(value: IAzScope2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzScope2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzScope2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzScope2> for ::windows::core::IUnknown {
-    fn from(value: &IAzScope2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzScope2> for super::super::System::Com::IDispatch {
-    fn from(value: IAzScope2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzScope2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzScope2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzScope2> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzScope2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzScope2> for IAzScope {
-    fn from(value: IAzScope2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzScope2> for &'a IAzScope {
-    fn from(value: &'a IAzScope2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzScope2> for IAzScope {
-    fn from(value: &IAzScope2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzScope2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzScope);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzScope2 {
     fn clone(&self) -> Self {
@@ -9410,41 +8138,7 @@ impl IAzScopes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzScopes> for ::windows::core::IUnknown {
-    fn from(value: IAzScopes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzScopes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzScopes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzScopes> for ::windows::core::IUnknown {
-    fn from(value: &IAzScopes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzScopes> for super::super::System::Com::IDispatch {
-    fn from(value: IAzScopes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzScopes> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzScopes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzScopes> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzScopes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzScopes, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzScopes {
     fn clone(&self) -> Self {
@@ -9643,41 +8337,7 @@ impl IAzTask {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzTask> for ::windows::core::IUnknown {
-    fn from(value: IAzTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzTask> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzTask> for ::windows::core::IUnknown {
-    fn from(value: &IAzTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzTask> for super::super::System::Com::IDispatch {
-    fn from(value: IAzTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzTask> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzTask> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzTask, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzTask {
     fn clone(&self) -> Self {
@@ -9944,59 +8604,7 @@ impl IAzTask2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzTask2> for ::windows::core::IUnknown {
-    fn from(value: IAzTask2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzTask2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzTask2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzTask2> for ::windows::core::IUnknown {
-    fn from(value: &IAzTask2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzTask2> for super::super::System::Com::IDispatch {
-    fn from(value: IAzTask2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzTask2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzTask2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzTask2> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzTask2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzTask2> for IAzTask {
-    fn from(value: IAzTask2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzTask2> for &'a IAzTask {
-    fn from(value: &'a IAzTask2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzTask2> for IAzTask {
-    fn from(value: &IAzTask2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzTask2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IAzTask);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzTask2 {
     fn clone(&self) -> Self {
@@ -10057,41 +8665,7 @@ impl IAzTasks {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzTasks> for ::windows::core::IUnknown {
-    fn from(value: IAzTasks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzTasks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAzTasks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzTasks> for ::windows::core::IUnknown {
-    fn from(value: &IAzTasks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAzTasks> for super::super::System::Com::IDispatch {
-    fn from(value: IAzTasks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAzTasks> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAzTasks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAzTasks> for super::super::System::Com::IDispatch {
-    fn from(value: &IAzTasks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAzTasks, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAzTasks {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/mod.rs
@@ -18,21 +18,7 @@ impl ISceSvcAttachmentData {
         (::windows::core::Vtable::vtable(self).CloseHandle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(scesvchandle)).ok()
     }
 }
-impl ::core::convert::From<ISceSvcAttachmentData> for ::windows::core::IUnknown {
-    fn from(value: ISceSvcAttachmentData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISceSvcAttachmentData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISceSvcAttachmentData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISceSvcAttachmentData> for ::windows::core::IUnknown {
-    fn from(value: &ISceSvcAttachmentData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISceSvcAttachmentData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISceSvcAttachmentData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -80,21 +66,7 @@ impl ISceSvcAttachmentPersistInfo {
         (::windows::core::Vtable::vtable(self).FreeBuffer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvdata)).ok()
     }
 }
-impl ::core::convert::From<ISceSvcAttachmentPersistInfo> for ::windows::core::IUnknown {
-    fn from(value: ISceSvcAttachmentPersistInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISceSvcAttachmentPersistInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISceSvcAttachmentPersistInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISceSvcAttachmentPersistInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISceSvcAttachmentPersistInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISceSvcAttachmentPersistInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISceSvcAttachmentPersistInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
@@ -312,41 +312,7 @@ impl IAlternativeName {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAlternativeName> for ::windows::core::IUnknown {
-    fn from(value: IAlternativeName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAlternativeName> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAlternativeName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAlternativeName> for ::windows::core::IUnknown {
-    fn from(value: &IAlternativeName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAlternativeName> for super::super::super::System::Com::IDispatch {
-    fn from(value: IAlternativeName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAlternativeName> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IAlternativeName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAlternativeName> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IAlternativeName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAlternativeName, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAlternativeName {
     fn clone(&self) -> Self {
@@ -430,41 +396,7 @@ impl IAlternativeNames {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAlternativeNames> for ::windows::core::IUnknown {
-    fn from(value: IAlternativeNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAlternativeNames> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAlternativeNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAlternativeNames> for ::windows::core::IUnknown {
-    fn from(value: &IAlternativeNames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAlternativeNames> for super::super::super::System::Com::IDispatch {
-    fn from(value: IAlternativeNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAlternativeNames> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IAlternativeNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAlternativeNames> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IAlternativeNames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAlternativeNames, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAlternativeNames {
     fn clone(&self) -> Self {
@@ -535,41 +467,7 @@ impl IBinaryConverter {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBinaryConverter> for ::windows::core::IUnknown {
-    fn from(value: IBinaryConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBinaryConverter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBinaryConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBinaryConverter> for ::windows::core::IUnknown {
-    fn from(value: &IBinaryConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBinaryConverter> for super::super::super::System::Com::IDispatch {
-    fn from(value: IBinaryConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBinaryConverter> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IBinaryConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBinaryConverter> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IBinaryConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBinaryConverter, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IBinaryConverter {
     fn clone(&self) -> Self {
@@ -649,59 +547,7 @@ impl IBinaryConverter2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBinaryConverter2> for ::windows::core::IUnknown {
-    fn from(value: IBinaryConverter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBinaryConverter2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBinaryConverter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBinaryConverter2> for ::windows::core::IUnknown {
-    fn from(value: &IBinaryConverter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBinaryConverter2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IBinaryConverter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBinaryConverter2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IBinaryConverter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBinaryConverter2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IBinaryConverter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBinaryConverter2> for IBinaryConverter {
-    fn from(value: IBinaryConverter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBinaryConverter2> for &'a IBinaryConverter {
-    fn from(value: &'a IBinaryConverter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBinaryConverter2> for IBinaryConverter {
-    fn from(value: &IBinaryConverter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBinaryConverter2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IBinaryConverter);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IBinaryConverter2 {
     fn clone(&self) -> Self {
@@ -969,41 +815,7 @@ impl ICEnroll {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll> for ::windows::core::IUnknown {
-    fn from(value: ICEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll> for ::windows::core::IUnknown {
-    fn from(value: &ICEnroll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICEnroll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICEnroll, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICEnroll {
     fn clone(&self) -> Self {
@@ -1371,59 +1183,7 @@ impl ICEnroll2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll2> for ::windows::core::IUnknown {
-    fn from(value: ICEnroll2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICEnroll2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll2> for ::windows::core::IUnknown {
-    fn from(value: &ICEnroll2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICEnroll2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICEnroll2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICEnroll2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll2> for ICEnroll {
-    fn from(value: ICEnroll2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll2> for &'a ICEnroll {
-    fn from(value: &'a ICEnroll2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll2> for ICEnroll {
-    fn from(value: &ICEnroll2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICEnroll2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICEnroll);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICEnroll2 {
     fn clone(&self) -> Self {
@@ -1812,77 +1572,7 @@ impl ICEnroll3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll3> for ::windows::core::IUnknown {
-    fn from(value: ICEnroll3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICEnroll3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll3> for ::windows::core::IUnknown {
-    fn from(value: &ICEnroll3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll3> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICEnroll3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll3> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICEnroll3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll3> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICEnroll3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll3> for ICEnroll {
-    fn from(value: ICEnroll3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll3> for &'a ICEnroll {
-    fn from(value: &'a ICEnroll3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll3> for ICEnroll {
-    fn from(value: &ICEnroll3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll3> for ICEnroll2 {
-    fn from(value: ICEnroll3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll3> for &'a ICEnroll2 {
-    fn from(value: &'a ICEnroll3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll3> for ICEnroll2 {
-    fn from(value: &ICEnroll3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICEnroll3, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICEnroll, ICEnroll2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICEnroll3 {
     fn clone(&self) -> Self {
@@ -2415,95 +2105,7 @@ impl ICEnroll4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll4> for ::windows::core::IUnknown {
-    fn from(value: ICEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll4> for ::windows::core::IUnknown {
-    fn from(value: &ICEnroll4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll4> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll4> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll4> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICEnroll4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll4> for ICEnroll {
-    fn from(value: ICEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll4> for &'a ICEnroll {
-    fn from(value: &'a ICEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll4> for ICEnroll {
-    fn from(value: &ICEnroll4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll4> for ICEnroll2 {
-    fn from(value: ICEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll4> for &'a ICEnroll2 {
-    fn from(value: &'a ICEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll4> for ICEnroll2 {
-    fn from(value: &ICEnroll4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICEnroll4> for ICEnroll3 {
-    fn from(value: ICEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICEnroll4> for &'a ICEnroll3 {
-    fn from(value: &'a ICEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICEnroll4> for ICEnroll3 {
-    fn from(value: &ICEnroll4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICEnroll4, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICEnroll, ICEnroll2, ICEnroll3);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICEnroll4 {
     fn clone(&self) -> Self {
@@ -2628,41 +2230,7 @@ impl ICertAdmin {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertAdmin> for ::windows::core::IUnknown {
-    fn from(value: ICertAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertAdmin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertAdmin> for ::windows::core::IUnknown {
-    fn from(value: &ICertAdmin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertAdmin> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertAdmin> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertAdmin> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertAdmin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertAdmin, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertAdmin {
     fn clone(&self) -> Self {
@@ -2803,59 +2371,7 @@ impl ICertAdmin2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertAdmin2> for ::windows::core::IUnknown {
-    fn from(value: ICertAdmin2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertAdmin2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertAdmin2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertAdmin2> for ::windows::core::IUnknown {
-    fn from(value: &ICertAdmin2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertAdmin2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertAdmin2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertAdmin2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertAdmin2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertAdmin2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertAdmin2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertAdmin2> for ICertAdmin {
-    fn from(value: ICertAdmin2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertAdmin2> for &'a ICertAdmin {
-    fn from(value: &'a ICertAdmin2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertAdmin2> for ICertAdmin {
-    fn from(value: &ICertAdmin2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertAdmin2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertAdmin);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertAdmin2 {
     fn clone(&self) -> Self {
@@ -2937,41 +2453,7 @@ impl ICertConfig {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertConfig> for ::windows::core::IUnknown {
-    fn from(value: ICertConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertConfig> for ::windows::core::IUnknown {
-    fn from(value: &ICertConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertConfig> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertConfig> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertConfig> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertConfig, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertConfig {
     fn clone(&self) -> Self {
@@ -3037,59 +2519,7 @@ impl ICertConfig2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertConfig2> for ::windows::core::IUnknown {
-    fn from(value: ICertConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertConfig2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertConfig2> for ::windows::core::IUnknown {
-    fn from(value: &ICertConfig2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertConfig2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertConfig2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertConfig2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertConfig2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertConfig2> for ICertConfig {
-    fn from(value: ICertConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertConfig2> for &'a ICertConfig {
-    fn from(value: &'a ICertConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertConfig2> for ICertConfig {
-    fn from(value: &ICertConfig2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertConfig2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertConfig);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertConfig2 {
     fn clone(&self) -> Self {
@@ -3158,41 +2588,7 @@ impl ICertEncodeAltName {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeAltName> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeAltName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeAltName> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeAltName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeAltName> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeAltName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeAltName> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeAltName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeAltName> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeAltName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeAltName> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeAltName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeAltName, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeAltName {
     fn clone(&self) -> Self {
@@ -3281,59 +2677,7 @@ impl ICertEncodeAltName2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeAltName2> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeAltName2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeAltName2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeAltName2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeAltName2> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeAltName2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeAltName2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeAltName2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeAltName2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeAltName2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeAltName2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeAltName2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeAltName2> for ICertEncodeAltName {
-    fn from(value: ICertEncodeAltName2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeAltName2> for &'a ICertEncodeAltName {
-    fn from(value: &'a ICertEncodeAltName2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeAltName2> for ICertEncodeAltName {
-    fn from(value: &ICertEncodeAltName2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeAltName2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertEncodeAltName);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeAltName2 {
     fn clone(&self) -> Self {
@@ -3395,41 +2739,7 @@ impl ICertEncodeBitString {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeBitString> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeBitString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeBitString> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeBitString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeBitString> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeBitString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeBitString> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeBitString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeBitString> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeBitString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeBitString> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeBitString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeBitString, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeBitString {
     fn clone(&self) -> Self {
@@ -3502,59 +2812,7 @@ impl ICertEncodeBitString2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeBitString2> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeBitString2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeBitString2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeBitString2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeBitString2> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeBitString2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeBitString2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeBitString2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeBitString2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeBitString2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeBitString2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeBitString2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeBitString2> for ICertEncodeBitString {
-    fn from(value: ICertEncodeBitString2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeBitString2> for &'a ICertEncodeBitString {
-    fn from(value: &'a ICertEncodeBitString2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeBitString2> for ICertEncodeBitString {
-    fn from(value: &ICertEncodeBitString2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeBitString2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertEncodeBitString);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeBitString2 {
     fn clone(&self) -> Self {
@@ -3632,41 +2890,7 @@ impl ICertEncodeCRLDistInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeCRLDistInfo> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeCRLDistInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeCRLDistInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeCRLDistInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeCRLDistInfo> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeCRLDistInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeCRLDistInfo> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeCRLDistInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeCRLDistInfo> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeCRLDistInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeCRLDistInfo> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeCRLDistInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeCRLDistInfo, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeCRLDistInfo {
     fn clone(&self) -> Self {
@@ -3757,59 +2981,7 @@ impl ICertEncodeCRLDistInfo2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeCRLDistInfo2> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeCRLDistInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeCRLDistInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeCRLDistInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeCRLDistInfo2> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeCRLDistInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeCRLDistInfo2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeCRLDistInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeCRLDistInfo2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeCRLDistInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeCRLDistInfo2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeCRLDistInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeCRLDistInfo2> for ICertEncodeCRLDistInfo {
-    fn from(value: ICertEncodeCRLDistInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeCRLDistInfo2> for &'a ICertEncodeCRLDistInfo {
-    fn from(value: &'a ICertEncodeCRLDistInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeCRLDistInfo2> for ICertEncodeCRLDistInfo {
-    fn from(value: &ICertEncodeCRLDistInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeCRLDistInfo2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertEncodeCRLDistInfo);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeCRLDistInfo2 {
     fn clone(&self) -> Self {
@@ -3875,41 +3047,7 @@ impl ICertEncodeDateArray {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeDateArray> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeDateArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeDateArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeDateArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeDateArray> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeDateArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeDateArray> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeDateArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeDateArray> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeDateArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeDateArray> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeDateArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeDateArray, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeDateArray {
     fn clone(&self) -> Self {
@@ -3986,59 +3124,7 @@ impl ICertEncodeDateArray2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeDateArray2> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeDateArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeDateArray2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeDateArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeDateArray2> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeDateArray2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeDateArray2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeDateArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeDateArray2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeDateArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeDateArray2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeDateArray2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeDateArray2> for ICertEncodeDateArray {
-    fn from(value: ICertEncodeDateArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeDateArray2> for &'a ICertEncodeDateArray {
-    fn from(value: &'a ICertEncodeDateArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeDateArray2> for ICertEncodeDateArray {
-    fn from(value: &ICertEncodeDateArray2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeDateArray2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertEncodeDateArray);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeDateArray2 {
     fn clone(&self) -> Self {
@@ -4104,41 +3190,7 @@ impl ICertEncodeLongArray {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeLongArray> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeLongArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeLongArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeLongArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeLongArray> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeLongArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeLongArray> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeLongArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeLongArray> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeLongArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeLongArray> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeLongArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeLongArray, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeLongArray {
     fn clone(&self) -> Self {
@@ -4215,59 +3267,7 @@ impl ICertEncodeLongArray2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeLongArray2> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeLongArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeLongArray2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeLongArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeLongArray2> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeLongArray2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeLongArray2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeLongArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeLongArray2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeLongArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeLongArray2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeLongArray2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeLongArray2> for ICertEncodeLongArray {
-    fn from(value: ICertEncodeLongArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeLongArray2> for &'a ICertEncodeLongArray {
-    fn from(value: &'a ICertEncodeLongArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeLongArray2> for ICertEncodeLongArray {
-    fn from(value: &ICertEncodeLongArray2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeLongArray2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertEncodeLongArray);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeLongArray2 {
     fn clone(&self) -> Self {
@@ -4337,41 +3337,7 @@ impl ICertEncodeStringArray {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeStringArray> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeStringArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeStringArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeStringArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeStringArray> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeStringArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeStringArray> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeStringArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeStringArray> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeStringArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeStringArray> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeStringArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeStringArray, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeStringArray {
     fn clone(&self) -> Self {
@@ -4453,59 +3419,7 @@ impl ICertEncodeStringArray2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeStringArray2> for ::windows::core::IUnknown {
-    fn from(value: ICertEncodeStringArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeStringArray2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertEncodeStringArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeStringArray2> for ::windows::core::IUnknown {
-    fn from(value: &ICertEncodeStringArray2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeStringArray2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertEncodeStringArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeStringArray2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertEncodeStringArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeStringArray2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertEncodeStringArray2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertEncodeStringArray2> for ICertEncodeStringArray {
-    fn from(value: ICertEncodeStringArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertEncodeStringArray2> for &'a ICertEncodeStringArray {
-    fn from(value: &'a ICertEncodeStringArray2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertEncodeStringArray2> for ICertEncodeStringArray {
-    fn from(value: &ICertEncodeStringArray2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertEncodeStringArray2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertEncodeStringArray);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertEncodeStringArray2 {
     fn clone(&self) -> Self {
@@ -4561,41 +3475,7 @@ impl ICertExit {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertExit> for ::windows::core::IUnknown {
-    fn from(value: ICertExit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertExit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertExit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertExit> for ::windows::core::IUnknown {
-    fn from(value: &ICertExit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertExit> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertExit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertExit> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertExit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertExit> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertExit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertExit, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertExit {
     fn clone(&self) -> Self {
@@ -4658,59 +3538,7 @@ impl ICertExit2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertExit2> for ::windows::core::IUnknown {
-    fn from(value: ICertExit2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertExit2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertExit2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertExit2> for ::windows::core::IUnknown {
-    fn from(value: &ICertExit2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertExit2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertExit2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertExit2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertExit2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertExit2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertExit2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertExit2> for ICertExit {
-    fn from(value: ICertExit2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertExit2> for &'a ICertExit {
-    fn from(value: &'a ICertExit2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertExit2> for ICertExit {
-    fn from(value: &ICertExit2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertExit2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertExit);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertExit2 {
     fn clone(&self) -> Self {
@@ -4761,41 +3589,7 @@ impl ICertGetConfig {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertGetConfig> for ::windows::core::IUnknown {
-    fn from(value: ICertGetConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertGetConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertGetConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertGetConfig> for ::windows::core::IUnknown {
-    fn from(value: &ICertGetConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertGetConfig> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertGetConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertGetConfig> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertGetConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertGetConfig> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertGetConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertGetConfig, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertGetConfig {
     fn clone(&self) -> Self {
@@ -4853,41 +3647,7 @@ impl ICertManageModule {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertManageModule> for ::windows::core::IUnknown {
-    fn from(value: ICertManageModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertManageModule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertManageModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertManageModule> for ::windows::core::IUnknown {
-    fn from(value: &ICertManageModule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertManageModule> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertManageModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertManageModule> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertManageModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertManageModule> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertManageModule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertManageModule, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertManageModule {
     fn clone(&self) -> Self {
@@ -4953,41 +3713,7 @@ impl ICertPolicy {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPolicy> for ::windows::core::IUnknown {
-    fn from(value: ICertPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPolicy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPolicy> for ::windows::core::IUnknown {
-    fn from(value: &ICertPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPolicy> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPolicy> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPolicy> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPolicy, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPolicy {
     fn clone(&self) -> Self {
@@ -5054,59 +3780,7 @@ impl ICertPolicy2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPolicy2> for ::windows::core::IUnknown {
-    fn from(value: ICertPolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPolicy2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPolicy2> for ::windows::core::IUnknown {
-    fn from(value: &ICertPolicy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPolicy2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPolicy2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPolicy2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPolicy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPolicy2> for ICertPolicy {
-    fn from(value: ICertPolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPolicy2> for &'a ICertPolicy {
-    fn from(value: &'a ICertPolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPolicy2> for ICertPolicy {
-    fn from(value: &ICertPolicy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPolicy2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertPolicy);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPolicy2 {
     fn clone(&self) -> Self {
@@ -5184,41 +3858,7 @@ impl ICertProperties {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertProperties> for ::windows::core::IUnknown {
-    fn from(value: ICertProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertProperties> for ::windows::core::IUnknown {
-    fn from(value: &ICertProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertProperties> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertProperties> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertProperties> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertProperties, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertProperties {
     fn clone(&self) -> Self {
@@ -5297,41 +3937,7 @@ impl ICertProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertProperty> for ::windows::core::IUnknown {
-    fn from(value: ICertProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertProperty> for ::windows::core::IUnknown {
-    fn from(value: &ICertProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertProperty> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertProperty> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertProperty> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertProperty, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertProperty {
     fn clone(&self) -> Self {
@@ -5411,59 +4017,7 @@ impl ICertPropertyArchived {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyArchived> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertyArchived) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyArchived> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertyArchived) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyArchived> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertyArchived) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyArchived> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertyArchived) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyArchived> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertyArchived) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyArchived> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertyArchived) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyArchived> for ICertProperty {
-    fn from(value: ICertPropertyArchived) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyArchived> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertyArchived) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyArchived> for ICertProperty {
-    fn from(value: &ICertPropertyArchived) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertyArchived, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertyArchived {
     fn clone(&self) -> Self {
@@ -5538,59 +4092,7 @@ impl ICertPropertyArchivedKeyHash {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyArchivedKeyHash> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertyArchivedKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyArchivedKeyHash> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertyArchivedKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyArchivedKeyHash> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertyArchivedKeyHash) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyArchivedKeyHash> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertyArchivedKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyArchivedKeyHash> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertyArchivedKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyArchivedKeyHash> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertyArchivedKeyHash) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyArchivedKeyHash> for ICertProperty {
-    fn from(value: ICertPropertyArchivedKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyArchivedKeyHash> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertyArchivedKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyArchivedKeyHash> for ICertProperty {
-    fn from(value: &ICertPropertyArchivedKeyHash) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertyArchivedKeyHash, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertyArchivedKeyHash {
     fn clone(&self) -> Self {
@@ -5665,59 +4167,7 @@ impl ICertPropertyAutoEnroll {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyAutoEnroll> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertyAutoEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyAutoEnroll> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertyAutoEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyAutoEnroll> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertyAutoEnroll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyAutoEnroll> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertyAutoEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyAutoEnroll> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertyAutoEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyAutoEnroll> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertyAutoEnroll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyAutoEnroll> for ICertProperty {
-    fn from(value: ICertPropertyAutoEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyAutoEnroll> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertyAutoEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyAutoEnroll> for ICertProperty {
-    fn from(value: &ICertPropertyAutoEnroll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertyAutoEnroll, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertyAutoEnroll {
     fn clone(&self) -> Self {
@@ -5799,59 +4249,7 @@ impl ICertPropertyBackedUp {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyBackedUp> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertyBackedUp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyBackedUp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertyBackedUp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyBackedUp> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertyBackedUp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyBackedUp> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertyBackedUp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyBackedUp> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertyBackedUp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyBackedUp> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertyBackedUp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyBackedUp> for ICertProperty {
-    fn from(value: ICertPropertyBackedUp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyBackedUp> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertyBackedUp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyBackedUp> for ICertProperty {
-    fn from(value: &ICertPropertyBackedUp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertyBackedUp, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertyBackedUp {
     fn clone(&self) -> Self {
@@ -5928,59 +4326,7 @@ impl ICertPropertyDescription {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyDescription> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertyDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyDescription> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertyDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyDescription> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertyDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyDescription> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertyDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyDescription> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertyDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyDescription> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertyDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyDescription> for ICertProperty {
-    fn from(value: ICertPropertyDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyDescription> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertyDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyDescription> for ICertProperty {
-    fn from(value: &ICertPropertyDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertyDescription, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertyDescription {
     fn clone(&self) -> Self {
@@ -6067,59 +4413,7 @@ impl ICertPropertyEnrollment {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyEnrollment> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertyEnrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyEnrollment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertyEnrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyEnrollment> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertyEnrollment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyEnrollment> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertyEnrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyEnrollment> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertyEnrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyEnrollment> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertyEnrollment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyEnrollment> for ICertProperty {
-    fn from(value: ICertPropertyEnrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyEnrollment> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertyEnrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyEnrollment> for ICertProperty {
-    fn from(value: &ICertPropertyEnrollment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertyEnrollment, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertyEnrollment {
     fn clone(&self) -> Self {
@@ -6225,59 +4519,7 @@ impl ICertPropertyEnrollmentPolicyServer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyEnrollmentPolicyServer> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertyEnrollmentPolicyServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyEnrollmentPolicyServer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertyEnrollmentPolicyServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyEnrollmentPolicyServer> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertyEnrollmentPolicyServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyEnrollmentPolicyServer> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertyEnrollmentPolicyServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyEnrollmentPolicyServer> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertyEnrollmentPolicyServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyEnrollmentPolicyServer> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertyEnrollmentPolicyServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyEnrollmentPolicyServer> for ICertProperty {
-    fn from(value: ICertPropertyEnrollmentPolicyServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyEnrollmentPolicyServer> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertyEnrollmentPolicyServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyEnrollmentPolicyServer> for ICertProperty {
-    fn from(value: &ICertPropertyEnrollmentPolicyServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertyEnrollmentPolicyServer, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertyEnrollmentPolicyServer {
     fn clone(&self) -> Self {
@@ -6359,59 +4601,7 @@ impl ICertPropertyFriendlyName {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyFriendlyName> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertyFriendlyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyFriendlyName> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertyFriendlyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyFriendlyName> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertyFriendlyName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyFriendlyName> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertyFriendlyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyFriendlyName> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertyFriendlyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyFriendlyName> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertyFriendlyName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyFriendlyName> for ICertProperty {
-    fn from(value: ICertPropertyFriendlyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyFriendlyName> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertyFriendlyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyFriendlyName> for ICertProperty {
-    fn from(value: &ICertPropertyFriendlyName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertyFriendlyName, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertyFriendlyName {
     fn clone(&self) -> Self {
@@ -6493,59 +4683,7 @@ impl ICertPropertyKeyProvInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyKeyProvInfo> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertyKeyProvInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyKeyProvInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertyKeyProvInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyKeyProvInfo> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertyKeyProvInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyKeyProvInfo> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertyKeyProvInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyKeyProvInfo> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertyKeyProvInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyKeyProvInfo> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertyKeyProvInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyKeyProvInfo> for ICertProperty {
-    fn from(value: ICertPropertyKeyProvInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyKeyProvInfo> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertyKeyProvInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyKeyProvInfo> for ICertProperty {
-    fn from(value: &ICertPropertyKeyProvInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertyKeyProvInfo, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertyKeyProvInfo {
     fn clone(&self) -> Self {
@@ -6629,59 +4767,7 @@ impl ICertPropertyRenewal {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyRenewal> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertyRenewal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyRenewal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertyRenewal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyRenewal> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertyRenewal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyRenewal> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertyRenewal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyRenewal> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertyRenewal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyRenewal> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertyRenewal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyRenewal> for ICertProperty {
-    fn from(value: ICertPropertyRenewal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyRenewal> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertyRenewal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyRenewal> for ICertProperty {
-    fn from(value: &ICertPropertyRenewal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertyRenewal, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertyRenewal {
     fn clone(&self) -> Self {
@@ -6760,59 +4846,7 @@ impl ICertPropertyRequestOriginator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyRequestOriginator> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertyRequestOriginator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyRequestOriginator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertyRequestOriginator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyRequestOriginator> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertyRequestOriginator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyRequestOriginator> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertyRequestOriginator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyRequestOriginator> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertyRequestOriginator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyRequestOriginator> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertyRequestOriginator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertyRequestOriginator> for ICertProperty {
-    fn from(value: ICertPropertyRequestOriginator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertyRequestOriginator> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertyRequestOriginator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertyRequestOriginator> for ICertProperty {
-    fn from(value: &ICertPropertyRequestOriginator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertyRequestOriginator, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertyRequestOriginator {
     fn clone(&self) -> Self {
@@ -6888,59 +4922,7 @@ impl ICertPropertySHA1Hash {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertySHA1Hash> for ::windows::core::IUnknown {
-    fn from(value: ICertPropertySHA1Hash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertySHA1Hash> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertPropertySHA1Hash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertySHA1Hash> for ::windows::core::IUnknown {
-    fn from(value: &ICertPropertySHA1Hash) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertySHA1Hash> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertPropertySHA1Hash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertySHA1Hash> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertPropertySHA1Hash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertySHA1Hash> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertPropertySHA1Hash) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertPropertySHA1Hash> for ICertProperty {
-    fn from(value: ICertPropertySHA1Hash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertPropertySHA1Hash> for &'a ICertProperty {
-    fn from(value: &'a ICertPropertySHA1Hash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertPropertySHA1Hash> for ICertProperty {
-    fn from(value: &ICertPropertySHA1Hash) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertPropertySHA1Hash, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertProperty);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertPropertySHA1Hash {
     fn clone(&self) -> Self {
@@ -7013,41 +4995,7 @@ impl ICertRequest {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertRequest> for ::windows::core::IUnknown {
-    fn from(value: ICertRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertRequest> for ::windows::core::IUnknown {
-    fn from(value: &ICertRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertRequest> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertRequest> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertRequest> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertRequest, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertRequest {
     fn clone(&self) -> Self {
@@ -7153,59 +5101,7 @@ impl ICertRequest2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertRequest2> for ::windows::core::IUnknown {
-    fn from(value: ICertRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertRequest2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertRequest2> for ::windows::core::IUnknown {
-    fn from(value: &ICertRequest2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertRequest2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertRequest2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertRequest2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertRequest2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertRequest2> for ICertRequest {
-    fn from(value: ICertRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertRequest2> for &'a ICertRequest {
-    fn from(value: &'a ICertRequest2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertRequest2> for ICertRequest {
-    fn from(value: &ICertRequest2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertRequest2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertRequest);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertRequest2 {
     fn clone(&self) -> Self {
@@ -7331,77 +5227,7 @@ impl ICertRequest3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertRequest3> for ::windows::core::IUnknown {
-    fn from(value: ICertRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertRequest3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertRequest3> for ::windows::core::IUnknown {
-    fn from(value: &ICertRequest3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertRequest3> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertRequest3> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertRequest3> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertRequest3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertRequest3> for ICertRequest {
-    fn from(value: ICertRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertRequest3> for &'a ICertRequest {
-    fn from(value: &'a ICertRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertRequest3> for ICertRequest {
-    fn from(value: &ICertRequest3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertRequest3> for ICertRequest2 {
-    fn from(value: ICertRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertRequest3> for &'a ICertRequest2 {
-    fn from(value: &'a ICertRequest3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertRequest3> for ICertRequest2 {
-    fn from(value: &ICertRequest3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertRequest3, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertRequest, ICertRequest2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertRequest3 {
     fn clone(&self) -> Self {
@@ -7465,21 +5291,7 @@ impl ICertRequestD {
         (::windows::core::Vtable::vtable(self).Ping)(::windows::core::Vtable::as_raw(self), pwszauthority.into()).ok()
     }
 }
-impl ::core::convert::From<ICertRequestD> for ::windows::core::IUnknown {
-    fn from(value: ICertRequestD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICertRequestD> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertRequestD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICertRequestD> for ::windows::core::IUnknown {
-    fn from(value: &ICertRequestD) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertRequestD, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICertRequestD {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7562,36 +5374,7 @@ impl ICertRequestD2 {
         (::windows::core::Vtable::vtable(self).Ping2)(::windows::core::Vtable::as_raw(self), pwszauthority.into()).ok()
     }
 }
-impl ::core::convert::From<ICertRequestD2> for ::windows::core::IUnknown {
-    fn from(value: ICertRequestD2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICertRequestD2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertRequestD2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICertRequestD2> for ::windows::core::IUnknown {
-    fn from(value: &ICertRequestD2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICertRequestD2> for ICertRequestD {
-    fn from(value: ICertRequestD2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICertRequestD2> for &'a ICertRequestD {
-    fn from(value: &'a ICertRequestD2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICertRequestD2> for ICertRequestD {
-    fn from(value: &ICertRequestD2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertRequestD2, ::windows::core::IUnknown, ICertRequestD);
 impl ::core::clone::Clone for ICertRequestD2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7680,41 +5463,7 @@ impl ICertServerExit {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertServerExit> for ::windows::core::IUnknown {
-    fn from(value: ICertServerExit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertServerExit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertServerExit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertServerExit> for ::windows::core::IUnknown {
-    fn from(value: &ICertServerExit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertServerExit> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertServerExit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertServerExit> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertServerExit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertServerExit> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertServerExit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertServerExit, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertServerExit {
     fn clone(&self) -> Self {
@@ -7837,41 +5586,7 @@ impl ICertServerPolicy {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertServerPolicy> for ::windows::core::IUnknown {
-    fn from(value: ICertServerPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertServerPolicy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertServerPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertServerPolicy> for ::windows::core::IUnknown {
-    fn from(value: &ICertServerPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertServerPolicy> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertServerPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertServerPolicy> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertServerPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertServerPolicy> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertServerPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertServerPolicy, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertServerPolicy {
     fn clone(&self) -> Self {
@@ -7975,41 +5690,7 @@ impl ICertView {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertView> for ::windows::core::IUnknown {
-    fn from(value: ICertView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertView> for ::windows::core::IUnknown {
-    fn from(value: &ICertView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertView> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertView> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertView> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertView, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertView {
     fn clone(&self) -> Self {
@@ -8104,59 +5785,7 @@ impl ICertView2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertView2> for ::windows::core::IUnknown {
-    fn from(value: ICertView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertView2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertView2> for ::windows::core::IUnknown {
-    fn from(value: &ICertView2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertView2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertView2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertView2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertView2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertView2> for ICertView {
-    fn from(value: ICertView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertView2> for &'a ICertView {
-    fn from(value: &'a ICertView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertView2> for ICertView {
-    fn from(value: &ICertView2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertView2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertView);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertView2 {
     fn clone(&self) -> Self {
@@ -8211,41 +5840,7 @@ impl ICertificateAttestationChallenge {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificateAttestationChallenge> for ::windows::core::IUnknown {
-    fn from(value: ICertificateAttestationChallenge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificateAttestationChallenge> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertificateAttestationChallenge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificateAttestationChallenge> for ::windows::core::IUnknown {
-    fn from(value: &ICertificateAttestationChallenge) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificateAttestationChallenge> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertificateAttestationChallenge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificateAttestationChallenge> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertificateAttestationChallenge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificateAttestationChallenge> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertificateAttestationChallenge) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertificateAttestationChallenge, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertificateAttestationChallenge {
     fn clone(&self) -> Self {
@@ -8308,59 +5903,7 @@ impl ICertificateAttestationChallenge2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificateAttestationChallenge2> for ::windows::core::IUnknown {
-    fn from(value: ICertificateAttestationChallenge2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificateAttestationChallenge2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertificateAttestationChallenge2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificateAttestationChallenge2> for ::windows::core::IUnknown {
-    fn from(value: &ICertificateAttestationChallenge2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificateAttestationChallenge2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertificateAttestationChallenge2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificateAttestationChallenge2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertificateAttestationChallenge2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificateAttestationChallenge2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertificateAttestationChallenge2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificateAttestationChallenge2> for ICertificateAttestationChallenge {
-    fn from(value: ICertificateAttestationChallenge2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificateAttestationChallenge2> for &'a ICertificateAttestationChallenge {
-    fn from(value: &'a ICertificateAttestationChallenge2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificateAttestationChallenge2> for ICertificateAttestationChallenge {
-    fn from(value: &ICertificateAttestationChallenge2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertificateAttestationChallenge2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ICertificateAttestationChallenge);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertificateAttestationChallenge2 {
     fn clone(&self) -> Self {
@@ -8433,41 +5976,7 @@ impl ICertificatePolicies {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificatePolicies> for ::windows::core::IUnknown {
-    fn from(value: ICertificatePolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificatePolicies> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertificatePolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificatePolicies> for ::windows::core::IUnknown {
-    fn from(value: &ICertificatePolicies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificatePolicies> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertificatePolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificatePolicies> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertificatePolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificatePolicies> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertificatePolicies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertificatePolicies, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertificatePolicies {
     fn clone(&self) -> Self {
@@ -8542,41 +6051,7 @@ impl ICertificatePolicy {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificatePolicy> for ::windows::core::IUnknown {
-    fn from(value: ICertificatePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificatePolicy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertificatePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificatePolicy> for ::windows::core::IUnknown {
-    fn from(value: &ICertificatePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificatePolicy> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertificatePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificatePolicy> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertificatePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificatePolicy> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertificatePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertificatePolicy, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertificatePolicy {
     fn clone(&self) -> Self {
@@ -8668,41 +6143,7 @@ impl ICertificationAuthorities {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificationAuthorities> for ::windows::core::IUnknown {
-    fn from(value: ICertificationAuthorities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificationAuthorities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertificationAuthorities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificationAuthorities> for ::windows::core::IUnknown {
-    fn from(value: &ICertificationAuthorities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificationAuthorities> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertificationAuthorities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificationAuthorities> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertificationAuthorities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificationAuthorities> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertificationAuthorities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertificationAuthorities, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertificationAuthorities {
     fn clone(&self) -> Self {
@@ -8768,41 +6209,7 @@ impl ICertificationAuthority {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificationAuthority> for ::windows::core::IUnknown {
-    fn from(value: ICertificationAuthority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificationAuthority> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertificationAuthority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificationAuthority> for ::windows::core::IUnknown {
-    fn from(value: &ICertificationAuthority) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificationAuthority> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICertificationAuthority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificationAuthority> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertificationAuthority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificationAuthority> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICertificationAuthority) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertificationAuthority, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertificationAuthority {
     fn clone(&self) -> Self {
@@ -8877,41 +6284,7 @@ impl ICryptAttribute {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICryptAttribute> for ::windows::core::IUnknown {
-    fn from(value: ICryptAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICryptAttribute> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICryptAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICryptAttribute> for ::windows::core::IUnknown {
-    fn from(value: &ICryptAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICryptAttribute> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICryptAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICryptAttribute> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICryptAttribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICryptAttribute> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICryptAttribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICryptAttribute, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICryptAttribute {
     fn clone(&self) -> Self {
@@ -9015,41 +6388,7 @@ impl ICryptAttributes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICryptAttributes> for ::windows::core::IUnknown {
-    fn from(value: ICryptAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICryptAttributes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICryptAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICryptAttributes> for ::windows::core::IUnknown {
-    fn from(value: &ICryptAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICryptAttributes> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICryptAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICryptAttributes> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICryptAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICryptAttributes> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICryptAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICryptAttributes, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICryptAttributes {
     fn clone(&self) -> Self {
@@ -9154,41 +6493,7 @@ impl ICspAlgorithm {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspAlgorithm> for ::windows::core::IUnknown {
-    fn from(value: ICspAlgorithm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspAlgorithm> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICspAlgorithm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspAlgorithm> for ::windows::core::IUnknown {
-    fn from(value: &ICspAlgorithm) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspAlgorithm> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICspAlgorithm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspAlgorithm> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICspAlgorithm) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspAlgorithm> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICspAlgorithm) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICspAlgorithm, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICspAlgorithm {
     fn clone(&self) -> Self {
@@ -9287,41 +6592,7 @@ impl ICspAlgorithms {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspAlgorithms> for ::windows::core::IUnknown {
-    fn from(value: ICspAlgorithms) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspAlgorithms> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICspAlgorithms) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspAlgorithms> for ::windows::core::IUnknown {
-    fn from(value: &ICspAlgorithms) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspAlgorithms> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICspAlgorithms) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspAlgorithms> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICspAlgorithms) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspAlgorithms> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICspAlgorithms) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICspAlgorithms, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICspAlgorithms {
     fn clone(&self) -> Self {
@@ -9462,41 +6733,7 @@ impl ICspInformation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspInformation> for ::windows::core::IUnknown {
-    fn from(value: ICspInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICspInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspInformation> for ::windows::core::IUnknown {
-    fn from(value: &ICspInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspInformation> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICspInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspInformation> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICspInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspInformation> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICspInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICspInformation, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICspInformation {
     fn clone(&self) -> Self {
@@ -9635,41 +6872,7 @@ impl ICspInformations {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspInformations> for ::windows::core::IUnknown {
-    fn from(value: ICspInformations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspInformations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICspInformations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspInformations> for ::windows::core::IUnknown {
-    fn from(value: &ICspInformations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspInformations> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICspInformations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspInformations> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICspInformations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspInformations> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICspInformations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICspInformations, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICspInformations {
     fn clone(&self) -> Self {
@@ -9783,41 +6986,7 @@ impl ICspStatus {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspStatus> for ::windows::core::IUnknown {
-    fn from(value: ICspStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICspStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspStatus> for ::windows::core::IUnknown {
-    fn from(value: &ICspStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspStatus> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICspStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspStatus> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICspStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspStatus> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICspStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICspStatus, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICspStatus {
     fn clone(&self) -> Self {
@@ -9934,41 +7103,7 @@ impl ICspStatuses {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspStatuses> for ::windows::core::IUnknown {
-    fn from(value: ICspStatuses) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspStatuses> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICspStatuses) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspStatuses> for ::windows::core::IUnknown {
-    fn from(value: &ICspStatuses) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICspStatuses> for super::super::super::System::Com::IDispatch {
-    fn from(value: ICspStatuses) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICspStatuses> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ICspStatuses) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICspStatuses> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ICspStatuses) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICspStatuses, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICspStatuses {
     fn clone(&self) -> Self {
@@ -10349,21 +7484,7 @@ impl IEnroll {
         (::windows::core::Vtable::vtable(self).CreatePKCS7RequestFromRequest)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prequest), ::core::mem::transmute(psigningcertcontext), ::core::mem::transmute(ppkcs7blob)).ok()
     }
 }
-impl ::core::convert::From<IEnroll> for ::windows::core::IUnknown {
-    fn from(value: IEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnroll> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnroll> for ::windows::core::IUnknown {
-    fn from(value: &IEnroll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnroll, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnroll {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10917,36 +8038,7 @@ impl IEnroll2 {
         (::windows::core::Vtable::vtable(self).EnableSMIMECapabilities)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(fenablesmimecapabilities)).ok()
     }
 }
-impl ::core::convert::From<IEnroll2> for ::windows::core::IUnknown {
-    fn from(value: IEnroll2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnroll2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnroll2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnroll2> for ::windows::core::IUnknown {
-    fn from(value: &IEnroll2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEnroll2> for IEnroll {
-    fn from(value: IEnroll2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnroll2> for &'a IEnroll {
-    fn from(value: &'a IEnroll2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnroll2> for IEnroll {
-    fn from(value: &IEnroll2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnroll2, ::windows::core::IUnknown, IEnroll);
 impl ::core::clone::Clone for IEnroll2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11586,51 +8678,7 @@ impl IEnroll4 {
         (::windows::core::Vtable::vtable(self).IncludeSubjectKeyID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfinclude)).ok()
     }
 }
-impl ::core::convert::From<IEnroll4> for ::windows::core::IUnknown {
-    fn from(value: IEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnroll4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnroll4> for ::windows::core::IUnknown {
-    fn from(value: &IEnroll4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEnroll4> for IEnroll {
-    fn from(value: IEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnroll4> for &'a IEnroll {
-    fn from(value: &'a IEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnroll4> for IEnroll {
-    fn from(value: &IEnroll4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEnroll4> for IEnroll2 {
-    fn from(value: IEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnroll4> for &'a IEnroll2 {
-    fn from(value: &'a IEnroll4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnroll4> for IEnroll2 {
-    fn from(value: &IEnroll4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnroll4, ::windows::core::IUnknown, IEnroll, IEnroll2);
 impl ::core::clone::Clone for IEnroll4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11743,41 +8791,7 @@ impl IEnumCERTVIEWATTRIBUTE {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumCERTVIEWATTRIBUTE> for ::windows::core::IUnknown {
-    fn from(value: IEnumCERTVIEWATTRIBUTE) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumCERTVIEWATTRIBUTE> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumCERTVIEWATTRIBUTE) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumCERTVIEWATTRIBUTE> for ::windows::core::IUnknown {
-    fn from(value: &IEnumCERTVIEWATTRIBUTE) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumCERTVIEWATTRIBUTE> for super::super::super::System::Com::IDispatch {
-    fn from(value: IEnumCERTVIEWATTRIBUTE) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumCERTVIEWATTRIBUTE> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IEnumCERTVIEWATTRIBUTE) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumCERTVIEWATTRIBUTE> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IEnumCERTVIEWATTRIBUTE) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumCERTVIEWATTRIBUTE, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IEnumCERTVIEWATTRIBUTE {
     fn clone(&self) -> Self {
@@ -11864,41 +8878,7 @@ impl IEnumCERTVIEWCOLUMN {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumCERTVIEWCOLUMN> for ::windows::core::IUnknown {
-    fn from(value: IEnumCERTVIEWCOLUMN) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumCERTVIEWCOLUMN> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumCERTVIEWCOLUMN) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumCERTVIEWCOLUMN> for ::windows::core::IUnknown {
-    fn from(value: &IEnumCERTVIEWCOLUMN) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumCERTVIEWCOLUMN> for super::super::super::System::Com::IDispatch {
-    fn from(value: IEnumCERTVIEWCOLUMN) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumCERTVIEWCOLUMN> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IEnumCERTVIEWCOLUMN) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumCERTVIEWCOLUMN> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IEnumCERTVIEWCOLUMN) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumCERTVIEWCOLUMN, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IEnumCERTVIEWCOLUMN {
     fn clone(&self) -> Self {
@@ -11983,41 +8963,7 @@ impl IEnumCERTVIEWEXTENSION {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumCERTVIEWEXTENSION> for ::windows::core::IUnknown {
-    fn from(value: IEnumCERTVIEWEXTENSION) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumCERTVIEWEXTENSION> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumCERTVIEWEXTENSION) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumCERTVIEWEXTENSION> for ::windows::core::IUnknown {
-    fn from(value: &IEnumCERTVIEWEXTENSION) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumCERTVIEWEXTENSION> for super::super::super::System::Com::IDispatch {
-    fn from(value: IEnumCERTVIEWEXTENSION) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumCERTVIEWEXTENSION> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IEnumCERTVIEWEXTENSION) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumCERTVIEWEXTENSION> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IEnumCERTVIEWEXTENSION) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumCERTVIEWEXTENSION, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IEnumCERTVIEWEXTENSION {
     fn clone(&self) -> Self {
@@ -12109,41 +9055,7 @@ impl IEnumCERTVIEWROW {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumCERTVIEWROW> for ::windows::core::IUnknown {
-    fn from(value: IEnumCERTVIEWROW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumCERTVIEWROW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumCERTVIEWROW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumCERTVIEWROW> for ::windows::core::IUnknown {
-    fn from(value: &IEnumCERTVIEWROW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumCERTVIEWROW> for super::super::super::System::Com::IDispatch {
-    fn from(value: IEnumCERTVIEWROW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumCERTVIEWROW> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IEnumCERTVIEWROW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumCERTVIEWROW> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IEnumCERTVIEWROW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumCERTVIEWROW, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IEnumCERTVIEWROW {
     fn clone(&self) -> Self {
@@ -12233,21 +9145,7 @@ impl INDESPolicy {
         (::windows::core::Vtable::vtable(self).Notify)(::windows::core::Vtable::as_raw(self), pwszchallenge.into(), pwsztransactionid.into(), disposition, lasthresult, ::core::mem::transmute(pctbissuedcertencoded)).ok()
     }
 }
-impl ::core::convert::From<INDESPolicy> for ::windows::core::IUnknown {
-    fn from(value: INDESPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INDESPolicy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INDESPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INDESPolicy> for ::windows::core::IUnknown {
-    fn from(value: &INDESPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INDESPolicy, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INDESPolicy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12335,41 +9233,7 @@ impl IOCSPAdmin {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOCSPAdmin> for ::windows::core::IUnknown {
-    fn from(value: IOCSPAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOCSPAdmin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOCSPAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOCSPAdmin> for ::windows::core::IUnknown {
-    fn from(value: &IOCSPAdmin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOCSPAdmin> for super::super::super::System::Com::IDispatch {
-    fn from(value: IOCSPAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOCSPAdmin> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IOCSPAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOCSPAdmin> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IOCSPAdmin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOCSPAdmin, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IOCSPAdmin {
     fn clone(&self) -> Self {
@@ -12544,41 +9408,7 @@ impl IOCSPCAConfiguration {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOCSPCAConfiguration> for ::windows::core::IUnknown {
-    fn from(value: IOCSPCAConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOCSPCAConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOCSPCAConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOCSPCAConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &IOCSPCAConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOCSPCAConfiguration> for super::super::super::System::Com::IDispatch {
-    fn from(value: IOCSPCAConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOCSPCAConfiguration> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IOCSPCAConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOCSPCAConfiguration> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IOCSPCAConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOCSPCAConfiguration, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IOCSPCAConfiguration {
     fn clone(&self) -> Self {
@@ -12698,41 +9528,7 @@ impl IOCSPCAConfigurationCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOCSPCAConfigurationCollection> for ::windows::core::IUnknown {
-    fn from(value: IOCSPCAConfigurationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOCSPCAConfigurationCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOCSPCAConfigurationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOCSPCAConfigurationCollection> for ::windows::core::IUnknown {
-    fn from(value: &IOCSPCAConfigurationCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOCSPCAConfigurationCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: IOCSPCAConfigurationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOCSPCAConfigurationCollection> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IOCSPCAConfigurationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOCSPCAConfigurationCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IOCSPCAConfigurationCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOCSPCAConfigurationCollection, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IOCSPCAConfigurationCollection {
     fn clone(&self) -> Self {
@@ -12812,41 +9608,7 @@ impl IOCSPProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOCSPProperty> for ::windows::core::IUnknown {
-    fn from(value: IOCSPProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOCSPProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOCSPProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOCSPProperty> for ::windows::core::IUnknown {
-    fn from(value: &IOCSPProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOCSPProperty> for super::super::super::System::Com::IDispatch {
-    fn from(value: IOCSPProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOCSPProperty> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IOCSPProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOCSPProperty> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IOCSPProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOCSPProperty, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IOCSPProperty {
     fn clone(&self) -> Self {
@@ -12939,41 +9701,7 @@ impl IOCSPPropertyCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOCSPPropertyCollection> for ::windows::core::IUnknown {
-    fn from(value: IOCSPPropertyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOCSPPropertyCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOCSPPropertyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOCSPPropertyCollection> for ::windows::core::IUnknown {
-    fn from(value: &IOCSPPropertyCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOCSPPropertyCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: IOCSPPropertyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOCSPPropertyCollection> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IOCSPPropertyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOCSPPropertyCollection> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IOCSPPropertyCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOCSPPropertyCollection, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IOCSPPropertyCollection {
     fn clone(&self) -> Self {
@@ -13067,41 +9795,7 @@ impl IObjectId {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IObjectId> for ::windows::core::IUnknown {
-    fn from(value: IObjectId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IObjectId> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IObjectId> for ::windows::core::IUnknown {
-    fn from(value: &IObjectId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IObjectId> for super::super::super::System::Com::IDispatch {
-    fn from(value: IObjectId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IObjectId> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IObjectId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IObjectId> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IObjectId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectId, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IObjectId {
     fn clone(&self) -> Self {
@@ -13188,41 +9882,7 @@ impl IObjectIds {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IObjectIds> for ::windows::core::IUnknown {
-    fn from(value: IObjectIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IObjectIds> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IObjectIds> for ::windows::core::IUnknown {
-    fn from(value: &IObjectIds) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IObjectIds> for super::super::super::System::Com::IDispatch {
-    fn from(value: IObjectIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IObjectIds> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IObjectIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IObjectIds> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IObjectIds) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectIds, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IObjectIds {
     fn clone(&self) -> Self {
@@ -13302,41 +9962,7 @@ impl IPolicyQualifier {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPolicyQualifier> for ::windows::core::IUnknown {
-    fn from(value: IPolicyQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPolicyQualifier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPolicyQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPolicyQualifier> for ::windows::core::IUnknown {
-    fn from(value: &IPolicyQualifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPolicyQualifier> for super::super::super::System::Com::IDispatch {
-    fn from(value: IPolicyQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPolicyQualifier> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IPolicyQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPolicyQualifier> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IPolicyQualifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPolicyQualifier, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPolicyQualifier {
     fn clone(&self) -> Self {
@@ -13415,41 +10041,7 @@ impl IPolicyQualifiers {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPolicyQualifiers> for ::windows::core::IUnknown {
-    fn from(value: IPolicyQualifiers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPolicyQualifiers> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPolicyQualifiers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPolicyQualifiers> for ::windows::core::IUnknown {
-    fn from(value: &IPolicyQualifiers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPolicyQualifiers> for super::super::super::System::Com::IDispatch {
-    fn from(value: IPolicyQualifiers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPolicyQualifiers> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IPolicyQualifiers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPolicyQualifiers> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IPolicyQualifiers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPolicyQualifiers, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPolicyQualifiers {
     fn clone(&self) -> Self {
@@ -13547,41 +10139,7 @@ impl ISignerCertificate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISignerCertificate> for ::windows::core::IUnknown {
-    fn from(value: ISignerCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISignerCertificate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISignerCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISignerCertificate> for ::windows::core::IUnknown {
-    fn from(value: &ISignerCertificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISignerCertificate> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISignerCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISignerCertificate> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISignerCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISignerCertificate> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISignerCertificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISignerCertificate, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISignerCertificate {
     fn clone(&self) -> Self {
@@ -13678,41 +10236,7 @@ impl ISignerCertificates {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISignerCertificates> for ::windows::core::IUnknown {
-    fn from(value: ISignerCertificates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISignerCertificates> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISignerCertificates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISignerCertificates> for ::windows::core::IUnknown {
-    fn from(value: &ISignerCertificates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISignerCertificates> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISignerCertificates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISignerCertificates> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISignerCertificates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISignerCertificates> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISignerCertificates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISignerCertificates, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISignerCertificates {
     fn clone(&self) -> Self {
@@ -13810,41 +10334,7 @@ impl ISmimeCapabilities {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISmimeCapabilities> for ::windows::core::IUnknown {
-    fn from(value: ISmimeCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISmimeCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISmimeCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISmimeCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &ISmimeCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISmimeCapabilities> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISmimeCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISmimeCapabilities> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISmimeCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISmimeCapabilities> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISmimeCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISmimeCapabilities, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISmimeCapabilities {
     fn clone(&self) -> Self {
@@ -13922,41 +10412,7 @@ impl ISmimeCapability {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISmimeCapability> for ::windows::core::IUnknown {
-    fn from(value: ISmimeCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISmimeCapability> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISmimeCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISmimeCapability> for ::windows::core::IUnknown {
-    fn from(value: &ISmimeCapability) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISmimeCapability> for super::super::super::System::Com::IDispatch {
-    fn from(value: ISmimeCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISmimeCapability> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ISmimeCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISmimeCapability> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ISmimeCapability) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISmimeCapability, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISmimeCapability {
     fn clone(&self) -> Self {
@@ -14022,41 +10478,7 @@ impl IX500DistinguishedName {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX500DistinguishedName> for ::windows::core::IUnknown {
-    fn from(value: IX500DistinguishedName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX500DistinguishedName> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX500DistinguishedName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX500DistinguishedName> for ::windows::core::IUnknown {
-    fn from(value: &IX500DistinguishedName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX500DistinguishedName> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX500DistinguishedName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX500DistinguishedName> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX500DistinguishedName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX500DistinguishedName> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX500DistinguishedName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX500DistinguishedName, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX500DistinguishedName {
     fn clone(&self) -> Self {
@@ -14121,41 +10543,7 @@ impl IX509Attribute {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Attribute> for ::windows::core::IUnknown {
-    fn from(value: IX509Attribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Attribute> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509Attribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Attribute> for ::windows::core::IUnknown {
-    fn from(value: &IX509Attribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Attribute> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509Attribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Attribute> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509Attribute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Attribute> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509Attribute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509Attribute, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509Attribute {
     fn clone(&self) -> Self {
@@ -14251,59 +10639,7 @@ impl IX509AttributeArchiveKey {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeArchiveKey> for ::windows::core::IUnknown {
-    fn from(value: IX509AttributeArchiveKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeArchiveKey> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509AttributeArchiveKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeArchiveKey> for ::windows::core::IUnknown {
-    fn from(value: &IX509AttributeArchiveKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeArchiveKey> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509AttributeArchiveKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeArchiveKey> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509AttributeArchiveKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeArchiveKey> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509AttributeArchiveKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeArchiveKey> for IX509Attribute {
-    fn from(value: IX509AttributeArchiveKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeArchiveKey> for &'a IX509Attribute {
-    fn from(value: &'a IX509AttributeArchiveKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeArchiveKey> for IX509Attribute {
-    fn from(value: &IX509AttributeArchiveKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509AttributeArchiveKey, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Attribute);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509AttributeArchiveKey {
     fn clone(&self) -> Self {
@@ -14385,59 +10721,7 @@ impl IX509AttributeArchiveKeyHash {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeArchiveKeyHash> for ::windows::core::IUnknown {
-    fn from(value: IX509AttributeArchiveKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeArchiveKeyHash> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509AttributeArchiveKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeArchiveKeyHash> for ::windows::core::IUnknown {
-    fn from(value: &IX509AttributeArchiveKeyHash) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeArchiveKeyHash> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509AttributeArchiveKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeArchiveKeyHash> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509AttributeArchiveKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeArchiveKeyHash> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509AttributeArchiveKeyHash) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeArchiveKeyHash> for IX509Attribute {
-    fn from(value: IX509AttributeArchiveKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeArchiveKeyHash> for &'a IX509Attribute {
-    fn from(value: &'a IX509AttributeArchiveKeyHash) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeArchiveKeyHash> for IX509Attribute {
-    fn from(value: &IX509AttributeArchiveKeyHash) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509AttributeArchiveKeyHash, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Attribute);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509AttributeArchiveKeyHash {
     fn clone(&self) -> Self {
@@ -14523,59 +10807,7 @@ impl IX509AttributeClientId {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeClientId> for ::windows::core::IUnknown {
-    fn from(value: IX509AttributeClientId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeClientId> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509AttributeClientId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeClientId> for ::windows::core::IUnknown {
-    fn from(value: &IX509AttributeClientId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeClientId> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509AttributeClientId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeClientId> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509AttributeClientId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeClientId> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509AttributeClientId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeClientId> for IX509Attribute {
-    fn from(value: IX509AttributeClientId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeClientId> for &'a IX509Attribute {
-    fn from(value: &'a IX509AttributeClientId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeClientId> for IX509Attribute {
-    fn from(value: &IX509AttributeClientId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509AttributeClientId, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Attribute);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509AttributeClientId {
     fn clone(&self) -> Self {
@@ -14660,59 +10892,7 @@ impl IX509AttributeCspProvider {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeCspProvider> for ::windows::core::IUnknown {
-    fn from(value: IX509AttributeCspProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeCspProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509AttributeCspProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeCspProvider> for ::windows::core::IUnknown {
-    fn from(value: &IX509AttributeCspProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeCspProvider> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509AttributeCspProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeCspProvider> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509AttributeCspProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeCspProvider> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509AttributeCspProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeCspProvider> for IX509Attribute {
-    fn from(value: IX509AttributeCspProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeCspProvider> for &'a IX509Attribute {
-    fn from(value: &'a IX509AttributeCspProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeCspProvider> for IX509Attribute {
-    fn from(value: &IX509AttributeCspProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509AttributeCspProvider, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Attribute);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509AttributeCspProvider {
     fn clone(&self) -> Self {
@@ -14795,59 +10975,7 @@ impl IX509AttributeExtensions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeExtensions> for ::windows::core::IUnknown {
-    fn from(value: IX509AttributeExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeExtensions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509AttributeExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeExtensions> for ::windows::core::IUnknown {
-    fn from(value: &IX509AttributeExtensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeExtensions> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509AttributeExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeExtensions> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509AttributeExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeExtensions> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509AttributeExtensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeExtensions> for IX509Attribute {
-    fn from(value: IX509AttributeExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeExtensions> for &'a IX509Attribute {
-    fn from(value: &'a IX509AttributeExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeExtensions> for IX509Attribute {
-    fn from(value: &IX509AttributeExtensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509AttributeExtensions, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Attribute);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509AttributeExtensions {
     fn clone(&self) -> Self {
@@ -14927,59 +11055,7 @@ impl IX509AttributeOSVersion {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeOSVersion> for ::windows::core::IUnknown {
-    fn from(value: IX509AttributeOSVersion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeOSVersion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509AttributeOSVersion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeOSVersion> for ::windows::core::IUnknown {
-    fn from(value: &IX509AttributeOSVersion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeOSVersion> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509AttributeOSVersion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeOSVersion> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509AttributeOSVersion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeOSVersion> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509AttributeOSVersion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeOSVersion> for IX509Attribute {
-    fn from(value: IX509AttributeOSVersion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeOSVersion> for &'a IX509Attribute {
-    fn from(value: &'a IX509AttributeOSVersion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeOSVersion> for IX509Attribute {
-    fn from(value: &IX509AttributeOSVersion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509AttributeOSVersion, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Attribute);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509AttributeOSVersion {
     fn clone(&self) -> Self {
@@ -15053,59 +11129,7 @@ impl IX509AttributeRenewalCertificate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeRenewalCertificate> for ::windows::core::IUnknown {
-    fn from(value: IX509AttributeRenewalCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeRenewalCertificate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509AttributeRenewalCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeRenewalCertificate> for ::windows::core::IUnknown {
-    fn from(value: &IX509AttributeRenewalCertificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeRenewalCertificate> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509AttributeRenewalCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeRenewalCertificate> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509AttributeRenewalCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeRenewalCertificate> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509AttributeRenewalCertificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509AttributeRenewalCertificate> for IX509Attribute {
-    fn from(value: IX509AttributeRenewalCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509AttributeRenewalCertificate> for &'a IX509Attribute {
-    fn from(value: &'a IX509AttributeRenewalCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509AttributeRenewalCertificate> for IX509Attribute {
-    fn from(value: &IX509AttributeRenewalCertificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509AttributeRenewalCertificate, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Attribute);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509AttributeRenewalCertificate {
     fn clone(&self) -> Self {
@@ -15179,41 +11203,7 @@ impl IX509Attributes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Attributes> for ::windows::core::IUnknown {
-    fn from(value: IX509Attributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Attributes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509Attributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Attributes> for ::windows::core::IUnknown {
-    fn from(value: &IX509Attributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Attributes> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509Attributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Attributes> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509Attributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Attributes> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509Attributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509Attributes, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509Attributes {
     fn clone(&self) -> Self {
@@ -15372,41 +11362,7 @@ impl IX509CertificateRequest {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequest> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequest> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequest> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequest> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequest> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRequest, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRequest {
     fn clone(&self) -> Self {
@@ -15790,77 +11746,7 @@ impl IX509CertificateRequestCertificate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCertificate> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRequestCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCertificate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRequestCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCertificate> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRequestCertificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCertificate> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRequestCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCertificate> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRequestCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCertificate> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRequestCertificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCertificate> for IX509CertificateRequest {
-    fn from(value: IX509CertificateRequestCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCertificate> for &'a IX509CertificateRequest {
-    fn from(value: &'a IX509CertificateRequestCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCertificate> for IX509CertificateRequest {
-    fn from(value: &IX509CertificateRequestCertificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCertificate> for IX509CertificateRequestPkcs10 {
-    fn from(value: IX509CertificateRequestCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCertificate> for &'a IX509CertificateRequestPkcs10 {
-    fn from(value: &'a IX509CertificateRequestCertificate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCertificate> for IX509CertificateRequestPkcs10 {
-    fn from(value: &IX509CertificateRequestCertificate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRequestCertificate, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509CertificateRequest, IX509CertificateRequestPkcs10);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRequestCertificate {
     fn clone(&self) -> Self {
@@ -16261,95 +12147,7 @@ impl IX509CertificateRequestCertificate2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCertificate2> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRequestCertificate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCertificate2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRequestCertificate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCertificate2> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRequestCertificate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCertificate2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRequestCertificate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCertificate2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRequestCertificate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCertificate2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRequestCertificate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCertificate2> for IX509CertificateRequest {
-    fn from(value: IX509CertificateRequestCertificate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCertificate2> for &'a IX509CertificateRequest {
-    fn from(value: &'a IX509CertificateRequestCertificate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCertificate2> for IX509CertificateRequest {
-    fn from(value: &IX509CertificateRequestCertificate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCertificate2> for IX509CertificateRequestPkcs10 {
-    fn from(value: IX509CertificateRequestCertificate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCertificate2> for &'a IX509CertificateRequestPkcs10 {
-    fn from(value: &'a IX509CertificateRequestCertificate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCertificate2> for IX509CertificateRequestPkcs10 {
-    fn from(value: &IX509CertificateRequestCertificate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCertificate2> for IX509CertificateRequestCertificate {
-    fn from(value: IX509CertificateRequestCertificate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCertificate2> for &'a IX509CertificateRequestCertificate {
-    fn from(value: &'a IX509CertificateRequestCertificate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCertificate2> for IX509CertificateRequestCertificate {
-    fn from(value: &IX509CertificateRequestCertificate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRequestCertificate2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509CertificateRequest, IX509CertificateRequestPkcs10, IX509CertificateRequestCertificate);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRequestCertificate2 {
     fn clone(&self) -> Self {
@@ -16663,77 +12461,7 @@ impl IX509CertificateRequestCmc {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCmc> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRequestCmc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCmc> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRequestCmc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCmc> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRequestCmc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCmc> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRequestCmc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCmc> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRequestCmc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCmc> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRequestCmc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCmc> for IX509CertificateRequest {
-    fn from(value: IX509CertificateRequestCmc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCmc> for &'a IX509CertificateRequest {
-    fn from(value: &'a IX509CertificateRequestCmc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCmc> for IX509CertificateRequest {
-    fn from(value: &IX509CertificateRequestCmc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCmc> for IX509CertificateRequestPkcs7 {
-    fn from(value: IX509CertificateRequestCmc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCmc> for &'a IX509CertificateRequestPkcs7 {
-    fn from(value: &'a IX509CertificateRequestCmc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCmc> for IX509CertificateRequestPkcs7 {
-    fn from(value: &IX509CertificateRequestCmc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRequestCmc, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509CertificateRequest, IX509CertificateRequestPkcs7);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRequestCmc {
     fn clone(&self) -> Self {
@@ -17129,95 +12857,7 @@ impl IX509CertificateRequestCmc2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCmc2> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRequestCmc2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCmc2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRequestCmc2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCmc2> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRequestCmc2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCmc2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRequestCmc2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCmc2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRequestCmc2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCmc2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRequestCmc2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCmc2> for IX509CertificateRequest {
-    fn from(value: IX509CertificateRequestCmc2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCmc2> for &'a IX509CertificateRequest {
-    fn from(value: &'a IX509CertificateRequestCmc2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCmc2> for IX509CertificateRequest {
-    fn from(value: &IX509CertificateRequestCmc2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCmc2> for IX509CertificateRequestPkcs7 {
-    fn from(value: IX509CertificateRequestCmc2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCmc2> for &'a IX509CertificateRequestPkcs7 {
-    fn from(value: &'a IX509CertificateRequestCmc2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCmc2> for IX509CertificateRequestPkcs7 {
-    fn from(value: &IX509CertificateRequestCmc2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestCmc2> for IX509CertificateRequestCmc {
-    fn from(value: IX509CertificateRequestCmc2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestCmc2> for &'a IX509CertificateRequestCmc {
-    fn from(value: &'a IX509CertificateRequestCmc2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestCmc2> for IX509CertificateRequestCmc {
-    fn from(value: &IX509CertificateRequestCmc2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRequestCmc2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509CertificateRequest, IX509CertificateRequestPkcs7, IX509CertificateRequestCmc);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRequestCmc2 {
     fn clone(&self) -> Self {
@@ -17525,59 +13165,7 @@ impl IX509CertificateRequestPkcs10 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRequestPkcs10) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRequestPkcs10) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRequestPkcs10) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRequestPkcs10) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRequestPkcs10) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRequestPkcs10) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10> for IX509CertificateRequest {
-    fn from(value: IX509CertificateRequestPkcs10) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10> for &'a IX509CertificateRequest {
-    fn from(value: &'a IX509CertificateRequestPkcs10) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10> for IX509CertificateRequest {
-    fn from(value: &IX509CertificateRequestPkcs10) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRequestPkcs10, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509CertificateRequest);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRequestPkcs10 {
     fn clone(&self) -> Self {
@@ -17975,77 +13563,7 @@ impl IX509CertificateRequestPkcs10V2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V2> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRequestPkcs10V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRequestPkcs10V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V2> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRequestPkcs10V2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRequestPkcs10V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRequestPkcs10V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRequestPkcs10V2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V2> for IX509CertificateRequest {
-    fn from(value: IX509CertificateRequestPkcs10V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V2> for &'a IX509CertificateRequest {
-    fn from(value: &'a IX509CertificateRequestPkcs10V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V2> for IX509CertificateRequest {
-    fn from(value: &IX509CertificateRequestPkcs10V2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V2> for IX509CertificateRequestPkcs10 {
-    fn from(value: IX509CertificateRequestPkcs10V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V2> for &'a IX509CertificateRequestPkcs10 {
-    fn from(value: &'a IX509CertificateRequestPkcs10V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V2> for IX509CertificateRequestPkcs10 {
-    fn from(value: &IX509CertificateRequestPkcs10V2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRequestPkcs10V2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509CertificateRequest, IX509CertificateRequestPkcs10);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRequestPkcs10V2 {
     fn clone(&self) -> Self {
@@ -18441,95 +13959,7 @@ impl IX509CertificateRequestPkcs10V3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V3> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRequestPkcs10V3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRequestPkcs10V3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V3> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRequestPkcs10V3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V3> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRequestPkcs10V3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V3> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRequestPkcs10V3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V3> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRequestPkcs10V3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V3> for IX509CertificateRequest {
-    fn from(value: IX509CertificateRequestPkcs10V3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V3> for &'a IX509CertificateRequest {
-    fn from(value: &'a IX509CertificateRequestPkcs10V3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V3> for IX509CertificateRequest {
-    fn from(value: &IX509CertificateRequestPkcs10V3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V3> for IX509CertificateRequestPkcs10 {
-    fn from(value: IX509CertificateRequestPkcs10V3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V3> for &'a IX509CertificateRequestPkcs10 {
-    fn from(value: &'a IX509CertificateRequestPkcs10V3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V3> for IX509CertificateRequestPkcs10 {
-    fn from(value: &IX509CertificateRequestPkcs10V3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V3> for IX509CertificateRequestPkcs10V2 {
-    fn from(value: IX509CertificateRequestPkcs10V3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V3> for &'a IX509CertificateRequestPkcs10V2 {
-    fn from(value: &'a IX509CertificateRequestPkcs10V3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V3> for IX509CertificateRequestPkcs10V2 {
-    fn from(value: &IX509CertificateRequestPkcs10V3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRequestPkcs10V3, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509CertificateRequest, IX509CertificateRequestPkcs10, IX509CertificateRequestPkcs10V2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRequestPkcs10V3 {
     fn clone(&self) -> Self {
@@ -18939,113 +14369,7 @@ impl IX509CertificateRequestPkcs10V4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V4> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V4> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRequestPkcs10V4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V4> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V4> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V4> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRequestPkcs10V4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V4> for IX509CertificateRequest {
-    fn from(value: IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V4> for &'a IX509CertificateRequest {
-    fn from(value: &'a IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V4> for IX509CertificateRequest {
-    fn from(value: &IX509CertificateRequestPkcs10V4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V4> for IX509CertificateRequestPkcs10 {
-    fn from(value: IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V4> for &'a IX509CertificateRequestPkcs10 {
-    fn from(value: &'a IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V4> for IX509CertificateRequestPkcs10 {
-    fn from(value: &IX509CertificateRequestPkcs10V4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V4> for IX509CertificateRequestPkcs10V2 {
-    fn from(value: IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V4> for &'a IX509CertificateRequestPkcs10V2 {
-    fn from(value: &'a IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V4> for IX509CertificateRequestPkcs10V2 {
-    fn from(value: &IX509CertificateRequestPkcs10V4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs10V4> for IX509CertificateRequestPkcs10V3 {
-    fn from(value: IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs10V4> for &'a IX509CertificateRequestPkcs10V3 {
-    fn from(value: &'a IX509CertificateRequestPkcs10V4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs10V4> for IX509CertificateRequestPkcs10V3 {
-    fn from(value: &IX509CertificateRequestPkcs10V4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRequestPkcs10V4, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509CertificateRequest, IX509CertificateRequestPkcs10, IX509CertificateRequestPkcs10V2, IX509CertificateRequestPkcs10V3);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRequestPkcs10V4 {
     fn clone(&self) -> Self {
@@ -19234,59 +14558,7 @@ impl IX509CertificateRequestPkcs7 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs7> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRequestPkcs7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRequestPkcs7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs7> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRequestPkcs7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs7> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRequestPkcs7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs7> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRequestPkcs7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs7> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRequestPkcs7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs7> for IX509CertificateRequest {
-    fn from(value: IX509CertificateRequestPkcs7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs7> for &'a IX509CertificateRequest {
-    fn from(value: &'a IX509CertificateRequestPkcs7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs7> for IX509CertificateRequest {
-    fn from(value: &IX509CertificateRequestPkcs7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRequestPkcs7, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509CertificateRequest);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRequestPkcs7 {
     fn clone(&self) -> Self {
@@ -19512,77 +14784,7 @@ impl IX509CertificateRequestPkcs7V2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs7V2> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRequestPkcs7V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs7V2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRequestPkcs7V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs7V2> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRequestPkcs7V2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs7V2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRequestPkcs7V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs7V2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRequestPkcs7V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs7V2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRequestPkcs7V2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs7V2> for IX509CertificateRequest {
-    fn from(value: IX509CertificateRequestPkcs7V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs7V2> for &'a IX509CertificateRequest {
-    fn from(value: &'a IX509CertificateRequestPkcs7V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs7V2> for IX509CertificateRequest {
-    fn from(value: &IX509CertificateRequestPkcs7V2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRequestPkcs7V2> for IX509CertificateRequestPkcs7 {
-    fn from(value: IX509CertificateRequestPkcs7V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRequestPkcs7V2> for &'a IX509CertificateRequestPkcs7 {
-    fn from(value: &'a IX509CertificateRequestPkcs7V2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRequestPkcs7V2> for IX509CertificateRequestPkcs7 {
-    fn from(value: &IX509CertificateRequestPkcs7V2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRequestPkcs7V2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509CertificateRequest, IX509CertificateRequestPkcs7);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRequestPkcs7V2 {
     fn clone(&self) -> Self {
@@ -19782,41 +14984,7 @@ impl IX509CertificateRevocationList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRevocationList> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRevocationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRevocationList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRevocationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRevocationList> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRevocationList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRevocationList> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRevocationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRevocationList> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRevocationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRevocationList> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRevocationList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRevocationList, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRevocationList {
     fn clone(&self) -> Self {
@@ -19963,41 +15131,7 @@ impl IX509CertificateRevocationListEntries {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRevocationListEntries> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRevocationListEntries) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRevocationListEntries> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRevocationListEntries) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRevocationListEntries> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRevocationListEntries) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRevocationListEntries> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRevocationListEntries) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRevocationListEntries> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRevocationListEntries) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRevocationListEntries> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRevocationListEntries) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRevocationListEntries, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRevocationListEntries {
     fn clone(&self) -> Self {
@@ -20087,41 +15221,7 @@ impl IX509CertificateRevocationListEntry {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRevocationListEntry> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateRevocationListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRevocationListEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateRevocationListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRevocationListEntry> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateRevocationListEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateRevocationListEntry> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateRevocationListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateRevocationListEntry> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateRevocationListEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateRevocationListEntry> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateRevocationListEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateRevocationListEntry, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateRevocationListEntry {
     fn clone(&self) -> Self {
@@ -20183,41 +15283,7 @@ impl IX509CertificateTemplate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateTemplate> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateTemplate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateTemplate> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateTemplate> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateTemplate> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateTemplate> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateTemplate, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateTemplate {
     fn clone(&self) -> Self {
@@ -20295,41 +15361,7 @@ impl IX509CertificateTemplateWritable {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateTemplateWritable> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateTemplateWritable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateTemplateWritable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateTemplateWritable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateTemplateWritable> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateTemplateWritable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateTemplateWritable> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateTemplateWritable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateTemplateWritable> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateTemplateWritable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateTemplateWritable> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateTemplateWritable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateTemplateWritable, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateTemplateWritable {
     fn clone(&self) -> Self {
@@ -20432,41 +15464,7 @@ impl IX509CertificateTemplates {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateTemplates> for ::windows::core::IUnknown {
-    fn from(value: IX509CertificateTemplates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateTemplates> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509CertificateTemplates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateTemplates> for ::windows::core::IUnknown {
-    fn from(value: &IX509CertificateTemplates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509CertificateTemplates> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509CertificateTemplates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509CertificateTemplates> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509CertificateTemplates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509CertificateTemplates> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509CertificateTemplates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509CertificateTemplates, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509CertificateTemplates {
     fn clone(&self) -> Self {
@@ -20570,41 +15568,7 @@ impl IX509EndorsementKey {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509EndorsementKey> for ::windows::core::IUnknown {
-    fn from(value: IX509EndorsementKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509EndorsementKey> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509EndorsementKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509EndorsementKey> for ::windows::core::IUnknown {
-    fn from(value: &IX509EndorsementKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509EndorsementKey> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509EndorsementKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509EndorsementKey> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509EndorsementKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509EndorsementKey> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509EndorsementKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509EndorsementKey, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509EndorsementKey {
     fn clone(&self) -> Self {
@@ -20755,41 +15719,7 @@ impl IX509Enrollment {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Enrollment> for ::windows::core::IUnknown {
-    fn from(value: IX509Enrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Enrollment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509Enrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Enrollment> for ::windows::core::IUnknown {
-    fn from(value: &IX509Enrollment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Enrollment> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509Enrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Enrollment> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509Enrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Enrollment> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509Enrollment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509Enrollment, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509Enrollment {
     fn clone(&self) -> Self {
@@ -20989,59 +15919,7 @@ impl IX509Enrollment2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Enrollment2> for ::windows::core::IUnknown {
-    fn from(value: IX509Enrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Enrollment2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509Enrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Enrollment2> for ::windows::core::IUnknown {
-    fn from(value: &IX509Enrollment2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Enrollment2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509Enrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Enrollment2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509Enrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Enrollment2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509Enrollment2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Enrollment2> for IX509Enrollment {
-    fn from(value: IX509Enrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Enrollment2> for &'a IX509Enrollment {
-    fn from(value: &'a IX509Enrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Enrollment2> for IX509Enrollment {
-    fn from(value: &IX509Enrollment2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509Enrollment2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Enrollment);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509Enrollment2 {
     fn clone(&self) -> Self {
@@ -21111,41 +15989,7 @@ impl IX509EnrollmentHelper {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509EnrollmentHelper> for ::windows::core::IUnknown {
-    fn from(value: IX509EnrollmentHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509EnrollmentHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509EnrollmentHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509EnrollmentHelper> for ::windows::core::IUnknown {
-    fn from(value: &IX509EnrollmentHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509EnrollmentHelper> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509EnrollmentHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509EnrollmentHelper> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509EnrollmentHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509EnrollmentHelper> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509EnrollmentHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509EnrollmentHelper, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509EnrollmentHelper {
     fn clone(&self) -> Self {
@@ -21300,41 +16144,7 @@ impl IX509EnrollmentPolicyServer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509EnrollmentPolicyServer> for ::windows::core::IUnknown {
-    fn from(value: IX509EnrollmentPolicyServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509EnrollmentPolicyServer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509EnrollmentPolicyServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509EnrollmentPolicyServer> for ::windows::core::IUnknown {
-    fn from(value: &IX509EnrollmentPolicyServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509EnrollmentPolicyServer> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509EnrollmentPolicyServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509EnrollmentPolicyServer> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509EnrollmentPolicyServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509EnrollmentPolicyServer> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509EnrollmentPolicyServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509EnrollmentPolicyServer, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509EnrollmentPolicyServer {
     fn clone(&self) -> Self {
@@ -21461,41 +16271,7 @@ impl IX509EnrollmentStatus {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509EnrollmentStatus> for ::windows::core::IUnknown {
-    fn from(value: IX509EnrollmentStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509EnrollmentStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509EnrollmentStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509EnrollmentStatus> for ::windows::core::IUnknown {
-    fn from(value: &IX509EnrollmentStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509EnrollmentStatus> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509EnrollmentStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509EnrollmentStatus> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509EnrollmentStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509EnrollmentStatus> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509EnrollmentStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509EnrollmentStatus, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509EnrollmentStatus {
     fn clone(&self) -> Self {
@@ -21554,41 +16330,7 @@ impl IX509EnrollmentWebClassFactory {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509EnrollmentWebClassFactory> for ::windows::core::IUnknown {
-    fn from(value: IX509EnrollmentWebClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509EnrollmentWebClassFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509EnrollmentWebClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509EnrollmentWebClassFactory> for ::windows::core::IUnknown {
-    fn from(value: &IX509EnrollmentWebClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509EnrollmentWebClassFactory> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509EnrollmentWebClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509EnrollmentWebClassFactory> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509EnrollmentWebClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509EnrollmentWebClassFactory> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509EnrollmentWebClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509EnrollmentWebClassFactory, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509EnrollmentWebClassFactory {
     fn clone(&self) -> Self {
@@ -21657,41 +16399,7 @@ impl IX509Extension {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Extension> for ::windows::core::IUnknown {
-    fn from(value: IX509Extension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Extension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509Extension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Extension> for ::windows::core::IUnknown {
-    fn from(value: &IX509Extension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Extension> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509Extension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Extension> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509Extension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Extension> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509Extension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509Extension, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509Extension {
     fn clone(&self) -> Self {
@@ -21787,59 +16495,7 @@ impl IX509ExtensionAlternativeNames {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionAlternativeNames> for ::windows::core::IUnknown {
-    fn from(value: IX509ExtensionAlternativeNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionAlternativeNames> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509ExtensionAlternativeNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionAlternativeNames> for ::windows::core::IUnknown {
-    fn from(value: &IX509ExtensionAlternativeNames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionAlternativeNames> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509ExtensionAlternativeNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionAlternativeNames> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509ExtensionAlternativeNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionAlternativeNames> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509ExtensionAlternativeNames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionAlternativeNames> for IX509Extension {
-    fn from(value: IX509ExtensionAlternativeNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionAlternativeNames> for &'a IX509Extension {
-    fn from(value: &'a IX509ExtensionAlternativeNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionAlternativeNames> for IX509Extension {
-    fn from(value: &IX509ExtensionAlternativeNames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509ExtensionAlternativeNames, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Extension);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509ExtensionAlternativeNames {
     fn clone(&self) -> Self {
@@ -21926,59 +16582,7 @@ impl IX509ExtensionAuthorityKeyIdentifier {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionAuthorityKeyIdentifier> for ::windows::core::IUnknown {
-    fn from(value: IX509ExtensionAuthorityKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionAuthorityKeyIdentifier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509ExtensionAuthorityKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionAuthorityKeyIdentifier> for ::windows::core::IUnknown {
-    fn from(value: &IX509ExtensionAuthorityKeyIdentifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionAuthorityKeyIdentifier> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509ExtensionAuthorityKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionAuthorityKeyIdentifier> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509ExtensionAuthorityKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionAuthorityKeyIdentifier> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509ExtensionAuthorityKeyIdentifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionAuthorityKeyIdentifier> for IX509Extension {
-    fn from(value: IX509ExtensionAuthorityKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionAuthorityKeyIdentifier> for &'a IX509Extension {
-    fn from(value: &'a IX509ExtensionAuthorityKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionAuthorityKeyIdentifier> for IX509Extension {
-    fn from(value: &IX509ExtensionAuthorityKeyIdentifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509ExtensionAuthorityKeyIdentifier, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Extension);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509ExtensionAuthorityKeyIdentifier {
     fn clone(&self) -> Self {
@@ -22063,59 +16667,7 @@ impl IX509ExtensionBasicConstraints {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionBasicConstraints> for ::windows::core::IUnknown {
-    fn from(value: IX509ExtensionBasicConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionBasicConstraints> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509ExtensionBasicConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionBasicConstraints> for ::windows::core::IUnknown {
-    fn from(value: &IX509ExtensionBasicConstraints) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionBasicConstraints> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509ExtensionBasicConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionBasicConstraints> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509ExtensionBasicConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionBasicConstraints> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509ExtensionBasicConstraints) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionBasicConstraints> for IX509Extension {
-    fn from(value: IX509ExtensionBasicConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionBasicConstraints> for &'a IX509Extension {
-    fn from(value: &'a IX509ExtensionBasicConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionBasicConstraints> for IX509Extension {
-    fn from(value: &IX509ExtensionBasicConstraints) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509ExtensionBasicConstraints, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Extension);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509ExtensionBasicConstraints {
     fn clone(&self) -> Self {
@@ -22204,59 +16756,7 @@ impl IX509ExtensionCertificatePolicies {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionCertificatePolicies> for ::windows::core::IUnknown {
-    fn from(value: IX509ExtensionCertificatePolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionCertificatePolicies> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509ExtensionCertificatePolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionCertificatePolicies> for ::windows::core::IUnknown {
-    fn from(value: &IX509ExtensionCertificatePolicies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionCertificatePolicies> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509ExtensionCertificatePolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionCertificatePolicies> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509ExtensionCertificatePolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionCertificatePolicies> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509ExtensionCertificatePolicies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionCertificatePolicies> for IX509Extension {
-    fn from(value: IX509ExtensionCertificatePolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionCertificatePolicies> for &'a IX509Extension {
-    fn from(value: &'a IX509ExtensionCertificatePolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionCertificatePolicies> for IX509Extension {
-    fn from(value: &IX509ExtensionCertificatePolicies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509ExtensionCertificatePolicies, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Extension);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509ExtensionCertificatePolicies {
     fn clone(&self) -> Self {
@@ -22350,59 +16850,7 @@ impl IX509ExtensionEnhancedKeyUsage {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionEnhancedKeyUsage> for ::windows::core::IUnknown {
-    fn from(value: IX509ExtensionEnhancedKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionEnhancedKeyUsage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509ExtensionEnhancedKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionEnhancedKeyUsage> for ::windows::core::IUnknown {
-    fn from(value: &IX509ExtensionEnhancedKeyUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionEnhancedKeyUsage> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509ExtensionEnhancedKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionEnhancedKeyUsage> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509ExtensionEnhancedKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionEnhancedKeyUsage> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509ExtensionEnhancedKeyUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionEnhancedKeyUsage> for IX509Extension {
-    fn from(value: IX509ExtensionEnhancedKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionEnhancedKeyUsage> for &'a IX509Extension {
-    fn from(value: &'a IX509ExtensionEnhancedKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionEnhancedKeyUsage> for IX509Extension {
-    fn from(value: &IX509ExtensionEnhancedKeyUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509ExtensionEnhancedKeyUsage, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Extension);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509ExtensionEnhancedKeyUsage {
     fn clone(&self) -> Self {
@@ -22489,59 +16937,7 @@ impl IX509ExtensionKeyUsage {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionKeyUsage> for ::windows::core::IUnknown {
-    fn from(value: IX509ExtensionKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionKeyUsage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509ExtensionKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionKeyUsage> for ::windows::core::IUnknown {
-    fn from(value: &IX509ExtensionKeyUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionKeyUsage> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509ExtensionKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionKeyUsage> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509ExtensionKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionKeyUsage> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509ExtensionKeyUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionKeyUsage> for IX509Extension {
-    fn from(value: IX509ExtensionKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionKeyUsage> for &'a IX509Extension {
-    fn from(value: &'a IX509ExtensionKeyUsage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionKeyUsage> for IX509Extension {
-    fn from(value: &IX509ExtensionKeyUsage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509ExtensionKeyUsage, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Extension);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509ExtensionKeyUsage {
     fn clone(&self) -> Self {
@@ -22629,59 +17025,7 @@ impl IX509ExtensionMSApplicationPolicies {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionMSApplicationPolicies> for ::windows::core::IUnknown {
-    fn from(value: IX509ExtensionMSApplicationPolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionMSApplicationPolicies> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509ExtensionMSApplicationPolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionMSApplicationPolicies> for ::windows::core::IUnknown {
-    fn from(value: &IX509ExtensionMSApplicationPolicies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionMSApplicationPolicies> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509ExtensionMSApplicationPolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionMSApplicationPolicies> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509ExtensionMSApplicationPolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionMSApplicationPolicies> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509ExtensionMSApplicationPolicies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionMSApplicationPolicies> for IX509Extension {
-    fn from(value: IX509ExtensionMSApplicationPolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionMSApplicationPolicies> for &'a IX509Extension {
-    fn from(value: &'a IX509ExtensionMSApplicationPolicies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionMSApplicationPolicies> for IX509Extension {
-    fn from(value: &IX509ExtensionMSApplicationPolicies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509ExtensionMSApplicationPolicies, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Extension);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509ExtensionMSApplicationPolicies {
     fn clone(&self) -> Self {
@@ -22775,59 +17119,7 @@ impl IX509ExtensionSmimeCapabilities {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionSmimeCapabilities> for ::windows::core::IUnknown {
-    fn from(value: IX509ExtensionSmimeCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionSmimeCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509ExtensionSmimeCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionSmimeCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &IX509ExtensionSmimeCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionSmimeCapabilities> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509ExtensionSmimeCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionSmimeCapabilities> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509ExtensionSmimeCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionSmimeCapabilities> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509ExtensionSmimeCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionSmimeCapabilities> for IX509Extension {
-    fn from(value: IX509ExtensionSmimeCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionSmimeCapabilities> for &'a IX509Extension {
-    fn from(value: &'a IX509ExtensionSmimeCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionSmimeCapabilities> for IX509Extension {
-    fn from(value: &IX509ExtensionSmimeCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509ExtensionSmimeCapabilities, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Extension);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509ExtensionSmimeCapabilities {
     fn clone(&self) -> Self {
@@ -22914,59 +17206,7 @@ impl IX509ExtensionSubjectKeyIdentifier {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionSubjectKeyIdentifier> for ::windows::core::IUnknown {
-    fn from(value: IX509ExtensionSubjectKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionSubjectKeyIdentifier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509ExtensionSubjectKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionSubjectKeyIdentifier> for ::windows::core::IUnknown {
-    fn from(value: &IX509ExtensionSubjectKeyIdentifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionSubjectKeyIdentifier> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509ExtensionSubjectKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionSubjectKeyIdentifier> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509ExtensionSubjectKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionSubjectKeyIdentifier> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509ExtensionSubjectKeyIdentifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionSubjectKeyIdentifier> for IX509Extension {
-    fn from(value: IX509ExtensionSubjectKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionSubjectKeyIdentifier> for &'a IX509Extension {
-    fn from(value: &'a IX509ExtensionSubjectKeyIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionSubjectKeyIdentifier> for IX509Extension {
-    fn from(value: &IX509ExtensionSubjectKeyIdentifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509ExtensionSubjectKeyIdentifier, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Extension);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509ExtensionSubjectKeyIdentifier {
     fn clone(&self) -> Self {
@@ -23062,59 +17302,7 @@ impl IX509ExtensionTemplate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionTemplate> for ::windows::core::IUnknown {
-    fn from(value: IX509ExtensionTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionTemplate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509ExtensionTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionTemplate> for ::windows::core::IUnknown {
-    fn from(value: &IX509ExtensionTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionTemplate> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509ExtensionTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionTemplate> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509ExtensionTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionTemplate> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509ExtensionTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionTemplate> for IX509Extension {
-    fn from(value: IX509ExtensionTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionTemplate> for &'a IX509Extension {
-    fn from(value: &'a IX509ExtensionTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionTemplate> for IX509Extension {
-    fn from(value: &IX509ExtensionTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509ExtensionTemplate, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Extension);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509ExtensionTemplate {
     fn clone(&self) -> Self {
@@ -23203,59 +17391,7 @@ impl IX509ExtensionTemplateName {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionTemplateName> for ::windows::core::IUnknown {
-    fn from(value: IX509ExtensionTemplateName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionTemplateName> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509ExtensionTemplateName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionTemplateName> for ::windows::core::IUnknown {
-    fn from(value: &IX509ExtensionTemplateName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionTemplateName> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509ExtensionTemplateName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionTemplateName> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509ExtensionTemplateName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionTemplateName> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509ExtensionTemplateName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509ExtensionTemplateName> for IX509Extension {
-    fn from(value: IX509ExtensionTemplateName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509ExtensionTemplateName> for &'a IX509Extension {
-    fn from(value: &'a IX509ExtensionTemplateName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509ExtensionTemplateName> for IX509Extension {
-    fn from(value: &IX509ExtensionTemplateName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509ExtensionTemplateName, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509Extension);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509ExtensionTemplateName {
     fn clone(&self) -> Self {
@@ -23346,41 +17482,7 @@ impl IX509Extensions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Extensions> for ::windows::core::IUnknown {
-    fn from(value: IX509Extensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Extensions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509Extensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Extensions> for ::windows::core::IUnknown {
-    fn from(value: &IX509Extensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509Extensions> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509Extensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509Extensions> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509Extensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509Extensions> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509Extensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509Extensions, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509Extensions {
     fn clone(&self) -> Self {
@@ -23449,41 +17551,7 @@ impl IX509MachineEnrollmentFactory {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509MachineEnrollmentFactory> for ::windows::core::IUnknown {
-    fn from(value: IX509MachineEnrollmentFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509MachineEnrollmentFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509MachineEnrollmentFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509MachineEnrollmentFactory> for ::windows::core::IUnknown {
-    fn from(value: &IX509MachineEnrollmentFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509MachineEnrollmentFactory> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509MachineEnrollmentFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509MachineEnrollmentFactory> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509MachineEnrollmentFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509MachineEnrollmentFactory> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509MachineEnrollmentFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509MachineEnrollmentFactory, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509MachineEnrollmentFactory {
     fn clone(&self) -> Self {
@@ -23541,41 +17609,7 @@ impl IX509NameValuePair {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509NameValuePair> for ::windows::core::IUnknown {
-    fn from(value: IX509NameValuePair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509NameValuePair> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509NameValuePair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509NameValuePair> for ::windows::core::IUnknown {
-    fn from(value: &IX509NameValuePair) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509NameValuePair> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509NameValuePair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509NameValuePair> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509NameValuePair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509NameValuePair> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509NameValuePair) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509NameValuePair, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509NameValuePair {
     fn clone(&self) -> Self {
@@ -23649,41 +17683,7 @@ impl IX509NameValuePairs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509NameValuePairs> for ::windows::core::IUnknown {
-    fn from(value: IX509NameValuePairs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509NameValuePairs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509NameValuePairs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509NameValuePairs> for ::windows::core::IUnknown {
-    fn from(value: &IX509NameValuePairs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509NameValuePairs> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509NameValuePairs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509NameValuePairs> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509NameValuePairs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509NameValuePairs> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509NameValuePairs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509NameValuePairs, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509NameValuePairs {
     fn clone(&self) -> Self {
@@ -23769,41 +17769,7 @@ impl IX509PolicyServerListManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509PolicyServerListManager> for ::windows::core::IUnknown {
-    fn from(value: IX509PolicyServerListManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509PolicyServerListManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509PolicyServerListManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509PolicyServerListManager> for ::windows::core::IUnknown {
-    fn from(value: &IX509PolicyServerListManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509PolicyServerListManager> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509PolicyServerListManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509PolicyServerListManager> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509PolicyServerListManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509PolicyServerListManager> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509PolicyServerListManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509PolicyServerListManager, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509PolicyServerListManager {
     fn clone(&self) -> Self {
@@ -23910,41 +17876,7 @@ impl IX509PolicyServerUrl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509PolicyServerUrl> for ::windows::core::IUnknown {
-    fn from(value: IX509PolicyServerUrl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509PolicyServerUrl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509PolicyServerUrl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509PolicyServerUrl> for ::windows::core::IUnknown {
-    fn from(value: &IX509PolicyServerUrl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509PolicyServerUrl> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509PolicyServerUrl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509PolicyServerUrl> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509PolicyServerUrl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509PolicyServerUrl> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509PolicyServerUrl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509PolicyServerUrl, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509PolicyServerUrl {
     fn clone(&self) -> Self {
@@ -24227,41 +18159,7 @@ impl IX509PrivateKey {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509PrivateKey> for ::windows::core::IUnknown {
-    fn from(value: IX509PrivateKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509PrivateKey> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509PrivateKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509PrivateKey> for ::windows::core::IUnknown {
-    fn from(value: &IX509PrivateKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509PrivateKey> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509PrivateKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509PrivateKey> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509PrivateKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509PrivateKey> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509PrivateKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509PrivateKey, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509PrivateKey {
     fn clone(&self) -> Self {
@@ -24643,59 +18541,7 @@ impl IX509PrivateKey2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509PrivateKey2> for ::windows::core::IUnknown {
-    fn from(value: IX509PrivateKey2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509PrivateKey2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509PrivateKey2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509PrivateKey2> for ::windows::core::IUnknown {
-    fn from(value: &IX509PrivateKey2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509PrivateKey2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509PrivateKey2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509PrivateKey2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509PrivateKey2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509PrivateKey2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509PrivateKey2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509PrivateKey2> for IX509PrivateKey {
-    fn from(value: IX509PrivateKey2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509PrivateKey2> for &'a IX509PrivateKey {
-    fn from(value: &'a IX509PrivateKey2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509PrivateKey2> for IX509PrivateKey {
-    fn from(value: &IX509PrivateKey2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509PrivateKey2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509PrivateKey);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509PrivateKey2 {
     fn clone(&self) -> Self {
@@ -24781,41 +18627,7 @@ impl IX509PublicKey {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509PublicKey> for ::windows::core::IUnknown {
-    fn from(value: IX509PublicKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509PublicKey> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509PublicKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509PublicKey> for ::windows::core::IUnknown {
-    fn from(value: &IX509PublicKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509PublicKey> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509PublicKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509PublicKey> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509PublicKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509PublicKey> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509PublicKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509PublicKey, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509PublicKey {
     fn clone(&self) -> Self {
@@ -24973,41 +18785,7 @@ impl IX509SCEPEnrollment {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509SCEPEnrollment> for ::windows::core::IUnknown {
-    fn from(value: IX509SCEPEnrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509SCEPEnrollment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509SCEPEnrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509SCEPEnrollment> for ::windows::core::IUnknown {
-    fn from(value: &IX509SCEPEnrollment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509SCEPEnrollment> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509SCEPEnrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509SCEPEnrollment> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509SCEPEnrollment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509SCEPEnrollment> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509SCEPEnrollment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509SCEPEnrollment, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509SCEPEnrollment {
     fn clone(&self) -> Self {
@@ -25218,59 +18996,7 @@ impl IX509SCEPEnrollment2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509SCEPEnrollment2> for ::windows::core::IUnknown {
-    fn from(value: IX509SCEPEnrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509SCEPEnrollment2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509SCEPEnrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509SCEPEnrollment2> for ::windows::core::IUnknown {
-    fn from(value: &IX509SCEPEnrollment2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509SCEPEnrollment2> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509SCEPEnrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509SCEPEnrollment2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509SCEPEnrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509SCEPEnrollment2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509SCEPEnrollment2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509SCEPEnrollment2> for IX509SCEPEnrollment {
-    fn from(value: IX509SCEPEnrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509SCEPEnrollment2> for &'a IX509SCEPEnrollment {
-    fn from(value: &'a IX509SCEPEnrollment2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509SCEPEnrollment2> for IX509SCEPEnrollment {
-    fn from(value: &IX509SCEPEnrollment2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509SCEPEnrollment2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, IX509SCEPEnrollment);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509SCEPEnrollment2 {
     fn clone(&self) -> Self {
@@ -25348,41 +19074,7 @@ impl IX509SCEPEnrollmentHelper {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509SCEPEnrollmentHelper> for ::windows::core::IUnknown {
-    fn from(value: IX509SCEPEnrollmentHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509SCEPEnrollmentHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509SCEPEnrollmentHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509SCEPEnrollmentHelper> for ::windows::core::IUnknown {
-    fn from(value: &IX509SCEPEnrollmentHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509SCEPEnrollmentHelper> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509SCEPEnrollmentHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509SCEPEnrollmentHelper> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509SCEPEnrollmentHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509SCEPEnrollmentHelper> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509SCEPEnrollmentHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509SCEPEnrollmentHelper, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509SCEPEnrollmentHelper {
     fn clone(&self) -> Self {
@@ -25499,41 +19191,7 @@ impl IX509SignatureInformation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509SignatureInformation> for ::windows::core::IUnknown {
-    fn from(value: IX509SignatureInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509SignatureInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IX509SignatureInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509SignatureInformation> for ::windows::core::IUnknown {
-    fn from(value: &IX509SignatureInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IX509SignatureInformation> for super::super::super::System::Com::IDispatch {
-    fn from(value: IX509SignatureInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IX509SignatureInformation> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IX509SignatureInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IX509SignatureInformation> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IX509SignatureInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IX509SignatureInformation, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IX509SignatureInformation {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
@@ -4769,41 +4769,7 @@ impl ICertSrvSetup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertSrvSetup> for ::windows::core::IUnknown {
-    fn from(value: ICertSrvSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertSrvSetup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertSrvSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertSrvSetup> for ::windows::core::IUnknown {
-    fn from(value: &ICertSrvSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertSrvSetup> for super::super::System::Com::IDispatch {
-    fn from(value: ICertSrvSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertSrvSetup> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertSrvSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertSrvSetup> for super::super::System::Com::IDispatch {
-    fn from(value: &ICertSrvSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertSrvSetup, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertSrvSetup {
     fn clone(&self) -> Self {
@@ -4942,41 +4908,7 @@ impl ICertSrvSetupKeyInformation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertSrvSetupKeyInformation> for ::windows::core::IUnknown {
-    fn from(value: ICertSrvSetupKeyInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertSrvSetupKeyInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertSrvSetupKeyInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertSrvSetupKeyInformation> for ::windows::core::IUnknown {
-    fn from(value: &ICertSrvSetupKeyInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertSrvSetupKeyInformation> for super::super::System::Com::IDispatch {
-    fn from(value: ICertSrvSetupKeyInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertSrvSetupKeyInformation> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertSrvSetupKeyInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertSrvSetupKeyInformation> for super::super::System::Com::IDispatch {
-    fn from(value: &ICertSrvSetupKeyInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertSrvSetupKeyInformation, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertSrvSetupKeyInformation {
     fn clone(&self) -> Self {
@@ -5059,41 +4991,7 @@ impl ICertSrvSetupKeyInformationCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertSrvSetupKeyInformationCollection> for ::windows::core::IUnknown {
-    fn from(value: ICertSrvSetupKeyInformationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertSrvSetupKeyInformationCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertSrvSetupKeyInformationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertSrvSetupKeyInformationCollection> for ::windows::core::IUnknown {
-    fn from(value: &ICertSrvSetupKeyInformationCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertSrvSetupKeyInformationCollection> for super::super::System::Com::IDispatch {
-    fn from(value: ICertSrvSetupKeyInformationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertSrvSetupKeyInformationCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertSrvSetupKeyInformationCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertSrvSetupKeyInformationCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &ICertSrvSetupKeyInformationCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertSrvSetupKeyInformationCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertSrvSetupKeyInformationCollection {
     fn clone(&self) -> Self {
@@ -5172,41 +5070,7 @@ impl ICertificateEnrollmentPolicyServerSetup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificateEnrollmentPolicyServerSetup> for ::windows::core::IUnknown {
-    fn from(value: ICertificateEnrollmentPolicyServerSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificateEnrollmentPolicyServerSetup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertificateEnrollmentPolicyServerSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificateEnrollmentPolicyServerSetup> for ::windows::core::IUnknown {
-    fn from(value: &ICertificateEnrollmentPolicyServerSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificateEnrollmentPolicyServerSetup> for super::super::System::Com::IDispatch {
-    fn from(value: ICertificateEnrollmentPolicyServerSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificateEnrollmentPolicyServerSetup> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertificateEnrollmentPolicyServerSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificateEnrollmentPolicyServerSetup> for super::super::System::Com::IDispatch {
-    fn from(value: &ICertificateEnrollmentPolicyServerSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertificateEnrollmentPolicyServerSetup, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertificateEnrollmentPolicyServerSetup {
     fn clone(&self) -> Self {
@@ -5293,41 +5157,7 @@ impl ICertificateEnrollmentServerSetup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificateEnrollmentServerSetup> for ::windows::core::IUnknown {
-    fn from(value: ICertificateEnrollmentServerSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificateEnrollmentServerSetup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICertificateEnrollmentServerSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificateEnrollmentServerSetup> for ::windows::core::IUnknown {
-    fn from(value: &ICertificateEnrollmentServerSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICertificateEnrollmentServerSetup> for super::super::System::Com::IDispatch {
-    fn from(value: ICertificateEnrollmentServerSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICertificateEnrollmentServerSetup> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ICertificateEnrollmentServerSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICertificateEnrollmentServerSetup> for super::super::System::Com::IDispatch {
-    fn from(value: &ICertificateEnrollmentServerSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICertificateEnrollmentServerSetup, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICertificateEnrollmentServerSetup {
     fn clone(&self) -> Self {
@@ -5436,41 +5266,7 @@ impl IMSCEPSetup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSCEPSetup> for ::windows::core::IUnknown {
-    fn from(value: IMSCEPSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSCEPSetup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSCEPSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSCEPSetup> for ::windows::core::IUnknown {
-    fn from(value: &IMSCEPSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSCEPSetup> for super::super::System::Com::IDispatch {
-    fn from(value: IMSCEPSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSCEPSetup> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IMSCEPSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSCEPSetup> for super::super::System::Com::IDispatch {
-    fn from(value: &IMSCEPSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSCEPSetup, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSCEPSetup {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/mod.rs
@@ -176,36 +176,7 @@ impl IProtectionPolicyManagerInterop {
         (::windows::core::Vtable::vtable(self).GetForWindow)(::windows::core::Vtable::as_raw(self), appwindow.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IProtectionPolicyManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: IProtectionPolicyManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtectionPolicyManagerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProtectionPolicyManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtectionPolicyManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: &IProtectionPolicyManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IProtectionPolicyManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: IProtectionPolicyManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtectionPolicyManagerInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IProtectionPolicyManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtectionPolicyManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: &IProtectionPolicyManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProtectionPolicyManagerInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IProtectionPolicyManagerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -300,36 +271,7 @@ impl IProtectionPolicyManagerInterop2 {
         (::windows::core::Vtable::vtable(self).RequestAccessForAppWithMessageForWindowAsync)(::windows::core::Vtable::as_raw(self), appwindow.into(), ::core::mem::transmute_copy(sourceidentity), ::core::mem::transmute_copy(apppackagefamilyname), auditinfounk.into().abi(), ::core::mem::transmute_copy(messagefromapp), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IProtectionPolicyManagerInterop2> for ::windows::core::IUnknown {
-    fn from(value: IProtectionPolicyManagerInterop2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtectionPolicyManagerInterop2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProtectionPolicyManagerInterop2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtectionPolicyManagerInterop2> for ::windows::core::IUnknown {
-    fn from(value: &IProtectionPolicyManagerInterop2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IProtectionPolicyManagerInterop2> for ::windows::core::IInspectable {
-    fn from(value: IProtectionPolicyManagerInterop2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtectionPolicyManagerInterop2> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IProtectionPolicyManagerInterop2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtectionPolicyManagerInterop2> for ::windows::core::IInspectable {
-    fn from(value: &IProtectionPolicyManagerInterop2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProtectionPolicyManagerInterop2, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IProtectionPolicyManagerInterop2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -452,36 +394,7 @@ impl IProtectionPolicyManagerInterop3 {
         (::windows::core::Vtable::vtable(self).RequestAccessToFilesForProcessWithMessageAndBehaviorForWindowAsync)(::windows::core::Vtable::as_raw(self), appwindow.into(), sourceitemlistunk.into().abi(), processid, auditinfounk.into().abi(), ::core::mem::transmute_copy(messagefromapp), behavior, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IProtectionPolicyManagerInterop3> for ::windows::core::IUnknown {
-    fn from(value: IProtectionPolicyManagerInterop3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtectionPolicyManagerInterop3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProtectionPolicyManagerInterop3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtectionPolicyManagerInterop3> for ::windows::core::IUnknown {
-    fn from(value: &IProtectionPolicyManagerInterop3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IProtectionPolicyManagerInterop3> for ::windows::core::IInspectable {
-    fn from(value: IProtectionPolicyManagerInterop3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtectionPolicyManagerInterop3> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IProtectionPolicyManagerInterop3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtectionPolicyManagerInterop3> for ::windows::core::IInspectable {
-    fn from(value: &IProtectionPolicyManagerInterop3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProtectionPolicyManagerInterop3, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IProtectionPolicyManagerInterop3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/mod.rs
@@ -390,21 +390,7 @@ impl IAccountingProviderConfig {
         (::windows::core::Vtable::vtable(self).Deactivate)(::windows::core::Vtable::as_raw(self), uconnectionparam, ureserved1, ureserved2).ok()
     }
 }
-impl ::core::convert::From<IAccountingProviderConfig> for ::windows::core::IUnknown {
-    fn from(value: IAccountingProviderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccountingProviderConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccountingProviderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccountingProviderConfig> for ::windows::core::IUnknown {
-    fn from(value: &IAccountingProviderConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccountingProviderConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccountingProviderConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -469,21 +455,7 @@ impl IAuthenticationProviderConfig {
         (::windows::core::Vtable::vtable(self).Deactivate)(::windows::core::Vtable::as_raw(self), uconnectionparam, ureserved1, ureserved2).ok()
     }
 }
-impl ::core::convert::From<IAuthenticationProviderConfig> for ::windows::core::IUnknown {
-    fn from(value: IAuthenticationProviderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAuthenticationProviderConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAuthenticationProviderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAuthenticationProviderConfig> for ::windows::core::IUnknown {
-    fn from(value: &IAuthenticationProviderConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAuthenticationProviderConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAuthenticationProviderConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -558,21 +530,7 @@ impl IEAPProviderConfig {
         (::windows::core::Vtable::vtable(self).RouterInvokeCredentialsUI)(::windows::core::Vtable::as_raw(self), dweaptypeid, uconnectionparam, hwndparent.into(), dwflags, ::core::mem::transmute(pconnectiondatain.as_ptr()), pconnectiondatain.len() as _, ::core::mem::transmute(puserdatain.as_ptr()), puserdatain.len() as _, ::core::mem::transmute(ppuserdataout), ::core::mem::transmute(pdwsizeofuserdataout)).ok()
     }
 }
-impl ::core::convert::From<IEAPProviderConfig> for ::windows::core::IUnknown {
-    fn from(value: IEAPProviderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEAPProviderConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEAPProviderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEAPProviderConfig> for ::windows::core::IUnknown {
-    fn from(value: &IEAPProviderConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEAPProviderConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEAPProviderConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -664,36 +622,7 @@ impl IEAPProviderConfig2 {
         (::windows::core::Vtable::vtable(self).GetGlobalConfig)(::windows::core::Vtable::as_raw(self), dweaptypeid, ::core::mem::transmute(ppconfigdataout), ::core::mem::transmute(pdwsizeofconfigdataout)).ok()
     }
 }
-impl ::core::convert::From<IEAPProviderConfig2> for ::windows::core::IUnknown {
-    fn from(value: IEAPProviderConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEAPProviderConfig2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEAPProviderConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEAPProviderConfig2> for ::windows::core::IUnknown {
-    fn from(value: &IEAPProviderConfig2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEAPProviderConfig2> for IEAPProviderConfig {
-    fn from(value: IEAPProviderConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEAPProviderConfig2> for &'a IEAPProviderConfig {
-    fn from(value: &'a IEAPProviderConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEAPProviderConfig2> for IEAPProviderConfig {
-    fn from(value: &IEAPProviderConfig2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEAPProviderConfig2, ::windows::core::IUnknown, IEAPProviderConfig);
 impl ::core::clone::Clone for IEAPProviderConfig2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -784,51 +713,7 @@ impl IEAPProviderConfig3 {
         (::windows::core::Vtable::vtable(self).ServerInvokeCertificateConfigUI)(::windows::core::Vtable::as_raw(self), dweaptypeid, uconnectionparam, hwnd.into(), ::core::mem::transmute(pconfigdatain), dwsizeofconfigdatain, ::core::mem::transmute(ppconfigdataout), ::core::mem::transmute(pdwsizeofconfigdataout), ureserved).ok()
     }
 }
-impl ::core::convert::From<IEAPProviderConfig3> for ::windows::core::IUnknown {
-    fn from(value: IEAPProviderConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEAPProviderConfig3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEAPProviderConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEAPProviderConfig3> for ::windows::core::IUnknown {
-    fn from(value: &IEAPProviderConfig3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEAPProviderConfig3> for IEAPProviderConfig {
-    fn from(value: IEAPProviderConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEAPProviderConfig3> for &'a IEAPProviderConfig {
-    fn from(value: &'a IEAPProviderConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEAPProviderConfig3> for IEAPProviderConfig {
-    fn from(value: &IEAPProviderConfig3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEAPProviderConfig3> for IEAPProviderConfig2 {
-    fn from(value: IEAPProviderConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEAPProviderConfig3> for &'a IEAPProviderConfig2 {
-    fn from(value: &'a IEAPProviderConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEAPProviderConfig3> for IEAPProviderConfig2 {
-    fn from(value: &IEAPProviderConfig3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEAPProviderConfig3, ::windows::core::IUnknown, IEAPProviderConfig, IEAPProviderConfig2);
 impl ::core::clone::Clone for IEAPProviderConfig3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -885,21 +770,7 @@ impl IRouterProtocolConfig {
         (::windows::core::Vtable::vtable(self).RemoveProtocol)(::windows::core::Vtable::as_raw(self), pszmachinename.into(), dwtransportid, dwprotocolid, hwnd.into(), dwflags, prouter.into().abi(), ureserved1).ok()
     }
 }
-impl ::core::convert::From<IRouterProtocolConfig> for ::windows::core::IUnknown {
-    fn from(value: IRouterProtocolConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRouterProtocolConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRouterProtocolConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRouterProtocolConfig> for ::windows::core::IUnknown {
-    fn from(value: &IRouterProtocolConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRouterProtocolConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRouterProtocolConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Isolation/mod.rs
@@ -140,21 +140,7 @@ impl IIsolatedAppLauncher {
         (::windows::core::Vtable::vtable(self).Launch)(::windows::core::Vtable::as_raw(self), appusermodelid.into(), arguments.into(), ::core::mem::transmute(telemetryparameters)).ok()
     }
 }
-impl ::core::convert::From<IIsolatedAppLauncher> for ::windows::core::IUnknown {
-    fn from(value: IIsolatedAppLauncher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIsolatedAppLauncher> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIsolatedAppLauncher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIsolatedAppLauncher> for ::windows::core::IUnknown {
-    fn from(value: &IIsolatedAppLauncher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIsolatedAppLauncher, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IIsolatedAppLauncher {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Security/Tpm/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Tpm/mod.rs
@@ -23,21 +23,7 @@ impl ITpmVirtualSmartCardManager {
         (::windows::core::Vtable::vtable(self).DestroyVirtualSmartCard)(::windows::core::Vtable::as_raw(self), pszinstanceid.into(), pstatuscallback.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITpmVirtualSmartCardManager> for ::windows::core::IUnknown {
-    fn from(value: ITpmVirtualSmartCardManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITpmVirtualSmartCardManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITpmVirtualSmartCardManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITpmVirtualSmartCardManager> for ::windows::core::IUnknown {
-    fn from(value: &ITpmVirtualSmartCardManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITpmVirtualSmartCardManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITpmVirtualSmartCardManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -127,36 +113,7 @@ impl ITpmVirtualSmartCardManager2 {
         .ok()
     }
 }
-impl ::core::convert::From<ITpmVirtualSmartCardManager2> for ::windows::core::IUnknown {
-    fn from(value: ITpmVirtualSmartCardManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITpmVirtualSmartCardManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITpmVirtualSmartCardManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITpmVirtualSmartCardManager2> for ::windows::core::IUnknown {
-    fn from(value: &ITpmVirtualSmartCardManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITpmVirtualSmartCardManager2> for ITpmVirtualSmartCardManager {
-    fn from(value: ITpmVirtualSmartCardManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITpmVirtualSmartCardManager2> for &'a ITpmVirtualSmartCardManager {
-    fn from(value: &'a ITpmVirtualSmartCardManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITpmVirtualSmartCardManager2> for ITpmVirtualSmartCardManager {
-    fn from(value: &ITpmVirtualSmartCardManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITpmVirtualSmartCardManager2, ::windows::core::IUnknown, ITpmVirtualSmartCardManager);
 impl ::core::clone::Clone for ITpmVirtualSmartCardManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -272,51 +229,7 @@ impl ITpmVirtualSmartCardManager3 {
         .from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ITpmVirtualSmartCardManager3> for ::windows::core::IUnknown {
-    fn from(value: ITpmVirtualSmartCardManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITpmVirtualSmartCardManager3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITpmVirtualSmartCardManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITpmVirtualSmartCardManager3> for ::windows::core::IUnknown {
-    fn from(value: &ITpmVirtualSmartCardManager3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITpmVirtualSmartCardManager3> for ITpmVirtualSmartCardManager {
-    fn from(value: ITpmVirtualSmartCardManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITpmVirtualSmartCardManager3> for &'a ITpmVirtualSmartCardManager {
-    fn from(value: &'a ITpmVirtualSmartCardManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITpmVirtualSmartCardManager3> for ITpmVirtualSmartCardManager {
-    fn from(value: &ITpmVirtualSmartCardManager3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITpmVirtualSmartCardManager3> for ITpmVirtualSmartCardManager2 {
-    fn from(value: ITpmVirtualSmartCardManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITpmVirtualSmartCardManager3> for &'a ITpmVirtualSmartCardManager2 {
-    fn from(value: &'a ITpmVirtualSmartCardManager3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITpmVirtualSmartCardManager3> for ITpmVirtualSmartCardManager2 {
-    fn from(value: &ITpmVirtualSmartCardManager3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITpmVirtualSmartCardManager3, ::windows::core::IUnknown, ITpmVirtualSmartCardManager, ITpmVirtualSmartCardManager2);
 impl ::core::clone::Clone for ITpmVirtualSmartCardManager3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -359,21 +272,7 @@ impl ITpmVirtualSmartCardManagerStatusCallback {
         (::windows::core::Vtable::vtable(self).ReportError)(::windows::core::Vtable::as_raw(self), error).ok()
     }
 }
-impl ::core::convert::From<ITpmVirtualSmartCardManagerStatusCallback> for ::windows::core::IUnknown {
-    fn from(value: ITpmVirtualSmartCardManagerStatusCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITpmVirtualSmartCardManagerStatusCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITpmVirtualSmartCardManagerStatusCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITpmVirtualSmartCardManagerStatusCallback> for ::windows::core::IUnknown {
-    fn from(value: &ITpmVirtualSmartCardManagerStatusCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITpmVirtualSmartCardManagerStatusCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITpmVirtualSmartCardManagerStatusCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/mod.rs
@@ -10,21 +10,7 @@ impl IDedupBackupSupport {
         (::windows::core::Vtable::vtable(self).RestoreFiles)(::windows::core::Vtable::as_raw(self), numberoffiles, ::core::mem::transmute(filefullpaths), store.into().abi(), flags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::HRESULT>(result__)
     }
 }
-impl ::core::convert::From<IDedupBackupSupport> for ::windows::core::IUnknown {
-    fn from(value: IDedupBackupSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDedupBackupSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDedupBackupSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDedupBackupSupport> for ::windows::core::IUnknown {
-    fn from(value: &IDedupBackupSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDedupBackupSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDedupBackupSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -76,21 +62,7 @@ impl IDedupChunkLibrary {
         (::windows::core::Vtable::vtable(self).StartChunking)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(iiditeratorinterfaceid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IDedupChunkLibrary> for ::windows::core::IUnknown {
-    fn from(value: IDedupChunkLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDedupChunkLibrary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDedupChunkLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDedupChunkLibrary> for ::windows::core::IUnknown {
-    fn from(value: &IDedupChunkLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDedupChunkLibrary, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDedupChunkLibrary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -184,21 +156,7 @@ impl IDedupDataPort {
         (::windows::core::Vtable::vtable(self).GetRequestResults)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(requestid), maxwaitms, ::core::mem::transmute(pbatchresult), ::core::mem::transmute(pbatchcount), ::core::mem::transmute(pstatus), ::core::mem::transmute(ppitemresults)).ok()
     }
 }
-impl ::core::convert::From<IDedupDataPort> for ::windows::core::IUnknown {
-    fn from(value: IDedupDataPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDedupDataPort> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDedupDataPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDedupDataPort> for ::windows::core::IUnknown {
-    fn from(value: &IDedupDataPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDedupDataPort, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDedupDataPort {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -260,21 +218,7 @@ impl IDedupDataPortManager {
         (::windows::core::Vtable::vtable(self).GetVolumeDataPort)(::windows::core::Vtable::as_raw(self), options, ::core::mem::transmute_copy(path), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDedupDataPort>(result__)
     }
 }
-impl ::core::convert::From<IDedupDataPortManager> for ::windows::core::IUnknown {
-    fn from(value: IDedupDataPortManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDedupDataPortManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDedupDataPortManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDedupDataPortManager> for ::windows::core::IUnknown {
-    fn from(value: &IDedupDataPortManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDedupDataPortManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDedupDataPortManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -322,21 +266,7 @@ impl IDedupIterateChunksHash32 {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDedupIterateChunksHash32> for ::windows::core::IUnknown {
-    fn from(value: IDedupIterateChunksHash32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDedupIterateChunksHash32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDedupIterateChunksHash32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDedupIterateChunksHash32> for ::windows::core::IUnknown {
-    fn from(value: &IDedupIterateChunksHash32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDedupIterateChunksHash32, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDedupIterateChunksHash32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -382,21 +312,7 @@ impl IDedupReadFileCallback {
         (::windows::core::Vtable::vtable(self).PreviewContainerRead)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(filefullpath), readoffsets.len() as _, ::core::mem::transmute(readoffsets.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IDedupReadFileCallback> for ::windows::core::IUnknown {
-    fn from(value: IDedupReadFileCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDedupReadFileCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDedupReadFileCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDedupReadFileCallback> for ::windows::core::IUnknown {
-    fn from(value: &IDedupReadFileCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDedupReadFileCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDedupReadFileCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/mod.rs
@@ -24,21 +24,7 @@ impl IEnhancedStorageACT {
         (::windows::core::Vtable::vtable(self).GetSilos)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pppienhancedstoragesilos), ::core::mem::transmute(pcenhancedstoragesilos)).ok()
     }
 }
-impl ::core::convert::From<IEnhancedStorageACT> for ::windows::core::IUnknown {
-    fn from(value: IEnhancedStorageACT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnhancedStorageACT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnhancedStorageACT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnhancedStorageACT> for ::windows::core::IUnknown {
-    fn from(value: &IEnhancedStorageACT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnhancedStorageACT, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnhancedStorageACT {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -108,36 +94,7 @@ impl IEnhancedStorageACT2 {
         (::windows::core::Vtable::vtable(self).IsDeviceRemovable)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IEnhancedStorageACT2> for ::windows::core::IUnknown {
-    fn from(value: IEnhancedStorageACT2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnhancedStorageACT2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnhancedStorageACT2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnhancedStorageACT2> for ::windows::core::IUnknown {
-    fn from(value: &IEnhancedStorageACT2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEnhancedStorageACT2> for IEnhancedStorageACT {
-    fn from(value: IEnhancedStorageACT2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnhancedStorageACT2> for &'a IEnhancedStorageACT {
-    fn from(value: &'a IEnhancedStorageACT2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnhancedStorageACT2> for IEnhancedStorageACT {
-    fn from(value: &IEnhancedStorageACT2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnhancedStorageACT2, ::windows::core::IUnknown, IEnhancedStorageACT);
 impl ::core::clone::Clone for IEnhancedStorageACT2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -221,51 +178,7 @@ impl IEnhancedStorageACT3 {
         (::windows::core::Vtable::vtable(self).GetShellExtSupport)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IEnhancedStorageACT3> for ::windows::core::IUnknown {
-    fn from(value: IEnhancedStorageACT3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnhancedStorageACT3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnhancedStorageACT3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnhancedStorageACT3> for ::windows::core::IUnknown {
-    fn from(value: &IEnhancedStorageACT3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEnhancedStorageACT3> for IEnhancedStorageACT {
-    fn from(value: IEnhancedStorageACT3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnhancedStorageACT3> for &'a IEnhancedStorageACT {
-    fn from(value: &'a IEnhancedStorageACT3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnhancedStorageACT3> for IEnhancedStorageACT {
-    fn from(value: &IEnhancedStorageACT3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEnhancedStorageACT3> for IEnhancedStorageACT2 {
-    fn from(value: IEnhancedStorageACT3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnhancedStorageACT3> for &'a IEnhancedStorageACT2 {
-    fn from(value: &'a IEnhancedStorageACT3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnhancedStorageACT3> for IEnhancedStorageACT2 {
-    fn from(value: &IEnhancedStorageACT3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnhancedStorageACT3, ::windows::core::IUnknown, IEnhancedStorageACT, IEnhancedStorageACT2);
 impl ::core::clone::Clone for IEnhancedStorageACT3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -327,21 +240,7 @@ impl IEnhancedStorageSilo {
         (::windows::core::Vtable::vtable(self).GetDevicePath)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IEnhancedStorageSilo> for ::windows::core::IUnknown {
-    fn from(value: IEnhancedStorageSilo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnhancedStorageSilo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnhancedStorageSilo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnhancedStorageSilo> for ::windows::core::IUnknown {
-    fn from(value: &IEnhancedStorageSilo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnhancedStorageSilo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnhancedStorageSilo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -393,21 +292,7 @@ impl IEnhancedStorageSiloAction {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IEnhancedStorageSiloAction> for ::windows::core::IUnknown {
-    fn from(value: IEnhancedStorageSiloAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnhancedStorageSiloAction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnhancedStorageSiloAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnhancedStorageSiloAction> for ::windows::core::IUnknown {
-    fn from(value: &IEnhancedStorageSiloAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnhancedStorageSiloAction, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnhancedStorageSiloAction {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -453,21 +338,7 @@ impl IEnumEnhancedStorageACT {
         (::windows::core::Vtable::vtable(self).GetMatchingACT)(::windows::core::Vtable::as_raw(self), szvolume.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnhancedStorageACT>(result__)
     }
 }
-impl ::core::convert::From<IEnumEnhancedStorageACT> for ::windows::core::IUnknown {
-    fn from(value: IEnumEnhancedStorageACT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumEnhancedStorageACT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumEnhancedStorageACT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumEnhancedStorageACT> for ::windows::core::IUnknown {
-    fn from(value: &IEnumEnhancedStorageACT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumEnhancedStorageACT, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumEnhancedStorageACT {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/mod.rs
@@ -164,21 +164,7 @@ impl IFhConfigMgr {
         (::windows::core::Vtable::vtable(self).QueryProtectionStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(protectionstate), ::core::mem::transmute(protecteduntiltime)).ok()
     }
 }
-impl ::core::convert::From<IFhConfigMgr> for ::windows::core::IUnknown {
-    fn from(value: IFhConfigMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFhConfigMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFhConfigMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFhConfigMgr> for ::windows::core::IUnknown {
-    fn from(value: &IFhConfigMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFhConfigMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFhConfigMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -260,21 +246,7 @@ impl IFhReassociation {
         (::windows::core::Vtable::vtable(self).PerformReassociation)(::windows::core::Vtable::as_raw(self), overwriteifexists.into()).ok()
     }
 }
-impl ::core::convert::From<IFhReassociation> for ::windows::core::IUnknown {
-    fn from(value: IFhReassociation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFhReassociation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFhReassociation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFhReassociation> for ::windows::core::IUnknown {
-    fn from(value: &IFhReassociation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFhReassociation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFhReassociation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -325,21 +297,7 @@ impl IFhScopeIterator {
         (::windows::core::Vtable::vtable(self).GetItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IFhScopeIterator> for ::windows::core::IUnknown {
-    fn from(value: IFhScopeIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFhScopeIterator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFhScopeIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFhScopeIterator> for ::windows::core::IUnknown {
-    fn from(value: &IFhScopeIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFhScopeIterator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFhScopeIterator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -382,21 +340,7 @@ impl IFhTarget {
         (::windows::core::Vtable::vtable(self).GetNumericalProperty)(::windows::core::Vtable::as_raw(self), propertytype, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IFhTarget> for ::windows::core::IUnknown {
-    fn from(value: IFhTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFhTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFhTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFhTarget> for ::windows::core::IUnknown {
-    fn from(value: &IFhTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFhTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFhTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileServerResourceManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileServerResourceManager/mod.rs
@@ -5,41 +5,7 @@ pub struct DIFsrmClassificationEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DIFsrmClassificationEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DIFsrmClassificationEvents> for ::windows::core::IUnknown {
-    fn from(value: DIFsrmClassificationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DIFsrmClassificationEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DIFsrmClassificationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DIFsrmClassificationEvents> for ::windows::core::IUnknown {
-    fn from(value: &DIFsrmClassificationEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DIFsrmClassificationEvents> for super::super::System::Com::IDispatch {
-    fn from(value: DIFsrmClassificationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DIFsrmClassificationEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DIFsrmClassificationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DIFsrmClassificationEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &DIFsrmClassificationEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DIFsrmClassificationEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DIFsrmClassificationEvents {
     fn clone(&self) -> Self {
@@ -86,41 +52,7 @@ impl IFsrmAccessDeniedRemediationClient {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmAccessDeniedRemediationClient> for ::windows::core::IUnknown {
-    fn from(value: IFsrmAccessDeniedRemediationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmAccessDeniedRemediationClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmAccessDeniedRemediationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmAccessDeniedRemediationClient> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmAccessDeniedRemediationClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmAccessDeniedRemediationClient> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmAccessDeniedRemediationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmAccessDeniedRemediationClient> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmAccessDeniedRemediationClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmAccessDeniedRemediationClient> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmAccessDeniedRemediationClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmAccessDeniedRemediationClient, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmAccessDeniedRemediationClient {
     fn clone(&self) -> Self {
@@ -182,41 +114,7 @@ impl IFsrmAction {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmAction> for ::windows::core::IUnknown {
-    fn from(value: IFsrmAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmAction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmAction> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmAction> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmAction> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmAction> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmAction, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmAction {
     fn clone(&self) -> Self {
@@ -331,59 +229,7 @@ impl IFsrmActionCommand {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionCommand> for ::windows::core::IUnknown {
-    fn from(value: IFsrmActionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionCommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmActionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionCommand> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmActionCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionCommand> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmActionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionCommand> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmActionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionCommand> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmActionCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionCommand> for IFsrmAction {
-    fn from(value: IFsrmActionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionCommand> for &'a IFsrmAction {
-    fn from(value: &'a IFsrmActionCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionCommand> for IFsrmAction {
-    fn from(value: &IFsrmActionCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmActionCommand, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmAction);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmActionCommand {
     fn clone(&self) -> Self {
@@ -507,59 +353,7 @@ impl IFsrmActionEmail {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionEmail> for ::windows::core::IUnknown {
-    fn from(value: IFsrmActionEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionEmail> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmActionEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionEmail> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmActionEmail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionEmail> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmActionEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionEmail> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmActionEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionEmail> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmActionEmail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionEmail> for IFsrmAction {
-    fn from(value: IFsrmActionEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionEmail> for &'a IFsrmAction {
-    fn from(value: &'a IFsrmActionEmail) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionEmail> for IFsrmAction {
-    fn from(value: &IFsrmActionEmail) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmActionEmail, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmAction);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmActionEmail {
     fn clone(&self) -> Self {
@@ -690,77 +484,7 @@ impl IFsrmActionEmail2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionEmail2> for ::windows::core::IUnknown {
-    fn from(value: IFsrmActionEmail2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionEmail2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmActionEmail2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionEmail2> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmActionEmail2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionEmail2> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmActionEmail2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionEmail2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmActionEmail2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionEmail2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmActionEmail2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionEmail2> for IFsrmAction {
-    fn from(value: IFsrmActionEmail2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionEmail2> for &'a IFsrmAction {
-    fn from(value: &'a IFsrmActionEmail2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionEmail2> for IFsrmAction {
-    fn from(value: &IFsrmActionEmail2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionEmail2> for IFsrmActionEmail {
-    fn from(value: IFsrmActionEmail2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionEmail2> for &'a IFsrmActionEmail {
-    fn from(value: &'a IFsrmActionEmail2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionEmail2> for IFsrmActionEmail {
-    fn from(value: &IFsrmActionEmail2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmActionEmail2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmAction, IFsrmActionEmail);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmActionEmail2 {
     fn clone(&self) -> Self {
@@ -837,59 +561,7 @@ impl IFsrmActionEventLog {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionEventLog> for ::windows::core::IUnknown {
-    fn from(value: IFsrmActionEventLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionEventLog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmActionEventLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionEventLog> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmActionEventLog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionEventLog> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmActionEventLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionEventLog> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmActionEventLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionEventLog> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmActionEventLog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionEventLog> for IFsrmAction {
-    fn from(value: IFsrmActionEventLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionEventLog> for &'a IFsrmAction {
-    fn from(value: &'a IFsrmActionEventLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionEventLog> for IFsrmAction {
-    fn from(value: &IFsrmActionEventLog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmActionEventLog, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmAction);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmActionEventLog {
     fn clone(&self) -> Self {
@@ -972,59 +644,7 @@ impl IFsrmActionReport {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionReport> for ::windows::core::IUnknown {
-    fn from(value: IFsrmActionReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmActionReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionReport> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmActionReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionReport> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmActionReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionReport> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmActionReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionReport> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmActionReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmActionReport> for IFsrmAction {
-    fn from(value: IFsrmActionReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmActionReport> for &'a IFsrmAction {
-    fn from(value: &'a IFsrmActionReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmActionReport> for IFsrmAction {
-    fn from(value: &IFsrmActionReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmActionReport, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmAction);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmActionReport {
     fn clone(&self) -> Self {
@@ -1182,95 +802,7 @@ impl IFsrmAutoApplyQuota {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmAutoApplyQuota> for ::windows::core::IUnknown {
-    fn from(value: IFsrmAutoApplyQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmAutoApplyQuota> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmAutoApplyQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmAutoApplyQuota> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmAutoApplyQuota) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmAutoApplyQuota> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmAutoApplyQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmAutoApplyQuota> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmAutoApplyQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmAutoApplyQuota> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmAutoApplyQuota) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmAutoApplyQuota> for IFsrmObject {
-    fn from(value: IFsrmAutoApplyQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmAutoApplyQuota> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmAutoApplyQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmAutoApplyQuota> for IFsrmObject {
-    fn from(value: &IFsrmAutoApplyQuota) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmAutoApplyQuota> for IFsrmQuotaBase {
-    fn from(value: IFsrmAutoApplyQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmAutoApplyQuota> for &'a IFsrmQuotaBase {
-    fn from(value: &'a IFsrmAutoApplyQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmAutoApplyQuota> for IFsrmQuotaBase {
-    fn from(value: &IFsrmAutoApplyQuota) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmAutoApplyQuota> for IFsrmQuotaObject {
-    fn from(value: IFsrmAutoApplyQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmAutoApplyQuota> for &'a IFsrmQuotaObject {
-    fn from(value: &'a IFsrmAutoApplyQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmAutoApplyQuota> for IFsrmQuotaObject {
-    fn from(value: &IFsrmAutoApplyQuota) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmAutoApplyQuota, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmQuotaBase, IFsrmQuotaObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmAutoApplyQuota {
     fn clone(&self) -> Self {
@@ -1451,41 +983,7 @@ impl IFsrmClassificationManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassificationManager> for ::windows::core::IUnknown {
-    fn from(value: IFsrmClassificationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassificationManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmClassificationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassificationManager> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmClassificationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassificationManager> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmClassificationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassificationManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmClassificationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassificationManager> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmClassificationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmClassificationManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmClassificationManager {
     fn clone(&self) -> Self {
@@ -1725,59 +1223,7 @@ impl IFsrmClassificationManager2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassificationManager2> for ::windows::core::IUnknown {
-    fn from(value: IFsrmClassificationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassificationManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmClassificationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassificationManager2> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmClassificationManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassificationManager2> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmClassificationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassificationManager2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmClassificationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassificationManager2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmClassificationManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassificationManager2> for IFsrmClassificationManager {
-    fn from(value: IFsrmClassificationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassificationManager2> for &'a IFsrmClassificationManager {
-    fn from(value: &'a IFsrmClassificationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassificationManager2> for IFsrmClassificationManager {
-    fn from(value: &IFsrmClassificationManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmClassificationManager2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmClassificationManager);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmClassificationManager2 {
     fn clone(&self) -> Self {
@@ -1915,77 +1361,7 @@ impl IFsrmClassificationRule {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassificationRule> for ::windows::core::IUnknown {
-    fn from(value: IFsrmClassificationRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassificationRule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmClassificationRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassificationRule> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmClassificationRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassificationRule> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmClassificationRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassificationRule> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmClassificationRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassificationRule> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmClassificationRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassificationRule> for IFsrmObject {
-    fn from(value: IFsrmClassificationRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassificationRule> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmClassificationRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassificationRule> for IFsrmObject {
-    fn from(value: &IFsrmClassificationRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassificationRule> for IFsrmRule {
-    fn from(value: IFsrmClassificationRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassificationRule> for &'a IFsrmRule {
-    fn from(value: &'a IFsrmClassificationRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassificationRule> for IFsrmRule {
-    fn from(value: &IFsrmClassificationRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmClassificationRule, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmRule);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmClassificationRule {
     fn clone(&self) -> Self {
@@ -2155,77 +1531,7 @@ impl IFsrmClassifierModuleDefinition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassifierModuleDefinition> for ::windows::core::IUnknown {
-    fn from(value: IFsrmClassifierModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassifierModuleDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmClassifierModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassifierModuleDefinition> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmClassifierModuleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassifierModuleDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmClassifierModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassifierModuleDefinition> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmClassifierModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassifierModuleDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmClassifierModuleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassifierModuleDefinition> for IFsrmObject {
-    fn from(value: IFsrmClassifierModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassifierModuleDefinition> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmClassifierModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassifierModuleDefinition> for IFsrmObject {
-    fn from(value: &IFsrmClassifierModuleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassifierModuleDefinition> for IFsrmPipelineModuleDefinition {
-    fn from(value: IFsrmClassifierModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassifierModuleDefinition> for &'a IFsrmPipelineModuleDefinition {
-    fn from(value: &'a IFsrmClassifierModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassifierModuleDefinition> for IFsrmPipelineModuleDefinition {
-    fn from(value: &IFsrmClassifierModuleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmClassifierModuleDefinition, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmPipelineModuleDefinition);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmClassifierModuleDefinition {
     fn clone(&self) -> Self {
@@ -2330,59 +1636,7 @@ impl IFsrmClassifierModuleImplementation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassifierModuleImplementation> for ::windows::core::IUnknown {
-    fn from(value: IFsrmClassifierModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassifierModuleImplementation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmClassifierModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassifierModuleImplementation> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmClassifierModuleImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassifierModuleImplementation> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmClassifierModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassifierModuleImplementation> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmClassifierModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassifierModuleImplementation> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmClassifierModuleImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmClassifierModuleImplementation> for IFsrmPipelineModuleImplementation {
-    fn from(value: IFsrmClassifierModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmClassifierModuleImplementation> for &'a IFsrmPipelineModuleImplementation {
-    fn from(value: &'a IFsrmClassifierModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmClassifierModuleImplementation> for IFsrmPipelineModuleImplementation {
-    fn from(value: &IFsrmClassifierModuleImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmClassifierModuleImplementation, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmPipelineModuleImplementation);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmClassifierModuleImplementation {
     fn clone(&self) -> Self {
@@ -2471,41 +1725,7 @@ impl IFsrmCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmCollection> for ::windows::core::IUnknown {
-    fn from(value: IFsrmCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmCollection> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmCollection {
     fn clone(&self) -> Self {
@@ -2618,77 +1838,7 @@ impl IFsrmCommittableCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmCommittableCollection> for ::windows::core::IUnknown {
-    fn from(value: IFsrmCommittableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmCommittableCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmCommittableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmCommittableCollection> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmCommittableCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmCommittableCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmCommittableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmCommittableCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmCommittableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmCommittableCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmCommittableCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmCommittableCollection> for IFsrmCollection {
-    fn from(value: IFsrmCommittableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmCommittableCollection> for &'a IFsrmCollection {
-    fn from(value: &'a IFsrmCommittableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmCommittableCollection> for IFsrmCollection {
-    fn from(value: &IFsrmCommittableCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmCommittableCollection> for IFsrmMutableCollection {
-    fn from(value: IFsrmCommittableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmCommittableCollection> for &'a IFsrmMutableCollection {
-    fn from(value: &'a IFsrmCommittableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmCommittableCollection> for IFsrmMutableCollection {
-    fn from(value: &IFsrmCommittableCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmCommittableCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmCollection, IFsrmMutableCollection);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmCommittableCollection {
     fn clone(&self) -> Self {
@@ -2747,41 +1897,7 @@ impl IFsrmDerivedObjectsResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmDerivedObjectsResult> for ::windows::core::IUnknown {
-    fn from(value: IFsrmDerivedObjectsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmDerivedObjectsResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmDerivedObjectsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmDerivedObjectsResult> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmDerivedObjectsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmDerivedObjectsResult> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmDerivedObjectsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmDerivedObjectsResult> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmDerivedObjectsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmDerivedObjectsResult> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmDerivedObjectsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmDerivedObjectsResult, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmDerivedObjectsResult {
     fn clone(&self) -> Self {
@@ -2865,41 +1981,7 @@ impl IFsrmExportImport {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmExportImport> for ::windows::core::IUnknown {
-    fn from(value: IFsrmExportImport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmExportImport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmExportImport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmExportImport> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmExportImport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmExportImport> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmExportImport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmExportImport> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmExportImport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmExportImport> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmExportImport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmExportImport, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmExportImport {
     fn clone(&self) -> Self {
@@ -2973,41 +2055,7 @@ impl IFsrmFileCondition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileCondition> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileCondition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileCondition> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileCondition> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileCondition> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileCondition> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileCondition, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileCondition {
     fn clone(&self) -> Self {
@@ -3101,59 +2149,7 @@ impl IFsrmFileConditionProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileConditionProperty> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileConditionProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileConditionProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileConditionProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileConditionProperty> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileConditionProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileConditionProperty> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileConditionProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileConditionProperty> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileConditionProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileConditionProperty> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileConditionProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileConditionProperty> for IFsrmFileCondition {
-    fn from(value: IFsrmFileConditionProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileConditionProperty> for &'a IFsrmFileCondition {
-    fn from(value: &'a IFsrmFileConditionProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileConditionProperty> for IFsrmFileCondition {
-    fn from(value: &IFsrmFileConditionProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileConditionProperty, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmFileCondition);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileConditionProperty {
     fn clone(&self) -> Self {
@@ -3264,59 +2260,7 @@ impl IFsrmFileGroup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileGroup> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileGroup> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileGroup> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileGroup> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileGroup> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileGroup> for IFsrmObject {
-    fn from(value: IFsrmFileGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileGroup> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmFileGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileGroup> for IFsrmObject {
-    fn from(value: &IFsrmFileGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileGroup, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileGroup {
     fn clone(&self) -> Self {
@@ -3436,77 +2380,7 @@ impl IFsrmFileGroupImported {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileGroupImported> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileGroupImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileGroupImported> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileGroupImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileGroupImported> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileGroupImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileGroupImported> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileGroupImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileGroupImported> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileGroupImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileGroupImported> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileGroupImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileGroupImported> for IFsrmObject {
-    fn from(value: IFsrmFileGroupImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileGroupImported> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmFileGroupImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileGroupImported> for IFsrmObject {
-    fn from(value: &IFsrmFileGroupImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileGroupImported> for IFsrmFileGroup {
-    fn from(value: IFsrmFileGroupImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileGroupImported> for &'a IFsrmFileGroup {
-    fn from(value: &'a IFsrmFileGroupImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileGroupImported> for IFsrmFileGroup {
-    fn from(value: &IFsrmFileGroupImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileGroupImported, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmFileGroup);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileGroupImported {
     fn clone(&self) -> Self {
@@ -3581,41 +2455,7 @@ impl IFsrmFileGroupManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileGroupManager> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileGroupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileGroupManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileGroupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileGroupManager> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileGroupManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileGroupManager> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileGroupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileGroupManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileGroupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileGroupManager> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileGroupManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileGroupManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileGroupManager {
     fn clone(&self) -> Self {
@@ -3896,59 +2736,7 @@ impl IFsrmFileManagementJob {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileManagementJob> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileManagementJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileManagementJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileManagementJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileManagementJob> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileManagementJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileManagementJob> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileManagementJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileManagementJob> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileManagementJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileManagementJob> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileManagementJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileManagementJob> for IFsrmObject {
-    fn from(value: IFsrmFileManagementJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileManagementJob> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmFileManagementJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileManagementJob> for IFsrmObject {
-    fn from(value: &IFsrmFileManagementJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileManagementJob, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileManagementJob {
     fn clone(&self) -> Self {
@@ -4109,41 +2897,7 @@ impl IFsrmFileManagementJobManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileManagementJobManager> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileManagementJobManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileManagementJobManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileManagementJobManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileManagementJobManager> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileManagementJobManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileManagementJobManager> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileManagementJobManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileManagementJobManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileManagementJobManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileManagementJobManager> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileManagementJobManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileManagementJobManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileManagementJobManager {
     fn clone(&self) -> Self {
@@ -4279,77 +3033,7 @@ impl IFsrmFileScreen {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreen> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreen> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreen> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileScreen) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreen> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreen> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreen> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileScreen) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreen> for IFsrmObject {
-    fn from(value: IFsrmFileScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreen> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmFileScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreen> for IFsrmObject {
-    fn from(value: &IFsrmFileScreen) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreen> for IFsrmFileScreenBase {
-    fn from(value: IFsrmFileScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreen> for &'a IFsrmFileScreenBase {
-    fn from(value: &'a IFsrmFileScreen) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreen> for IFsrmFileScreenBase {
-    fn from(value: &IFsrmFileScreen) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileScreen, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmFileScreenBase);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileScreen {
     fn clone(&self) -> Self {
@@ -4448,59 +3132,7 @@ impl IFsrmFileScreenBase {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenBase> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileScreenBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileScreenBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenBase> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileScreenBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenBase> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileScreenBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenBase> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileScreenBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenBase> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileScreenBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenBase> for IFsrmObject {
-    fn from(value: IFsrmFileScreenBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenBase> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmFileScreenBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenBase> for IFsrmObject {
-    fn from(value: &IFsrmFileScreenBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileScreenBase, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileScreenBase {
     fn clone(&self) -> Self {
@@ -4596,59 +3228,7 @@ impl IFsrmFileScreenException {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenException> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileScreenException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenException> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileScreenException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenException> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileScreenException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenException> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileScreenException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenException> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileScreenException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenException> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileScreenException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenException> for IFsrmObject {
-    fn from(value: IFsrmFileScreenException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenException> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmFileScreenException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenException> for IFsrmObject {
-    fn from(value: &IFsrmFileScreenException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileScreenException, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileScreenException {
     fn clone(&self) -> Self {
@@ -4754,41 +3334,7 @@ impl IFsrmFileScreenManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenManager> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileScreenManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileScreenManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenManager> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileScreenManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenManager> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileScreenManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileScreenManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenManager> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileScreenManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileScreenManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileScreenManager {
     fn clone(&self) -> Self {
@@ -4933,77 +3479,7 @@ impl IFsrmFileScreenTemplate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenTemplate> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileScreenTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenTemplate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileScreenTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenTemplate> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileScreenTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenTemplate> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileScreenTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenTemplate> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileScreenTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenTemplate> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileScreenTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenTemplate> for IFsrmObject {
-    fn from(value: IFsrmFileScreenTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenTemplate> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmFileScreenTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenTemplate> for IFsrmObject {
-    fn from(value: &IFsrmFileScreenTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenTemplate> for IFsrmFileScreenBase {
-    fn from(value: IFsrmFileScreenTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenTemplate> for &'a IFsrmFileScreenBase {
-    fn from(value: &'a IFsrmFileScreenTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenTemplate> for IFsrmFileScreenBase {
-    fn from(value: &IFsrmFileScreenTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileScreenTemplate, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmFileScreenBase);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileScreenTemplate {
     fn clone(&self) -> Self {
@@ -5126,95 +3602,7 @@ impl IFsrmFileScreenTemplateImported {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenTemplateImported> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileScreenTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenTemplateImported> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileScreenTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenTemplateImported> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileScreenTemplateImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenTemplateImported> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileScreenTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenTemplateImported> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileScreenTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenTemplateImported> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileScreenTemplateImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenTemplateImported> for IFsrmObject {
-    fn from(value: IFsrmFileScreenTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenTemplateImported> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmFileScreenTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenTemplateImported> for IFsrmObject {
-    fn from(value: &IFsrmFileScreenTemplateImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenTemplateImported> for IFsrmFileScreenBase {
-    fn from(value: IFsrmFileScreenTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenTemplateImported> for &'a IFsrmFileScreenBase {
-    fn from(value: &'a IFsrmFileScreenTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenTemplateImported> for IFsrmFileScreenBase {
-    fn from(value: &IFsrmFileScreenTemplateImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenTemplateImported> for IFsrmFileScreenTemplate {
-    fn from(value: IFsrmFileScreenTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenTemplateImported> for &'a IFsrmFileScreenTemplate {
-    fn from(value: &'a IFsrmFileScreenTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenTemplateImported> for IFsrmFileScreenTemplate {
-    fn from(value: &IFsrmFileScreenTemplateImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileScreenTemplateImported, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmFileScreenBase, IFsrmFileScreenTemplate);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileScreenTemplateImported {
     fn clone(&self) -> Self {
@@ -5289,41 +3677,7 @@ impl IFsrmFileScreenTemplateManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenTemplateManager> for ::windows::core::IUnknown {
-    fn from(value: IFsrmFileScreenTemplateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenTemplateManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmFileScreenTemplateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenTemplateManager> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmFileScreenTemplateManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmFileScreenTemplateManager> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmFileScreenTemplateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmFileScreenTemplateManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmFileScreenTemplateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmFileScreenTemplateManager> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmFileScreenTemplateManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmFileScreenTemplateManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmFileScreenTemplateManager {
     fn clone(&self) -> Self {
@@ -5437,59 +3791,7 @@ impl IFsrmMutableCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmMutableCollection> for ::windows::core::IUnknown {
-    fn from(value: IFsrmMutableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmMutableCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmMutableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmMutableCollection> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmMutableCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmMutableCollection> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmMutableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmMutableCollection> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmMutableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmMutableCollection> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmMutableCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmMutableCollection> for IFsrmCollection {
-    fn from(value: IFsrmMutableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmMutableCollection> for &'a IFsrmCollection {
-    fn from(value: &'a IFsrmMutableCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmMutableCollection> for IFsrmCollection {
-    fn from(value: &IFsrmMutableCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmMutableCollection, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmCollection);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmMutableCollection {
     fn clone(&self) -> Self {
@@ -5559,41 +3861,7 @@ impl IFsrmObject {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmObject> for ::windows::core::IUnknown {
-    fn from(value: IFsrmObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmObject> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmObject> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmObject> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmObject> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmObject, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmObject {
     fn clone(&self) -> Self {
@@ -5647,41 +3915,7 @@ impl IFsrmPathMapper {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPathMapper> for ::windows::core::IUnknown {
-    fn from(value: IFsrmPathMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPathMapper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmPathMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPathMapper> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmPathMapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPathMapper> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmPathMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPathMapper> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmPathMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPathMapper> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmPathMapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmPathMapper, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmPathMapper {
     fn clone(&self) -> Self {
@@ -5755,41 +3989,7 @@ impl IFsrmPipelineModuleConnector {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPipelineModuleConnector> for ::windows::core::IUnknown {
-    fn from(value: IFsrmPipelineModuleConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPipelineModuleConnector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmPipelineModuleConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPipelineModuleConnector> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmPipelineModuleConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPipelineModuleConnector> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmPipelineModuleConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPipelineModuleConnector> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmPipelineModuleConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPipelineModuleConnector> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmPipelineModuleConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmPipelineModuleConnector, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmPipelineModuleConnector {
     fn clone(&self) -> Self {
@@ -5935,59 +4135,7 @@ impl IFsrmPipelineModuleDefinition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPipelineModuleDefinition> for ::windows::core::IUnknown {
-    fn from(value: IFsrmPipelineModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPipelineModuleDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmPipelineModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPipelineModuleDefinition> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmPipelineModuleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPipelineModuleDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmPipelineModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPipelineModuleDefinition> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmPipelineModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPipelineModuleDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmPipelineModuleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPipelineModuleDefinition> for IFsrmObject {
-    fn from(value: IFsrmPipelineModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPipelineModuleDefinition> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmPipelineModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPipelineModuleDefinition> for IFsrmObject {
-    fn from(value: &IFsrmPipelineModuleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmPipelineModuleDefinition, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmPipelineModuleDefinition {
     fn clone(&self) -> Self {
@@ -6073,41 +4221,7 @@ impl IFsrmPipelineModuleImplementation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPipelineModuleImplementation> for ::windows::core::IUnknown {
-    fn from(value: IFsrmPipelineModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPipelineModuleImplementation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmPipelineModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPipelineModuleImplementation> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmPipelineModuleImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPipelineModuleImplementation> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmPipelineModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPipelineModuleImplementation> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmPipelineModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPipelineModuleImplementation> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmPipelineModuleImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmPipelineModuleImplementation, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmPipelineModuleImplementation {
     fn clone(&self) -> Self {
@@ -6173,41 +4287,7 @@ impl IFsrmProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmProperty> for ::windows::core::IUnknown {
-    fn from(value: IFsrmProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmProperty> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmProperty> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmProperty> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmProperty> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmProperty, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmProperty {
     fn clone(&self) -> Self {
@@ -6361,41 +4441,7 @@ impl IFsrmPropertyBag {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyBag> for ::windows::core::IUnknown {
-    fn from(value: IFsrmPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyBag> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyBag> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmPropertyBag) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyBag> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyBag> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyBag> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmPropertyBag) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmPropertyBag, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmPropertyBag {
     fn clone(&self) -> Self {
@@ -6608,59 +4654,7 @@ impl IFsrmPropertyBag2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyBag2> for ::windows::core::IUnknown {
-    fn from(value: IFsrmPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyBag2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyBag2> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmPropertyBag2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyBag2> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyBag2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyBag2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmPropertyBag2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyBag2> for IFsrmPropertyBag {
-    fn from(value: IFsrmPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyBag2> for &'a IFsrmPropertyBag {
-    fn from(value: &'a IFsrmPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyBag2> for IFsrmPropertyBag {
-    fn from(value: &IFsrmPropertyBag2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmPropertyBag2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmPropertyBag);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmPropertyBag2 {
     fn clone(&self) -> Self {
@@ -6735,41 +4729,7 @@ impl IFsrmPropertyCondition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyCondition> for ::windows::core::IUnknown {
-    fn from(value: IFsrmPropertyCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyCondition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmPropertyCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyCondition> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmPropertyCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyCondition> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmPropertyCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyCondition> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmPropertyCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyCondition> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmPropertyCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmPropertyCondition, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmPropertyCondition {
     fn clone(&self) -> Self {
@@ -6883,59 +4843,7 @@ impl IFsrmPropertyDefinition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyDefinition> for ::windows::core::IUnknown {
-    fn from(value: IFsrmPropertyDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmPropertyDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyDefinition> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmPropertyDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmPropertyDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyDefinition> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmPropertyDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmPropertyDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyDefinition> for IFsrmObject {
-    fn from(value: IFsrmPropertyDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyDefinition> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmPropertyDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyDefinition> for IFsrmObject {
-    fn from(value: &IFsrmPropertyDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmPropertyDefinition, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmPropertyDefinition {
     fn clone(&self) -> Self {
@@ -7091,77 +4999,7 @@ impl IFsrmPropertyDefinition2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyDefinition2> for ::windows::core::IUnknown {
-    fn from(value: IFsrmPropertyDefinition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyDefinition2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmPropertyDefinition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyDefinition2> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmPropertyDefinition2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyDefinition2> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmPropertyDefinition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyDefinition2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmPropertyDefinition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyDefinition2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmPropertyDefinition2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyDefinition2> for IFsrmObject {
-    fn from(value: IFsrmPropertyDefinition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyDefinition2> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmPropertyDefinition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyDefinition2> for IFsrmObject {
-    fn from(value: &IFsrmPropertyDefinition2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyDefinition2> for IFsrmPropertyDefinition {
-    fn from(value: IFsrmPropertyDefinition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyDefinition2> for &'a IFsrmPropertyDefinition {
-    fn from(value: &'a IFsrmPropertyDefinition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyDefinition2> for IFsrmPropertyDefinition {
-    fn from(value: &IFsrmPropertyDefinition2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmPropertyDefinition2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmPropertyDefinition);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmPropertyDefinition2 {
     fn clone(&self) -> Self {
@@ -7228,41 +5066,7 @@ impl IFsrmPropertyDefinitionValue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyDefinitionValue> for ::windows::core::IUnknown {
-    fn from(value: IFsrmPropertyDefinitionValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyDefinitionValue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmPropertyDefinitionValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyDefinitionValue> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmPropertyDefinitionValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmPropertyDefinitionValue> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmPropertyDefinitionValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmPropertyDefinitionValue> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmPropertyDefinitionValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmPropertyDefinitionValue> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmPropertyDefinitionValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmPropertyDefinitionValue, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmPropertyDefinitionValue {
     fn clone(&self) -> Self {
@@ -7419,95 +5223,7 @@ impl IFsrmQuota {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuota> for ::windows::core::IUnknown {
-    fn from(value: IFsrmQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuota> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuota> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmQuota) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuota> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuota> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuota> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmQuota) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuota> for IFsrmObject {
-    fn from(value: IFsrmQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuota> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuota> for IFsrmObject {
-    fn from(value: &IFsrmQuota) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuota> for IFsrmQuotaBase {
-    fn from(value: IFsrmQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuota> for &'a IFsrmQuotaBase {
-    fn from(value: &'a IFsrmQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuota> for IFsrmQuotaBase {
-    fn from(value: &IFsrmQuota) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuota> for IFsrmQuotaObject {
-    fn from(value: IFsrmQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuota> for &'a IFsrmQuotaObject {
-    fn from(value: &'a IFsrmQuota) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuota> for IFsrmQuotaObject {
-    fn from(value: &IFsrmQuota) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmQuota, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmQuotaBase, IFsrmQuotaObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmQuota {
     fn clone(&self) -> Self {
@@ -7626,59 +5342,7 @@ impl IFsrmQuotaBase {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaBase> for ::windows::core::IUnknown {
-    fn from(value: IFsrmQuotaBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmQuotaBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaBase> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmQuotaBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaBase> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmQuotaBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaBase> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmQuotaBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaBase> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmQuotaBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaBase> for IFsrmObject {
-    fn from(value: IFsrmQuotaBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaBase> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmQuotaBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaBase> for IFsrmObject {
-    fn from(value: &IFsrmQuotaBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmQuotaBase, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmQuotaBase {
     fn clone(&self) -> Self {
@@ -7815,41 +5479,7 @@ impl IFsrmQuotaManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaManager> for ::windows::core::IUnknown {
-    fn from(value: IFsrmQuotaManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmQuotaManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaManager> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmQuotaManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaManager> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmQuotaManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmQuotaManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaManager> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmQuotaManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmQuotaManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmQuotaManager {
     fn clone(&self) -> Self {
@@ -8010,59 +5640,7 @@ impl IFsrmQuotaManagerEx {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaManagerEx> for ::windows::core::IUnknown {
-    fn from(value: IFsrmQuotaManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaManagerEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmQuotaManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaManagerEx> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmQuotaManagerEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaManagerEx> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmQuotaManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaManagerEx> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmQuotaManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaManagerEx> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmQuotaManagerEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaManagerEx> for IFsrmQuotaManager {
-    fn from(value: IFsrmQuotaManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaManagerEx> for &'a IFsrmQuotaManager {
-    fn from(value: &'a IFsrmQuotaManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaManagerEx> for IFsrmQuotaManager {
-    fn from(value: &IFsrmQuotaManagerEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmQuotaManagerEx, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmQuotaManager);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmQuotaManagerEx {
     fn clone(&self) -> Self {
@@ -8194,77 +5772,7 @@ impl IFsrmQuotaObject {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaObject> for ::windows::core::IUnknown {
-    fn from(value: IFsrmQuotaObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmQuotaObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaObject> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmQuotaObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaObject> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmQuotaObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaObject> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmQuotaObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaObject> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmQuotaObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaObject> for IFsrmObject {
-    fn from(value: IFsrmQuotaObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaObject> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmQuotaObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaObject> for IFsrmObject {
-    fn from(value: &IFsrmQuotaObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaObject> for IFsrmQuotaBase {
-    fn from(value: IFsrmQuotaObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaObject> for &'a IFsrmQuotaBase {
-    fn from(value: &'a IFsrmQuotaObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaObject> for IFsrmQuotaBase {
-    fn from(value: &IFsrmQuotaObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmQuotaObject, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmQuotaBase);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmQuotaObject {
     fn clone(&self) -> Self {
@@ -8394,77 +5902,7 @@ impl IFsrmQuotaTemplate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaTemplate> for ::windows::core::IUnknown {
-    fn from(value: IFsrmQuotaTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaTemplate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmQuotaTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaTemplate> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmQuotaTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaTemplate> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmQuotaTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaTemplate> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmQuotaTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaTemplate> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmQuotaTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaTemplate> for IFsrmObject {
-    fn from(value: IFsrmQuotaTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaTemplate> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmQuotaTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaTemplate> for IFsrmObject {
-    fn from(value: &IFsrmQuotaTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaTemplate> for IFsrmQuotaBase {
-    fn from(value: IFsrmQuotaTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaTemplate> for &'a IFsrmQuotaBase {
-    fn from(value: &'a IFsrmQuotaTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaTemplate> for IFsrmQuotaBase {
-    fn from(value: &IFsrmQuotaTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmQuotaTemplate, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmQuotaBase);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmQuotaTemplate {
     fn clone(&self) -> Self {
@@ -8602,95 +6040,7 @@ impl IFsrmQuotaTemplateImported {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaTemplateImported> for ::windows::core::IUnknown {
-    fn from(value: IFsrmQuotaTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaTemplateImported> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmQuotaTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaTemplateImported> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmQuotaTemplateImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaTemplateImported> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmQuotaTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaTemplateImported> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmQuotaTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaTemplateImported> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmQuotaTemplateImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaTemplateImported> for IFsrmObject {
-    fn from(value: IFsrmQuotaTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaTemplateImported> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmQuotaTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaTemplateImported> for IFsrmObject {
-    fn from(value: &IFsrmQuotaTemplateImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaTemplateImported> for IFsrmQuotaBase {
-    fn from(value: IFsrmQuotaTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaTemplateImported> for &'a IFsrmQuotaBase {
-    fn from(value: &'a IFsrmQuotaTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaTemplateImported> for IFsrmQuotaBase {
-    fn from(value: &IFsrmQuotaTemplateImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaTemplateImported> for IFsrmQuotaTemplate {
-    fn from(value: IFsrmQuotaTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaTemplateImported> for &'a IFsrmQuotaTemplate {
-    fn from(value: &'a IFsrmQuotaTemplateImported) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaTemplateImported> for IFsrmQuotaTemplate {
-    fn from(value: &IFsrmQuotaTemplateImported) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmQuotaTemplateImported, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmQuotaBase, IFsrmQuotaTemplate);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmQuotaTemplateImported {
     fn clone(&self) -> Self {
@@ -8765,41 +6115,7 @@ impl IFsrmQuotaTemplateManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaTemplateManager> for ::windows::core::IUnknown {
-    fn from(value: IFsrmQuotaTemplateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaTemplateManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmQuotaTemplateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaTemplateManager> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmQuotaTemplateManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmQuotaTemplateManager> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmQuotaTemplateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmQuotaTemplateManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmQuotaTemplateManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmQuotaTemplateManager> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmQuotaTemplateManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmQuotaTemplateManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmQuotaTemplateManager {
     fn clone(&self) -> Self {
@@ -8901,41 +6217,7 @@ impl IFsrmReport {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmReport> for ::windows::core::IUnknown {
-    fn from(value: IFsrmReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmReport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmReport> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmReport> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmReport> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmReport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmReport> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmReport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmReport, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmReport {
     fn clone(&self) -> Self {
@@ -9084,59 +6366,7 @@ impl IFsrmReportJob {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmReportJob> for ::windows::core::IUnknown {
-    fn from(value: IFsrmReportJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmReportJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmReportJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmReportJob> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmReportJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmReportJob> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmReportJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmReportJob> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmReportJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmReportJob> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmReportJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmReportJob> for IFsrmObject {
-    fn from(value: IFsrmReportJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmReportJob> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmReportJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmReportJob> for IFsrmObject {
-    fn from(value: &IFsrmReportJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmReportJob, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmReportJob {
     fn clone(&self) -> Self {
@@ -9271,41 +6501,7 @@ impl IFsrmReportManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmReportManager> for ::windows::core::IUnknown {
-    fn from(value: IFsrmReportManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmReportManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmReportManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmReportManager> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmReportManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmReportManager> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmReportManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmReportManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmReportManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmReportManager> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmReportManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmReportManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmReportManager {
     fn clone(&self) -> Self {
@@ -9397,41 +6593,7 @@ impl IFsrmReportScheduler {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmReportScheduler> for ::windows::core::IUnknown {
-    fn from(value: IFsrmReportScheduler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmReportScheduler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmReportScheduler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmReportScheduler> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmReportScheduler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmReportScheduler> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmReportScheduler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmReportScheduler> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmReportScheduler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmReportScheduler> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmReportScheduler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmReportScheduler, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmReportScheduler {
     fn clone(&self) -> Self {
@@ -9557,59 +6719,7 @@ impl IFsrmRule {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmRule> for ::windows::core::IUnknown {
-    fn from(value: IFsrmRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmRule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmRule> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmRule> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmRule> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmRule> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmRule> for IFsrmObject {
-    fn from(value: IFsrmRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmRule> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmRule> for IFsrmObject {
-    fn from(value: &IFsrmRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmRule, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmRule {
     fn clone(&self) -> Self {
@@ -9724,41 +6834,7 @@ impl IFsrmSetting {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmSetting> for ::windows::core::IUnknown {
-    fn from(value: IFsrmSetting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmSetting> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmSetting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmSetting> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmSetting) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmSetting> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmSetting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmSetting> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmSetting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmSetting> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmSetting) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmSetting, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmSetting {
     fn clone(&self) -> Self {
@@ -9927,77 +7003,7 @@ impl IFsrmStorageModuleDefinition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmStorageModuleDefinition> for ::windows::core::IUnknown {
-    fn from(value: IFsrmStorageModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmStorageModuleDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmStorageModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmStorageModuleDefinition> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmStorageModuleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmStorageModuleDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmStorageModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmStorageModuleDefinition> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmStorageModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmStorageModuleDefinition> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmStorageModuleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmStorageModuleDefinition> for IFsrmObject {
-    fn from(value: IFsrmStorageModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmStorageModuleDefinition> for &'a IFsrmObject {
-    fn from(value: &'a IFsrmStorageModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmStorageModuleDefinition> for IFsrmObject {
-    fn from(value: &IFsrmStorageModuleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmStorageModuleDefinition> for IFsrmPipelineModuleDefinition {
-    fn from(value: IFsrmStorageModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmStorageModuleDefinition> for &'a IFsrmPipelineModuleDefinition {
-    fn from(value: &'a IFsrmStorageModuleDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmStorageModuleDefinition> for IFsrmPipelineModuleDefinition {
-    fn from(value: &IFsrmStorageModuleDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmStorageModuleDefinition, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmObject, IFsrmPipelineModuleDefinition);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmStorageModuleDefinition {
     fn clone(&self) -> Self {
@@ -10082,59 +7088,7 @@ impl IFsrmStorageModuleImplementation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmStorageModuleImplementation> for ::windows::core::IUnknown {
-    fn from(value: IFsrmStorageModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmStorageModuleImplementation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsrmStorageModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmStorageModuleImplementation> for ::windows::core::IUnknown {
-    fn from(value: &IFsrmStorageModuleImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmStorageModuleImplementation> for super::super::System::Com::IDispatch {
-    fn from(value: IFsrmStorageModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmStorageModuleImplementation> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsrmStorageModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmStorageModuleImplementation> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsrmStorageModuleImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsrmStorageModuleImplementation> for IFsrmPipelineModuleImplementation {
-    fn from(value: IFsrmStorageModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsrmStorageModuleImplementation> for &'a IFsrmPipelineModuleImplementation {
-    fn from(value: &'a IFsrmStorageModuleImplementation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsrmStorageModuleImplementation> for IFsrmPipelineModuleImplementation {
-    fn from(value: &IFsrmStorageModuleImplementation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsrmStorageModuleImplementation, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsrmPipelineModuleImplementation);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsrmStorageModuleImplementation {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -5324,41 +5324,7 @@ impl IDiskQuotaControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiskQuotaControl> for ::windows::core::IUnknown {
-    fn from(value: IDiskQuotaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiskQuotaControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiskQuotaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiskQuotaControl> for ::windows::core::IUnknown {
-    fn from(value: &IDiskQuotaControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiskQuotaControl> for super::super::System::Com::IConnectionPointContainer {
-    fn from(value: IDiskQuotaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiskQuotaControl> for &'a super::super::System::Com::IConnectionPointContainer {
-    fn from(value: &'a IDiskQuotaControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiskQuotaControl> for super::super::System::Com::IConnectionPointContainer {
-    fn from(value: &IDiskQuotaControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiskQuotaControl, ::windows::core::IUnknown, super::super::System::Com::IConnectionPointContainer);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDiskQuotaControl {
     fn clone(&self) -> Self {
@@ -5437,21 +5403,7 @@ impl IDiskQuotaEvents {
         (::windows::core::Vtable::vtable(self).OnUserNameChanged)(::windows::core::Vtable::as_raw(self), puser.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDiskQuotaEvents> for ::windows::core::IUnknown {
-    fn from(value: IDiskQuotaEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDiskQuotaEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiskQuotaEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDiskQuotaEvents> for ::windows::core::IUnknown {
-    fn from(value: &IDiskQuotaEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiskQuotaEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDiskQuotaEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5554,21 +5506,7 @@ impl IDiskQuotaUser {
         (::windows::core::Vtable::vtable(self).GetAccountStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwstatus)).ok()
     }
 }
-impl ::core::convert::From<IDiskQuotaUser> for ::windows::core::IUnknown {
-    fn from(value: IDiskQuotaUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDiskQuotaUser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiskQuotaUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDiskQuotaUser> for ::windows::core::IUnknown {
-    fn from(value: &IDiskQuotaUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiskQuotaUser, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDiskQuotaUser {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5640,21 +5578,7 @@ impl IDiskQuotaUserBatch {
         (::windows::core::Vtable::vtable(self).FlushToDisk)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDiskQuotaUserBatch> for ::windows::core::IUnknown {
-    fn from(value: IDiskQuotaUserBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDiskQuotaUserBatch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiskQuotaUserBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDiskQuotaUserBatch> for ::windows::core::IUnknown {
-    fn from(value: &IDiskQuotaUserBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiskQuotaUserBatch, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDiskQuotaUserBatch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5704,21 +5628,7 @@ impl IEnumDiskQuotaUsers {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDiskQuotaUsers>(result__)
     }
 }
-impl ::core::convert::From<IEnumDiskQuotaUsers> for ::windows::core::IUnknown {
-    fn from(value: IEnumDiskQuotaUsers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDiskQuotaUsers> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDiskQuotaUsers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDiskQuotaUsers> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDiskQuotaUsers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDiskQuotaUsers, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDiskQuotaUsers {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
@@ -80,41 +80,7 @@ impl DDiscFormat2DataEvents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DDiscFormat2DataEvents> for ::windows::core::IUnknown {
-    fn from(value: DDiscFormat2DataEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DDiscFormat2DataEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DDiscFormat2DataEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DDiscFormat2DataEvents> for ::windows::core::IUnknown {
-    fn from(value: &DDiscFormat2DataEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DDiscFormat2DataEvents> for super::super::System::Com::IDispatch {
-    fn from(value: DDiscFormat2DataEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DDiscFormat2DataEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DDiscFormat2DataEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DDiscFormat2DataEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &DDiscFormat2DataEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DDiscFormat2DataEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DDiscFormat2DataEvents {
     fn clone(&self) -> Self {
@@ -169,41 +135,7 @@ impl DDiscFormat2EraseEvents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DDiscFormat2EraseEvents> for ::windows::core::IUnknown {
-    fn from(value: DDiscFormat2EraseEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DDiscFormat2EraseEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DDiscFormat2EraseEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DDiscFormat2EraseEvents> for ::windows::core::IUnknown {
-    fn from(value: &DDiscFormat2EraseEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DDiscFormat2EraseEvents> for super::super::System::Com::IDispatch {
-    fn from(value: DDiscFormat2EraseEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DDiscFormat2EraseEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DDiscFormat2EraseEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DDiscFormat2EraseEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &DDiscFormat2EraseEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DDiscFormat2EraseEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DDiscFormat2EraseEvents {
     fn clone(&self) -> Self {
@@ -259,41 +191,7 @@ impl DDiscFormat2RawCDEvents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DDiscFormat2RawCDEvents> for ::windows::core::IUnknown {
-    fn from(value: DDiscFormat2RawCDEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DDiscFormat2RawCDEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DDiscFormat2RawCDEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DDiscFormat2RawCDEvents> for ::windows::core::IUnknown {
-    fn from(value: &DDiscFormat2RawCDEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DDiscFormat2RawCDEvents> for super::super::System::Com::IDispatch {
-    fn from(value: DDiscFormat2RawCDEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DDiscFormat2RawCDEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DDiscFormat2RawCDEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DDiscFormat2RawCDEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &DDiscFormat2RawCDEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DDiscFormat2RawCDEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DDiscFormat2RawCDEvents {
     fn clone(&self) -> Self {
@@ -349,41 +247,7 @@ impl DDiscFormat2TrackAtOnceEvents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DDiscFormat2TrackAtOnceEvents> for ::windows::core::IUnknown {
-    fn from(value: DDiscFormat2TrackAtOnceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DDiscFormat2TrackAtOnceEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DDiscFormat2TrackAtOnceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DDiscFormat2TrackAtOnceEvents> for ::windows::core::IUnknown {
-    fn from(value: &DDiscFormat2TrackAtOnceEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DDiscFormat2TrackAtOnceEvents> for super::super::System::Com::IDispatch {
-    fn from(value: DDiscFormat2TrackAtOnceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DDiscFormat2TrackAtOnceEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DDiscFormat2TrackAtOnceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DDiscFormat2TrackAtOnceEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &DDiscFormat2TrackAtOnceEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DDiscFormat2TrackAtOnceEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DDiscFormat2TrackAtOnceEvents {
     fn clone(&self) -> Self {
@@ -446,41 +310,7 @@ impl DDiscMaster2Events {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DDiscMaster2Events> for ::windows::core::IUnknown {
-    fn from(value: DDiscMaster2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DDiscMaster2Events> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DDiscMaster2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DDiscMaster2Events> for ::windows::core::IUnknown {
-    fn from(value: &DDiscMaster2Events) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DDiscMaster2Events> for super::super::System::Com::IDispatch {
-    fn from(value: DDiscMaster2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DDiscMaster2Events> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DDiscMaster2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DDiscMaster2Events> for super::super::System::Com::IDispatch {
-    fn from(value: &DDiscMaster2Events) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DDiscMaster2Events, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DDiscMaster2Events {
     fn clone(&self) -> Self {
@@ -539,41 +369,7 @@ impl DFileSystemImageEvents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DFileSystemImageEvents> for ::windows::core::IUnknown {
-    fn from(value: DFileSystemImageEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DFileSystemImageEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DFileSystemImageEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DFileSystemImageEvents> for ::windows::core::IUnknown {
-    fn from(value: &DFileSystemImageEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DFileSystemImageEvents> for super::super::System::Com::IDispatch {
-    fn from(value: DFileSystemImageEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DFileSystemImageEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DFileSystemImageEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DFileSystemImageEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &DFileSystemImageEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DFileSystemImageEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DFileSystemImageEvents {
     fn clone(&self) -> Self {
@@ -628,41 +424,7 @@ impl DFileSystemImageImportEvents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DFileSystemImageImportEvents> for ::windows::core::IUnknown {
-    fn from(value: DFileSystemImageImportEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DFileSystemImageImportEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DFileSystemImageImportEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DFileSystemImageImportEvents> for ::windows::core::IUnknown {
-    fn from(value: &DFileSystemImageImportEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DFileSystemImageImportEvents> for super::super::System::Com::IDispatch {
-    fn from(value: DFileSystemImageImportEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DFileSystemImageImportEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DFileSystemImageImportEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DFileSystemImageImportEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &DFileSystemImageImportEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DFileSystemImageImportEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DFileSystemImageImportEvents {
     fn clone(&self) -> Self {
@@ -718,41 +480,7 @@ impl DWriteEngine2Events {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DWriteEngine2Events> for ::windows::core::IUnknown {
-    fn from(value: DWriteEngine2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DWriteEngine2Events> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DWriteEngine2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DWriteEngine2Events> for ::windows::core::IUnknown {
-    fn from(value: &DWriteEngine2Events) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DWriteEngine2Events> for super::super::System::Com::IDispatch {
-    fn from(value: DWriteEngine2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DWriteEngine2Events> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DWriteEngine2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DWriteEngine2Events> for super::super::System::Com::IDispatch {
-    fn from(value: &DWriteEngine2Events) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DWriteEngine2Events, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DWriteEngine2Events {
     fn clone(&self) -> Self {
@@ -807,41 +535,7 @@ impl IBlockRange {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBlockRange> for ::windows::core::IUnknown {
-    fn from(value: IBlockRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBlockRange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBlockRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBlockRange> for ::windows::core::IUnknown {
-    fn from(value: &IBlockRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBlockRange> for super::super::System::Com::IDispatch {
-    fn from(value: IBlockRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBlockRange> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IBlockRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBlockRange> for super::super::System::Com::IDispatch {
-    fn from(value: &IBlockRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBlockRange, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IBlockRange {
     fn clone(&self) -> Self {
@@ -892,41 +586,7 @@ impl IBlockRangeList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBlockRangeList> for ::windows::core::IUnknown {
-    fn from(value: IBlockRangeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBlockRangeList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBlockRangeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBlockRangeList> for ::windows::core::IUnknown {
-    fn from(value: &IBlockRangeList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBlockRangeList> for super::super::System::Com::IDispatch {
-    fn from(value: IBlockRangeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBlockRangeList> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IBlockRangeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBlockRangeList> for super::super::System::Com::IDispatch {
-    fn from(value: &IBlockRangeList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBlockRangeList, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IBlockRangeList {
     fn clone(&self) -> Self {
@@ -1012,41 +672,7 @@ impl IBootOptions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBootOptions> for ::windows::core::IUnknown {
-    fn from(value: IBootOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBootOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBootOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBootOptions> for ::windows::core::IUnknown {
-    fn from(value: &IBootOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBootOptions> for super::super::System::Com::IDispatch {
-    fn from(value: IBootOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBootOptions> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IBootOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBootOptions> for super::super::System::Com::IDispatch {
-    fn from(value: &IBootOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBootOptions, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IBootOptions {
     fn clone(&self) -> Self {
@@ -1108,21 +734,7 @@ impl IBurnVerification {
         (::windows::core::Vtable::vtable(self).BurnVerificationLevel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMAPI_BURN_VERIFICATION_LEVEL>(result__)
     }
 }
-impl ::core::convert::From<IBurnVerification> for ::windows::core::IUnknown {
-    fn from(value: IBurnVerification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBurnVerification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBurnVerification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBurnVerification> for ::windows::core::IUnknown {
-    fn from(value: &IBurnVerification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBurnVerification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBurnVerification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1192,41 +804,7 @@ impl IDiscFormat2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2> for ::windows::core::IUnknown {
-    fn from(value: IDiscFormat2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscFormat2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2> for ::windows::core::IUnknown {
-    fn from(value: &IDiscFormat2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2> for super::super::System::Com::IDispatch {
-    fn from(value: IDiscFormat2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDiscFormat2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2> for super::super::System::Com::IDispatch {
-    fn from(value: &IDiscFormat2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscFormat2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDiscFormat2 {
     fn clone(&self) -> Self {
@@ -1451,59 +1029,7 @@ impl IDiscFormat2Data {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2Data> for ::windows::core::IUnknown {
-    fn from(value: IDiscFormat2Data) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2Data> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscFormat2Data) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2Data> for ::windows::core::IUnknown {
-    fn from(value: &IDiscFormat2Data) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2Data> for super::super::System::Com::IDispatch {
-    fn from(value: IDiscFormat2Data) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2Data> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDiscFormat2Data) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2Data> for super::super::System::Com::IDispatch {
-    fn from(value: &IDiscFormat2Data) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2Data> for IDiscFormat2 {
-    fn from(value: IDiscFormat2Data) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2Data> for &'a IDiscFormat2 {
-    fn from(value: &'a IDiscFormat2Data) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2Data> for IDiscFormat2 {
-    fn from(value: &IDiscFormat2Data) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscFormat2Data, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IDiscFormat2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDiscFormat2Data {
     fn clone(&self) -> Self {
@@ -1640,59 +1166,7 @@ impl IDiscFormat2DataEventArgs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2DataEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IDiscFormat2DataEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2DataEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscFormat2DataEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2DataEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IDiscFormat2DataEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2DataEventArgs> for super::super::System::Com::IDispatch {
-    fn from(value: IDiscFormat2DataEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2DataEventArgs> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDiscFormat2DataEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2DataEventArgs> for super::super::System::Com::IDispatch {
-    fn from(value: &IDiscFormat2DataEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2DataEventArgs> for IWriteEngine2EventArgs {
-    fn from(value: IDiscFormat2DataEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2DataEventArgs> for &'a IWriteEngine2EventArgs {
-    fn from(value: &'a IDiscFormat2DataEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2DataEventArgs> for IWriteEngine2EventArgs {
-    fn from(value: &IDiscFormat2DataEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscFormat2DataEventArgs, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWriteEngine2EventArgs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDiscFormat2DataEventArgs {
     fn clone(&self) -> Self {
@@ -1806,59 +1280,7 @@ impl IDiscFormat2Erase {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2Erase> for ::windows::core::IUnknown {
-    fn from(value: IDiscFormat2Erase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2Erase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscFormat2Erase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2Erase> for ::windows::core::IUnknown {
-    fn from(value: &IDiscFormat2Erase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2Erase> for super::super::System::Com::IDispatch {
-    fn from(value: IDiscFormat2Erase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2Erase> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDiscFormat2Erase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2Erase> for super::super::System::Com::IDispatch {
-    fn from(value: &IDiscFormat2Erase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2Erase> for IDiscFormat2 {
-    fn from(value: IDiscFormat2Erase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2Erase> for &'a IDiscFormat2 {
-    fn from(value: &'a IDiscFormat2Erase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2Erase> for IDiscFormat2 {
-    fn from(value: &IDiscFormat2Erase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscFormat2Erase, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IDiscFormat2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDiscFormat2Erase {
     fn clone(&self) -> Self {
@@ -2056,59 +1478,7 @@ impl IDiscFormat2RawCD {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2RawCD> for ::windows::core::IUnknown {
-    fn from(value: IDiscFormat2RawCD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2RawCD> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscFormat2RawCD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2RawCD> for ::windows::core::IUnknown {
-    fn from(value: &IDiscFormat2RawCD) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2RawCD> for super::super::System::Com::IDispatch {
-    fn from(value: IDiscFormat2RawCD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2RawCD> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDiscFormat2RawCD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2RawCD> for super::super::System::Com::IDispatch {
-    fn from(value: &IDiscFormat2RawCD) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2RawCD> for IDiscFormat2 {
-    fn from(value: IDiscFormat2RawCD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2RawCD> for &'a IDiscFormat2 {
-    fn from(value: &'a IDiscFormat2RawCD) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2RawCD> for IDiscFormat2 {
-    fn from(value: &IDiscFormat2RawCD) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscFormat2RawCD, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IDiscFormat2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDiscFormat2RawCD {
     fn clone(&self) -> Self {
@@ -2236,59 +1606,7 @@ impl IDiscFormat2RawCDEventArgs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2RawCDEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IDiscFormat2RawCDEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2RawCDEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscFormat2RawCDEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2RawCDEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IDiscFormat2RawCDEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2RawCDEventArgs> for super::super::System::Com::IDispatch {
-    fn from(value: IDiscFormat2RawCDEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2RawCDEventArgs> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDiscFormat2RawCDEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2RawCDEventArgs> for super::super::System::Com::IDispatch {
-    fn from(value: &IDiscFormat2RawCDEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2RawCDEventArgs> for IWriteEngine2EventArgs {
-    fn from(value: IDiscFormat2RawCDEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2RawCDEventArgs> for &'a IWriteEngine2EventArgs {
-    fn from(value: &'a IDiscFormat2RawCDEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2RawCDEventArgs> for IWriteEngine2EventArgs {
-    fn from(value: &IDiscFormat2RawCDEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscFormat2RawCDEventArgs, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWriteEngine2EventArgs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDiscFormat2RawCDEventArgs {
     fn clone(&self) -> Self {
@@ -2475,59 +1793,7 @@ impl IDiscFormat2TrackAtOnce {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2TrackAtOnce> for ::windows::core::IUnknown {
-    fn from(value: IDiscFormat2TrackAtOnce) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2TrackAtOnce> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscFormat2TrackAtOnce) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2TrackAtOnce> for ::windows::core::IUnknown {
-    fn from(value: &IDiscFormat2TrackAtOnce) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2TrackAtOnce> for super::super::System::Com::IDispatch {
-    fn from(value: IDiscFormat2TrackAtOnce) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2TrackAtOnce> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDiscFormat2TrackAtOnce) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2TrackAtOnce> for super::super::System::Com::IDispatch {
-    fn from(value: &IDiscFormat2TrackAtOnce) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2TrackAtOnce> for IDiscFormat2 {
-    fn from(value: IDiscFormat2TrackAtOnce) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2TrackAtOnce> for &'a IDiscFormat2 {
-    fn from(value: &'a IDiscFormat2TrackAtOnce) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2TrackAtOnce> for IDiscFormat2 {
-    fn from(value: &IDiscFormat2TrackAtOnce) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscFormat2TrackAtOnce, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IDiscFormat2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDiscFormat2TrackAtOnce {
     fn clone(&self) -> Self {
@@ -2657,59 +1923,7 @@ impl IDiscFormat2TrackAtOnceEventArgs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2TrackAtOnceEventArgs> for ::windows::core::IUnknown {
-    fn from(value: IDiscFormat2TrackAtOnceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2TrackAtOnceEventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscFormat2TrackAtOnceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2TrackAtOnceEventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IDiscFormat2TrackAtOnceEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2TrackAtOnceEventArgs> for super::super::System::Com::IDispatch {
-    fn from(value: IDiscFormat2TrackAtOnceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2TrackAtOnceEventArgs> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDiscFormat2TrackAtOnceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2TrackAtOnceEventArgs> for super::super::System::Com::IDispatch {
-    fn from(value: &IDiscFormat2TrackAtOnceEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscFormat2TrackAtOnceEventArgs> for IWriteEngine2EventArgs {
-    fn from(value: IDiscFormat2TrackAtOnceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscFormat2TrackAtOnceEventArgs> for &'a IWriteEngine2EventArgs {
-    fn from(value: &'a IDiscFormat2TrackAtOnceEventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscFormat2TrackAtOnceEventArgs> for IWriteEngine2EventArgs {
-    fn from(value: &IDiscFormat2TrackAtOnceEventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscFormat2TrackAtOnceEventArgs, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWriteEngine2EventArgs);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDiscFormat2TrackAtOnceEventArgs {
     fn clone(&self) -> Self {
@@ -2800,21 +2014,7 @@ impl IDiscMaster {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDiscMaster> for ::windows::core::IUnknown {
-    fn from(value: IDiscMaster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDiscMaster> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscMaster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDiscMaster> for ::windows::core::IUnknown {
-    fn from(value: &IDiscMaster) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscMaster, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDiscMaster {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2880,41 +2080,7 @@ impl IDiscMaster2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscMaster2> for ::windows::core::IUnknown {
-    fn from(value: IDiscMaster2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscMaster2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscMaster2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscMaster2> for ::windows::core::IUnknown {
-    fn from(value: &IDiscMaster2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscMaster2> for super::super::System::Com::IDispatch {
-    fn from(value: IDiscMaster2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscMaster2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDiscMaster2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscMaster2> for super::super::System::Com::IDispatch {
-    fn from(value: &IDiscMaster2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscMaster2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDiscMaster2 {
     fn clone(&self) -> Self {
@@ -2989,21 +2155,7 @@ impl IDiscMasterProgressEvents {
         (::windows::core::Vtable::vtable(self).NotifyEraseComplete)(::windows::core::Vtable::as_raw(self), status).ok()
     }
 }
-impl ::core::convert::From<IDiscMasterProgressEvents> for ::windows::core::IUnknown {
-    fn from(value: IDiscMasterProgressEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDiscMasterProgressEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscMasterProgressEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDiscMasterProgressEvents> for ::windows::core::IUnknown {
-    fn from(value: &IDiscMasterProgressEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscMasterProgressEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDiscMasterProgressEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3102,21 +2254,7 @@ impl IDiscRecorder {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDiscRecorder> for ::windows::core::IUnknown {
-    fn from(value: IDiscRecorder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDiscRecorder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscRecorder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDiscRecorder> for ::windows::core::IUnknown {
-    fn from(value: &IDiscRecorder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscRecorder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDiscRecorder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3262,41 +2400,7 @@ impl IDiscRecorder2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscRecorder2> for ::windows::core::IUnknown {
-    fn from(value: IDiscRecorder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscRecorder2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscRecorder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscRecorder2> for ::windows::core::IUnknown {
-    fn from(value: &IDiscRecorder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDiscRecorder2> for super::super::System::Com::IDispatch {
-    fn from(value: IDiscRecorder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDiscRecorder2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IDiscRecorder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDiscRecorder2> for super::super::System::Com::IDispatch {
-    fn from(value: &IDiscRecorder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscRecorder2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDiscRecorder2 {
     fn clone(&self) -> Self {
@@ -3447,21 +2551,7 @@ impl IDiscRecorder2Ex {
         (::windows::core::Vtable::vtable(self).GetMaximumPageAlignedTransferSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDiscRecorder2Ex> for ::windows::core::IUnknown {
-    fn from(value: IDiscRecorder2Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDiscRecorder2Ex> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDiscRecorder2Ex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDiscRecorder2Ex> for ::windows::core::IUnknown {
-    fn from(value: &IDiscRecorder2Ex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDiscRecorder2Ex, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDiscRecorder2Ex {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3534,21 +2624,7 @@ impl IEnumDiscMasterFormats {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDiscMasterFormats>(result__)
     }
 }
-impl ::core::convert::From<IEnumDiscMasterFormats> for ::windows::core::IUnknown {
-    fn from(value: IEnumDiscMasterFormats) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDiscMasterFormats> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDiscMasterFormats) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDiscMasterFormats> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDiscMasterFormats) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDiscMasterFormats, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDiscMasterFormats {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3598,21 +2674,7 @@ impl IEnumDiscRecorders {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDiscRecorders>(result__)
     }
 }
-impl ::core::convert::From<IEnumDiscRecorders> for ::windows::core::IUnknown {
-    fn from(value: IEnumDiscRecorders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDiscRecorders> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDiscRecorders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDiscRecorders> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDiscRecorders) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDiscRecorders, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDiscRecorders {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3664,21 +2726,7 @@ impl IEnumFsiItems {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumFsiItems>(result__)
     }
 }
-impl ::core::convert::From<IEnumFsiItems> for ::windows::core::IUnknown {
-    fn from(value: IEnumFsiItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumFsiItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumFsiItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumFsiItems> for ::windows::core::IUnknown {
-    fn from(value: &IEnumFsiItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumFsiItems, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumFsiItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3733,21 +2781,7 @@ impl IEnumProgressItems {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumProgressItems>(result__)
     }
 }
-impl ::core::convert::From<IEnumProgressItems> for ::windows::core::IUnknown {
-    fn from(value: IEnumProgressItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumProgressItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumProgressItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumProgressItems> for ::windows::core::IUnknown {
-    fn from(value: &IEnumProgressItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumProgressItems, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumProgressItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4010,41 +3044,7 @@ impl IFileSystemImage {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImage> for ::windows::core::IUnknown {
-    fn from(value: IFileSystemImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSystemImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImage> for ::windows::core::IUnknown {
-    fn from(value: &IFileSystemImage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImage> for super::super::System::Com::IDispatch {
-    fn from(value: IFileSystemImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImage> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFileSystemImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImage> for super::super::System::Com::IDispatch {
-    fn from(value: &IFileSystemImage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSystemImage, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFileSystemImage {
     fn clone(&self) -> Self {
@@ -4407,59 +3407,7 @@ impl IFileSystemImage2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImage2> for ::windows::core::IUnknown {
-    fn from(value: IFileSystemImage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImage2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSystemImage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImage2> for ::windows::core::IUnknown {
-    fn from(value: &IFileSystemImage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImage2> for super::super::System::Com::IDispatch {
-    fn from(value: IFileSystemImage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImage2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFileSystemImage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImage2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFileSystemImage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImage2> for IFileSystemImage {
-    fn from(value: IFileSystemImage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImage2> for &'a IFileSystemImage {
-    fn from(value: &'a IFileSystemImage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImage2> for IFileSystemImage {
-    fn from(value: &IFileSystemImage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSystemImage2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFileSystemImage);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFileSystemImage2 {
     fn clone(&self) -> Self {
@@ -4752,77 +3700,7 @@ impl IFileSystemImage3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImage3> for ::windows::core::IUnknown {
-    fn from(value: IFileSystemImage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImage3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSystemImage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImage3> for ::windows::core::IUnknown {
-    fn from(value: &IFileSystemImage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImage3> for super::super::System::Com::IDispatch {
-    fn from(value: IFileSystemImage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImage3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFileSystemImage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImage3> for super::super::System::Com::IDispatch {
-    fn from(value: &IFileSystemImage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImage3> for IFileSystemImage {
-    fn from(value: IFileSystemImage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImage3> for &'a IFileSystemImage {
-    fn from(value: &'a IFileSystemImage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImage3> for IFileSystemImage {
-    fn from(value: &IFileSystemImage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImage3> for IFileSystemImage2 {
-    fn from(value: IFileSystemImage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImage3> for &'a IFileSystemImage2 {
-    fn from(value: &'a IFileSystemImage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImage3> for IFileSystemImage2 {
-    fn from(value: &IFileSystemImage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSystemImage3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFileSystemImage, IFileSystemImage2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFileSystemImage3 {
     fn clone(&self) -> Self {
@@ -4892,41 +3770,7 @@ impl IFileSystemImageResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImageResult> for ::windows::core::IUnknown {
-    fn from(value: IFileSystemImageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImageResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSystemImageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImageResult> for ::windows::core::IUnknown {
-    fn from(value: &IFileSystemImageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImageResult> for super::super::System::Com::IDispatch {
-    fn from(value: IFileSystemImageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImageResult> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFileSystemImageResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImageResult> for super::super::System::Com::IDispatch {
-    fn from(value: &IFileSystemImageResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSystemImageResult, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFileSystemImageResult {
     fn clone(&self) -> Self {
@@ -5010,59 +3854,7 @@ impl IFileSystemImageResult2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImageResult2> for ::windows::core::IUnknown {
-    fn from(value: IFileSystemImageResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImageResult2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSystemImageResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImageResult2> for ::windows::core::IUnknown {
-    fn from(value: &IFileSystemImageResult2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImageResult2> for super::super::System::Com::IDispatch {
-    fn from(value: IFileSystemImageResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImageResult2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFileSystemImageResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImageResult2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFileSystemImageResult2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSystemImageResult2> for IFileSystemImageResult {
-    fn from(value: IFileSystemImageResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSystemImageResult2> for &'a IFileSystemImageResult {
-    fn from(value: &'a IFileSystemImageResult2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSystemImageResult2> for IFileSystemImageResult {
-    fn from(value: &IFileSystemImageResult2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSystemImageResult2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFileSystemImageResult);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFileSystemImageResult2 {
     fn clone(&self) -> Self {
@@ -5201,59 +3993,7 @@ impl IFsiDirectoryItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiDirectoryItem> for ::windows::core::IUnknown {
-    fn from(value: IFsiDirectoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiDirectoryItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsiDirectoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiDirectoryItem> for ::windows::core::IUnknown {
-    fn from(value: &IFsiDirectoryItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiDirectoryItem> for super::super::System::Com::IDispatch {
-    fn from(value: IFsiDirectoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiDirectoryItem> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsiDirectoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiDirectoryItem> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsiDirectoryItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiDirectoryItem> for IFsiItem {
-    fn from(value: IFsiDirectoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiDirectoryItem> for &'a IFsiItem {
-    fn from(value: &'a IFsiDirectoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiDirectoryItem> for IFsiItem {
-    fn from(value: &IFsiDirectoryItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsiDirectoryItem, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsiItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsiDirectoryItem {
     fn clone(&self) -> Self {
@@ -5413,77 +4153,7 @@ impl IFsiDirectoryItem2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiDirectoryItem2> for ::windows::core::IUnknown {
-    fn from(value: IFsiDirectoryItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiDirectoryItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsiDirectoryItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiDirectoryItem2> for ::windows::core::IUnknown {
-    fn from(value: &IFsiDirectoryItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiDirectoryItem2> for super::super::System::Com::IDispatch {
-    fn from(value: IFsiDirectoryItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiDirectoryItem2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsiDirectoryItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiDirectoryItem2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsiDirectoryItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiDirectoryItem2> for IFsiItem {
-    fn from(value: IFsiDirectoryItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiDirectoryItem2> for &'a IFsiItem {
-    fn from(value: &'a IFsiDirectoryItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiDirectoryItem2> for IFsiItem {
-    fn from(value: &IFsiDirectoryItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiDirectoryItem2> for IFsiDirectoryItem {
-    fn from(value: IFsiDirectoryItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiDirectoryItem2> for &'a IFsiDirectoryItem {
-    fn from(value: &'a IFsiDirectoryItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiDirectoryItem2> for IFsiDirectoryItem {
-    fn from(value: &IFsiDirectoryItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsiDirectoryItem2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsiItem, IFsiDirectoryItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsiDirectoryItem2 {
     fn clone(&self) -> Self {
@@ -5597,59 +4267,7 @@ impl IFsiFileItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiFileItem> for ::windows::core::IUnknown {
-    fn from(value: IFsiFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiFileItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsiFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiFileItem> for ::windows::core::IUnknown {
-    fn from(value: &IFsiFileItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiFileItem> for super::super::System::Com::IDispatch {
-    fn from(value: IFsiFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiFileItem> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsiFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiFileItem> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsiFileItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiFileItem> for IFsiItem {
-    fn from(value: IFsiFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiFileItem> for &'a IFsiItem {
-    fn from(value: &'a IFsiFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiFileItem> for IFsiItem {
-    fn from(value: &IFsiFileItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsiFileItem, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsiItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsiFileItem {
     fn clone(&self) -> Self {
@@ -5801,77 +4419,7 @@ impl IFsiFileItem2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiFileItem2> for ::windows::core::IUnknown {
-    fn from(value: IFsiFileItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiFileItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsiFileItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiFileItem2> for ::windows::core::IUnknown {
-    fn from(value: &IFsiFileItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiFileItem2> for super::super::System::Com::IDispatch {
-    fn from(value: IFsiFileItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiFileItem2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsiFileItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiFileItem2> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsiFileItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiFileItem2> for IFsiItem {
-    fn from(value: IFsiFileItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiFileItem2> for &'a IFsiItem {
-    fn from(value: &'a IFsiFileItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiFileItem2> for IFsiItem {
-    fn from(value: &IFsiFileItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiFileItem2> for IFsiFileItem {
-    fn from(value: IFsiFileItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiFileItem2> for &'a IFsiFileItem {
-    fn from(value: &'a IFsiFileItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiFileItem2> for IFsiFileItem {
-    fn from(value: &IFsiFileItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsiFileItem2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IFsiItem, IFsiFileItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsiFileItem2 {
     fn clone(&self) -> Self {
@@ -5970,41 +4518,7 @@ impl IFsiItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiItem> for ::windows::core::IUnknown {
-    fn from(value: IFsiItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsiItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiItem> for ::windows::core::IUnknown {
-    fn from(value: &IFsiItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiItem> for super::super::System::Com::IDispatch {
-    fn from(value: IFsiItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiItem> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsiItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiItem> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsiItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsiItem, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsiItem {
     fn clone(&self) -> Self {
@@ -6079,41 +4593,7 @@ impl IFsiNamedStreams {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiNamedStreams> for ::windows::core::IUnknown {
-    fn from(value: IFsiNamedStreams) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiNamedStreams> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFsiNamedStreams) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiNamedStreams> for ::windows::core::IUnknown {
-    fn from(value: &IFsiNamedStreams) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFsiNamedStreams> for super::super::System::Com::IDispatch {
-    fn from(value: IFsiNamedStreams) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFsiNamedStreams> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFsiNamedStreams) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFsiNamedStreams> for super::super::System::Com::IDispatch {
-    fn from(value: &IFsiNamedStreams) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFsiNamedStreams, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFsiNamedStreams {
     fn clone(&self) -> Self {
@@ -6190,41 +4670,7 @@ impl IIsoImageManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IIsoImageManager> for ::windows::core::IUnknown {
-    fn from(value: IIsoImageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IIsoImageManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIsoImageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IIsoImageManager> for ::windows::core::IUnknown {
-    fn from(value: &IIsoImageManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IIsoImageManager> for super::super::System::Com::IDispatch {
-    fn from(value: IIsoImageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IIsoImageManager> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IIsoImageManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IIsoImageManager> for super::super::System::Com::IDispatch {
-    fn from(value: &IIsoImageManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIsoImageManager, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IIsoImageManager {
     fn clone(&self) -> Self {
@@ -6309,21 +4755,7 @@ impl IJolietDiscMaster {
         (::windows::core::Vtable::vtable(self).SetJolietProperties)(::windows::core::Vtable::as_raw(self), ppropstg.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IJolietDiscMaster> for ::windows::core::IUnknown {
-    fn from(value: IJolietDiscMaster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IJolietDiscMaster> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IJolietDiscMaster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IJolietDiscMaster> for ::windows::core::IUnknown {
-    fn from(value: &IJolietDiscMaster) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IJolietDiscMaster, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IJolietDiscMaster {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6391,41 +4823,7 @@ impl IMultisession {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisession> for ::windows::core::IUnknown {
-    fn from(value: IMultisession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultisession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisession> for ::windows::core::IUnknown {
-    fn from(value: &IMultisession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisession> for super::super::System::Com::IDispatch {
-    fn from(value: IMultisession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisession> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IMultisession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisession> for super::super::System::Com::IDispatch {
-    fn from(value: &IMultisession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultisession, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMultisession {
     fn clone(&self) -> Self {
@@ -6504,59 +4902,7 @@ impl IMultisessionRandomWrite {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisessionRandomWrite> for ::windows::core::IUnknown {
-    fn from(value: IMultisessionRandomWrite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisessionRandomWrite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultisessionRandomWrite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisessionRandomWrite> for ::windows::core::IUnknown {
-    fn from(value: &IMultisessionRandomWrite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisessionRandomWrite> for super::super::System::Com::IDispatch {
-    fn from(value: IMultisessionRandomWrite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisessionRandomWrite> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IMultisessionRandomWrite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisessionRandomWrite> for super::super::System::Com::IDispatch {
-    fn from(value: &IMultisessionRandomWrite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisessionRandomWrite> for IMultisession {
-    fn from(value: IMultisessionRandomWrite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisessionRandomWrite> for &'a IMultisession {
-    fn from(value: &'a IMultisessionRandomWrite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisessionRandomWrite> for IMultisession {
-    fn from(value: &IMultisessionRandomWrite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultisessionRandomWrite, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IMultisession);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMultisessionRandomWrite {
     fn clone(&self) -> Self {
@@ -6639,59 +4985,7 @@ impl IMultisessionSequential {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisessionSequential> for ::windows::core::IUnknown {
-    fn from(value: IMultisessionSequential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisessionSequential> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultisessionSequential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisessionSequential> for ::windows::core::IUnknown {
-    fn from(value: &IMultisessionSequential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisessionSequential> for super::super::System::Com::IDispatch {
-    fn from(value: IMultisessionSequential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisessionSequential> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IMultisessionSequential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisessionSequential> for super::super::System::Com::IDispatch {
-    fn from(value: &IMultisessionSequential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisessionSequential> for IMultisession {
-    fn from(value: IMultisessionSequential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisessionSequential> for &'a IMultisession {
-    fn from(value: &'a IMultisessionSequential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisessionSequential> for IMultisession {
-    fn from(value: &IMultisessionSequential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultisessionSequential, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IMultisession);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMultisessionSequential {
     fn clone(&self) -> Self {
@@ -6780,77 +5074,7 @@ impl IMultisessionSequential2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisessionSequential2> for ::windows::core::IUnknown {
-    fn from(value: IMultisessionSequential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisessionSequential2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultisessionSequential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisessionSequential2> for ::windows::core::IUnknown {
-    fn from(value: &IMultisessionSequential2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisessionSequential2> for super::super::System::Com::IDispatch {
-    fn from(value: IMultisessionSequential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisessionSequential2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IMultisessionSequential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisessionSequential2> for super::super::System::Com::IDispatch {
-    fn from(value: &IMultisessionSequential2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisessionSequential2> for IMultisession {
-    fn from(value: IMultisessionSequential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisessionSequential2> for &'a IMultisession {
-    fn from(value: &'a IMultisessionSequential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisessionSequential2> for IMultisession {
-    fn from(value: &IMultisessionSequential2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMultisessionSequential2> for IMultisessionSequential {
-    fn from(value: IMultisessionSequential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMultisessionSequential2> for &'a IMultisessionSequential {
-    fn from(value: &'a IMultisessionSequential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMultisessionSequential2> for IMultisessionSequential {
-    fn from(value: &IMultisessionSequential2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultisessionSequential2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IMultisession, IMultisessionSequential);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMultisessionSequential2 {
     fn clone(&self) -> Self {
@@ -6910,41 +5134,7 @@ impl IProgressItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IProgressItem> for ::windows::core::IUnknown {
-    fn from(value: IProgressItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IProgressItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProgressItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IProgressItem> for ::windows::core::IUnknown {
-    fn from(value: &IProgressItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IProgressItem> for super::super::System::Com::IDispatch {
-    fn from(value: IProgressItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IProgressItem> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IProgressItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IProgressItem> for super::super::System::Com::IDispatch {
-    fn from(value: &IProgressItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProgressItem, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IProgressItem {
     fn clone(&self) -> Self {
@@ -7023,41 +5213,7 @@ impl IProgressItems {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IProgressItems> for ::windows::core::IUnknown {
-    fn from(value: IProgressItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IProgressItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProgressItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IProgressItems> for ::windows::core::IUnknown {
-    fn from(value: &IProgressItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IProgressItems> for super::super::System::Com::IDispatch {
-    fn from(value: IProgressItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IProgressItems> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IProgressItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IProgressItems> for super::super::System::Com::IDispatch {
-    fn from(value: &IProgressItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProgressItems, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IProgressItems {
     fn clone(&self) -> Self {
@@ -7208,41 +5364,7 @@ impl IRawCDImageCreator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRawCDImageCreator> for ::windows::core::IUnknown {
-    fn from(value: IRawCDImageCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRawCDImageCreator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawCDImageCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRawCDImageCreator> for ::windows::core::IUnknown {
-    fn from(value: &IRawCDImageCreator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRawCDImageCreator> for super::super::System::Com::IDispatch {
-    fn from(value: IRawCDImageCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRawCDImageCreator> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IRawCDImageCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRawCDImageCreator> for super::super::System::Com::IDispatch {
-    fn from(value: &IRawCDImageCreator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawCDImageCreator, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRawCDImageCreator {
     fn clone(&self) -> Self {
@@ -7371,41 +5493,7 @@ impl IRawCDImageTrackInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRawCDImageTrackInfo> for ::windows::core::IUnknown {
-    fn from(value: IRawCDImageTrackInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRawCDImageTrackInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawCDImageTrackInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRawCDImageTrackInfo> for ::windows::core::IUnknown {
-    fn from(value: &IRawCDImageTrackInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRawCDImageTrackInfo> for super::super::System::Com::IDispatch {
-    fn from(value: IRawCDImageTrackInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRawCDImageTrackInfo> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IRawCDImageTrackInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRawCDImageTrackInfo> for super::super::System::Com::IDispatch {
-    fn from(value: &IRawCDImageTrackInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawCDImageTrackInfo, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRawCDImageTrackInfo {
     fn clone(&self) -> Self {
@@ -7490,21 +5578,7 @@ impl IRedbookDiscMaster {
         (::windows::core::Vtable::vtable(self).CloseAudioTrack)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IRedbookDiscMaster> for ::windows::core::IUnknown {
-    fn from(value: IRedbookDiscMaster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRedbookDiscMaster> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRedbookDiscMaster) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRedbookDiscMaster> for ::windows::core::IUnknown {
-    fn from(value: &IRedbookDiscMaster) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRedbookDiscMaster, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRedbookDiscMaster {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7635,59 +5709,7 @@ impl IStreamConcatenate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamConcatenate> for ::windows::core::IUnknown {
-    fn from(value: IStreamConcatenate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamConcatenate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStreamConcatenate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamConcatenate> for ::windows::core::IUnknown {
-    fn from(value: &IStreamConcatenate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamConcatenate> for super::super::System::Com::ISequentialStream {
-    fn from(value: IStreamConcatenate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamConcatenate> for &'a super::super::System::Com::ISequentialStream {
-    fn from(value: &'a IStreamConcatenate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamConcatenate> for super::super::System::Com::ISequentialStream {
-    fn from(value: &IStreamConcatenate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamConcatenate> for super::super::System::Com::IStream {
-    fn from(value: IStreamConcatenate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamConcatenate> for &'a super::super::System::Com::IStream {
-    fn from(value: &'a IStreamConcatenate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamConcatenate> for super::super::System::Com::IStream {
-    fn from(value: &IStreamConcatenate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStreamConcatenate, ::windows::core::IUnknown, super::super::System::Com::ISequentialStream, super::super::System::Com::IStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IStreamConcatenate {
     fn clone(&self) -> Self {
@@ -7811,59 +5833,7 @@ impl IStreamInterleave {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamInterleave> for ::windows::core::IUnknown {
-    fn from(value: IStreamInterleave) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamInterleave> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStreamInterleave) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamInterleave> for ::windows::core::IUnknown {
-    fn from(value: &IStreamInterleave) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamInterleave> for super::super::System::Com::ISequentialStream {
-    fn from(value: IStreamInterleave) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamInterleave> for &'a super::super::System::Com::ISequentialStream {
-    fn from(value: &'a IStreamInterleave) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamInterleave> for super::super::System::Com::ISequentialStream {
-    fn from(value: &IStreamInterleave) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamInterleave> for super::super::System::Com::IStream {
-    fn from(value: IStreamInterleave) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamInterleave> for &'a super::super::System::Com::IStream {
-    fn from(value: &'a IStreamInterleave) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamInterleave> for super::super::System::Com::IStream {
-    fn from(value: &IStreamInterleave) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStreamInterleave, ::windows::core::IUnknown, super::super::System::Com::ISequentialStream, super::super::System::Com::IStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IStreamInterleave {
     fn clone(&self) -> Self {
@@ -7983,59 +5953,7 @@ impl IStreamPseudoRandomBased {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamPseudoRandomBased> for ::windows::core::IUnknown {
-    fn from(value: IStreamPseudoRandomBased) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamPseudoRandomBased> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStreamPseudoRandomBased) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamPseudoRandomBased> for ::windows::core::IUnknown {
-    fn from(value: &IStreamPseudoRandomBased) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamPseudoRandomBased> for super::super::System::Com::ISequentialStream {
-    fn from(value: IStreamPseudoRandomBased) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamPseudoRandomBased> for &'a super::super::System::Com::ISequentialStream {
-    fn from(value: &'a IStreamPseudoRandomBased) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamPseudoRandomBased> for super::super::System::Com::ISequentialStream {
-    fn from(value: &IStreamPseudoRandomBased) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamPseudoRandomBased> for super::super::System::Com::IStream {
-    fn from(value: IStreamPseudoRandomBased) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamPseudoRandomBased> for &'a super::super::System::Com::IStream {
-    fn from(value: &'a IStreamPseudoRandomBased) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamPseudoRandomBased> for super::super::System::Com::IStream {
-    fn from(value: &IStreamPseudoRandomBased) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStreamPseudoRandomBased, ::windows::core::IUnknown, super::super::System::Com::ISequentialStream, super::super::System::Com::IStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IStreamPseudoRandomBased {
     fn clone(&self) -> Self {
@@ -8135,41 +6053,7 @@ impl IWriteEngine2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWriteEngine2> for ::windows::core::IUnknown {
-    fn from(value: IWriteEngine2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWriteEngine2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWriteEngine2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWriteEngine2> for ::windows::core::IUnknown {
-    fn from(value: &IWriteEngine2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWriteEngine2> for super::super::System::Com::IDispatch {
-    fn from(value: IWriteEngine2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWriteEngine2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWriteEngine2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWriteEngine2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWriteEngine2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWriteEngine2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWriteEngine2 {
     fn clone(&self) -> Self {
@@ -8256,41 +6140,7 @@ impl IWriteEngine2EventArgs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWriteEngine2EventArgs> for ::windows::core::IUnknown {
-    fn from(value: IWriteEngine2EventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWriteEngine2EventArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWriteEngine2EventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWriteEngine2EventArgs> for ::windows::core::IUnknown {
-    fn from(value: &IWriteEngine2EventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWriteEngine2EventArgs> for super::super::System::Com::IDispatch {
-    fn from(value: IWriteEngine2EventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWriteEngine2EventArgs> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWriteEngine2EventArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWriteEngine2EventArgs> for super::super::System::Com::IDispatch {
-    fn from(value: &IWriteEngine2EventArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWriteEngine2EventArgs, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWriteEngine2EventArgs {
     fn clone(&self) -> Self {
@@ -8352,41 +6202,7 @@ impl IWriteSpeedDescriptor {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWriteSpeedDescriptor> for ::windows::core::IUnknown {
-    fn from(value: IWriteSpeedDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWriteSpeedDescriptor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWriteSpeedDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWriteSpeedDescriptor> for ::windows::core::IUnknown {
-    fn from(value: &IWriteSpeedDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWriteSpeedDescriptor> for super::super::System::Com::IDispatch {
-    fn from(value: IWriteSpeedDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWriteSpeedDescriptor> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWriteSpeedDescriptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWriteSpeedDescriptor> for super::super::System::Com::IDispatch {
-    fn from(value: &IWriteSpeedDescriptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWriteSpeedDescriptor, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWriteSpeedDescriptor {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/mod.rs
@@ -77,21 +77,7 @@ impl IFilter {
         (::windows::core::Vtable::vtable(self).BindRegion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(origpos), ::core::mem::transmute(riid), ::core::mem::transmute(ppunk))
     }
 }
-impl ::core::convert::From<IFilter> for ::windows::core::IUnknown {
-    fn from(value: IFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFilter> for ::windows::core::IUnknown {
-    fn from(value: &IFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -151,21 +137,7 @@ impl IPhraseSink {
         (::windows::core::Vtable::vtable(self).PutPhrase)(::windows::core::Vtable::as_raw(self), pwcphrase.into(), cwcphrase).ok()
     }
 }
-impl ::core::convert::From<IPhraseSink> for ::windows::core::IUnknown {
-    fn from(value: IPhraseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPhraseSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPhraseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPhraseSink> for ::windows::core::IUnknown {
-    fn from(value: &IPhraseSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPhraseSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPhraseSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/mod.rs
@@ -58,21 +58,7 @@ impl IEnumOfflineFilesItems {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumOfflineFilesItems>(result__)
     }
 }
-impl ::core::convert::From<IEnumOfflineFilesItems> for ::windows::core::IUnknown {
-    fn from(value: IEnumOfflineFilesItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumOfflineFilesItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumOfflineFilesItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumOfflineFilesItems> for ::windows::core::IUnknown {
-    fn from(value: &IEnumOfflineFilesItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumOfflineFilesItems, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumOfflineFilesItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -122,21 +108,7 @@ impl IEnumOfflineFilesSettings {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumOfflineFilesSettings>(result__)
     }
 }
-impl ::core::convert::From<IEnumOfflineFilesSettings> for ::windows::core::IUnknown {
-    fn from(value: IEnumOfflineFilesSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumOfflineFilesSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumOfflineFilesSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumOfflineFilesSettings> for ::windows::core::IUnknown {
-    fn from(value: &IEnumOfflineFilesSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumOfflineFilesSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumOfflineFilesSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -305,21 +277,7 @@ impl IOfflineFilesCache {
         (::windows::core::Vtable::vtable(self).IsPathCacheable)(::windows::core::Vtable::as_raw(self), pszpath.into(), ::core::mem::transmute(pbcacheable), ::core::mem::transmute(psharecachingmode)).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesCache> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesCache> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesCache> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesCache) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesCache, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesCache {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -538,36 +496,7 @@ impl IOfflineFilesCache2 {
         (::windows::core::Vtable::vtable(self).RenameItemEx)(::windows::core::Vtable::as_raw(self), pszpathoriginal.into(), pszpathnew.into(), breplaceifexists.into()).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesCache2> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesCache2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesCache2> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesCache2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesCache2> for IOfflineFilesCache {
-    fn from(value: IOfflineFilesCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesCache2> for &'a IOfflineFilesCache {
-    fn from(value: &'a IOfflineFilesCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesCache2> for IOfflineFilesCache {
-    fn from(value: &IOfflineFilesCache2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesCache2, ::windows::core::IUnknown, IOfflineFilesCache);
 impl ::core::clone::Clone for IOfflineFilesCache2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -639,21 +568,7 @@ impl IOfflineFilesChangeInfo {
         (::windows::core::Vtable::vtable(self).IsLocallyModifiedTime)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesChangeInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesChangeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesChangeInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesChangeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesChangeInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesChangeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesChangeInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesChangeInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -739,21 +654,7 @@ impl IOfflineFilesConnectionInfo {
         (::windows::core::Vtable::vtable(self).TransitionOffline)(::windows::core::Vtable::as_raw(self), hwndparent.into(), dwflags, bforceopenfilesclosed.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesConnectionInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesConnectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesConnectionInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesConnectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesConnectionInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesConnectionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesConnectionInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesConnectionInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -820,36 +721,7 @@ impl IOfflineFilesDirectoryItem {
         (::windows::core::Vtable::vtable(self).base__.IsMarkedForDeletion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesDirectoryItem> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesDirectoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesDirectoryItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesDirectoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesDirectoryItem> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesDirectoryItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesDirectoryItem> for IOfflineFilesItem {
-    fn from(value: IOfflineFilesDirectoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesDirectoryItem> for &'a IOfflineFilesItem {
-    fn from(value: &'a IOfflineFilesDirectoryItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesDirectoryItem> for IOfflineFilesItem {
-    fn from(value: &IOfflineFilesDirectoryItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesDirectoryItem, ::windows::core::IUnknown, IOfflineFilesItem);
 impl ::core::clone::Clone for IOfflineFilesDirectoryItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -890,21 +762,7 @@ impl IOfflineFilesDirtyInfo {
         (::windows::core::Vtable::vtable(self).RemoteDirtyByteCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i64>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesDirtyInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesDirtyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesDirtyInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesDirtyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesDirtyInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesDirtyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesDirtyInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesDirtyInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -949,21 +807,7 @@ impl IOfflineFilesErrorInfo {
         (::windows::core::Vtable::vtable(self).GetDescription)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesErrorInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesErrorInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1146,21 +990,7 @@ impl IOfflineFilesEvents {
         (::windows::core::Vtable::vtable(self).Ping)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesEvents> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesEvents> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1408,36 +1238,7 @@ impl IOfflineFilesEvents2 {
         (::windows::core::Vtable::vtable(self).SettingsChangesApplied)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesEvents2> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesEvents2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesEvents2> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesEvents2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesEvents2> for IOfflineFilesEvents {
-    fn from(value: IOfflineFilesEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesEvents2> for &'a IOfflineFilesEvents {
-    fn from(value: &'a IOfflineFilesEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesEvents2> for IOfflineFilesEvents {
-    fn from(value: &IOfflineFilesEvents2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesEvents2, ::windows::core::IUnknown, IOfflineFilesEvents);
 impl ::core::clone::Clone for IOfflineFilesEvents2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1674,51 +1475,7 @@ impl IOfflineFilesEvents3 {
         (::windows::core::Vtable::vtable(self).PrefetchFileEnd)(::windows::core::Vtable::as_raw(self), pszpath.into(), hrresult).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesEvents3> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesEvents3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesEvents3> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesEvents3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesEvents3> for IOfflineFilesEvents {
-    fn from(value: IOfflineFilesEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesEvents3> for &'a IOfflineFilesEvents {
-    fn from(value: &'a IOfflineFilesEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesEvents3> for IOfflineFilesEvents {
-    fn from(value: &IOfflineFilesEvents3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesEvents3> for IOfflineFilesEvents2 {
-    fn from(value: IOfflineFilesEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesEvents3> for &'a IOfflineFilesEvents2 {
-    fn from(value: &'a IOfflineFilesEvents3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesEvents3> for IOfflineFilesEvents2 {
-    fn from(value: &IOfflineFilesEvents3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesEvents3, ::windows::core::IUnknown, IOfflineFilesEvents, IOfflineFilesEvents2);
 impl ::core::clone::Clone for IOfflineFilesEvents3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1958,66 +1715,7 @@ impl IOfflineFilesEvents4 {
         (::windows::core::Vtable::vtable(self).PrefetchCloseHandleEnd)(::windows::core::Vtable::as_raw(self), dwclosedhandlecount, dwopenhandlecount, hrresult).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesEvents4> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesEvents4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesEvents4> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesEvents4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesEvents4> for IOfflineFilesEvents {
-    fn from(value: IOfflineFilesEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesEvents4> for &'a IOfflineFilesEvents {
-    fn from(value: &'a IOfflineFilesEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesEvents4> for IOfflineFilesEvents {
-    fn from(value: &IOfflineFilesEvents4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesEvents4> for IOfflineFilesEvents2 {
-    fn from(value: IOfflineFilesEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesEvents4> for &'a IOfflineFilesEvents2 {
-    fn from(value: &'a IOfflineFilesEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesEvents4> for IOfflineFilesEvents2 {
-    fn from(value: &IOfflineFilesEvents4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesEvents4> for IOfflineFilesEvents3 {
-    fn from(value: IOfflineFilesEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesEvents4> for &'a IOfflineFilesEvents3 {
-    fn from(value: &'a IOfflineFilesEvents4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesEvents4> for IOfflineFilesEvents3 {
-    fn from(value: &IOfflineFilesEvents4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesEvents4, ::windows::core::IUnknown, IOfflineFilesEvents, IOfflineFilesEvents2, IOfflineFilesEvents3);
 impl ::core::clone::Clone for IOfflineFilesEvents4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2061,21 +1759,7 @@ impl IOfflineFilesEventsFilter {
         (::windows::core::Vtable::vtable(self).GetExcludedEvents)(::windows::core::Vtable::as_raw(self), celements, ::core::mem::transmute(prgevents), ::core::mem::transmute(pcevents)).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesEventsFilter> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesEventsFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesEventsFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesEventsFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesEventsFilter> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesEventsFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesEventsFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesEventsFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2144,36 +1828,7 @@ impl IOfflineFilesFileItem {
         (::windows::core::Vtable::vtable(self).IsEncrypted)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesFileItem> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesFileItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesFileItem> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesFileItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesFileItem> for IOfflineFilesItem {
-    fn from(value: IOfflineFilesFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesFileItem> for &'a IOfflineFilesItem {
-    fn from(value: &'a IOfflineFilesFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesFileItem> for IOfflineFilesItem {
-    fn from(value: &IOfflineFilesFileItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesFileItem, ::windows::core::IUnknown, IOfflineFilesItem);
 impl ::core::clone::Clone for IOfflineFilesFileItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2227,21 +1882,7 @@ impl IOfflineFilesFileSysInfo {
         (::windows::core::Vtable::vtable(self).GetFileSize)(::windows::core::Vtable::as_raw(self), copy, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i64>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesFileSysInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesFileSysInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesFileSysInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesFileSysInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesFileSysInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesFileSysInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesFileSysInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesFileSysInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2286,21 +1927,7 @@ impl IOfflineFilesGhostInfo {
         (::windows::core::Vtable::vtable(self).IsGhosted)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesGhostInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesGhostInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesGhostInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesGhostInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesGhostInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesGhostInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesGhostInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesGhostInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2358,21 +1985,7 @@ impl IOfflineFilesItem {
         (::windows::core::Vtable::vtable(self).IsMarkedForDeletion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesItem> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesItem> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2427,21 +2040,7 @@ impl IOfflineFilesItemContainer {
         (::windows::core::Vtable::vtable(self).EnumItemsEx)(::windows::core::Vtable::as_raw(self), pincludefilefilter.into().abi(), pincludedirfilter.into().abi(), pexcludefilefilter.into().abi(), pexcludedirfilter.into().abi(), dwenumflags, dwqueryflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumOfflineFilesItems>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesItemContainer> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesItemContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesItemContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesItemContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesItemContainer> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesItemContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesItemContainer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesItemContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2487,21 +2086,7 @@ impl IOfflineFilesItemFilter {
         (::windows::core::Vtable::vtable(self).GetPatternFilter)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pszpattern.as_ptr()), pszpattern.len() as _).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesItemFilter> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesItemFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesItemFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesItemFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesItemFilter> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesItemFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesItemFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesItemFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2566,21 +2151,7 @@ impl IOfflineFilesPinInfo {
         (::windows::core::Vtable::vtable(self).IsPinnedForFolderRedirection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbpinnedforfolderredirection), ::core::mem::transmute(pbinherit)).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesPinInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesPinInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesPinInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesPinInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesPinInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesPinInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesPinInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesPinInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2665,36 +2236,7 @@ impl IOfflineFilesPinInfo2 {
         (::windows::core::Vtable::vtable(self).IsPartlyPinned)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesPinInfo2> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesPinInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesPinInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesPinInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesPinInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesPinInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesPinInfo2> for IOfflineFilesPinInfo {
-    fn from(value: IOfflineFilesPinInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesPinInfo2> for &'a IOfflineFilesPinInfo {
-    fn from(value: &'a IOfflineFilesPinInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesPinInfo2> for IOfflineFilesPinInfo {
-    fn from(value: &IOfflineFilesPinInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesPinInfo2, ::windows::core::IUnknown, IOfflineFilesPinInfo);
 impl ::core::clone::Clone for IOfflineFilesPinInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2746,21 +2288,7 @@ impl IOfflineFilesProgress {
         (::windows::core::Vtable::vtable(self).End)(::windows::core::Vtable::as_raw(self), hrresult).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesProgress> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesProgress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesProgress> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesProgress, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesProgress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2823,36 +2351,7 @@ impl IOfflineFilesServerItem {
         (::windows::core::Vtable::vtable(self).base__.IsMarkedForDeletion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesServerItem> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesServerItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesServerItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesServerItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesServerItem> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesServerItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesServerItem> for IOfflineFilesItem {
-    fn from(value: IOfflineFilesServerItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesServerItem> for &'a IOfflineFilesItem {
-    fn from(value: &'a IOfflineFilesServerItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesServerItem> for IOfflineFilesItem {
-    fn from(value: &IOfflineFilesServerItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesServerItem, ::windows::core::IUnknown, IOfflineFilesItem);
 impl ::core::clone::Clone for IOfflineFilesServerItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2924,21 +2423,7 @@ impl IOfflineFilesSetting {
         (::windows::core::Vtable::vtable(self).GetValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvarvalue), ::core::mem::transmute(pbsetbypolicy)).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesSetting> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesSetting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesSetting> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesSetting) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesSetting> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesSetting) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesSetting, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesSetting {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3006,21 +2491,7 @@ impl IOfflineFilesShareInfo {
         (::windows::core::Vtable::vtable(self).IsShareDfsJunction)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesShareInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesShareInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesShareInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesShareInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesShareInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesShareInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesShareInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesShareInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3080,36 +2551,7 @@ impl IOfflineFilesShareItem {
         (::windows::core::Vtable::vtable(self).base__.IsMarkedForDeletion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesShareItem> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesShareItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesShareItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesShareItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesShareItem> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesShareItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesShareItem> for IOfflineFilesItem {
-    fn from(value: IOfflineFilesShareItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesShareItem> for &'a IOfflineFilesItem {
-    fn from(value: &'a IOfflineFilesShareItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesShareItem> for IOfflineFilesItem {
-    fn from(value: &IOfflineFilesShareItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesShareItem, ::windows::core::IUnknown, IOfflineFilesItem);
 impl ::core::clone::Clone for IOfflineFilesShareItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3171,36 +2613,7 @@ impl IOfflineFilesSimpleProgress {
         (::windows::core::Vtable::vtable(self).ItemResult)(::windows::core::Vtable::as_raw(self), pszfile.into(), hrresult, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<OFFLINEFILES_OP_RESPONSE>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesSimpleProgress> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesSimpleProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesSimpleProgress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesSimpleProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesSimpleProgress> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesSimpleProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesSimpleProgress> for IOfflineFilesProgress {
-    fn from(value: IOfflineFilesSimpleProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesSimpleProgress> for &'a IOfflineFilesProgress {
-    fn from(value: &'a IOfflineFilesSimpleProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesSimpleProgress> for IOfflineFilesProgress {
-    fn from(value: &IOfflineFilesSimpleProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesSimpleProgress, ::windows::core::IUnknown, IOfflineFilesProgress);
 impl ::core::clone::Clone for IOfflineFilesSimpleProgress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3243,21 +2656,7 @@ impl IOfflineFilesSuspend {
         (::windows::core::Vtable::vtable(self).SuspendRoot)(::windows::core::Vtable::as_raw(self), bsuspend.into()).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesSuspend> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesSuspend) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesSuspend> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesSuspend) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesSuspend> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesSuspend) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesSuspend, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesSuspend {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3299,21 +2698,7 @@ impl IOfflineFilesSuspendInfo {
         (::windows::core::Vtable::vtable(self).IsSuspended)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbsuspended), ::core::mem::transmute(pbsuspendedroot)).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesSuspendInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesSuspendInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesSuspendInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesSuspendInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesSuspendInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesSuspendInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesSuspendInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesSuspendInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3356,21 +2741,7 @@ impl IOfflineFilesSyncConflictHandler {
         (::windows::core::Vtable::vtable(self).ResolveConflict)(::windows::core::Vtable::as_raw(self), pszpath.into(), fstateknown, state, fchangedetails, ::core::mem::transmute(pconflictresolution), ::core::mem::transmute(ppsznewname)).ok()
     }
 }
-impl ::core::convert::From<IOfflineFilesSyncConflictHandler> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesSyncConflictHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesSyncConflictHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesSyncConflictHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesSyncConflictHandler> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesSyncConflictHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesSyncConflictHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesSyncConflictHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3444,36 +2815,7 @@ impl IOfflineFilesSyncErrorInfo {
         (::windows::core::Vtable::vtable(self).GetOriginalInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOfflineFilesSyncErrorItemInfo>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesSyncErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesSyncErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesSyncErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesSyncErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesSyncErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesSyncErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesSyncErrorInfo> for IOfflineFilesErrorInfo {
-    fn from(value: IOfflineFilesSyncErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesSyncErrorInfo> for &'a IOfflineFilesErrorInfo {
-    fn from(value: &'a IOfflineFilesSyncErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesSyncErrorInfo> for IOfflineFilesErrorInfo {
-    fn from(value: &IOfflineFilesSyncErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesSyncErrorInfo, ::windows::core::IUnknown, IOfflineFilesErrorInfo);
 impl ::core::clone::Clone for IOfflineFilesSyncErrorInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3532,21 +2874,7 @@ impl IOfflineFilesSyncErrorItemInfo {
         (::windows::core::Vtable::vtable(self).GetFileSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i64>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesSyncErrorItemInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesSyncErrorItemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesSyncErrorItemInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesSyncErrorItemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesSyncErrorItemInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesSyncErrorItemInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesSyncErrorItemInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesSyncErrorItemInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3615,36 +2943,7 @@ impl IOfflineFilesSyncProgress {
         (::windows::core::Vtable::vtable(self).SyncItemResult)(::windows::core::Vtable::as_raw(self), pszfile.into(), hrresult, perrorinfo.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<OFFLINEFILES_OP_RESPONSE>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesSyncProgress> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesSyncProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesSyncProgress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesSyncProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesSyncProgress> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesSyncProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOfflineFilesSyncProgress> for IOfflineFilesProgress {
-    fn from(value: IOfflineFilesSyncProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesSyncProgress> for &'a IOfflineFilesProgress {
-    fn from(value: &'a IOfflineFilesSyncProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesSyncProgress> for IOfflineFilesProgress {
-    fn from(value: &IOfflineFilesSyncProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesSyncProgress, ::windows::core::IUnknown, IOfflineFilesProgress);
 impl ::core::clone::Clone for IOfflineFilesSyncProgress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3685,21 +2984,7 @@ impl IOfflineFilesTransparentCacheInfo {
         (::windows::core::Vtable::vtable(self).IsTransparentlyCached)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IOfflineFilesTransparentCacheInfo> for ::windows::core::IUnknown {
-    fn from(value: IOfflineFilesTransparentCacheInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOfflineFilesTransparentCacheInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOfflineFilesTransparentCacheInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOfflineFilesTransparentCacheInfo> for ::windows::core::IUnknown {
-    fn from(value: &IOfflineFilesTransparentCacheInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOfflineFilesTransparentCacheInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOfflineFilesTransparentCacheInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
@@ -760,21 +760,7 @@ impl IAppxBlockMapBlock {
         (::windows::core::Vtable::vtable(self).GetCompressedSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAppxBlockMapBlock> for ::windows::core::IUnknown {
-    fn from(value: IAppxBlockMapBlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBlockMapBlock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBlockMapBlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBlockMapBlock> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBlockMapBlock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBlockMapBlock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBlockMapBlock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -825,21 +811,7 @@ impl IAppxBlockMapBlocksEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxBlockMapBlocksEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxBlockMapBlocksEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBlockMapBlocksEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBlockMapBlocksEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBlockMapBlocksEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBlockMapBlocksEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBlockMapBlocksEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBlockMapBlocksEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -906,21 +878,7 @@ impl IAppxBlockMapFile {
         (::windows::core::Vtable::vtable(self).ValidateFileHash)(::windows::core::Vtable::as_raw(self), filestream.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxBlockMapFile> for ::windows::core::IUnknown {
-    fn from(value: IAppxBlockMapFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBlockMapFile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBlockMapFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBlockMapFile> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBlockMapFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBlockMapFile, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBlockMapFile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -977,21 +935,7 @@ impl IAppxBlockMapFilesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxBlockMapFilesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxBlockMapFilesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBlockMapFilesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBlockMapFilesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBlockMapFilesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBlockMapFilesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBlockMapFilesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBlockMapFilesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1056,21 +1000,7 @@ impl IAppxBlockMapReader {
         (::windows::core::Vtable::vtable(self).GetStream)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IAppxBlockMapReader> for ::windows::core::IUnknown {
-    fn from(value: IAppxBlockMapReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBlockMapReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBlockMapReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBlockMapReader> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBlockMapReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBlockMapReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBlockMapReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1140,21 +1070,7 @@ impl IAppxBundleFactory {
         (::windows::core::Vtable::vtable(self).CreateBundleManifestReader)(::windows::core::Vtable::as_raw(self), inputstream.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxBundleManifestReader>(result__)
     }
 }
-impl ::core::convert::From<IAppxBundleFactory> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleFactory> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1211,21 +1127,7 @@ impl IAppxBundleManifestOptionalBundleInfo {
         (::windows::core::Vtable::vtable(self).GetPackageInfoItems)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxBundleManifestPackageInfoEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxBundleManifestOptionalBundleInfo> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleManifestOptionalBundleInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleManifestOptionalBundleInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleManifestOptionalBundleInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleManifestOptionalBundleInfo> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleManifestOptionalBundleInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleManifestOptionalBundleInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleManifestOptionalBundleInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1277,21 +1179,7 @@ impl IAppxBundleManifestOptionalBundleInfoEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxBundleManifestOptionalBundleInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleManifestOptionalBundleInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleManifestOptionalBundleInfoEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleManifestOptionalBundleInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleManifestOptionalBundleInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleManifestOptionalBundleInfoEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleManifestOptionalBundleInfoEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleManifestOptionalBundleInfoEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1357,21 +1245,7 @@ impl IAppxBundleManifestPackageInfo {
         (::windows::core::Vtable::vtable(self).GetResources)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxManifestQualifiedResourcesEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxBundleManifestPackageInfo> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleManifestPackageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleManifestPackageInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleManifestPackageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleManifestPackageInfo> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleManifestPackageInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleManifestPackageInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleManifestPackageInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1428,21 +1302,7 @@ impl IAppxBundleManifestPackageInfo2 {
         (::windows::core::Vtable::vtable(self).GetIsDefaultApplicablePackage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxBundleManifestPackageInfo2> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleManifestPackageInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleManifestPackageInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleManifestPackageInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleManifestPackageInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleManifestPackageInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleManifestPackageInfo2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleManifestPackageInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1491,21 +1351,7 @@ impl IAppxBundleManifestPackageInfo3 {
         (::windows::core::Vtable::vtable(self).GetTargetDeviceFamilies)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxManifestTargetDeviceFamiliesEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxBundleManifestPackageInfo3> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleManifestPackageInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleManifestPackageInfo3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleManifestPackageInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleManifestPackageInfo3> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleManifestPackageInfo3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleManifestPackageInfo3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleManifestPackageInfo3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1545,21 +1391,7 @@ impl IAppxBundleManifestPackageInfo4 {
         (::windows::core::Vtable::vtable(self).GetIsStub)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxBundleManifestPackageInfo4> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleManifestPackageInfo4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleManifestPackageInfo4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleManifestPackageInfo4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleManifestPackageInfo4> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleManifestPackageInfo4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleManifestPackageInfo4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleManifestPackageInfo4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1612,21 +1444,7 @@ impl IAppxBundleManifestPackageInfoEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxBundleManifestPackageInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleManifestPackageInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleManifestPackageInfoEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleManifestPackageInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleManifestPackageInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleManifestPackageInfoEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleManifestPackageInfoEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleManifestPackageInfoEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1682,21 +1500,7 @@ impl IAppxBundleManifestReader {
         (::windows::core::Vtable::vtable(self).GetStream)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IAppxBundleManifestReader> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleManifestReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleManifestReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleManifestReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleManifestReader> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleManifestReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleManifestReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleManifestReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1739,21 +1543,7 @@ impl IAppxBundleManifestReader2 {
         (::windows::core::Vtable::vtable(self).GetOptionalBundles)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxBundleManifestOptionalBundleInfoEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxBundleManifestReader2> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleManifestReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleManifestReader2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleManifestReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleManifestReader2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleManifestReader2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleManifestReader2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleManifestReader2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1810,21 +1600,7 @@ impl IAppxBundleReader {
         (::windows::core::Vtable::vtable(self).GetPayloadPackage)(::windows::core::Vtable::as_raw(self), filename.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxFile>(result__)
     }
 }
-impl ::core::convert::From<IAppxBundleReader> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleReader> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1874,21 +1650,7 @@ impl IAppxBundleWriter {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAppxBundleWriter> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleWriter> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1935,21 +1697,7 @@ impl IAppxBundleWriter2 {
         (::windows::core::Vtable::vtable(self).AddExternalPackageReference)(::windows::core::Vtable::as_raw(self), filename.into(), inputstream.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAppxBundleWriter2> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleWriter2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleWriter2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleWriter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleWriter2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleWriter2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2001,21 +1749,7 @@ impl IAppxBundleWriter3 {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self), hashmethodstring.into()).ok()
     }
 }
-impl ::core::convert::From<IAppxBundleWriter3> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleWriter3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleWriter3> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleWriter3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleWriter3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleWriter3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2083,21 +1817,7 @@ impl IAppxBundleWriter4 {
         (::windows::core::Vtable::vtable(self).AddExternalPackageReference)(::windows::core::Vtable::as_raw(self), filename.into(), inputstream.into().abi(), isdefaultapplicablepackage.into()).ok()
     }
 }
-impl ::core::convert::From<IAppxBundleWriter4> for ::windows::core::IUnknown {
-    fn from(value: IAppxBundleWriter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxBundleWriter4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxBundleWriter4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxBundleWriter4> for ::windows::core::IUnknown {
-    fn from(value: &IAppxBundleWriter4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxBundleWriter4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxBundleWriter4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2150,21 +1870,7 @@ impl IAppxContentGroup {
         (::windows::core::Vtable::vtable(self).GetFiles)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxContentGroupFilesEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxContentGroup> for ::windows::core::IUnknown {
-    fn from(value: IAppxContentGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxContentGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxContentGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxContentGroup> for ::windows::core::IUnknown {
-    fn from(value: &IAppxContentGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxContentGroup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxContentGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2215,21 +1921,7 @@ impl IAppxContentGroupFilesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxContentGroupFilesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxContentGroupFilesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxContentGroupFilesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxContentGroupFilesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxContentGroupFilesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxContentGroupFilesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxContentGroupFilesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxContentGroupFilesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2279,21 +1971,7 @@ impl IAppxContentGroupMapReader {
         (::windows::core::Vtable::vtable(self).GetAutomaticGroups)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxContentGroupsEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxContentGroupMapReader> for ::windows::core::IUnknown {
-    fn from(value: IAppxContentGroupMapReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxContentGroupMapReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxContentGroupMapReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxContentGroupMapReader> for ::windows::core::IUnknown {
-    fn from(value: &IAppxContentGroupMapReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxContentGroupMapReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxContentGroupMapReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2343,21 +2021,7 @@ impl IAppxContentGroupMapWriter {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAppxContentGroupMapWriter> for ::windows::core::IUnknown {
-    fn from(value: IAppxContentGroupMapWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxContentGroupMapWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxContentGroupMapWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxContentGroupMapWriter> for ::windows::core::IUnknown {
-    fn from(value: &IAppxContentGroupMapWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxContentGroupMapWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxContentGroupMapWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2409,21 +2073,7 @@ impl IAppxContentGroupsEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxContentGroupsEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxContentGroupsEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxContentGroupsEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxContentGroupsEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxContentGroupsEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxContentGroupsEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxContentGroupsEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxContentGroupsEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2477,21 +2127,7 @@ impl IAppxEncryptedBundleWriter {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAppxEncryptedBundleWriter> for ::windows::core::IUnknown {
-    fn from(value: IAppxEncryptedBundleWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxEncryptedBundleWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxEncryptedBundleWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxEncryptedBundleWriter> for ::windows::core::IUnknown {
-    fn from(value: &IAppxEncryptedBundleWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxEncryptedBundleWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxEncryptedBundleWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2538,21 +2174,7 @@ impl IAppxEncryptedBundleWriter2 {
         (::windows::core::Vtable::vtable(self).AddExternalPackageReference)(::windows::core::Vtable::as_raw(self), filename.into(), inputstream.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAppxEncryptedBundleWriter2> for ::windows::core::IUnknown {
-    fn from(value: IAppxEncryptedBundleWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxEncryptedBundleWriter2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxEncryptedBundleWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxEncryptedBundleWriter2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxEncryptedBundleWriter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxEncryptedBundleWriter2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxEncryptedBundleWriter2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2609,21 +2231,7 @@ impl IAppxEncryptedBundleWriter3 {
         (::windows::core::Vtable::vtable(self).AddExternalPackageReference)(::windows::core::Vtable::as_raw(self), filename.into(), inputstream.into().abi(), isdefaultapplicablepackage.into()).ok()
     }
 }
-impl ::core::convert::From<IAppxEncryptedBundleWriter3> for ::windows::core::IUnknown {
-    fn from(value: IAppxEncryptedBundleWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxEncryptedBundleWriter3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxEncryptedBundleWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxEncryptedBundleWriter3> for ::windows::core::IUnknown {
-    fn from(value: &IAppxEncryptedBundleWriter3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxEncryptedBundleWriter3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxEncryptedBundleWriter3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2676,21 +2284,7 @@ impl IAppxEncryptedPackageWriter {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAppxEncryptedPackageWriter> for ::windows::core::IUnknown {
-    fn from(value: IAppxEncryptedPackageWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxEncryptedPackageWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxEncryptedPackageWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxEncryptedPackageWriter> for ::windows::core::IUnknown {
-    fn from(value: &IAppxEncryptedPackageWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxEncryptedPackageWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxEncryptedPackageWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2733,21 +2327,7 @@ impl IAppxEncryptedPackageWriter2 {
         (::windows::core::Vtable::vtable(self).AddPayloadFilesEncrypted)(::windows::core::Vtable::as_raw(self), payloadfiles.len() as _, ::core::mem::transmute(payloadfiles.as_ptr()), memorylimit).ok()
     }
 }
-impl ::core::convert::From<IAppxEncryptedPackageWriter2> for ::windows::core::IUnknown {
-    fn from(value: IAppxEncryptedPackageWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxEncryptedPackageWriter2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxEncryptedPackageWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxEncryptedPackageWriter2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxEncryptedPackageWriter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxEncryptedPackageWriter2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxEncryptedPackageWriter2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2857,21 +2437,7 @@ impl IAppxEncryptionFactory {
         (::windows::core::Vtable::vtable(self).CreateEncryptedBundleReader)(::windows::core::Vtable::as_raw(self), inputstream.into().abi(), ::core::mem::transmute(keyinfo), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxBundleReader>(result__)
     }
 }
-impl ::core::convert::From<IAppxEncryptionFactory> for ::windows::core::IUnknown {
-    fn from(value: IAppxEncryptionFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxEncryptionFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxEncryptionFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxEncryptionFactory> for ::windows::core::IUnknown {
-    fn from(value: &IAppxEncryptionFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxEncryptionFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxEncryptionFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2947,21 +2513,7 @@ impl IAppxEncryptionFactory2 {
         (::windows::core::Vtable::vtable(self).CreateEncryptedPackageWriter)(::windows::core::Vtable::as_raw(self), outputstream.into().abi(), manifeststream.into().abi(), contentgroupmapstream.into().abi(), ::core::mem::transmute(settings), ::core::mem::transmute(keyinfo), ::core::mem::transmute(exemptedfiles), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxEncryptedPackageWriter>(result__)
     }
 }
-impl ::core::convert::From<IAppxEncryptionFactory2> for ::windows::core::IUnknown {
-    fn from(value: IAppxEncryptionFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxEncryptionFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxEncryptionFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxEncryptionFactory2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxEncryptionFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxEncryptionFactory2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxEncryptionFactory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3036,21 +2588,7 @@ impl IAppxEncryptionFactory3 {
         (::windows::core::Vtable::vtable(self).CreateEncryptedBundleWriter)(::windows::core::Vtable::as_raw(self), outputstream.into().abi(), bundleversion, ::core::mem::transmute(settings), ::core::mem::transmute(keyinfo), ::core::mem::transmute(exemptedfiles), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxEncryptedBundleWriter>(result__)
     }
 }
-impl ::core::convert::From<IAppxEncryptionFactory3> for ::windows::core::IUnknown {
-    fn from(value: IAppxEncryptionFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxEncryptionFactory3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxEncryptionFactory3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxEncryptionFactory3> for ::windows::core::IUnknown {
-    fn from(value: &IAppxEncryptionFactory3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxEncryptionFactory3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxEncryptionFactory3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3108,21 +2646,7 @@ impl IAppxEncryptionFactory4 {
         (::windows::core::Vtable::vtable(self).EncryptPackage)(::windows::core::Vtable::as_raw(self), inputstream.into().abi(), outputstream.into().abi(), ::core::mem::transmute(settings), ::core::mem::transmute(keyinfo), ::core::mem::transmute(exemptedfiles), memorylimit).ok()
     }
 }
-impl ::core::convert::From<IAppxEncryptionFactory4> for ::windows::core::IUnknown {
-    fn from(value: IAppxEncryptionFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxEncryptionFactory4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxEncryptionFactory4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxEncryptionFactory4> for ::windows::core::IUnknown {
-    fn from(value: &IAppxEncryptionFactory4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxEncryptionFactory4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxEncryptionFactory4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3205,21 +2729,7 @@ impl IAppxFactory {
         (::windows::core::Vtable::vtable(self).CreateValidatedBlockMapReader)(::windows::core::Vtable::as_raw(self), blockmapstream.into().abi(), signaturefilename.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxBlockMapReader>(result__)
     }
 }
-impl ::core::convert::From<IAppxFactory> for ::windows::core::IUnknown {
-    fn from(value: IAppxFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxFactory> for ::windows::core::IUnknown {
-    fn from(value: &IAppxFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3299,21 +2809,7 @@ impl IAppxFactory2 {
         (::windows::core::Vtable::vtable(self).CreateContentGroupMapWriter)(::windows::core::Vtable::as_raw(self), stream.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxContentGroupMapWriter>(result__)
     }
 }
-impl ::core::convert::From<IAppxFactory2> for ::windows::core::IUnknown {
-    fn from(value: IAppxFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxFactory2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxFactory2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxFactory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3380,21 +2876,7 @@ impl IAppxFile {
         (::windows::core::Vtable::vtable(self).GetStream)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IAppxFile> for ::windows::core::IUnknown {
-    fn from(value: IAppxFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxFile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxFile> for ::windows::core::IUnknown {
-    fn from(value: &IAppxFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxFile, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxFile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3451,21 +2933,7 @@ impl IAppxFilesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxFilesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxFilesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxFilesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxFilesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxFilesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxFilesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxFilesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxFilesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3518,21 +2986,7 @@ impl IAppxManifestApplication {
         (::windows::core::Vtable::vtable(self).GetAppUserModelId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestApplication> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestApplication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestApplication> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestApplication, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestApplication {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3583,21 +3037,7 @@ impl IAppxManifestApplicationsEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestApplicationsEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestApplicationsEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestApplicationsEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestApplicationsEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestApplicationsEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestApplicationsEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestApplicationsEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestApplicationsEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3655,21 +3095,7 @@ impl IAppxManifestCapabilitiesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestCapabilitiesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestCapabilitiesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestCapabilitiesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestCapabilitiesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestCapabilitiesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestCapabilitiesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestCapabilitiesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestCapabilitiesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3727,21 +3153,7 @@ impl IAppxManifestDeviceCapabilitiesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestDeviceCapabilitiesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestDeviceCapabilitiesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestDeviceCapabilitiesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestDeviceCapabilitiesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestDeviceCapabilitiesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestDeviceCapabilitiesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestDeviceCapabilitiesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestDeviceCapabilitiesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3795,21 +3207,7 @@ impl IAppxManifestDriverConstraint {
         (::windows::core::Vtable::vtable(self).GetMinDate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestDriverConstraint> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestDriverConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestDriverConstraint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestDriverConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestDriverConstraint> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestDriverConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestDriverConstraint, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestDriverConstraint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3861,21 +3259,7 @@ impl IAppxManifestDriverConstraintsEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestDriverConstraintsEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestDriverConstraintsEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestDriverConstraintsEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestDriverConstraintsEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestDriverConstraintsEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestDriverConstraintsEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestDriverConstraintsEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestDriverConstraintsEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3933,21 +3317,7 @@ impl IAppxManifestDriverDependenciesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestDriverDependenciesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestDriverDependenciesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestDriverDependenciesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestDriverDependenciesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestDriverDependenciesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestDriverDependenciesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestDriverDependenciesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestDriverDependenciesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3993,21 +3363,7 @@ impl IAppxManifestDriverDependency {
         (::windows::core::Vtable::vtable(self).GetDriverConstraints)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxManifestDriverConstraintsEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestDriverDependency> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestDriverDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestDriverDependency> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestDriverDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestDriverDependency> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestDriverDependency) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestDriverDependency, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestDriverDependency {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4057,21 +3413,7 @@ impl IAppxManifestHostRuntimeDependenciesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestHostRuntimeDependenciesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestHostRuntimeDependenciesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestHostRuntimeDependenciesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestHostRuntimeDependenciesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestHostRuntimeDependenciesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestHostRuntimeDependenciesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestHostRuntimeDependenciesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestHostRuntimeDependenciesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4125,21 +3467,7 @@ impl IAppxManifestHostRuntimeDependency {
         (::windows::core::Vtable::vtable(self).GetMinVersion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestHostRuntimeDependency> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestHostRuntimeDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestHostRuntimeDependency> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestHostRuntimeDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestHostRuntimeDependency> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestHostRuntimeDependency) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestHostRuntimeDependency, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestHostRuntimeDependency {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4179,21 +3507,7 @@ impl IAppxManifestHostRuntimeDependency2 {
         (::windows::core::Vtable::vtable(self).GetPackageFamilyName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestHostRuntimeDependency2> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestHostRuntimeDependency2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestHostRuntimeDependency2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestHostRuntimeDependency2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestHostRuntimeDependency2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestHostRuntimeDependency2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestHostRuntimeDependency2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestHostRuntimeDependency2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4243,21 +3557,7 @@ impl IAppxManifestMainPackageDependenciesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestMainPackageDependenciesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestMainPackageDependenciesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestMainPackageDependenciesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestMainPackageDependenciesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestMainPackageDependenciesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestMainPackageDependenciesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestMainPackageDependenciesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestMainPackageDependenciesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4311,21 +3611,7 @@ impl IAppxManifestMainPackageDependency {
         (::windows::core::Vtable::vtable(self).GetPackageFamilyName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestMainPackageDependency> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestMainPackageDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestMainPackageDependency> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestMainPackageDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestMainPackageDependency> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestMainPackageDependency) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestMainPackageDependency, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestMainPackageDependency {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4377,21 +3663,7 @@ impl IAppxManifestOSPackageDependenciesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestOSPackageDependenciesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestOSPackageDependenciesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestOSPackageDependenciesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestOSPackageDependenciesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestOSPackageDependenciesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestOSPackageDependenciesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestOSPackageDependenciesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestOSPackageDependenciesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4441,21 +3713,7 @@ impl IAppxManifestOSPackageDependency {
         (::windows::core::Vtable::vtable(self).GetVersion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestOSPackageDependency> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestOSPackageDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestOSPackageDependency> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestOSPackageDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestOSPackageDependency> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestOSPackageDependency) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestOSPackageDependency, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestOSPackageDependency {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4500,21 +3758,7 @@ impl IAppxManifestOptionalPackageInfo {
         (::windows::core::Vtable::vtable(self).GetMainPackageName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestOptionalPackageInfo> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestOptionalPackageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestOptionalPackageInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestOptionalPackageInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestOptionalPackageInfo> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestOptionalPackageInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestOptionalPackageInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestOptionalPackageInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4568,21 +3812,7 @@ impl IAppxManifestPackageDependenciesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestPackageDependenciesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestPackageDependenciesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestPackageDependenciesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestPackageDependenciesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestPackageDependenciesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestPackageDependenciesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestPackageDependenciesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestPackageDependenciesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4636,21 +3866,7 @@ impl IAppxManifestPackageDependency {
         (::windows::core::Vtable::vtable(self).GetMinVersion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestPackageDependency> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestPackageDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestPackageDependency> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestPackageDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestPackageDependency> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestPackageDependency) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestPackageDependency, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestPackageDependency {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4702,36 +3918,7 @@ impl IAppxManifestPackageDependency2 {
         (::windows::core::Vtable::vtable(self).GetMaxMajorVersionTested)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u16>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestPackageDependency2> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestPackageDependency2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestPackageDependency2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestPackageDependency2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestPackageDependency2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestPackageDependency2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppxManifestPackageDependency2> for IAppxManifestPackageDependency {
-    fn from(value: IAppxManifestPackageDependency2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestPackageDependency2> for &'a IAppxManifestPackageDependency {
-    fn from(value: &'a IAppxManifestPackageDependency2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestPackageDependency2> for IAppxManifestPackageDependency {
-    fn from(value: &IAppxManifestPackageDependency2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestPackageDependency2, ::windows::core::IUnknown, IAppxManifestPackageDependency);
 impl ::core::clone::Clone for IAppxManifestPackageDependency2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4771,21 +3958,7 @@ impl IAppxManifestPackageDependency3 {
         (::windows::core::Vtable::vtable(self).GetIsOptional)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestPackageDependency3> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestPackageDependency3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestPackageDependency3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestPackageDependency3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestPackageDependency3> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestPackageDependency3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestPackageDependency3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestPackageDependency3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4859,21 +4032,7 @@ impl IAppxManifestPackageId {
         (::windows::core::Vtable::vtable(self).GetPackageFamilyName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestPackageId> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestPackageId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestPackageId> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestPackageId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestPackageId> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestPackageId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestPackageId, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestPackageId {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4958,36 +4117,7 @@ impl IAppxManifestPackageId2 {
         (::windows::core::Vtable::vtable(self).GetArchitecture2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<APPX_PACKAGE_ARCHITECTURE2>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestPackageId2> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestPackageId2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestPackageId2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestPackageId2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestPackageId2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestPackageId2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppxManifestPackageId2> for IAppxManifestPackageId {
-    fn from(value: IAppxManifestPackageId2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestPackageId2> for &'a IAppxManifestPackageId {
-    fn from(value: &'a IAppxManifestPackageId2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestPackageId2> for IAppxManifestPackageId {
-    fn from(value: &IAppxManifestPackageId2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestPackageId2, ::windows::core::IUnknown, IAppxManifestPackageId);
 impl ::core::clone::Clone for IAppxManifestPackageId2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5037,21 +4167,7 @@ impl IAppxManifestProperties {
         (::windows::core::Vtable::vtable(self).GetStringValue)(::windows::core::Vtable::as_raw(self), name.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestProperties> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestProperties> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5101,21 +4217,7 @@ impl IAppxManifestQualifiedResource {
         (::windows::core::Vtable::vtable(self).GetDXFeatureLevel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DX_FEATURE_LEVEL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestQualifiedResource> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestQualifiedResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestQualifiedResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestQualifiedResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestQualifiedResource> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestQualifiedResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestQualifiedResource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestQualifiedResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5167,21 +4269,7 @@ impl IAppxManifestQualifiedResourcesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestQualifiedResourcesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestQualifiedResourcesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestQualifiedResourcesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestQualifiedResourcesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestQualifiedResourcesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestQualifiedResourcesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestQualifiedResourcesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestQualifiedResourcesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5264,21 +4352,7 @@ impl IAppxManifestReader {
         (::windows::core::Vtable::vtable(self).GetStream)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestReader> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5368,36 +4442,7 @@ impl IAppxManifestReader2 {
         (::windows::core::Vtable::vtable(self).GetQualifiedResources)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxManifestQualifiedResourcesEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestReader2> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestReader2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppxManifestReader2> for IAppxManifestReader {
-    fn from(value: IAppxManifestReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader2> for &'a IAppxManifestReader {
-    fn from(value: &'a IAppxManifestReader2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader2> for IAppxManifestReader {
-    fn from(value: &IAppxManifestReader2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestReader2, ::windows::core::IUnknown, IAppxManifestReader);
 impl ::core::clone::Clone for IAppxManifestReader2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5484,51 +4529,7 @@ impl IAppxManifestReader3 {
         (::windows::core::Vtable::vtable(self).GetTargetDeviceFamilies)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxManifestTargetDeviceFamiliesEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestReader3> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader3> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestReader3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppxManifestReader3> for IAppxManifestReader {
-    fn from(value: IAppxManifestReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader3> for &'a IAppxManifestReader {
-    fn from(value: &'a IAppxManifestReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader3> for IAppxManifestReader {
-    fn from(value: &IAppxManifestReader3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppxManifestReader3> for IAppxManifestReader2 {
-    fn from(value: IAppxManifestReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader3> for &'a IAppxManifestReader2 {
-    fn from(value: &'a IAppxManifestReader3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader3> for IAppxManifestReader2 {
-    fn from(value: &IAppxManifestReader3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestReader3, ::windows::core::IUnknown, IAppxManifestReader, IAppxManifestReader2);
 impl ::core::clone::Clone for IAppxManifestReader3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5620,66 +4621,7 @@ impl IAppxManifestReader4 {
         (::windows::core::Vtable::vtable(self).GetOptionalPackageInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxManifestOptionalPackageInfo>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestReader4> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestReader4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestReader4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader4> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestReader4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppxManifestReader4> for IAppxManifestReader {
-    fn from(value: IAppxManifestReader4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader4> for &'a IAppxManifestReader {
-    fn from(value: &'a IAppxManifestReader4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader4> for IAppxManifestReader {
-    fn from(value: &IAppxManifestReader4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppxManifestReader4> for IAppxManifestReader2 {
-    fn from(value: IAppxManifestReader4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader4> for &'a IAppxManifestReader2 {
-    fn from(value: &'a IAppxManifestReader4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader4> for IAppxManifestReader2 {
-    fn from(value: &IAppxManifestReader4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAppxManifestReader4> for IAppxManifestReader3 {
-    fn from(value: IAppxManifestReader4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader4> for &'a IAppxManifestReader3 {
-    fn from(value: &'a IAppxManifestReader4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader4> for IAppxManifestReader3 {
-    fn from(value: &IAppxManifestReader4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestReader4, ::windows::core::IUnknown, IAppxManifestReader, IAppxManifestReader2, IAppxManifestReader3);
 impl ::core::clone::Clone for IAppxManifestReader4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5717,21 +4659,7 @@ impl IAppxManifestReader5 {
         (::windows::core::Vtable::vtable(self).GetMainPackageDependencies)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxManifestMainPackageDependenciesEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestReader5> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestReader5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestReader5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader5> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestReader5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestReader5, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestReader5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5771,21 +4699,7 @@ impl IAppxManifestReader6 {
         (::windows::core::Vtable::vtable(self).GetIsNonQualifiedResourcePackage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestReader6> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestReader6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestReader6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader6> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestReader6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestReader6, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestReader6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5834,21 +4748,7 @@ impl IAppxManifestReader7 {
         (::windows::core::Vtable::vtable(self).GetHostRuntimeDependencies)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxManifestHostRuntimeDependenciesEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestReader7> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestReader7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestReader7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestReader7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestReader7> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestReader7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestReader7, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestReader7 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5900,21 +4800,7 @@ impl IAppxManifestResourcesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestResourcesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestResourcesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestResourcesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestResourcesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestResourcesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestResourcesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestResourcesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestResourcesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5972,21 +4858,7 @@ impl IAppxManifestTargetDeviceFamiliesEnumerator {
         (::windows::core::Vtable::vtable(self).MoveNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestTargetDeviceFamiliesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestTargetDeviceFamiliesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestTargetDeviceFamiliesEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestTargetDeviceFamiliesEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestTargetDeviceFamiliesEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestTargetDeviceFamiliesEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestTargetDeviceFamiliesEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestTargetDeviceFamiliesEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6040,21 +4912,7 @@ impl IAppxManifestTargetDeviceFamily {
         (::windows::core::Vtable::vtable(self).GetMaxVersionTested)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IAppxManifestTargetDeviceFamily> for ::windows::core::IUnknown {
-    fn from(value: IAppxManifestTargetDeviceFamily) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxManifestTargetDeviceFamily> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxManifestTargetDeviceFamily) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxManifestTargetDeviceFamily> for ::windows::core::IUnknown {
-    fn from(value: &IAppxManifestTargetDeviceFamily) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxManifestTargetDeviceFamily, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxManifestTargetDeviceFamily {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6145,21 +5003,7 @@ impl IAppxPackageEditor {
         (::windows::core::Vtable::vtable(self).UpdatePackageManifest)(::windows::core::Vtable::as_raw(self), packagestream.into().abi(), updatedmanifeststream.into().abi(), ispackageencrypted.into(), options).ok()
     }
 }
-impl ::core::convert::From<IAppxPackageEditor> for ::windows::core::IUnknown {
-    fn from(value: IAppxPackageEditor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxPackageEditor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxPackageEditor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxPackageEditor> for ::windows::core::IUnknown {
-    fn from(value: &IAppxPackageEditor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxPackageEditor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxPackageEditor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6236,21 +5080,7 @@ impl IAppxPackageReader {
         (::windows::core::Vtable::vtable(self).GetManifest)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxManifestReader>(result__)
     }
 }
-impl ::core::convert::From<IAppxPackageReader> for ::windows::core::IUnknown {
-    fn from(value: IAppxPackageReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxPackageReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxPackageReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxPackageReader> for ::windows::core::IUnknown {
-    fn from(value: &IAppxPackageReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxPackageReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxPackageReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6306,21 +5136,7 @@ impl IAppxPackageWriter {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self), manifest.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAppxPackageWriter> for ::windows::core::IUnknown {
-    fn from(value: IAppxPackageWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxPackageWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxPackageWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxPackageWriter> for ::windows::core::IUnknown {
-    fn from(value: &IAppxPackageWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxPackageWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxPackageWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6370,21 +5186,7 @@ impl IAppxPackageWriter2 {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self), manifest.into().abi(), contentgroupmap.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAppxPackageWriter2> for ::windows::core::IUnknown {
-    fn from(value: IAppxPackageWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxPackageWriter2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxPackageWriter2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxPackageWriter2> for ::windows::core::IUnknown {
-    fn from(value: &IAppxPackageWriter2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxPackageWriter2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxPackageWriter2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6426,21 +5228,7 @@ impl IAppxPackageWriter3 {
         (::windows::core::Vtable::vtable(self).AddPayloadFiles)(::windows::core::Vtable::as_raw(self), payloadfiles.len() as _, ::core::mem::transmute(payloadfiles.as_ptr()), memorylimit).ok()
     }
 }
-impl ::core::convert::From<IAppxPackageWriter3> for ::windows::core::IUnknown {
-    fn from(value: IAppxPackageWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxPackageWriter3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxPackageWriter3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxPackageWriter3> for ::windows::core::IUnknown {
-    fn from(value: &IAppxPackageWriter3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxPackageWriter3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxPackageWriter3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6491,21 +5279,7 @@ impl IAppxPackagingDiagnosticEventSink {
         (::windows::core::Vtable::vtable(self).ReportError)(::windows::core::Vtable::as_raw(self), errormessage.into()).ok()
     }
 }
-impl ::core::convert::From<IAppxPackagingDiagnosticEventSink> for ::windows::core::IUnknown {
-    fn from(value: IAppxPackagingDiagnosticEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxPackagingDiagnosticEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxPackagingDiagnosticEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxPackagingDiagnosticEventSink> for ::windows::core::IUnknown {
-    fn from(value: &IAppxPackagingDiagnosticEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxPackagingDiagnosticEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxPackagingDiagnosticEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6546,21 +5320,7 @@ impl IAppxPackagingDiagnosticEventSinkManager {
         (::windows::core::Vtable::vtable(self).SetSinkForProcess)(::windows::core::Vtable::as_raw(self), sink.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAppxPackagingDiagnosticEventSinkManager> for ::windows::core::IUnknown {
-    fn from(value: IAppxPackagingDiagnosticEventSinkManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxPackagingDiagnosticEventSinkManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxPackagingDiagnosticEventSinkManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxPackagingDiagnosticEventSinkManager> for ::windows::core::IUnknown {
-    fn from(value: &IAppxPackagingDiagnosticEventSinkManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxPackagingDiagnosticEventSinkManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxPackagingDiagnosticEventSinkManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6602,21 +5362,7 @@ impl IAppxSourceContentGroupMapReader {
         (::windows::core::Vtable::vtable(self).GetAutomaticGroups)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAppxContentGroupsEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IAppxSourceContentGroupMapReader> for ::windows::core::IUnknown {
-    fn from(value: IAppxSourceContentGroupMapReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppxSourceContentGroupMapReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppxSourceContentGroupMapReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppxSourceContentGroupMapReader> for ::windows::core::IUnknown {
-    fn from(value: &IAppxSourceContentGroupMapReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppxSourceContentGroupMapReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppxSourceContentGroupMapReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/mod.rs
@@ -22,21 +22,7 @@ impl IOpcCertificateEnumerator {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcCertificateEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcCertificateEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IOpcCertificateEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcCertificateEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcCertificateEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcCertificateEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IOpcCertificateEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcCertificateEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcCertificateEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -96,21 +82,7 @@ impl IOpcCertificateSet {
         (::windows::core::Vtable::vtable(self).GetEnumerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcCertificateEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcCertificateSet> for ::windows::core::IUnknown {
-    fn from(value: IOpcCertificateSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcCertificateSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcCertificateSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcCertificateSet> for ::windows::core::IUnknown {
-    fn from(value: &IOpcCertificateSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcCertificateSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcCertificateSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -209,21 +181,7 @@ impl IOpcDigitalSignature {
         (::windows::core::Vtable::vtable(self).GetSignatureXml)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(signaturexml), ::core::mem::transmute(count)).ok()
     }
 }
-impl ::core::convert::From<IOpcDigitalSignature> for ::windows::core::IUnknown {
-    fn from(value: IOpcDigitalSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcDigitalSignature> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcDigitalSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcDigitalSignature> for ::windows::core::IUnknown {
-    fn from(value: &IOpcDigitalSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcDigitalSignature, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcDigitalSignature {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -294,21 +252,7 @@ impl IOpcDigitalSignatureEnumerator {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcDigitalSignatureEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcDigitalSignatureEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IOpcDigitalSignatureEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcDigitalSignatureEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcDigitalSignatureEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcDigitalSignatureEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IOpcDigitalSignatureEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcDigitalSignatureEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcDigitalSignatureEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -407,21 +351,7 @@ impl IOpcDigitalSignatureManager {
         (::windows::core::Vtable::vtable(self).ReplaceSignatureXml)(::windows::core::Vtable::as_raw(self), signaturepartname.into().abi(), ::core::mem::transmute(newsignaturexml), count, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcDigitalSignature>(result__)
     }
 }
-impl ::core::convert::From<IOpcDigitalSignatureManager> for ::windows::core::IUnknown {
-    fn from(value: IOpcDigitalSignatureManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcDigitalSignatureManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcDigitalSignatureManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcDigitalSignatureManager> for ::windows::core::IUnknown {
-    fn from(value: &IOpcDigitalSignatureManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcDigitalSignatureManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcDigitalSignatureManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -533,21 +463,7 @@ impl IOpcFactory {
         (::windows::core::Vtable::vtable(self).CreateDigitalSignatureManager)(::windows::core::Vtable::as_raw(self), package.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcDigitalSignatureManager>(result__)
     }
 }
-impl ::core::convert::From<IOpcFactory> for ::windows::core::IUnknown {
-    fn from(value: IOpcFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcFactory> for ::windows::core::IUnknown {
-    fn from(value: &IOpcFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -610,21 +526,7 @@ impl IOpcPackage {
         (::windows::core::Vtable::vtable(self).GetRelationshipSet)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcRelationshipSet>(result__)
     }
 }
-impl ::core::convert::From<IOpcPackage> for ::windows::core::IUnknown {
-    fn from(value: IOpcPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcPackage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcPackage> for ::windows::core::IUnknown {
-    fn from(value: &IOpcPackage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcPackage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcPackage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -683,21 +585,7 @@ impl IOpcPart {
         (::windows::core::Vtable::vtable(self).GetCompressionOptions)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<OPC_COMPRESSION_OPTIONS>(result__)
     }
 }
-impl ::core::convert::From<IOpcPart> for ::windows::core::IUnknown {
-    fn from(value: IOpcPart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcPart> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcPart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcPart> for ::windows::core::IUnknown {
-    fn from(value: &IOpcPart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcPart, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcPart {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -761,21 +649,7 @@ impl IOpcPartEnumerator {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcPartEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcPartEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IOpcPartEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcPartEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcPartEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcPartEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IOpcPartEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcPartEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcPartEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -858,21 +732,7 @@ impl IOpcPartSet {
         (::windows::core::Vtable::vtable(self).GetEnumerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcPartEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcPartSet> for ::windows::core::IUnknown {
-    fn from(value: IOpcPartSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcPartSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcPartSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcPartSet> for ::windows::core::IUnknown {
-    fn from(value: &IOpcPartSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcPartSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcPartSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1120,59 +980,7 @@ impl IOpcPartUri {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOpcPartUri> for ::windows::core::IUnknown {
-    fn from(value: IOpcPartUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOpcPartUri> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcPartUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOpcPartUri> for ::windows::core::IUnknown {
-    fn from(value: &IOpcPartUri) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOpcPartUri> for super::super::super::System::Com::IUri {
-    fn from(value: IOpcPartUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOpcPartUri> for &'a super::super::super::System::Com::IUri {
-    fn from(value: &'a IOpcPartUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOpcPartUri> for super::super::super::System::Com::IUri {
-    fn from(value: &IOpcPartUri) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOpcPartUri> for IOpcUri {
-    fn from(value: IOpcPartUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOpcPartUri> for &'a IOpcUri {
-    fn from(value: &'a IOpcPartUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOpcPartUri> for IOpcUri {
-    fn from(value: &IOpcPartUri) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcPartUri, ::windows::core::IUnknown, super::super::super::System::Com::IUri, IOpcUri);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IOpcPartUri {
     fn clone(&self) -> Self {
@@ -1248,21 +1056,7 @@ impl IOpcRelationship {
         (::windows::core::Vtable::vtable(self).GetTargetMode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<OPC_URI_TARGET_MODE>(result__)
     }
 }
-impl ::core::convert::From<IOpcRelationship> for ::windows::core::IUnknown {
-    fn from(value: IOpcRelationship) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcRelationship> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcRelationship) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcRelationship> for ::windows::core::IUnknown {
-    fn from(value: &IOpcRelationship) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcRelationship, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcRelationship {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1326,21 +1120,7 @@ impl IOpcRelationshipEnumerator {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcRelationshipEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcRelationshipEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IOpcRelationshipEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcRelationshipEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcRelationshipEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcRelationshipEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IOpcRelationshipEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcRelationshipEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcRelationshipEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1391,21 +1171,7 @@ impl IOpcRelationshipSelector {
         (::windows::core::Vtable::vtable(self).GetSelectionCriterion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IOpcRelationshipSelector> for ::windows::core::IUnknown {
-    fn from(value: IOpcRelationshipSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcRelationshipSelector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcRelationshipSelector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcRelationshipSelector> for ::windows::core::IUnknown {
-    fn from(value: &IOpcRelationshipSelector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcRelationshipSelector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcRelationshipSelector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1460,21 +1226,7 @@ impl IOpcRelationshipSelectorEnumerator {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcRelationshipSelectorEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcRelationshipSelectorEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IOpcRelationshipSelectorEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcRelationshipSelectorEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcRelationshipSelectorEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcRelationshipSelectorEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IOpcRelationshipSelectorEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcRelationshipSelectorEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcRelationshipSelectorEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1534,21 +1286,7 @@ impl IOpcRelationshipSelectorSet {
         (::windows::core::Vtable::vtable(self).GetEnumerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcRelationshipSelectorEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcRelationshipSelectorSet> for ::windows::core::IUnknown {
-    fn from(value: IOpcRelationshipSelectorSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcRelationshipSelectorSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcRelationshipSelectorSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcRelationshipSelectorSet> for ::windows::core::IUnknown {
-    fn from(value: &IOpcRelationshipSelectorSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcRelationshipSelectorSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcRelationshipSelectorSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1634,21 +1372,7 @@ impl IOpcRelationshipSet {
         (::windows::core::Vtable::vtable(self).GetRelationshipsContentStream)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IOpcRelationshipSet> for ::windows::core::IUnknown {
-    fn from(value: IOpcRelationshipSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcRelationshipSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcRelationshipSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcRelationshipSet> for ::windows::core::IUnknown {
-    fn from(value: &IOpcRelationshipSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcRelationshipSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcRelationshipSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1700,21 +1424,7 @@ impl IOpcSignatureCustomObject {
         (::windows::core::Vtable::vtable(self).GetXml)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(xmlmarkup), ::core::mem::transmute(count)).ok()
     }
 }
-impl ::core::convert::From<IOpcSignatureCustomObject> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignatureCustomObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignatureCustomObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignatureCustomObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignatureCustomObject> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignatureCustomObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignatureCustomObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignatureCustomObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1768,21 +1478,7 @@ impl IOpcSignatureCustomObjectEnumerator {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcSignatureCustomObjectEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcSignatureCustomObjectEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignatureCustomObjectEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignatureCustomObjectEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignatureCustomObjectEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignatureCustomObjectEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignatureCustomObjectEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignatureCustomObjectEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignatureCustomObjectEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1839,21 +1535,7 @@ impl IOpcSignatureCustomObjectSet {
         (::windows::core::Vtable::vtable(self).GetEnumerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcSignatureCustomObjectEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcSignatureCustomObjectSet> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignatureCustomObjectSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignatureCustomObjectSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignatureCustomObjectSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignatureCustomObjectSet> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignatureCustomObjectSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignatureCustomObjectSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignatureCustomObjectSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1910,21 +1592,7 @@ impl IOpcSignaturePartReference {
         (::windows::core::Vtable::vtable(self).GetTransformMethod)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<OPC_CANONICALIZATION_METHOD>(result__)
     }
 }
-impl ::core::convert::From<IOpcSignaturePartReference> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignaturePartReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignaturePartReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignaturePartReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignaturePartReference> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignaturePartReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignaturePartReference, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignaturePartReference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1985,21 +1653,7 @@ impl IOpcSignaturePartReferenceEnumerator {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcSignaturePartReferenceEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcSignaturePartReferenceEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignaturePartReferenceEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignaturePartReferenceEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignaturePartReferenceEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignaturePartReferenceEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignaturePartReferenceEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignaturePartReferenceEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignaturePartReferenceEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2062,21 +1716,7 @@ impl IOpcSignaturePartReferenceSet {
         (::windows::core::Vtable::vtable(self).GetEnumerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcSignaturePartReferenceEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcSignaturePartReferenceSet> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignaturePartReferenceSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignaturePartReferenceSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignaturePartReferenceSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignaturePartReferenceSet> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignaturePartReferenceSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignaturePartReferenceSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignaturePartReferenceSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2140,21 +1780,7 @@ impl IOpcSignatureReference {
         (::windows::core::Vtable::vtable(self).GetDigestValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(digestvalue), ::core::mem::transmute(count)).ok()
     }
 }
-impl ::core::convert::From<IOpcSignatureReference> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignatureReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignatureReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignatureReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignatureReference> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignatureReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignatureReference, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignatureReference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2216,21 +1842,7 @@ impl IOpcSignatureReferenceEnumerator {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcSignatureReferenceEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcSignatureReferenceEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignatureReferenceEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignatureReferenceEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignatureReferenceEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignatureReferenceEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignatureReferenceEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignatureReferenceEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignatureReferenceEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2295,21 +1907,7 @@ impl IOpcSignatureReferenceSet {
         (::windows::core::Vtable::vtable(self).GetEnumerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcSignatureReferenceEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcSignatureReferenceSet> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignatureReferenceSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignatureReferenceSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignatureReferenceSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignatureReferenceSet> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignatureReferenceSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignatureReferenceSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignatureReferenceSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2373,21 +1971,7 @@ impl IOpcSignatureRelationshipReference {
         (::windows::core::Vtable::vtable(self).GetRelationshipSelectorEnumerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcRelationshipSelectorEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcSignatureRelationshipReference> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignatureRelationshipReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignatureRelationshipReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignatureRelationshipReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignatureRelationshipReference> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignatureRelationshipReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignatureRelationshipReference, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignatureRelationshipReference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2449,21 +2033,7 @@ impl IOpcSignatureRelationshipReferenceEnumerator {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcSignatureRelationshipReferenceEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcSignatureRelationshipReferenceEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignatureRelationshipReferenceEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignatureRelationshipReferenceEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignatureRelationshipReferenceEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignatureRelationshipReferenceEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignatureRelationshipReferenceEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignatureRelationshipReferenceEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignatureRelationshipReferenceEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2531,21 +2101,7 @@ impl IOpcSignatureRelationshipReferenceSet {
         (::windows::core::Vtable::vtable(self).GetEnumerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOpcSignatureRelationshipReferenceEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IOpcSignatureRelationshipReferenceSet> for ::windows::core::IUnknown {
-    fn from(value: IOpcSignatureRelationshipReferenceSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSignatureRelationshipReferenceSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSignatureRelationshipReferenceSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSignatureRelationshipReferenceSet> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSignatureRelationshipReferenceSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSignatureRelationshipReferenceSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSignatureRelationshipReferenceSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2663,21 +2219,7 @@ impl IOpcSigningOptions {
         (::windows::core::Vtable::vtable(self).SetSignaturePartName)(::windows::core::Vtable::as_raw(self), signaturepartname.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IOpcSigningOptions> for ::windows::core::IUnknown {
-    fn from(value: IOpcSigningOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpcSigningOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcSigningOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpcSigningOptions> for ::windows::core::IUnknown {
-    fn from(value: &IOpcSigningOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcSigningOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpcSigningOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2910,41 +2452,7 @@ impl IOpcUri {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOpcUri> for ::windows::core::IUnknown {
-    fn from(value: IOpcUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOpcUri> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpcUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOpcUri> for ::windows::core::IUnknown {
-    fn from(value: &IOpcUri) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IOpcUri> for super::super::super::System::Com::IUri {
-    fn from(value: IOpcUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IOpcUri> for &'a super::super::super::System::Com::IUri {
-    fn from(value: &'a IOpcUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IOpcUri> for super::super::super::System::Com::IUri {
-    fn from(value: &IOpcUri) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpcUri, ::windows::core::IUnknown, super::super::super::System::Com::IUri);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IOpcUri {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
@@ -16,21 +16,7 @@ impl IEnumVdsObject {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumVdsObject>(result__)
     }
 }
-impl ::core::convert::From<IEnumVdsObject> for ::windows::core::IUnknown {
-    fn from(value: IEnumVdsObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumVdsObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumVdsObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumVdsObject> for ::windows::core::IUnknown {
-    fn from(value: &IEnumVdsObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumVdsObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumVdsObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -78,21 +64,7 @@ impl IVdsAdmin {
         (::windows::core::Vtable::vtable(self).UnregisterProvider)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(providerid)).ok()
     }
 }
-impl ::core::convert::From<IVdsAdmin> for ::windows::core::IUnknown {
-    fn from(value: IVdsAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsAdmin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsAdmin> for ::windows::core::IUnknown {
-    fn from(value: &IVdsAdmin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsAdmin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsAdmin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -130,21 +102,7 @@ impl IVdsAdviseSink {
         (::windows::core::Vtable::vtable(self).OnNotify)(::windows::core::Vtable::as_raw(self), pnotificationarray.len() as _, ::core::mem::transmute(pnotificationarray.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IVdsAdviseSink> for ::windows::core::IUnknown {
-    fn from(value: IVdsAdviseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsAdviseSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsAdviseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsAdviseSink> for ::windows::core::IUnknown {
-    fn from(value: &IVdsAdviseSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsAdviseSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsAdviseSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -187,21 +145,7 @@ impl IVdsAsync {
         (::windows::core::Vtable::vtable(self).QueryStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phrresult), ::core::mem::transmute(pulpercentcompleted)).ok()
     }
 }
-impl ::core::convert::From<IVdsAsync> for ::windows::core::IUnknown {
-    fn from(value: IVdsAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsAsync> for ::windows::core::IUnknown {
-    fn from(value: &IVdsAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsAsync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsAsync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -265,21 +209,7 @@ impl IVdsController {
         (::windows::core::Vtable::vtable(self).SetStatus)(::windows::core::Vtable::as_raw(self), status).ok()
     }
 }
-impl ::core::convert::From<IVdsController> for ::windows::core::IUnknown {
-    fn from(value: IVdsController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsController> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsController> for ::windows::core::IUnknown {
-    fn from(value: &IVdsController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsController, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsController {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -324,21 +254,7 @@ impl IVdsControllerControllerPort {
         (::windows::core::Vtable::vtable(self).QueryControllerPorts)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumVdsObject>(result__)
     }
 }
-impl ::core::convert::From<IVdsControllerControllerPort> for ::windows::core::IUnknown {
-    fn from(value: IVdsControllerControllerPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsControllerControllerPort> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsControllerControllerPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsControllerControllerPort> for ::windows::core::IUnknown {
-    fn from(value: &IVdsControllerControllerPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsControllerControllerPort, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsControllerControllerPort {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -390,21 +306,7 @@ impl IVdsControllerPort {
         (::windows::core::Vtable::vtable(self).SetStatus)(::windows::core::Vtable::as_raw(self), status).ok()
     }
 }
-impl ::core::convert::From<IVdsControllerPort> for ::windows::core::IUnknown {
-    fn from(value: IVdsControllerPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsControllerPort> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsControllerPort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsControllerPort> for ::windows::core::IUnknown {
-    fn from(value: &IVdsControllerPort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsControllerPort, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsControllerPort {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -464,21 +366,7 @@ impl IVdsDrive {
         (::windows::core::Vtable::vtable(self).SetStatus)(::windows::core::Vtable::as_raw(self), status).ok()
     }
 }
-impl ::core::convert::From<IVdsDrive> for ::windows::core::IUnknown {
-    fn from(value: IVdsDrive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsDrive> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsDrive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsDrive> for ::windows::core::IUnknown {
-    fn from(value: &IVdsDrive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsDrive, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsDrive {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -524,21 +412,7 @@ impl IVdsDrive2 {
         (::windows::core::Vtable::vtable(self).GetProperties2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<VDS_DRIVE_PROP2>(result__)
     }
 }
-impl ::core::convert::From<IVdsDrive2> for ::windows::core::IUnknown {
-    fn from(value: IVdsDrive2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsDrive2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsDrive2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsDrive2> for ::windows::core::IUnknown {
-    fn from(value: &IVdsDrive2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsDrive2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsDrive2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -582,21 +456,7 @@ impl IVdsHwProvider {
         (::windows::core::Vtable::vtable(self).Refresh)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IVdsHwProvider> for ::windows::core::IUnknown {
-    fn from(value: IVdsHwProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsHwProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsHwProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsHwProvider> for ::windows::core::IUnknown {
-    fn from(value: &IVdsHwProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsHwProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsHwProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -641,21 +501,7 @@ impl IVdsHwProviderPrivate {
         (::windows::core::Vtable::vtable(self).QueryIfCreatedLun)(::windows::core::Vtable::as_raw(self), pwszdevicepath.into(), ::core::mem::transmute(pvdsluninformation), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IVdsHwProviderPrivate> for ::windows::core::IUnknown {
-    fn from(value: IVdsHwProviderPrivate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsHwProviderPrivate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsHwProviderPrivate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsHwProviderPrivate> for ::windows::core::IUnknown {
-    fn from(value: &IVdsHwProviderPrivate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsHwProviderPrivate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsHwProviderPrivate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -695,21 +541,7 @@ impl IVdsHwProviderPrivateMpio {
         (::windows::core::Vtable::vtable(self).SetAllPathStatusesFromHbaPort)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(hbaportprop), status).ok()
     }
 }
-impl ::core::convert::From<IVdsHwProviderPrivateMpio> for ::windows::core::IUnknown {
-    fn from(value: IVdsHwProviderPrivateMpio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsHwProviderPrivateMpio> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsHwProviderPrivateMpio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsHwProviderPrivateMpio> for ::windows::core::IUnknown {
-    fn from(value: &IVdsHwProviderPrivateMpio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsHwProviderPrivateMpio, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsHwProviderPrivateMpio {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -764,21 +596,7 @@ impl IVdsHwProviderStoragePools {
         (::windows::core::Vtable::vtable(self).QueryMaxLunCreateSizeInStoragePool)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(storagepoolid), ::core::mem::transmute(phints2.unwrap_or(::std::ptr::null())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IVdsHwProviderStoragePools> for ::windows::core::IUnknown {
-    fn from(value: IVdsHwProviderStoragePools) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsHwProviderStoragePools> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsHwProviderStoragePools) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsHwProviderStoragePools> for ::windows::core::IUnknown {
-    fn from(value: &IVdsHwProviderStoragePools) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsHwProviderStoragePools, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsHwProviderStoragePools {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -827,21 +645,7 @@ impl IVdsHwProviderType {
         (::windows::core::Vtable::vtable(self).GetProviderType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<VDS_HWPROVIDER_TYPE>(result__)
     }
 }
-impl ::core::convert::From<IVdsHwProviderType> for ::windows::core::IUnknown {
-    fn from(value: IVdsHwProviderType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsHwProviderType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsHwProviderType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsHwProviderType> for ::windows::core::IUnknown {
-    fn from(value: &IVdsHwProviderType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsHwProviderType, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsHwProviderType {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -879,21 +683,7 @@ impl IVdsHwProviderType2 {
         (::windows::core::Vtable::vtable(self).GetProviderType2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<VDS_HWPROVIDER_TYPE>(result__)
     }
 }
-impl ::core::convert::From<IVdsHwProviderType2> for ::windows::core::IUnknown {
-    fn from(value: IVdsHwProviderType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsHwProviderType2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsHwProviderType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsHwProviderType2> for ::windows::core::IUnknown {
-    fn from(value: &IVdsHwProviderType2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsHwProviderType2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsHwProviderType2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -952,21 +742,7 @@ impl IVdsIscsiPortal {
         (::windows::core::Vtable::vtable(self).SetIpsecSecurity)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinitiatorportaladdress), ullsecurityflags, ::core::mem::transmute(pipseckey.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IVdsIscsiPortal> for ::windows::core::IUnknown {
-    fn from(value: IVdsIscsiPortal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsIscsiPortal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsIscsiPortal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsIscsiPortal> for ::windows::core::IUnknown {
-    fn from(value: &IVdsIscsiPortal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsIscsiPortal, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsIscsiPortal {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1030,21 +806,7 @@ impl IVdsIscsiPortalGroup {
         (::windows::core::Vtable::vtable(self).Delete)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IVdsAsync>(result__)
     }
 }
-impl ::core::convert::From<IVdsIscsiPortalGroup> for ::windows::core::IUnknown {
-    fn from(value: IVdsIscsiPortalGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsIscsiPortalGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsIscsiPortalGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsIscsiPortalGroup> for ::windows::core::IUnknown {
-    fn from(value: &IVdsIscsiPortalGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsIscsiPortalGroup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsIscsiPortalGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1130,21 +892,7 @@ impl IVdsIscsiTarget {
         (::windows::core::Vtable::vtable(self).GetConnectedInitiators)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pppwszinitiatorlist), ::core::mem::transmute(plnumberofinitiators)).ok()
     }
 }
-impl ::core::convert::From<IVdsIscsiTarget> for ::windows::core::IUnknown {
-    fn from(value: IVdsIscsiTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsIscsiTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsIscsiTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsIscsiTarget> for ::windows::core::IUnknown {
-    fn from(value: &IVdsIscsiTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsIscsiTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsIscsiTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1262,21 +1010,7 @@ impl IVdsLun {
         (::windows::core::Vtable::vtable(self).QueryMaxLunExtendSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdriveidarray.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), pdriveidarray.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IVdsLun> for ::windows::core::IUnknown {
-    fn from(value: IVdsLun) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsLun> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsLun) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsLun> for ::windows::core::IUnknown {
-    fn from(value: &IVdsLun) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsLun, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsLun {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1346,21 +1080,7 @@ impl IVdsLun2 {
         (::windows::core::Vtable::vtable(self).ApplyHints2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phints2)).ok()
     }
 }
-impl ::core::convert::From<IVdsLun2> for ::windows::core::IUnknown {
-    fn from(value: IVdsLun2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsLun2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsLun2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsLun2> for ::windows::core::IUnknown {
-    fn from(value: &IVdsLun2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsLun2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsLun2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1408,21 +1128,7 @@ impl IVdsLunControllerPorts {
         (::windows::core::Vtable::vtable(self).QueryActiveControllerPorts)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumVdsObject>(result__)
     }
 }
-impl ::core::convert::From<IVdsLunControllerPorts> for ::windows::core::IUnknown {
-    fn from(value: IVdsLunControllerPorts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsLunControllerPorts> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsLunControllerPorts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsLunControllerPorts> for ::windows::core::IUnknown {
-    fn from(value: &IVdsLunControllerPorts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsLunControllerPorts, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsLunControllerPorts {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1464,21 +1170,7 @@ impl IVdsLunIscsi {
         (::windows::core::Vtable::vtable(self).QueryAssociatedTargets)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumVdsObject>(result__)
     }
 }
-impl ::core::convert::From<IVdsLunIscsi> for ::windows::core::IUnknown {
-    fn from(value: IVdsLunIscsi) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsLunIscsi> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsLunIscsi) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsLunIscsi> for ::windows::core::IUnknown {
-    fn from(value: &IVdsLunIscsi) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsLunIscsi, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsLunIscsi {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1530,21 +1222,7 @@ impl IVdsLunMpio {
         (::windows::core::Vtable::vtable(self).GetSupportedLbPolicies)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IVdsLunMpio> for ::windows::core::IUnknown {
-    fn from(value: IVdsLunMpio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsLunMpio> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsLunMpio) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsLunMpio> for ::windows::core::IUnknown {
-    fn from(value: &IVdsLunMpio) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsLunMpio, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsLunMpio {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1593,21 +1271,7 @@ impl IVdsLunNaming {
         (::windows::core::Vtable::vtable(self).SetFriendlyName)(::windows::core::Vtable::as_raw(self), pwszfriendlyname.into()).ok()
     }
 }
-impl ::core::convert::From<IVdsLunNaming> for ::windows::core::IUnknown {
-    fn from(value: IVdsLunNaming) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsLunNaming> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsLunNaming) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsLunNaming> for ::windows::core::IUnknown {
-    fn from(value: &IVdsLunNaming) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsLunNaming, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsLunNaming {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1645,21 +1309,7 @@ impl IVdsLunNumber {
         (::windows::core::Vtable::vtable(self).GetLunNumber)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IVdsLunNumber> for ::windows::core::IUnknown {
-    fn from(value: IVdsLunNumber) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsLunNumber> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsLunNumber) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsLunNumber> for ::windows::core::IUnknown {
-    fn from(value: &IVdsLunNumber) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsLunNumber, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsLunNumber {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1717,21 +1367,7 @@ impl IVdsLunPlex {
         (::windows::core::Vtable::vtable(self).ApplyHints)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phints)).ok()
     }
 }
-impl ::core::convert::From<IVdsLunPlex> for ::windows::core::IUnknown {
-    fn from(value: IVdsLunPlex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsLunPlex> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsLunPlex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsLunPlex> for ::windows::core::IUnknown {
-    fn from(value: &IVdsLunPlex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsLunPlex, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsLunPlex {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1787,21 +1423,7 @@ impl IVdsMaintenance {
         (::windows::core::Vtable::vtable(self).PulseMaintenance)(::windows::core::Vtable::as_raw(self), operation, ulcount).ok()
     }
 }
-impl ::core::convert::From<IVdsMaintenance> for ::windows::core::IUnknown {
-    fn from(value: IVdsMaintenance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsMaintenance> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsMaintenance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsMaintenance> for ::windows::core::IUnknown {
-    fn from(value: &IVdsMaintenance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsMaintenance, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsMaintenance {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1841,21 +1463,7 @@ impl IVdsProvider {
         (::windows::core::Vtable::vtable(self).GetProperties)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<VDS_PROVIDER_PROP>(result__)
     }
 }
-impl ::core::convert::From<IVdsProvider> for ::windows::core::IUnknown {
-    fn from(value: IVdsProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsProvider> for ::windows::core::IUnknown {
-    fn from(value: &IVdsProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1908,21 +1516,7 @@ impl IVdsProviderPrivate {
         (::windows::core::Vtable::vtable(self).OnUnload)(::windows::core::Vtable::as_raw(self), bforceunload.into()).ok()
     }
 }
-impl ::core::convert::From<IVdsProviderPrivate> for ::windows::core::IUnknown {
-    fn from(value: IVdsProviderPrivate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsProviderPrivate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsProviderPrivate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsProviderPrivate> for ::windows::core::IUnknown {
-    fn from(value: &IVdsProviderPrivate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsProviderPrivate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsProviderPrivate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1965,21 +1559,7 @@ impl IVdsProviderSupport {
         (::windows::core::Vtable::vtable(self).GetVersionSupport)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IVdsProviderSupport> for ::windows::core::IUnknown {
-    fn from(value: IVdsProviderSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsProviderSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsProviderSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsProviderSupport> for ::windows::core::IUnknown {
-    fn from(value: &IVdsProviderSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsProviderSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsProviderSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2040,21 +1620,7 @@ impl IVdsStoragePool {
         (::windows::core::Vtable::vtable(self).QueryAllocatedStoragePools)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumVdsObject>(result__)
     }
 }
-impl ::core::convert::From<IVdsStoragePool> for ::windows::core::IUnknown {
-    fn from(value: IVdsStoragePool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsStoragePool> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsStoragePool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsStoragePool> for ::windows::core::IUnknown {
-    fn from(value: &IVdsStoragePool) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsStoragePool, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsStoragePool {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2150,21 +1716,7 @@ impl IVdsSubSystem {
         (::windows::core::Vtable::vtable(self).QueryMaxLunCreateSize)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(pdriveidarray.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), pdriveidarray.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(phints.unwrap_or(::std::ptr::null())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IVdsSubSystem> for ::windows::core::IUnknown {
-    fn from(value: IVdsSubSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsSubSystem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsSubSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsSubSystem> for ::windows::core::IUnknown {
-    fn from(value: &IVdsSubSystem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsSubSystem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsSubSystem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2238,21 +1790,7 @@ impl IVdsSubSystem2 {
         (::windows::core::Vtable::vtable(self).QueryMaxLunCreateSize2)(::windows::core::Vtable::as_raw(self), r#type, ::core::mem::transmute(pdriveidarray.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), pdriveidarray.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(phints2.unwrap_or(::std::ptr::null())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IVdsSubSystem2> for ::windows::core::IUnknown {
-    fn from(value: IVdsSubSystem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsSubSystem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsSubSystem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsSubSystem2> for ::windows::core::IUnknown {
-    fn from(value: &IVdsSubSystem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsSubSystem2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsSubSystem2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2299,21 +1837,7 @@ impl IVdsSubSystemInterconnect {
         (::windows::core::Vtable::vtable(self).GetSupportedInterconnects)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IVdsSubSystemInterconnect> for ::windows::core::IUnknown {
-    fn from(value: IVdsSubSystemInterconnect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsSubSystemInterconnect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsSubSystemInterconnect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsSubSystemInterconnect> for ::windows::core::IUnknown {
-    fn from(value: &IVdsSubSystemInterconnect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsSubSystemInterconnect, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsSubSystemInterconnect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2366,21 +1890,7 @@ impl IVdsSubSystemIscsi {
         (::windows::core::Vtable::vtable(self).SetIpsecGroupPresharedKey)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pipseckey.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IVdsSubSystemIscsi> for ::windows::core::IUnknown {
-    fn from(value: IVdsSubSystemIscsi) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsSubSystemIscsi> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsSubSystemIscsi) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsSubSystemIscsi> for ::windows::core::IUnknown {
-    fn from(value: &IVdsSubSystemIscsi) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsSubSystemIscsi, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsSubSystemIscsi {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2423,21 +1933,7 @@ impl IVdsSubSystemNaming {
         (::windows::core::Vtable::vtable(self).SetFriendlyName)(::windows::core::Vtable::as_raw(self), pwszfriendlyname.into()).ok()
     }
 }
-impl ::core::convert::From<IVdsSubSystemNaming> for ::windows::core::IUnknown {
-    fn from(value: IVdsSubSystemNaming) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVdsSubSystemNaming> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVdsSubSystemNaming) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVdsSubSystemNaming> for ::windows::core::IUnknown {
-    fn from(value: &IVdsSubSystemNaming) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVdsSubSystemNaming, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVdsSubSystemNaming {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
@@ -26,21 +26,7 @@ impl IVssAdmin {
         (::windows::core::Vtable::vtable(self).AbortAllSnapshotsInProgress)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IVssAdmin> for ::windows::core::IUnknown {
-    fn from(value: IVssAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssAdmin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssAdmin> for ::windows::core::IUnknown {
-    fn from(value: &IVssAdmin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssAdmin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssAdmin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -101,36 +87,7 @@ impl IVssAdminEx {
         (::windows::core::Vtable::vtable(self).SetProviderContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(providerid), lcontext).ok()
     }
 }
-impl ::core::convert::From<IVssAdminEx> for ::windows::core::IUnknown {
-    fn from(value: IVssAdminEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssAdminEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssAdminEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssAdminEx> for ::windows::core::IUnknown {
-    fn from(value: &IVssAdminEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVssAdminEx> for IVssAdmin {
-    fn from(value: IVssAdminEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssAdminEx> for &'a IVssAdmin {
-    fn from(value: &'a IVssAdminEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssAdminEx> for IVssAdmin {
-    fn from(value: &IVssAdminEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssAdminEx, ::windows::core::IUnknown, IVssAdmin);
 impl ::core::clone::Clone for IVssAdminEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -175,21 +132,7 @@ impl IVssAsync {
         (::windows::core::Vtable::vtable(self).QueryStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phrresult), ::core::mem::transmute(preserved)).ok()
     }
 }
-impl ::core::convert::From<IVssAsync> for ::windows::core::IUnknown {
-    fn from(value: IVssAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssAsync> for ::windows::core::IUnknown {
-    fn from(value: &IVssAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssAsync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssAsync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -386,21 +329,7 @@ impl IVssComponent {
         (::windows::core::Vtable::vtable(self).GetDifferencedFile)(::windows::core::Vtable::as_raw(self), idifferencedfile, ::core::mem::transmute(pbstrpath), ::core::mem::transmute(pbstrfilespec), ::core::mem::transmute(pbrecursive), ::core::mem::transmute(pbstrlsnstring), ::core::mem::transmute(pftlastmodifytime)).ok()
     }
 }
-impl ::core::convert::From<IVssComponent> for ::windows::core::IUnknown {
-    fn from(value: IVssComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssComponent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssComponent> for ::windows::core::IUnknown {
-    fn from(value: &IVssComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssComponent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssComponent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -672,36 +601,7 @@ impl IVssComponentEx {
         (::windows::core::Vtable::vtable(self).GetRestoreName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IVssComponentEx> for ::windows::core::IUnknown {
-    fn from(value: IVssComponentEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssComponentEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssComponentEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssComponentEx> for ::windows::core::IUnknown {
-    fn from(value: &IVssComponentEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVssComponentEx> for IVssComponent {
-    fn from(value: IVssComponentEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssComponentEx> for &'a IVssComponent {
-    fn from(value: &'a IVssComponentEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssComponentEx> for IVssComponent {
-    fn from(value: &IVssComponentEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssComponentEx, ::windows::core::IUnknown, IVssComponent);
 impl ::core::clone::Clone for IVssComponentEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -942,51 +842,7 @@ impl IVssComponentEx2 {
         (::windows::core::Vtable::vtable(self).GetFailure)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phr), ::core::mem::transmute(phrapplication), ::core::mem::transmute(pbstrapplicationmessage), ::core::mem::transmute(pdwreserved)).ok()
     }
 }
-impl ::core::convert::From<IVssComponentEx2> for ::windows::core::IUnknown {
-    fn from(value: IVssComponentEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssComponentEx2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssComponentEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssComponentEx2> for ::windows::core::IUnknown {
-    fn from(value: &IVssComponentEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVssComponentEx2> for IVssComponent {
-    fn from(value: IVssComponentEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssComponentEx2> for &'a IVssComponent {
-    fn from(value: &'a IVssComponentEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssComponentEx2> for IVssComponent {
-    fn from(value: &IVssComponentEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVssComponentEx2> for IVssComponentEx {
-    fn from(value: IVssComponentEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssComponentEx2> for &'a IVssComponentEx {
-    fn from(value: &'a IVssComponentEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssComponentEx2> for IVssComponentEx {
-    fn from(value: &IVssComponentEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssComponentEx2, ::windows::core::IUnknown, IVssComponent, IVssComponentEx);
 impl ::core::clone::Clone for IVssComponentEx2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1069,21 +925,7 @@ impl IVssCreateExpressWriterMetadata {
         (::windows::core::Vtable::vtable(self).SaveAsXML)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IVssCreateExpressWriterMetadata> for ::windows::core::IUnknown {
-    fn from(value: IVssCreateExpressWriterMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssCreateExpressWriterMetadata> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssCreateExpressWriterMetadata) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssCreateExpressWriterMetadata> for ::windows::core::IUnknown {
-    fn from(value: &IVssCreateExpressWriterMetadata) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssCreateExpressWriterMetadata, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssCreateExpressWriterMetadata {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1284,21 +1126,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt {
         (::windows::core::Vtable::vtable(self).QueryDiffAreasForSnapshot)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(snapshotid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IVssEnumMgmtObject>(result__)
     }
 }
-impl ::core::convert::From<IVssDifferentialSoftwareSnapshotMgmt> for ::windows::core::IUnknown {
-    fn from(value: IVssDifferentialSoftwareSnapshotMgmt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssDifferentialSoftwareSnapshotMgmt> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssDifferentialSoftwareSnapshotMgmt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssDifferentialSoftwareSnapshotMgmt> for ::windows::core::IUnknown {
-    fn from(value: &IVssDifferentialSoftwareSnapshotMgmt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssDifferentialSoftwareSnapshotMgmt, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssDifferentialSoftwareSnapshotMgmt {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1377,36 +1205,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt2 {
         (::windows::core::Vtable::vtable(self).SetSnapshotPriority)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(idsnapshot), priority).ok()
     }
 }
-impl ::core::convert::From<IVssDifferentialSoftwareSnapshotMgmt2> for ::windows::core::IUnknown {
-    fn from(value: IVssDifferentialSoftwareSnapshotMgmt2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssDifferentialSoftwareSnapshotMgmt2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssDifferentialSoftwareSnapshotMgmt2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssDifferentialSoftwareSnapshotMgmt2> for ::windows::core::IUnknown {
-    fn from(value: &IVssDifferentialSoftwareSnapshotMgmt2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVssDifferentialSoftwareSnapshotMgmt2> for IVssDifferentialSoftwareSnapshotMgmt {
-    fn from(value: IVssDifferentialSoftwareSnapshotMgmt2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssDifferentialSoftwareSnapshotMgmt2> for &'a IVssDifferentialSoftwareSnapshotMgmt {
-    fn from(value: &'a IVssDifferentialSoftwareSnapshotMgmt2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssDifferentialSoftwareSnapshotMgmt2> for IVssDifferentialSoftwareSnapshotMgmt {
-    fn from(value: &IVssDifferentialSoftwareSnapshotMgmt2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssDifferentialSoftwareSnapshotMgmt2, ::windows::core::IUnknown, IVssDifferentialSoftwareSnapshotMgmt);
 impl ::core::clone::Clone for IVssDifferentialSoftwareSnapshotMgmt2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1504,51 +1303,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt3 {
         (::windows::core::Vtable::vtable(self).QuerySnapshotDeltaBitmap)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(idsnapshotolder), ::core::mem::transmute(idsnapshotyounger), ::core::mem::transmute(pcblocksizeperbit), ::core::mem::transmute(pcbitmaplength), ::core::mem::transmute(ppbbitmap)).ok()
     }
 }
-impl ::core::convert::From<IVssDifferentialSoftwareSnapshotMgmt3> for ::windows::core::IUnknown {
-    fn from(value: IVssDifferentialSoftwareSnapshotMgmt3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssDifferentialSoftwareSnapshotMgmt3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssDifferentialSoftwareSnapshotMgmt3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssDifferentialSoftwareSnapshotMgmt3> for ::windows::core::IUnknown {
-    fn from(value: &IVssDifferentialSoftwareSnapshotMgmt3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVssDifferentialSoftwareSnapshotMgmt3> for IVssDifferentialSoftwareSnapshotMgmt {
-    fn from(value: IVssDifferentialSoftwareSnapshotMgmt3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssDifferentialSoftwareSnapshotMgmt3> for &'a IVssDifferentialSoftwareSnapshotMgmt {
-    fn from(value: &'a IVssDifferentialSoftwareSnapshotMgmt3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssDifferentialSoftwareSnapshotMgmt3> for IVssDifferentialSoftwareSnapshotMgmt {
-    fn from(value: &IVssDifferentialSoftwareSnapshotMgmt3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVssDifferentialSoftwareSnapshotMgmt3> for IVssDifferentialSoftwareSnapshotMgmt2 {
-    fn from(value: IVssDifferentialSoftwareSnapshotMgmt3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssDifferentialSoftwareSnapshotMgmt3> for &'a IVssDifferentialSoftwareSnapshotMgmt2 {
-    fn from(value: &'a IVssDifferentialSoftwareSnapshotMgmt3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssDifferentialSoftwareSnapshotMgmt3> for IVssDifferentialSoftwareSnapshotMgmt2 {
-    fn from(value: &IVssDifferentialSoftwareSnapshotMgmt3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssDifferentialSoftwareSnapshotMgmt3, ::windows::core::IUnknown, IVssDifferentialSoftwareSnapshotMgmt, IVssDifferentialSoftwareSnapshotMgmt2);
 impl ::core::clone::Clone for IVssDifferentialSoftwareSnapshotMgmt3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1601,21 +1356,7 @@ impl IVssEnumMgmtObject {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppenum)).ok()
     }
 }
-impl ::core::convert::From<IVssEnumMgmtObject> for ::windows::core::IUnknown {
-    fn from(value: IVssEnumMgmtObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssEnumMgmtObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssEnumMgmtObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssEnumMgmtObject> for ::windows::core::IUnknown {
-    fn from(value: &IVssEnumMgmtObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssEnumMgmtObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssEnumMgmtObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1664,21 +1405,7 @@ impl IVssEnumObject {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppenum)).ok()
     }
 }
-impl ::core::convert::From<IVssEnumObject> for ::windows::core::IUnknown {
-    fn from(value: IVssEnumObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssEnumObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssEnumObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssEnumObject> for ::windows::core::IUnknown {
-    fn from(value: &IVssEnumObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssEnumObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssEnumObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1734,21 +1461,7 @@ impl IVssExpressWriter {
         (::windows::core::Vtable::vtable(self).Unregister)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(writerid)).ok()
     }
 }
-impl ::core::convert::From<IVssExpressWriter> for ::windows::core::IUnknown {
-    fn from(value: IVssExpressWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssExpressWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssExpressWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssExpressWriter> for ::windows::core::IUnknown {
-    fn from(value: &IVssExpressWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssExpressWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssExpressWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1826,21 +1539,7 @@ impl IVssFileShareSnapshotProvider {
         (::windows::core::Vtable::vtable(self).SetSnapshotProperty)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(snapshotid), esnapshotpropertyid, vproperty.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IVssFileShareSnapshotProvider> for ::windows::core::IUnknown {
-    fn from(value: IVssFileShareSnapshotProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssFileShareSnapshotProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssFileShareSnapshotProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssFileShareSnapshotProvider> for ::windows::core::IUnknown {
-    fn from(value: &IVssFileShareSnapshotProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssFileShareSnapshotProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssFileShareSnapshotProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1923,21 +1622,7 @@ impl IVssHardwareSnapshotProvider {
         (::windows::core::Vtable::vtable(self).OnLunEmpty)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(wszdevicename), ::core::mem::transmute(pinformation)).ok()
     }
 }
-impl ::core::convert::From<IVssHardwareSnapshotProvider> for ::windows::core::IUnknown {
-    fn from(value: IVssHardwareSnapshotProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssHardwareSnapshotProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssHardwareSnapshotProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssHardwareSnapshotProvider> for ::windows::core::IUnknown {
-    fn from(value: &IVssHardwareSnapshotProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssHardwareSnapshotProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssHardwareSnapshotProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2044,36 +1729,7 @@ impl IVssHardwareSnapshotProviderEx {
         (::windows::core::Vtable::vtable(self).OnReuseLuns)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(psnapshotluns), ::core::mem::transmute(poriginalluns), dwcount).ok()
     }
 }
-impl ::core::convert::From<IVssHardwareSnapshotProviderEx> for ::windows::core::IUnknown {
-    fn from(value: IVssHardwareSnapshotProviderEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssHardwareSnapshotProviderEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssHardwareSnapshotProviderEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssHardwareSnapshotProviderEx> for ::windows::core::IUnknown {
-    fn from(value: &IVssHardwareSnapshotProviderEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVssHardwareSnapshotProviderEx> for IVssHardwareSnapshotProvider {
-    fn from(value: IVssHardwareSnapshotProviderEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssHardwareSnapshotProviderEx> for &'a IVssHardwareSnapshotProvider {
-    fn from(value: &'a IVssHardwareSnapshotProviderEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssHardwareSnapshotProviderEx> for IVssHardwareSnapshotProvider {
-    fn from(value: &IVssHardwareSnapshotProviderEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssHardwareSnapshotProviderEx, ::windows::core::IUnknown, IVssHardwareSnapshotProvider);
 impl ::core::clone::Clone for IVssHardwareSnapshotProviderEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2140,21 +1796,7 @@ impl IVssProviderCreateSnapshotSet {
         (::windows::core::Vtable::vtable(self).AbortSnapshots)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(snapshotsetid)).ok()
     }
 }
-impl ::core::convert::From<IVssProviderCreateSnapshotSet> for ::windows::core::IUnknown {
-    fn from(value: IVssProviderCreateSnapshotSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssProviderCreateSnapshotSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssProviderCreateSnapshotSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssProviderCreateSnapshotSet> for ::windows::core::IUnknown {
-    fn from(value: &IVssProviderCreateSnapshotSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssProviderCreateSnapshotSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssProviderCreateSnapshotSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2208,21 +1850,7 @@ impl IVssProviderNotifications {
         (::windows::core::Vtable::vtable(self).OnUnload)(::windows::core::Vtable::as_raw(self), bforceunload.into()).ok()
     }
 }
-impl ::core::convert::From<IVssProviderNotifications> for ::windows::core::IUnknown {
-    fn from(value: IVssProviderNotifications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssProviderNotifications> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssProviderNotifications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssProviderNotifications> for ::windows::core::IUnknown {
-    fn from(value: &IVssProviderNotifications) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssProviderNotifications, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssProviderNotifications {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2272,21 +1900,7 @@ impl IVssSnapshotMgmt {
         (::windows::core::Vtable::vtable(self).QuerySnapshotsByVolume)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwszvolumename), ::core::mem::transmute(providerid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IVssEnumObject>(result__)
     }
 }
-impl ::core::convert::From<IVssSnapshotMgmt> for ::windows::core::IUnknown {
-    fn from(value: IVssSnapshotMgmt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssSnapshotMgmt> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssSnapshotMgmt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssSnapshotMgmt> for ::windows::core::IUnknown {
-    fn from(value: &IVssSnapshotMgmt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssSnapshotMgmt, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssSnapshotMgmt {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2326,21 +1940,7 @@ impl IVssSnapshotMgmt2 {
         (::windows::core::Vtable::vtable(self).GetMinDiffAreaSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i64>(result__)
     }
 }
-impl ::core::convert::From<IVssSnapshotMgmt2> for ::windows::core::IUnknown {
-    fn from(value: IVssSnapshotMgmt2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssSnapshotMgmt2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssSnapshotMgmt2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssSnapshotMgmt2> for ::windows::core::IUnknown {
-    fn from(value: &IVssSnapshotMgmt2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssSnapshotMgmt2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssSnapshotMgmt2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2422,21 +2022,7 @@ impl IVssSoftwareSnapshotProvider {
         (::windows::core::Vtable::vtable(self).QueryRevertStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwszvolume), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IVssAsync>(result__)
     }
 }
-impl ::core::convert::From<IVssSoftwareSnapshotProvider> for ::windows::core::IUnknown {
-    fn from(value: IVssSoftwareSnapshotProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssSoftwareSnapshotProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssSoftwareSnapshotProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssSoftwareSnapshotProvider> for ::windows::core::IUnknown {
-    fn from(value: &IVssSoftwareSnapshotProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssSoftwareSnapshotProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssSoftwareSnapshotProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2500,21 +2086,7 @@ impl IVssWMDependency {
         (::windows::core::Vtable::vtable(self).GetComponentName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbstrcomponentname)).ok()
     }
 }
-impl ::core::convert::From<IVssWMDependency> for ::windows::core::IUnknown {
-    fn from(value: IVssWMDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssWMDependency> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssWMDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssWMDependency> for ::windows::core::IUnknown {
-    fn from(value: &IVssWMDependency) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssWMDependency, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssWMDependency {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2570,21 +2142,7 @@ impl IVssWMFiledesc {
         (::windows::core::Vtable::vtable(self).GetBackupTypeMask)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IVssWMFiledesc> for ::windows::core::IUnknown {
-    fn from(value: IVssWMFiledesc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssWMFiledesc> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssWMFiledesc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssWMFiledesc> for ::windows::core::IUnknown {
-    fn from(value: &IVssWMFiledesc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssWMFiledesc, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssWMFiledesc {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2755,21 +2313,7 @@ impl IVssWriterImpl {
         (::windows::core::Vtable::vtable(self).IsWriterShuttingDown)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IVssWriterImpl> for ::windows::core::IUnknown {
-    fn from(value: IVssWriterImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVssWriterImpl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVssWriterImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVssWriterImpl> for ::windows::core::IUnknown {
-    fn from(value: &IVssWriterImpl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVssWriterImpl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVssWriterImpl {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/mod.rs
@@ -43,41 +43,7 @@ impl IPrintDocumentPackageStatusEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintDocumentPackageStatusEvent> for ::windows::core::IUnknown {
-    fn from(value: IPrintDocumentPackageStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintDocumentPackageStatusEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintDocumentPackageStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintDocumentPackageStatusEvent> for ::windows::core::IUnknown {
-    fn from(value: &IPrintDocumentPackageStatusEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrintDocumentPackageStatusEvent> for super::super::super::System::Com::IDispatch {
-    fn from(value: IPrintDocumentPackageStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrintDocumentPackageStatusEvent> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a IPrintDocumentPackageStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrintDocumentPackageStatusEvent> for super::super::super::System::Com::IDispatch {
-    fn from(value: &IPrintDocumentPackageStatusEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintDocumentPackageStatusEvent, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrintDocumentPackageStatusEvent {
     fn clone(&self) -> Self {
@@ -131,21 +97,7 @@ impl IPrintDocumentPackageTarget {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrintDocumentPackageTarget> for ::windows::core::IUnknown {
-    fn from(value: IPrintDocumentPackageTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintDocumentPackageTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintDocumentPackageTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintDocumentPackageTarget> for ::windows::core::IUnknown {
-    fn from(value: &IPrintDocumentPackageTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintDocumentPackageTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintDocumentPackageTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -193,21 +145,7 @@ impl IPrintDocumentPackageTargetFactory {
         (::windows::core::Vtable::vtable(self).CreateDocumentPackageTargetForPrintJob)(::windows::core::Vtable::as_raw(self), printername.into(), jobname.into(), joboutputstream.into().abi(), jobprintticketstream.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPrintDocumentPackageTarget>(result__)
     }
 }
-impl ::core::convert::From<IPrintDocumentPackageTargetFactory> for ::windows::core::IUnknown {
-    fn from(value: IPrintDocumentPackageTargetFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintDocumentPackageTargetFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintDocumentPackageTargetFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintDocumentPackageTargetFactory> for ::windows::core::IUnknown {
-    fn from(value: &IPrintDocumentPackageTargetFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintDocumentPackageTargetFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintDocumentPackageTargetFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -251,21 +189,7 @@ impl IXpsPrintJob {
         (::windows::core::Vtable::vtable(self).GetJobStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<XPS_JOB_STATUS>(result__)
     }
 }
-impl ::core::convert::From<IXpsPrintJob> for ::windows::core::IUnknown {
-    fn from(value: IXpsPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsPrintJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsPrintJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsPrintJob> for ::windows::core::IUnknown {
-    fn from(value: &IXpsPrintJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsPrintJob, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsPrintJob {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -316,41 +240,7 @@ impl IXpsPrintJobStream {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXpsPrintJobStream> for ::windows::core::IUnknown {
-    fn from(value: IXpsPrintJobStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXpsPrintJobStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsPrintJobStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXpsPrintJobStream> for ::windows::core::IUnknown {
-    fn from(value: &IXpsPrintJobStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IXpsPrintJobStream> for super::super::super::System::Com::ISequentialStream {
-    fn from(value: IXpsPrintJobStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IXpsPrintJobStream> for &'a super::super::super::System::Com::ISequentialStream {
-    fn from(value: &'a IXpsPrintJobStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IXpsPrintJobStream> for super::super::super::System::Com::ISequentialStream {
-    fn from(value: &IXpsPrintJobStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsPrintJobStream, ::windows::core::IUnknown, super::super::super::System::Com::ISequentialStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IXpsPrintJobStream {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
@@ -182,21 +182,7 @@ impl IXpsDocumentPackageTarget {
         (::windows::core::Vtable::vtable(self).GetXpsType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<XPS_DOCUMENT_TYPE>(result__)
     }
 }
-impl ::core::convert::From<IXpsDocumentPackageTarget> for ::windows::core::IUnknown {
-    fn from(value: IXpsDocumentPackageTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsDocumentPackageTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsDocumentPackageTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsDocumentPackageTarget> for ::windows::core::IUnknown {
-    fn from(value: &IXpsDocumentPackageTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsDocumentPackageTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsDocumentPackageTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -251,21 +237,7 @@ impl IXpsDocumentPackageTarget3D {
         (::windows::core::Vtable::vtable(self).GetXpsOMFactory)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMObjectFactory>(result__)
     }
 }
-impl ::core::convert::From<IXpsDocumentPackageTarget3D> for ::windows::core::IUnknown {
-    fn from(value: IXpsDocumentPackageTarget3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsDocumentPackageTarget3D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsDocumentPackageTarget3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsDocumentPackageTarget3D> for ::windows::core::IUnknown {
-    fn from(value: &IXpsDocumentPackageTarget3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsDocumentPackageTarget3D, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsDocumentPackageTarget3D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -318,36 +290,7 @@ impl IXpsOMBrush {
         (::windows::core::Vtable::vtable(self).SetOpacity)(::windows::core::Vtable::as_raw(self), opacity).ok()
     }
 }
-impl ::core::convert::From<IXpsOMBrush> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMBrush> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMBrush> for IXpsOMShareable {
-    fn from(value: IXpsOMBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMBrush> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMBrush> for IXpsOMShareable {
-    fn from(value: &IXpsOMBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMBrush, ::windows::core::IUnknown, IXpsOMShareable);
 impl ::core::clone::Clone for IXpsOMBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -583,51 +526,7 @@ impl IXpsOMCanvas {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMCanvas>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMCanvas> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMCanvas) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMCanvas> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMCanvas) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMCanvas> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMCanvas) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMCanvas> for IXpsOMShareable {
-    fn from(value: IXpsOMCanvas) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMCanvas> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMCanvas) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMCanvas> for IXpsOMShareable {
-    fn from(value: &IXpsOMCanvas) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMCanvas> for IXpsOMVisual {
-    fn from(value: IXpsOMCanvas) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMCanvas> for &'a IXpsOMVisual {
-    fn from(value: &'a IXpsOMCanvas) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMCanvas> for IXpsOMVisual {
-    fn from(value: &IXpsOMCanvas) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMCanvas, ::windows::core::IUnknown, IXpsOMShareable, IXpsOMVisual);
 impl ::core::clone::Clone for IXpsOMCanvas {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -708,51 +607,7 @@ impl IXpsOMColorProfileResource {
         (::windows::core::Vtable::vtable(self).SetContent)(::windows::core::Vtable::as_raw(self), sourcestream.into().abi(), partname.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMColorProfileResource> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMColorProfileResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMColorProfileResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMColorProfileResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMColorProfileResource> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMColorProfileResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMColorProfileResource> for IXpsOMPart {
-    fn from(value: IXpsOMColorProfileResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMColorProfileResource> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMColorProfileResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMColorProfileResource> for IXpsOMPart {
-    fn from(value: &IXpsOMColorProfileResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMColorProfileResource> for IXpsOMResource {
-    fn from(value: IXpsOMColorProfileResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMColorProfileResource> for &'a IXpsOMResource {
-    fn from(value: &'a IXpsOMColorProfileResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMColorProfileResource> for IXpsOMResource {
-    fn from(value: &IXpsOMColorProfileResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMColorProfileResource, ::windows::core::IUnknown, IXpsOMPart, IXpsOMResource);
 impl ::core::clone::Clone for IXpsOMColorProfileResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -831,21 +686,7 @@ impl IXpsOMColorProfileResourceCollection {
         (::windows::core::Vtable::vtable(self).GetByPartName)(::windows::core::Vtable::as_raw(self), partname.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMColorProfileResource>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMColorProfileResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMColorProfileResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMColorProfileResourceCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMColorProfileResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMColorProfileResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMColorProfileResourceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMColorProfileResourceCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMColorProfileResourceCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1073,36 +914,7 @@ impl IXpsOMCoreProperties {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMCoreProperties>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMCoreProperties> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMCoreProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMCoreProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMCoreProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMCoreProperties> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMCoreProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMCoreProperties> for IXpsOMPart {
-    fn from(value: IXpsOMCoreProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMCoreProperties> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMCoreProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMCoreProperties> for IXpsOMPart {
-    fn from(value: &IXpsOMCoreProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMCoreProperties, ::windows::core::IUnknown, IXpsOMPart);
 impl ::core::clone::Clone for IXpsOMCoreProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1207,21 +1019,7 @@ impl IXpsOMDashCollection {
         (::windows::core::Vtable::vtable(self).Append)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(dash)).ok()
     }
 }
-impl ::core::convert::From<IXpsOMDashCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMDashCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMDashCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMDashCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMDashCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMDashCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMDashCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMDashCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1314,21 +1112,7 @@ impl IXpsOMDictionary {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMDictionary>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMDictionary> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMDictionary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMDictionary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMDictionary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMDictionary> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMDictionary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMDictionary, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMDictionary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1421,36 +1205,7 @@ impl IXpsOMDocument {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMDocument>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMDocument> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMDocument> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMDocument> for IXpsOMPart {
-    fn from(value: IXpsOMDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMDocument> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMDocument> for IXpsOMPart {
-    fn from(value: &IXpsOMDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMDocument, ::windows::core::IUnknown, IXpsOMPart);
 impl ::core::clone::Clone for IXpsOMDocument {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1520,21 +1275,7 @@ impl IXpsOMDocumentCollection {
         (::windows::core::Vtable::vtable(self).Append)(::windows::core::Vtable::as_raw(self), document.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMDocumentCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMDocumentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMDocumentCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMDocumentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMDocumentCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMDocumentCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMDocumentCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMDocumentCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1605,36 +1346,7 @@ impl IXpsOMDocumentSequence {
         (::windows::core::Vtable::vtable(self).SetPrintTicketResource)(::windows::core::Vtable::as_raw(self), printticketresource.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMDocumentSequence> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMDocumentSequence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMDocumentSequence> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMDocumentSequence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMDocumentSequence> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMDocumentSequence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMDocumentSequence> for IXpsOMPart {
-    fn from(value: IXpsOMDocumentSequence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMDocumentSequence> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMDocumentSequence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMDocumentSequence> for IXpsOMPart {
-    fn from(value: &IXpsOMDocumentSequence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMDocumentSequence, ::windows::core::IUnknown, IXpsOMPart);
 impl ::core::clone::Clone for IXpsOMDocumentSequence {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1704,51 +1416,7 @@ impl IXpsOMDocumentStructureResource {
         (::windows::core::Vtable::vtable(self).SetContent)(::windows::core::Vtable::as_raw(self), sourcestream.into().abi(), partname.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMDocumentStructureResource> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMDocumentStructureResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMDocumentStructureResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMDocumentStructureResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMDocumentStructureResource> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMDocumentStructureResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMDocumentStructureResource> for IXpsOMPart {
-    fn from(value: IXpsOMDocumentStructureResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMDocumentStructureResource> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMDocumentStructureResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMDocumentStructureResource> for IXpsOMPart {
-    fn from(value: &IXpsOMDocumentStructureResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMDocumentStructureResource> for IXpsOMResource {
-    fn from(value: IXpsOMDocumentStructureResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMDocumentStructureResource> for &'a IXpsOMResource {
-    fn from(value: &'a IXpsOMDocumentStructureResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMDocumentStructureResource> for IXpsOMResource {
-    fn from(value: &IXpsOMDocumentStructureResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMDocumentStructureResource, ::windows::core::IUnknown, IXpsOMPart, IXpsOMResource);
 impl ::core::clone::Clone for IXpsOMDocumentStructureResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1823,51 +1491,7 @@ impl IXpsOMFontResource {
         (::windows::core::Vtable::vtable(self).GetEmbeddingOption)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<XPS_FONT_EMBEDDING>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMFontResource> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMFontResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMFontResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMFontResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMFontResource> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMFontResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMFontResource> for IXpsOMPart {
-    fn from(value: IXpsOMFontResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMFontResource> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMFontResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMFontResource> for IXpsOMPart {
-    fn from(value: &IXpsOMFontResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMFontResource> for IXpsOMResource {
-    fn from(value: IXpsOMFontResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMFontResource> for &'a IXpsOMResource {
-    fn from(value: &'a IXpsOMFontResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMFontResource> for IXpsOMResource {
-    fn from(value: &IXpsOMFontResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMFontResource, ::windows::core::IUnknown, IXpsOMPart, IXpsOMResource);
 impl ::core::clone::Clone for IXpsOMFontResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1947,21 +1571,7 @@ impl IXpsOMFontResourceCollection {
         (::windows::core::Vtable::vtable(self).GetByPartName)(::windows::core::Vtable::as_raw(self), partname.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMFontResource>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMFontResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMFontResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMFontResourceCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMFontResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMFontResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMFontResourceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMFontResourceCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMFontResourceCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2051,36 +1661,7 @@ impl IXpsOMGeometry {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMGeometry>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMGeometry> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGeometry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGeometry> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMGeometry> for IXpsOMShareable {
-    fn from(value: IXpsOMGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGeometry> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMGeometry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGeometry> for IXpsOMShareable {
-    fn from(value: &IXpsOMGeometry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMGeometry, ::windows::core::IUnknown, IXpsOMShareable);
 impl ::core::clone::Clone for IXpsOMGeometry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2193,21 +1774,7 @@ impl IXpsOMGeometryFigure {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMGeometryFigure>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMGeometryFigure> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMGeometryFigure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGeometryFigure> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMGeometryFigure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGeometryFigure> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMGeometryFigure) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMGeometryFigure, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMGeometryFigure {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2302,21 +1869,7 @@ impl IXpsOMGeometryFigureCollection {
         (::windows::core::Vtable::vtable(self).Append)(::windows::core::Vtable::as_raw(self), geometryfigure.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMGeometryFigureCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMGeometryFigureCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGeometryFigureCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMGeometryFigureCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGeometryFigureCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMGeometryFigureCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMGeometryFigureCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMGeometryFigureCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2599,51 +2152,7 @@ impl IXpsOMGlyphs {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMGlyphs>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMGlyphs> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMGlyphs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGlyphs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMGlyphs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGlyphs> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMGlyphs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMGlyphs> for IXpsOMShareable {
-    fn from(value: IXpsOMGlyphs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGlyphs> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMGlyphs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGlyphs> for IXpsOMShareable {
-    fn from(value: &IXpsOMGlyphs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMGlyphs> for IXpsOMVisual {
-    fn from(value: IXpsOMGlyphs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGlyphs> for &'a IXpsOMVisual {
-    fn from(value: &'a IXpsOMGlyphs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGlyphs> for IXpsOMVisual {
-    fn from(value: &IXpsOMGlyphs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMGlyphs, ::windows::core::IUnknown, IXpsOMShareable, IXpsOMVisual);
 impl ::core::clone::Clone for IXpsOMGlyphs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2780,21 +2289,7 @@ impl IXpsOMGlyphsEditor {
         (::windows::core::Vtable::vtable(self).SetDeviceFontName)(::windows::core::Vtable::as_raw(self), devicefontname.into()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMGlyphsEditor> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMGlyphsEditor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGlyphsEditor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMGlyphsEditor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGlyphsEditor> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMGlyphsEditor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMGlyphsEditor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMGlyphsEditor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2908,51 +2403,7 @@ impl IXpsOMGradientBrush {
         (::windows::core::Vtable::vtable(self).SetColorInterpolationMode)(::windows::core::Vtable::as_raw(self), colorinterpolationmode).ok()
     }
 }
-impl ::core::convert::From<IXpsOMGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGradientBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMGradientBrush> for IXpsOMShareable {
-    fn from(value: IXpsOMGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGradientBrush> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGradientBrush> for IXpsOMShareable {
-    fn from(value: &IXpsOMGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMGradientBrush> for IXpsOMBrush {
-    fn from(value: IXpsOMGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGradientBrush> for &'a IXpsOMBrush {
-    fn from(value: &'a IXpsOMGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGradientBrush> for IXpsOMBrush {
-    fn from(value: &IXpsOMGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMGradientBrush, ::windows::core::IUnknown, IXpsOMShareable, IXpsOMBrush);
 impl ::core::clone::Clone for IXpsOMGradientBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3019,21 +2470,7 @@ impl IXpsOMGradientStop {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMGradientStop>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMGradientStop> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMGradientStop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGradientStop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMGradientStop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGradientStop> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMGradientStop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMGradientStop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMGradientStop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3101,21 +2538,7 @@ impl IXpsOMGradientStopCollection {
         (::windows::core::Vtable::vtable(self).Append)(::windows::core::Vtable::as_raw(self), stop.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMGradientStopCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMGradientStopCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMGradientStopCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMGradientStopCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMGradientStopCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMGradientStopCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMGradientStopCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMGradientStopCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3238,66 +2661,7 @@ impl IXpsOMImageBrush {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMImageBrush>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMImageBrush> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMImageBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMImageBrush> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMImageBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMImageBrush> for IXpsOMShareable {
-    fn from(value: IXpsOMImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMImageBrush> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMImageBrush> for IXpsOMShareable {
-    fn from(value: &IXpsOMImageBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMImageBrush> for IXpsOMBrush {
-    fn from(value: IXpsOMImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMImageBrush> for &'a IXpsOMBrush {
-    fn from(value: &'a IXpsOMImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMImageBrush> for IXpsOMBrush {
-    fn from(value: &IXpsOMImageBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMImageBrush> for IXpsOMTileBrush {
-    fn from(value: IXpsOMImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMImageBrush> for &'a IXpsOMTileBrush {
-    fn from(value: &'a IXpsOMImageBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMImageBrush> for IXpsOMTileBrush {
-    fn from(value: &IXpsOMImageBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMImageBrush, ::windows::core::IUnknown, IXpsOMShareable, IXpsOMBrush, IXpsOMTileBrush);
 impl ::core::clone::Clone for IXpsOMImageBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3368,51 +2732,7 @@ impl IXpsOMImageResource {
         (::windows::core::Vtable::vtable(self).GetImageType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<XPS_IMAGE_TYPE>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMImageResource> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMImageResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMImageResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMImageResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMImageResource> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMImageResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMImageResource> for IXpsOMPart {
-    fn from(value: IXpsOMImageResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMImageResource> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMImageResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMImageResource> for IXpsOMPart {
-    fn from(value: &IXpsOMImageResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMImageResource> for IXpsOMResource {
-    fn from(value: IXpsOMImageResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMImageResource> for &'a IXpsOMResource {
-    fn from(value: &'a IXpsOMImageResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMImageResource> for IXpsOMResource {
-    fn from(value: &IXpsOMImageResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMImageResource, ::windows::core::IUnknown, IXpsOMPart, IXpsOMResource);
 impl ::core::clone::Clone for IXpsOMImageResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3492,21 +2812,7 @@ impl IXpsOMImageResourceCollection {
         (::windows::core::Vtable::vtable(self).GetByPartName)(::windows::core::Vtable::as_raw(self), partname.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMImageResource>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMImageResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMImageResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMImageResourceCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMImageResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMImageResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMImageResourceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMImageResourceCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMImageResourceCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3624,66 +2930,7 @@ impl IXpsOMLinearGradientBrush {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMLinearGradientBrush>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMLinearGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMLinearGradientBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMLinearGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMLinearGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMLinearGradientBrush> for IXpsOMShareable {
-    fn from(value: IXpsOMLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMLinearGradientBrush> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMLinearGradientBrush> for IXpsOMShareable {
-    fn from(value: &IXpsOMLinearGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMLinearGradientBrush> for IXpsOMBrush {
-    fn from(value: IXpsOMLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMLinearGradientBrush> for &'a IXpsOMBrush {
-    fn from(value: &'a IXpsOMLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMLinearGradientBrush> for IXpsOMBrush {
-    fn from(value: &IXpsOMLinearGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMLinearGradientBrush> for IXpsOMGradientBrush {
-    fn from(value: IXpsOMLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMLinearGradientBrush> for &'a IXpsOMGradientBrush {
-    fn from(value: &'a IXpsOMLinearGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMLinearGradientBrush> for IXpsOMGradientBrush {
-    fn from(value: &IXpsOMLinearGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMLinearGradientBrush, ::windows::core::IUnknown, IXpsOMShareable, IXpsOMBrush, IXpsOMGradientBrush);
 impl ::core::clone::Clone for IXpsOMLinearGradientBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3740,36 +2987,7 @@ impl IXpsOMMatrixTransform {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMMatrixTransform>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMMatrixTransform> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMMatrixTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMMatrixTransform> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMMatrixTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMMatrixTransform> for IXpsOMShareable {
-    fn from(value: IXpsOMMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMMatrixTransform> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMMatrixTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMMatrixTransform> for IXpsOMShareable {
-    fn from(value: &IXpsOMMatrixTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMMatrixTransform, ::windows::core::IUnknown, IXpsOMShareable);
 impl ::core::clone::Clone for IXpsOMMatrixTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3813,21 +3031,7 @@ impl IXpsOMNameCollection {
         (::windows::core::Vtable::vtable(self).GetAt)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMNameCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMNameCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMNameCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMNameCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMNameCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMNameCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMNameCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMNameCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4159,21 +3363,7 @@ impl IXpsOMObjectFactory {
         (::windows::core::Vtable::vtable(self).CreateReadOnlyStreamOnFile)(::windows::core::Vtable::as_raw(self), filename.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMObjectFactory> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMObjectFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMObjectFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMObjectFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMObjectFactory> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMObjectFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMObjectFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMObjectFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4715,36 +3905,7 @@ impl IXpsOMObjectFactory1 {
         (::windows::core::Vtable::vtable(self).CreateRemoteDictionaryResourceFromStream1)(::windows::core::Vtable::as_raw(self), dictionarymarkupstream.into().abi(), parturi.into().abi(), resources.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMRemoteDictionaryResource>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMObjectFactory1> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMObjectFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMObjectFactory1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMObjectFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMObjectFactory1> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMObjectFactory1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMObjectFactory1> for IXpsOMObjectFactory {
-    fn from(value: IXpsOMObjectFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMObjectFactory1> for &'a IXpsOMObjectFactory {
-    fn from(value: &'a IXpsOMObjectFactory1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMObjectFactory1> for IXpsOMObjectFactory {
-    fn from(value: &IXpsOMObjectFactory1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMObjectFactory1, ::windows::core::IUnknown, IXpsOMObjectFactory);
 impl ::core::clone::Clone for IXpsOMObjectFactory1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4875,21 +4036,7 @@ impl IXpsOMPackage {
         (::windows::core::Vtable::vtable(self).WriteToStream)(::windows::core::Vtable::as_raw(self), stream.into().abi(), optimizemarkupsize.into()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMPackage> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPackage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPackage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPackage> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPackage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPackage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMPackage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5028,36 +4175,7 @@ impl IXpsOMPackage1 {
         (::windows::core::Vtable::vtable(self).WriteToStream1)(::windows::core::Vtable::as_raw(self), outputstream.into().abi(), optimizemarkupsize.into(), documenttype).ok()
     }
 }
-impl ::core::convert::From<IXpsOMPackage1> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPackage1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPackage1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPackage1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPackage1> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPackage1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMPackage1> for IXpsOMPackage {
-    fn from(value: IXpsOMPackage1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPackage1> for &'a IXpsOMPackage {
-    fn from(value: &'a IXpsOMPackage1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPackage1> for IXpsOMPackage {
-    fn from(value: &IXpsOMPackage1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPackage1, ::windows::core::IUnknown, IXpsOMPackage);
 impl ::core::clone::Clone for IXpsOMPackage1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5110,21 +4228,7 @@ impl IXpsOMPackageTarget {
         (::windows::core::Vtable::vtable(self).CreateXpsOMPackageWriter)(::windows::core::Vtable::as_raw(self), documentsequencepartname.into().abi(), documentsequenceprintticket.into().abi(), discardcontrolpartname.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMPackageWriter>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMPackageTarget> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPackageTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPackageTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPackageTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPackageTarget> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPackageTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPackageTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMPackageTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5198,21 +4302,7 @@ impl IXpsOMPackageWriter {
         (::windows::core::Vtable::vtable(self).IsClosed)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMPackageWriter> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPackageWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPackageWriter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPackageWriter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPackageWriter> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPackageWriter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPackageWriter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMPackageWriter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5311,36 +4401,7 @@ impl IXpsOMPackageWriter3D {
         (::windows::core::Vtable::vtable(self).SetModelPrintTicket)(::windows::core::Vtable::as_raw(self), printticketpartname.into().abi(), printticketdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMPackageWriter3D> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPackageWriter3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPackageWriter3D> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPackageWriter3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPackageWriter3D> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPackageWriter3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMPackageWriter3D> for IXpsOMPackageWriter {
-    fn from(value: IXpsOMPackageWriter3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPackageWriter3D> for &'a IXpsOMPackageWriter {
-    fn from(value: &'a IXpsOMPackageWriter3D) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPackageWriter3D> for IXpsOMPackageWriter {
-    fn from(value: &IXpsOMPackageWriter3D) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPackageWriter3D, ::windows::core::IUnknown, IXpsOMPackageWriter);
 impl ::core::clone::Clone for IXpsOMPackageWriter3D {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5499,36 +4560,7 @@ impl IXpsOMPage {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMPage>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMPage> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPage> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMPage> for IXpsOMPart {
-    fn from(value: IXpsOMPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPage> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPage> for IXpsOMPart {
-    fn from(value: &IXpsOMPage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPage, ::windows::core::IUnknown, IXpsOMPart);
 impl ::core::clone::Clone for IXpsOMPage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5723,51 +4755,7 @@ impl IXpsOMPage1 {
         (::windows::core::Vtable::vtable(self).Write1)(::windows::core::Vtable::as_raw(self), stream.into().abi(), optimizemarkupsize.into(), documenttype).ok()
     }
 }
-impl ::core::convert::From<IXpsOMPage1> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPage1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPage1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPage1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPage1> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPage1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMPage1> for IXpsOMPart {
-    fn from(value: IXpsOMPage1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPage1> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMPage1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPage1> for IXpsOMPart {
-    fn from(value: &IXpsOMPage1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMPage1> for IXpsOMPage {
-    fn from(value: IXpsOMPage1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPage1> for &'a IXpsOMPage {
-    fn from(value: &'a IXpsOMPage1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPage1> for IXpsOMPage {
-    fn from(value: &IXpsOMPage1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPage1, ::windows::core::IUnknown, IXpsOMPart, IXpsOMPage);
 impl ::core::clone::Clone for IXpsOMPage1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5883,21 +4871,7 @@ impl IXpsOMPageReference {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMPageReference>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMPageReference> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPageReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPageReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPageReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPageReference> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPageReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPageReference, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMPageReference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5982,21 +4956,7 @@ impl IXpsOMPageReferenceCollection {
         (::windows::core::Vtable::vtable(self).Append)(::windows::core::Vtable::as_raw(self), pagereference.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMPageReferenceCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPageReferenceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPageReferenceCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPageReferenceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPageReferenceCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPageReferenceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPageReferenceCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMPageReferenceCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6049,21 +5009,7 @@ impl IXpsOMPart {
         (::windows::core::Vtable::vtable(self).SetPartName)(::windows::core::Vtable::as_raw(self), parturi.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMPart> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPart> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPart> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPart, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMPart {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6120,21 +5066,7 @@ impl IXpsOMPartResources {
         (::windows::core::Vtable::vtable(self).GetRemoteDictionaryResources)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMRemoteDictionaryResourceCollection>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMPartResources> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPartResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPartResources> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPartResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPartResources> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPartResources) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPartResources, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMPartResources {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6208,21 +5140,7 @@ impl IXpsOMPartUriCollection {
         (::windows::core::Vtable::vtable(self).Append)(::windows::core::Vtable::as_raw(self), parturi.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMPartUriCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPartUriCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPartUriCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPartUriCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPartUriCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPartUriCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPartUriCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMPartUriCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6571,51 +5489,7 @@ impl IXpsOMPath {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMPath>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMPath> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPath> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPath> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMPath> for IXpsOMShareable {
-    fn from(value: IXpsOMPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPath> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPath> for IXpsOMShareable {
-    fn from(value: &IXpsOMPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMPath> for IXpsOMVisual {
-    fn from(value: IXpsOMPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPath> for &'a IXpsOMVisual {
-    fn from(value: &'a IXpsOMPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPath> for IXpsOMVisual {
-    fn from(value: &IXpsOMPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPath, ::windows::core::IUnknown, IXpsOMShareable, IXpsOMVisual);
 impl ::core::clone::Clone for IXpsOMPath {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6720,51 +5594,7 @@ impl IXpsOMPrintTicketResource {
         (::windows::core::Vtable::vtable(self).SetContent)(::windows::core::Vtable::as_raw(self), sourcestream.into().abi(), partname.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMPrintTicketResource> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMPrintTicketResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPrintTicketResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMPrintTicketResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPrintTicketResource> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMPrintTicketResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMPrintTicketResource> for IXpsOMPart {
-    fn from(value: IXpsOMPrintTicketResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPrintTicketResource> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMPrintTicketResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPrintTicketResource> for IXpsOMPart {
-    fn from(value: &IXpsOMPrintTicketResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMPrintTicketResource> for IXpsOMResource {
-    fn from(value: IXpsOMPrintTicketResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMPrintTicketResource> for &'a IXpsOMResource {
-    fn from(value: &'a IXpsOMPrintTicketResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMPrintTicketResource> for IXpsOMResource {
-    fn from(value: &IXpsOMPrintTicketResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMPrintTicketResource, ::windows::core::IUnknown, IXpsOMPart, IXpsOMResource);
 impl ::core::clone::Clone for IXpsOMPrintTicketResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6887,66 +5717,7 @@ impl IXpsOMRadialGradientBrush {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMRadialGradientBrush>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMRadialGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRadialGradientBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRadialGradientBrush> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMRadialGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMRadialGradientBrush> for IXpsOMShareable {
-    fn from(value: IXpsOMRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRadialGradientBrush> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRadialGradientBrush> for IXpsOMShareable {
-    fn from(value: &IXpsOMRadialGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMRadialGradientBrush> for IXpsOMBrush {
-    fn from(value: IXpsOMRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRadialGradientBrush> for &'a IXpsOMBrush {
-    fn from(value: &'a IXpsOMRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRadialGradientBrush> for IXpsOMBrush {
-    fn from(value: &IXpsOMRadialGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMRadialGradientBrush> for IXpsOMGradientBrush {
-    fn from(value: IXpsOMRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRadialGradientBrush> for &'a IXpsOMGradientBrush {
-    fn from(value: &'a IXpsOMRadialGradientBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRadialGradientBrush> for IXpsOMGradientBrush {
-    fn from(value: &IXpsOMRadialGradientBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMRadialGradientBrush, ::windows::core::IUnknown, IXpsOMShareable, IXpsOMBrush, IXpsOMGradientBrush);
 impl ::core::clone::Clone for IXpsOMRadialGradientBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7010,51 +5781,7 @@ impl IXpsOMRemoteDictionaryResource {
         (::windows::core::Vtable::vtable(self).SetDictionary)(::windows::core::Vtable::as_raw(self), dictionary.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMRemoteDictionaryResource> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMRemoteDictionaryResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRemoteDictionaryResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMRemoteDictionaryResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRemoteDictionaryResource> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMRemoteDictionaryResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMRemoteDictionaryResource> for IXpsOMPart {
-    fn from(value: IXpsOMRemoteDictionaryResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRemoteDictionaryResource> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMRemoteDictionaryResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRemoteDictionaryResource> for IXpsOMPart {
-    fn from(value: &IXpsOMRemoteDictionaryResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMRemoteDictionaryResource> for IXpsOMResource {
-    fn from(value: IXpsOMRemoteDictionaryResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRemoteDictionaryResource> for &'a IXpsOMResource {
-    fn from(value: &'a IXpsOMRemoteDictionaryResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRemoteDictionaryResource> for IXpsOMResource {
-    fn from(value: &IXpsOMRemoteDictionaryResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMRemoteDictionaryResource, ::windows::core::IUnknown, IXpsOMPart, IXpsOMResource);
 impl ::core::clone::Clone for IXpsOMRemoteDictionaryResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7125,66 +5852,7 @@ impl IXpsOMRemoteDictionaryResource1 {
         (::windows::core::Vtable::vtable(self).Write1)(::windows::core::Vtable::as_raw(self), stream.into().abi(), documenttype).ok()
     }
 }
-impl ::core::convert::From<IXpsOMRemoteDictionaryResource1> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMRemoteDictionaryResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRemoteDictionaryResource1> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMRemoteDictionaryResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRemoteDictionaryResource1> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMRemoteDictionaryResource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMRemoteDictionaryResource1> for IXpsOMPart {
-    fn from(value: IXpsOMRemoteDictionaryResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRemoteDictionaryResource1> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMRemoteDictionaryResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRemoteDictionaryResource1> for IXpsOMPart {
-    fn from(value: &IXpsOMRemoteDictionaryResource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMRemoteDictionaryResource1> for IXpsOMResource {
-    fn from(value: IXpsOMRemoteDictionaryResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRemoteDictionaryResource1> for &'a IXpsOMResource {
-    fn from(value: &'a IXpsOMRemoteDictionaryResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRemoteDictionaryResource1> for IXpsOMResource {
-    fn from(value: &IXpsOMRemoteDictionaryResource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMRemoteDictionaryResource1> for IXpsOMRemoteDictionaryResource {
-    fn from(value: IXpsOMRemoteDictionaryResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRemoteDictionaryResource1> for &'a IXpsOMRemoteDictionaryResource {
-    fn from(value: &'a IXpsOMRemoteDictionaryResource1) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRemoteDictionaryResource1> for IXpsOMRemoteDictionaryResource {
-    fn from(value: &IXpsOMRemoteDictionaryResource1) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMRemoteDictionaryResource1, ::windows::core::IUnknown, IXpsOMPart, IXpsOMResource, IXpsOMRemoteDictionaryResource);
 impl ::core::clone::Clone for IXpsOMRemoteDictionaryResource1 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7260,21 +5928,7 @@ impl IXpsOMRemoteDictionaryResourceCollection {
         (::windows::core::Vtable::vtable(self).GetByPartName)(::windows::core::Vtable::as_raw(self), partname.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMRemoteDictionaryResource>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMRemoteDictionaryResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMRemoteDictionaryResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMRemoteDictionaryResourceCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMRemoteDictionaryResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMRemoteDictionaryResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMRemoteDictionaryResourceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMRemoteDictionaryResourceCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMRemoteDictionaryResourceCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7331,36 +5985,7 @@ impl IXpsOMResource {
         (::windows::core::Vtable::vtable(self).base__.SetPartName)(::windows::core::Vtable::as_raw(self), parturi.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMResource> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMResource> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMResource> for IXpsOMPart {
-    fn from(value: IXpsOMResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMResource> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMResource> for IXpsOMPart {
-    fn from(value: &IXpsOMResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMResource, ::windows::core::IUnknown, IXpsOMPart);
 impl ::core::clone::Clone for IXpsOMResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7401,21 +6026,7 @@ impl IXpsOMShareable {
         (::windows::core::Vtable::vtable(self).GetType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<XPS_OBJECT_TYPE>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMShareable> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMShareable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMShareable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMShareable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMShareable> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMShareable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMShareable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMShareable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7483,51 +6094,7 @@ impl IXpsOMSignatureBlockResource {
         (::windows::core::Vtable::vtable(self).SetContent)(::windows::core::Vtable::as_raw(self), sourcestream.into().abi(), partname.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMSignatureBlockResource> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMSignatureBlockResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMSignatureBlockResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMSignatureBlockResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMSignatureBlockResource> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMSignatureBlockResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMSignatureBlockResource> for IXpsOMPart {
-    fn from(value: IXpsOMSignatureBlockResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMSignatureBlockResource> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMSignatureBlockResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMSignatureBlockResource> for IXpsOMPart {
-    fn from(value: &IXpsOMSignatureBlockResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMSignatureBlockResource> for IXpsOMResource {
-    fn from(value: IXpsOMSignatureBlockResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMSignatureBlockResource> for &'a IXpsOMResource {
-    fn from(value: &'a IXpsOMSignatureBlockResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMSignatureBlockResource> for IXpsOMResource {
-    fn from(value: &IXpsOMSignatureBlockResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMSignatureBlockResource, ::windows::core::IUnknown, IXpsOMPart, IXpsOMResource);
 impl ::core::clone::Clone for IXpsOMSignatureBlockResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7607,21 +6174,7 @@ impl IXpsOMSignatureBlockResourceCollection {
         (::windows::core::Vtable::vtable(self).GetByPartName)(::windows::core::Vtable::as_raw(self), partname.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMSignatureBlockResource>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMSignatureBlockResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMSignatureBlockResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMSignatureBlockResourceCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMSignatureBlockResourceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMSignatureBlockResourceCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMSignatureBlockResourceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMSignatureBlockResourceCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMSignatureBlockResourceCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7692,51 +6245,7 @@ impl IXpsOMSolidColorBrush {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMSolidColorBrush>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMSolidColorBrush> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMSolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMSolidColorBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMSolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMSolidColorBrush> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMSolidColorBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMSolidColorBrush> for IXpsOMShareable {
-    fn from(value: IXpsOMSolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMSolidColorBrush> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMSolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMSolidColorBrush> for IXpsOMShareable {
-    fn from(value: &IXpsOMSolidColorBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMSolidColorBrush> for IXpsOMBrush {
-    fn from(value: IXpsOMSolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMSolidColorBrush> for &'a IXpsOMBrush {
-    fn from(value: &'a IXpsOMSolidColorBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMSolidColorBrush> for IXpsOMBrush {
-    fn from(value: &IXpsOMSolidColorBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMSolidColorBrush, ::windows::core::IUnknown, IXpsOMShareable, IXpsOMBrush);
 impl ::core::clone::Clone for IXpsOMSolidColorBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7805,51 +6314,7 @@ impl IXpsOMStoryFragmentsResource {
         (::windows::core::Vtable::vtable(self).SetContent)(::windows::core::Vtable::as_raw(self), sourcestream.into().abi(), partname.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMStoryFragmentsResource> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMStoryFragmentsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMStoryFragmentsResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMStoryFragmentsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMStoryFragmentsResource> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMStoryFragmentsResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMStoryFragmentsResource> for IXpsOMPart {
-    fn from(value: IXpsOMStoryFragmentsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMStoryFragmentsResource> for &'a IXpsOMPart {
-    fn from(value: &'a IXpsOMStoryFragmentsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMStoryFragmentsResource> for IXpsOMPart {
-    fn from(value: &IXpsOMStoryFragmentsResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMStoryFragmentsResource> for IXpsOMResource {
-    fn from(value: IXpsOMStoryFragmentsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMStoryFragmentsResource> for &'a IXpsOMResource {
-    fn from(value: &'a IXpsOMStoryFragmentsResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMStoryFragmentsResource> for IXpsOMResource {
-    fn from(value: &IXpsOMStoryFragmentsResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMStoryFragmentsResource, ::windows::core::IUnknown, IXpsOMPart, IXpsOMResource);
 impl ::core::clone::Clone for IXpsOMStoryFragmentsResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7901,21 +6366,7 @@ impl IXpsOMThumbnailGenerator {
         (::windows::core::Vtable::vtable(self).GenerateThumbnail)(::windows::core::Vtable::as_raw(self), page.into().abi(), thumbnailtype, thumbnailsize, imageresourcepartname.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMImageResource>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMThumbnailGenerator> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMThumbnailGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMThumbnailGenerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMThumbnailGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMThumbnailGenerator> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMThumbnailGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMThumbnailGenerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMThumbnailGenerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8012,51 +6463,7 @@ impl IXpsOMTileBrush {
         (::windows::core::Vtable::vtable(self).SetTileMode)(::windows::core::Vtable::as_raw(self), tilemode).ok()
     }
 }
-impl ::core::convert::From<IXpsOMTileBrush> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMTileBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMTileBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMTileBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMTileBrush> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMTileBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMTileBrush> for IXpsOMShareable {
-    fn from(value: IXpsOMTileBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMTileBrush> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMTileBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMTileBrush> for IXpsOMShareable {
-    fn from(value: &IXpsOMTileBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMTileBrush> for IXpsOMBrush {
-    fn from(value: IXpsOMTileBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMTileBrush> for &'a IXpsOMBrush {
-    fn from(value: &'a IXpsOMTileBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMTileBrush> for IXpsOMBrush {
-    fn from(value: &IXpsOMTileBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMTileBrush, ::windows::core::IUnknown, IXpsOMShareable, IXpsOMBrush);
 impl ::core::clone::Clone for IXpsOMTileBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8235,36 +6642,7 @@ impl IXpsOMVisual {
         (::windows::core::Vtable::vtable(self).SetLanguage)(::windows::core::Vtable::as_raw(self), language.into()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMVisual> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMVisual> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMVisual> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMVisual> for IXpsOMShareable {
-    fn from(value: IXpsOMVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMVisual> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMVisual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMVisual> for IXpsOMShareable {
-    fn from(value: &IXpsOMVisual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMVisual, ::windows::core::IUnknown, IXpsOMShareable);
 impl ::core::clone::Clone for IXpsOMVisual {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8422,66 +6800,7 @@ impl IXpsOMVisualBrush {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsOMVisualBrush>(result__)
     }
 }
-impl ::core::convert::From<IXpsOMVisualBrush> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMVisualBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMVisualBrush> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMVisualBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMVisualBrush> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMVisualBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMVisualBrush> for IXpsOMShareable {
-    fn from(value: IXpsOMVisualBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMVisualBrush> for &'a IXpsOMShareable {
-    fn from(value: &'a IXpsOMVisualBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMVisualBrush> for IXpsOMShareable {
-    fn from(value: &IXpsOMVisualBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMVisualBrush> for IXpsOMBrush {
-    fn from(value: IXpsOMVisualBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMVisualBrush> for &'a IXpsOMBrush {
-    fn from(value: &'a IXpsOMVisualBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMVisualBrush> for IXpsOMBrush {
-    fn from(value: &IXpsOMVisualBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IXpsOMVisualBrush> for IXpsOMTileBrush {
-    fn from(value: IXpsOMVisualBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMVisualBrush> for &'a IXpsOMTileBrush {
-    fn from(value: &'a IXpsOMVisualBrush) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMVisualBrush> for IXpsOMTileBrush {
-    fn from(value: &IXpsOMVisualBrush) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMVisualBrush, ::windows::core::IUnknown, IXpsOMShareable, IXpsOMBrush, IXpsOMTileBrush);
 impl ::core::clone::Clone for IXpsOMVisualBrush {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8549,21 +6868,7 @@ impl IXpsOMVisualCollection {
         (::windows::core::Vtable::vtable(self).Append)(::windows::core::Vtable::as_raw(self), object.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsOMVisualCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsOMVisualCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsOMVisualCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsOMVisualCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsOMVisualCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsOMVisualCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsOMVisualCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsOMVisualCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8659,21 +6964,7 @@ impl IXpsSignature {
         (::windows::core::Vtable::vtable(self).SetSignatureXml)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(signaturexml.as_ptr()), signaturexml.len() as _).ok()
     }
 }
-impl ::core::convert::From<IXpsSignature> for ::windows::core::IUnknown {
-    fn from(value: IXpsSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsSignature> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsSignature> for ::windows::core::IUnknown {
-    fn from(value: &IXpsSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsSignature, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsSignature {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8763,21 +7054,7 @@ impl IXpsSignatureBlock {
         (::windows::core::Vtable::vtable(self).CreateRequest)(::windows::core::Vtable::as_raw(self), requestid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsSignatureRequest>(result__)
     }
 }
-impl ::core::convert::From<IXpsSignatureBlock> for ::windows::core::IUnknown {
-    fn from(value: IXpsSignatureBlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsSignatureBlock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsSignatureBlock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsSignatureBlock> for ::windows::core::IUnknown {
-    fn from(value: &IXpsSignatureBlock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsSignatureBlock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsSignatureBlock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8832,21 +7109,7 @@ impl IXpsSignatureBlockCollection {
         (::windows::core::Vtable::vtable(self).RemoveAt)(::windows::core::Vtable::as_raw(self), index).ok()
     }
 }
-impl ::core::convert::From<IXpsSignatureBlockCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsSignatureBlockCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsSignatureBlockCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsSignatureBlockCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsSignatureBlockCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsSignatureBlockCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsSignatureBlockCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsSignatureBlockCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8893,21 +7156,7 @@ impl IXpsSignatureCollection {
         (::windows::core::Vtable::vtable(self).RemoveAt)(::windows::core::Vtable::as_raw(self), index).ok()
     }
 }
-impl ::core::convert::From<IXpsSignatureCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsSignatureCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsSignatureCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsSignatureCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsSignatureCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsSignatureCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsSignatureCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsSignatureCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9017,21 +7266,7 @@ impl IXpsSignatureManager {
         (::windows::core::Vtable::vtable(self).SavePackageToStream)(::windows::core::Vtable::as_raw(self), stream.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXpsSignatureManager> for ::windows::core::IUnknown {
-    fn from(value: IXpsSignatureManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsSignatureManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsSignatureManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsSignatureManager> for ::windows::core::IUnknown {
-    fn from(value: &IXpsSignatureManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsSignatureManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsSignatureManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9152,21 +7387,7 @@ impl IXpsSignatureRequest {
         (::windows::core::Vtable::vtable(self).GetSignature)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IXpsSignature>(result__)
     }
 }
-impl ::core::convert::From<IXpsSignatureRequest> for ::windows::core::IUnknown {
-    fn from(value: IXpsSignatureRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsSignatureRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsSignatureRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsSignatureRequest> for ::windows::core::IUnknown {
-    fn from(value: &IXpsSignatureRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsSignatureRequest, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsSignatureRequest {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9225,21 +7446,7 @@ impl IXpsSignatureRequestCollection {
         (::windows::core::Vtable::vtable(self).RemoveAt)(::windows::core::Vtable::as_raw(self), index).ok()
     }
 }
-impl ::core::convert::From<IXpsSignatureRequestCollection> for ::windows::core::IUnknown {
-    fn from(value: IXpsSignatureRequestCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsSignatureRequestCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsSignatureRequestCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsSignatureRequestCollection> for ::windows::core::IUnknown {
-    fn from(value: &IXpsSignatureRequestCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsSignatureRequestCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsSignatureRequestCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9362,21 +7569,7 @@ impl IXpsSigningOptions {
         (::windows::core::Vtable::vtable(self).SetFlags)(::windows::core::Vtable::as_raw(self), flags).ok()
     }
 }
-impl ::core::convert::From<IXpsSigningOptions> for ::windows::core::IUnknown {
-    fn from(value: IXpsSigningOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXpsSigningOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXpsSigningOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXpsSigningOptions> for ::windows::core::IUnknown {
-    fn from(value: &IXpsSigningOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXpsSigningOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXpsSigningOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
@@ -681,51 +681,7 @@ impl IABContainer {
         (::windows::core::Vtable::vtable(self).ResolveNames)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpproptagarray.unwrap_or(::std::ptr::null())), ulflags, ::core::mem::transmute(lpadrlist), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<FlagList>(result__)
     }
 }
-impl ::core::convert::From<IABContainer> for ::windows::core::IUnknown {
-    fn from(value: IABContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IABContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IABContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IABContainer> for ::windows::core::IUnknown {
-    fn from(value: &IABContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IABContainer> for IMAPIProp {
-    fn from(value: IABContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IABContainer> for &'a IMAPIProp {
-    fn from(value: &'a IABContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IABContainer> for IMAPIProp {
-    fn from(value: &IABContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IABContainer> for IMAPIContainer {
-    fn from(value: IABContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IABContainer> for &'a IMAPIContainer {
-    fn from(value: &'a IABContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IABContainer> for IMAPIContainer {
-    fn from(value: &IABContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IABContainer, ::windows::core::IUnknown, IMAPIProp, IMAPIContainer);
 impl ::core::clone::Clone for IABContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -879,36 +835,7 @@ impl IAddrBook {
         (::windows::core::Vtable::vtable(self).PrepareRecips)(::windows::core::Vtable::as_raw(self), ulflags, ::core::mem::transmute(lpproptagarray), ::core::mem::transmute(lpreciplist)).ok()
     }
 }
-impl ::core::convert::From<IAddrBook> for ::windows::core::IUnknown {
-    fn from(value: IAddrBook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAddrBook> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAddrBook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAddrBook> for ::windows::core::IUnknown {
-    fn from(value: &IAddrBook) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAddrBook> for IMAPIProp {
-    fn from(value: IAddrBook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAddrBook> for &'a IMAPIProp {
-    fn from(value: &'a IAddrBook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAddrBook> for IMAPIProp {
-    fn from(value: &IAddrBook) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAddrBook, ::windows::core::IUnknown, IMAPIProp);
 impl ::core::clone::Clone for IAddrBook {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1023,36 +950,7 @@ impl IAttach {
         (::windows::core::Vtable::vtable(self).base__.GetIDsFromNames)(::windows::core::Vtable::as_raw(self), cpropnames, ::core::mem::transmute(lpppropnames), ulflags, ::core::mem::transmute(lppproptags)).ok()
     }
 }
-impl ::core::convert::From<IAttach> for ::windows::core::IUnknown {
-    fn from(value: IAttach) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAttach> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAttach) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAttach> for ::windows::core::IUnknown {
-    fn from(value: &IAttach) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAttach> for IMAPIProp {
-    fn from(value: IAttach) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAttach> for &'a IMAPIProp {
-    fn from(value: &'a IAttach) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAttach> for IMAPIProp {
-    fn from(value: &IAttach) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAttach, ::windows::core::IUnknown, IMAPIProp);
 impl ::core::clone::Clone for IAttach {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1168,51 +1066,7 @@ impl IDistList {
         (::windows::core::Vtable::vtable(self).ResolveNames)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpproptagarray.unwrap_or(::std::ptr::null())), ulflags, ::core::mem::transmute(lpadrlist), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<FlagList>(result__)
     }
 }
-impl ::core::convert::From<IDistList> for ::windows::core::IUnknown {
-    fn from(value: IDistList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDistList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDistList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDistList> for ::windows::core::IUnknown {
-    fn from(value: &IDistList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDistList> for IMAPIProp {
-    fn from(value: IDistList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDistList> for &'a IMAPIProp {
-    fn from(value: &'a IDistList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDistList> for IMAPIProp {
-    fn from(value: &IDistList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDistList> for IMAPIContainer {
-    fn from(value: IDistList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDistList> for &'a IMAPIContainer {
-    fn from(value: &'a IDistList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDistList> for IMAPIContainer {
-    fn from(value: &IDistList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDistList, ::windows::core::IUnknown, IMAPIProp, IMAPIContainer);
 impl ::core::clone::Clone for IDistList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1257,21 +1111,7 @@ impl IMAPIAdviseSink {
         (::windows::core::Vtable::vtable(self).OnNotify)(::windows::core::Vtable::as_raw(self), cnotif, ::core::mem::transmute(lpnotifications))
     }
 }
-impl ::core::convert::From<IMAPIAdviseSink> for ::windows::core::IUnknown {
-    fn from(value: IMAPIAdviseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPIAdviseSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMAPIAdviseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPIAdviseSink> for ::windows::core::IUnknown {
-    fn from(value: &IMAPIAdviseSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMAPIAdviseSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMAPIAdviseSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1372,36 +1212,7 @@ impl IMAPIContainer {
         (::windows::core::Vtable::vtable(self).GetSearchCriteria)(::windows::core::Vtable::as_raw(self), ulflags, ::core::mem::transmute(lpprestriction.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(lppcontainerlist.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(lpulsearchstate.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMAPIContainer> for ::windows::core::IUnknown {
-    fn from(value: IMAPIContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPIContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMAPIContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPIContainer> for ::windows::core::IUnknown {
-    fn from(value: &IMAPIContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMAPIContainer> for IMAPIProp {
-    fn from(value: IMAPIContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPIContainer> for &'a IMAPIProp {
-    fn from(value: &'a IMAPIContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPIContainer> for IMAPIProp {
-    fn from(value: &IMAPIContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMAPIContainer, ::windows::core::IUnknown, IMAPIProp);
 impl ::core::clone::Clone for IMAPIContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1455,21 +1266,7 @@ impl IMAPIControl {
         (::windows::core::Vtable::vtable(self).GetState)(::windows::core::Vtable::as_raw(self), ulflags, ::core::mem::transmute(lpulstate)).ok()
     }
 }
-impl ::core::convert::From<IMAPIControl> for ::windows::core::IUnknown {
-    fn from(value: IMAPIControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPIControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMAPIControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPIControl> for ::windows::core::IUnknown {
-    fn from(value: &IMAPIControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMAPIControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMAPIControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1623,51 +1420,7 @@ impl IMAPIFolder {
         (::windows::core::Vtable::vtable(self).EmptyFolder)(::windows::core::Vtable::as_raw(self), uluiparam, lpprogress.into().abi(), ulflags).ok()
     }
 }
-impl ::core::convert::From<IMAPIFolder> for ::windows::core::IUnknown {
-    fn from(value: IMAPIFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPIFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMAPIFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPIFolder> for ::windows::core::IUnknown {
-    fn from(value: &IMAPIFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMAPIFolder> for IMAPIProp {
-    fn from(value: IMAPIFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPIFolder> for &'a IMAPIProp {
-    fn from(value: &'a IMAPIFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPIFolder> for IMAPIProp {
-    fn from(value: &IMAPIFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMAPIFolder> for IMAPIContainer {
-    fn from(value: IMAPIFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPIFolder> for &'a IMAPIContainer {
-    fn from(value: &'a IMAPIFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPIFolder> for IMAPIContainer {
-    fn from(value: &IMAPIFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMAPIFolder, ::windows::core::IUnknown, IMAPIProp, IMAPIContainer);
 impl ::core::clone::Clone for IMAPIFolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1726,21 +1479,7 @@ impl IMAPIProgress {
         (::windows::core::Vtable::vtable(self).SetLimits)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpulmin), ::core::mem::transmute(lpulmax), ::core::mem::transmute(lpulflags)).ok()
     }
 }
-impl ::core::convert::From<IMAPIProgress> for ::windows::core::IUnknown {
-    fn from(value: IMAPIProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPIProgress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMAPIProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPIProgress> for ::windows::core::IUnknown {
-    fn from(value: &IMAPIProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMAPIProgress, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMAPIProgress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1821,21 +1560,7 @@ impl IMAPIProp {
         (::windows::core::Vtable::vtable(self).GetIDsFromNames)(::windows::core::Vtable::as_raw(self), cpropnames, ::core::mem::transmute(lpppropnames), ulflags, ::core::mem::transmute(lppproptags)).ok()
     }
 }
-impl ::core::convert::From<IMAPIProp> for ::windows::core::IUnknown {
-    fn from(value: IMAPIProp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPIProp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMAPIProp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPIProp> for ::windows::core::IUnknown {
-    fn from(value: &IMAPIProp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMAPIProp, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMAPIProp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1940,36 +1665,7 @@ impl IMAPIStatus {
         (::windows::core::Vtable::vtable(self).FlushQueues)(::windows::core::Vtable::as_raw(self), uluiparam, lptargettransport.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(lptargettransport.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ulflags).ok()
     }
 }
-impl ::core::convert::From<IMAPIStatus> for ::windows::core::IUnknown {
-    fn from(value: IMAPIStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPIStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMAPIStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPIStatus> for ::windows::core::IUnknown {
-    fn from(value: &IMAPIStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMAPIStatus> for IMAPIProp {
-    fn from(value: IMAPIStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPIStatus> for &'a IMAPIProp {
-    fn from(value: &'a IMAPIStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPIStatus> for IMAPIProp {
-    fn from(value: &IMAPIStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMAPIStatus, ::windows::core::IUnknown, IMAPIProp);
 impl ::core::clone::Clone for IMAPIStatus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2086,21 +1782,7 @@ impl IMAPITable {
         (::windows::core::Vtable::vtable(self).SetCollapseState)(::windows::core::Vtable::as_raw(self), ulflags, cbcollapsestate, ::core::mem::transmute(pbcollapsestate), ::core::mem::transmute(lpbklocation)).ok()
     }
 }
-impl ::core::convert::From<IMAPITable> for ::windows::core::IUnknown {
-    fn from(value: IMAPITable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMAPITable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMAPITable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMAPITable> for ::windows::core::IUnknown {
-    fn from(value: &IMAPITable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMAPITable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMAPITable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2211,36 +1893,7 @@ impl IMailUser {
         (::windows::core::Vtable::vtable(self).base__.GetIDsFromNames)(::windows::core::Vtable::as_raw(self), cpropnames, ::core::mem::transmute(lpppropnames), ulflags, ::core::mem::transmute(lppproptags)).ok()
     }
 }
-impl ::core::convert::From<IMailUser> for ::windows::core::IUnknown {
-    fn from(value: IMailUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMailUser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMailUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMailUser> for ::windows::core::IUnknown {
-    fn from(value: &IMailUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMailUser> for IMAPIProp {
-    fn from(value: IMailUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMailUser> for &'a IMAPIProp {
-    fn from(value: &'a IMailUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMailUser> for IMAPIProp {
-    fn from(value: &IMailUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMailUser, ::windows::core::IUnknown, IMAPIProp);
 impl ::core::clone::Clone for IMailUser {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2348,36 +2001,7 @@ impl IMessage {
         (::windows::core::Vtable::vtable(self).SetReadFlag)(::windows::core::Vtable::as_raw(self), ulflags).ok()
     }
 }
-impl ::core::convert::From<IMessage> for ::windows::core::IUnknown {
-    fn from(value: IMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMessage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMessage> for ::windows::core::IUnknown {
-    fn from(value: &IMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMessage> for IMAPIProp {
-    fn from(value: IMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMessage> for &'a IMAPIProp {
-    fn from(value: &'a IMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMessage> for IMAPIProp {
-    fn from(value: &IMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMessage, ::windows::core::IUnknown, IMAPIProp);
 impl ::core::clone::Clone for IMessage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2515,36 +2139,7 @@ impl IMsgStore {
         (::windows::core::Vtable::vtable(self).NotifyNewMail)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpnotification)).ok()
     }
 }
-impl ::core::convert::From<IMsgStore> for ::windows::core::IUnknown {
-    fn from(value: IMsgStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMsgStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMsgStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMsgStore> for ::windows::core::IUnknown {
-    fn from(value: &IMsgStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMsgStore> for IMAPIProp {
-    fn from(value: IMsgStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMsgStore> for &'a IMAPIProp {
-    fn from(value: &'a IMsgStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMsgStore> for IMAPIProp {
-    fn from(value: &IMsgStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMsgStore, ::windows::core::IUnknown, IMAPIProp);
 impl ::core::clone::Clone for IMsgStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2636,36 +2231,7 @@ impl IProfSect {
         (::windows::core::Vtable::vtable(self).base__.GetIDsFromNames)(::windows::core::Vtable::as_raw(self), cpropnames, ::core::mem::transmute(lpppropnames), ulflags, ::core::mem::transmute(lppproptags)).ok()
     }
 }
-impl ::core::convert::From<IProfSect> for ::windows::core::IUnknown {
-    fn from(value: IProfSect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProfSect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProfSect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProfSect> for ::windows::core::IUnknown {
-    fn from(value: &IProfSect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IProfSect> for IMAPIProp {
-    fn from(value: IProfSect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProfSect> for &'a IMAPIProp {
-    fn from(value: &'a IProfSect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProfSect> for IMAPIProp {
-    fn from(value: &IProfSect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProfSect, ::windows::core::IUnknown, IMAPIProp);
 impl ::core::clone::Clone for IProfSect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2753,36 +2319,7 @@ impl IPropData {
         (::windows::core::Vtable::vtable(self).HrAddObjProps)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lppproptagarray), ::core::mem::transmute(lprgulaccess)).ok()
     }
 }
-impl ::core::convert::From<IPropData> for ::windows::core::IUnknown {
-    fn from(value: IPropData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropData> for ::windows::core::IUnknown {
-    fn from(value: &IPropData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropData> for IMAPIProp {
-    fn from(value: IPropData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropData> for &'a IMAPIProp {
-    fn from(value: &'a IPropData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropData> for IMAPIProp {
-    fn from(value: &IPropData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropData, ::windows::core::IUnknown, IMAPIProp);
 impl ::core::clone::Clone for IPropData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2840,21 +2377,7 @@ impl IProviderAdmin {
         (::windows::core::Vtable::vtable(self).OpenProfileSection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpuid.unwrap_or(::std::ptr::null())), ::core::mem::transmute(lpinterface.unwrap_or(::std::ptr::null())), ulflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IProfSect>(result__)
     }
 }
-impl ::core::convert::From<IProviderAdmin> for ::windows::core::IUnknown {
-    fn from(value: IProviderAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProviderAdmin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProviderAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProviderAdmin> for ::windows::core::IUnknown {
-    fn from(value: &IProviderAdmin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProviderAdmin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProviderAdmin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2938,21 +2461,7 @@ impl ITableData {
         (::windows::core::Vtable::vtable(self).HrDeleteRows)(::windows::core::Vtable::as_raw(self), ulflags, ::core::mem::transmute(lprowsettodelete), ::core::mem::transmute(crowsdeleted)).ok()
     }
 }
-impl ::core::convert::From<ITableData> for ::windows::core::IUnknown {
-    fn from(value: ITableData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITableData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITableData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITableData> for ::windows::core::IUnknown {
-    fn from(value: &ITableData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITableData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITableData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3023,21 +2532,7 @@ impl IWABExtInit {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpwabextdisplay)).ok()
     }
 }
-impl ::core::convert::From<IWABExtInit> for ::windows::core::IUnknown {
-    fn from(value: IWABExtInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWABExtInit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWABExtInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWABExtInit> for ::windows::core::IUnknown {
-    fn from(value: &IWABExtInit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWABExtInit, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWABExtInit {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3327,21 +2822,7 @@ impl IWABObject {
         (::windows::core::Vtable::vtable(self).SetMe)(::windows::core::Vtable::as_raw(self), lpiab.into().abi(), ulflags, ::core::mem::transmute(sbeid), hwnd.into()).ok()
     }
 }
-impl ::core::convert::From<IWABObject> for ::windows::core::IUnknown {
-    fn from(value: IWABObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWABObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWABObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWABObject> for ::windows::core::IUnknown {
-    fn from(value: &IWABObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWABObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWABObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Antimalware/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Antimalware/mod.rs
@@ -118,21 +118,7 @@ impl IAmsiStream {
         (::windows::core::Vtable::vtable(self).Read)(::windows::core::Vtable::as_raw(self), position, buffer.len() as _, ::core::mem::transmute(buffer.as_ptr()), ::core::mem::transmute(readsize)).ok()
     }
 }
-impl ::core::convert::From<IAmsiStream> for ::windows::core::IUnknown {
-    fn from(value: IAmsiStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAmsiStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAmsiStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAmsiStream> for ::windows::core::IUnknown {
-    fn from(value: &IAmsiStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAmsiStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAmsiStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -176,21 +162,7 @@ impl IAntimalware {
         (::windows::core::Vtable::vtable(self).CloseSession)(::windows::core::Vtable::as_raw(self), session)
     }
 }
-impl ::core::convert::From<IAntimalware> for ::windows::core::IUnknown {
-    fn from(value: IAntimalware) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAntimalware> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAntimalware) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAntimalware> for ::windows::core::IUnknown {
-    fn from(value: &IAntimalware) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAntimalware, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAntimalware {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -242,36 +214,7 @@ impl IAntimalware2 {
         (::windows::core::Vtable::vtable(self).Notify)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(buffer), length, contentname.into(), appname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<AMSI_RESULT>(result__)
     }
 }
-impl ::core::convert::From<IAntimalware2> for ::windows::core::IUnknown {
-    fn from(value: IAntimalware2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAntimalware2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAntimalware2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAntimalware2> for ::windows::core::IUnknown {
-    fn from(value: &IAntimalware2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAntimalware2> for IAntimalware {
-    fn from(value: IAntimalware2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAntimalware2> for &'a IAntimalware {
-    fn from(value: &'a IAntimalware2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAntimalware2> for IAntimalware {
-    fn from(value: &IAntimalware2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAntimalware2, ::windows::core::IUnknown, IAntimalware);
 impl ::core::clone::Clone for IAntimalware2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -319,21 +262,7 @@ impl IAntimalwareProvider {
         (::windows::core::Vtable::vtable(self).DisplayName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IAntimalwareProvider> for ::windows::core::IUnknown {
-    fn from(value: IAntimalwareProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAntimalwareProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAntimalwareProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAntimalwareProvider> for ::windows::core::IUnknown {
-    fn from(value: &IAntimalwareProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAntimalwareProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAntimalwareProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -391,36 +320,7 @@ impl IAntimalwareProvider2 {
         (::windows::core::Vtable::vtable(self).Notify)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(buffer), length, contentname.into(), appname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<AMSI_RESULT>(result__)
     }
 }
-impl ::core::convert::From<IAntimalwareProvider2> for ::windows::core::IUnknown {
-    fn from(value: IAntimalwareProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAntimalwareProvider2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAntimalwareProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAntimalwareProvider2> for ::windows::core::IUnknown {
-    fn from(value: &IAntimalwareProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAntimalwareProvider2> for IAntimalwareProvider {
-    fn from(value: IAntimalwareProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAntimalwareProvider2> for &'a IAntimalwareProvider {
-    fn from(value: &'a IAntimalwareProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAntimalwareProvider2> for IAntimalwareProvider {
-    fn from(value: &IAntimalwareProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAntimalwareProvider2, ::windows::core::IUnknown, IAntimalwareProvider);
 impl ::core::clone::Clone for IAntimalwareProvider2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -464,21 +364,7 @@ impl IAntimalwareUacProvider {
         (::windows::core::Vtable::vtable(self).DisplayName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IAntimalwareUacProvider> for ::windows::core::IUnknown {
-    fn from(value: IAntimalwareUacProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAntimalwareUacProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAntimalwareUacProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAntimalwareUacProvider> for ::windows::core::IUnknown {
-    fn from(value: &IAntimalwareUacProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAntimalwareUacProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAntimalwareUacProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
@@ -4230,21 +4230,7 @@ impl IAssemblyCache {
         (::windows::core::Vtable::vtable(self).InstallAssembly)(::windows::core::Vtable::as_raw(self), dwflags, pszmanifestfilepath.into(), ::core::mem::transmute(prefdata)).ok()
     }
 }
-impl ::core::convert::From<IAssemblyCache> for ::windows::core::IUnknown {
-    fn from(value: IAssemblyCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAssemblyCache> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAssemblyCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAssemblyCache> for ::windows::core::IUnknown {
-    fn from(value: &IAssemblyCache) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAssemblyCache, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAssemblyCache {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4296,21 +4282,7 @@ impl IAssemblyCacheItem {
         (::windows::core::Vtable::vtable(self).AbortItem)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAssemblyCacheItem> for ::windows::core::IUnknown {
-    fn from(value: IAssemblyCacheItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAssemblyCacheItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAssemblyCacheItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAssemblyCacheItem> for ::windows::core::IUnknown {
-    fn from(value: &IAssemblyCacheItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAssemblyCacheItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAssemblyCacheItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4385,21 +4357,7 @@ impl IAssemblyName {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAssemblyName>(result__)
     }
 }
-impl ::core::convert::From<IAssemblyName> for ::windows::core::IUnknown {
-    fn from(value: IAssemblyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAssemblyName> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAssemblyName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAssemblyName> for ::windows::core::IUnknown {
-    fn from(value: &IAssemblyName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAssemblyName, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAssemblyName {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4456,21 +4414,7 @@ impl IEnumMsmDependency {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumMsmDependency>(result__)
     }
 }
-impl ::core::convert::From<IEnumMsmDependency> for ::windows::core::IUnknown {
-    fn from(value: IEnumMsmDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumMsmDependency> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumMsmDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumMsmDependency> for ::windows::core::IUnknown {
-    fn from(value: &IEnumMsmDependency) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumMsmDependency, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumMsmDependency {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4525,21 +4469,7 @@ impl IEnumMsmError {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumMsmError>(result__)
     }
 }
-impl ::core::convert::From<IEnumMsmError> for ::windows::core::IUnknown {
-    fn from(value: IEnumMsmError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumMsmError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumMsmError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumMsmError> for ::windows::core::IUnknown {
-    fn from(value: &IEnumMsmError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumMsmError, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumMsmError {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4592,21 +4522,7 @@ impl IEnumMsmString {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumMsmString>(result__)
     }
 }
-impl ::core::convert::From<IEnumMsmString> for ::windows::core::IUnknown {
-    fn from(value: IEnumMsmString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumMsmString> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumMsmString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumMsmString> for ::windows::core::IUnknown {
-    fn from(value: &IEnumMsmString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumMsmString, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumMsmString {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4659,41 +4575,7 @@ impl IMsmDependencies {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmDependencies> for ::windows::core::IUnknown {
-    fn from(value: IMsmDependencies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmDependencies> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMsmDependencies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmDependencies> for ::windows::core::IUnknown {
-    fn from(value: &IMsmDependencies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmDependencies> for super::Com::IDispatch {
-    fn from(value: IMsmDependencies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmDependencies> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMsmDependencies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmDependencies> for super::Com::IDispatch {
-    fn from(value: &IMsmDependencies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMsmDependencies, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMsmDependencies {
     fn clone(&self) -> Self {
@@ -4751,41 +4633,7 @@ impl IMsmDependency {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmDependency> for ::windows::core::IUnknown {
-    fn from(value: IMsmDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmDependency> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMsmDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmDependency> for ::windows::core::IUnknown {
-    fn from(value: &IMsmDependency) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmDependency> for super::Com::IDispatch {
-    fn from(value: IMsmDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmDependency> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMsmDependency) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmDependency> for super::Com::IDispatch {
-    fn from(value: &IMsmDependency) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMsmDependency, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMsmDependency {
     fn clone(&self) -> Self {
@@ -4858,41 +4706,7 @@ impl IMsmError {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmError> for ::windows::core::IUnknown {
-    fn from(value: IMsmError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMsmError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmError> for ::windows::core::IUnknown {
-    fn from(value: &IMsmError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmError> for super::Com::IDispatch {
-    fn from(value: IMsmError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmError> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMsmError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmError> for super::Com::IDispatch {
-    fn from(value: &IMsmError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMsmError, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMsmError {
     fn clone(&self) -> Self {
@@ -4961,41 +4775,7 @@ impl IMsmErrors {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmErrors> for ::windows::core::IUnknown {
-    fn from(value: IMsmErrors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmErrors> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMsmErrors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmErrors> for ::windows::core::IUnknown {
-    fn from(value: &IMsmErrors) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmErrors> for super::Com::IDispatch {
-    fn from(value: IMsmErrors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmErrors> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMsmErrors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmErrors> for super::Com::IDispatch {
-    fn from(value: &IMsmErrors) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMsmErrors, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMsmErrors {
     fn clone(&self) -> Self {
@@ -5050,41 +4830,7 @@ impl IMsmGetFiles {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmGetFiles> for ::windows::core::IUnknown {
-    fn from(value: IMsmGetFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmGetFiles> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMsmGetFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmGetFiles> for ::windows::core::IUnknown {
-    fn from(value: &IMsmGetFiles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmGetFiles> for super::Com::IDispatch {
-    fn from(value: IMsmGetFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmGetFiles> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMsmGetFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmGetFiles> for super::Com::IDispatch {
-    fn from(value: &IMsmGetFiles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMsmGetFiles, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMsmGetFiles {
     fn clone(&self) -> Self {
@@ -5176,41 +4922,7 @@ impl IMsmMerge {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmMerge> for ::windows::core::IUnknown {
-    fn from(value: IMsmMerge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmMerge> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMsmMerge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmMerge> for ::windows::core::IUnknown {
-    fn from(value: &IMsmMerge) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmMerge> for super::Com::IDispatch {
-    fn from(value: IMsmMerge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmMerge> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMsmMerge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmMerge> for super::Com::IDispatch {
-    fn from(value: &IMsmMerge) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMsmMerge, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMsmMerge {
     fn clone(&self) -> Self {
@@ -5282,41 +4994,7 @@ impl IMsmStrings {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmStrings> for ::windows::core::IUnknown {
-    fn from(value: IMsmStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmStrings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMsmStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmStrings> for ::windows::core::IUnknown {
-    fn from(value: &IMsmStrings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMsmStrings> for super::Com::IDispatch {
-    fn from(value: IMsmStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMsmStrings> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMsmStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMsmStrings> for super::Com::IDispatch {
-    fn from(value: &IMsmStrings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMsmStrings, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMsmStrings {
     fn clone(&self) -> Self {
@@ -5635,21 +5313,7 @@ impl IPMApplicationInfo {
         (::windows::core::Vtable::vtable(self).set_Title)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(apptitle)).ok()
     }
 }
-impl ::core::convert::From<IPMApplicationInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMApplicationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMApplicationInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMApplicationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMApplicationInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMApplicationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMApplicationInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMApplicationInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5828,21 +5492,7 @@ impl IPMApplicationInfoEnumerator {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPMApplicationInfo>(result__)
     }
 }
-impl ::core::convert::From<IPMApplicationInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IPMApplicationInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMApplicationInfoEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMApplicationInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMApplicationInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IPMApplicationInfoEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMApplicationInfoEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMApplicationInfoEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5942,21 +5592,7 @@ impl IPMBackgroundServiceAgentInfo {
         (::windows::core::Vtable::vtable(self).set_IsScheduleAllowed)(::windows::core::Vtable::as_raw(self), isscheduleallowed.into()).ok()
     }
 }
-impl ::core::convert::From<IPMBackgroundServiceAgentInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMBackgroundServiceAgentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMBackgroundServiceAgentInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMBackgroundServiceAgentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMBackgroundServiceAgentInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMBackgroundServiceAgentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMBackgroundServiceAgentInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMBackgroundServiceAgentInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6025,21 +5661,7 @@ impl IPMBackgroundServiceAgentInfoEnumerator {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPMBackgroundServiceAgentInfo>(result__)
     }
 }
-impl ::core::convert::From<IPMBackgroundServiceAgentInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IPMBackgroundServiceAgentInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMBackgroundServiceAgentInfoEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMBackgroundServiceAgentInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMBackgroundServiceAgentInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IPMBackgroundServiceAgentInfoEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMBackgroundServiceAgentInfoEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMBackgroundServiceAgentInfoEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6097,21 +5719,7 @@ impl IPMBackgroundWorkerInfo {
         (::windows::core::Vtable::vtable(self).IsBootWorker)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IPMBackgroundWorkerInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMBackgroundWorkerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMBackgroundWorkerInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMBackgroundWorkerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMBackgroundWorkerInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMBackgroundWorkerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMBackgroundWorkerInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMBackgroundWorkerInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6157,21 +5765,7 @@ impl IPMBackgroundWorkerInfoEnumerator {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPMBackgroundWorkerInfo>(result__)
     }
 }
-impl ::core::convert::From<IPMBackgroundWorkerInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IPMBackgroundWorkerInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMBackgroundWorkerInfoEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMBackgroundWorkerInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMBackgroundWorkerInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IPMBackgroundWorkerInfoEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMBackgroundWorkerInfoEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMBackgroundWorkerInfoEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6358,21 +5952,7 @@ impl IPMDeploymentManager {
         (::windows::core::Vtable::vtable(self).FixJunctionsForAppsOnSDCard)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPMDeploymentManager> for ::windows::core::IUnknown {
-    fn from(value: IPMDeploymentManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMDeploymentManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMDeploymentManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMDeploymentManager> for ::windows::core::IUnknown {
-    fn from(value: &IPMDeploymentManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMDeploymentManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMDeploymentManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6552,21 +6132,7 @@ impl IPMEnumerationManager {
         (::windows::core::Vtable::vtable(self).get_StartAppEnumeratorBlob)(::windows::core::Vtable::as_raw(self), filter.into().abi(), ::core::mem::transmute(pcapps), ::core::mem::transmute(ppappblobs)).ok()
     }
 }
-impl ::core::convert::From<IPMEnumerationManager> for ::windows::core::IUnknown {
-    fn from(value: IPMEnumerationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMEnumerationManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMEnumerationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMEnumerationManager> for ::windows::core::IUnknown {
-    fn from(value: &IPMEnumerationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMEnumerationManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMEnumerationManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6629,21 +6195,7 @@ impl IPMExtensionCachedFileUpdaterInfo {
         (::windows::core::Vtable::vtable(self).SupportsUpdates)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IPMExtensionCachedFileUpdaterInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMExtensionCachedFileUpdaterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMExtensionCachedFileUpdaterInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMExtensionCachedFileUpdaterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMExtensionCachedFileUpdaterInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMExtensionCachedFileUpdaterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMExtensionCachedFileUpdaterInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMExtensionCachedFileUpdaterInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6683,21 +6235,7 @@ impl IPMExtensionContractInfo {
         (::windows::core::Vtable::vtable(self).get_InvocationInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(paumid), ::core::mem::transmute(pargs)).ok()
     }
 }
-impl ::core::convert::From<IPMExtensionContractInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMExtensionContractInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMExtensionContractInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMExtensionContractInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMExtensionContractInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMExtensionContractInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMExtensionContractInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMExtensionContractInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6752,21 +6290,7 @@ impl IPMExtensionFileExtensionInfo {
         (::windows::core::Vtable::vtable(self).get_AllFileTypes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcbtypes), ::core::mem::transmute(pptypes)).ok()
     }
 }
-impl ::core::convert::From<IPMExtensionFileExtensionInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMExtensionFileExtensionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMExtensionFileExtensionInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMExtensionFileExtensionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMExtensionFileExtensionInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMExtensionFileExtensionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMExtensionFileExtensionInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMExtensionFileExtensionInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6815,21 +6339,7 @@ impl IPMExtensionFileOpenPickerInfo {
         (::windows::core::Vtable::vtable(self).SupportsAllFileTypes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IPMExtensionFileOpenPickerInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMExtensionFileOpenPickerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMExtensionFileOpenPickerInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMExtensionFileOpenPickerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMExtensionFileOpenPickerInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMExtensionFileOpenPickerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMExtensionFileOpenPickerInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMExtensionFileOpenPickerInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6876,21 +6386,7 @@ impl IPMExtensionFileSavePickerInfo {
         (::windows::core::Vtable::vtable(self).SupportsAllFileTypes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IPMExtensionFileSavePickerInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMExtensionFileSavePickerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMExtensionFileSavePickerInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMExtensionFileSavePickerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMExtensionFileSavePickerInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMExtensionFileSavePickerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMExtensionFileSavePickerInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMExtensionFileSavePickerInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6947,21 +6443,7 @@ impl IPMExtensionInfo {
         (::windows::core::Vtable::vtable(self).get_InvocationInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pimageurn), ::core::mem::transmute(pparameters)).ok()
     }
 }
-impl ::core::convert::From<IPMExtensionInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMExtensionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMExtensionInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMExtensionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMExtensionInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMExtensionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMExtensionInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMExtensionInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7004,21 +6486,7 @@ impl IPMExtensionInfoEnumerator {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPMExtensionInfo>(result__)
     }
 }
-impl ::core::convert::From<IPMExtensionInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IPMExtensionInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMExtensionInfoEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMExtensionInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMExtensionInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IPMExtensionInfoEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMExtensionInfoEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMExtensionInfoEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7058,21 +6526,7 @@ impl IPMExtensionProtocolInfo {
         (::windows::core::Vtable::vtable(self).get_InvocationInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pimageurn), ::core::mem::transmute(pparameters)).ok()
     }
 }
-impl ::core::convert::From<IPMExtensionProtocolInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMExtensionProtocolInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMExtensionProtocolInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMExtensionProtocolInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMExtensionProtocolInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMExtensionProtocolInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMExtensionProtocolInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMExtensionProtocolInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7119,21 +6573,7 @@ impl IPMExtensionShareTargetInfo {
         (::windows::core::Vtable::vtable(self).SupportsAllFileTypes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IPMExtensionShareTargetInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMExtensionShareTargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMExtensionShareTargetInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMExtensionShareTargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMExtensionShareTargetInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMExtensionShareTargetInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMExtensionShareTargetInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMExtensionShareTargetInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7269,21 +6709,7 @@ impl IPMLiveTileJobInfo {
         (::windows::core::Vtable::vtable(self).set_DownloadState)(::windows::core::Vtable::as_raw(self), uldownloadstate).ok()
     }
 }
-impl ::core::convert::From<IPMLiveTileJobInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMLiveTileJobInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMLiveTileJobInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMLiveTileJobInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMLiveTileJobInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMLiveTileJobInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMLiveTileJobInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMLiveTileJobInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7362,21 +6788,7 @@ impl IPMLiveTileJobInfoEnumerator {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPMLiveTileJobInfo>(result__)
     }
 }
-impl ::core::convert::From<IPMLiveTileJobInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IPMLiveTileJobInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMLiveTileJobInfoEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMLiveTileJobInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMLiveTileJobInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IPMLiveTileJobInfoEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMLiveTileJobInfoEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMLiveTileJobInfoEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7493,21 +6905,7 @@ impl IPMTaskInfo {
         (::windows::core::Vtable::vtable(self).IsOptedForExtendedMem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IPMTaskInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMTaskInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMTaskInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMTaskInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMTaskInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMTaskInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMTaskInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMTaskInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7577,21 +6975,7 @@ impl IPMTaskInfoEnumerator {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPMTaskInfo>(result__)
     }
 }
-impl ::core::convert::From<IPMTaskInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IPMTaskInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMTaskInfoEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMTaskInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMTaskInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IPMTaskInfoEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMTaskInfoEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMTaskInfoEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7744,21 +7128,7 @@ impl IPMTileInfo {
         (::windows::core::Vtable::vtable(self).set_IsAutoRestoreDisabled)(::windows::core::Vtable::as_raw(self), autorestoredisabled.into()).ok()
     }
 }
-impl ::core::convert::From<IPMTileInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMTileInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMTileInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMTileInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMTileInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMTileInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMTileInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMTileInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7852,21 +7222,7 @@ impl IPMTileInfoEnumerator {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPMTileInfo>(result__)
     }
 }
-impl ::core::convert::From<IPMTileInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IPMTileInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMTileInfoEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMTileInfoEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMTileInfoEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IPMTileInfoEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMTileInfoEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMTileInfoEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7904,21 +7260,7 @@ impl IPMTilePropertyEnumerator {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IPMTilePropertyInfo>(result__)
     }
 }
-impl ::core::convert::From<IPMTilePropertyEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IPMTilePropertyEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMTilePropertyEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMTilePropertyEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMTilePropertyEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IPMTilePropertyEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMTilePropertyEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMTilePropertyEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7962,21 +7304,7 @@ impl IPMTilePropertyInfo {
         (::windows::core::Vtable::vtable(self).set_Property)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(propvalue)).ok()
     }
 }
-impl ::core::convert::From<IPMTilePropertyInfo> for ::windows::core::IUnknown {
-    fn from(value: IPMTilePropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPMTilePropertyInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPMTilePropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPMTilePropertyInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPMTilePropertyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPMTilePropertyInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPMTilePropertyInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8046,21 +7374,7 @@ impl IValidate {
         (::windows::core::Vtable::vtable(self).Validate)(::windows::core::Vtable::as_raw(self), wzices.into()).ok()
     }
 }
-impl ::core::convert::From<IValidate> for ::windows::core::IUnknown {
-    fn from(value: IValidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IValidate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IValidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IValidate> for ::windows::core::IUnknown {
-    fn from(value: &IValidate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IValidate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IValidate {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/mod.rs
@@ -182,59 +182,7 @@ impl IAccessibleWinSAT {
     }
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Accessibility"))]
-impl ::core::convert::From<IAccessibleWinSAT> for ::windows::core::IUnknown {
-    fn from(value: IAccessibleWinSAT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Accessibility"))]
-impl<'a> ::core::convert::From<&'a IAccessibleWinSAT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccessibleWinSAT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Accessibility"))]
-impl ::core::convert::From<&IAccessibleWinSAT> for ::windows::core::IUnknown {
-    fn from(value: &IAccessibleWinSAT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Accessibility"))]
-impl ::core::convert::From<IAccessibleWinSAT> for super::Com::IDispatch {
-    fn from(value: IAccessibleWinSAT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Accessibility"))]
-impl<'a> ::core::convert::From<&'a IAccessibleWinSAT> for &'a super::Com::IDispatch {
-    fn from(value: &'a IAccessibleWinSAT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Accessibility"))]
-impl ::core::convert::From<&IAccessibleWinSAT> for super::Com::IDispatch {
-    fn from(value: &IAccessibleWinSAT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Accessibility"))]
-impl ::core::convert::From<IAccessibleWinSAT> for super::super::UI::Accessibility::IAccessible {
-    fn from(value: IAccessibleWinSAT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Accessibility"))]
-impl<'a> ::core::convert::From<&'a IAccessibleWinSAT> for &'a super::super::UI::Accessibility::IAccessible {
-    fn from(value: &'a IAccessibleWinSAT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Accessibility"))]
-impl ::core::convert::From<&IAccessibleWinSAT> for super::super::UI::Accessibility::IAccessible {
-    fn from(value: &IAccessibleWinSAT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccessibleWinSAT, ::windows::core::IUnknown, super::Com::IDispatch, super::super::UI::Accessibility::IAccessible);
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Accessibility"))]
 impl ::core::clone::Clone for IAccessibleWinSAT {
     fn clone(&self) -> Self {
@@ -297,21 +245,7 @@ impl IInitiateWinSATAssessment {
         (::windows::core::Vtable::vtable(self).CancelAssessment)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInitiateWinSATAssessment> for ::windows::core::IUnknown {
-    fn from(value: IInitiateWinSATAssessment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitiateWinSATAssessment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitiateWinSATAssessment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitiateWinSATAssessment> for ::windows::core::IUnknown {
-    fn from(value: &IInitiateWinSATAssessment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitiateWinSATAssessment, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInitiateWinSATAssessment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -368,41 +302,7 @@ impl IProvideWinSATAssessmentInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IProvideWinSATAssessmentInfo> for ::windows::core::IUnknown {
-    fn from(value: IProvideWinSATAssessmentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IProvideWinSATAssessmentInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvideWinSATAssessmentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IProvideWinSATAssessmentInfo> for ::windows::core::IUnknown {
-    fn from(value: &IProvideWinSATAssessmentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IProvideWinSATAssessmentInfo> for super::Com::IDispatch {
-    fn from(value: IProvideWinSATAssessmentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IProvideWinSATAssessmentInfo> for &'a super::Com::IDispatch {
-    fn from(value: &'a IProvideWinSATAssessmentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IProvideWinSATAssessmentInfo> for super::Com::IDispatch {
-    fn from(value: &IProvideWinSATAssessmentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvideWinSATAssessmentInfo, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IProvideWinSATAssessmentInfo {
     fn clone(&self) -> Self {
@@ -472,41 +372,7 @@ impl IProvideWinSATResultsInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IProvideWinSATResultsInfo> for ::windows::core::IUnknown {
-    fn from(value: IProvideWinSATResultsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IProvideWinSATResultsInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvideWinSATResultsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IProvideWinSATResultsInfo> for ::windows::core::IUnknown {
-    fn from(value: &IProvideWinSATResultsInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IProvideWinSATResultsInfo> for super::Com::IDispatch {
-    fn from(value: IProvideWinSATResultsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IProvideWinSATResultsInfo> for &'a super::Com::IDispatch {
-    fn from(value: &'a IProvideWinSATResultsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IProvideWinSATResultsInfo> for super::Com::IDispatch {
-    fn from(value: &IProvideWinSATResultsInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvideWinSATResultsInfo, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IProvideWinSATResultsInfo {
     fn clone(&self) -> Self {
@@ -563,21 +429,7 @@ impl IProvideWinSATVisuals {
         (::windows::core::Vtable::vtable(self).get_Bitmap)(::windows::core::Vtable::as_raw(self), bitmapsize, state, rating, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Graphics::Gdi::HBITMAP>(result__)
     }
 }
-impl ::core::convert::From<IProvideWinSATVisuals> for ::windows::core::IUnknown {
-    fn from(value: IProvideWinSATVisuals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvideWinSATVisuals> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvideWinSATVisuals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvideWinSATVisuals> for ::windows::core::IUnknown {
-    fn from(value: &IProvideWinSATVisuals) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvideWinSATVisuals, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProvideWinSATVisuals {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -623,41 +475,7 @@ impl IQueryAllWinSATAssessments {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IQueryAllWinSATAssessments> for ::windows::core::IUnknown {
-    fn from(value: IQueryAllWinSATAssessments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IQueryAllWinSATAssessments> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryAllWinSATAssessments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IQueryAllWinSATAssessments> for ::windows::core::IUnknown {
-    fn from(value: &IQueryAllWinSATAssessments) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IQueryAllWinSATAssessments> for super::Com::IDispatch {
-    fn from(value: IQueryAllWinSATAssessments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IQueryAllWinSATAssessments> for &'a super::Com::IDispatch {
-    fn from(value: &'a IQueryAllWinSATAssessments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IQueryAllWinSATAssessments> for super::Com::IDispatch {
-    fn from(value: &IQueryAllWinSATAssessments) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryAllWinSATAssessments, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IQueryAllWinSATAssessments {
     fn clone(&self) -> Self {
@@ -705,21 +523,7 @@ impl IQueryOEMWinSATCustomization {
         (::windows::core::Vtable::vtable(self).GetOEMPrePopulationInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WINSAT_OEM_CUSTOMIZATION_STATE>(result__)
     }
 }
-impl ::core::convert::From<IQueryOEMWinSATCustomization> for ::windows::core::IUnknown {
-    fn from(value: IQueryOEMWinSATCustomization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQueryOEMWinSATCustomization> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryOEMWinSATCustomization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQueryOEMWinSATCustomization> for ::windows::core::IUnknown {
-    fn from(value: &IQueryOEMWinSATCustomization) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryOEMWinSATCustomization, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IQueryOEMWinSATCustomization {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -768,41 +572,7 @@ impl IQueryRecentWinSATAssessment {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IQueryRecentWinSATAssessment> for ::windows::core::IUnknown {
-    fn from(value: IQueryRecentWinSATAssessment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IQueryRecentWinSATAssessment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryRecentWinSATAssessment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IQueryRecentWinSATAssessment> for ::windows::core::IUnknown {
-    fn from(value: &IQueryRecentWinSATAssessment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IQueryRecentWinSATAssessment> for super::Com::IDispatch {
-    fn from(value: IQueryRecentWinSATAssessment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IQueryRecentWinSATAssessment> for &'a super::Com::IDispatch {
-    fn from(value: &'a IQueryRecentWinSATAssessment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IQueryRecentWinSATAssessment> for super::Com::IDispatch {
-    fn from(value: &IQueryRecentWinSATAssessment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryRecentWinSATAssessment, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IQueryRecentWinSATAssessment {
     fn clone(&self) -> Self {
@@ -862,21 +632,7 @@ impl IWinSATInitiateEvents {
         (::windows::core::Vtable::vtable(self).WinSATUpdate)(::windows::core::Vtable::as_raw(self), ucurrenttick, uticktotal, strcurrentstate.into()).ok()
     }
 }
-impl ::core::convert::From<IWinSATInitiateEvents> for ::windows::core::IUnknown {
-    fn from(value: IWinSATInitiateEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinSATInitiateEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWinSATInitiateEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinSATInitiateEvents> for ::windows::core::IUnknown {
-    fn from(value: &IWinSATInitiateEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWinSATInitiateEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWinSATInitiateEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/mod.rs
@@ -122,21 +122,7 @@ impl ICallFrame {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvreceiver)).ok()
     }
 }
-impl ::core::convert::From<ICallFrame> for ::windows::core::IUnknown {
-    fn from(value: ICallFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICallFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICallFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICallFrame> for ::windows::core::IUnknown {
-    fn from(value: &ICallFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICallFrame, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICallFrame {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -218,21 +204,7 @@ impl ICallFrameEvents {
         (::windows::core::Vtable::vtable(self).OnCall)(::windows::core::Vtable::as_raw(self), pframe.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ICallFrameEvents> for ::windows::core::IUnknown {
-    fn from(value: ICallFrameEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICallFrameEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICallFrameEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICallFrameEvents> for ::windows::core::IUnknown {
-    fn from(value: &ICallFrameEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICallFrameEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICallFrameEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -275,21 +247,7 @@ impl ICallFrameWalker {
         (::windows::core::Vtable::vtable(self).OnWalkInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(iid), ::core::mem::transmute(ppvinterface), fin.into(), fout.into()).ok()
     }
 }
-impl ::core::convert::From<ICallFrameWalker> for ::windows::core::IUnknown {
-    fn from(value: ICallFrameWalker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICallFrameWalker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICallFrameWalker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICallFrameWalker> for ::windows::core::IUnknown {
-    fn from(value: &ICallFrameWalker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICallFrameWalker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICallFrameWalker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -343,21 +301,7 @@ impl ICallIndirect {
         (::windows::core::Vtable::vtable(self).GetIID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(piid.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pfderivesfromidispatch.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pcmethod.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pwszinterface.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<ICallIndirect> for ::windows::core::IUnknown {
-    fn from(value: ICallIndirect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICallIndirect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICallIndirect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICallIndirect> for ::windows::core::IUnknown {
-    fn from(value: &ICallIndirect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICallIndirect, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICallIndirect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -427,36 +371,7 @@ impl ICallInterceptor {
         (::windows::core::Vtable::vtable(self).GetRegisteredSink)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ICallFrameEvents>(result__)
     }
 }
-impl ::core::convert::From<ICallInterceptor> for ::windows::core::IUnknown {
-    fn from(value: ICallInterceptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICallInterceptor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICallInterceptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICallInterceptor> for ::windows::core::IUnknown {
-    fn from(value: &ICallInterceptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICallInterceptor> for ICallIndirect {
-    fn from(value: ICallInterceptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICallInterceptor> for &'a ICallIndirect {
-    fn from(value: &'a ICallInterceptor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICallInterceptor> for ICallIndirect {
-    fn from(value: &ICallInterceptor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICallInterceptor, ::windows::core::IUnknown, ICallIndirect);
 impl ::core::clone::Clone for ICallInterceptor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -504,21 +419,7 @@ impl ICallUnmarshal {
         (::windows::core::Vtable::vtable(self).ReleaseMarshalData)(::windows::core::Vtable::as_raw(self), imethod, ::core::mem::transmute(pbuffer.as_ptr()), pbuffer.len() as _, ibfirstrelease, datarep, ::core::mem::transmute(pcontext)).ok()
     }
 }
-impl ::core::convert::From<ICallUnmarshal> for ::windows::core::IUnknown {
-    fn from(value: ICallUnmarshal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICallUnmarshal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICallUnmarshal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICallUnmarshal> for ::windows::core::IUnknown {
-    fn from(value: &ICallUnmarshal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICallUnmarshal, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICallUnmarshal {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -566,21 +467,7 @@ impl IInterfaceRelated {
         (::windows::core::Vtable::vtable(self).GetIID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IInterfaceRelated> for ::windows::core::IUnknown {
-    fn from(value: IInterfaceRelated) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInterfaceRelated> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInterfaceRelated) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInterfaceRelated> for ::windows::core::IUnknown {
-    fn from(value: &IInterfaceRelated) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInterfaceRelated, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInterfaceRelated {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Com/ChannelCredentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/ChannelCredentials/mod.rs
@@ -48,36 +48,7 @@ impl IChannelCredentials {
         (::windows::core::Vtable::vtable(self).SetIssuedToken)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(localissueraddres), ::core::mem::transmute_copy(localissuerbindingtype), ::core::mem::transmute_copy(localissuerbinding)).ok()
     }
 }
-impl ::core::convert::From<IChannelCredentials> for ::windows::core::IUnknown {
-    fn from(value: IChannelCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IChannelCredentials> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IChannelCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IChannelCredentials> for ::windows::core::IUnknown {
-    fn from(value: &IChannelCredentials) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IChannelCredentials> for super::IDispatch {
-    fn from(value: IChannelCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IChannelCredentials> for &'a super::IDispatch {
-    fn from(value: &'a IChannelCredentials) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IChannelCredentials> for super::IDispatch {
-    fn from(value: &IChannelCredentials) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IChannelCredentials, ::windows::core::IUnknown, super::IDispatch);
 impl ::core::clone::Clone for IChannelCredentials {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Events/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Events/mod.rs
@@ -2,21 +2,7 @@
 #[repr(transparent)]
 pub struct IDontSupportEventSubscription(::windows::core::IUnknown);
 impl IDontSupportEventSubscription {}
-impl ::core::convert::From<IDontSupportEventSubscription> for ::windows::core::IUnknown {
-    fn from(value: IDontSupportEventSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDontSupportEventSubscription> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDontSupportEventSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDontSupportEventSubscription> for ::windows::core::IUnknown {
-    fn from(value: &IDontSupportEventSubscription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDontSupportEventSubscription, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDontSupportEventSubscription {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -62,21 +48,7 @@ impl IEnumEventObject {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), cskipelem).ok()
     }
 }
-impl ::core::convert::From<IEnumEventObject> for ::windows::core::IUnknown {
-    fn from(value: IEnumEventObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumEventObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumEventObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumEventObject> for ::windows::core::IUnknown {
-    fn from(value: &IEnumEventObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumEventObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumEventObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -162,36 +134,7 @@ impl IEventClass {
         (::windows::core::Vtable::vtable(self).SetTypeLib)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrtypelib)).ok()
     }
 }
-impl ::core::convert::From<IEventClass> for ::windows::core::IUnknown {
-    fn from(value: IEventClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventClass> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventClass> for ::windows::core::IUnknown {
-    fn from(value: &IEventClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEventClass> for super::IDispatch {
-    fn from(value: IEventClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventClass> for &'a super::IDispatch {
-    fn from(value: &'a IEventClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventClass> for super::IDispatch {
-    fn from(value: &IEventClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventClass, ::windows::core::IUnknown, super::IDispatch);
 impl ::core::clone::Clone for IEventClass {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -329,51 +272,7 @@ impl IEventClass2 {
         (::windows::core::Vtable::vtable(self).SetFireInParallel)(::windows::core::Vtable::as_raw(self), ffireinparallel.into()).ok()
     }
 }
-impl ::core::convert::From<IEventClass2> for ::windows::core::IUnknown {
-    fn from(value: IEventClass2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventClass2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventClass2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventClass2> for ::windows::core::IUnknown {
-    fn from(value: &IEventClass2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEventClass2> for super::IDispatch {
-    fn from(value: IEventClass2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventClass2> for &'a super::IDispatch {
-    fn from(value: &'a IEventClass2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventClass2> for super::IDispatch {
-    fn from(value: &IEventClass2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEventClass2> for IEventClass {
-    fn from(value: IEventClass2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventClass2> for &'a IEventClass {
-    fn from(value: &'a IEventClass2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventClass2> for IEventClass {
-    fn from(value: &IEventClass2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventClass2, ::windows::core::IUnknown, super::IDispatch, IEventClass);
 impl ::core::clone::Clone for IEventClass2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -454,36 +353,7 @@ impl IEventControl {
         (::windows::core::Vtable::vtable(self).SetDefaultQuery)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(methodname), ::core::mem::transmute_copy(criteria), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IEventControl> for ::windows::core::IUnknown {
-    fn from(value: IEventControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventControl> for ::windows::core::IUnknown {
-    fn from(value: &IEventControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEventControl> for super::IDispatch {
-    fn from(value: IEventControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventControl> for &'a super::IDispatch {
-    fn from(value: &'a IEventControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventControl> for super::IDispatch {
-    fn from(value: &IEventControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventControl, ::windows::core::IUnknown, super::IDispatch);
 impl ::core::clone::Clone for IEventControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -536,21 +406,7 @@ impl IEventObjectChange {
         (::windows::core::Vtable::vtable(self).ChangedPublisher)(::windows::core::Vtable::as_raw(self), changetype, ::core::mem::transmute_copy(bstrpublisherid)).ok()
     }
 }
-impl ::core::convert::From<IEventObjectChange> for ::windows::core::IUnknown {
-    fn from(value: IEventObjectChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventObjectChange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventObjectChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventObjectChange> for ::windows::core::IUnknown {
-    fn from(value: &IEventObjectChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventObjectChange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEventObjectChange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -592,21 +448,7 @@ impl IEventObjectChange2 {
         (::windows::core::Vtable::vtable(self).ChangedEventClass)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo)).ok()
     }
 }
-impl ::core::convert::From<IEventObjectChange2> for ::windows::core::IUnknown {
-    fn from(value: IEventObjectChange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventObjectChange2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventObjectChange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventObjectChange2> for ::windows::core::IUnknown {
-    fn from(value: &IEventObjectChange2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventObjectChange2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEventObjectChange2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -667,36 +509,7 @@ impl IEventObjectCollection {
         (::windows::core::Vtable::vtable(self).Remove)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(objectid)).ok()
     }
 }
-impl ::core::convert::From<IEventObjectCollection> for ::windows::core::IUnknown {
-    fn from(value: IEventObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventObjectCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventObjectCollection> for ::windows::core::IUnknown {
-    fn from(value: &IEventObjectCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEventObjectCollection> for super::IDispatch {
-    fn from(value: IEventObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventObjectCollection> for &'a super::IDispatch {
-    fn from(value: &'a IEventObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventObjectCollection> for super::IDispatch {
-    fn from(value: &IEventObjectCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventObjectCollection, ::windows::core::IUnknown, super::IDispatch);
 impl ::core::clone::Clone for IEventObjectCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -759,36 +572,7 @@ impl IEventProperty {
         (::windows::core::Vtable::vtable(self).SetValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(propertyvalue)).ok()
     }
 }
-impl ::core::convert::From<IEventProperty> for ::windows::core::IUnknown {
-    fn from(value: IEventProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventProperty> for ::windows::core::IUnknown {
-    fn from(value: &IEventProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEventProperty> for super::IDispatch {
-    fn from(value: IEventProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventProperty> for &'a super::IDispatch {
-    fn from(value: &'a IEventProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventProperty> for super::IDispatch {
-    fn from(value: &IEventProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventProperty, ::windows::core::IUnknown, super::IDispatch);
 impl ::core::clone::Clone for IEventProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -884,36 +668,7 @@ impl IEventPublisher {
         (::windows::core::Vtable::vtable(self).GetDefaultPropertyCollection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEventObjectCollection>(result__)
     }
 }
-impl ::core::convert::From<IEventPublisher> for ::windows::core::IUnknown {
-    fn from(value: IEventPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventPublisher> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventPublisher> for ::windows::core::IUnknown {
-    fn from(value: &IEventPublisher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEventPublisher> for super::IDispatch {
-    fn from(value: IEventPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventPublisher> for &'a super::IDispatch {
-    fn from(value: &'a IEventPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventPublisher> for super::IDispatch {
-    fn from(value: &IEventPublisher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventPublisher, ::windows::core::IUnknown, super::IDispatch);
 impl ::core::clone::Clone for IEventPublisher {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1110,36 +865,7 @@ impl IEventSubscription {
         (::windows::core::Vtable::vtable(self).SetInterfaceID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrinterfaceid)).ok()
     }
 }
-impl ::core::convert::From<IEventSubscription> for ::windows::core::IUnknown {
-    fn from(value: IEventSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventSubscription> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventSubscription> for ::windows::core::IUnknown {
-    fn from(value: &IEventSubscription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEventSubscription> for super::IDispatch {
-    fn from(value: IEventSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventSubscription> for &'a super::IDispatch {
-    fn from(value: &'a IEventSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventSubscription> for super::IDispatch {
-    fn from(value: &IEventSubscription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventSubscription, ::windows::core::IUnknown, super::IDispatch);
 impl ::core::clone::Clone for IEventSubscription {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1254,36 +980,7 @@ impl IEventSystem {
         (::windows::core::Vtable::vtable(self).RemoveS)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(progid), ::core::mem::transmute_copy(querycriteria)).ok()
     }
 }
-impl ::core::convert::From<IEventSystem> for ::windows::core::IUnknown {
-    fn from(value: IEventSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventSystem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventSystem> for ::windows::core::IUnknown {
-    fn from(value: &IEventSystem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEventSystem> for super::IDispatch {
-    fn from(value: IEventSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEventSystem> for &'a super::IDispatch {
-    fn from(value: &'a IEventSystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEventSystem> for super::IDispatch {
-    fn from(value: &IEventSystem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventSystem, ::windows::core::IUnknown, super::IDispatch);
 impl ::core::clone::Clone for IEventSystem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1328,36 +1025,7 @@ impl IFiringControl {
         (::windows::core::Vtable::vtable(self).FireSubscription)(::windows::core::Vtable::as_raw(self), subscription.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IFiringControl> for ::windows::core::IUnknown {
-    fn from(value: IFiringControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFiringControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFiringControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFiringControl> for ::windows::core::IUnknown {
-    fn from(value: &IFiringControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFiringControl> for super::IDispatch {
-    fn from(value: IFiringControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFiringControl> for &'a super::IDispatch {
-    fn from(value: &'a IFiringControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFiringControl> for super::IDispatch {
-    fn from(value: &IFiringControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFiringControl, ::windows::core::IUnknown, super::IDispatch);
 impl ::core::clone::Clone for IFiringControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1433,21 +1101,7 @@ impl IMultiInterfaceEventControl {
         (::windows::core::Vtable::vtable(self).SetFireInParallel)(::windows::core::Vtable::as_raw(self), ffireinparallel.into()).ok()
     }
 }
-impl ::core::convert::From<IMultiInterfaceEventControl> for ::windows::core::IUnknown {
-    fn from(value: IMultiInterfaceEventControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMultiInterfaceEventControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultiInterfaceEventControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMultiInterfaceEventControl> for ::windows::core::IUnknown {
-    fn from(value: &IMultiInterfaceEventControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultiInterfaceEventControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMultiInterfaceEventControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1511,21 +1165,7 @@ impl IMultiInterfacePublisherFilter {
         (::windows::core::Vtable::vtable(self).PrepareToFire)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(iid), ::core::mem::transmute_copy(methodname), firingcontrol.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMultiInterfacePublisherFilter> for ::windows::core::IUnknown {
-    fn from(value: IMultiInterfacePublisherFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMultiInterfacePublisherFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultiInterfacePublisherFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMultiInterfacePublisherFilter> for ::windows::core::IUnknown {
-    fn from(value: &IMultiInterfacePublisherFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultiInterfacePublisherFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMultiInterfacePublisherFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1572,21 +1212,7 @@ impl IPublisherFilter {
         (::windows::core::Vtable::vtable(self).PrepareToFire)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(methodname), firingcontrol.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPublisherFilter> for ::windows::core::IUnknown {
-    fn from(value: IPublisherFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPublisherFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPublisherFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPublisherFilter> for ::windows::core::IUnknown {
-    fn from(value: &IPublisherFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPublisherFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPublisherFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/mod.rs
@@ -1225,21 +1225,7 @@ impl IMarshal {
         (::windows::core::Vtable::vtable(self).DisconnectObject)(::windows::core::Vtable::as_raw(self), dwreserved).ok()
     }
 }
-impl ::core::convert::From<IMarshal> for ::windows::core::IUnknown {
-    fn from(value: IMarshal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMarshal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMarshal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMarshal> for ::windows::core::IUnknown {
-    fn from(value: &IMarshal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMarshal, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMarshal {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1305,36 +1291,7 @@ impl IMarshal2 {
         (::windows::core::Vtable::vtable(self).base__.DisconnectObject)(::windows::core::Vtable::as_raw(self), dwreserved).ok()
     }
 }
-impl ::core::convert::From<IMarshal2> for ::windows::core::IUnknown {
-    fn from(value: IMarshal2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMarshal2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMarshal2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMarshal2> for ::windows::core::IUnknown {
-    fn from(value: &IMarshal2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMarshal2> for IMarshal {
-    fn from(value: IMarshal2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMarshal2> for &'a IMarshal {
-    fn from(value: &'a IMarshal2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMarshal2> for IMarshal {
-    fn from(value: &IMarshal2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMarshal2, ::windows::core::IUnknown, IMarshal);
 impl ::core::clone::Clone for IMarshal2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1411,51 +1368,7 @@ impl IMarshalingStream {
         (::windows::core::Vtable::vtable(self).GetMarshalingContextAttribute)(::windows::core::Vtable::as_raw(self), attribute, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<usize>(result__)
     }
 }
-impl ::core::convert::From<IMarshalingStream> for ::windows::core::IUnknown {
-    fn from(value: IMarshalingStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMarshalingStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMarshalingStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMarshalingStream> for ::windows::core::IUnknown {
-    fn from(value: &IMarshalingStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMarshalingStream> for super::ISequentialStream {
-    fn from(value: IMarshalingStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMarshalingStream> for &'a super::ISequentialStream {
-    fn from(value: &'a IMarshalingStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMarshalingStream> for super::ISequentialStream {
-    fn from(value: &IMarshalingStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMarshalingStream> for super::IStream {
-    fn from(value: IMarshalingStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMarshalingStream> for &'a super::IStream {
-    fn from(value: &'a IMarshalingStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMarshalingStream> for super::IStream {
-    fn from(value: &IMarshalingStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMarshalingStream, ::windows::core::IUnknown, super::ISequentialStream, super::IStream);
 impl ::core::clone::Clone for IMarshalingStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
@@ -574,21 +574,7 @@ impl IDirectWriterLock {
         (::windows::core::Vtable::vtable(self).HaveWriteAccess)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDirectWriterLock> for ::windows::core::IUnknown {
-    fn from(value: IDirectWriterLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirectWriterLock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirectWriterLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirectWriterLock> for ::windows::core::IUnknown {
-    fn from(value: &IDirectWriterLock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirectWriterLock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirectWriterLock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -639,21 +625,7 @@ impl IEnumSTATPROPSETSTG {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSTATPROPSETSTG>(result__)
     }
 }
-impl ::core::convert::From<IEnumSTATPROPSETSTG> for ::windows::core::IUnknown {
-    fn from(value: IEnumSTATPROPSETSTG) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSTATPROPSETSTG> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSTATPROPSETSTG) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSTATPROPSETSTG> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSTATPROPSETSTG) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSTATPROPSETSTG, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSTATPROPSETSTG {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -706,21 +678,7 @@ impl IEnumSTATPROPSTG {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSTATPROPSTG>(result__)
     }
 }
-impl ::core::convert::From<IEnumSTATPROPSTG> for ::windows::core::IUnknown {
-    fn from(value: IEnumSTATPROPSTG) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSTATPROPSTG> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSTATPROPSTG) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSTATPROPSTG> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSTATPROPSTG) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSTATPROPSTG, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSTATPROPSTG {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -772,21 +730,7 @@ impl IEnumSTATSTG {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSTATSTG>(result__)
     }
 }
-impl ::core::convert::From<IEnumSTATSTG> for ::windows::core::IUnknown {
-    fn from(value: IEnumSTATSTG) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSTATSTG> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSTATSTG) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSTATSTG> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSTATSTG) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSTATSTG, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSTATSTG {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -845,21 +789,7 @@ impl IFillLockBytes {
         (::windows::core::Vtable::vtable(self).Terminate)(::windows::core::Vtable::as_raw(self), bcanceled.into()).ok()
     }
 }
-impl ::core::convert::From<IFillLockBytes> for ::windows::core::IUnknown {
-    fn from(value: IFillLockBytes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFillLockBytes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFillLockBytes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFillLockBytes> for ::windows::core::IUnknown {
-    fn from(value: &IFillLockBytes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFillLockBytes, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFillLockBytes {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -920,21 +850,7 @@ impl ILayoutStorage {
         (::windows::core::Vtable::vtable(self).ReLayoutDocfileOnILockBytes)(::windows::core::Vtable::as_raw(self), pilockbytes.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ILayoutStorage> for ::windows::core::IUnknown {
-    fn from(value: ILayoutStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILayoutStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILayoutStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILayoutStorage> for ::windows::core::IUnknown {
-    fn from(value: &ILayoutStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILayoutStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILayoutStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -996,21 +912,7 @@ impl ILockBytes {
         (::windows::core::Vtable::vtable(self).Stat)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pstatstg), grfstatflag).ok()
     }
 }
-impl ::core::convert::From<ILockBytes> for ::windows::core::IUnknown {
-    fn from(value: ILockBytes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILockBytes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILockBytes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILockBytes> for ::windows::core::IUnknown {
-    fn from(value: &ILockBytes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILockBytes, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILockBytes {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1090,36 +992,7 @@ impl IPersistStorage {
         (::windows::core::Vtable::vtable(self).HandsOffStorage)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPersistStorage> for ::windows::core::IUnknown {
-    fn from(value: IPersistStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistStorage> for ::windows::core::IUnknown {
-    fn from(value: &IPersistStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPersistStorage> for super::IPersist {
-    fn from(value: IPersistStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistStorage> for &'a super::IPersist {
-    fn from(value: &'a IPersistStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistStorage> for super::IPersist {
-    fn from(value: &IPersistStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistStorage, ::windows::core::IUnknown, super::IPersist);
 impl ::core::clone::Clone for IPersistStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1178,21 +1051,7 @@ impl IPropertyBag {
         (::windows::core::Vtable::vtable(self).Write)(::windows::core::Vtable::as_raw(self), pszpropname.into(), ::core::mem::transmute(pvar)).ok()
     }
 }
-impl ::core::convert::From<IPropertyBag> for ::windows::core::IUnknown {
-    fn from(value: IPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyBag> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyBag> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyBag) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyBag, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyBag {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1261,21 +1120,7 @@ impl IPropertyBag2 {
         (::windows::core::Vtable::vtable(self).LoadObject)(::windows::core::Vtable::as_raw(self), pstrname.into(), dwhint, punkobject.into().abi(), perrlog.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IPropertyBag2> for ::windows::core::IUnknown {
-    fn from(value: IPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyBag2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyBag2> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyBag2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyBag2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyBag2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1334,21 +1179,7 @@ impl IPropertySetStorage {
         (::windows::core::Vtable::vtable(self).Enum)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSTATPROPSETSTG>(result__)
     }
 }
-impl ::core::convert::From<IPropertySetStorage> for ::windows::core::IUnknown {
-    fn from(value: IPropertySetStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertySetStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertySetStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertySetStorage> for ::windows::core::IUnknown {
-    fn from(value: &IPropertySetStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertySetStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertySetStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1433,21 +1264,7 @@ impl IPropertyStorage {
         (::windows::core::Vtable::vtable(self).Stat)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<STATPROPSETSTG>(result__)
     }
 }
-impl ::core::convert::From<IPropertyStorage> for ::windows::core::IUnknown {
-    fn from(value: IPropertyStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyStorage> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1510,21 +1327,7 @@ impl IRootStorage {
         (::windows::core::Vtable::vtable(self).SwitchToFile)(::windows::core::Vtable::as_raw(self), pszfile.into()).ok()
     }
 }
-impl ::core::convert::From<IRootStorage> for ::windows::core::IUnknown {
-    fn from(value: IRootStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRootStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRootStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRootStorage> for ::windows::core::IUnknown {
-    fn from(value: &IRootStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRootStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRootStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1641,21 +1444,7 @@ impl IStorage {
         (::windows::core::Vtable::vtable(self).Stat)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pstatstg), grfstatflag).ok()
     }
 }
-impl ::core::convert::From<IStorage> for ::windows::core::IUnknown {
-    fn from(value: IStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorage> for ::windows::core::IUnknown {
-    fn from(value: &IStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Com/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/UI/mod.rs
@@ -12,21 +12,7 @@ impl IDummyHICONIncluder {
         (::windows::core::Vtable::vtable(self).Dummy)(::windows::core::Vtable::as_raw(self), h1.into(), h2.into()).ok()
     }
 }
-impl ::core::convert::From<IDummyHICONIncluder> for ::windows::core::IUnknown {
-    fn from(value: IDummyHICONIncluder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDummyHICONIncluder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDummyHICONIncluder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDummyHICONIncluder> for ::windows::core::IUnknown {
-    fn from(value: &IDummyHICONIncluder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDummyHICONIncluder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDummyHICONIncluder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -79,21 +65,7 @@ impl IThumbnailExtractor {
         (::windows::core::Vtable::vtable(self).OnFileUpdated)(::windows::core::Vtable::as_raw(self), pstg.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IThumbnailExtractor> for ::windows::core::IUnknown {
-    fn from(value: IThumbnailExtractor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IThumbnailExtractor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IThumbnailExtractor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IThumbnailExtractor> for ::windows::core::IUnknown {
-    fn from(value: &IThumbnailExtractor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IThumbnailExtractor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IThumbnailExtractor {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/mod.rs
@@ -920,21 +920,7 @@ impl IBindCallbackRedirect {
         (::windows::core::Vtable::vtable(self).Redirect)(::windows::core::Vtable::as_raw(self), lpcurl.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i16>(result__)
     }
 }
-impl ::core::convert::From<IBindCallbackRedirect> for ::windows::core::IUnknown {
-    fn from(value: IBindCallbackRedirect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBindCallbackRedirect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBindCallbackRedirect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBindCallbackRedirect> for ::windows::core::IUnknown {
-    fn from(value: &IBindCallbackRedirect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBindCallbackRedirect, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBindCallbackRedirect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -972,21 +958,7 @@ impl IBindHttpSecurity {
         (::windows::core::Vtable::vtable(self).GetIgnoreCertMask)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IBindHttpSecurity> for ::windows::core::IUnknown {
-    fn from(value: IBindHttpSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBindHttpSecurity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBindHttpSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBindHttpSecurity> for ::windows::core::IUnknown {
-    fn from(value: &IBindHttpSecurity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBindHttpSecurity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBindHttpSecurity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1028,21 +1000,7 @@ impl IBindProtocol {
         (::windows::core::Vtable::vtable(self).CreateBinding)(::windows::core::Vtable::as_raw(self), szurl.into(), pbc.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::IBinding>(result__)
     }
 }
-impl ::core::convert::From<IBindProtocol> for ::windows::core::IUnknown {
-    fn from(value: IBindProtocol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBindProtocol> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBindProtocol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBindProtocol> for ::windows::core::IUnknown {
-    fn from(value: &IBindProtocol) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBindProtocol, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBindProtocol {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1083,21 +1041,7 @@ impl ICatalogFileInfo {
         (::windows::core::Vtable::vtable(self).GetJavaTrust)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppjavatrust)).ok()
     }
 }
-impl ::core::convert::From<ICatalogFileInfo> for ::windows::core::IUnknown {
-    fn from(value: ICatalogFileInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICatalogFileInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICatalogFileInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICatalogFileInfo> for ::windows::core::IUnknown {
-    fn from(value: &ICatalogFileInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICatalogFileInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICatalogFileInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1145,36 +1089,7 @@ impl ICodeInstall {
         (::windows::core::Vtable::vtable(self).OnCodeInstallProblem)(::windows::core::Vtable::as_raw(self), ulstatuscode, szdestination.into(), szsource.into(), dwreserved).ok()
     }
 }
-impl ::core::convert::From<ICodeInstall> for ::windows::core::IUnknown {
-    fn from(value: ICodeInstall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICodeInstall> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICodeInstall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICodeInstall> for ::windows::core::IUnknown {
-    fn from(value: &ICodeInstall) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICodeInstall> for IWindowForBindingUI {
-    fn from(value: ICodeInstall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICodeInstall> for &'a IWindowForBindingUI {
-    fn from(value: &'a ICodeInstall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICodeInstall> for IWindowForBindingUI {
-    fn from(value: &ICodeInstall) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICodeInstall, ::windows::core::IUnknown, IWindowForBindingUI);
 impl ::core::clone::Clone for ICodeInstall {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1217,21 +1132,7 @@ impl IDataFilter {
         (::windows::core::Vtable::vtable(self).SetEncodingLevel)(::windows::core::Vtable::as_raw(self), dwenclevel).ok()
     }
 }
-impl ::core::convert::From<IDataFilter> for ::windows::core::IUnknown {
-    fn from(value: IDataFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataFilter> for ::windows::core::IUnknown {
-    fn from(value: &IDataFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1283,21 +1184,7 @@ impl IEncodingFilterFactory {
         (::windows::core::Vtable::vtable(self).GetDefaultFilter)(::windows::core::Vtable::as_raw(self), pwzcodein.into(), pwzcodeout.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDataFilter>(result__)
     }
 }
-impl ::core::convert::From<IEncodingFilterFactory> for ::windows::core::IUnknown {
-    fn from(value: IEncodingFilterFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEncodingFilterFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEncodingFilterFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEncodingFilterFactory> for ::windows::core::IUnknown {
-    fn from(value: &IEncodingFilterFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEncodingFilterFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEncodingFilterFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1338,21 +1225,7 @@ impl IGetBindHandle {
         (::windows::core::Vtable::vtable(self).GetBindHandle)(::windows::core::Vtable::as_raw(self), enumrequestedhandle, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::HANDLE>(result__)
     }
 }
-impl ::core::convert::From<IGetBindHandle> for ::windows::core::IUnknown {
-    fn from(value: IGetBindHandle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetBindHandle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetBindHandle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetBindHandle> for ::windows::core::IUnknown {
-    fn from(value: &IGetBindHandle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetBindHandle, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetBindHandle {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1405,21 +1278,7 @@ impl IHttpNegotiate {
         (::windows::core::Vtable::vtable(self).OnResponse)(::windows::core::Vtable::as_raw(self), dwresponsecode, szresponseheaders.into(), szrequestheaders.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IHttpNegotiate> for ::windows::core::IUnknown {
-    fn from(value: IHttpNegotiate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpNegotiate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHttpNegotiate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpNegotiate> for ::windows::core::IUnknown {
-    fn from(value: &IHttpNegotiate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHttpNegotiate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHttpNegotiate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1473,36 +1332,7 @@ impl IHttpNegotiate2 {
         (::windows::core::Vtable::vtable(self).GetRootSecurityId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbsecurityid), ::core::mem::transmute(pcbsecurityid), dwreserved).ok()
     }
 }
-impl ::core::convert::From<IHttpNegotiate2> for ::windows::core::IUnknown {
-    fn from(value: IHttpNegotiate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpNegotiate2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHttpNegotiate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpNegotiate2> for ::windows::core::IUnknown {
-    fn from(value: &IHttpNegotiate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHttpNegotiate2> for IHttpNegotiate {
-    fn from(value: IHttpNegotiate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpNegotiate2> for &'a IHttpNegotiate {
-    fn from(value: &'a IHttpNegotiate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpNegotiate2> for IHttpNegotiate {
-    fn from(value: &IHttpNegotiate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHttpNegotiate2, ::windows::core::IUnknown, IHttpNegotiate);
 impl ::core::clone::Clone for IHttpNegotiate2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1558,51 +1388,7 @@ impl IHttpNegotiate3 {
         (::windows::core::Vtable::vtable(self).GetSerializedClientCertContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppbcert), ::core::mem::transmute(pcbcert)).ok()
     }
 }
-impl ::core::convert::From<IHttpNegotiate3> for ::windows::core::IUnknown {
-    fn from(value: IHttpNegotiate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpNegotiate3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHttpNegotiate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpNegotiate3> for ::windows::core::IUnknown {
-    fn from(value: &IHttpNegotiate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHttpNegotiate3> for IHttpNegotiate {
-    fn from(value: IHttpNegotiate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpNegotiate3> for &'a IHttpNegotiate {
-    fn from(value: &'a IHttpNegotiate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpNegotiate3> for IHttpNegotiate {
-    fn from(value: &IHttpNegotiate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHttpNegotiate3> for IHttpNegotiate2 {
-    fn from(value: IHttpNegotiate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpNegotiate3> for &'a IHttpNegotiate2 {
-    fn from(value: &'a IHttpNegotiate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpNegotiate3> for IHttpNegotiate2 {
-    fn from(value: &IHttpNegotiate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHttpNegotiate3, ::windows::core::IUnknown, IHttpNegotiate, IHttpNegotiate2);
 impl ::core::clone::Clone for IHttpNegotiate3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1645,36 +1431,7 @@ impl IHttpSecurity {
         (::windows::core::Vtable::vtable(self).OnSecurityProblem)(::windows::core::Vtable::as_raw(self), dwproblem).ok()
     }
 }
-impl ::core::convert::From<IHttpSecurity> for ::windows::core::IUnknown {
-    fn from(value: IHttpSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpSecurity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHttpSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpSecurity> for ::windows::core::IUnknown {
-    fn from(value: &IHttpSecurity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHttpSecurity> for IWindowForBindingUI {
-    fn from(value: IHttpSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHttpSecurity> for &'a IWindowForBindingUI {
-    fn from(value: &'a IHttpSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHttpSecurity> for IWindowForBindingUI {
-    fn from(value: &IHttpSecurity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHttpSecurity, ::windows::core::IUnknown, IWindowForBindingUI);
 impl ::core::clone::Clone for IHttpSecurity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1707,21 +1464,7 @@ pub struct IHttpSecurity_Vtbl {
 #[repr(transparent)]
 pub struct IInternet(::windows::core::IUnknown);
 impl IInternet {}
-impl ::core::convert::From<IInternet> for ::windows::core::IUnknown {
-    fn from(value: IInternet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternet> for ::windows::core::IUnknown {
-    fn from(value: &IInternet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1762,21 +1505,7 @@ impl IInternetBindInfo {
         (::windows::core::Vtable::vtable(self).GetBindString)(::windows::core::Vtable::as_raw(self), ulstringtype, ::core::mem::transmute(ppwzstr), cel, ::core::mem::transmute(pcelfetched)).ok()
     }
 }
-impl ::core::convert::From<IInternetBindInfo> for ::windows::core::IUnknown {
-    fn from(value: IInternetBindInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetBindInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetBindInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetBindInfo> for ::windows::core::IUnknown {
-    fn from(value: &IInternetBindInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetBindInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetBindInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1827,36 +1556,7 @@ impl IInternetBindInfoEx {
         (::windows::core::Vtable::vtable(self).GetBindInfoEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(grfbindf), ::core::mem::transmute(pbindinfo), ::core::mem::transmute(grfbindf2), ::core::mem::transmute(pdwreserved)).ok()
     }
 }
-impl ::core::convert::From<IInternetBindInfoEx> for ::windows::core::IUnknown {
-    fn from(value: IInternetBindInfoEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetBindInfoEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetBindInfoEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetBindInfoEx> for ::windows::core::IUnknown {
-    fn from(value: &IInternetBindInfoEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInternetBindInfoEx> for IInternetBindInfo {
-    fn from(value: IInternetBindInfoEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetBindInfoEx> for &'a IInternetBindInfo {
-    fn from(value: &'a IInternetBindInfoEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetBindInfoEx> for IInternetBindInfo {
-    fn from(value: &IInternetBindInfoEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetBindInfoEx, ::windows::core::IUnknown, IInternetBindInfo);
 impl ::core::clone::Clone for IInternetBindInfoEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1902,21 +1602,7 @@ impl IInternetHostSecurityManager {
         (::windows::core::Vtable::vtable(self).QueryCustomPolicy)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidkey), ::core::mem::transmute(pppolicy.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pcbpolicy), ::core::mem::transmute(pcontext.as_ptr()), pcontext.len() as _, dwreserved).ok()
     }
 }
-impl ::core::convert::From<IInternetHostSecurityManager> for ::windows::core::IUnknown {
-    fn from(value: IInternetHostSecurityManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetHostSecurityManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetHostSecurityManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetHostSecurityManager> for ::windows::core::IUnknown {
-    fn from(value: &IInternetHostSecurityManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetHostSecurityManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetHostSecurityManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1959,21 +1645,7 @@ impl IInternetPriority {
         (::windows::core::Vtable::vtable(self).GetPriority)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IInternetPriority> for ::windows::core::IUnknown {
-    fn from(value: IInternetPriority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetPriority> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetPriority) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetPriority> for ::windows::core::IUnknown {
-    fn from(value: &IInternetPriority) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetPriority, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetPriority {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2047,36 +1719,7 @@ impl IInternetProtocol {
         (::windows::core::Vtable::vtable(self).UnlockRequest)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInternetProtocol> for ::windows::core::IUnknown {
-    fn from(value: IInternetProtocol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetProtocol> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetProtocol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetProtocol> for ::windows::core::IUnknown {
-    fn from(value: &IInternetProtocol) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInternetProtocol> for IInternetProtocolRoot {
-    fn from(value: IInternetProtocol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetProtocol> for &'a IInternetProtocolRoot {
-    fn from(value: &'a IInternetProtocol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetProtocol> for IInternetProtocolRoot {
-    fn from(value: &IInternetProtocol) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetProtocol, ::windows::core::IUnknown, IInternetProtocolRoot);
 impl ::core::clone::Clone for IInternetProtocol {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2163,51 +1806,7 @@ impl IInternetProtocolEx {
         (::windows::core::Vtable::vtable(self).StartEx)(::windows::core::Vtable::as_raw(self), puri.into().abi(), poiprotsink.into().abi(), poibindinfo.into().abi(), grfpi, dwreserved.into()).ok()
     }
 }
-impl ::core::convert::From<IInternetProtocolEx> for ::windows::core::IUnknown {
-    fn from(value: IInternetProtocolEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetProtocolEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetProtocolEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetProtocolEx> for ::windows::core::IUnknown {
-    fn from(value: &IInternetProtocolEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInternetProtocolEx> for IInternetProtocolRoot {
-    fn from(value: IInternetProtocolEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetProtocolEx> for &'a IInternetProtocolRoot {
-    fn from(value: &'a IInternetProtocolEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetProtocolEx> for IInternetProtocolRoot {
-    fn from(value: &IInternetProtocolEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInternetProtocolEx> for IInternetProtocol {
-    fn from(value: IInternetProtocolEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetProtocolEx> for &'a IInternetProtocol {
-    fn from(value: &'a IInternetProtocolEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetProtocolEx> for IInternetProtocol {
-    fn from(value: &IInternetProtocolEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetProtocolEx, ::windows::core::IUnknown, IInternetProtocolRoot, IInternetProtocol);
 impl ::core::clone::Clone for IInternetProtocolEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2271,21 +1870,7 @@ impl IInternetProtocolInfo {
         (::windows::core::Vtable::vtable(self).QueryInfo)(::windows::core::Vtable::as_raw(self), pwzurl.into(), oueryoption, dwqueryflags, ::core::mem::transmute(pbuffer), cbbuffer, ::core::mem::transmute(pcbbuf), dwreserved).ok()
     }
 }
-impl ::core::convert::From<IInternetProtocolInfo> for ::windows::core::IUnknown {
-    fn from(value: IInternetProtocolInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetProtocolInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetProtocolInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetProtocolInfo> for ::windows::core::IUnknown {
-    fn from(value: &IInternetProtocolInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetProtocolInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetProtocolInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2348,21 +1933,7 @@ impl IInternetProtocolRoot {
         (::windows::core::Vtable::vtable(self).Resume)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInternetProtocolRoot> for ::windows::core::IUnknown {
-    fn from(value: IInternetProtocolRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetProtocolRoot> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetProtocolRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetProtocolRoot> for ::windows::core::IUnknown {
-    fn from(value: &IInternetProtocolRoot) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetProtocolRoot, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetProtocolRoot {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2422,21 +1993,7 @@ impl IInternetProtocolSink {
         (::windows::core::Vtable::vtable(self).ReportResult)(::windows::core::Vtable::as_raw(self), hrresult, dwerror, szresult.into()).ok()
     }
 }
-impl ::core::convert::From<IInternetProtocolSink> for ::windows::core::IUnknown {
-    fn from(value: IInternetProtocolSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetProtocolSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetProtocolSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetProtocolSink> for ::windows::core::IUnknown {
-    fn from(value: &IInternetProtocolSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetProtocolSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetProtocolSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2485,21 +2042,7 @@ impl IInternetProtocolSinkStackable {
         (::windows::core::Vtable::vtable(self).RollbackSwitch)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInternetProtocolSinkStackable> for ::windows::core::IUnknown {
-    fn from(value: IInternetProtocolSinkStackable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetProtocolSinkStackable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetProtocolSinkStackable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetProtocolSinkStackable> for ::windows::core::IUnknown {
-    fn from(value: &IInternetProtocolSinkStackable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetProtocolSinkStackable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetProtocolSinkStackable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2578,21 +2121,7 @@ impl IInternetSecurityManager {
         (::windows::core::Vtable::vtable(self).GetZoneMappings)(::windows::core::Vtable::as_raw(self), dwzone, ::core::mem::transmute(ppenumstring), dwflags).ok()
     }
 }
-impl ::core::convert::From<IInternetSecurityManager> for ::windows::core::IUnknown {
-    fn from(value: IInternetSecurityManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetSecurityManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetSecurityManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetSecurityManager> for ::windows::core::IUnknown {
-    fn from(value: &IInternetSecurityManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetSecurityManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetSecurityManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2682,36 +2211,7 @@ impl IInternetSecurityManagerEx {
         (::windows::core::Vtable::vtable(self).ProcessUrlActionEx)(::windows::core::Vtable::as_raw(self), pwszurl.into(), dwaction, ::core::mem::transmute(ppolicy.as_ptr()), ppolicy.len() as _, ::core::mem::transmute(pcontext), cbcontext, dwflags, dwreserved, ::core::mem::transmute(pdwoutflags)).ok()
     }
 }
-impl ::core::convert::From<IInternetSecurityManagerEx> for ::windows::core::IUnknown {
-    fn from(value: IInternetSecurityManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetSecurityManagerEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetSecurityManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetSecurityManagerEx> for ::windows::core::IUnknown {
-    fn from(value: &IInternetSecurityManagerEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInternetSecurityManagerEx> for IInternetSecurityManager {
-    fn from(value: IInternetSecurityManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetSecurityManagerEx> for &'a IInternetSecurityManager {
-    fn from(value: &'a IInternetSecurityManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetSecurityManagerEx> for IInternetSecurityManager {
-    fn from(value: &IInternetSecurityManagerEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetSecurityManagerEx, ::windows::core::IUnknown, IInternetSecurityManager);
 impl ::core::clone::Clone for IInternetSecurityManagerEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2818,51 +2318,7 @@ impl IInternetSecurityManagerEx2 {
         (::windows::core::Vtable::vtable(self).QueryCustomPolicyEx2)(::windows::core::Vtable::as_raw(self), puri.into().abi(), ::core::mem::transmute(guidkey), ::core::mem::transmute(pppolicy), ::core::mem::transmute(pcbpolicy), ::core::mem::transmute(pcontext), cbcontext, dwreserved).ok()
     }
 }
-impl ::core::convert::From<IInternetSecurityManagerEx2> for ::windows::core::IUnknown {
-    fn from(value: IInternetSecurityManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetSecurityManagerEx2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetSecurityManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetSecurityManagerEx2> for ::windows::core::IUnknown {
-    fn from(value: &IInternetSecurityManagerEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInternetSecurityManagerEx2> for IInternetSecurityManager {
-    fn from(value: IInternetSecurityManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetSecurityManagerEx2> for &'a IInternetSecurityManager {
-    fn from(value: &'a IInternetSecurityManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetSecurityManagerEx2> for IInternetSecurityManager {
-    fn from(value: &IInternetSecurityManagerEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInternetSecurityManagerEx2> for IInternetSecurityManagerEx {
-    fn from(value: IInternetSecurityManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetSecurityManagerEx2> for &'a IInternetSecurityManagerEx {
-    fn from(value: &'a IInternetSecurityManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetSecurityManagerEx2> for IInternetSecurityManagerEx {
-    fn from(value: &IInternetSecurityManagerEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetSecurityManagerEx2, ::windows::core::IUnknown, IInternetSecurityManager, IInternetSecurityManagerEx);
 impl ::core::clone::Clone for IInternetSecurityManagerEx2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2913,21 +2369,7 @@ impl IInternetSecurityMgrSite {
         (::windows::core::Vtable::vtable(self).EnableModeless)(::windows::core::Vtable::as_raw(self), fenable.into()).ok()
     }
 }
-impl ::core::convert::From<IInternetSecurityMgrSite> for ::windows::core::IUnknown {
-    fn from(value: IInternetSecurityMgrSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetSecurityMgrSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetSecurityMgrSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetSecurityMgrSite> for ::windows::core::IUnknown {
-    fn from(value: &IInternetSecurityMgrSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetSecurityMgrSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetSecurityMgrSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3010,21 +2452,7 @@ impl IInternetSession {
         (::windows::core::Vtable::vtable(self).GetSessionOption)(::windows::core::Vtable::as_raw(self), dwoption, ::core::mem::transmute(pbuffer), ::core::mem::transmute(pdwbufferlength), dwreserved).ok()
     }
 }
-impl ::core::convert::From<IInternetSession> for ::windows::core::IUnknown {
-    fn from(value: IInternetSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetSession> for ::windows::core::IUnknown {
-    fn from(value: &IInternetSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3070,21 +2498,7 @@ impl IInternetThreadSwitch {
         (::windows::core::Vtable::vtable(self).Continue)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInternetThreadSwitch> for ::windows::core::IUnknown {
-    fn from(value: IInternetThreadSwitch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetThreadSwitch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetThreadSwitch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetThreadSwitch> for ::windows::core::IUnknown {
-    fn from(value: &IInternetThreadSwitch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetThreadSwitch, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetThreadSwitch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3167,21 +2581,7 @@ impl IInternetZoneManager {
         (::windows::core::Vtable::vtable(self).CopyTemplatePoliciesToZone)(::windows::core::Vtable::as_raw(self), dwtemplate, dwzone, dwreserved).ok()
     }
 }
-impl ::core::convert::From<IInternetZoneManager> for ::windows::core::IUnknown {
-    fn from(value: IInternetZoneManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetZoneManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetZoneManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetZoneManager> for ::windows::core::IUnknown {
-    fn from(value: &IInternetZoneManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetZoneManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternetZoneManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3283,36 +2683,7 @@ impl IInternetZoneManagerEx {
         (::windows::core::Vtable::vtable(self).SetZoneActionPolicyEx)(::windows::core::Vtable::as_raw(self), dwzone, dwaction, ::core::mem::transmute(ppolicy.as_ptr()), ppolicy.len() as _, urlzonereg, dwflags).ok()
     }
 }
-impl ::core::convert::From<IInternetZoneManagerEx> for ::windows::core::IUnknown {
-    fn from(value: IInternetZoneManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetZoneManagerEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetZoneManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetZoneManagerEx> for ::windows::core::IUnknown {
-    fn from(value: &IInternetZoneManagerEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInternetZoneManagerEx> for IInternetZoneManager {
-    fn from(value: IInternetZoneManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetZoneManagerEx> for &'a IInternetZoneManager {
-    fn from(value: &'a IInternetZoneManagerEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetZoneManagerEx> for IInternetZoneManager {
-    fn from(value: &IInternetZoneManagerEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetZoneManagerEx, ::windows::core::IUnknown, IInternetZoneManager);
 impl ::core::clone::Clone for IInternetZoneManagerEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3424,51 +2795,7 @@ impl IInternetZoneManagerEx2 {
         (::windows::core::Vtable::vtable(self).FixUnsecureSettings)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInternetZoneManagerEx2> for ::windows::core::IUnknown {
-    fn from(value: IInternetZoneManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetZoneManagerEx2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternetZoneManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetZoneManagerEx2> for ::windows::core::IUnknown {
-    fn from(value: &IInternetZoneManagerEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInternetZoneManagerEx2> for IInternetZoneManager {
-    fn from(value: IInternetZoneManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetZoneManagerEx2> for &'a IInternetZoneManager {
-    fn from(value: &'a IInternetZoneManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetZoneManagerEx2> for IInternetZoneManager {
-    fn from(value: &IInternetZoneManagerEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInternetZoneManagerEx2> for IInternetZoneManagerEx {
-    fn from(value: IInternetZoneManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternetZoneManagerEx2> for &'a IInternetZoneManagerEx {
-    fn from(value: &'a IInternetZoneManagerEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternetZoneManagerEx2> for IInternetZoneManagerEx {
-    fn from(value: &IInternetZoneManagerEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternetZoneManagerEx2, ::windows::core::IUnknown, IInternetZoneManager, IInternetZoneManagerEx);
 impl ::core::clone::Clone for IInternetZoneManagerEx2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3517,21 +2844,7 @@ impl IMonikerProp {
         (::windows::core::Vtable::vtable(self).PutProperty)(::windows::core::Vtable::as_raw(self), mkp, val.into()).ok()
     }
 }
-impl ::core::convert::From<IMonikerProp> for ::windows::core::IUnknown {
-    fn from(value: IMonikerProp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMonikerProp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMonikerProp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMonikerProp> for ::windows::core::IUnknown {
-    fn from(value: &IMonikerProp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMonikerProp, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMonikerProp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3603,21 +2916,7 @@ impl IPersistMoniker {
         (::windows::core::Vtable::vtable(self).GetCurMoniker)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::IMoniker>(result__)
     }
 }
-impl ::core::convert::From<IPersistMoniker> for ::windows::core::IUnknown {
-    fn from(value: IPersistMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistMoniker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistMoniker> for ::windows::core::IUnknown {
-    fn from(value: &IPersistMoniker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistMoniker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPersistMoniker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3683,21 +2982,7 @@ impl ISoftDistExt {
         (::windows::core::Vtable::vtable(self).AsyncInstallDistributionUnit)(::windows::core::Vtable::as_raw(self), pbc.into().abi(), ::core::mem::transmute(pvreserved), flags, ::core::mem::transmute(lpcbh)).ok()
     }
 }
-impl ::core::convert::From<ISoftDistExt> for ::windows::core::IUnknown {
-    fn from(value: ISoftDistExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISoftDistExt> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISoftDistExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISoftDistExt> for ::windows::core::IUnknown {
-    fn from(value: &ISoftDistExt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISoftDistExt, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISoftDistExt {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3745,21 +3030,7 @@ impl IUriBuilderFactory {
         (::windows::core::Vtable::vtable(self).CreateInitializedIUriBuilder)(::windows::core::Vtable::as_raw(self), dwflags, dwreserved, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::IUriBuilder>(result__)
     }
 }
-impl ::core::convert::From<IUriBuilderFactory> for ::windows::core::IUnknown {
-    fn from(value: IUriBuilderFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUriBuilderFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUriBuilderFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUriBuilderFactory> for ::windows::core::IUnknown {
-    fn from(value: &IUriBuilderFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUriBuilderFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUriBuilderFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3798,21 +3069,7 @@ impl IUriContainer {
         (::windows::core::Vtable::vtable(self).GetIUri)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::IUri>(result__)
     }
 }
-impl ::core::convert::From<IUriContainer> for ::windows::core::IUnknown {
-    fn from(value: IUriContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUriContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUriContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUriContainer> for ::windows::core::IUnknown {
-    fn from(value: &IUriContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUriContainer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUriContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3852,21 +3109,7 @@ impl IWinInetCacheHints {
         (::windows::core::Vtable::vtable(self).SetCacheExtension)(::windows::core::Vtable::as_raw(self), pwzext.into(), ::core::mem::transmute(pszcachefile), ::core::mem::transmute(pcbcachefile), ::core::mem::transmute(pdwwinineterror), ::core::mem::transmute(pdwreserved)).ok()
     }
 }
-impl ::core::convert::From<IWinInetCacheHints> for ::windows::core::IUnknown {
-    fn from(value: IWinInetCacheHints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinInetCacheHints> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWinInetCacheHints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinInetCacheHints> for ::windows::core::IUnknown {
-    fn from(value: &IWinInetCacheHints) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWinInetCacheHints, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWinInetCacheHints {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3912,36 +3155,7 @@ impl IWinInetCacheHints2 {
         (::windows::core::Vtable::vtable(self).SetCacheExtension2)(::windows::core::Vtable::as_raw(self), pwzext.into(), ::core::mem::transmute(pwzcachefile), ::core::mem::transmute(pcchcachefile), ::core::mem::transmute(pdwwinineterror), ::core::mem::transmute(pdwreserved)).ok()
     }
 }
-impl ::core::convert::From<IWinInetCacheHints2> for ::windows::core::IUnknown {
-    fn from(value: IWinInetCacheHints2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinInetCacheHints2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWinInetCacheHints2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinInetCacheHints2> for ::windows::core::IUnknown {
-    fn from(value: &IWinInetCacheHints2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWinInetCacheHints2> for IWinInetCacheHints {
-    fn from(value: IWinInetCacheHints2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinInetCacheHints2> for &'a IWinInetCacheHints {
-    fn from(value: &'a IWinInetCacheHints2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinInetCacheHints2> for IWinInetCacheHints {
-    fn from(value: &IWinInetCacheHints2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWinInetCacheHints2, ::windows::core::IUnknown, IWinInetCacheHints);
 impl ::core::clone::Clone for IWinInetCacheHints2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3981,21 +3195,7 @@ impl IWinInetFileStream {
         (::windows::core::Vtable::vtable(self).SetDeleteFile)(::windows::core::Vtable::as_raw(self), dwreserved).ok()
     }
 }
-impl ::core::convert::From<IWinInetFileStream> for ::windows::core::IUnknown {
-    fn from(value: IWinInetFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinInetFileStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWinInetFileStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinInetFileStream> for ::windows::core::IUnknown {
-    fn from(value: &IWinInetFileStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWinInetFileStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWinInetFileStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4036,36 +3236,7 @@ impl IWinInetHttpInfo {
         (::windows::core::Vtable::vtable(self).QueryInfo)(::windows::core::Vtable::as_raw(self), dwoption, ::core::mem::transmute(pbuffer), ::core::mem::transmute(pcbbuf), ::core::mem::transmute(pdwflags), ::core::mem::transmute(pdwreserved)).ok()
     }
 }
-impl ::core::convert::From<IWinInetHttpInfo> for ::windows::core::IUnknown {
-    fn from(value: IWinInetHttpInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinInetHttpInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWinInetHttpInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinInetHttpInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWinInetHttpInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWinInetHttpInfo> for IWinInetInfo {
-    fn from(value: IWinInetHttpInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinInetHttpInfo> for &'a IWinInetInfo {
-    fn from(value: &'a IWinInetHttpInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinInetHttpInfo> for IWinInetInfo {
-    fn from(value: &IWinInetHttpInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWinInetHttpInfo, ::windows::core::IUnknown, IWinInetInfo);
 impl ::core::clone::Clone for IWinInetHttpInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4102,21 +3273,7 @@ impl IWinInetHttpTimeouts {
         (::windows::core::Vtable::vtable(self).GetRequestTimeouts)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwconnecttimeout), ::core::mem::transmute(pdwsendtimeout), ::core::mem::transmute(pdwreceivetimeout)).ok()
     }
 }
-impl ::core::convert::From<IWinInetHttpTimeouts> for ::windows::core::IUnknown {
-    fn from(value: IWinInetHttpTimeouts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinInetHttpTimeouts> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWinInetHttpTimeouts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinInetHttpTimeouts> for ::windows::core::IUnknown {
-    fn from(value: &IWinInetHttpTimeouts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWinInetHttpTimeouts, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWinInetHttpTimeouts {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4153,21 +3310,7 @@ impl IWinInetInfo {
         (::windows::core::Vtable::vtable(self).QueryOption)(::windows::core::Vtable::as_raw(self), dwoption, ::core::mem::transmute(pbuffer), ::core::mem::transmute(pcbbuf)).ok()
     }
 }
-impl ::core::convert::From<IWinInetInfo> for ::windows::core::IUnknown {
-    fn from(value: IWinInetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWinInetInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWinInetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWinInetInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWinInetInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWinInetInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWinInetInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4207,21 +3350,7 @@ impl IWindowForBindingUI {
         (::windows::core::Vtable::vtable(self).GetWindow)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rguidreason), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::HWND>(result__)
     }
 }
-impl ::core::convert::From<IWindowForBindingUI> for ::windows::core::IUnknown {
-    fn from(value: IWindowForBindingUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowForBindingUI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowForBindingUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowForBindingUI> for ::windows::core::IUnknown {
-    fn from(value: &IWindowForBindingUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowForBindingUI, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWindowForBindingUI {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4261,21 +3390,7 @@ impl IWrappedProtocol {
         (::windows::core::Vtable::vtable(self).GetWrapperCode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pncode), dwreserved).ok()
     }
 }
-impl ::core::convert::From<IWrappedProtocol> for ::windows::core::IUnknown {
-    fn from(value: IWrappedProtocol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWrappedProtocol> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWrappedProtocol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWrappedProtocol> for ::windows::core::IUnknown {
-    fn from(value: &IWrappedProtocol) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWrappedProtocol, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWrappedProtocol {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4319,21 +3434,7 @@ impl IZoneIdentifier {
         (::windows::core::Vtable::vtable(self).Remove)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IZoneIdentifier> for ::windows::core::IUnknown {
-    fn from(value: IZoneIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IZoneIdentifier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IZoneIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IZoneIdentifier> for ::windows::core::IUnknown {
-    fn from(value: &IZoneIdentifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IZoneIdentifier, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IZoneIdentifier {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4402,36 +3503,7 @@ impl IZoneIdentifier2 {
         (::windows::core::Vtable::vtable(self).RemoveAppZoneId)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IZoneIdentifier2> for ::windows::core::IUnknown {
-    fn from(value: IZoneIdentifier2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IZoneIdentifier2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IZoneIdentifier2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IZoneIdentifier2> for ::windows::core::IUnknown {
-    fn from(value: &IZoneIdentifier2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IZoneIdentifier2> for IZoneIdentifier {
-    fn from(value: IZoneIdentifier2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IZoneIdentifier2> for &'a IZoneIdentifier {
-    fn from(value: &'a IZoneIdentifier2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IZoneIdentifier2> for IZoneIdentifier {
-    fn from(value: &IZoneIdentifier2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IZoneIdentifier2, ::windows::core::IUnknown, IZoneIdentifier);
 impl ::core::clone::Clone for IZoneIdentifier2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
@@ -1280,21 +1280,7 @@ impl AsyncIAdviseSink {
         (::windows::core::Vtable::vtable(self).Finish_OnClose)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<AsyncIAdviseSink> for ::windows::core::IUnknown {
-    fn from(value: AsyncIAdviseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIAdviseSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIAdviseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIAdviseSink> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIAdviseSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIAdviseSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIAdviseSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1384,36 +1370,7 @@ impl AsyncIAdviseSink2 {
         (::windows::core::Vtable::vtable(self).Finish_OnLinkSrcChange)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<AsyncIAdviseSink2> for ::windows::core::IUnknown {
-    fn from(value: AsyncIAdviseSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIAdviseSink2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIAdviseSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIAdviseSink2> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIAdviseSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<AsyncIAdviseSink2> for AsyncIAdviseSink {
-    fn from(value: AsyncIAdviseSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIAdviseSink2> for &'a AsyncIAdviseSink {
-    fn from(value: &'a AsyncIAdviseSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIAdviseSink2> for AsyncIAdviseSink {
-    fn from(value: &AsyncIAdviseSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIAdviseSink2, ::windows::core::IUnknown, AsyncIAdviseSink);
 impl ::core::clone::Clone for AsyncIAdviseSink2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1454,21 +1411,7 @@ impl AsyncIMultiQI {
         (::windows::core::Vtable::vtable(self).Finish_QueryMultipleInterfaces)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmqis)).ok()
     }
 }
-impl ::core::convert::From<AsyncIMultiQI> for ::windows::core::IUnknown {
-    fn from(value: AsyncIMultiQI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIMultiQI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIMultiQI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIMultiQI> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIMultiQI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIMultiQI, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIMultiQI {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1515,21 +1458,7 @@ impl AsyncIPipeByte {
         (::windows::core::Vtable::vtable(self).Finish_Push)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIPipeByte> for ::windows::core::IUnknown {
-    fn from(value: AsyncIPipeByte) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIPipeByte> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIPipeByte) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIPipeByte> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIPipeByte) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIPipeByte, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIPipeByte {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1578,21 +1507,7 @@ impl AsyncIPipeDouble {
         (::windows::core::Vtable::vtable(self).Finish_Push)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIPipeDouble> for ::windows::core::IUnknown {
-    fn from(value: AsyncIPipeDouble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIPipeDouble> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIPipeDouble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIPipeDouble> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIPipeDouble) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIPipeDouble, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIPipeDouble {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1641,21 +1556,7 @@ impl AsyncIPipeLong {
         (::windows::core::Vtable::vtable(self).Finish_Push)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIPipeLong> for ::windows::core::IUnknown {
-    fn from(value: AsyncIPipeLong) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIPipeLong> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIPipeLong) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIPipeLong> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIPipeLong) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIPipeLong, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIPipeLong {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1710,21 +1611,7 @@ impl AsyncIUnknown {
         (::windows::core::Vtable::vtable(self).Finish_Release)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<AsyncIUnknown> for ::windows::core::IUnknown {
-    fn from(value: AsyncIUnknown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIUnknown> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIUnknown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIUnknown> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIUnknown) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIUnknown, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIUnknown {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1767,21 +1654,7 @@ impl IActivationFilter {
         (::windows::core::Vtable::vtable(self).HandleActivation)(::windows::core::Vtable::as_raw(self), dwactivationtype, ::core::mem::transmute(rclsid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IActivationFilter> for ::windows::core::IUnknown {
-    fn from(value: IActivationFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActivationFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActivationFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActivationFilter> for ::windows::core::IUnknown {
-    fn from(value: &IActivationFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActivationFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActivationFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1824,21 +1697,7 @@ impl IAddrExclusionControl {
         (::windows::core::Vtable::vtable(self).UpdateAddrExclusionList)(::windows::core::Vtable::as_raw(self), penumerator.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAddrExclusionControl> for ::windows::core::IUnknown {
-    fn from(value: IAddrExclusionControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAddrExclusionControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAddrExclusionControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAddrExclusionControl> for ::windows::core::IUnknown {
-    fn from(value: &IAddrExclusionControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAddrExclusionControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAddrExclusionControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1879,21 +1738,7 @@ impl IAddrTrackingControl {
         (::windows::core::Vtable::vtable(self).DisableCOMDynamicAddrTracking)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAddrTrackingControl> for ::windows::core::IUnknown {
-    fn from(value: IAddrTrackingControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAddrTrackingControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAddrTrackingControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAddrTrackingControl> for ::windows::core::IUnknown {
-    fn from(value: &IAddrTrackingControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAddrTrackingControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAddrTrackingControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1948,21 +1793,7 @@ impl IAdviseSink {
         (::windows::core::Vtable::vtable(self).OnClose)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IAdviseSink> for ::windows::core::IUnknown {
-    fn from(value: IAdviseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdviseSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAdviseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdviseSink> for ::windows::core::IUnknown {
-    fn from(value: &IAdviseSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAdviseSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAdviseSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2029,36 +1860,7 @@ impl IAdviseSink2 {
         (::windows::core::Vtable::vtable(self).OnLinkSrcChange)(::windows::core::Vtable::as_raw(self), pmk.into().abi())
     }
 }
-impl ::core::convert::From<IAdviseSink2> for ::windows::core::IUnknown {
-    fn from(value: IAdviseSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdviseSink2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAdviseSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdviseSink2> for ::windows::core::IUnknown {
-    fn from(value: &IAdviseSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAdviseSink2> for IAdviseSink {
-    fn from(value: IAdviseSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAdviseSink2> for &'a IAdviseSink {
-    fn from(value: &'a IAdviseSink2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAdviseSink2> for IAdviseSink {
-    fn from(value: &IAdviseSink2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAdviseSink2, ::windows::core::IUnknown, IAdviseSink);
 impl ::core::clone::Clone for IAdviseSink2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2091,21 +1893,7 @@ pub struct IAdviseSink2_Vtbl {
 #[repr(transparent)]
 pub struct IAgileObject(::windows::core::IUnknown);
 impl IAgileObject {}
-impl ::core::convert::From<IAgileObject> for ::windows::core::IUnknown {
-    fn from(value: IAgileObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAgileObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAgileObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAgileObject> for ::windows::core::IUnknown {
-    fn from(value: &IAgileObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAgileObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAgileObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2148,21 +1936,7 @@ impl IAsyncManager {
         (::windows::core::Vtable::vtable(self).GetState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAsyncManager> for ::windows::core::IUnknown {
-    fn from(value: IAsyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAsyncManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncManager> for ::windows::core::IUnknown {
-    fn from(value: &IAsyncManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAsyncManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAsyncManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2229,51 +2003,7 @@ impl IAsyncRpcChannelBuffer {
         (::windows::core::Vtable::vtable(self).GetDestCtxEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg), ::core::mem::transmute(pdwdestcontext), ::core::mem::transmute(ppvdestcontext.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IAsyncRpcChannelBuffer> for ::windows::core::IUnknown {
-    fn from(value: IAsyncRpcChannelBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncRpcChannelBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAsyncRpcChannelBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncRpcChannelBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IAsyncRpcChannelBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAsyncRpcChannelBuffer> for IRpcChannelBuffer {
-    fn from(value: IAsyncRpcChannelBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncRpcChannelBuffer> for &'a IRpcChannelBuffer {
-    fn from(value: &'a IAsyncRpcChannelBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncRpcChannelBuffer> for IRpcChannelBuffer {
-    fn from(value: &IAsyncRpcChannelBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAsyncRpcChannelBuffer> for IRpcChannelBuffer2 {
-    fn from(value: IAsyncRpcChannelBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncRpcChannelBuffer> for &'a IRpcChannelBuffer2 {
-    fn from(value: &'a IAsyncRpcChannelBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncRpcChannelBuffer> for IRpcChannelBuffer2 {
-    fn from(value: &IAsyncRpcChannelBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAsyncRpcChannelBuffer, ::windows::core::IUnknown, IRpcChannelBuffer, IRpcChannelBuffer2);
 impl ::core::clone::Clone for IAsyncRpcChannelBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2314,21 +2044,7 @@ impl IAuthenticate {
         (::windows::core::Vtable::vtable(self).Authenticate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phwnd), ::core::mem::transmute(pszusername), ::core::mem::transmute(pszpassword)).ok()
     }
 }
-impl ::core::convert::From<IAuthenticate> for ::windows::core::IUnknown {
-    fn from(value: IAuthenticate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAuthenticate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAuthenticate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAuthenticate> for ::windows::core::IUnknown {
-    fn from(value: &IAuthenticate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAuthenticate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAuthenticate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2375,36 +2091,7 @@ impl IAuthenticateEx {
         (::windows::core::Vtable::vtable(self).AuthenticateEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phwnd), ::core::mem::transmute(pszusername), ::core::mem::transmute(pszpassword), ::core::mem::transmute(pauthinfo)).ok()
     }
 }
-impl ::core::convert::From<IAuthenticateEx> for ::windows::core::IUnknown {
-    fn from(value: IAuthenticateEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAuthenticateEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAuthenticateEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAuthenticateEx> for ::windows::core::IUnknown {
-    fn from(value: &IAuthenticateEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAuthenticateEx> for IAuthenticate {
-    fn from(value: IAuthenticateEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAuthenticateEx> for &'a IAuthenticate {
-    fn from(value: &'a IAuthenticateEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAuthenticateEx> for IAuthenticate {
-    fn from(value: &IAuthenticateEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAuthenticateEx, ::windows::core::IUnknown, IAuthenticate);
 impl ::core::clone::Clone for IAuthenticateEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2490,21 +2177,7 @@ impl IBindCtx {
         (::windows::core::Vtable::vtable(self).RevokeObjectParam)(::windows::core::Vtable::as_raw(self), pszkey.into()).ok()
     }
 }
-impl ::core::convert::From<IBindCtx> for ::windows::core::IUnknown {
-    fn from(value: IBindCtx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBindCtx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBindCtx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBindCtx> for ::windows::core::IUnknown {
-    fn from(value: &IBindCtx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBindCtx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBindCtx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2570,21 +2243,7 @@ impl IBindHost {
         (::windows::core::Vtable::vtable(self).MonikerBindToObject)(::windows::core::Vtable::as_raw(self), pmk.into().abi(), pbc.into().abi(), pbsc.into().abi(), ::core::mem::transmute(riid), ::core::mem::transmute(ppvobj)).ok()
     }
 }
-impl ::core::convert::From<IBindHost> for ::windows::core::IUnknown {
-    fn from(value: IBindHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBindHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBindHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBindHost> for ::windows::core::IUnknown {
-    fn from(value: &IBindHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBindHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBindHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2661,21 +2320,7 @@ impl IBindStatusCallback {
         (::windows::core::Vtable::vtable(self).OnObjectAvailable)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), punk.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IBindStatusCallback> for ::windows::core::IUnknown {
-    fn from(value: IBindStatusCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBindStatusCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBindStatusCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBindStatusCallback> for ::windows::core::IUnknown {
-    fn from(value: &IBindStatusCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBindStatusCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBindStatusCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2768,36 +2413,7 @@ impl IBindStatusCallbackEx {
         (::windows::core::Vtable::vtable(self).GetBindInfoEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(grfbindf), ::core::mem::transmute(pbindinfo), ::core::mem::transmute(grfbindf2), ::core::mem::transmute(pdwreserved)).ok()
     }
 }
-impl ::core::convert::From<IBindStatusCallbackEx> for ::windows::core::IUnknown {
-    fn from(value: IBindStatusCallbackEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBindStatusCallbackEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBindStatusCallbackEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBindStatusCallbackEx> for ::windows::core::IUnknown {
-    fn from(value: &IBindStatusCallbackEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBindStatusCallbackEx> for IBindStatusCallback {
-    fn from(value: IBindStatusCallbackEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBindStatusCallbackEx> for &'a IBindStatusCallback {
-    fn from(value: &'a IBindStatusCallbackEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBindStatusCallbackEx> for IBindStatusCallback {
-    fn from(value: &IBindStatusCallbackEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBindStatusCallbackEx, ::windows::core::IUnknown, IBindStatusCallback);
 impl ::core::clone::Clone for IBindStatusCallbackEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2853,21 +2469,7 @@ impl IBinding {
         (::windows::core::Vtable::vtable(self).GetBindResult)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pclsidprotocol), ::core::mem::transmute(pdwresult), ::core::mem::transmute(pszresult), ::core::mem::transmute(pdwreserved)).ok()
     }
 }
-impl ::core::convert::From<IBinding> for ::windows::core::IUnknown {
-    fn from(value: IBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBinding> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBinding) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBinding> for ::windows::core::IUnknown {
-    fn from(value: &IBinding) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBinding, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBinding {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2912,21 +2514,7 @@ impl IBlockingLock {
         (::windows::core::Vtable::vtable(self).Unlock)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IBlockingLock> for ::windows::core::IUnknown {
-    fn from(value: IBlockingLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBlockingLock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBlockingLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBlockingLock> for ::windows::core::IUnknown {
-    fn from(value: &IBlockingLock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBlockingLock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBlockingLock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2968,21 +2556,7 @@ impl ICallFactory {
         (::windows::core::Vtable::vtable(self).CreateCall)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), pctrlunk.into().abi(), ::core::mem::transmute(riid2), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<ICallFactory> for ::windows::core::IUnknown {
-    fn from(value: ICallFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICallFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICallFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICallFactory> for ::windows::core::IUnknown {
-    fn from(value: &ICallFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICallFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICallFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3022,21 +2596,7 @@ impl ICancelMethodCalls {
         (::windows::core::Vtable::vtable(self).TestCancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ICancelMethodCalls> for ::windows::core::IUnknown {
-    fn from(value: ICancelMethodCalls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICancelMethodCalls> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICancelMethodCalls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICancelMethodCalls> for ::windows::core::IUnknown {
-    fn from(value: &ICancelMethodCalls) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICancelMethodCalls, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICancelMethodCalls {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3094,21 +2654,7 @@ impl ICatInformation {
         (::windows::core::Vtable::vtable(self).EnumReqCategoriesOfClass)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumGUID>(result__)
     }
 }
-impl ::core::convert::From<ICatInformation> for ::windows::core::IUnknown {
-    fn from(value: ICatInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICatInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICatInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICatInformation> for ::windows::core::IUnknown {
-    fn from(value: &ICatInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICatInformation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICatInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3165,21 +2711,7 @@ impl ICatRegister {
         (::windows::core::Vtable::vtable(self).UnRegisterClassReqCategories)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid), rgcatid.len() as _, ::core::mem::transmute(rgcatid.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<ICatRegister> for ::windows::core::IUnknown {
-    fn from(value: ICatRegister) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICatRegister> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICatRegister) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICatRegister> for ::windows::core::IUnknown {
-    fn from(value: &ICatRegister) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICatRegister, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICatRegister {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3236,21 +2768,7 @@ impl IChannelHook {
         (::windows::core::Vtable::vtable(self).ServerFillBuffer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(uextent), ::core::mem::transmute(riid), ::core::mem::transmute(pdatasize), ::core::mem::transmute(pdatabuffer), hrfault)
     }
 }
-impl ::core::convert::From<IChannelHook> for ::windows::core::IUnknown {
-    fn from(value: IChannelHook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IChannelHook> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IChannelHook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IChannelHook> for ::windows::core::IUnknown {
-    fn from(value: &IChannelHook) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IChannelHook, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IChannelHook {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3296,21 +2814,7 @@ impl IClassActivator {
         (::windows::core::Vtable::vtable(self).GetClassObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid), dwclasscontext, locale, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IClassActivator> for ::windows::core::IUnknown {
-    fn from(value: IClassActivator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IClassActivator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IClassActivator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IClassActivator> for ::windows::core::IUnknown {
-    fn from(value: &IClassActivator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IClassActivator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IClassActivator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3360,21 +2864,7 @@ impl IClassFactory {
         (::windows::core::Vtable::vtable(self).LockServer)(::windows::core::Vtable::as_raw(self), flock.into()).ok()
     }
 }
-impl ::core::convert::From<IClassFactory> for ::windows::core::IUnknown {
-    fn from(value: IClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IClassFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IClassFactory> for ::windows::core::IUnknown {
-    fn from(value: &IClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IClassFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IClassFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3443,21 +2933,7 @@ impl IClientSecurity {
         (::windows::core::Vtable::vtable(self).CopyProxy)(::windows::core::Vtable::as_raw(self), pproxy.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IClientSecurity> for ::windows::core::IUnknown {
-    fn from(value: IClientSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IClientSecurity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IClientSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IClientSecurity> for ::windows::core::IUnknown {
-    fn from(value: &IClientSecurity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IClientSecurity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IClientSecurity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3508,21 +2984,7 @@ impl IComThreadingInfo {
         (::windows::core::Vtable::vtable(self).SetCurrentLogicalThreadId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rguid)).ok()
     }
 }
-impl ::core::convert::From<IComThreadingInfo> for ::windows::core::IUnknown {
-    fn from(value: IComThreadingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComThreadingInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComThreadingInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComThreadingInfo> for ::windows::core::IUnknown {
-    fn from(value: &IComThreadingInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComThreadingInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComThreadingInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3581,21 +3043,7 @@ impl IConnectionPoint {
         (::windows::core::Vtable::vtable(self).EnumConnections)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumConnections>(result__)
     }
 }
-impl ::core::convert::From<IConnectionPoint> for ::windows::core::IUnknown {
-    fn from(value: IConnectionPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConnectionPoint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConnectionPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConnectionPoint> for ::windows::core::IUnknown {
-    fn from(value: &IConnectionPoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConnectionPoint, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConnectionPoint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3641,21 +3089,7 @@ impl IConnectionPointContainer {
         (::windows::core::Vtable::vtable(self).FindConnectionPoint)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IConnectionPoint>(result__)
     }
 }
-impl ::core::convert::From<IConnectionPointContainer> for ::windows::core::IUnknown {
-    fn from(value: IConnectionPointContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConnectionPointContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConnectionPointContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConnectionPointContainer> for ::windows::core::IUnknown {
-    fn from(value: &IConnectionPointContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConnectionPointContainer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConnectionPointContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3696,21 +3130,7 @@ impl IContextCallback {
         (::windows::core::Vtable::vtable(self).ContextCallback)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfncallback), ::core::mem::transmute(pparam), ::core::mem::transmute(riid), imethod, punk.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IContextCallback> for ::windows::core::IUnknown {
-    fn from(value: IContextCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextCallback> for ::windows::core::IUnknown {
-    fn from(value: &IContextCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContextCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3765,21 +3185,7 @@ impl IDataAdviseHolder {
         (::windows::core::Vtable::vtable(self).SendOnDataChange)(::windows::core::Vtable::as_raw(self), pdataobject.into().abi(), dwreserved, advf).ok()
     }
 }
-impl ::core::convert::From<IDataAdviseHolder> for ::windows::core::IUnknown {
-    fn from(value: IDataAdviseHolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataAdviseHolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataAdviseHolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataAdviseHolder> for ::windows::core::IUnknown {
-    fn from(value: &IDataAdviseHolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataAdviseHolder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataAdviseHolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3859,21 +3265,7 @@ impl IDataObject {
         (::windows::core::Vtable::vtable(self).EnumDAdvise)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSTATDATA>(result__)
     }
 }
-impl ::core::convert::From<IDataObject> for ::windows::core::IUnknown {
-    fn from(value: IDataObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataObject> for ::windows::core::IUnknown {
-    fn from(value: &IDataObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3941,21 +3333,7 @@ impl IDispatch {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self), dispidmember, ::core::mem::transmute(riid), lcid, wflags, ::core::mem::transmute(pdispparams), ::core::mem::transmute(pvarresult.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pexcepinfo.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(puargerr.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDispatch> for ::windows::core::IUnknown {
-    fn from(value: IDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDispatch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDispatch> for ::windows::core::IUnknown {
-    fn from(value: &IDispatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDispatch, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDispatch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4008,21 +3386,7 @@ impl IEnumCATEGORYINFO {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumCATEGORYINFO>(result__)
     }
 }
-impl ::core::convert::From<IEnumCATEGORYINFO> for ::windows::core::IUnknown {
-    fn from(value: IEnumCATEGORYINFO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumCATEGORYINFO> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumCATEGORYINFO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumCATEGORYINFO> for ::windows::core::IUnknown {
-    fn from(value: &IEnumCATEGORYINFO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumCATEGORYINFO, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumCATEGORYINFO {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4072,21 +3436,7 @@ impl IEnumConnectionPoints {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumConnectionPoints>(result__)
     }
 }
-impl ::core::convert::From<IEnumConnectionPoints> for ::windows::core::IUnknown {
-    fn from(value: IEnumConnectionPoints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumConnectionPoints> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumConnectionPoints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumConnectionPoints> for ::windows::core::IUnknown {
-    fn from(value: &IEnumConnectionPoints) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumConnectionPoints, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumConnectionPoints {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4136,21 +3486,7 @@ impl IEnumConnections {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumConnections>(result__)
     }
 }
-impl ::core::convert::From<IEnumConnections> for ::windows::core::IUnknown {
-    fn from(value: IEnumConnections) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumConnections> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumConnections) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumConnections> for ::windows::core::IUnknown {
-    fn from(value: &IEnumConnections) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumConnections, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumConnections {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4200,21 +3536,7 @@ impl IEnumFORMATETC {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumFORMATETC>(result__)
     }
 }
-impl ::core::convert::From<IEnumFORMATETC> for ::windows::core::IUnknown {
-    fn from(value: IEnumFORMATETC) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumFORMATETC> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumFORMATETC) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumFORMATETC> for ::windows::core::IUnknown {
-    fn from(value: &IEnumFORMATETC) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumFORMATETC, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumFORMATETC {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4264,21 +3586,7 @@ impl IEnumGUID {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumGUID>(result__)
     }
 }
-impl ::core::convert::From<IEnumGUID> for ::windows::core::IUnknown {
-    fn from(value: IEnumGUID) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumGUID> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumGUID) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumGUID> for ::windows::core::IUnknown {
-    fn from(value: &IEnumGUID) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumGUID, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumGUID {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4328,21 +3636,7 @@ impl IEnumMoniker {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumMoniker>(result__)
     }
 }
-impl ::core::convert::From<IEnumMoniker> for ::windows::core::IUnknown {
-    fn from(value: IEnumMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumMoniker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumMoniker> for ::windows::core::IUnknown {
-    fn from(value: &IEnumMoniker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumMoniker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumMoniker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4392,21 +3686,7 @@ impl IEnumSTATDATA {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSTATDATA>(result__)
     }
 }
-impl ::core::convert::From<IEnumSTATDATA> for ::windows::core::IUnknown {
-    fn from(value: IEnumSTATDATA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSTATDATA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSTATDATA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSTATDATA> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSTATDATA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSTATDATA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSTATDATA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4456,21 +3736,7 @@ impl IEnumString {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumString>(result__)
     }
 }
-impl ::core::convert::From<IEnumString> for ::windows::core::IUnknown {
-    fn from(value: IEnumString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumString> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumString> for ::windows::core::IUnknown {
-    fn from(value: &IEnumString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumString, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumString {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4520,21 +3786,7 @@ impl IEnumUnknown {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumUnknown>(result__)
     }
 }
-impl ::core::convert::From<IEnumUnknown> for ::windows::core::IUnknown {
-    fn from(value: IEnumUnknown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumUnknown> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumUnknown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumUnknown> for ::windows::core::IUnknown {
-    fn from(value: &IEnumUnknown) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumUnknown, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumUnknown {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4591,21 +3843,7 @@ impl IErrorInfo {
         (::windows::core::Vtable::vtable(self).GetHelpContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: IErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &IErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IErrorInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IErrorInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4649,21 +3887,7 @@ impl IErrorLog {
         (::windows::core::Vtable::vtable(self).AddError)(::windows::core::Vtable::as_raw(self), pszpropname.into(), ::core::mem::transmute(pexcepinfo)).ok()
     }
 }
-impl ::core::convert::From<IErrorLog> for ::windows::core::IUnknown {
-    fn from(value: IErrorLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IErrorLog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IErrorLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IErrorLog> for ::windows::core::IUnknown {
-    fn from(value: &IErrorLog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IErrorLog, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IErrorLog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4708,21 +3932,7 @@ impl IExternalConnection {
         (::windows::core::Vtable::vtable(self).ReleaseConnection)(::windows::core::Vtable::as_raw(self), extconn, reserved, flastreleasecloses.into())
     }
 }
-impl ::core::convert::From<IExternalConnection> for ::windows::core::IUnknown {
-    fn from(value: IExternalConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExternalConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExternalConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExternalConnection> for ::windows::core::IUnknown {
-    fn from(value: &IExternalConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExternalConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExternalConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4759,21 +3969,7 @@ pub struct IExternalConnection_Vtbl {
 #[repr(transparent)]
 pub struct IFastRundown(::windows::core::IUnknown);
 impl IFastRundown {}
-impl ::core::convert::From<IFastRundown> for ::windows::core::IUnknown {
-    fn from(value: IFastRundown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFastRundown> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFastRundown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFastRundown> for ::windows::core::IUnknown {
-    fn from(value: &IFastRundown) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFastRundown, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFastRundown {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4809,21 +4005,7 @@ impl IForegroundTransfer {
         (::windows::core::Vtable::vtable(self).AllowForegroundTransfer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpvreserved.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IForegroundTransfer> for ::windows::core::IUnknown {
-    fn from(value: IForegroundTransfer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IForegroundTransfer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IForegroundTransfer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IForegroundTransfer> for ::windows::core::IUnknown {
-    fn from(value: &IForegroundTransfer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IForegroundTransfer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IForegroundTransfer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4870,21 +4052,7 @@ impl IGlobalInterfaceTable {
         (::windows::core::Vtable::vtable(self).GetInterfaceFromGlobal)(::windows::core::Vtable::as_raw(self), dwcookie, ::core::mem::transmute(riid), ::core::mem::transmute(ppv)).ok()
     }
 }
-impl ::core::convert::From<IGlobalInterfaceTable> for ::windows::core::IUnknown {
-    fn from(value: IGlobalInterfaceTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGlobalInterfaceTable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGlobalInterfaceTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGlobalInterfaceTable> for ::windows::core::IUnknown {
-    fn from(value: &IGlobalInterfaceTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGlobalInterfaceTable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGlobalInterfaceTable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4927,21 +4095,7 @@ impl IGlobalOptions {
         (::windows::core::Vtable::vtable(self).Query)(::windows::core::Vtable::as_raw(self), dwproperty, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<usize>(result__)
     }
 }
-impl ::core::convert::From<IGlobalOptions> for ::windows::core::IUnknown {
-    fn from(value: IGlobalOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGlobalOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGlobalOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGlobalOptions> for ::windows::core::IUnknown {
-    fn from(value: &IGlobalOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGlobalOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGlobalOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4988,21 +4142,7 @@ impl IInitializeSpy {
         (::windows::core::Vtable::vtable(self).PostUninitialize)(::windows::core::Vtable::as_raw(self), dwnewthreadaptrefs).ok()
     }
 }
-impl ::core::convert::From<IInitializeSpy> for ::windows::core::IUnknown {
-    fn from(value: IInitializeSpy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeSpy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitializeSpy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeSpy> for ::windows::core::IUnknown {
-    fn from(value: &IInitializeSpy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitializeSpy, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInitializeSpy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5042,21 +4182,7 @@ impl IInternalUnknown {
         (::windows::core::Vtable::vtable(self).QueryInternalInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(ppv)).ok()
     }
 }
-impl ::core::convert::From<IInternalUnknown> for ::windows::core::IUnknown {
-    fn from(value: IInternalUnknown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternalUnknown> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternalUnknown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternalUnknown> for ::windows::core::IUnknown {
-    fn from(value: &IInternalUnknown) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternalUnknown, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternalUnknown {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5109,21 +4235,7 @@ impl IMachineGlobalObjectTable {
         (::windows::core::Vtable::vtable(self).RevokeObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(token)).ok()
     }
 }
-impl ::core::convert::From<IMachineGlobalObjectTable> for ::windows::core::IUnknown {
-    fn from(value: IMachineGlobalObjectTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMachineGlobalObjectTable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMachineGlobalObjectTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMachineGlobalObjectTable> for ::windows::core::IUnknown {
-    fn from(value: &IMachineGlobalObjectTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMachineGlobalObjectTable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMachineGlobalObjectTable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5177,21 +4289,7 @@ impl IMalloc {
         (::windows::core::Vtable::vtable(self).HeapMinimize)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMalloc> for ::windows::core::IUnknown {
-    fn from(value: IMalloc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMalloc> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMalloc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMalloc> for ::windows::core::IUnknown {
-    fn from(value: &IMalloc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMalloc, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMalloc {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5306,21 +4404,7 @@ impl IMallocSpy {
         (::windows::core::Vtable::vtable(self).PostHeapMinimize)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IMallocSpy> for ::windows::core::IUnknown {
-    fn from(value: IMallocSpy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMallocSpy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMallocSpy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMallocSpy> for ::windows::core::IUnknown {
-    fn from(value: &IMallocSpy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMallocSpy, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMallocSpy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5520,51 +4604,7 @@ impl IMoniker {
         (::windows::core::Vtable::vtable(self).IsSystemMoniker)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMoniker> for ::windows::core::IUnknown {
-    fn from(value: IMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMoniker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMoniker> for ::windows::core::IUnknown {
-    fn from(value: &IMoniker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMoniker> for IPersist {
-    fn from(value: IMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMoniker> for &'a IPersist {
-    fn from(value: &'a IMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMoniker> for IPersist {
-    fn from(value: &IMoniker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMoniker> for IPersistStream {
-    fn from(value: IMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMoniker> for &'a IPersistStream {
-    fn from(value: &'a IMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMoniker> for IPersistStream {
-    fn from(value: &IMoniker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMoniker, ::windows::core::IUnknown, IPersist, IPersistStream);
 impl ::core::clone::Clone for IMoniker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5624,21 +4664,7 @@ impl IMultiQI {
         (::windows::core::Vtable::vtable(self).QueryMultipleInterfaces)(::windows::core::Vtable::as_raw(self), pmqis.len() as _, ::core::mem::transmute(pmqis.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IMultiQI> for ::windows::core::IUnknown {
-    fn from(value: IMultiQI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMultiQI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultiQI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMultiQI> for ::windows::core::IUnknown {
-    fn from(value: &IMultiQI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultiQI, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMultiQI {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5671,21 +4697,7 @@ pub struct IMultiQI_Vtbl {
 #[repr(transparent)]
 pub struct INoMarshal(::windows::core::IUnknown);
 impl INoMarshal {}
-impl ::core::convert::From<INoMarshal> for ::windows::core::IUnknown {
-    fn from(value: INoMarshal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INoMarshal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INoMarshal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INoMarshal> for ::windows::core::IUnknown {
-    fn from(value: &INoMarshal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INoMarshal, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INoMarshal {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5734,21 +4746,7 @@ impl IOplockStorage {
         (::windows::core::Vtable::vtable(self).OpenStorageEx)(::windows::core::Vtable::as_raw(self), pwcsname.into(), grfmode, stgfmt, grfattrs, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IOplockStorage> for ::windows::core::IUnknown {
-    fn from(value: IOplockStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOplockStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOplockStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOplockStorage> for ::windows::core::IUnknown {
-    fn from(value: &IOplockStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOplockStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOplockStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5796,21 +4794,7 @@ impl IPSFactoryBuffer {
         (::windows::core::Vtable::vtable(self).CreateStub)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), punkserver.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRpcStubBuffer>(result__)
     }
 }
-impl ::core::convert::From<IPSFactoryBuffer> for ::windows::core::IUnknown {
-    fn from(value: IPSFactoryBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPSFactoryBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPSFactoryBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPSFactoryBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IPSFactoryBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPSFactoryBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPSFactoryBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5849,21 +4833,7 @@ impl IPersist {
         (::windows::core::Vtable::vtable(self).GetClassID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IPersist> for ::windows::core::IUnknown {
-    fn from(value: IPersist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersist> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersist> for ::windows::core::IUnknown {
-    fn from(value: &IPersist) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersist, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPersist {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5929,36 +4899,7 @@ impl IPersistFile {
         (::windows::core::Vtable::vtable(self).GetCurFile)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IPersistFile> for ::windows::core::IUnknown {
-    fn from(value: IPersistFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistFile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistFile> for ::windows::core::IUnknown {
-    fn from(value: &IPersistFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPersistFile> for IPersist {
-    fn from(value: IPersistFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistFile> for &'a IPersist {
-    fn from(value: &'a IPersistFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistFile> for IPersist {
-    fn from(value: &IPersistFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistFile, ::windows::core::IUnknown, IPersist);
 impl ::core::clone::Clone for IPersistFile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6024,36 +4965,7 @@ impl IPersistMemory {
         (::windows::core::Vtable::vtable(self).InitNew)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPersistMemory> for ::windows::core::IUnknown {
-    fn from(value: IPersistMemory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistMemory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistMemory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistMemory> for ::windows::core::IUnknown {
-    fn from(value: &IPersistMemory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPersistMemory> for IPersist {
-    fn from(value: IPersistMemory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistMemory> for &'a IPersist {
-    fn from(value: &'a IPersistMemory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistMemory> for IPersist {
-    fn from(value: &IPersistMemory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistMemory, ::windows::core::IUnknown, IPersist);
 impl ::core::clone::Clone for IPersistMemory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6120,36 +5032,7 @@ impl IPersistStream {
         (::windows::core::Vtable::vtable(self).GetSizeMax)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IPersistStream> for ::windows::core::IUnknown {
-    fn from(value: IPersistStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistStream> for ::windows::core::IUnknown {
-    fn from(value: &IPersistStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPersistStream> for IPersist {
-    fn from(value: IPersistStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistStream> for &'a IPersist {
-    fn from(value: &'a IPersistStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistStream> for IPersist {
-    fn from(value: &IPersistStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistStream, ::windows::core::IUnknown, IPersist);
 impl ::core::clone::Clone for IPersistStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6218,36 +5101,7 @@ impl IPersistStreamInit {
         (::windows::core::Vtable::vtable(self).InitNew)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPersistStreamInit> for ::windows::core::IUnknown {
-    fn from(value: IPersistStreamInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistStreamInit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistStreamInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistStreamInit> for ::windows::core::IUnknown {
-    fn from(value: &IPersistStreamInit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPersistStreamInit> for IPersist {
-    fn from(value: IPersistStreamInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistStreamInit> for &'a IPersist {
-    fn from(value: &'a IPersistStreamInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistStreamInit> for IPersist {
-    fn from(value: &IPersistStreamInit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistStreamInit, ::windows::core::IUnknown, IPersist);
 impl ::core::clone::Clone for IPersistStreamInit {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6294,21 +5148,7 @@ impl IPipeByte {
         (::windows::core::Vtable::vtable(self).Push)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(buf.as_ptr()), buf.len() as _).ok()
     }
 }
-impl ::core::convert::From<IPipeByte> for ::windows::core::IUnknown {
-    fn from(value: IPipeByte) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPipeByte> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPipeByte) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPipeByte> for ::windows::core::IUnknown {
-    fn from(value: &IPipeByte) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPipeByte, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPipeByte {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6349,21 +5189,7 @@ impl IPipeDouble {
         (::windows::core::Vtable::vtable(self).Push)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(buf.as_ptr()), buf.len() as _).ok()
     }
 }
-impl ::core::convert::From<IPipeDouble> for ::windows::core::IUnknown {
-    fn from(value: IPipeDouble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPipeDouble> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPipeDouble) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPipeDouble> for ::windows::core::IUnknown {
-    fn from(value: &IPipeDouble) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPipeDouble, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPipeDouble {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6404,21 +5230,7 @@ impl IPipeLong {
         (::windows::core::Vtable::vtable(self).Push)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(buf.as_ptr()), buf.len() as _).ok()
     }
 }
-impl ::core::convert::From<IPipeLong> for ::windows::core::IUnknown {
-    fn from(value: IPipeLong) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPipeLong> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPipeLong) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPipeLong> for ::windows::core::IUnknown {
-    fn from(value: &IPipeLong) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPipeLong, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPipeLong {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6456,21 +5268,7 @@ impl IProcessInitControl {
         (::windows::core::Vtable::vtable(self).ResetInitializerTimeout)(::windows::core::Vtable::as_raw(self), dwsecondsremaining).ok()
     }
 }
-impl ::core::convert::From<IProcessInitControl> for ::windows::core::IUnknown {
-    fn from(value: IProcessInitControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProcessInitControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProcessInitControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProcessInitControl> for ::windows::core::IUnknown {
-    fn from(value: &IProcessInitControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProcessInitControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProcessInitControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6510,21 +5308,7 @@ impl IProcessLock {
         (::windows::core::Vtable::vtable(self).ReleaseRefOnProcess)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IProcessLock> for ::windows::core::IUnknown {
-    fn from(value: IProcessLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProcessLock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProcessLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProcessLock> for ::windows::core::IUnknown {
-    fn from(value: &IProcessLock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProcessLock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProcessLock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6568,21 +5352,7 @@ impl IProgressNotify {
         (::windows::core::Vtable::vtable(self).OnProgress)(::windows::core::Vtable::as_raw(self), dwprogresscurrent, dwprogressmaximum, faccurate.into(), fowner.into()).ok()
     }
 }
-impl ::core::convert::From<IProgressNotify> for ::windows::core::IUnknown {
-    fn from(value: IProgressNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProgressNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProgressNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProgressNotify> for ::windows::core::IUnknown {
-    fn from(value: &IProgressNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProgressNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProgressNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6622,21 +5392,7 @@ impl IROTData {
         (::windows::core::Vtable::vtable(self).GetComparisonData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbdata.as_ptr()), pbdata.len() as _, ::core::mem::transmute(pcbdata)).ok()
     }
 }
-impl ::core::convert::From<IROTData> for ::windows::core::IUnknown {
-    fn from(value: IROTData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IROTData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IROTData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IROTData> for ::windows::core::IUnknown {
-    fn from(value: &IROTData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IROTData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IROTData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6676,21 +5432,7 @@ impl IReleaseMarshalBuffers {
         (::windows::core::Vtable::vtable(self).ReleaseMarshalBuffer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg), dwflags, pchnl.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IReleaseMarshalBuffers> for ::windows::core::IUnknown {
-    fn from(value: IReleaseMarshalBuffers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IReleaseMarshalBuffers> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IReleaseMarshalBuffers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IReleaseMarshalBuffers> for ::windows::core::IUnknown {
-    fn from(value: &IReleaseMarshalBuffers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IReleaseMarshalBuffers, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IReleaseMarshalBuffers {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6739,21 +5481,7 @@ impl IRpcChannelBuffer {
         (::windows::core::Vtable::vtable(self).IsConnected)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IRpcChannelBuffer> for ::windows::core::IUnknown {
-    fn from(value: IRpcChannelBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRpcChannelBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRpcChannelBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRpcChannelBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IRpcChannelBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRpcChannelBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRpcChannelBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6810,36 +5538,7 @@ impl IRpcChannelBuffer2 {
         (::windows::core::Vtable::vtable(self).GetProtocolVersion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IRpcChannelBuffer2> for ::windows::core::IUnknown {
-    fn from(value: IRpcChannelBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRpcChannelBuffer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRpcChannelBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRpcChannelBuffer2> for ::windows::core::IUnknown {
-    fn from(value: &IRpcChannelBuffer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRpcChannelBuffer2> for IRpcChannelBuffer {
-    fn from(value: IRpcChannelBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRpcChannelBuffer2> for &'a IRpcChannelBuffer {
-    fn from(value: &'a IRpcChannelBuffer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRpcChannelBuffer2> for IRpcChannelBuffer {
-    fn from(value: &IRpcChannelBuffer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRpcChannelBuffer2, ::windows::core::IUnknown, IRpcChannelBuffer);
 impl ::core::clone::Clone for IRpcChannelBuffer2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6917,51 +5616,7 @@ impl IRpcChannelBuffer3 {
         (::windows::core::Vtable::vtable(self).RegisterAsync)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg), pasyncmgr.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IRpcChannelBuffer3> for ::windows::core::IUnknown {
-    fn from(value: IRpcChannelBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRpcChannelBuffer3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRpcChannelBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRpcChannelBuffer3> for ::windows::core::IUnknown {
-    fn from(value: &IRpcChannelBuffer3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRpcChannelBuffer3> for IRpcChannelBuffer {
-    fn from(value: IRpcChannelBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRpcChannelBuffer3> for &'a IRpcChannelBuffer {
-    fn from(value: &'a IRpcChannelBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRpcChannelBuffer3> for IRpcChannelBuffer {
-    fn from(value: &IRpcChannelBuffer3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRpcChannelBuffer3> for IRpcChannelBuffer2 {
-    fn from(value: IRpcChannelBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRpcChannelBuffer3> for &'a IRpcChannelBuffer2 {
-    fn from(value: &'a IRpcChannelBuffer3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRpcChannelBuffer3> for IRpcChannelBuffer2 {
-    fn from(value: &IRpcChannelBuffer3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRpcChannelBuffer3, ::windows::core::IUnknown, IRpcChannelBuffer, IRpcChannelBuffer2);
 impl ::core::clone::Clone for IRpcChannelBuffer3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7009,21 +5664,7 @@ impl IRpcHelper {
         (::windows::core::Vtable::vtable(self).GetIIDFromOBJREF)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pobjref), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut ::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IRpcHelper> for ::windows::core::IUnknown {
-    fn from(value: IRpcHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRpcHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRpcHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRpcHelper> for ::windows::core::IUnknown {
-    fn from(value: &IRpcHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRpcHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRpcHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7071,21 +5712,7 @@ impl IRpcOptions {
         (::windows::core::Vtable::vtable(self).Query)(::windows::core::Vtable::as_raw(self), pprx.into().abi(), dwproperty, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<usize>(result__)
     }
 }
-impl ::core::convert::From<IRpcOptions> for ::windows::core::IUnknown {
-    fn from(value: IRpcOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRpcOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRpcOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRpcOptions> for ::windows::core::IUnknown {
-    fn from(value: &IRpcOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRpcOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRpcOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7129,21 +5756,7 @@ impl IRpcProxyBuffer {
         (::windows::core::Vtable::vtable(self).Disconnect)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IRpcProxyBuffer> for ::windows::core::IUnknown {
-    fn from(value: IRpcProxyBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRpcProxyBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRpcProxyBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRpcProxyBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IRpcProxyBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRpcProxyBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRpcProxyBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7205,21 +5818,7 @@ impl IRpcStubBuffer {
         (::windows::core::Vtable::vtable(self).DebugServerRelease)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pv))
     }
 }
-impl ::core::convert::From<IRpcStubBuffer> for ::windows::core::IUnknown {
-    fn from(value: IRpcStubBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRpcStubBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRpcStubBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRpcStubBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IRpcStubBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRpcStubBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRpcStubBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7262,21 +5861,7 @@ impl IRpcSyntaxNegotiate {
         (::windows::core::Vtable::vtable(self).NegotiateSyntax)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg)).ok()
     }
 }
-impl ::core::convert::From<IRpcSyntaxNegotiate> for ::windows::core::IUnknown {
-    fn from(value: IRpcSyntaxNegotiate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRpcSyntaxNegotiate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRpcSyntaxNegotiate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRpcSyntaxNegotiate> for ::windows::core::IUnknown {
-    fn from(value: &IRpcSyntaxNegotiate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRpcSyntaxNegotiate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRpcSyntaxNegotiate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7342,21 +5927,7 @@ impl IRunnableObject {
         (::windows::core::Vtable::vtable(self).SetContainedObject)(::windows::core::Vtable::as_raw(self), fcontained.into()).ok()
     }
 }
-impl ::core::convert::From<IRunnableObject> for ::windows::core::IUnknown {
-    fn from(value: IRunnableObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRunnableObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRunnableObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRunnableObject> for ::windows::core::IUnknown {
-    fn from(value: &IRunnableObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRunnableObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRunnableObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7445,21 +6016,7 @@ impl IRunningObjectTable {
         (::windows::core::Vtable::vtable(self).EnumRunning)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumMoniker>(result__)
     }
 }
-impl ::core::convert::From<IRunningObjectTable> for ::windows::core::IUnknown {
-    fn from(value: IRunningObjectTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRunningObjectTable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRunningObjectTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRunningObjectTable> for ::windows::core::IUnknown {
-    fn from(value: &IRunningObjectTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRunningObjectTable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRunningObjectTable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7511,21 +6068,7 @@ impl ISequentialStream {
         (::windows::core::Vtable::vtable(self).Write)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pv), cb, ::core::mem::transmute(pcbwritten.unwrap_or(::std::ptr::null_mut())))
     }
 }
-impl ::core::convert::From<ISequentialStream> for ::windows::core::IUnknown {
-    fn from(value: ISequentialStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISequentialStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISequentialStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISequentialStream> for ::windows::core::IUnknown {
-    fn from(value: &ISequentialStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISequentialStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISequentialStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7584,21 +6127,7 @@ impl IServerSecurity {
         (::windows::core::Vtable::vtable(self).IsImpersonating)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IServerSecurity> for ::windows::core::IUnknown {
-    fn from(value: IServerSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServerSecurity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServerSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServerSecurity> for ::windows::core::IUnknown {
-    fn from(value: &IServerSecurity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServerSecurity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServerSecurity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7641,21 +6170,7 @@ impl IServiceProvider {
         (::windows::core::Vtable::vtable(self).QueryService)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidservice), ::core::mem::transmute(riid), ::core::mem::transmute(ppvobject)).ok()
     }
 }
-impl ::core::convert::From<IServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: IServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: &IServiceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServiceProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7692,21 +6207,7 @@ impl IStdMarshalInfo {
         (::windows::core::Vtable::vtable(self).GetClassForHandler)(::windows::core::Vtable::as_raw(self), dwdestcontext, ::core::mem::transmute(pvdestcontext.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pclsid)).ok()
     }
 }
-impl ::core::convert::From<IStdMarshalInfo> for ::windows::core::IUnknown {
-    fn from(value: IStdMarshalInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStdMarshalInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStdMarshalInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStdMarshalInfo> for ::windows::core::IUnknown {
-    fn from(value: &IStdMarshalInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStdMarshalInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStdMarshalInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7780,36 +6281,7 @@ impl IStream {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IStream>(result__)
     }
 }
-impl ::core::convert::From<IStream> for ::windows::core::IUnknown {
-    fn from(value: IStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStream> for ::windows::core::IUnknown {
-    fn from(value: &IStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStream> for ISequentialStream {
-    fn from(value: IStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStream> for &'a ISequentialStream {
-    fn from(value: &'a IStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStream> for ISequentialStream {
-    fn from(value: &IStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStream, ::windows::core::IUnknown, ISequentialStream);
 impl ::core::clone::Clone for IStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7857,21 +6329,7 @@ impl ISupportErrorInfo {
         (::windows::core::Vtable::vtable(self).InterfaceSupportsErrorInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid)).ok()
     }
 }
-impl ::core::convert::From<ISupportErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: ISupportErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISupportErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISupportErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISupportErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISupportErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISupportErrorInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISupportErrorInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7911,21 +6369,7 @@ impl ISurrogate {
         (::windows::core::Vtable::vtable(self).FreeSurrogate)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISurrogate> for ::windows::core::IUnknown {
-    fn from(value: ISurrogate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISurrogate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISurrogate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISurrogate> for ::windows::core::IUnknown {
-    fn from(value: &ISurrogate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISurrogate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISurrogate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7981,21 +6425,7 @@ impl ISurrogateService {
         (::windows::core::Vtable::vtable(self).ProcessShutdown)(::windows::core::Vtable::as_raw(self), shutdowntype).ok()
     }
 }
-impl ::core::convert::From<ISurrogateService> for ::windows::core::IUnknown {
-    fn from(value: ISurrogateService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISurrogateService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISurrogateService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISurrogateService> for ::windows::core::IUnknown {
-    fn from(value: &ISurrogateService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISurrogateService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISurrogateService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8045,21 +6475,7 @@ impl ISynchronize {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISynchronize> for ::windows::core::IUnknown {
-    fn from(value: ISynchronize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISynchronize> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISynchronize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISynchronize> for ::windows::core::IUnknown {
-    fn from(value: &ISynchronize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISynchronize, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISynchronize {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8105,21 +6521,7 @@ impl ISynchronizeContainer {
         (::windows::core::Vtable::vtable(self).WaitMultiple)(::windows::core::Vtable::as_raw(self), dwflags, dwtimeout, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISynchronize>(result__)
     }
 }
-impl ::core::convert::From<ISynchronizeContainer> for ::windows::core::IUnknown {
-    fn from(value: ISynchronizeContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISynchronizeContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISynchronizeContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISynchronizeContainer> for ::windows::core::IUnknown {
-    fn from(value: &ISynchronizeContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISynchronizeContainer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISynchronizeContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8165,36 +6567,7 @@ impl ISynchronizeEvent {
         (::windows::core::Vtable::vtable(self).SetEventHandle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ph)).ok()
     }
 }
-impl ::core::convert::From<ISynchronizeEvent> for ::windows::core::IUnknown {
-    fn from(value: ISynchronizeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISynchronizeEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISynchronizeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISynchronizeEvent> for ::windows::core::IUnknown {
-    fn from(value: &ISynchronizeEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISynchronizeEvent> for ISynchronizeHandle {
-    fn from(value: ISynchronizeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISynchronizeEvent> for &'a ISynchronizeHandle {
-    fn from(value: &'a ISynchronizeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISynchronizeEvent> for ISynchronizeHandle {
-    fn from(value: &ISynchronizeEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISynchronizeEvent, ::windows::core::IUnknown, ISynchronizeHandle);
 impl ::core::clone::Clone for ISynchronizeEvent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8237,21 +6610,7 @@ impl ISynchronizeHandle {
         (::windows::core::Vtable::vtable(self).GetHandle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::HANDLE>(result__)
     }
 }
-impl ::core::convert::From<ISynchronizeHandle> for ::windows::core::IUnknown {
-    fn from(value: ISynchronizeHandle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISynchronizeHandle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISynchronizeHandle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISynchronizeHandle> for ::windows::core::IUnknown {
-    fn from(value: &ISynchronizeHandle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISynchronizeHandle, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISynchronizeHandle {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8300,36 +6659,7 @@ impl ISynchronizeMutex {
         (::windows::core::Vtable::vtable(self).ReleaseMutex)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISynchronizeMutex> for ::windows::core::IUnknown {
-    fn from(value: ISynchronizeMutex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISynchronizeMutex> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISynchronizeMutex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISynchronizeMutex> for ::windows::core::IUnknown {
-    fn from(value: &ISynchronizeMutex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISynchronizeMutex> for ISynchronize {
-    fn from(value: ISynchronizeMutex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISynchronizeMutex> for &'a ISynchronize {
-    fn from(value: &'a ISynchronizeMutex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISynchronizeMutex> for ISynchronize {
-    fn from(value: &ISynchronizeMutex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISynchronizeMutex, ::windows::core::IUnknown, ISynchronize);
 impl ::core::clone::Clone for ISynchronizeMutex {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8366,21 +6696,7 @@ impl ITimeAndNoticeControl {
         (::windows::core::Vtable::vtable(self).SuppressChanges)(::windows::core::Vtable::as_raw(self), res1, res2).ok()
     }
 }
-impl ::core::convert::From<ITimeAndNoticeControl> for ::windows::core::IUnknown {
-    fn from(value: ITimeAndNoticeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITimeAndNoticeControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITimeAndNoticeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITimeAndNoticeControl> for ::windows::core::IUnknown {
-    fn from(value: &ITimeAndNoticeControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITimeAndNoticeControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITimeAndNoticeControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8428,21 +6744,7 @@ impl ITypeComp {
         (::windows::core::Vtable::vtable(self).BindType)(::windows::core::Vtable::as_raw(self), szname.into(), lhashval, ::core::mem::transmute(pptinfo), ::core::mem::transmute(pptcomp)).ok()
     }
 }
-impl ::core::convert::From<ITypeComp> for ::windows::core::IUnknown {
-    fn from(value: ITypeComp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeComp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITypeComp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeComp> for ::windows::core::IUnknown {
-    fn from(value: &ITypeComp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITypeComp, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITypeComp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8565,21 +6867,7 @@ impl ITypeInfo {
         (::windows::core::Vtable::vtable(self).ReleaseVarDesc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvardesc))
     }
 }
-impl ::core::convert::From<ITypeInfo> for ::windows::core::IUnknown {
-    fn from(value: ITypeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITypeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeInfo> for ::windows::core::IUnknown {
-    fn from(value: &ITypeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITypeInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITypeInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8816,36 +7104,7 @@ impl ITypeInfo2 {
         (::windows::core::Vtable::vtable(self).GetAllImplTypeCustData)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<CUSTDATA>(result__)
     }
 }
-impl ::core::convert::From<ITypeInfo2> for ::windows::core::IUnknown {
-    fn from(value: ITypeInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITypeInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeInfo2> for ::windows::core::IUnknown {
-    fn from(value: &ITypeInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITypeInfo2> for ITypeInfo {
-    fn from(value: ITypeInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeInfo2> for &'a ITypeInfo {
-    fn from(value: &'a ITypeInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeInfo2> for ITypeInfo {
-    fn from(value: &ITypeInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITypeInfo2, ::windows::core::IUnknown, ITypeInfo);
 impl ::core::clone::Clone for ITypeInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8960,21 +7219,7 @@ impl ITypeLib {
         (::windows::core::Vtable::vtable(self).ReleaseTLibAttr)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptlibattr))
     }
 }
-impl ::core::convert::From<ITypeLib> for ::windows::core::IUnknown {
-    fn from(value: ITypeLib) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeLib> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITypeLib) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeLib> for ::windows::core::IUnknown {
-    fn from(value: &ITypeLib) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITypeLib, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITypeLib {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9075,36 +7320,7 @@ impl ITypeLib2 {
         (::windows::core::Vtable::vtable(self).GetAllCustData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<CUSTDATA>(result__)
     }
 }
-impl ::core::convert::From<ITypeLib2> for ::windows::core::IUnknown {
-    fn from(value: ITypeLib2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeLib2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITypeLib2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeLib2> for ::windows::core::IUnknown {
-    fn from(value: &ITypeLib2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITypeLib2> for ITypeLib {
-    fn from(value: ITypeLib2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeLib2> for &'a ITypeLib {
-    fn from(value: &'a ITypeLib2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeLib2> for ITypeLib {
-    fn from(value: &ITypeLib2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITypeLib2, ::windows::core::IUnknown, ITypeLib);
 impl ::core::clone::Clone for ITypeLib2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9179,21 +7395,7 @@ impl ITypeLibRegistration {
         (::windows::core::Vtable::vtable(self).GetHelpDir)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITypeLibRegistration> for ::windows::core::IUnknown {
-    fn from(value: ITypeLibRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeLibRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITypeLibRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeLibRegistration> for ::windows::core::IUnknown {
-    fn from(value: &ITypeLibRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITypeLibRegistration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITypeLibRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9238,21 +7440,7 @@ impl ITypeLibRegistrationReader {
         (::windows::core::Vtable::vtable(self).EnumTypeLibRegistrations)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumUnknown>(result__)
     }
 }
-impl ::core::convert::From<ITypeLibRegistrationReader> for ::windows::core::IUnknown {
-    fn from(value: ITypeLibRegistrationReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeLibRegistrationReader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITypeLibRegistrationReader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeLibRegistrationReader> for ::windows::core::IUnknown {
-    fn from(value: &ITypeLibRegistrationReader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITypeLibRegistrationReader, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITypeLibRegistrationReader {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9390,21 +7578,7 @@ impl IUri {
         (::windows::core::Vtable::vtable(self).IsEqual)(::windows::core::Vtable::as_raw(self), puri.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IUri> for ::windows::core::IUnknown {
-    fn from(value: IUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUri> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUri) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUri> for ::windows::core::IUnknown {
-    fn from(value: &IUri) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUri, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUri {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9575,21 +7749,7 @@ impl IUriBuilder {
         (::windows::core::Vtable::vtable(self).HasBeenModified)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IUriBuilder> for ::windows::core::IUnknown {
-    fn from(value: IUriBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUriBuilder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUriBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUriBuilder> for ::windows::core::IUnknown {
-    fn from(value: &IUriBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUriBuilder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUriBuilder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9663,21 +7823,7 @@ impl IUrlMon {
         (::windows::core::Vtable::vtable(self).AsyncGetClassBits)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid), psztype.into(), pszext.into(), dwfileversionms, dwfileversionls, pszcodebase.into(), pbc.into().abi(), dwclasscontext, ::core::mem::transmute(riid), flags).ok()
     }
 }
-impl ::core::convert::From<IUrlMon> for ::windows::core::IUnknown {
-    fn from(value: IUrlMon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUrlMon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUrlMon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUrlMon> for ::windows::core::IUnknown {
-    fn from(value: &IUrlMon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUrlMon, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUrlMon {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9721,21 +7867,7 @@ impl IWaitMultiple {
         (::windows::core::Vtable::vtable(self).AddSynchronize)(::windows::core::Vtable::as_raw(self), psync.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWaitMultiple> for ::windows::core::IUnknown {
-    fn from(value: IWaitMultiple) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWaitMultiple> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWaitMultiple) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWaitMultiple> for ::windows::core::IUnknown {
-    fn from(value: &IWaitMultiple) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWaitMultiple, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWaitMultiple {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/ComponentServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ComponentServices/mod.rs
@@ -121,41 +121,7 @@ impl ContextInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ContextInfo> for ::windows::core::IUnknown {
-    fn from(value: ContextInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ContextInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ContextInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ContextInfo> for ::windows::core::IUnknown {
-    fn from(value: &ContextInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ContextInfo> for super::Com::IDispatch {
-    fn from(value: ContextInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ContextInfo> for &'a super::Com::IDispatch {
-    fn from(value: &'a ContextInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ContextInfo> for super::Com::IDispatch {
-    fn from(value: &ContextInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ContextInfo, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ContextInfo {
     fn clone(&self) -> Self {
@@ -235,59 +201,7 @@ impl ContextInfo2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ContextInfo2> for ::windows::core::IUnknown {
-    fn from(value: ContextInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ContextInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ContextInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ContextInfo2> for ::windows::core::IUnknown {
-    fn from(value: &ContextInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ContextInfo2> for super::Com::IDispatch {
-    fn from(value: ContextInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ContextInfo2> for &'a super::Com::IDispatch {
-    fn from(value: &'a ContextInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ContextInfo2> for super::Com::IDispatch {
-    fn from(value: &ContextInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ContextInfo2> for ContextInfo {
-    fn from(value: ContextInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ContextInfo2> for &'a ContextInfo {
-    fn from(value: &'a ContextInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ContextInfo2> for ContextInfo {
-    fn from(value: &ContextInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ContextInfo2, ::windows::core::IUnknown, super::Com::IDispatch, ContextInfo);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ContextInfo2 {
     fn clone(&self) -> Self {
@@ -345,41 +259,7 @@ impl IAppDomainHelper {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAppDomainHelper> for ::windows::core::IUnknown {
-    fn from(value: IAppDomainHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAppDomainHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppDomainHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAppDomainHelper> for ::windows::core::IUnknown {
-    fn from(value: &IAppDomainHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAppDomainHelper> for super::Com::IDispatch {
-    fn from(value: IAppDomainHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAppDomainHelper> for &'a super::Com::IDispatch {
-    fn from(value: &'a IAppDomainHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAppDomainHelper> for super::Com::IDispatch {
-    fn from(value: &IAppDomainHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppDomainHelper, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAppDomainHelper {
     fn clone(&self) -> Self {
@@ -430,41 +310,7 @@ impl IAssemblyLocator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAssemblyLocator> for ::windows::core::IUnknown {
-    fn from(value: IAssemblyLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAssemblyLocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAssemblyLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAssemblyLocator> for ::windows::core::IUnknown {
-    fn from(value: &IAssemblyLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAssemblyLocator> for super::Com::IDispatch {
-    fn from(value: IAssemblyLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAssemblyLocator> for &'a super::Com::IDispatch {
-    fn from(value: &'a IAssemblyLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAssemblyLocator> for super::Com::IDispatch {
-    fn from(value: &IAssemblyLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAssemblyLocator, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAssemblyLocator {
     fn clone(&self) -> Self {
@@ -511,21 +357,7 @@ impl IAsyncErrorNotify {
         (::windows::core::Vtable::vtable(self).OnError)(::windows::core::Vtable::as_raw(self), hr).ok()
     }
 }
-impl ::core::convert::From<IAsyncErrorNotify> for ::windows::core::IUnknown {
-    fn from(value: IAsyncErrorNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsyncErrorNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAsyncErrorNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsyncErrorNotify> for ::windows::core::IUnknown {
-    fn from(value: &IAsyncErrorNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAsyncErrorNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAsyncErrorNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -662,41 +494,7 @@ impl ICOMAdminCatalog {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICOMAdminCatalog> for ::windows::core::IUnknown {
-    fn from(value: ICOMAdminCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICOMAdminCatalog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICOMAdminCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICOMAdminCatalog> for ::windows::core::IUnknown {
-    fn from(value: &ICOMAdminCatalog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICOMAdminCatalog> for super::Com::IDispatch {
-    fn from(value: ICOMAdminCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICOMAdminCatalog> for &'a super::Com::IDispatch {
-    fn from(value: &'a ICOMAdminCatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICOMAdminCatalog> for super::Com::IDispatch {
-    fn from(value: &ICOMAdminCatalog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICOMAdminCatalog, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICOMAdminCatalog {
     fn clone(&self) -> Self {
@@ -1022,59 +820,7 @@ impl ICOMAdminCatalog2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICOMAdminCatalog2> for ::windows::core::IUnknown {
-    fn from(value: ICOMAdminCatalog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICOMAdminCatalog2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICOMAdminCatalog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICOMAdminCatalog2> for ::windows::core::IUnknown {
-    fn from(value: &ICOMAdminCatalog2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICOMAdminCatalog2> for super::Com::IDispatch {
-    fn from(value: ICOMAdminCatalog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICOMAdminCatalog2> for &'a super::Com::IDispatch {
-    fn from(value: &'a ICOMAdminCatalog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICOMAdminCatalog2> for super::Com::IDispatch {
-    fn from(value: &ICOMAdminCatalog2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICOMAdminCatalog2> for ICOMAdminCatalog {
-    fn from(value: ICOMAdminCatalog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICOMAdminCatalog2> for &'a ICOMAdminCatalog {
-    fn from(value: &'a ICOMAdminCatalog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICOMAdminCatalog2> for ICOMAdminCatalog {
-    fn from(value: &ICOMAdminCatalog2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICOMAdminCatalog2, ::windows::core::IUnknown, super::Com::IDispatch, ICOMAdminCatalog);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICOMAdminCatalog2 {
     fn clone(&self) -> Self {
@@ -1196,21 +942,7 @@ impl ICOMLBArguments {
         (::windows::core::Vtable::vtable(self).SetMachineName)(::windows::core::Vtable::as_raw(self), szservername.len() as _, ::core::mem::transmute(szservername.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<ICOMLBArguments> for ::windows::core::IUnknown {
-    fn from(value: ICOMLBArguments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICOMLBArguments> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICOMLBArguments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICOMLBArguments> for ::windows::core::IUnknown {
-    fn from(value: &ICOMLBArguments) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICOMLBArguments, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICOMLBArguments {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1325,41 +1057,7 @@ impl ICatalogCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICatalogCollection> for ::windows::core::IUnknown {
-    fn from(value: ICatalogCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICatalogCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICatalogCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICatalogCollection> for ::windows::core::IUnknown {
-    fn from(value: &ICatalogCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICatalogCollection> for super::Com::IDispatch {
-    fn from(value: ICatalogCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICatalogCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a ICatalogCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICatalogCollection> for super::Com::IDispatch {
-    fn from(value: &ICatalogCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICatalogCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICatalogCollection {
     fn clone(&self) -> Self {
@@ -1474,41 +1172,7 @@ impl ICatalogObject {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICatalogObject> for ::windows::core::IUnknown {
-    fn from(value: ICatalogObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICatalogObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICatalogObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICatalogObject> for ::windows::core::IUnknown {
-    fn from(value: &ICatalogObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICatalogObject> for super::Com::IDispatch {
-    fn from(value: ICatalogObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICatalogObject> for &'a super::Com::IDispatch {
-    fn from(value: &'a ICatalogObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICatalogObject> for super::Com::IDispatch {
-    fn from(value: &ICatalogObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICatalogObject, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICatalogObject {
     fn clone(&self) -> Self {
@@ -1575,21 +1239,7 @@ impl ICheckSxsConfig {
         (::windows::core::Vtable::vtable(self).IsSameSxsConfig)(::windows::core::Vtable::as_raw(self), wszsxsname.into(), wszsxsdirectory.into(), wszsxsappname.into()).ok()
     }
 }
-impl ::core::convert::From<ICheckSxsConfig> for ::windows::core::IUnknown {
-    fn from(value: ICheckSxsConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICheckSxsConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICheckSxsConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICheckSxsConfig> for ::windows::core::IUnknown {
-    fn from(value: &ICheckSxsConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICheckSxsConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICheckSxsConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1644,21 +1294,7 @@ impl IComActivityEvents {
         (::windows::core::Vtable::vtable(self).OnActivityLeaveSame)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidcurrent), dwcalldepth).ok()
     }
 }
-impl ::core::convert::From<IComActivityEvents> for ::windows::core::IUnknown {
-    fn from(value: IComActivityEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComActivityEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComActivityEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComActivityEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComActivityEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComActivityEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComActivityEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1718,21 +1354,7 @@ impl IComApp2Events {
         (::windows::core::Vtable::vtable(self).OnAppRecycle2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidapp), ::core::mem::transmute(guidprocess), lreason).ok()
     }
 }
-impl ::core::convert::From<IComApp2Events> for ::windows::core::IUnknown {
-    fn from(value: IComApp2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComApp2Events> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComApp2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComApp2Events> for ::windows::core::IUnknown {
-    fn from(value: &IComApp2Events) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComApp2Events, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComApp2Events {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1782,21 +1404,7 @@ impl IComAppEvents {
         (::windows::core::Vtable::vtable(self).OnAppForceShutdown)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidapp)).ok()
     }
 }
-impl ::core::convert::From<IComAppEvents> for ::windows::core::IUnknown {
-    fn from(value: IComAppEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComAppEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComAppEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComAppEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComAppEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComAppEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComAppEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1887,21 +1495,7 @@ impl IComCRMEvents {
         (::windows::core::Vtable::vtable(self).OnCRMDeliver)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidclerkclsid), fvariants.into(), dwrecordsize).ok()
     }
 }
-impl ::core::convert::From<IComCRMEvents> for ::windows::core::IUnknown {
-    fn from(value: IComCRMEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComCRMEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComCRMEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComCRMEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComCRMEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComCRMEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComCRMEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1961,21 +1555,7 @@ impl IComExceptionEvents {
         (::windows::core::Vtable::vtable(self).OnExceptionUser)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), code, address, pszstacktrace.into()).ok()
     }
 }
-impl ::core::convert::From<IComExceptionEvents> for ::windows::core::IUnknown {
-    fn from(value: IComExceptionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComExceptionEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComExceptionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComExceptionEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComExceptionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComExceptionEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComExceptionEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2017,21 +1597,7 @@ impl IComIdentityEvents {
         (::windows::core::Vtable::vtable(self).OnIISRequestInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), objid, pszclientip.into(), pszserverip.into(), pszurl.into()).ok()
     }
 }
-impl ::core::convert::From<IComIdentityEvents> for ::windows::core::IUnknown {
-    fn from(value: IComIdentityEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComIdentityEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComIdentityEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComIdentityEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComIdentityEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComIdentityEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComIdentityEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2071,21 +1637,7 @@ impl IComInstance2Events {
         (::windows::core::Vtable::vtable(self).OnObjectDestroy2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ctxtid).ok()
     }
 }
-impl ::core::convert::From<IComInstance2Events> for ::windows::core::IUnknown {
-    fn from(value: IComInstance2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComInstance2Events> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComInstance2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComInstance2Events> for ::windows::core::IUnknown {
-    fn from(value: &IComInstance2Events) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComInstance2Events, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComInstance2Events {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2126,21 +1678,7 @@ impl IComInstanceEvents {
         (::windows::core::Vtable::vtable(self).OnObjectDestroy)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ctxtid).ok()
     }
 }
-impl ::core::convert::From<IComInstanceEvents> for ::windows::core::IUnknown {
-    fn from(value: IComInstanceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComInstanceEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComInstanceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComInstanceEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComInstanceEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComInstanceEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComInstanceEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2200,21 +1738,7 @@ impl IComLTxEvents {
         (::windows::core::Vtable::vtable(self).OnLtxTransactionPromote)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidltx), ::core::mem::transmute(txnid)).ok()
     }
 }
-impl ::core::convert::From<IComLTxEvents> for ::windows::core::IUnknown {
-    fn from(value: IComLTxEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComLTxEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComLTxEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComLTxEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComLTxEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComLTxEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComLTxEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2267,21 +1791,7 @@ impl IComMethod2Events {
         (::windows::core::Vtable::vtable(self).OnMethodException2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), oid, ::core::mem::transmute(guidcid), ::core::mem::transmute(guidrid), dwthread, imeth).ok()
     }
 }
-impl ::core::convert::From<IComMethod2Events> for ::windows::core::IUnknown {
-    fn from(value: IComMethod2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComMethod2Events> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComMethod2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComMethod2Events> for ::windows::core::IUnknown {
-    fn from(value: &IComMethod2Events) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComMethod2Events, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComMethod2Events {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2326,21 +1836,7 @@ impl IComMethodEvents {
         (::windows::core::Vtable::vtable(self).OnMethodException)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), oid, ::core::mem::transmute(guidcid), ::core::mem::transmute(guidrid), imeth).ok()
     }
 }
-impl ::core::convert::From<IComMethodEvents> for ::windows::core::IUnknown {
-    fn from(value: IComMethodEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComMethodEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComMethodEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComMethodEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComMethodEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComMethodEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComMethodEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2390,21 +1886,7 @@ impl IComMtaThreadPoolKnobs {
         (::windows::core::Vtable::vtable(self).MTAGetThrottleValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IComMtaThreadPoolKnobs> for ::windows::core::IUnknown {
-    fn from(value: IComMtaThreadPoolKnobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComMtaThreadPoolKnobs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComMtaThreadPoolKnobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComMtaThreadPoolKnobs> for ::windows::core::IUnknown {
-    fn from(value: &IComMtaThreadPoolKnobs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComMtaThreadPoolKnobs, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComMtaThreadPoolKnobs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2447,21 +1929,7 @@ impl IComObjectConstruction2Events {
         (::windows::core::Vtable::vtable(self).OnObjectConstruct2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidobject), sconstructstring.into(), oid, ::core::mem::transmute(guidpartition)).ok()
     }
 }
-impl ::core::convert::From<IComObjectConstruction2Events> for ::windows::core::IUnknown {
-    fn from(value: IComObjectConstruction2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComObjectConstruction2Events> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComObjectConstruction2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComObjectConstruction2Events> for ::windows::core::IUnknown {
-    fn from(value: &IComObjectConstruction2Events) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComObjectConstruction2Events, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComObjectConstruction2Events {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2501,21 +1969,7 @@ impl IComObjectConstructionEvents {
         (::windows::core::Vtable::vtable(self).OnObjectConstruct)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidobject), sconstructstring.into(), oid).ok()
     }
 }
-impl ::core::convert::From<IComObjectConstructionEvents> for ::windows::core::IUnknown {
-    fn from(value: IComObjectConstructionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComObjectConstructionEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComObjectConstructionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComObjectConstructionEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComObjectConstructionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComObjectConstructionEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComObjectConstructionEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2567,21 +2021,7 @@ impl IComObjectEvents {
         (::windows::core::Vtable::vtable(self).OnSetAbort)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ctxtid).ok()
     }
 }
-impl ::core::convert::From<IComObjectEvents> for ::windows::core::IUnknown {
-    fn from(value: IComObjectEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComObjectEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComObjectEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComObjectEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComObjectEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComObjectEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComObjectEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2632,21 +2072,7 @@ impl IComObjectPool2Events {
         (::windows::core::Vtable::vtable(self).OnObjPoolGetFromTx2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidactivity), ::core::mem::transmute(guidobject), ::core::mem::transmute(guidtx), objid, ::core::mem::transmute(guidpartition)).ok()
     }
 }
-impl ::core::convert::From<IComObjectPool2Events> for ::windows::core::IUnknown {
-    fn from(value: IComObjectPool2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComObjectPool2Events> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComObjectPool2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComObjectPool2Events> for ::windows::core::IUnknown {
-    fn from(value: &IComObjectPool2Events) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComObjectPool2Events, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComObjectPool2Events {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2695,21 +2121,7 @@ impl IComObjectPoolEvents {
         (::windows::core::Vtable::vtable(self).OnObjPoolGetFromTx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidactivity), ::core::mem::transmute(guidobject), ::core::mem::transmute(guidtx), objid).ok()
     }
 }
-impl ::core::convert::From<IComObjectPoolEvents> for ::windows::core::IUnknown {
-    fn from(value: IComObjectPoolEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComObjectPoolEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComObjectPoolEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComObjectPoolEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComObjectPoolEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComObjectPoolEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComObjectPoolEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2761,21 +2173,7 @@ impl IComObjectPoolEvents2 {
         (::windows::core::Vtable::vtable(self).OnObjPoolCreatePool)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidobject), dwmin, dwmax, dwtimeout).ok()
     }
 }
-impl ::core::convert::From<IComObjectPoolEvents2> for ::windows::core::IUnknown {
-    fn from(value: IComObjectPoolEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComObjectPoolEvents2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComObjectPoolEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComObjectPoolEvents2> for ::windows::core::IUnknown {
-    fn from(value: &IComObjectPoolEvents2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComObjectPoolEvents2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComObjectPoolEvents2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2834,21 +2232,7 @@ impl IComQCEvents {
         (::windows::core::Vtable::vtable(self).OnQCPlayback)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), objid, ::core::mem::transmute(guidmsgid), ::core::mem::transmute(guidworkflowid), hr).ok()
     }
 }
-impl ::core::convert::From<IComQCEvents> for ::windows::core::IUnknown {
-    fn from(value: IComQCEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComQCEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComQCEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComQCEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComQCEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComQCEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComQCEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2927,21 +2311,7 @@ impl IComResourceEvents {
         (::windows::core::Vtable::vtable(self).OnResourceTrack)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), objectid, psztype.into(), resid, enlisted.into()).ok()
     }
 }
-impl ::core::convert::From<IComResourceEvents> for ::windows::core::IUnknown {
-    fn from(value: IComResourceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComResourceEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComResourceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComResourceEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComResourceEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComResourceEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComResourceEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3004,21 +2374,7 @@ impl IComSecurityEvents {
         (::windows::core::Vtable::vtable(self).OnAuthenticateFail)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidactivity), objectid, ::core::mem::transmute(guidiid), imeth, psidoriginaluser.len() as _, ::core::mem::transmute(psidoriginaluser.as_ptr()), psidcurrentuser.len() as _, ::core::mem::transmute(psidcurrentuser.as_ptr()), bcurrentuserinpersonatinginproc.into()).ok()
     }
 }
-impl ::core::convert::From<IComSecurityEvents> for ::windows::core::IUnknown {
-    fn from(value: IComSecurityEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComSecurityEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComSecurityEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComSecurityEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComSecurityEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComSecurityEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComSecurityEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3098,21 +2454,7 @@ impl IComStaThreadPoolKnobs {
         (::windows::core::Vtable::vtable(self).SetQueueDepth)(::windows::core::Vtable::as_raw(self), dwqdepth).ok()
     }
 }
-impl ::core::convert::From<IComStaThreadPoolKnobs> for ::windows::core::IUnknown {
-    fn from(value: IComStaThreadPoolKnobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComStaThreadPoolKnobs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComStaThreadPoolKnobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComStaThreadPoolKnobs> for ::windows::core::IUnknown {
-    fn from(value: &IComStaThreadPoolKnobs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComStaThreadPoolKnobs, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComStaThreadPoolKnobs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3244,36 +2586,7 @@ impl IComStaThreadPoolKnobs2 {
         (::windows::core::Vtable::vtable(self).SetWaitTimeForThreadCleanup)(::windows::core::Vtable::as_raw(self), dwthreadcleanupwaittime).ok()
     }
 }
-impl ::core::convert::From<IComStaThreadPoolKnobs2> for ::windows::core::IUnknown {
-    fn from(value: IComStaThreadPoolKnobs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComStaThreadPoolKnobs2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComStaThreadPoolKnobs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComStaThreadPoolKnobs2> for ::windows::core::IUnknown {
-    fn from(value: &IComStaThreadPoolKnobs2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IComStaThreadPoolKnobs2> for IComStaThreadPoolKnobs {
-    fn from(value: IComStaThreadPoolKnobs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComStaThreadPoolKnobs2> for &'a IComStaThreadPoolKnobs {
-    fn from(value: &'a IComStaThreadPoolKnobs2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComStaThreadPoolKnobs2> for IComStaThreadPoolKnobs {
-    fn from(value: &IComStaThreadPoolKnobs2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComStaThreadPoolKnobs2, ::windows::core::IUnknown, IComStaThreadPoolKnobs);
 impl ::core::clone::Clone for IComStaThreadPoolKnobs2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3361,21 +2674,7 @@ impl IComThreadEvents {
         (::windows::core::Vtable::vtable(self).OnThreadUnassignApartment)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), aptid).ok()
     }
 }
-impl ::core::convert::From<IComThreadEvents> for ::windows::core::IUnknown {
-    fn from(value: IComThreadEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComThreadEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComThreadEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComThreadEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComThreadEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComThreadEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComThreadEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3430,21 +2729,7 @@ impl IComTrackingInfoCollection {
         (::windows::core::Vtable::vtable(self).Item)(::windows::core::Vtable::as_raw(self), ulindex, ::core::mem::transmute(riid), ::core::mem::transmute(ppv)).ok()
     }
 }
-impl ::core::convert::From<IComTrackingInfoCollection> for ::windows::core::IUnknown {
-    fn from(value: IComTrackingInfoCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComTrackingInfoCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComTrackingInfoCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComTrackingInfoCollection> for ::windows::core::IUnknown {
-    fn from(value: &IComTrackingInfoCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComTrackingInfoCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComTrackingInfoCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3486,21 +2771,7 @@ impl IComTrackingInfoEvents {
         (::windows::core::Vtable::vtable(self).OnNewTrackingInfo)(::windows::core::Vtable::as_raw(self), ptoplevelcollection.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IComTrackingInfoEvents> for ::windows::core::IUnknown {
-    fn from(value: IComTrackingInfoEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComTrackingInfoEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComTrackingInfoEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComTrackingInfoEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComTrackingInfoEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComTrackingInfoEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComTrackingInfoEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3543,21 +2814,7 @@ impl IComTrackingInfoObject {
         (::windows::core::Vtable::vtable(self).GetValue)(::windows::core::Vtable::as_raw(self), szpropertyname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<IComTrackingInfoObject> for ::windows::core::IUnknown {
-    fn from(value: IComTrackingInfoObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComTrackingInfoObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComTrackingInfoObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComTrackingInfoObject> for ::windows::core::IUnknown {
-    fn from(value: &IComTrackingInfoObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComTrackingInfoObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComTrackingInfoObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3602,21 +2859,7 @@ impl IComTrackingInfoProperties {
         (::windows::core::Vtable::vtable(self).GetPropName)(::windows::core::Vtable::as_raw(self), ulindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IComTrackingInfoProperties> for ::windows::core::IUnknown {
-    fn from(value: IComTrackingInfoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComTrackingInfoProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComTrackingInfoProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComTrackingInfoProperties> for ::windows::core::IUnknown {
-    fn from(value: &IComTrackingInfoProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComTrackingInfoProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComTrackingInfoProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3673,21 +2916,7 @@ impl IComTransaction2Events {
         (::windows::core::Vtable::vtable(self).OnTransactionCommit2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidtx)).ok()
     }
 }
-impl ::core::convert::From<IComTransaction2Events> for ::windows::core::IUnknown {
-    fn from(value: IComTransaction2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComTransaction2Events> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComTransaction2Events) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComTransaction2Events> for ::windows::core::IUnknown {
-    fn from(value: &IComTransaction2Events) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComTransaction2Events, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComTransaction2Events {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3752,21 +2981,7 @@ impl IComTransactionEvents {
         (::windows::core::Vtable::vtable(self).OnTransactionCommit)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(guidtx)).ok()
     }
 }
-impl ::core::convert::From<IComTransactionEvents> for ::windows::core::IUnknown {
-    fn from(value: IComTransactionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComTransactionEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComTransactionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComTransactionEvents> for ::windows::core::IUnknown {
-    fn from(value: &IComTransactionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComTransactionEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComTransactionEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3814,21 +3029,7 @@ impl IComUserEvent {
         (::windows::core::Vtable::vtable(self).OnUserEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pinfo), ::core::mem::transmute(pvarevent)).ok()
     }
 }
-impl ::core::convert::From<IComUserEvent> for ::windows::core::IUnknown {
-    fn from(value: IComUserEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComUserEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComUserEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComUserEvent> for ::windows::core::IUnknown {
-    fn from(value: &IComUserEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComUserEvent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComUserEvent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3888,21 +3089,7 @@ impl IContextProperties {
         (::windows::core::Vtable::vtable(self).RemoveProperty)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(name)).ok()
     }
 }
-impl ::core::convert::From<IContextProperties> for ::windows::core::IUnknown {
-    fn from(value: IContextProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextProperties> for ::windows::core::IUnknown {
-    fn from(value: &IContextProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContextProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3959,21 +3146,7 @@ impl IContextSecurityPerimeter {
         (::windows::core::Vtable::vtable(self).SetPerimeterFlag)(::windows::core::Vtable::as_raw(self), fflag.into()).ok()
     }
 }
-impl ::core::convert::From<IContextSecurityPerimeter> for ::windows::core::IUnknown {
-    fn from(value: IContextSecurityPerimeter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextSecurityPerimeter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextSecurityPerimeter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextSecurityPerimeter> for ::windows::core::IUnknown {
-    fn from(value: &IContextSecurityPerimeter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextSecurityPerimeter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContextSecurityPerimeter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4026,21 +3199,7 @@ impl IContextState {
         (::windows::core::Vtable::vtable(self).GetMyTransactionVote)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptxvote)).ok()
     }
 }
-impl ::core::convert::From<IContextState> for ::windows::core::IUnknown {
-    fn from(value: IContextState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextState> for ::windows::core::IUnknown {
-    fn from(value: &IContextState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextState, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContextState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4083,21 +3242,7 @@ impl ICreateWithLocalTransaction {
         (::windows::core::Vtable::vtable(self).CreateInstanceWithSysTx)(::windows::core::Vtable::as_raw(self), ptransaction.into().abi(), ::core::mem::transmute(rclsid), ::core::mem::transmute(riid), ::core::mem::transmute(pobject)).ok()
     }
 }
-impl ::core::convert::From<ICreateWithLocalTransaction> for ::windows::core::IUnknown {
-    fn from(value: ICreateWithLocalTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateWithLocalTransaction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateWithLocalTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateWithLocalTransaction> for ::windows::core::IUnknown {
-    fn from(value: &ICreateWithLocalTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateWithLocalTransaction, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICreateWithLocalTransaction {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4138,21 +3283,7 @@ impl ICreateWithTipTransactionEx {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrtipurl), ::core::mem::transmute(rclsid), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ICreateWithTipTransactionEx> for ::windows::core::IUnknown {
-    fn from(value: ICreateWithTipTransactionEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateWithTipTransactionEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateWithTipTransactionEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateWithTipTransactionEx> for ::windows::core::IUnknown {
-    fn from(value: &ICreateWithTipTransactionEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateWithTipTransactionEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICreateWithTipTransactionEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4196,21 +3327,7 @@ impl ICreateWithTransactionEx {
         (::windows::core::Vtable::vtable(self).CreateInstance)(::windows::core::Vtable::as_raw(self), ptransaction.into().abi(), ::core::mem::transmute(rclsid), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ICreateWithTransactionEx> for ::windows::core::IUnknown {
-    fn from(value: ICreateWithTransactionEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateWithTransactionEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateWithTransactionEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateWithTransactionEx> for ::windows::core::IUnknown {
-    fn from(value: &ICreateWithTransactionEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateWithTransactionEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICreateWithTransactionEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4302,21 +3419,7 @@ impl ICrmCompensator {
         (::windows::core::Vtable::vtable(self).EndAbort)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ICrmCompensator> for ::windows::core::IUnknown {
-    fn from(value: ICrmCompensator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICrmCompensator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICrmCompensator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICrmCompensator> for ::windows::core::IUnknown {
-    fn from(value: &ICrmCompensator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICrmCompensator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICrmCompensator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4420,21 +3523,7 @@ impl ICrmCompensatorVariants {
         (::windows::core::Vtable::vtable(self).EndAbortVariants)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ICrmCompensatorVariants> for ::windows::core::IUnknown {
-    fn from(value: ICrmCompensatorVariants) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICrmCompensatorVariants> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICrmCompensatorVariants) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICrmCompensatorVariants> for ::windows::core::IUnknown {
-    fn from(value: &ICrmCompensatorVariants) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICrmCompensatorVariants, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICrmCompensatorVariants {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4511,21 +3600,7 @@ impl ICrmFormatLogRecords {
         (::windows::core::Vtable::vtable(self).GetColumnVariants)(::windows::core::Vtable::as_raw(self), logrecord.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<ICrmFormatLogRecords> for ::windows::core::IUnknown {
-    fn from(value: ICrmFormatLogRecords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICrmFormatLogRecords> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICrmFormatLogRecords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICrmFormatLogRecords> for ::windows::core::IUnknown {
-    fn from(value: &ICrmFormatLogRecords) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICrmFormatLogRecords, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICrmFormatLogRecords {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4601,21 +3676,7 @@ impl ICrmLogControl {
         (::windows::core::Vtable::vtable(self).WriteLogRecord)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rgblob.as_ptr()), rgblob.len() as _).ok()
     }
 }
-impl ::core::convert::From<ICrmLogControl> for ::windows::core::IUnknown {
-    fn from(value: ICrmLogControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICrmLogControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICrmLogControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICrmLogControl> for ::windows::core::IUnknown {
-    fn from(value: &ICrmLogControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICrmLogControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICrmLogControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4676,21 +3737,7 @@ impl ICrmMonitor {
         (::windows::core::Vtable::vtable(self).HoldClerk)(::windows::core::Vtable::as_raw(self), index.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<ICrmMonitor> for ::windows::core::IUnknown {
-    fn from(value: ICrmMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICrmMonitor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICrmMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICrmMonitor> for ::windows::core::IUnknown {
-    fn from(value: &ICrmMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICrmMonitor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICrmMonitor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4787,41 +3834,7 @@ impl ICrmMonitorClerks {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICrmMonitorClerks> for ::windows::core::IUnknown {
-    fn from(value: ICrmMonitorClerks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICrmMonitorClerks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICrmMonitorClerks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICrmMonitorClerks> for ::windows::core::IUnknown {
-    fn from(value: &ICrmMonitorClerks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICrmMonitorClerks> for super::Com::IDispatch {
-    fn from(value: ICrmMonitorClerks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICrmMonitorClerks> for &'a super::Com::IDispatch {
-    fn from(value: &'a ICrmMonitorClerks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICrmMonitorClerks> for super::Com::IDispatch {
-    fn from(value: &ICrmMonitorClerks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICrmMonitorClerks, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICrmMonitorClerks {
     fn clone(&self) -> Self {
@@ -4909,21 +3922,7 @@ impl ICrmMonitorLogRecords {
         (::windows::core::Vtable::vtable(self).GetLogRecordVariants)(::windows::core::Vtable::as_raw(self), indexnumber.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<ICrmMonitorLogRecords> for ::windows::core::IUnknown {
-    fn from(value: ICrmMonitorLogRecords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICrmMonitorLogRecords> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICrmMonitorLogRecords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICrmMonitorLogRecords> for ::windows::core::IUnknown {
-    fn from(value: &ICrmMonitorLogRecords) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICrmMonitorLogRecords, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICrmMonitorLogRecords {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4990,21 +3989,7 @@ impl IDispenserDriver {
         (::windows::core::Vtable::vtable(self).DestroyResourceS)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(resid)).ok()
     }
 }
-impl ::core::convert::From<IDispenserDriver> for ::windows::core::IUnknown {
-    fn from(value: IDispenserDriver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDispenserDriver> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDispenserDriver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDispenserDriver> for ::windows::core::IUnknown {
-    fn from(value: &IDispenserDriver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDispenserDriver, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDispenserDriver {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5057,21 +4042,7 @@ impl IDispenserManager {
         (::windows::core::Vtable::vtable(self).GetContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(__midl__idispensermanager0002), ::core::mem::transmute(__midl__idispensermanager0003)).ok()
     }
 }
-impl ::core::convert::From<IDispenserManager> for ::windows::core::IUnknown {
-    fn from(value: IDispenserManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDispenserManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDispenserManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDispenserManager> for ::windows::core::IUnknown {
-    fn from(value: &IDispenserManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDispenserManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDispenserManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5119,21 +4090,7 @@ impl IEnumNames {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNames>(result__)
     }
 }
-impl ::core::convert::From<IEnumNames> for ::windows::core::IUnknown {
-    fn from(value: IEnumNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumNames> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumNames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumNames> for ::windows::core::IUnknown {
-    fn from(value: &IEnumNames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumNames, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumNames {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5182,41 +4139,7 @@ impl IEventServerTrace {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEventServerTrace> for ::windows::core::IUnknown {
-    fn from(value: IEventServerTrace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEventServerTrace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventServerTrace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEventServerTrace> for ::windows::core::IUnknown {
-    fn from(value: &IEventServerTrace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEventServerTrace> for super::Com::IDispatch {
-    fn from(value: IEventServerTrace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEventServerTrace> for &'a super::Com::IDispatch {
-    fn from(value: &'a IEventServerTrace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEventServerTrace> for super::Com::IDispatch {
-    fn from(value: &IEventServerTrace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventServerTrace, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IEventServerTrace {
     fn clone(&self) -> Self {
@@ -5288,21 +4211,7 @@ impl IGetAppTrackerData {
         (::windows::core::Vtable::vtable(self).GetSuggestedPollingInterval)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IGetAppTrackerData> for ::windows::core::IUnknown {
-    fn from(value: IGetAppTrackerData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetAppTrackerData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetAppTrackerData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetAppTrackerData> for ::windows::core::IUnknown {
-    fn from(value: &IGetAppTrackerData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetAppTrackerData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetAppTrackerData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5363,21 +4272,7 @@ impl IGetContextProperties {
         (::windows::core::Vtable::vtable(self).EnumNames)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumNames>(result__)
     }
 }
-impl ::core::convert::From<IGetContextProperties> for ::windows::core::IUnknown {
-    fn from(value: IGetContextProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetContextProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetContextProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetContextProperties> for ::windows::core::IUnknown {
-    fn from(value: &IGetContextProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetContextProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetContextProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5425,41 +4320,7 @@ impl IGetSecurityCallContext {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGetSecurityCallContext> for ::windows::core::IUnknown {
-    fn from(value: IGetSecurityCallContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGetSecurityCallContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetSecurityCallContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGetSecurityCallContext> for ::windows::core::IUnknown {
-    fn from(value: &IGetSecurityCallContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGetSecurityCallContext> for super::Com::IDispatch {
-    fn from(value: IGetSecurityCallContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGetSecurityCallContext> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGetSecurityCallContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGetSecurityCallContext> for super::Com::IDispatch {
-    fn from(value: &IGetSecurityCallContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetSecurityCallContext, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGetSecurityCallContext {
     fn clone(&self) -> Self {
@@ -5537,21 +4398,7 @@ impl IHolder {
         (::windows::core::Vtable::vtable(self).RequestDestroyResource)(::windows::core::Vtable::as_raw(self), __midl__iholder0009).ok()
     }
 }
-impl ::core::convert::From<IHolder> for ::windows::core::IUnknown {
-    fn from(value: IHolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHolder> for ::windows::core::IUnknown {
-    fn from(value: &IHolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHolder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5609,21 +4456,7 @@ impl ILBEvents {
         (::windows::core::Vtable::vtable(self).EngineDefined)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrpropname), ::core::mem::transmute(varpropvalue), ::core::mem::transmute_copy(bstrclsideng)).ok()
     }
 }
-impl ::core::convert::From<ILBEvents> for ::windows::core::IUnknown {
-    fn from(value: ILBEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILBEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILBEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILBEvents> for ::windows::core::IUnknown {
-    fn from(value: &ILBEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILBEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILBEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5683,21 +4516,7 @@ impl IMTSActivity {
         (::windows::core::Vtable::vtable(self).UnbindFromThread)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMTSActivity> for ::windows::core::IUnknown {
-    fn from(value: IMTSActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMTSActivity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMTSActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMTSActivity> for ::windows::core::IUnknown {
-    fn from(value: &IMTSActivity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMTSActivity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMTSActivity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5738,21 +4557,7 @@ impl IMTSCall {
         (::windows::core::Vtable::vtable(self).OnCall)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMTSCall> for ::windows::core::IUnknown {
-    fn from(value: IMTSCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMTSCall> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMTSCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMTSCall> for ::windows::core::IUnknown {
-    fn from(value: &IMTSCall) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMTSCall, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMTSCall {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5793,41 +4598,7 @@ impl IMTSLocator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMTSLocator> for ::windows::core::IUnknown {
-    fn from(value: IMTSLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMTSLocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMTSLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMTSLocator> for ::windows::core::IUnknown {
-    fn from(value: &IMTSLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMTSLocator> for super::Com::IDispatch {
-    fn from(value: IMTSLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMTSLocator> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMTSLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMTSLocator> for super::Com::IDispatch {
-    fn from(value: &IMTSLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMTSLocator, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMTSLocator {
     fn clone(&self) -> Self {
@@ -5883,21 +4654,7 @@ impl IManagedActivationEvents {
         (::windows::core::Vtable::vtable(self).DestroyManagedStub)(::windows::core::Vtable::as_raw(self), pinfo.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IManagedActivationEvents> for ::windows::core::IUnknown {
-    fn from(value: IManagedActivationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IManagedActivationEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IManagedActivationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IManagedActivationEvents> for ::windows::core::IUnknown {
-    fn from(value: &IManagedActivationEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IManagedActivationEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IManagedActivationEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5960,21 +4717,7 @@ impl IManagedObjectInfo {
         (::windows::core::Vtable::vtable(self).SetWrapperStrength)(::windows::core::Vtable::as_raw(self), bstrong.into()).ok()
     }
 }
-impl ::core::convert::From<IManagedObjectInfo> for ::windows::core::IUnknown {
-    fn from(value: IManagedObjectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IManagedObjectInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IManagedObjectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IManagedObjectInfo> for ::windows::core::IUnknown {
-    fn from(value: &IManagedObjectInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IManagedObjectInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IManagedObjectInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6020,21 +4763,7 @@ impl IManagedPoolAction {
         (::windows::core::Vtable::vtable(self).LastRelease)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IManagedPoolAction> for ::windows::core::IUnknown {
-    fn from(value: IManagedPoolAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IManagedPoolAction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IManagedPoolAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IManagedPoolAction> for ::windows::core::IUnknown {
-    fn from(value: &IManagedPoolAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IManagedPoolAction, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IManagedPoolAction {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6076,21 +4805,7 @@ impl IManagedPooledObj {
         (::windows::core::Vtable::vtable(self).SetHeld)(::windows::core::Vtable::as_raw(self), m_bheld.into()).ok()
     }
 }
-impl ::core::convert::From<IManagedPooledObj> for ::windows::core::IUnknown {
-    fn from(value: IManagedPooledObj) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IManagedPooledObj> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IManagedPooledObj) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IManagedPooledObj> for ::windows::core::IUnknown {
-    fn from(value: &IManagedPooledObj) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IManagedPooledObj, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IManagedPooledObj {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6155,41 +4870,7 @@ impl IMessageMover {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMessageMover> for ::windows::core::IUnknown {
-    fn from(value: IMessageMover) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMessageMover> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMessageMover) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMessageMover> for ::windows::core::IUnknown {
-    fn from(value: &IMessageMover) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMessageMover> for super::Com::IDispatch {
-    fn from(value: IMessageMover) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMessageMover> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMessageMover) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMessageMover> for super::Com::IDispatch {
-    fn from(value: &IMessageMover) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMessageMover, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMessageMover {
     fn clone(&self) -> Self {
@@ -6261,41 +4942,7 @@ impl IMtsEventInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMtsEventInfo> for ::windows::core::IUnknown {
-    fn from(value: IMtsEventInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMtsEventInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMtsEventInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMtsEventInfo> for ::windows::core::IUnknown {
-    fn from(value: &IMtsEventInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMtsEventInfo> for super::Com::IDispatch {
-    fn from(value: IMtsEventInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMtsEventInfo> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMtsEventInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMtsEventInfo> for super::Com::IDispatch {
-    fn from(value: &IMtsEventInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMtsEventInfo, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMtsEventInfo {
     fn clone(&self) -> Self {
@@ -6367,41 +5014,7 @@ impl IMtsEvents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMtsEvents> for ::windows::core::IUnknown {
-    fn from(value: IMtsEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMtsEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMtsEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMtsEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMtsEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMtsEvents> for super::Com::IDispatch {
-    fn from(value: IMtsEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMtsEvents> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMtsEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMtsEvents> for super::Com::IDispatch {
-    fn from(value: &IMtsEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMtsEvents, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMtsEvents {
     fn clone(&self) -> Self {
@@ -6463,41 +5076,7 @@ impl IMtsGrp {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMtsGrp> for ::windows::core::IUnknown {
-    fn from(value: IMtsGrp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMtsGrp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMtsGrp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMtsGrp> for ::windows::core::IUnknown {
-    fn from(value: &IMtsGrp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMtsGrp> for super::Com::IDispatch {
-    fn from(value: IMtsGrp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMtsGrp> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMtsGrp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMtsGrp> for super::Com::IDispatch {
-    fn from(value: &IMtsGrp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMtsGrp, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMtsGrp {
     fn clone(&self) -> Self {
@@ -6564,21 +5143,7 @@ impl IObjPool {
         (::windows::core::Vtable::vtable(self).Reserved6)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IObjPool> for ::windows::core::IUnknown {
-    fn from(value: IObjPool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjPool> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjPool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjPool> for ::windows::core::IUnknown {
-    fn from(value: &IObjPool) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjPool, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjPool {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6626,21 +5191,7 @@ impl IObjectConstruct {
         (::windows::core::Vtable::vtable(self).Construct)(::windows::core::Vtable::as_raw(self), pctorobj.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IObjectConstruct> for ::windows::core::IUnknown {
-    fn from(value: IObjectConstruct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectConstruct> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectConstruct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectConstruct> for ::windows::core::IUnknown {
-    fn from(value: &IObjectConstruct) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectConstruct, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectConstruct {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6683,41 +5234,7 @@ impl IObjectConstructString {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IObjectConstructString> for ::windows::core::IUnknown {
-    fn from(value: IObjectConstructString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IObjectConstructString> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectConstructString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IObjectConstructString> for ::windows::core::IUnknown {
-    fn from(value: &IObjectConstructString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IObjectConstructString> for super::Com::IDispatch {
-    fn from(value: IObjectConstructString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IObjectConstructString> for &'a super::Com::IDispatch {
-    fn from(value: &'a IObjectConstructString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IObjectConstructString> for super::Com::IDispatch {
-    fn from(value: &IObjectConstructString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectConstructString, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IObjectConstructString {
     fn clone(&self) -> Self {
@@ -6788,21 +5305,7 @@ impl IObjectContext {
         (::windows::core::Vtable::vtable(self).IsCallerInRole)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrrole), ::core::mem::transmute(pfisinrole)).ok()
     }
 }
-impl ::core::convert::From<IObjectContext> for ::windows::core::IUnknown {
-    fn from(value: IObjectContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectContext> for ::windows::core::IUnknown {
-    fn from(value: &IObjectContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6855,21 +5358,7 @@ impl IObjectContextActivity {
         (::windows::core::Vtable::vtable(self).GetActivityId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguid)).ok()
     }
 }
-impl ::core::convert::From<IObjectContextActivity> for ::windows::core::IUnknown {
-    fn from(value: IObjectContextActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectContextActivity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectContextActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectContextActivity> for ::windows::core::IUnknown {
-    fn from(value: &IObjectContextActivity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectContextActivity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectContextActivity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6921,21 +5410,7 @@ impl IObjectContextInfo {
         (::windows::core::Vtable::vtable(self).GetContextId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguid)).ok()
     }
 }
-impl ::core::convert::From<IObjectContextInfo> for ::windows::core::IUnknown {
-    fn from(value: IObjectContextInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectContextInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectContextInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectContextInfo> for ::windows::core::IUnknown {
-    fn from(value: &IObjectContextInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectContextInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectContextInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7003,36 +5478,7 @@ impl IObjectContextInfo2 {
         (::windows::core::Vtable::vtable(self).GetApplicationInstanceId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguid)).ok()
     }
 }
-impl ::core::convert::From<IObjectContextInfo2> for ::windows::core::IUnknown {
-    fn from(value: IObjectContextInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectContextInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectContextInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectContextInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IObjectContextInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IObjectContextInfo2> for IObjectContextInfo {
-    fn from(value: IObjectContextInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectContextInfo2> for &'a IObjectContextInfo {
-    fn from(value: &'a IObjectContextInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectContextInfo2> for IObjectContextInfo {
-    fn from(value: &IObjectContextInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectContextInfo2, ::windows::core::IUnknown, IObjectContextInfo);
 impl ::core::clone::Clone for IObjectContextInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7071,21 +5517,7 @@ impl IObjectContextTip {
         (::windows::core::Vtable::vtable(self).GetTipUrl)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptipurl)).ok()
     }
 }
-impl ::core::convert::From<IObjectContextTip> for ::windows::core::IUnknown {
-    fn from(value: IObjectContextTip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectContextTip> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectContextTip) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectContextTip> for ::windows::core::IUnknown {
-    fn from(value: &IObjectContextTip) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectContextTip, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectContextTip {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7130,21 +5562,7 @@ impl IObjectControl {
         (::windows::core::Vtable::vtable(self).CanBePooled)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IObjectControl> for ::windows::core::IUnknown {
-    fn from(value: IObjectControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectControl> for ::windows::core::IUnknown {
-    fn from(value: &IObjectControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7189,21 +5607,7 @@ impl IPlaybackControl {
         (::windows::core::Vtable::vtable(self).FinalServerRetry)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPlaybackControl> for ::windows::core::IUnknown {
-    fn from(value: IPlaybackControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlaybackControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlaybackControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlaybackControl> for ::windows::core::IUnknown {
-    fn from(value: &IPlaybackControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlaybackControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPlaybackControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7244,41 +5648,7 @@ impl IPoolManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPoolManager> for ::windows::core::IUnknown {
-    fn from(value: IPoolManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPoolManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPoolManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPoolManager> for ::windows::core::IUnknown {
-    fn from(value: &IPoolManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPoolManager> for super::Com::IDispatch {
-    fn from(value: IPoolManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPoolManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a IPoolManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPoolManager> for super::Com::IDispatch {
-    fn from(value: &IPoolManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPoolManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPoolManager {
     fn clone(&self) -> Self {
@@ -7328,21 +5698,7 @@ impl IProcessInitializer {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IProcessInitializer> for ::windows::core::IUnknown {
-    fn from(value: IProcessInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProcessInitializer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProcessInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProcessInitializer> for ::windows::core::IUnknown {
-    fn from(value: &IProcessInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProcessInitializer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProcessInitializer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7408,41 +5764,7 @@ impl ISecurityCallContext {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISecurityCallContext> for ::windows::core::IUnknown {
-    fn from(value: ISecurityCallContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISecurityCallContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISecurityCallContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISecurityCallContext> for ::windows::core::IUnknown {
-    fn from(value: &ISecurityCallContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISecurityCallContext> for super::Com::IDispatch {
-    fn from(value: ISecurityCallContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISecurityCallContext> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISecurityCallContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISecurityCallContext> for super::Com::IDispatch {
-    fn from(value: &ISecurityCallContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISecurityCallContext, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISecurityCallContext {
     fn clone(&self) -> Self {
@@ -7511,41 +5833,7 @@ impl ISecurityCallersColl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISecurityCallersColl> for ::windows::core::IUnknown {
-    fn from(value: ISecurityCallersColl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISecurityCallersColl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISecurityCallersColl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISecurityCallersColl> for ::windows::core::IUnknown {
-    fn from(value: &ISecurityCallersColl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISecurityCallersColl> for super::Com::IDispatch {
-    fn from(value: ISecurityCallersColl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISecurityCallersColl> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISecurityCallersColl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISecurityCallersColl> for super::Com::IDispatch {
-    fn from(value: &ISecurityCallersColl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISecurityCallersColl, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISecurityCallersColl {
     fn clone(&self) -> Self {
@@ -7608,41 +5896,7 @@ impl ISecurityIdentityColl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISecurityIdentityColl> for ::windows::core::IUnknown {
-    fn from(value: ISecurityIdentityColl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISecurityIdentityColl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISecurityIdentityColl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISecurityIdentityColl> for ::windows::core::IUnknown {
-    fn from(value: &ISecurityIdentityColl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISecurityIdentityColl> for super::Com::IDispatch {
-    fn from(value: ISecurityIdentityColl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISecurityIdentityColl> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISecurityIdentityColl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISecurityIdentityColl> for super::Com::IDispatch {
-    fn from(value: &ISecurityIdentityColl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISecurityIdentityColl, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISecurityIdentityColl {
     fn clone(&self) -> Self {
@@ -7716,21 +5970,7 @@ impl ISecurityProperty {
         (::windows::core::Vtable::vtable(self).ReleaseSID)(::windows::core::Vtable::as_raw(self), psid.into()).ok()
     }
 }
-impl ::core::convert::From<ISecurityProperty> for ::windows::core::IUnknown {
-    fn from(value: ISecurityProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISecurityProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISecurityProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISecurityProperty> for ::windows::core::IUnknown {
-    fn from(value: &ISecurityProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISecurityProperty, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISecurityProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7792,21 +6032,7 @@ impl ISelectCOMLBServer {
         (::windows::core::Vtable::vtable(self).GetLBServer)(::windows::core::Vtable::as_raw(self), punk.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISelectCOMLBServer> for ::windows::core::IUnknown {
-    fn from(value: ISelectCOMLBServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISelectCOMLBServer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISelectCOMLBServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISelectCOMLBServer> for ::windows::core::IUnknown {
-    fn from(value: &ISelectCOMLBServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISelectCOMLBServer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISelectCOMLBServer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7847,21 +6073,7 @@ impl ISendMethodEvents {
         (::windows::core::Vtable::vtable(self).SendMethodReturn)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidentity), ::core::mem::transmute(riid), dwmeth, hrcall, hrserver).ok()
     }
 }
-impl ::core::convert::From<ISendMethodEvents> for ::windows::core::IUnknown {
-    fn from(value: ISendMethodEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISendMethodEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISendMethodEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISendMethodEvents> for ::windows::core::IUnknown {
-    fn from(value: &ISendMethodEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISendMethodEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISendMethodEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7914,21 +6126,7 @@ impl IServiceActivity {
         (::windows::core::Vtable::vtable(self).UnbindFromThread)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IServiceActivity> for ::windows::core::IUnknown {
-    fn from(value: IServiceActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceActivity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceActivity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceActivity> for ::windows::core::IUnknown {
-    fn from(value: &IServiceActivity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceActivity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServiceActivity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7968,21 +6166,7 @@ impl IServiceCall {
         (::windows::core::Vtable::vtable(self).OnCall)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IServiceCall> for ::windows::core::IUnknown {
-    fn from(value: IServiceCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceCall> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceCall) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceCall> for ::windows::core::IUnknown {
-    fn from(value: &IServiceCall) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceCall, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServiceCall {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8019,21 +6203,7 @@ impl IServiceComTIIntrinsicsConfig {
         (::windows::core::Vtable::vtable(self).ComTIIntrinsicsConfig)(::windows::core::Vtable::as_raw(self), comtiintrinsicsconfig).ok()
     }
 }
-impl ::core::convert::From<IServiceComTIIntrinsicsConfig> for ::windows::core::IUnknown {
-    fn from(value: IServiceComTIIntrinsicsConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceComTIIntrinsicsConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceComTIIntrinsicsConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceComTIIntrinsicsConfig> for ::windows::core::IUnknown {
-    fn from(value: &IServiceComTIIntrinsicsConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceComTIIntrinsicsConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServiceComTIIntrinsicsConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8070,21 +6240,7 @@ impl IServiceIISIntrinsicsConfig {
         (::windows::core::Vtable::vtable(self).IISIntrinsicsConfig)(::windows::core::Vtable::as_raw(self), iisintrinsicsconfig).ok()
     }
 }
-impl ::core::convert::From<IServiceIISIntrinsicsConfig> for ::windows::core::IUnknown {
-    fn from(value: IServiceIISIntrinsicsConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceIISIntrinsicsConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceIISIntrinsicsConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceIISIntrinsicsConfig> for ::windows::core::IUnknown {
-    fn from(value: &IServiceIISIntrinsicsConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceIISIntrinsicsConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServiceIISIntrinsicsConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8121,21 +6277,7 @@ impl IServiceInheritanceConfig {
         (::windows::core::Vtable::vtable(self).ContainingContextTreatment)(::windows::core::Vtable::as_raw(self), inheritanceconfig).ok()
     }
 }
-impl ::core::convert::From<IServiceInheritanceConfig> for ::windows::core::IUnknown {
-    fn from(value: IServiceInheritanceConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceInheritanceConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceInheritanceConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceInheritanceConfig> for ::windows::core::IUnknown {
-    fn from(value: &IServiceInheritanceConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceInheritanceConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServiceInheritanceConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8175,21 +6317,7 @@ impl IServicePartitionConfig {
         (::windows::core::Vtable::vtable(self).PartitionID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidpartitionid)).ok()
     }
 }
-impl ::core::convert::From<IServicePartitionConfig> for ::windows::core::IUnknown {
-    fn from(value: IServicePartitionConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServicePartitionConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServicePartitionConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServicePartitionConfig> for ::windows::core::IUnknown {
-    fn from(value: &IServicePartitionConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServicePartitionConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServicePartitionConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8236,21 +6364,7 @@ impl IServicePool {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IServicePool> for ::windows::core::IUnknown {
-    fn from(value: IServicePool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServicePool> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServicePool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServicePool> for ::windows::core::IUnknown {
-    fn from(value: &IServicePool) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServicePool, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServicePool {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8331,21 +6445,7 @@ impl IServicePoolConfig {
         (::windows::core::Vtable::vtable(self).ClassFactory)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::IClassFactory>(result__)
     }
 }
-impl ::core::convert::From<IServicePoolConfig> for ::windows::core::IUnknown {
-    fn from(value: IServicePoolConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServicePoolConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServicePoolConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServicePoolConfig> for ::windows::core::IUnknown {
-    fn from(value: &IServicePoolConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServicePoolConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServicePoolConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8415,21 +6515,7 @@ impl IServiceSxsConfig {
         (::windows::core::Vtable::vtable(self).SxsDirectory)(::windows::core::Vtable::as_raw(self), szsxsdirectory.into()).ok()
     }
 }
-impl ::core::convert::From<IServiceSxsConfig> for ::windows::core::IUnknown {
-    fn from(value: IServiceSxsConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceSxsConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceSxsConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceSxsConfig> for ::windows::core::IUnknown {
-    fn from(value: &IServiceSxsConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceSxsConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServiceSxsConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8468,21 +6554,7 @@ impl IServiceSynchronizationConfig {
         (::windows::core::Vtable::vtable(self).ConfigureSynchronization)(::windows::core::Vtable::as_raw(self), synchconfig).ok()
     }
 }
-impl ::core::convert::From<IServiceSynchronizationConfig> for ::windows::core::IUnknown {
-    fn from(value: IServiceSynchronizationConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceSynchronizationConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceSynchronizationConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceSynchronizationConfig> for ::windows::core::IUnknown {
-    fn from(value: &IServiceSynchronizationConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceSynchronizationConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServiceSynchronizationConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8551,51 +6623,7 @@ impl IServiceSysTxnConfig {
         (::windows::core::Vtable::vtable(self).ConfigureBYOTSysTxn)(::windows::core::Vtable::as_raw(self), ptxproxy.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IServiceSysTxnConfig> for ::windows::core::IUnknown {
-    fn from(value: IServiceSysTxnConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceSysTxnConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceSysTxnConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceSysTxnConfig> for ::windows::core::IUnknown {
-    fn from(value: &IServiceSysTxnConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IServiceSysTxnConfig> for IServiceTransactionConfigBase {
-    fn from(value: IServiceSysTxnConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceSysTxnConfig> for &'a IServiceTransactionConfigBase {
-    fn from(value: &'a IServiceSysTxnConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceSysTxnConfig> for IServiceTransactionConfigBase {
-    fn from(value: &IServiceSysTxnConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IServiceSysTxnConfig> for IServiceTransactionConfig {
-    fn from(value: IServiceSysTxnConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceSysTxnConfig> for &'a IServiceTransactionConfig {
-    fn from(value: &'a IServiceSysTxnConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceSysTxnConfig> for IServiceTransactionConfig {
-    fn from(value: &IServiceSysTxnConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceSysTxnConfig, ::windows::core::IUnknown, IServiceTransactionConfigBase, IServiceTransactionConfig);
 impl ::core::clone::Clone for IServiceSysTxnConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8635,21 +6663,7 @@ impl IServiceThreadPoolConfig {
         (::windows::core::Vtable::vtable(self).SetBindingInfo)(::windows::core::Vtable::as_raw(self), binding).ok()
     }
 }
-impl ::core::convert::From<IServiceThreadPoolConfig> for ::windows::core::IUnknown {
-    fn from(value: IServiceThreadPoolConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceThreadPoolConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceThreadPoolConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceThreadPoolConfig> for ::windows::core::IUnknown {
-    fn from(value: &IServiceThreadPoolConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceThreadPoolConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServiceThreadPoolConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8691,21 +6705,7 @@ impl IServiceTrackerConfig {
         (::windows::core::Vtable::vtable(self).TrackerConfig)(::windows::core::Vtable::as_raw(self), trackerconfig, sztrackerappname.into(), sztrackerctxname.into()).ok()
     }
 }
-impl ::core::convert::From<IServiceTrackerConfig> for ::windows::core::IUnknown {
-    fn from(value: IServiceTrackerConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceTrackerConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceTrackerConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceTrackerConfig> for ::windows::core::IUnknown {
-    fn from(value: &IServiceTrackerConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceTrackerConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServiceTrackerConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8768,36 +6768,7 @@ impl IServiceTransactionConfig {
         (::windows::core::Vtable::vtable(self).ConfigureBYOT)(::windows::core::Vtable::as_raw(self), pitxbyot.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IServiceTransactionConfig> for ::windows::core::IUnknown {
-    fn from(value: IServiceTransactionConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceTransactionConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceTransactionConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceTransactionConfig> for ::windows::core::IUnknown {
-    fn from(value: &IServiceTransactionConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IServiceTransactionConfig> for IServiceTransactionConfigBase {
-    fn from(value: IServiceTransactionConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceTransactionConfig> for &'a IServiceTransactionConfigBase {
-    fn from(value: &'a IServiceTransactionConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceTransactionConfig> for IServiceTransactionConfigBase {
-    fn from(value: &IServiceTransactionConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceTransactionConfig, ::windows::core::IUnknown, IServiceTransactionConfigBase);
 impl ::core::clone::Clone for IServiceTransactionConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8855,21 +6826,7 @@ impl IServiceTransactionConfigBase {
         (::windows::core::Vtable::vtable(self).NewTransactionDescription)(::windows::core::Vtable::as_raw(self), sztxdesc.into()).ok()
     }
 }
-impl ::core::convert::From<IServiceTransactionConfigBase> for ::windows::core::IUnknown {
-    fn from(value: IServiceTransactionConfigBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IServiceTransactionConfigBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IServiceTransactionConfigBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IServiceTransactionConfigBase> for ::windows::core::IUnknown {
-    fn from(value: &IServiceTransactionConfigBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IServiceTransactionConfigBase, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IServiceTransactionConfigBase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8924,41 +6881,7 @@ impl ISharedProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISharedProperty> for ::windows::core::IUnknown {
-    fn from(value: ISharedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISharedProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISharedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISharedProperty> for ::windows::core::IUnknown {
-    fn from(value: &ISharedProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISharedProperty> for super::Com::IDispatch {
-    fn from(value: ISharedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISharedProperty> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISharedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISharedProperty> for super::Com::IDispatch {
-    fn from(value: &ISharedProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISharedProperty, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISharedProperty {
     fn clone(&self) -> Self {
@@ -9031,41 +6954,7 @@ impl ISharedPropertyGroup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISharedPropertyGroup> for ::windows::core::IUnknown {
-    fn from(value: ISharedPropertyGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISharedPropertyGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISharedPropertyGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISharedPropertyGroup> for ::windows::core::IUnknown {
-    fn from(value: &ISharedPropertyGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISharedPropertyGroup> for super::Com::IDispatch {
-    fn from(value: ISharedPropertyGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISharedPropertyGroup> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISharedPropertyGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISharedPropertyGroup> for super::Com::IDispatch {
-    fn from(value: &ISharedPropertyGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISharedPropertyGroup, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISharedPropertyGroup {
     fn clone(&self) -> Self {
@@ -9139,41 +7028,7 @@ impl ISharedPropertyGroupManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISharedPropertyGroupManager> for ::windows::core::IUnknown {
-    fn from(value: ISharedPropertyGroupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISharedPropertyGroupManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISharedPropertyGroupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISharedPropertyGroupManager> for ::windows::core::IUnknown {
-    fn from(value: &ISharedPropertyGroupManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISharedPropertyGroupManager> for super::Com::IDispatch {
-    fn from(value: ISharedPropertyGroupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISharedPropertyGroupManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISharedPropertyGroupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISharedPropertyGroupManager> for super::Com::IDispatch {
-    fn from(value: &ISharedPropertyGroupManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISharedPropertyGroupManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISharedPropertyGroupManager {
     fn clone(&self) -> Self {
@@ -9228,21 +7083,7 @@ impl ISystemAppEventData {
         (::windows::core::Vtable::vtable(self).OnDataChanged)(::windows::core::Vtable::as_raw(self), dwpid, dwmask, dwnumbersinks, ::core::mem::transmute_copy(bstrdwmethodmask), dwreason, u64tracehandle).ok()
     }
 }
-impl ::core::convert::From<ISystemAppEventData> for ::windows::core::IUnknown {
-    fn from(value: ISystemAppEventData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISystemAppEventData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISystemAppEventData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISystemAppEventData> for ::windows::core::IUnknown {
-    fn from(value: &ISystemAppEventData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISystemAppEventData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISystemAppEventData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9307,21 +7148,7 @@ impl IThreadPoolKnobs {
         (::windows::core::Vtable::vtable(self).SetQueueDepth)(::windows::core::Vtable::as_raw(self), lcqueuedepth).ok()
     }
 }
-impl ::core::convert::From<IThreadPoolKnobs> for ::windows::core::IUnknown {
-    fn from(value: IThreadPoolKnobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IThreadPoolKnobs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IThreadPoolKnobs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IThreadPoolKnobs> for ::windows::core::IUnknown {
-    fn from(value: &IThreadPoolKnobs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IThreadPoolKnobs, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IThreadPoolKnobs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9379,41 +7206,7 @@ impl ITransactionContext {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITransactionContext> for ::windows::core::IUnknown {
-    fn from(value: ITransactionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITransactionContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITransactionContext> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITransactionContext> for super::Com::IDispatch {
-    fn from(value: ITransactionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITransactionContext> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITransactionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITransactionContext> for super::Com::IDispatch {
-    fn from(value: &ITransactionContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionContext, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITransactionContext {
     fn clone(&self) -> Self {
@@ -9472,21 +7265,7 @@ impl ITransactionContextEx {
         (::windows::core::Vtable::vtable(self).Abort)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITransactionContextEx> for ::windows::core::IUnknown {
-    fn from(value: ITransactionContextEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionContextEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionContextEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionContextEx> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionContextEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionContextEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionContextEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9577,21 +7356,7 @@ impl ITransactionProperty {
         (::windows::core::Vtable::vtable(self).Reserved17)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ITransactionProperty> for ::windows::core::IUnknown {
-    fn from(value: ITransactionProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionProperty> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionProperty, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9674,21 +7439,7 @@ impl ITransactionProxy {
         (::windows::core::Vtable::vtable(self).IsReusable)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfisreusable)).ok()
     }
 }
-impl ::core::convert::From<ITransactionProxy> for ::windows::core::IUnknown {
-    fn from(value: ITransactionProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionProxy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionProxy> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionProxy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionProxy, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionProxy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9751,21 +7502,7 @@ impl ITransactionResourcePool {
         (::windows::core::Vtable::vtable(self).GetResource)(::windows::core::Vtable::as_raw(self), ppool.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<ITransactionResourcePool> for ::windows::core::IUnknown {
-    fn from(value: ITransactionResourcePool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionResourcePool> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionResourcePool) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionResourcePool> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionResourcePool) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionResourcePool, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionResourcePool {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9806,21 +7543,7 @@ impl ITransactionStatus {
         (::windows::core::Vtable::vtable(self).GetTransactionStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phrstatus)).ok()
     }
 }
-impl ::core::convert::From<ITransactionStatus> for ::windows::core::IUnknown {
-    fn from(value: ITransactionStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionStatus> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionStatus, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionStatus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9858,21 +7581,7 @@ impl ITxProxyHolder {
         (::windows::core::Vtable::vtable(self).GetIdentifier)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguidltx))
     }
 }
-impl ::core::convert::From<ITxProxyHolder> for ::windows::core::IUnknown {
-    fn from(value: ITxProxyHolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITxProxyHolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITxProxyHolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITxProxyHolder> for ::windows::core::IUnknown {
-    fn from(value: &ITxProxyHolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITxProxyHolder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITxProxyHolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9965,41 +7674,7 @@ impl ObjectContext {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ObjectContext> for ::windows::core::IUnknown {
-    fn from(value: ObjectContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ObjectContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ObjectContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ObjectContext> for ::windows::core::IUnknown {
-    fn from(value: &ObjectContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ObjectContext> for super::Com::IDispatch {
-    fn from(value: ObjectContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ObjectContext> for &'a super::Com::IDispatch {
-    fn from(value: &'a ObjectContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ObjectContext> for super::Com::IDispatch {
-    fn from(value: &ObjectContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ObjectContext, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ObjectContext {
     fn clone(&self) -> Self {
@@ -10073,21 +7748,7 @@ impl ObjectControl {
         (::windows::core::Vtable::vtable(self).CanBePooled)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbpoolable)).ok()
     }
 }
-impl ::core::convert::From<ObjectControl> for ::windows::core::IUnknown {
-    fn from(value: ObjectControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ObjectControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ObjectControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ObjectControl> for ::windows::core::IUnknown {
-    fn from(value: &ObjectControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ObjectControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ObjectControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10142,41 +7803,7 @@ impl SecurityProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<SecurityProperty> for ::windows::core::IUnknown {
-    fn from(value: SecurityProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a SecurityProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a SecurityProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&SecurityProperty> for ::windows::core::IUnknown {
-    fn from(value: &SecurityProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<SecurityProperty> for super::Com::IDispatch {
-    fn from(value: SecurityProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a SecurityProperty> for &'a super::Com::IDispatch {
-    fn from(value: &'a SecurityProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&SecurityProperty> for super::Com::IDispatch {
-    fn from(value: &SecurityProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(SecurityProperty, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for SecurityProperty {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
@@ -12,21 +12,7 @@ impl IContact {
         (::windows::core::Vtable::vtable(self).CommitChanges)(::windows::core::Vtable::as_raw(self), dwcommitflags).ok()
     }
 }
-impl ::core::convert::From<IContact> for ::windows::core::IUnknown {
-    fn from(value: IContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContact> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContact> for ::windows::core::IUnknown {
-    fn from(value: &IContact) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContact, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContact {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -100,21 +86,7 @@ impl IContactAggregationAggregate {
         (::windows::core::Vtable::vtable(self).Id)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IContactAggregationAggregate> for ::windows::core::IUnknown {
-    fn from(value: IContactAggregationAggregate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactAggregationAggregate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactAggregationAggregate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactAggregationAggregate> for ::windows::core::IUnknown {
-    fn from(value: &IContactAggregationAggregate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactAggregationAggregate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactAggregationAggregate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -175,21 +147,7 @@ impl IContactAggregationAggregateCollection {
         (::windows::core::Vtable::vtable(self).Count)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IContactAggregationAggregateCollection> for ::windows::core::IUnknown {
-    fn from(value: IContactAggregationAggregateCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactAggregationAggregateCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactAggregationAggregateCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactAggregationAggregateCollection> for ::windows::core::IUnknown {
-    fn from(value: &IContactAggregationAggregateCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactAggregationAggregateCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactAggregationAggregateCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -302,21 +260,7 @@ impl IContactAggregationContact {
         (::windows::core::Vtable::vtable(self).SetSyncIdentityHash)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(psyncidentityhash)).ok()
     }
 }
-impl ::core::convert::From<IContactAggregationContact> for ::windows::core::IUnknown {
-    fn from(value: IContactAggregationContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactAggregationContact> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactAggregationContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactAggregationContact> for ::windows::core::IUnknown {
-    fn from(value: &IContactAggregationContact) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactAggregationContact, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactAggregationContact {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -401,21 +345,7 @@ impl IContactAggregationContactCollection {
         (::windows::core::Vtable::vtable(self).FindFirstByRemoteId)(::windows::core::Vtable::as_raw(self), psourcetype.into(), paccountid.into(), ::core::mem::transmute(premoteobjectid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IContactAggregationContact>(result__)
     }
 }
-impl ::core::convert::From<IContactAggregationContactCollection> for ::windows::core::IUnknown {
-    fn from(value: IContactAggregationContactCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactAggregationContactCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactAggregationContactCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactAggregationContactCollection> for ::windows::core::IUnknown {
-    fn from(value: &IContactAggregationContactCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactAggregationContactCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactAggregationContactCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -496,21 +426,7 @@ impl IContactAggregationGroup {
         (::windows::core::Vtable::vtable(self).SetName)(::windows::core::Vtable::as_raw(self), pname.into()).ok()
     }
 }
-impl ::core::convert::From<IContactAggregationGroup> for ::windows::core::IUnknown {
-    fn from(value: IContactAggregationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactAggregationGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactAggregationGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactAggregationGroup> for ::windows::core::IUnknown {
-    fn from(value: &IContactAggregationGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactAggregationGroup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactAggregationGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -569,21 +485,7 @@ impl IContactAggregationGroupCollection {
         (::windows::core::Vtable::vtable(self).Count)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IContactAggregationGroupCollection> for ::windows::core::IUnknown {
-    fn from(value: IContactAggregationGroupCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactAggregationGroupCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactAggregationGroupCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactAggregationGroupCollection> for ::windows::core::IUnknown {
-    fn from(value: &IContactAggregationGroupCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactAggregationGroupCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactAggregationGroupCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -698,21 +600,7 @@ impl IContactAggregationLink {
         (::windows::core::Vtable::vtable(self).SetSyncIdentityHash)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(psyncidentityhash)).ok()
     }
 }
-impl ::core::convert::From<IContactAggregationLink> for ::windows::core::IUnknown {
-    fn from(value: IContactAggregationLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactAggregationLink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactAggregationLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactAggregationLink> for ::windows::core::IUnknown {
-    fn from(value: &IContactAggregationLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactAggregationLink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactAggregationLink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -788,21 +676,7 @@ impl IContactAggregationLinkCollection {
         (::windows::core::Vtable::vtable(self).Count)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IContactAggregationLinkCollection> for ::windows::core::IUnknown {
-    fn from(value: IContactAggregationLinkCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactAggregationLinkCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactAggregationLinkCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactAggregationLinkCollection> for ::windows::core::IUnknown {
-    fn from(value: &IContactAggregationLinkCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactAggregationLinkCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactAggregationLinkCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -916,21 +790,7 @@ impl IContactAggregationManager {
         (::windows::core::Vtable::vtable(self).get_ServerContactLinks)(::windows::core::Vtable::as_raw(self), ppersonitemid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IContactAggregationLinkCollection>(result__)
     }
 }
-impl ::core::convert::From<IContactAggregationManager> for ::windows::core::IUnknown {
-    fn from(value: IContactAggregationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactAggregationManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactAggregationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactAggregationManager> for ::windows::core::IUnknown {
-    fn from(value: &IContactAggregationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactAggregationManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactAggregationManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1083,21 +943,7 @@ impl IContactAggregationServerPerson {
         (::windows::core::Vtable::vtable(self).SetObjectId)(::windows::core::Vtable::as_raw(self), pobjectid.into()).ok()
     }
 }
-impl ::core::convert::From<IContactAggregationServerPerson> for ::windows::core::IUnknown {
-    fn from(value: IContactAggregationServerPerson) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactAggregationServerPerson> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactAggregationServerPerson) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactAggregationServerPerson> for ::windows::core::IUnknown {
-    fn from(value: &IContactAggregationServerPerson) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactAggregationServerPerson, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactAggregationServerPerson {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1192,21 +1038,7 @@ impl IContactAggregationServerPersonCollection {
         (::windows::core::Vtable::vtable(self).Count)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IContactAggregationServerPersonCollection> for ::windows::core::IUnknown {
-    fn from(value: IContactAggregationServerPersonCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactAggregationServerPersonCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactAggregationServerPersonCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactAggregationServerPersonCollection> for ::windows::core::IUnknown {
-    fn from(value: &IContactAggregationServerPersonCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactAggregationServerPersonCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactAggregationServerPersonCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1255,21 +1087,7 @@ impl IContactCollection {
         (::windows::core::Vtable::vtable(self).GetCurrent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IContact>(result__)
     }
 }
-impl ::core::convert::From<IContactCollection> for ::windows::core::IUnknown {
-    fn from(value: IContactCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactCollection> for ::windows::core::IUnknown {
-    fn from(value: &IContactCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1340,21 +1158,7 @@ impl IContactManager {
         (::windows::core::Vtable::vtable(self).GetContactCollection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IContactCollection>(result__)
     }
 }
-impl ::core::convert::From<IContactManager> for ::windows::core::IUnknown {
-    fn from(value: IContactManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactManager> for ::windows::core::IUnknown {
-    fn from(value: &IContactManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1488,21 +1292,7 @@ impl IContactProperties {
         (::windows::core::Vtable::vtable(self).GetPropertyCollection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pppropertycollection), dwflags, pszmultivaluename.into(), ppszlabels.len() as _, ::core::mem::transmute(ppszlabels.as_ptr()), fanylabelmatches.into()).ok()
     }
 }
-impl ::core::convert::From<IContactProperties> for ::windows::core::IUnknown {
-    fn from(value: IContactProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactProperties> for ::windows::core::IUnknown {
-    fn from(value: &IContactProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1589,21 +1379,7 @@ impl IContactPropertyCollection {
         (::windows::core::Vtable::vtable(self).GetPropertyArrayElementID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pszarrayelementid.as_ptr()), pszarrayelementid.len() as _, ::core::mem::transmute(pdwccharrayelementidrequired)).ok()
     }
 }
-impl ::core::convert::From<IContactPropertyCollection> for ::windows::core::IUnknown {
-    fn from(value: IContactPropertyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactPropertyCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactPropertyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactPropertyCollection> for ::windows::core::IUnknown {
-    fn from(value: &IContactPropertyCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactPropertyCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactPropertyCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/mod.rs
@@ -1173,41 +1173,7 @@ impl IWdsTransportCacheable {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportCacheable> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportCacheable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportCacheable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportCacheable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportCacheable> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportCacheable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportCacheable> for super::Com::IDispatch {
-    fn from(value: IWdsTransportCacheable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportCacheable> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportCacheable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportCacheable> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportCacheable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportCacheable, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportCacheable {
     fn clone(&self) -> Self {
@@ -1303,41 +1269,7 @@ impl IWdsTransportClient {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportClient> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportClient> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportClient> for super::Com::IDispatch {
-    fn from(value: IWdsTransportClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportClient> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportClient> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportClient, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportClient {
     fn clone(&self) -> Self {
@@ -1409,41 +1341,7 @@ impl IWdsTransportCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportCollection> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportCollection> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportCollection> for super::Com::IDispatch {
-    fn from(value: IWdsTransportCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportCollection> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportCollection {
     fn clone(&self) -> Self {
@@ -1526,41 +1424,7 @@ impl IWdsTransportConfigurationManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportConfigurationManager> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportConfigurationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportConfigurationManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportConfigurationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportConfigurationManager> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportConfigurationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportConfigurationManager> for super::Com::IDispatch {
-    fn from(value: IWdsTransportConfigurationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportConfigurationManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportConfigurationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportConfigurationManager> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportConfigurationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportConfigurationManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportConfigurationManager {
     fn clone(&self) -> Self {
@@ -1658,59 +1522,7 @@ impl IWdsTransportConfigurationManager2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportConfigurationManager2> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportConfigurationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportConfigurationManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportConfigurationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportConfigurationManager2> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportConfigurationManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportConfigurationManager2> for super::Com::IDispatch {
-    fn from(value: IWdsTransportConfigurationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportConfigurationManager2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportConfigurationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportConfigurationManager2> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportConfigurationManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportConfigurationManager2> for IWdsTransportConfigurationManager {
-    fn from(value: IWdsTransportConfigurationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportConfigurationManager2> for &'a IWdsTransportConfigurationManager {
-    fn from(value: &'a IWdsTransportConfigurationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportConfigurationManager2> for IWdsTransportConfigurationManager {
-    fn from(value: &IWdsTransportConfigurationManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportConfigurationManager2, ::windows::core::IUnknown, super::Com::IDispatch, IWdsTransportConfigurationManager);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportConfigurationManager2 {
     fn clone(&self) -> Self {
@@ -1780,41 +1592,7 @@ impl IWdsTransportContent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportContent> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportContent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportContent> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportContent> for super::Com::IDispatch {
-    fn from(value: IWdsTransportContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportContent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportContent> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportContent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportContent {
     fn clone(&self) -> Self {
@@ -1884,41 +1662,7 @@ impl IWdsTransportContentProvider {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportContentProvider> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportContentProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportContentProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportContentProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportContentProvider> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportContentProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportContentProvider> for super::Com::IDispatch {
-    fn from(value: IWdsTransportContentProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportContentProvider> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportContentProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportContentProvider> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportContentProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportContentProvider, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportContentProvider {
     fn clone(&self) -> Self {
@@ -1992,59 +1736,7 @@ impl IWdsTransportDiagnosticsPolicy {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportDiagnosticsPolicy> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportDiagnosticsPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportDiagnosticsPolicy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportDiagnosticsPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportDiagnosticsPolicy> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportDiagnosticsPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportDiagnosticsPolicy> for super::Com::IDispatch {
-    fn from(value: IWdsTransportDiagnosticsPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportDiagnosticsPolicy> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportDiagnosticsPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportDiagnosticsPolicy> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportDiagnosticsPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportDiagnosticsPolicy> for IWdsTransportCacheable {
-    fn from(value: IWdsTransportDiagnosticsPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportDiagnosticsPolicy> for &'a IWdsTransportCacheable {
-    fn from(value: &'a IWdsTransportDiagnosticsPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportDiagnosticsPolicy> for IWdsTransportCacheable {
-    fn from(value: &IWdsTransportDiagnosticsPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportDiagnosticsPolicy, ::windows::core::IUnknown, super::Com::IDispatch, IWdsTransportCacheable);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportDiagnosticsPolicy {
     fn clone(&self) -> Self {
@@ -2097,41 +1789,7 @@ impl IWdsTransportManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportManager> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportManager> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportManager> for super::Com::IDispatch {
-    fn from(value: IWdsTransportManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportManager> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportManager {
     fn clone(&self) -> Self {
@@ -2219,59 +1877,7 @@ impl IWdsTransportMulticastSessionPolicy {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportMulticastSessionPolicy> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportMulticastSessionPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportMulticastSessionPolicy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportMulticastSessionPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportMulticastSessionPolicy> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportMulticastSessionPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportMulticastSessionPolicy> for super::Com::IDispatch {
-    fn from(value: IWdsTransportMulticastSessionPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportMulticastSessionPolicy> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportMulticastSessionPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportMulticastSessionPolicy> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportMulticastSessionPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportMulticastSessionPolicy> for IWdsTransportCacheable {
-    fn from(value: IWdsTransportMulticastSessionPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportMulticastSessionPolicy> for &'a IWdsTransportCacheable {
-    fn from(value: &'a IWdsTransportMulticastSessionPolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportMulticastSessionPolicy> for IWdsTransportCacheable {
-    fn from(value: &IWdsTransportMulticastSessionPolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportMulticastSessionPolicy, ::windows::core::IUnknown, super::Com::IDispatch, IWdsTransportCacheable);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportMulticastSessionPolicy {
     fn clone(&self) -> Self {
@@ -2402,41 +2008,7 @@ impl IWdsTransportNamespace {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespace> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportNamespace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportNamespace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespace> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportNamespace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespace> for super::Com::IDispatch {
-    fn from(value: IWdsTransportNamespace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespace> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportNamespace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespace> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportNamespace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportNamespace, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportNamespace {
     fn clone(&self) -> Self {
@@ -2586,59 +2158,7 @@ impl IWdsTransportNamespaceAutoCast {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceAutoCast> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportNamespaceAutoCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceAutoCast> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportNamespaceAutoCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceAutoCast> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportNamespaceAutoCast) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceAutoCast> for super::Com::IDispatch {
-    fn from(value: IWdsTransportNamespaceAutoCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceAutoCast> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportNamespaceAutoCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceAutoCast> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportNamespaceAutoCast) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceAutoCast> for IWdsTransportNamespace {
-    fn from(value: IWdsTransportNamespaceAutoCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceAutoCast> for &'a IWdsTransportNamespace {
-    fn from(value: &'a IWdsTransportNamespaceAutoCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceAutoCast> for IWdsTransportNamespace {
-    fn from(value: &IWdsTransportNamespaceAutoCast) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportNamespaceAutoCast, ::windows::core::IUnknown, super::Com::IDispatch, IWdsTransportNamespace);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportNamespaceAutoCast {
     fn clone(&self) -> Self {
@@ -2699,41 +2219,7 @@ impl IWdsTransportNamespaceManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceManager> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportNamespaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportNamespaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceManager> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportNamespaceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceManager> for super::Com::IDispatch {
-    fn from(value: IWdsTransportNamespaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportNamespaceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceManager> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportNamespaceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportNamespaceManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportNamespaceManager {
     fn clone(&self) -> Self {
@@ -2871,59 +2357,7 @@ impl IWdsTransportNamespaceScheduledCast {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceScheduledCast> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportNamespaceScheduledCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceScheduledCast> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportNamespaceScheduledCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceScheduledCast> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportNamespaceScheduledCast) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceScheduledCast> for super::Com::IDispatch {
-    fn from(value: IWdsTransportNamespaceScheduledCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceScheduledCast> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportNamespaceScheduledCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceScheduledCast> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportNamespaceScheduledCast) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceScheduledCast> for IWdsTransportNamespace {
-    fn from(value: IWdsTransportNamespaceScheduledCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceScheduledCast> for &'a IWdsTransportNamespace {
-    fn from(value: &'a IWdsTransportNamespaceScheduledCast) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceScheduledCast> for IWdsTransportNamespace {
-    fn from(value: &IWdsTransportNamespaceScheduledCast) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportNamespaceScheduledCast, ::windows::core::IUnknown, super::Com::IDispatch, IWdsTransportNamespace);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportNamespaceScheduledCast {
     fn clone(&self) -> Self {
@@ -3064,77 +2498,7 @@ impl IWdsTransportNamespaceScheduledCastAutoStart {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceScheduledCastAutoStart> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceScheduledCastAutoStart> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceScheduledCastAutoStart> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceScheduledCastAutoStart> for super::Com::IDispatch {
-    fn from(value: IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceScheduledCastAutoStart> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceScheduledCastAutoStart> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceScheduledCastAutoStart> for IWdsTransportNamespace {
-    fn from(value: IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceScheduledCastAutoStart> for &'a IWdsTransportNamespace {
-    fn from(value: &'a IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceScheduledCastAutoStart> for IWdsTransportNamespace {
-    fn from(value: &IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceScheduledCastAutoStart> for IWdsTransportNamespaceScheduledCast {
-    fn from(value: IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceScheduledCastAutoStart> for &'a IWdsTransportNamespaceScheduledCast {
-    fn from(value: &'a IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceScheduledCastAutoStart> for IWdsTransportNamespaceScheduledCast {
-    fn from(value: &IWdsTransportNamespaceScheduledCastAutoStart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportNamespaceScheduledCastAutoStart, ::windows::core::IUnknown, super::Com::IDispatch, IWdsTransportNamespace, IWdsTransportNamespaceScheduledCast);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportNamespaceScheduledCastAutoStart {
     fn clone(&self) -> Self {
@@ -3264,77 +2628,7 @@ impl IWdsTransportNamespaceScheduledCastManualStart {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceScheduledCastManualStart> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceScheduledCastManualStart> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceScheduledCastManualStart> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceScheduledCastManualStart> for super::Com::IDispatch {
-    fn from(value: IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceScheduledCastManualStart> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceScheduledCastManualStart> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceScheduledCastManualStart> for IWdsTransportNamespace {
-    fn from(value: IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceScheduledCastManualStart> for &'a IWdsTransportNamespace {
-    fn from(value: &'a IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceScheduledCastManualStart> for IWdsTransportNamespace {
-    fn from(value: &IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportNamespaceScheduledCastManualStart> for IWdsTransportNamespaceScheduledCast {
-    fn from(value: IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportNamespaceScheduledCastManualStart> for &'a IWdsTransportNamespaceScheduledCast {
-    fn from(value: &'a IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportNamespaceScheduledCastManualStart> for IWdsTransportNamespaceScheduledCast {
-    fn from(value: &IWdsTransportNamespaceScheduledCastManualStart) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportNamespaceScheduledCastManualStart, ::windows::core::IUnknown, super::Com::IDispatch, IWdsTransportNamespace, IWdsTransportNamespaceScheduledCast);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportNamespaceScheduledCastManualStart {
     fn clone(&self) -> Self {
@@ -3402,41 +2696,7 @@ impl IWdsTransportServer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServer> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServer> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServer> for super::Com::IDispatch {
-    fn from(value: IWdsTransportServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServer> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServer> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportServer, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportServer {
     fn clone(&self) -> Self {
@@ -3524,59 +2784,7 @@ impl IWdsTransportServer2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServer2> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServer2> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportServer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServer2> for super::Com::IDispatch {
-    fn from(value: IWdsTransportServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServer2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServer2> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportServer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServer2> for IWdsTransportServer {
-    fn from(value: IWdsTransportServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServer2> for &'a IWdsTransportServer {
-    fn from(value: &'a IWdsTransportServer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServer2> for IWdsTransportServer {
-    fn from(value: &IWdsTransportServer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportServer2, ::windows::core::IUnknown, super::Com::IDispatch, IWdsTransportServer);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportServer2 {
     fn clone(&self) -> Self {
@@ -3678,59 +2886,7 @@ impl IWdsTransportServicePolicy {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServicePolicy> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportServicePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServicePolicy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportServicePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServicePolicy> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportServicePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServicePolicy> for super::Com::IDispatch {
-    fn from(value: IWdsTransportServicePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServicePolicy> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportServicePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServicePolicy> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportServicePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServicePolicy> for IWdsTransportCacheable {
-    fn from(value: IWdsTransportServicePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServicePolicy> for &'a IWdsTransportCacheable {
-    fn from(value: &'a IWdsTransportServicePolicy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServicePolicy> for IWdsTransportCacheable {
-    fn from(value: &IWdsTransportServicePolicy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportServicePolicy, ::windows::core::IUnknown, super::Com::IDispatch, IWdsTransportCacheable);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportServicePolicy {
     fn clone(&self) -> Self {
@@ -3861,77 +3017,7 @@ impl IWdsTransportServicePolicy2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServicePolicy2> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportServicePolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServicePolicy2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportServicePolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServicePolicy2> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportServicePolicy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServicePolicy2> for super::Com::IDispatch {
-    fn from(value: IWdsTransportServicePolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServicePolicy2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportServicePolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServicePolicy2> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportServicePolicy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServicePolicy2> for IWdsTransportCacheable {
-    fn from(value: IWdsTransportServicePolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServicePolicy2> for &'a IWdsTransportCacheable {
-    fn from(value: &'a IWdsTransportServicePolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServicePolicy2> for IWdsTransportCacheable {
-    fn from(value: &IWdsTransportServicePolicy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportServicePolicy2> for IWdsTransportServicePolicy {
-    fn from(value: IWdsTransportServicePolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportServicePolicy2> for &'a IWdsTransportServicePolicy {
-    fn from(value: &'a IWdsTransportServicePolicy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportServicePolicy2> for IWdsTransportServicePolicy {
-    fn from(value: &IWdsTransportServicePolicy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportServicePolicy2, ::windows::core::IUnknown, super::Com::IDispatch, IWdsTransportCacheable, IWdsTransportServicePolicy);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportServicePolicy2 {
     fn clone(&self) -> Self {
@@ -4015,41 +3101,7 @@ impl IWdsTransportSession {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportSession> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportSession> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportSession> for super::Com::IDispatch {
-    fn from(value: IWdsTransportSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportSession> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportSession> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportSession, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportSession {
     fn clone(&self) -> Self {
@@ -4124,41 +3176,7 @@ impl IWdsTransportSetupManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportSetupManager> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportSetupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportSetupManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportSetupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportSetupManager> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportSetupManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportSetupManager> for super::Com::IDispatch {
-    fn from(value: IWdsTransportSetupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportSetupManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportSetupManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportSetupManager> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportSetupManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportSetupManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportSetupManager {
     fn clone(&self) -> Self {
@@ -4234,59 +3252,7 @@ impl IWdsTransportSetupManager2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportSetupManager2> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportSetupManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportSetupManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportSetupManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportSetupManager2> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportSetupManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportSetupManager2> for super::Com::IDispatch {
-    fn from(value: IWdsTransportSetupManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportSetupManager2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportSetupManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportSetupManager2> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportSetupManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportSetupManager2> for IWdsTransportSetupManager {
-    fn from(value: IWdsTransportSetupManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportSetupManager2> for &'a IWdsTransportSetupManager {
-    fn from(value: &'a IWdsTransportSetupManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportSetupManager2> for IWdsTransportSetupManager {
-    fn from(value: &IWdsTransportSetupManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportSetupManager2, ::windows::core::IUnknown, super::Com::IDispatch, IWdsTransportSetupManager);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportSetupManager2 {
     fn clone(&self) -> Self {
@@ -4362,41 +3328,7 @@ impl IWdsTransportTftpClient {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportTftpClient> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportTftpClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportTftpClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportTftpClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportTftpClient> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportTftpClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportTftpClient> for super::Com::IDispatch {
-    fn from(value: IWdsTransportTftpClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportTftpClient> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportTftpClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportTftpClient> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportTftpClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportTftpClient, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportTftpClient {
     fn clone(&self) -> Self {
@@ -4452,41 +3384,7 @@ impl IWdsTransportTftpManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportTftpManager> for ::windows::core::IUnknown {
-    fn from(value: IWdsTransportTftpManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportTftpManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWdsTransportTftpManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportTftpManager> for ::windows::core::IUnknown {
-    fn from(value: &IWdsTransportTftpManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWdsTransportTftpManager> for super::Com::IDispatch {
-    fn from(value: IWdsTransportTftpManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWdsTransportTftpManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWdsTransportTftpManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWdsTransportTftpManager> for super::Com::IDispatch {
-    fn from(value: &IWdsTransportTftpManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWdsTransportTftpManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWdsTransportTftpManager {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/mod.rs
@@ -31,41 +31,7 @@ impl IRDPSRAPIApplication {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIApplication> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIApplication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIApplication> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIApplication> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIApplication> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIApplication> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIApplication, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIApplication {
     fn clone(&self) -> Self {
@@ -136,41 +102,7 @@ impl IRDPSRAPIApplicationFilter {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIApplicationFilter> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIApplicationFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIApplicationFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIApplicationFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIApplicationFilter> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIApplicationFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIApplicationFilter> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIApplicationFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIApplicationFilter> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIApplicationFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIApplicationFilter> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIApplicationFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIApplicationFilter, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIApplicationFilter {
     fn clone(&self) -> Self {
@@ -233,41 +165,7 @@ impl IRDPSRAPIApplicationList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIApplicationList> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIApplicationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIApplicationList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIApplicationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIApplicationList> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIApplicationList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIApplicationList> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIApplicationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIApplicationList> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIApplicationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIApplicationList> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIApplicationList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIApplicationList, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIApplicationList {
     fn clone(&self) -> Self {
@@ -347,41 +245,7 @@ impl IRDPSRAPIAttendee {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIAttendee> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIAttendee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIAttendee> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIAttendee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIAttendee> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIAttendee) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIAttendee> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIAttendee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIAttendee> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIAttendee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIAttendee> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIAttendee) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIAttendee, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIAttendee {
     fn clone(&self) -> Self {
@@ -449,41 +313,7 @@ impl IRDPSRAPIAttendeeDisconnectInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIAttendeeDisconnectInfo> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIAttendeeDisconnectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIAttendeeDisconnectInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIAttendeeDisconnectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIAttendeeDisconnectInfo> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIAttendeeDisconnectInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIAttendeeDisconnectInfo> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIAttendeeDisconnectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIAttendeeDisconnectInfo> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIAttendeeDisconnectInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIAttendeeDisconnectInfo> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIAttendeeDisconnectInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIAttendeeDisconnectInfo, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIAttendeeDisconnectInfo {
     fn clone(&self) -> Self {
@@ -542,41 +372,7 @@ impl IRDPSRAPIAttendeeManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIAttendeeManager> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIAttendeeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIAttendeeManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIAttendeeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIAttendeeManager> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIAttendeeManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIAttendeeManager> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIAttendeeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIAttendeeManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIAttendeeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIAttendeeManager> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIAttendeeManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIAttendeeManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIAttendeeManager {
     fn clone(&self) -> Self {
@@ -637,21 +433,7 @@ impl IRDPSRAPIAudioStream {
         (::windows::core::Vtable::vtable(self).FreeBuffer)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IRDPSRAPIAudioStream> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIAudioStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRDPSRAPIAudioStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIAudioStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRDPSRAPIAudioStream> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIAudioStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIAudioStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRDPSRAPIAudioStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -698,21 +480,7 @@ impl IRDPSRAPIClipboardUseEvents {
         (::windows::core::Vtable::vtable(self).OnPasteFromClipboard)(::windows::core::Vtable::as_raw(self), clipboardformat, pattendee.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i16>(result__)
     }
 }
-impl ::core::convert::From<IRDPSRAPIClipboardUseEvents> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIClipboardUseEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRDPSRAPIClipboardUseEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIClipboardUseEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRDPSRAPIClipboardUseEvents> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIClipboardUseEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIClipboardUseEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRDPSRAPIClipboardUseEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -756,21 +524,7 @@ impl IRDPSRAPIDebug {
         (::windows::core::Vtable::vtable(self).CLXCmdLine)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IRDPSRAPIDebug> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRDPSRAPIDebug> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRDPSRAPIDebug> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIDebug, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRDPSRAPIDebug {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -826,41 +580,7 @@ impl IRDPSRAPIFrameBuffer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIFrameBuffer> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIFrameBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIFrameBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIFrameBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIFrameBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIFrameBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIFrameBuffer> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIFrameBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIFrameBuffer> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIFrameBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIFrameBuffer> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIFrameBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIFrameBuffer, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIFrameBuffer {
     fn clone(&self) -> Self {
@@ -936,41 +656,7 @@ impl IRDPSRAPIInvitation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIInvitation> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIInvitation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIInvitation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIInvitation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIInvitation> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIInvitation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIInvitation> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIInvitation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIInvitation> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIInvitation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIInvitation> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIInvitation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIInvitation, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIInvitation {
     fn clone(&self) -> Self {
@@ -1043,41 +729,7 @@ impl IRDPSRAPIInvitationManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIInvitationManager> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIInvitationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIInvitationManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIInvitationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIInvitationManager> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIInvitationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIInvitationManager> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIInvitationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIInvitationManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIInvitationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIInvitationManager> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIInvitationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIInvitationManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIInvitationManager {
     fn clone(&self) -> Self {
@@ -1130,21 +782,7 @@ impl IRDPSRAPIPerfCounterLogger {
         (::windows::core::Vtable::vtable(self).LogValue)(::windows::core::Vtable::as_raw(self), lvalue).ok()
     }
 }
-impl ::core::convert::From<IRDPSRAPIPerfCounterLogger> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIPerfCounterLogger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRDPSRAPIPerfCounterLogger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIPerfCounterLogger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRDPSRAPIPerfCounterLogger> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIPerfCounterLogger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIPerfCounterLogger, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRDPSRAPIPerfCounterLogger {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1182,21 +820,7 @@ impl IRDPSRAPIPerfCounterLoggingManager {
         (::windows::core::Vtable::vtable(self).CreateLogger)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrcountername), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRDPSRAPIPerfCounterLogger>(result__)
     }
 }
-impl ::core::convert::From<IRDPSRAPIPerfCounterLoggingManager> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIPerfCounterLoggingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRDPSRAPIPerfCounterLoggingManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIPerfCounterLoggingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRDPSRAPIPerfCounterLoggingManager> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIPerfCounterLoggingManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIPerfCounterLoggingManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRDPSRAPIPerfCounterLoggingManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1247,41 +871,7 @@ impl IRDPSRAPISessionProperties {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPISessionProperties> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPISessionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPISessionProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPISessionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPISessionProperties> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPISessionProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPISessionProperties> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPISessionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPISessionProperties> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPISessionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPISessionProperties> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPISessionProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPISessionProperties, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPISessionProperties {
     fn clone(&self) -> Self {
@@ -1390,41 +980,7 @@ impl IRDPSRAPISharingSession {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPISharingSession> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPISharingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPISharingSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPISharingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPISharingSession> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPISharingSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPISharingSession> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPISharingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPISharingSession> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPISharingSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPISharingSession> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPISharingSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPISharingSession, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPISharingSession {
     fn clone(&self) -> Self {
@@ -1574,59 +1130,7 @@ impl IRDPSRAPISharingSession2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPISharingSession2> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPISharingSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPISharingSession2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPISharingSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPISharingSession2> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPISharingSession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPISharingSession2> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPISharingSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPISharingSession2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPISharingSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPISharingSession2> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPISharingSession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPISharingSession2> for IRDPSRAPISharingSession {
-    fn from(value: IRDPSRAPISharingSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPISharingSession2> for &'a IRDPSRAPISharingSession {
-    fn from(value: &'a IRDPSRAPISharingSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPISharingSession2> for IRDPSRAPISharingSession {
-    fn from(value: &IRDPSRAPISharingSession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPISharingSession2, ::windows::core::IUnknown, super::Com::IDispatch, IRDPSRAPISharingSession);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPISharingSession2 {
     fn clone(&self) -> Self {
@@ -1698,41 +1202,7 @@ impl IRDPSRAPITcpConnectionInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPITcpConnectionInfo> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPITcpConnectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPITcpConnectionInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPITcpConnectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPITcpConnectionInfo> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPITcpConnectionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPITcpConnectionInfo> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPITcpConnectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPITcpConnectionInfo> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPITcpConnectionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPITcpConnectionInfo> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPITcpConnectionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPITcpConnectionInfo, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPITcpConnectionInfo {
     fn clone(&self) -> Self {
@@ -1808,21 +1278,7 @@ impl IRDPSRAPITransportStream {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IRDPSRAPITransportStream> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPITransportStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRDPSRAPITransportStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPITransportStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRDPSRAPITransportStream> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPITransportStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPITransportStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRDPSRAPITransportStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1900,21 +1356,7 @@ impl IRDPSRAPITransportStreamBuffer {
         (::windows::core::Vtable::vtable(self).SetContext)(::windows::core::Vtable::as_raw(self), pcontext.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IRDPSRAPITransportStreamBuffer> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPITransportStreamBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRDPSRAPITransportStreamBuffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPITransportStreamBuffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRDPSRAPITransportStreamBuffer> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPITransportStreamBuffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPITransportStreamBuffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRDPSRAPITransportStreamBuffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1972,21 +1414,7 @@ impl IRDPSRAPITransportStreamEvents {
         (::windows::core::Vtable::vtable(self).OnStreamClosed)(::windows::core::Vtable::as_raw(self), hrreason)
     }
 }
-impl ::core::convert::From<IRDPSRAPITransportStreamEvents> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPITransportStreamEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRDPSRAPITransportStreamEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPITransportStreamEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRDPSRAPITransportStreamEvents> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPITransportStreamEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPITransportStreamEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRDPSRAPITransportStreamEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2085,41 +1513,7 @@ impl IRDPSRAPIViewer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIViewer> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIViewer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIViewer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIViewer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIViewer> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIViewer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIViewer> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIViewer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIViewer> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIViewer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIViewer> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIViewer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIViewer, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIViewer {
     fn clone(&self) -> Self {
@@ -2209,41 +1603,7 @@ impl IRDPSRAPIVirtualChannel {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIVirtualChannel> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIVirtualChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIVirtualChannel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIVirtualChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIVirtualChannel> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIVirtualChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIVirtualChannel> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIVirtualChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIVirtualChannel> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIVirtualChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIVirtualChannel> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIVirtualChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIVirtualChannel, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIVirtualChannel {
     fn clone(&self) -> Self {
@@ -2310,41 +1670,7 @@ impl IRDPSRAPIVirtualChannelManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIVirtualChannelManager> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIVirtualChannelManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIVirtualChannelManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIVirtualChannelManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIVirtualChannelManager> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIVirtualChannelManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIVirtualChannelManager> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIVirtualChannelManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIVirtualChannelManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIVirtualChannelManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIVirtualChannelManager> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIVirtualChannelManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIVirtualChannelManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIVirtualChannelManager {
     fn clone(&self) -> Self {
@@ -2424,41 +1750,7 @@ impl IRDPSRAPIWindow {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIWindow> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIWindow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIWindow> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIWindow> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIWindow> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIWindow> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIWindow, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIWindow {
     fn clone(&self) -> Self {
@@ -2521,41 +1813,7 @@ impl IRDPSRAPIWindowList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIWindowList> for ::windows::core::IUnknown {
-    fn from(value: IRDPSRAPIWindowList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIWindowList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPSRAPIWindowList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIWindowList> for ::windows::core::IUnknown {
-    fn from(value: &IRDPSRAPIWindowList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRDPSRAPIWindowList> for super::Com::IDispatch {
-    fn from(value: IRDPSRAPIWindowList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRDPSRAPIWindowList> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRDPSRAPIWindowList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRDPSRAPIWindowList> for super::Com::IDispatch {
-    fn from(value: &IRDPSRAPIWindowList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPSRAPIWindowList, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRDPSRAPIWindowList {
     fn clone(&self) -> Self {
@@ -2624,21 +1882,7 @@ impl IRDPViewerInputSink {
         (::windows::core::Vtable::vtable(self).EndTouchFrame)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IRDPViewerInputSink> for ::windows::core::IUnknown {
-    fn from(value: IRDPViewerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRDPViewerInputSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRDPViewerInputSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRDPViewerInputSink> for ::windows::core::IUnknown {
-    fn from(value: &IRDPViewerInputSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRDPViewerInputSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRDPViewerInputSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2681,41 +1925,7 @@ pub struct _IRDPSessionEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _IRDPSessionEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IRDPSessionEvents> for ::windows::core::IUnknown {
-    fn from(value: _IRDPSessionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IRDPSessionEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IRDPSessionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IRDPSessionEvents> for ::windows::core::IUnknown {
-    fn from(value: &_IRDPSessionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IRDPSessionEvents> for super::Com::IDispatch {
-    fn from(value: _IRDPSessionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IRDPSessionEvents> for &'a super::Com::IDispatch {
-    fn from(value: &'a _IRDPSessionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IRDPSessionEvents> for super::Com::IDispatch {
-    fn from(value: &_IRDPSessionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IRDPSessionEvents, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IRDPSessionEvents {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
@@ -4220,21 +4220,7 @@ impl AsyncIDebugApplicationNodeEvents {
         (::windows::core::Vtable::vtable(self).Finish_onAttach)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIDebugApplicationNodeEvents> for ::windows::core::IUnknown {
-    fn from(value: AsyncIDebugApplicationNodeEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIDebugApplicationNodeEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIDebugApplicationNodeEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIDebugApplicationNodeEvents> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIDebugApplicationNodeEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIDebugApplicationNodeEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIDebugApplicationNodeEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4334,36 +4320,7 @@ impl DebugBaseEventCallbacks {
         (::windows::core::Vtable::vtable(self).base__.ChangeSymbolState)(::windows::core::Vtable::as_raw(self), flags, argument).ok()
     }
 }
-impl ::core::convert::From<DebugBaseEventCallbacks> for ::windows::core::IUnknown {
-    fn from(value: DebugBaseEventCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a DebugBaseEventCallbacks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DebugBaseEventCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DebugBaseEventCallbacks> for ::windows::core::IUnknown {
-    fn from(value: &DebugBaseEventCallbacks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<DebugBaseEventCallbacks> for IDebugEventCallbacks {
-    fn from(value: DebugBaseEventCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a DebugBaseEventCallbacks> for &'a IDebugEventCallbacks {
-    fn from(value: &'a DebugBaseEventCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DebugBaseEventCallbacks> for IDebugEventCallbacks {
-    fn from(value: &DebugBaseEventCallbacks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DebugBaseEventCallbacks, ::windows::core::IUnknown, IDebugEventCallbacks);
 impl ::core::clone::Clone for DebugBaseEventCallbacks {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4455,36 +4412,7 @@ impl DebugBaseEventCallbacksWide {
         (::windows::core::Vtable::vtable(self).base__.ChangeSymbolState)(::windows::core::Vtable::as_raw(self), flags, argument).ok()
     }
 }
-impl ::core::convert::From<DebugBaseEventCallbacksWide> for ::windows::core::IUnknown {
-    fn from(value: DebugBaseEventCallbacksWide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a DebugBaseEventCallbacksWide> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DebugBaseEventCallbacksWide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DebugBaseEventCallbacksWide> for ::windows::core::IUnknown {
-    fn from(value: &DebugBaseEventCallbacksWide) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<DebugBaseEventCallbacksWide> for IDebugEventCallbacksWide {
-    fn from(value: DebugBaseEventCallbacksWide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a DebugBaseEventCallbacksWide> for &'a IDebugEventCallbacksWide {
-    fn from(value: &'a DebugBaseEventCallbacksWide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DebugBaseEventCallbacksWide> for IDebugEventCallbacksWide {
-    fn from(value: &DebugBaseEventCallbacksWide) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DebugBaseEventCallbacksWide, ::windows::core::IUnknown, IDebugEventCallbacksWide);
 impl ::core::clone::Clone for DebugBaseEventCallbacksWide {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4579,21 +4507,7 @@ impl IActiveScript {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IActiveScript>(result__)
     }
 }
-impl ::core::convert::From<IActiveScript> for ::windows::core::IUnknown {
-    fn from(value: IActiveScript) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScript> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScript) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScript> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScript) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScript, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScript {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4735,21 +4649,7 @@ impl IActiveScriptAuthor {
         (::windows::core::Vtable::vtable(self).IsCommitChar)(::windows::core::Vtable::as_raw(self), ch, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptAuthor> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptAuthor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptAuthor> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptAuthor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptAuthor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptAuthor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4818,21 +4718,7 @@ impl IActiveScriptAuthorProcedure {
         (::windows::core::Vtable::vtable(self).ParseProcedureText)(::windows::core::Vtable::as_raw(self), pszcode.into(), pszformalparams.into(), pszprocedurename.into(), pszitemname.into(), pszdelimiter.into(), dwcookie, dwflags, pdispfor.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptAuthorProcedure> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptAuthorProcedure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptAuthorProcedure> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptAuthorProcedure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptAuthorProcedure> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptAuthorProcedure) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptAuthorProcedure, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptAuthorProcedure {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4887,21 +4773,7 @@ impl IActiveScriptDebug32 {
         (::windows::core::Vtable::vtable(self).EnumCodeContextsOfPosition)(::windows::core::Vtable::as_raw(self), dwsourcecontext, ucharacteroffset, unumchars, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugCodeContexts>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptDebug32> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptDebug32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptDebug32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptDebug32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptDebug32> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptDebug32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptDebug32, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptDebug32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4955,21 +4827,7 @@ impl IActiveScriptDebug64 {
         (::windows::core::Vtable::vtable(self).EnumCodeContextsOfPosition)(::windows::core::Vtable::as_raw(self), dwsourcecontext, ucharacteroffset, unumchars, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugCodeContexts>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptDebug64> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptDebug64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptDebug64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptDebug64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptDebug64> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptDebug64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptDebug64, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptDebug64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5020,21 +4878,7 @@ impl IActiveScriptEncode {
         (::windows::core::Vtable::vtable(self).GetEncodeProgId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbstrout)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptEncode> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptEncode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptEncode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptEncode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptEncode> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptEncode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptEncode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptEncode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5083,21 +4927,7 @@ impl IActiveScriptError {
         (::windows::core::Vtable::vtable(self).GetSourceLineText)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptError> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptError> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptError, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptError {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5152,36 +4982,7 @@ impl IActiveScriptError64 {
         (::windows::core::Vtable::vtable(self).GetSourcePosition64)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwsourcecontext), ::core::mem::transmute(pullinenumber), ::core::mem::transmute(plcharacterposition)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptError64> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptError64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptError64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptError64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptError64> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptError64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptError64> for IActiveScriptError {
-    fn from(value: IActiveScriptError64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptError64> for &'a IActiveScriptError {
-    fn from(value: &'a IActiveScriptError64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptError64> for IActiveScriptError {
-    fn from(value: &IActiveScriptError64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptError64, ::windows::core::IUnknown, IActiveScriptError);
 impl ::core::clone::Clone for IActiveScriptError64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5236,36 +5037,7 @@ impl IActiveScriptErrorDebug {
         (::windows::core::Vtable::vtable(self).GetStackFrame)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugStackFrame>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptErrorDebug> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptErrorDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptErrorDebug> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptErrorDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptErrorDebug> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptErrorDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptErrorDebug> for IActiveScriptError {
-    fn from(value: IActiveScriptErrorDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptErrorDebug> for &'a IActiveScriptError {
-    fn from(value: &'a IActiveScriptErrorDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptErrorDebug> for IActiveScriptError {
-    fn from(value: &IActiveScriptErrorDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptErrorDebug, ::windows::core::IUnknown, IActiveScriptError);
 impl ::core::clone::Clone for IActiveScriptErrorDebug {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5304,21 +5076,7 @@ impl IActiveScriptErrorDebug110 {
         (::windows::core::Vtable::vtable(self).GetExceptionThrownKind)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<SCRIPT_ERROR_DEBUG_EXCEPTION_THROWN_KIND>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptErrorDebug110> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptErrorDebug110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptErrorDebug110> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptErrorDebug110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptErrorDebug110> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptErrorDebug110) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptErrorDebug110, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptErrorDebug110 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5355,21 +5113,7 @@ impl IActiveScriptGarbageCollector {
         (::windows::core::Vtable::vtable(self).CollectGarbage)(::windows::core::Vtable::as_raw(self), scriptgctype).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptGarbageCollector> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptGarbageCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptGarbageCollector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptGarbageCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptGarbageCollector> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptGarbageCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptGarbageCollector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptGarbageCollector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5406,21 +5150,7 @@ impl IActiveScriptHostEncode {
         (::windows::core::Vtable::vtable(self).EncodeScriptHostFile)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrinfile), ::core::mem::transmute(pbstroutfile), cflags, ::core::mem::transmute_copy(bstrdefaultlang)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptHostEncode> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptHostEncode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptHostEncode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptHostEncode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptHostEncode> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptHostEncode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptHostEncode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptHostEncode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5481,21 +5211,7 @@ impl IActiveScriptParse32 {
         (::windows::core::Vtable::vtable(self).ParseScriptText)(::windows::core::Vtable::as_raw(self), pstrcode.into(), pstritemname.into(), punkcontext.into().abi(), pstrdelimiter.into(), dwsourcecontextcookie, ulstartinglinenumber, dwflags, ::core::mem::transmute(pvarresult), ::core::mem::transmute(pexcepinfo)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptParse32> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptParse32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptParse32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptParse32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptParse32> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptParse32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptParse32, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptParse32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5564,21 +5280,7 @@ impl IActiveScriptParse64 {
         (::windows::core::Vtable::vtable(self).ParseScriptText)(::windows::core::Vtable::as_raw(self), pstrcode.into(), pstritemname.into(), punkcontext.into().abi(), pstrdelimiter.into(), dwsourcecontextcookie, ulstartinglinenumber, dwflags, ::core::mem::transmute(pvarresult), ::core::mem::transmute(pexcepinfo)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptParse64> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptParse64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptParse64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptParse64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptParse64> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptParse64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptParse64, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptParse64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5634,36 +5336,7 @@ impl IActiveScriptParseProcedure2_32 {
         (::windows::core::Vtable::vtable(self).base__.ParseProcedureText)(::windows::core::Vtable::as_raw(self), pstrcode.into(), pstrformalparams.into(), pstrprocedurename.into(), pstritemname.into(), punkcontext.into().abi(), pstrdelimiter.into(), dwsourcecontextcookie, ulstartinglinenumber, dwflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Com::IDispatch>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptParseProcedure2_32> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptParseProcedure2_32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptParseProcedure2_32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptParseProcedure2_32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptParseProcedure2_32> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptParseProcedure2_32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptParseProcedure2_32> for IActiveScriptParseProcedure32 {
-    fn from(value: IActiveScriptParseProcedure2_32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptParseProcedure2_32> for &'a IActiveScriptParseProcedure32 {
-    fn from(value: &'a IActiveScriptParseProcedure2_32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptParseProcedure2_32> for IActiveScriptParseProcedure32 {
-    fn from(value: &IActiveScriptParseProcedure2_32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptParseProcedure2_32, ::windows::core::IUnknown, IActiveScriptParseProcedure32);
 impl ::core::clone::Clone for IActiveScriptParseProcedure2_32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5710,36 +5383,7 @@ impl IActiveScriptParseProcedure2_64 {
         (::windows::core::Vtable::vtable(self).base__.ParseProcedureText)(::windows::core::Vtable::as_raw(self), pstrcode.into(), pstrformalparams.into(), pstrprocedurename.into(), pstritemname.into(), punkcontext.into().abi(), pstrdelimiter.into(), dwsourcecontextcookie, ulstartinglinenumber, dwflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Com::IDispatch>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptParseProcedure2_64> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptParseProcedure2_64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptParseProcedure2_64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptParseProcedure2_64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptParseProcedure2_64> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptParseProcedure2_64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptParseProcedure2_64> for IActiveScriptParseProcedure64 {
-    fn from(value: IActiveScriptParseProcedure2_64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptParseProcedure2_64> for &'a IActiveScriptParseProcedure64 {
-    fn from(value: &'a IActiveScriptParseProcedure2_64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptParseProcedure2_64> for IActiveScriptParseProcedure64 {
-    fn from(value: &IActiveScriptParseProcedure2_64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptParseProcedure2_64, ::windows::core::IUnknown, IActiveScriptParseProcedure64);
 impl ::core::clone::Clone for IActiveScriptParseProcedure2_64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5786,21 +5430,7 @@ impl IActiveScriptParseProcedure32 {
         (::windows::core::Vtable::vtable(self).ParseProcedureText)(::windows::core::Vtable::as_raw(self), pstrcode.into(), pstrformalparams.into(), pstrprocedurename.into(), pstritemname.into(), punkcontext.into().abi(), pstrdelimiter.into(), dwsourcecontextcookie, ulstartinglinenumber, dwflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Com::IDispatch>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptParseProcedure32> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptParseProcedure32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptParseProcedure32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptParseProcedure32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptParseProcedure32> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptParseProcedure32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptParseProcedure32, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptParseProcedure32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5851,21 +5481,7 @@ impl IActiveScriptParseProcedure64 {
         (::windows::core::Vtable::vtable(self).ParseProcedureText)(::windows::core::Vtable::as_raw(self), pstrcode.into(), pstrformalparams.into(), pstrprocedurename.into(), pstritemname.into(), punkcontext.into().abi(), pstrdelimiter.into(), dwsourcecontextcookie, ulstartinglinenumber, dwflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Com::IDispatch>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptParseProcedure64> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptParseProcedure64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptParseProcedure64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptParseProcedure64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptParseProcedure64> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptParseProcedure64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptParseProcedure64, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptParseProcedure64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5915,21 +5531,7 @@ impl IActiveScriptParseProcedureOld32 {
         (::windows::core::Vtable::vtable(self).ParseProcedureText)(::windows::core::Vtable::as_raw(self), pstrcode.into(), pstrformalparams.into(), pstritemname.into(), punkcontext.into().abi(), pstrdelimiter.into(), dwsourcecontextcookie, ulstartinglinenumber, dwflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Com::IDispatch>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptParseProcedureOld32> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptParseProcedureOld32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptParseProcedureOld32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptParseProcedureOld32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptParseProcedureOld32> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptParseProcedureOld32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptParseProcedureOld32, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptParseProcedureOld32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5979,21 +5581,7 @@ impl IActiveScriptParseProcedureOld64 {
         (::windows::core::Vtable::vtable(self).ParseProcedureText)(::windows::core::Vtable::as_raw(self), pstrcode.into(), pstrformalparams.into(), pstritemname.into(), punkcontext.into().abi(), pstrdelimiter.into(), dwsourcecontextcookie, ulstartinglinenumber, dwflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Com::IDispatch>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptParseProcedureOld64> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptParseProcedureOld64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptParseProcedureOld64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptParseProcedureOld64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptParseProcedureOld64> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptParseProcedureOld64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptParseProcedureOld64, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptParseProcedureOld64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6056,21 +5644,7 @@ impl IActiveScriptProfilerCallback {
         (::windows::core::Vtable::vtable(self).OnFunctionExit)(::windows::core::Vtable::as_raw(self), scriptid, functionid).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptProfilerCallback> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptProfilerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptProfilerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerCallback> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptProfilerCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptProfilerCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptProfilerCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6147,36 +5721,7 @@ impl IActiveScriptProfilerCallback2 {
         (::windows::core::Vtable::vtable(self).OnFunctionExitByName)(::windows::core::Vtable::as_raw(self), pwszfunctionname.into(), r#type).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptProfilerCallback2> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptProfilerCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerCallback2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptProfilerCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerCallback2> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptProfilerCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerCallback2> for IActiveScriptProfilerCallback {
-    fn from(value: IActiveScriptProfilerCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerCallback2> for &'a IActiveScriptProfilerCallback {
-    fn from(value: &'a IActiveScriptProfilerCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerCallback2> for IActiveScriptProfilerCallback {
-    fn from(value: &IActiveScriptProfilerCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptProfilerCallback2, ::windows::core::IUnknown, IActiveScriptProfilerCallback);
 impl ::core::clone::Clone for IActiveScriptProfilerCallback2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6252,51 +5797,7 @@ impl IActiveScriptProfilerCallback3 {
         (::windows::core::Vtable::vtable(self).SetWebWorkerId)(::windows::core::Vtable::as_raw(self), webworkerid).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptProfilerCallback3> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptProfilerCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerCallback3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptProfilerCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerCallback3> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptProfilerCallback3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerCallback3> for IActiveScriptProfilerCallback {
-    fn from(value: IActiveScriptProfilerCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerCallback3> for &'a IActiveScriptProfilerCallback {
-    fn from(value: &'a IActiveScriptProfilerCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerCallback3> for IActiveScriptProfilerCallback {
-    fn from(value: &IActiveScriptProfilerCallback3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerCallback3> for IActiveScriptProfilerCallback2 {
-    fn from(value: IActiveScriptProfilerCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerCallback3> for &'a IActiveScriptProfilerCallback2 {
-    fn from(value: &'a IActiveScriptProfilerCallback3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerCallback3> for IActiveScriptProfilerCallback2 {
-    fn from(value: &IActiveScriptProfilerCallback3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptProfilerCallback3, ::windows::core::IUnknown, IActiveScriptProfilerCallback, IActiveScriptProfilerCallback2);
 impl ::core::clone::Clone for IActiveScriptProfilerCallback3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6339,21 +5840,7 @@ impl IActiveScriptProfilerControl {
         (::windows::core::Vtable::vtable(self).StopProfiling)(::windows::core::Vtable::as_raw(self), hrshutdownreason).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptProfilerControl> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptProfilerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptProfilerControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptProfilerControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptProfilerControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptProfilerControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6404,36 +5891,7 @@ impl IActiveScriptProfilerControl2 {
         (::windows::core::Vtable::vtable(self).PrepareProfilerStop)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptProfilerControl2> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptProfilerControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptProfilerControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl2> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptProfilerControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerControl2> for IActiveScriptProfilerControl {
-    fn from(value: IActiveScriptProfilerControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl2> for &'a IActiveScriptProfilerControl {
-    fn from(value: &'a IActiveScriptProfilerControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl2> for IActiveScriptProfilerControl {
-    fn from(value: &IActiveScriptProfilerControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptProfilerControl2, ::windows::core::IUnknown, IActiveScriptProfilerControl);
 impl ::core::clone::Clone for IActiveScriptProfilerControl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6487,51 +5945,7 @@ impl IActiveScriptProfilerControl3 {
         (::windows::core::Vtable::vtable(self).EnumHeap)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IActiveScriptProfilerHeapEnum>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptProfilerControl3> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptProfilerControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptProfilerControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl3> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptProfilerControl3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerControl3> for IActiveScriptProfilerControl {
-    fn from(value: IActiveScriptProfilerControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl3> for &'a IActiveScriptProfilerControl {
-    fn from(value: &'a IActiveScriptProfilerControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl3> for IActiveScriptProfilerControl {
-    fn from(value: &IActiveScriptProfilerControl3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerControl3> for IActiveScriptProfilerControl2 {
-    fn from(value: IActiveScriptProfilerControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl3> for &'a IActiveScriptProfilerControl2 {
-    fn from(value: &'a IActiveScriptProfilerControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl3> for IActiveScriptProfilerControl2 {
-    fn from(value: &IActiveScriptProfilerControl3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptProfilerControl3, ::windows::core::IUnknown, IActiveScriptProfilerControl, IActiveScriptProfilerControl2);
 impl ::core::clone::Clone for IActiveScriptProfilerControl3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6587,66 +6001,7 @@ impl IActiveScriptProfilerControl4 {
         (::windows::core::Vtable::vtable(self).SummarizeHeap)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(heapsummary)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptProfilerControl4> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptProfilerControl4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptProfilerControl4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl4> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptProfilerControl4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerControl4> for IActiveScriptProfilerControl {
-    fn from(value: IActiveScriptProfilerControl4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl4> for &'a IActiveScriptProfilerControl {
-    fn from(value: &'a IActiveScriptProfilerControl4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl4> for IActiveScriptProfilerControl {
-    fn from(value: &IActiveScriptProfilerControl4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerControl4> for IActiveScriptProfilerControl2 {
-    fn from(value: IActiveScriptProfilerControl4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl4> for &'a IActiveScriptProfilerControl2 {
-    fn from(value: &'a IActiveScriptProfilerControl4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl4> for IActiveScriptProfilerControl2 {
-    fn from(value: &IActiveScriptProfilerControl4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerControl4> for IActiveScriptProfilerControl3 {
-    fn from(value: IActiveScriptProfilerControl4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl4> for &'a IActiveScriptProfilerControl3 {
-    fn from(value: &'a IActiveScriptProfilerControl4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl4> for IActiveScriptProfilerControl3 {
-    fn from(value: &IActiveScriptProfilerControl4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptProfilerControl4, ::windows::core::IUnknown, IActiveScriptProfilerControl, IActiveScriptProfilerControl2, IActiveScriptProfilerControl3);
 impl ::core::clone::Clone for IActiveScriptProfilerControl4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6706,81 +6061,7 @@ impl IActiveScriptProfilerControl5 {
         (::windows::core::Vtable::vtable(self).EnumHeap2)(::windows::core::Vtable::as_raw(self), enumflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IActiveScriptProfilerHeapEnum>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptProfilerControl5> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptProfilerControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptProfilerControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl5> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptProfilerControl5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerControl5> for IActiveScriptProfilerControl {
-    fn from(value: IActiveScriptProfilerControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl5> for &'a IActiveScriptProfilerControl {
-    fn from(value: &'a IActiveScriptProfilerControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl5> for IActiveScriptProfilerControl {
-    fn from(value: &IActiveScriptProfilerControl5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerControl5> for IActiveScriptProfilerControl2 {
-    fn from(value: IActiveScriptProfilerControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl5> for &'a IActiveScriptProfilerControl2 {
-    fn from(value: &'a IActiveScriptProfilerControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl5> for IActiveScriptProfilerControl2 {
-    fn from(value: &IActiveScriptProfilerControl5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerControl5> for IActiveScriptProfilerControl3 {
-    fn from(value: IActiveScriptProfilerControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl5> for &'a IActiveScriptProfilerControl3 {
-    fn from(value: &'a IActiveScriptProfilerControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl5> for IActiveScriptProfilerControl3 {
-    fn from(value: &IActiveScriptProfilerControl5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptProfilerControl5> for IActiveScriptProfilerControl4 {
-    fn from(value: IActiveScriptProfilerControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerControl5> for &'a IActiveScriptProfilerControl4 {
-    fn from(value: &'a IActiveScriptProfilerControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerControl5> for IActiveScriptProfilerControl4 {
-    fn from(value: &IActiveScriptProfilerControl5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptProfilerControl5, ::windows::core::IUnknown, IActiveScriptProfilerControl, IActiveScriptProfilerControl2, IActiveScriptProfilerControl3, IActiveScriptProfilerControl4);
 impl ::core::clone::Clone for IActiveScriptProfilerControl5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6826,21 +6107,7 @@ impl IActiveScriptProfilerHeapEnum {
         (::windows::core::Vtable::vtable(self).GetNameIdMap)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pnamelist), ::core::mem::transmute(pcelt)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptProfilerHeapEnum> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptProfilerHeapEnum) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProfilerHeapEnum> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptProfilerHeapEnum) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProfilerHeapEnum> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptProfilerHeapEnum) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptProfilerHeapEnum, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptProfilerHeapEnum {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6888,21 +6155,7 @@ impl IActiveScriptProperty {
         (::windows::core::Vtable::vtable(self).SetProperty)(::windows::core::Vtable::as_raw(self), dwproperty, ::core::mem::transmute(pvarindex), ::core::mem::transmute(pvarvalue)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptProperty> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptProperty> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptProperty, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6947,21 +6200,7 @@ impl IActiveScriptSIPInfo {
         (::windows::core::Vtable::vtable(self).GetSIPOID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptSIPInfo> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptSIPInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptSIPInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptSIPInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptSIPInfo> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptSIPInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptSIPInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptSIPInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7031,21 +6270,7 @@ impl IActiveScriptSite {
         (::windows::core::Vtable::vtable(self).OnLeaveScript)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptSite> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptSite> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7112,21 +6337,7 @@ impl IActiveScriptSiteDebug32 {
         (::windows::core::Vtable::vtable(self).OnScriptErrorDebug)(::windows::core::Vtable::as_raw(self), perrordebug.into().abi(), ::core::mem::transmute(pfenterdebugger), ::core::mem::transmute(pfcallonscripterrorwhencontinuing)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptSiteDebug32> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptSiteDebug32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptSiteDebug32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptSiteDebug32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptSiteDebug32> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptSiteDebug32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptSiteDebug32, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptSiteDebug32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7186,21 +6397,7 @@ impl IActiveScriptSiteDebug64 {
         (::windows::core::Vtable::vtable(self).OnScriptErrorDebug)(::windows::core::Vtable::as_raw(self), perrordebug.into().abi(), ::core::mem::transmute(pfenterdebugger), ::core::mem::transmute(pfcallonscripterrorwhencontinuing)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptSiteDebug64> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptSiteDebug64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptSiteDebug64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptSiteDebug64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptSiteDebug64> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptSiteDebug64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptSiteDebug64, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptSiteDebug64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7249,21 +6446,7 @@ impl IActiveScriptSiteDebugEx {
         (::windows::core::Vtable::vtable(self).OnCanNotJITScriptErrorDebug)(::windows::core::Vtable::as_raw(self), perrordebug.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptSiteDebugEx> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptSiteDebugEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptSiteDebugEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptSiteDebugEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptSiteDebugEx> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptSiteDebugEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptSiteDebugEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptSiteDebugEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7303,21 +6486,7 @@ impl IActiveScriptSiteInterruptPoll {
         (::windows::core::Vtable::vtable(self).QueryContinue)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptSiteInterruptPoll> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptSiteInterruptPoll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptSiteInterruptPoll> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptSiteInterruptPoll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptSiteInterruptPoll> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptSiteInterruptPoll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptSiteInterruptPoll, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptSiteInterruptPoll {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7354,21 +6523,7 @@ impl IActiveScriptSiteTraceInfo {
         (::windows::core::Vtable::vtable(self).SendScriptTraceInfo)(::windows::core::Vtable::as_raw(self), stieventtype, ::core::mem::transmute(guidcontextid), dwscriptcontextcookie, lscriptstatementstart, lscriptstatementend, dwreserved).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptSiteTraceInfo> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptSiteTraceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptSiteTraceInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptSiteTraceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptSiteTraceInfo> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptSiteTraceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptSiteTraceInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptSiteTraceInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7406,21 +6561,7 @@ impl IActiveScriptSiteUIControl {
         (::windows::core::Vtable::vtable(self).GetUIBehavior)(::windows::core::Vtable::as_raw(self), uicitem, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<SCRIPTUICHANDLING>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptSiteUIControl> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptSiteUIControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptSiteUIControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptSiteUIControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptSiteUIControl> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptSiteUIControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptSiteUIControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptSiteUIControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7468,21 +6609,7 @@ impl IActiveScriptSiteWindow {
         (::windows::core::Vtable::vtable(self).EnableModeless)(::windows::core::Vtable::as_raw(self), fenable.into()).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptSiteWindow> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptSiteWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptSiteWindow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptSiteWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptSiteWindow> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptSiteWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptSiteWindow, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptSiteWindow {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7532,21 +6659,7 @@ impl IActiveScriptStats {
         (::windows::core::Vtable::vtable(self).ResetStats)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptStats> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptStats) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptStats> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptStats) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptStats> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptStats) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptStats, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptStats {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7586,21 +6699,7 @@ impl IActiveScriptStringCompare {
         (::windows::core::Vtable::vtable(self).StrComp)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bszstr1), ::core::mem::transmute_copy(bszstr2), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptStringCompare> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptStringCompare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptStringCompare> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptStringCompare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptStringCompare> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptStringCompare) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptStringCompare, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptStringCompare {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7643,21 +6742,7 @@ impl IActiveScriptTraceInfo {
         (::windows::core::Vtable::vtable(self).StopScriptTracing)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IActiveScriptTraceInfo> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptTraceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptTraceInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptTraceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptTraceInfo> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptTraceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptTraceInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveScriptTraceInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7717,36 +6802,7 @@ impl IActiveScriptWinRTErrorDebug {
         (::windows::core::Vtable::vtable(self).GetCapabilitySid)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IActiveScriptWinRTErrorDebug> for ::windows::core::IUnknown {
-    fn from(value: IActiveScriptWinRTErrorDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptWinRTErrorDebug> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveScriptWinRTErrorDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptWinRTErrorDebug> for ::windows::core::IUnknown {
-    fn from(value: &IActiveScriptWinRTErrorDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveScriptWinRTErrorDebug> for IActiveScriptError {
-    fn from(value: IActiveScriptWinRTErrorDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveScriptWinRTErrorDebug> for &'a IActiveScriptError {
-    fn from(value: &'a IActiveScriptWinRTErrorDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveScriptWinRTErrorDebug> for IActiveScriptError {
-    fn from(value: &IActiveScriptWinRTErrorDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveScriptWinRTErrorDebug, ::windows::core::IUnknown, IActiveScriptError);
 impl ::core::clone::Clone for IActiveScriptWinRTErrorDebug {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7814,21 +6870,7 @@ impl IApplicationDebugger {
         (::windows::core::Vtable::vtable(self).onDebuggerEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), punk.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IApplicationDebugger> for ::windows::core::IUnknown {
-    fn from(value: IApplicationDebugger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationDebugger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApplicationDebugger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationDebugger> for ::windows::core::IUnknown {
-    fn from(value: &IApplicationDebugger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApplicationDebugger, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApplicationDebugger {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7879,21 +6921,7 @@ impl IApplicationDebuggerUI {
         (::windows::core::Vtable::vtable(self).BringDocumentContextToTop)(::windows::core::Vtable::as_raw(self), pddc.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IApplicationDebuggerUI> for ::windows::core::IUnknown {
-    fn from(value: IApplicationDebuggerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationDebuggerUI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApplicationDebuggerUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationDebuggerUI> for ::windows::core::IUnknown {
-    fn from(value: &IApplicationDebuggerUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApplicationDebuggerUI, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApplicationDebuggerUI {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7937,21 +6965,7 @@ impl IBindEventHandler {
         (::windows::core::Vtable::vtable(self).BindHandler)(::windows::core::Vtable::as_raw(self), pstrevent.into(), pdisp.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IBindEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IBindEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBindEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBindEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBindEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IBindEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBindEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBindEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7995,21 +7009,7 @@ impl ICodeAddressConcept {
         (::windows::core::Vtable::vtable(self).GetContainingSymbol)(::windows::core::Vtable::as_raw(self), pcontextobject.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugHostSymbol>(result__)
     }
 }
-impl ::core::convert::From<ICodeAddressConcept> for ::windows::core::IUnknown {
-    fn from(value: ICodeAddressConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICodeAddressConcept> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICodeAddressConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICodeAddressConcept> for ::windows::core::IUnknown {
-    fn from(value: &ICodeAddressConcept) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICodeAddressConcept, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICodeAddressConcept {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8051,21 +7051,7 @@ impl IComparableConcept {
         (::windows::core::Vtable::vtable(self).CompareObjects)(::windows::core::Vtable::as_raw(self), contextobject.into().abi(), otherobject.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IComparableConcept> for ::windows::core::IUnknown {
-    fn from(value: IComparableConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComparableConcept> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComparableConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComparableConcept> for ::windows::core::IUnknown {
-    fn from(value: &IComparableConcept) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComparableConcept, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComparableConcept {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8111,21 +7097,7 @@ impl IDataModelConcept {
         (::windows::core::Vtable::vtable(self).GetName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IDataModelConcept> for ::windows::core::IUnknown {
-    fn from(value: IDataModelConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelConcept> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelConcept> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelConcept) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelConcept, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelConcept {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8291,21 +7263,7 @@ impl IDataModelManager {
         (::windows::core::Vtable::vtable(self).AcquireNamedModel)(::windows::core::Vtable::as_raw(self), modelname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IModelObject>(result__)
     }
 }
-impl ::core::convert::From<IDataModelManager> for ::windows::core::IUnknown {
-    fn from(value: IDataModelManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelManager> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8515,36 +7473,7 @@ impl IDataModelManager2 {
         (::windows::core::Vtable::vtable(self).CreateTypedIntrinsicObjectEx)(::windows::core::Vtable::as_raw(self), context.into().abi(), ::core::mem::transmute(intrinsicdata), r#type.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IModelObject>(result__)
     }
 }
-impl ::core::convert::From<IDataModelManager2> for ::windows::core::IUnknown {
-    fn from(value: IDataModelManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelManager2> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDataModelManager2> for IDataModelManager {
-    fn from(value: IDataModelManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelManager2> for &'a IDataModelManager {
-    fn from(value: &'a IDataModelManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelManager2> for IDataModelManager {
-    fn from(value: &IDataModelManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelManager2, ::windows::core::IUnknown, IDataModelManager);
 impl ::core::clone::Clone for IDataModelManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8610,21 +7539,7 @@ impl IDataModelNameBinder {
         (::windows::core::Vtable::vtable(self).EnumerateReferences)(::windows::core::Vtable::as_raw(self), contextobject.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IKeyEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IDataModelNameBinder> for ::windows::core::IUnknown {
-    fn from(value: IDataModelNameBinder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelNameBinder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelNameBinder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelNameBinder> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelNameBinder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelNameBinder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelNameBinder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8698,21 +7613,7 @@ impl IDataModelScript {
         (::windows::core::Vtable::vtable(self).InvokeMain)(::windows::core::Vtable::as_raw(self), client.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDataModelScript> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScript) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScript> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScript) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScript> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScript) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScript, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScript {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8761,21 +7662,7 @@ impl IDataModelScriptClient {
         (::windows::core::Vtable::vtable(self).ReportError)(::windows::core::Vtable::as_raw(self), errclass, hrfail, message.into(), line, position).ok()
     }
 }
-impl ::core::convert::From<IDataModelScriptClient> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptClient> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8850,21 +7737,7 @@ impl IDataModelScriptDebug {
         (::windows::core::Vtable::vtable(self).StopDebugging)(::windows::core::Vtable::as_raw(self), debugclient.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDataModelScriptDebug> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptDebug> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptDebug> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptDebug, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptDebug {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8955,36 +7828,7 @@ impl IDataModelScriptDebug2 {
         (::windows::core::Vtable::vtable(self).SetBreakpointAtFunction)(::windows::core::Vtable::as_raw(self), functionname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDataModelScriptDebugBreakpoint>(result__)
     }
 }
-impl ::core::convert::From<IDataModelScriptDebug2> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptDebug2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptDebug2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptDebug2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptDebug2> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptDebug2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDataModelScriptDebug2> for IDataModelScriptDebug {
-    fn from(value: IDataModelScriptDebug2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptDebug2> for &'a IDataModelScriptDebug {
-    fn from(value: &'a IDataModelScriptDebug2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptDebug2> for IDataModelScriptDebug {
-    fn from(value: &IDataModelScriptDebug2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptDebug2, ::windows::core::IUnknown, IDataModelScriptDebug);
 impl ::core::clone::Clone for IDataModelScriptDebug2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9036,21 +7880,7 @@ impl IDataModelScriptDebugBreakpoint {
         (::windows::core::Vtable::vtable(self).GetPosition)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(position), ::core::mem::transmute(positionspanend.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(linetext.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDataModelScriptDebugBreakpoint> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptDebugBreakpoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptDebugBreakpoint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptDebugBreakpoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptDebugBreakpoint> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptDebugBreakpoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptDebugBreakpoint, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptDebugBreakpoint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9096,21 +7926,7 @@ impl IDataModelScriptDebugBreakpointEnumerator {
         (::windows::core::Vtable::vtable(self).GetNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDataModelScriptDebugBreakpoint>(result__)
     }
 }
-impl ::core::convert::From<IDataModelScriptDebugBreakpointEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptDebugBreakpointEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptDebugBreakpointEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptDebugBreakpointEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptDebugBreakpointEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptDebugBreakpointEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptDebugBreakpointEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptDebugBreakpointEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9152,21 +7968,7 @@ impl IDataModelScriptDebugClient {
         (::windows::core::Vtable::vtable(self).NotifyDebugEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(peventinfo), pscript.into().abi(), peventdataobject.into().abi(), ::core::mem::transmute(resumeeventkind)).ok()
     }
 }
-impl ::core::convert::From<IDataModelScriptDebugClient> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptDebugClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptDebugClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptDebugClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptDebugClient> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptDebugClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptDebugClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptDebugClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9207,21 +8009,7 @@ impl IDataModelScriptDebugStack {
         (::windows::core::Vtable::vtable(self).GetStackFrame)(::windows::core::Vtable::as_raw(self), framenumber, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDataModelScriptDebugStackFrame>(result__)
     }
 }
-impl ::core::convert::From<IDataModelScriptDebugStack> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptDebugStack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptDebugStack> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptDebugStack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptDebugStack> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptDebugStack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptDebugStack, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptDebugStack {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9285,21 +8073,7 @@ impl IDataModelScriptDebugStackFrame {
         (::windows::core::Vtable::vtable(self).EnumerateArguments)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDataModelScriptDebugVariableSetEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IDataModelScriptDebugStackFrame> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptDebugStackFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptDebugStackFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptDebugStackFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptDebugStackFrame> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptDebugStackFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptDebugStackFrame, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptDebugStackFrame {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9345,21 +8119,7 @@ impl IDataModelScriptDebugVariableSetEnumerator {
         (::windows::core::Vtable::vtable(self).GetNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(variablename), ::core::mem::transmute(variablevalue.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(variablemetadata.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDataModelScriptDebugVariableSetEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptDebugVariableSetEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptDebugVariableSetEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptDebugVariableSetEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptDebugVariableSetEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptDebugVariableSetEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptDebugVariableSetEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptDebugVariableSetEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9404,21 +8164,7 @@ impl IDataModelScriptHostContext {
         (::windows::core::Vtable::vtable(self).GetNamespaceObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IModelObject>(result__)
     }
 }
-impl ::core::convert::From<IDataModelScriptHostContext> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptHostContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptHostContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptHostContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptHostContext> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptHostContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptHostContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptHostContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9487,21 +8233,7 @@ impl IDataModelScriptManager {
         (::windows::core::Vtable::vtable(self).EnumerateScriptProviders)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDataModelScriptProviderEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IDataModelScriptManager> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptManager> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9560,21 +8292,7 @@ impl IDataModelScriptProvider {
         (::windows::core::Vtable::vtable(self).EnumerateTemplates)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDataModelScriptTemplateEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IDataModelScriptProvider> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptProvider> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9619,21 +8337,7 @@ impl IDataModelScriptProviderEnumerator {
         (::windows::core::Vtable::vtable(self).GetNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDataModelScriptProvider>(result__)
     }
 }
-impl ::core::convert::From<IDataModelScriptProviderEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptProviderEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptProviderEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptProviderEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptProviderEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptProviderEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptProviderEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptProviderEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9682,21 +8386,7 @@ impl IDataModelScriptTemplate {
         (::windows::core::Vtable::vtable(self).GetContent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IDataModelScriptTemplate> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptTemplate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptTemplate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptTemplate> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptTemplate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptTemplate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptTemplate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9742,21 +8432,7 @@ impl IDataModelScriptTemplateEnumerator {
         (::windows::core::Vtable::vtable(self).GetNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDataModelScriptTemplate>(result__)
     }
 }
-impl ::core::convert::From<IDataModelScriptTemplateEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IDataModelScriptTemplateEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataModelScriptTemplateEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataModelScriptTemplateEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataModelScriptTemplateEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IDataModelScriptTemplateEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataModelScriptTemplateEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataModelScriptTemplateEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9797,21 +8473,7 @@ impl IDebugAdvanced {
         (::windows::core::Vtable::vtable(self).SetThreadContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(context), contextsize).ok()
     }
 }
-impl ::core::convert::From<IDebugAdvanced> for ::windows::core::IUnknown {
-    fn from(value: IDebugAdvanced) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugAdvanced> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugAdvanced) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugAdvanced> for ::windows::core::IUnknown {
-    fn from(value: &IDebugAdvanced) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugAdvanced, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugAdvanced {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9873,21 +8535,7 @@ impl IDebugAdvanced2 {
         (::windows::core::Vtable::vtable(self).GetSystemObjectInformation)(::windows::core::Vtable::as_raw(self), which, arg64, arg32, ::core::mem::transmute(buffer.unwrap_or(::std::ptr::null_mut())), buffersize, ::core::mem::transmute(infosize.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDebugAdvanced2> for ::windows::core::IUnknown {
-    fn from(value: IDebugAdvanced2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugAdvanced2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugAdvanced2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugAdvanced2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugAdvanced2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugAdvanced2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugAdvanced2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9969,21 +8617,7 @@ impl IDebugAdvanced3 {
         (::windows::core::Vtable::vtable(self).GetSymbolInformationWide)(::windows::core::Vtable::as_raw(self), which, arg64, arg32, ::core::mem::transmute(buffer.unwrap_or(::std::ptr::null_mut())), buffersize, ::core::mem::transmute(infosize.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(stringbuffer.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), stringbuffer.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(stringsize.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDebugAdvanced3> for ::windows::core::IUnknown {
-    fn from(value: IDebugAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugAdvanced3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugAdvanced3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugAdvanced3> for ::windows::core::IUnknown {
-    fn from(value: &IDebugAdvanced3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugAdvanced3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugAdvanced3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10084,21 +8718,7 @@ impl IDebugAdvanced4 {
         .ok()
     }
 }
-impl ::core::convert::From<IDebugAdvanced4> for ::windows::core::IUnknown {
-    fn from(value: IDebugAdvanced4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugAdvanced4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugAdvanced4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugAdvanced4> for ::windows::core::IUnknown {
-    fn from(value: &IDebugAdvanced4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugAdvanced4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugAdvanced4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10171,36 +8791,7 @@ impl IDebugApplication11032 {
         (::windows::core::Vtable::vtable(self).CallableWaitForHandles)(::windows::core::Vtable::as_raw(self), phandles.len() as _, ::core::mem::transmute(phandles.as_ptr()), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDebugApplication11032> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplication11032) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplication11032> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplication11032) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplication11032> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplication11032) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugApplication11032> for IRemoteDebugApplication110 {
-    fn from(value: IDebugApplication11032) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplication11032> for &'a IRemoteDebugApplication110 {
-    fn from(value: &'a IDebugApplication11032) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplication11032> for IRemoteDebugApplication110 {
-    fn from(value: &IDebugApplication11032) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplication11032, ::windows::core::IUnknown, IRemoteDebugApplication110);
 impl ::core::clone::Clone for IDebugApplication11032 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10268,36 +8859,7 @@ impl IDebugApplication11064 {
         (::windows::core::Vtable::vtable(self).CallableWaitForHandles)(::windows::core::Vtable::as_raw(self), phandles.len() as _, ::core::mem::transmute(phandles.as_ptr()), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDebugApplication11064> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplication11064) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplication11064> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplication11064) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplication11064> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplication11064) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugApplication11064> for IRemoteDebugApplication110 {
-    fn from(value: IDebugApplication11064) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplication11064> for &'a IRemoteDebugApplication110 {
-    fn from(value: &'a IDebugApplication11064) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplication11064> for IRemoteDebugApplication110 {
-    fn from(value: &IDebugApplication11064) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplication11064, ::windows::core::IUnknown, IRemoteDebugApplication110);
 impl ::core::clone::Clone for IDebugApplication11064 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10481,36 +9043,7 @@ impl IDebugApplication32 {
         (::windows::core::Vtable::vtable(self).RemoveGlobalExpressionContextProvider)(::windows::core::Vtable::as_raw(self), dwcookie).ok()
     }
 }
-impl ::core::convert::From<IDebugApplication32> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplication32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplication32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplication32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplication32> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplication32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugApplication32> for IRemoteDebugApplication {
-    fn from(value: IDebugApplication32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplication32> for &'a IRemoteDebugApplication {
-    fn from(value: &'a IDebugApplication32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplication32> for IRemoteDebugApplication {
-    fn from(value: &IDebugApplication32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplication32, ::windows::core::IUnknown, IRemoteDebugApplication);
 impl ::core::clone::Clone for IDebugApplication32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10717,36 +9250,7 @@ impl IDebugApplication64 {
         (::windows::core::Vtable::vtable(self).RemoveGlobalExpressionContextProvider)(::windows::core::Vtable::as_raw(self), dwcookie).ok()
     }
 }
-impl ::core::convert::From<IDebugApplication64> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplication64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplication64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplication64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplication64> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplication64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugApplication64> for IRemoteDebugApplication {
-    fn from(value: IDebugApplication64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplication64> for &'a IRemoteDebugApplication {
-    fn from(value: &'a IDebugApplication64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplication64> for IRemoteDebugApplication {
-    fn from(value: &IDebugApplication64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplication64, ::windows::core::IUnknown, IRemoteDebugApplication);
 impl ::core::clone::Clone for IDebugApplication64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10846,51 +9350,7 @@ impl IDebugApplicationNode {
         (::windows::core::Vtable::vtable(self).Detach)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDebugApplicationNode> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationNode> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplicationNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugApplicationNode> for IDebugDocumentInfo {
-    fn from(value: IDebugApplicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationNode> for &'a IDebugDocumentInfo {
-    fn from(value: &'a IDebugApplicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationNode> for IDebugDocumentInfo {
-    fn from(value: &IDebugApplicationNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugApplicationNode> for IDebugDocumentProvider {
-    fn from(value: IDebugApplicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationNode> for &'a IDebugDocumentProvider {
-    fn from(value: &'a IDebugApplicationNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationNode> for IDebugDocumentProvider {
-    fn from(value: &IDebugApplicationNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplicationNode, ::windows::core::IUnknown, IDebugDocumentInfo, IDebugDocumentProvider);
 impl ::core::clone::Clone for IDebugApplicationNode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10942,21 +9402,7 @@ impl IDebugApplicationNode100 {
         (::windows::core::Vtable::vtable(self).QueryIsChildNode)(::windows::core::Vtable::as_raw(self), psearchkey.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDebugApplicationNode100> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplicationNode100) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationNode100> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplicationNode100) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationNode100> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplicationNode100) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplicationNode100, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugApplicationNode100 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11013,21 +9459,7 @@ impl IDebugApplicationNodeEvents {
         (::windows::core::Vtable::vtable(self).onAttach)(::windows::core::Vtable::as_raw(self), prddpparent.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDebugApplicationNodeEvents> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplicationNodeEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationNodeEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplicationNodeEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationNodeEvents> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplicationNodeEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplicationNodeEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugApplicationNodeEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11126,36 +9558,7 @@ impl IDebugApplicationThread {
         (::windows::core::Vtable::vtable(self).SetStateString)(::windows::core::Vtable::as_raw(self), pstrstate.into()).ok()
     }
 }
-impl ::core::convert::From<IDebugApplicationThread> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplicationThread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationThread> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplicationThread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationThread> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplicationThread) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugApplicationThread> for IRemoteDebugApplicationThread {
-    fn from(value: IDebugApplicationThread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationThread> for &'a IRemoteDebugApplicationThread {
-    fn from(value: &'a IDebugApplicationThread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationThread> for IRemoteDebugApplicationThread {
-    fn from(value: &IDebugApplicationThread) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplicationThread, ::windows::core::IUnknown, IRemoteDebugApplicationThread);
 impl ::core::clone::Clone for IDebugApplicationThread {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11215,21 +9618,7 @@ impl IDebugApplicationThread11032 {
         (::windows::core::Vtable::vtable(self).AsynchronousCallIntoThread)(::windows::core::Vtable::as_raw(self), pptc.into().abi(), dwparam1, dwparam2, dwparam3).ok()
     }
 }
-impl ::core::convert::From<IDebugApplicationThread11032> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplicationThread11032) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationThread11032> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplicationThread11032) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationThread11032> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplicationThread11032) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplicationThread11032, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugApplicationThread11032 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11294,21 +9683,7 @@ impl IDebugApplicationThread11064 {
         (::windows::core::Vtable::vtable(self).AsynchronousCallIntoThread)(::windows::core::Vtable::as_raw(self), pptc.into().abi(), dwparam1, dwparam2, dwparam3).ok()
     }
 }
-impl ::core::convert::From<IDebugApplicationThread11064> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplicationThread11064) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationThread11064> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplicationThread11064) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationThread11064> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplicationThread11064) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplicationThread11064, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugApplicationThread11064 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11419,51 +9794,7 @@ impl IDebugApplicationThread64 {
         (::windows::core::Vtable::vtable(self).SynchronousCallIntoThread64)(::windows::core::Vtable::as_raw(self), pstcb.into().abi(), dwparam1, dwparam2, dwparam3).ok()
     }
 }
-impl ::core::convert::From<IDebugApplicationThread64> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplicationThread64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationThread64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplicationThread64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationThread64> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplicationThread64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugApplicationThread64> for IRemoteDebugApplicationThread {
-    fn from(value: IDebugApplicationThread64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationThread64> for &'a IRemoteDebugApplicationThread {
-    fn from(value: &'a IDebugApplicationThread64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationThread64> for IRemoteDebugApplicationThread {
-    fn from(value: &IDebugApplicationThread64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugApplicationThread64> for IDebugApplicationThread {
-    fn from(value: IDebugApplicationThread64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationThread64> for &'a IDebugApplicationThread {
-    fn from(value: &'a IDebugApplicationThread64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationThread64> for IDebugApplicationThread {
-    fn from(value: &IDebugApplicationThread64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplicationThread64, ::windows::core::IUnknown, IRemoteDebugApplicationThread, IDebugApplicationThread);
 impl ::core::clone::Clone for IDebugApplicationThread64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11509,21 +9840,7 @@ impl IDebugApplicationThreadEvents110 {
         (::windows::core::Vtable::vtable(self).OnBeginThreadRequest)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDebugApplicationThreadEvents110> for ::windows::core::IUnknown {
-    fn from(value: IDebugApplicationThreadEvents110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugApplicationThreadEvents110> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugApplicationThreadEvents110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugApplicationThreadEvents110> for ::windows::core::IUnknown {
-    fn from(value: &IDebugApplicationThreadEvents110) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugApplicationThreadEvents110, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugApplicationThreadEvents110 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11579,21 +9896,7 @@ impl IDebugAsyncOperation {
         (::windows::core::Vtable::vtable(self).GetResult)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phrresult), ::core::mem::transmute(ppunkresult)).ok()
     }
 }
-impl ::core::convert::From<IDebugAsyncOperation> for ::windows::core::IUnknown {
-    fn from(value: IDebugAsyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugAsyncOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugAsyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugAsyncOperation> for ::windows::core::IUnknown {
-    fn from(value: &IDebugAsyncOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugAsyncOperation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugAsyncOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11634,21 +9937,7 @@ impl IDebugAsyncOperationCallBack {
         (::windows::core::Vtable::vtable(self).onComplete)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDebugAsyncOperationCallBack> for ::windows::core::IUnknown {
-    fn from(value: IDebugAsyncOperationCallBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugAsyncOperationCallBack> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugAsyncOperationCallBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugAsyncOperationCallBack> for ::windows::core::IUnknown {
-    fn from(value: &IDebugAsyncOperationCallBack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugAsyncOperationCallBack, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugAsyncOperationCallBack {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11759,21 +10048,7 @@ impl IDebugBreakpoint {
         (::windows::core::Vtable::vtable(self).GetParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DEBUG_BREAKPOINT_PARAMETERS>(result__)
     }
 }
-impl ::core::convert::From<IDebugBreakpoint> for ::windows::core::IUnknown {
-    fn from(value: IDebugBreakpoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugBreakpoint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugBreakpoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugBreakpoint> for ::windows::core::IUnknown {
-    fn from(value: &IDebugBreakpoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugBreakpoint, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugBreakpoint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11922,21 +10197,7 @@ impl IDebugBreakpoint2 {
         (::windows::core::Vtable::vtable(self).SetOffsetExpressionWide)(::windows::core::Vtable::as_raw(self), expression.into()).ok()
     }
 }
-impl ::core::convert::From<IDebugBreakpoint2> for ::windows::core::IUnknown {
-    fn from(value: IDebugBreakpoint2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugBreakpoint2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugBreakpoint2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugBreakpoint2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugBreakpoint2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugBreakpoint2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugBreakpoint2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12093,21 +10354,7 @@ impl IDebugBreakpoint3 {
         (::windows::core::Vtable::vtable(self).GetGuid)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IDebugBreakpoint3> for ::windows::core::IUnknown {
-    fn from(value: IDebugBreakpoint3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugBreakpoint3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugBreakpoint3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugBreakpoint3> for ::windows::core::IUnknown {
-    fn from(value: &IDebugBreakpoint3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugBreakpoint3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugBreakpoint3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12381,21 +10628,7 @@ impl IDebugClient {
         (::windows::core::Vtable::vtable(self).FlushCallbacks)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDebugClient> for ::windows::core::IUnknown {
-    fn from(value: IDebugClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugClient> for ::windows::core::IUnknown {
-    fn from(value: &IDebugClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12719,21 +10952,7 @@ impl IDebugClient2 {
         (::windows::core::Vtable::vtable(self).AbandonCurrentProcess)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDebugClient2> for ::windows::core::IUnknown {
-    fn from(value: IDebugClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugClient2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugClient2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugClient2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugClient2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugClient2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13099,21 +11318,7 @@ impl IDebugClient3 {
         (::windows::core::Vtable::vtable(self).CreateProcessAndAttachWide)(::windows::core::Vtable::as_raw(self), server, commandline.into(), createflags, processid, attachflags).ok()
     }
 }
-impl ::core::convert::From<IDebugClient3> for ::windows::core::IUnknown {
-    fn from(value: IDebugClient3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugClient3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugClient3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugClient3> for ::windows::core::IUnknown {
-    fn from(value: &IDebugClient3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugClient3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugClient3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13512,21 +11717,7 @@ impl IDebugClient4 {
         (::windows::core::Vtable::vtable(self).GetDumpFileWide)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(buffer.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), buffer.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(namesize.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(handle.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(r#type)).ok()
     }
 }
-impl ::core::convert::From<IDebugClient4> for ::windows::core::IUnknown {
-    fn from(value: IDebugClient4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugClient4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugClient4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugClient4> for ::windows::core::IUnknown {
-    fn from(value: &IDebugClient4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugClient4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugClient4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14088,21 +12279,7 @@ impl IDebugClient5 {
         (::windows::core::Vtable::vtable(self).SetQuitLockStringWide)(::windows::core::Vtable::as_raw(self), string.into()).ok()
     }
 }
-impl ::core::convert::From<IDebugClient5> for ::windows::core::IUnknown {
-    fn from(value: IDebugClient5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugClient5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugClient5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugClient5> for ::windows::core::IUnknown {
-    fn from(value: &IDebugClient5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugClient5, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugClient5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14699,21 +12876,7 @@ impl IDebugClient6 {
         (::windows::core::Vtable::vtable(self).SetEventContextCallbacks)(::windows::core::Vtable::as_raw(self), callbacks.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDebugClient6> for ::windows::core::IUnknown {
-    fn from(value: IDebugClient6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugClient6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugClient6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugClient6> for ::windows::core::IUnknown {
-    fn from(value: &IDebugClient6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugClient6, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugClient6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15314,21 +13477,7 @@ impl IDebugClient7 {
         (::windows::core::Vtable::vtable(self).SetClientContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(context), contextsize).ok()
     }
 }
-impl ::core::convert::From<IDebugClient7> for ::windows::core::IUnknown {
-    fn from(value: IDebugClient7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugClient7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugClient7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugClient7> for ::windows::core::IUnknown {
-    fn from(value: &IDebugClient7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugClient7, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugClient7 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15936,21 +14085,7 @@ impl IDebugClient8 {
         (::windows::core::Vtable::vtable(self).OpenDumpFileWide2)(::windows::core::Vtable::as_raw(self), filename.into(), filehandle, alternatearch).ok()
     }
 }
-impl ::core::convert::From<IDebugClient8> for ::windows::core::IUnknown {
-    fn from(value: IDebugClient8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugClient8> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugClient8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugClient8> for ::windows::core::IUnknown {
-    fn from(value: &IDebugClient8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugClient8, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugClient8 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16085,21 +14220,7 @@ impl IDebugCodeContext {
         (::windows::core::Vtable::vtable(self).SetBreakPoint)(::windows::core::Vtable::as_raw(self), bps).ok()
     }
 }
-impl ::core::convert::From<IDebugCodeContext> for ::windows::core::IUnknown {
-    fn from(value: IDebugCodeContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugCodeContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugCodeContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugCodeContext> for ::windows::core::IUnknown {
-    fn from(value: &IDebugCodeContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugCodeContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugCodeContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16559,21 +14680,7 @@ impl IDebugControl {
         .ok()
     }
 }
-impl ::core::convert::From<IDebugControl> for ::windows::core::IUnknown {
-    fn from(value: IDebugControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugControl> for ::windows::core::IUnknown {
-    fn from(value: &IDebugControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17199,21 +15306,7 @@ impl IDebugControl2 {
         (::windows::core::Vtable::vtable(self).OutputTextReplacements)(::windows::core::Vtable::as_raw(self), outputcontrol, flags).ok()
     }
 }
-impl ::core::convert::From<IDebugControl2> for ::windows::core::IUnknown {
-    fn from(value: IDebugControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugControl2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugControl2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugControl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17909,21 +16002,7 @@ impl IDebugControl3 {
         (::windows::core::Vtable::vtable(self).SetNextEventIndex)(::windows::core::Vtable::as_raw(self), relation, value, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDebugControl3> for ::windows::core::IUnknown {
-    fn from(value: IDebugControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugControl3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugControl3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugControl3> for ::windows::core::IUnknown {
-    fn from(value: &IDebugControl3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugControl3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugControl3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18937,21 +17016,7 @@ impl IDebugControl4 {
         (::windows::core::Vtable::vtable(self).ResetManagedStatus)(::windows::core::Vtable::as_raw(self), flags).ok()
     }
 }
-impl ::core::convert::From<IDebugControl4> for ::windows::core::IUnknown {
-    fn from(value: IDebugControl4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugControl4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugControl4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugControl4> for ::windows::core::IUnknown {
-    fn from(value: &IDebugControl4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugControl4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugControl4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20060,21 +18125,7 @@ impl IDebugControl5 {
         (::windows::core::Vtable::vtable(self).GetBreakpointByGuid)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugBreakpoint3>(result__)
     }
 }
-impl ::core::convert::From<IDebugControl5> for ::windows::core::IUnknown {
-    fn from(value: IDebugControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugControl5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugControl5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugControl5> for ::windows::core::IUnknown {
-    fn from(value: &IDebugControl5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugControl5, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugControl5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21207,21 +19258,7 @@ impl IDebugControl6 {
         (::windows::core::Vtable::vtable(self).GetSynchronizationStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(sendsattempted), ::core::mem::transmute(secondssincelastresponse)).ok()
     }
 }
-impl ::core::convert::From<IDebugControl6> for ::windows::core::IUnknown {
-    fn from(value: IDebugControl6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugControl6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugControl6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugControl6> for ::windows::core::IUnknown {
-    fn from(value: &IDebugControl6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugControl6, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugControl6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22359,21 +20396,7 @@ impl IDebugControl7 {
         (::windows::core::Vtable::vtable(self).GetDebuggeeType2)(::windows::core::Vtable::as_raw(self), flags, ::core::mem::transmute(class), ::core::mem::transmute(qualifier)).ok()
     }
 }
-impl ::core::convert::From<IDebugControl7> for ::windows::core::IUnknown {
-    fn from(value: IDebugControl7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugControl7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugControl7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugControl7> for ::windows::core::IUnknown {
-    fn from(value: &IDebugControl7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugControl7, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugControl7 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22643,21 +20666,7 @@ impl IDebugCookie {
         (::windows::core::Vtable::vtable(self).SetDebugCookie)(::windows::core::Vtable::as_raw(self), dwdebugappcookie).ok()
     }
 }
-impl ::core::convert::From<IDebugCookie> for ::windows::core::IUnknown {
-    fn from(value: IDebugCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugCookie> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugCookie> for ::windows::core::IUnknown {
-    fn from(value: &IDebugCookie) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugCookie, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugCookie {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22759,21 +20768,7 @@ impl IDebugDataSpaces {
         (::windows::core::Vtable::vtable(self).ReadProcessorSystemData)(::windows::core::Vtable::as_raw(self), processor, index, ::core::mem::transmute(buffer), buffersize, ::core::mem::transmute(datasize.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDebugDataSpaces> for ::windows::core::IUnknown {
-    fn from(value: IDebugDataSpaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDataSpaces> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDataSpaces) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDataSpaces> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDataSpaces) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDataSpaces, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugDataSpaces {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22918,21 +20913,7 @@ impl IDebugDataSpaces2 {
         (::windows::core::Vtable::vtable(self).QueryVirtual)(::windows::core::Vtable::as_raw(self), offset, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Memory::MEMORY_BASIC_INFORMATION64>(result__)
     }
 }
-impl ::core::convert::From<IDebugDataSpaces2> for ::windows::core::IUnknown {
-    fn from(value: IDebugDataSpaces2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDataSpaces2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDataSpaces2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDataSpaces2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDataSpaces2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDataSpaces2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugDataSpaces2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23105,21 +21086,7 @@ impl IDebugDataSpaces3 {
         (::windows::core::Vtable::vtable(self).EndEnumTagged)(::windows::core::Vtable::as_raw(self), handle).ok()
     }
 }
-impl ::core::convert::From<IDebugDataSpaces3> for ::windows::core::IUnknown {
-    fn from(value: IDebugDataSpaces3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDataSpaces3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDataSpaces3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDataSpaces3> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDataSpaces3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDataSpaces3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugDataSpaces3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23333,21 +21300,7 @@ impl IDebugDataSpaces4 {
         (::windows::core::Vtable::vtable(self).WritePhysical2)(::windows::core::Vtable::as_raw(self), offset, flags, ::core::mem::transmute(buffer), buffersize, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDebugDataSpaces4> for ::windows::core::IUnknown {
-    fn from(value: IDebugDataSpaces4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDataSpaces4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDataSpaces4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDataSpaces4> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDataSpaces4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDataSpaces4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugDataSpaces4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23435,36 +21388,7 @@ impl IDebugDocument {
         (::windows::core::Vtable::vtable(self).base__.GetDocumentClassId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IDebugDocument> for ::windows::core::IUnknown {
-    fn from(value: IDebugDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocument> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugDocument> for IDebugDocumentInfo {
-    fn from(value: IDebugDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocument> for &'a IDebugDocumentInfo {
-    fn from(value: &'a IDebugDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocument> for IDebugDocumentInfo {
-    fn from(value: &IDebugDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDocument, ::windows::core::IUnknown, IDebugDocumentInfo);
 impl ::core::clone::Clone for IDebugDocument {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23505,21 +21429,7 @@ impl IDebugDocumentContext {
         (::windows::core::Vtable::vtable(self).EnumCodeContexts)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugCodeContexts>(result__)
     }
 }
-impl ::core::convert::From<IDebugDocumentContext> for ::windows::core::IUnknown {
-    fn from(value: IDebugDocumentContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDocumentContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentContext> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDocumentContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDocumentContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugDocumentContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23643,21 +21553,7 @@ impl IDebugDocumentHelper32 {
         (::windows::core::Vtable::vtable(self).BringDocumentContextToTop)(::windows::core::Vtable::as_raw(self), pddc.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDebugDocumentHelper32> for ::windows::core::IUnknown {
-    fn from(value: IDebugDocumentHelper32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentHelper32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDocumentHelper32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentHelper32> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDocumentHelper32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDocumentHelper32, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugDocumentHelper32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23800,21 +21696,7 @@ impl IDebugDocumentHelper64 {
         (::windows::core::Vtable::vtable(self).BringDocumentContextToTop)(::windows::core::Vtable::as_raw(self), pddc.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDebugDocumentHelper64> for ::windows::core::IUnknown {
-    fn from(value: IDebugDocumentHelper64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentHelper64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDocumentHelper64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentHelper64> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDocumentHelper64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDocumentHelper64, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugDocumentHelper64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23894,21 +21776,7 @@ impl IDebugDocumentHost {
         (::windows::core::Vtable::vtable(self).NotifyChanged)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDebugDocumentHost> for ::windows::core::IUnknown {
-    fn from(value: IDebugDocumentHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDocumentHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentHost> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDocumentHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDocumentHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugDocumentHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23958,21 +21826,7 @@ impl IDebugDocumentInfo {
         (::windows::core::Vtable::vtable(self).GetDocumentClassId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IDebugDocumentInfo> for ::windows::core::IUnknown {
-    fn from(value: IDebugDocumentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDocumentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentInfo> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDocumentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDocumentInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugDocumentInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24019,36 +21873,7 @@ impl IDebugDocumentProvider {
         (::windows::core::Vtable::vtable(self).GetDocument)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugDocument>(result__)
     }
 }
-impl ::core::convert::From<IDebugDocumentProvider> for ::windows::core::IUnknown {
-    fn from(value: IDebugDocumentProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDocumentProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentProvider> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDocumentProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugDocumentProvider> for IDebugDocumentInfo {
-    fn from(value: IDebugDocumentProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentProvider> for &'a IDebugDocumentInfo {
-    fn from(value: &'a IDebugDocumentProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentProvider> for IDebugDocumentInfo {
-    fn from(value: &IDebugDocumentProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDocumentProvider, ::windows::core::IUnknown, IDebugDocumentInfo);
 impl ::core::clone::Clone for IDebugDocumentProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24117,51 +21942,7 @@ impl IDebugDocumentText {
         (::windows::core::Vtable::vtable(self).GetContextOfPosition)(::windows::core::Vtable::as_raw(self), ccharacterposition, cnumchars, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugDocumentContext>(result__)
     }
 }
-impl ::core::convert::From<IDebugDocumentText> for ::windows::core::IUnknown {
-    fn from(value: IDebugDocumentText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentText> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDocumentText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentText> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDocumentText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugDocumentText> for IDebugDocumentInfo {
-    fn from(value: IDebugDocumentText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentText> for &'a IDebugDocumentInfo {
-    fn from(value: &'a IDebugDocumentText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentText> for IDebugDocumentInfo {
-    fn from(value: &IDebugDocumentText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugDocumentText> for IDebugDocument {
-    fn from(value: IDebugDocumentText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentText> for &'a IDebugDocument {
-    fn from(value: &'a IDebugDocumentText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentText> for IDebugDocument {
-    fn from(value: &IDebugDocumentText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDocumentText, ::windows::core::IUnknown, IDebugDocumentInfo, IDebugDocument);
 impl ::core::clone::Clone for IDebugDocumentText {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24245,66 +22026,7 @@ impl IDebugDocumentTextAuthor {
         (::windows::core::Vtable::vtable(self).ReplaceText)(::windows::core::Vtable::as_raw(self), ccharacterposition, pchartext.len() as _, ::core::mem::transmute(pchartext.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IDebugDocumentTextAuthor> for ::windows::core::IUnknown {
-    fn from(value: IDebugDocumentTextAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentTextAuthor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDocumentTextAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentTextAuthor> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDocumentTextAuthor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugDocumentTextAuthor> for IDebugDocumentInfo {
-    fn from(value: IDebugDocumentTextAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentTextAuthor> for &'a IDebugDocumentInfo {
-    fn from(value: &'a IDebugDocumentTextAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentTextAuthor> for IDebugDocumentInfo {
-    fn from(value: &IDebugDocumentTextAuthor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugDocumentTextAuthor> for IDebugDocument {
-    fn from(value: IDebugDocumentTextAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentTextAuthor> for &'a IDebugDocument {
-    fn from(value: &'a IDebugDocumentTextAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentTextAuthor> for IDebugDocument {
-    fn from(value: &IDebugDocumentTextAuthor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugDocumentTextAuthor> for IDebugDocumentText {
-    fn from(value: IDebugDocumentTextAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentTextAuthor> for &'a IDebugDocumentText {
-    fn from(value: &'a IDebugDocumentTextAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentTextAuthor> for IDebugDocumentText {
-    fn from(value: &IDebugDocumentTextAuthor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDocumentTextAuthor, ::windows::core::IUnknown, IDebugDocumentInfo, IDebugDocument, IDebugDocumentText);
 impl ::core::clone::Clone for IDebugDocumentTextAuthor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24358,21 +22080,7 @@ impl IDebugDocumentTextEvents {
         (::windows::core::Vtable::vtable(self).onUpdateDocumentAttributes)(::windows::core::Vtable::as_raw(self), textdocattr).ok()
     }
 }
-impl ::core::convert::From<IDebugDocumentTextEvents> for ::windows::core::IUnknown {
-    fn from(value: IDebugDocumentTextEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentTextEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDocumentTextEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentTextEvents> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDocumentTextEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDocumentTextEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugDocumentTextEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24423,21 +22131,7 @@ impl IDebugDocumentTextExternalAuthor {
         (::windows::core::Vtable::vtable(self).NotifyChanged)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDebugDocumentTextExternalAuthor> for ::windows::core::IUnknown {
-    fn from(value: IDebugDocumentTextExternalAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugDocumentTextExternalAuthor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugDocumentTextExternalAuthor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugDocumentTextExternalAuthor> for ::windows::core::IUnknown {
-    fn from(value: &IDebugDocumentTextExternalAuthor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugDocumentTextExternalAuthor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugDocumentTextExternalAuthor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24535,21 +22229,7 @@ impl IDebugEventCallbacks {
         (::windows::core::Vtable::vtable(self).ChangeSymbolState)(::windows::core::Vtable::as_raw(self), flags, argument).ok()
     }
 }
-impl ::core::convert::From<IDebugEventCallbacks> for ::windows::core::IUnknown {
-    fn from(value: IDebugEventCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugEventCallbacks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugEventCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugEventCallbacks> for ::windows::core::IUnknown {
-    fn from(value: &IDebugEventCallbacks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugEventCallbacks, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugEventCallbacks {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24658,21 +22338,7 @@ impl IDebugEventCallbacksWide {
         (::windows::core::Vtable::vtable(self).ChangeSymbolState)(::windows::core::Vtable::as_raw(self), flags, argument).ok()
     }
 }
-impl ::core::convert::From<IDebugEventCallbacksWide> for ::windows::core::IUnknown {
-    fn from(value: IDebugEventCallbacksWide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugEventCallbacksWide> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugEventCallbacksWide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugEventCallbacksWide> for ::windows::core::IUnknown {
-    fn from(value: &IDebugEventCallbacksWide) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugEventCallbacksWide, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugEventCallbacksWide {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24781,21 +22447,7 @@ impl IDebugEventContextCallbacks {
         (::windows::core::Vtable::vtable(self).ChangeSymbolState)(::windows::core::Vtable::as_raw(self), flags, argument).ok()
     }
 }
-impl ::core::convert::From<IDebugEventContextCallbacks> for ::windows::core::IUnknown {
-    fn from(value: IDebugEventContextCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugEventContextCallbacks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugEventContextCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugEventContextCallbacks> for ::windows::core::IUnknown {
-    fn from(value: &IDebugEventContextCallbacks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugEventContextCallbacks, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugEventContextCallbacks {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24863,21 +22515,7 @@ impl IDebugExpression {
         (::windows::core::Vtable::vtable(self).GetResultAsDebugProperty)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phrresult), ::core::mem::transmute(ppdp)).ok()
     }
 }
-impl ::core::convert::From<IDebugExpression> for ::windows::core::IUnknown {
-    fn from(value: IDebugExpression) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugExpression> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugExpression) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugExpression> for ::windows::core::IUnknown {
-    fn from(value: &IDebugExpression) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugExpression, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugExpression {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24918,21 +22556,7 @@ impl IDebugExpressionCallBack {
         (::windows::core::Vtable::vtable(self).onComplete)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDebugExpressionCallBack> for ::windows::core::IUnknown {
-    fn from(value: IDebugExpressionCallBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugExpressionCallBack> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugExpressionCallBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugExpressionCallBack> for ::windows::core::IUnknown {
-    fn from(value: &IDebugExpressionCallBack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugExpressionCallBack, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugExpressionCallBack {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24977,21 +22601,7 @@ impl IDebugExpressionContext {
         (::windows::core::Vtable::vtable(self).GetLanguageInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbstrlanguagename), ::core::mem::transmute(planguageid)).ok()
     }
 }
-impl ::core::convert::From<IDebugExpressionContext> for ::windows::core::IUnknown {
-    fn from(value: IDebugExpressionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugExpressionContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugExpressionContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugExpressionContext> for ::windows::core::IUnknown {
-    fn from(value: &IDebugExpressionContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugExpressionContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugExpressionContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25060,36 +22670,7 @@ impl IDebugExtendedProperty {
         (::windows::core::Vtable::vtable(self).EnumExtendedMembers)(::windows::core::Vtable::as_raw(self), dwfieldspec, nradix, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugExtendedPropertyInfo>(result__)
     }
 }
-impl ::core::convert::From<IDebugExtendedProperty> for ::windows::core::IUnknown {
-    fn from(value: IDebugExtendedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugExtendedProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugExtendedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugExtendedProperty> for ::windows::core::IUnknown {
-    fn from(value: &IDebugExtendedProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugExtendedProperty> for IDebugProperty {
-    fn from(value: IDebugExtendedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugExtendedProperty> for &'a IDebugProperty {
-    fn from(value: &'a IDebugExtendedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugExtendedProperty> for IDebugProperty {
-    fn from(value: &IDebugExtendedProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugExtendedProperty, ::windows::core::IUnknown, IDebugProperty);
 impl ::core::clone::Clone for IDebugExtendedProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25148,21 +22729,7 @@ impl IDebugFormatter {
         (::windows::core::Vtable::vtable(self).GetStringForVarType)(::windows::core::Vtable::as_raw(self), vt, ::core::mem::transmute(ptdescarraytype), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IDebugFormatter> for ::windows::core::IUnknown {
-    fn from(value: IDebugFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugFormatter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugFormatter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugFormatter> for ::windows::core::IUnknown {
-    fn from(value: &IDebugFormatter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugFormatter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugFormatter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25237,21 +22804,7 @@ impl IDebugHelper {
         (::windows::core::Vtable::vtable(self).CreateSimpleConnectionPoint)(::windows::core::Vtable::as_raw(self), pdisp.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISimpleConnectionPoint>(result__)
     }
 }
-impl ::core::convert::From<IDebugHelper> for ::windows::core::IUnknown {
-    fn from(value: IDebugHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHelper> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25308,21 +22861,7 @@ impl IDebugHost {
         (::windows::core::Vtable::vtable(self).GetDefaultMetadata)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IKeyStore>(result__)
     }
 }
-impl ::core::convert::From<IDebugHost> for ::windows::core::IUnknown {
-    fn from(value: IDebugHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHost> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25396,36 +22935,7 @@ impl IDebugHostBaseClass {
         (::windows::core::Vtable::vtable(self).GetOffset)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostBaseClass> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostBaseClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostBaseClass> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostBaseClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostBaseClass> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostBaseClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostBaseClass> for IDebugHostSymbol {
-    fn from(value: IDebugHostBaseClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostBaseClass> for &'a IDebugHostSymbol {
-    fn from(value: &'a IDebugHostBaseClass) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostBaseClass> for IDebugHostSymbol {
-    fn from(value: &IDebugHostBaseClass) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostBaseClass, ::windows::core::IUnknown, IDebugHostSymbol);
 impl ::core::clone::Clone for IDebugHostBaseClass {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25499,36 +23009,7 @@ impl IDebugHostConstant {
         (::windows::core::Vtable::vtable(self).GetValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostConstant> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostConstant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostConstant> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostConstant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostConstant> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostConstant) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostConstant> for IDebugHostSymbol {
-    fn from(value: IDebugHostConstant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostConstant> for &'a IDebugHostSymbol {
-    fn from(value: &'a IDebugHostConstant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostConstant> for IDebugHostSymbol {
-    fn from(value: &IDebugHostConstant) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostConstant, ::windows::core::IUnknown, IDebugHostSymbol);
 impl ::core::clone::Clone for IDebugHostConstant {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25572,21 +23053,7 @@ impl IDebugHostContext {
         (::windows::core::Vtable::vtable(self).IsEqualTo)(::windows::core::Vtable::as_raw(self), pcontext.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<bool>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostContext> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostContext> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25668,36 +23135,7 @@ impl IDebugHostData {
         (::windows::core::Vtable::vtable(self).GetValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostData> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostData> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostData> for IDebugHostSymbol {
-    fn from(value: IDebugHostData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostData> for &'a IDebugHostSymbol {
-    fn from(value: &'a IDebugHostData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostData> for IDebugHostSymbol {
-    fn from(value: &IDebugHostData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostData, ::windows::core::IUnknown, IDebugHostSymbol);
 impl ::core::clone::Clone for IDebugHostData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25742,21 +23180,7 @@ impl IDebugHostErrorSink {
         (::windows::core::Vtable::vtable(self).ReportError)(::windows::core::Vtable::as_raw(self), errclass, hrerror, message.into()).ok()
     }
 }
-impl ::core::convert::From<IDebugHostErrorSink> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostErrorSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostErrorSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostErrorSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostErrorSink> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostErrorSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostErrorSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostErrorSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25806,21 +23230,7 @@ impl IDebugHostEvaluator {
         (::windows::core::Vtable::vtable(self).EvaluateExtendedExpression)(::windows::core::Vtable::as_raw(self), context.into().abi(), expression.into(), bindingcontext.into().abi(), ::core::mem::transmute(result), ::core::mem::transmute(metadata.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDebugHostEvaluator> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostEvaluator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostEvaluator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostEvaluator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostEvaluator> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostEvaluator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostEvaluator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostEvaluator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25878,36 +23288,7 @@ impl IDebugHostEvaluator2 {
         (::windows::core::Vtable::vtable(self).AssignTo)(::windows::core::Vtable::as_raw(self), assignmentreference.into().abi(), assignmentvalue.into().abi(), ::core::mem::transmute(assignmentresult), ::core::mem::transmute(assignmentmetadata.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDebugHostEvaluator2> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostEvaluator2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostEvaluator2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostEvaluator2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostEvaluator2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostEvaluator2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostEvaluator2> for IDebugHostEvaluator {
-    fn from(value: IDebugHostEvaluator2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostEvaluator2> for &'a IDebugHostEvaluator {
-    fn from(value: &'a IDebugHostEvaluator2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostEvaluator2> for IDebugHostEvaluator {
-    fn from(value: &IDebugHostEvaluator2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostEvaluator2, ::windows::core::IUnknown, IDebugHostEvaluator);
 impl ::core::clone::Clone for IDebugHostEvaluator2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25954,21 +23335,7 @@ impl IDebugHostExtensibility {
         (::windows::core::Vtable::vtable(self).DestroyFunctionAlias)(::windows::core::Vtable::as_raw(self), aliasname.into()).ok()
     }
 }
-impl ::core::convert::From<IDebugHostExtensibility> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostExtensibility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostExtensibility> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostExtensibility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostExtensibility> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostExtensibility) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostExtensibility, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostExtensibility {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26055,36 +23422,7 @@ impl IDebugHostField {
         (::windows::core::Vtable::vtable(self).GetValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostField> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostField> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostField> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostField) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostField> for IDebugHostSymbol {
-    fn from(value: IDebugHostField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostField> for &'a IDebugHostSymbol {
-    fn from(value: &'a IDebugHostField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostField> for IDebugHostSymbol {
-    fn from(value: &IDebugHostField) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostField, ::windows::core::IUnknown, IDebugHostSymbol);
 impl ::core::clone::Clone for IDebugHostField {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26156,21 +23494,7 @@ impl IDebugHostMemory {
         (::windows::core::Vtable::vtable(self).GetDisplayStringForLocation)(::windows::core::Vtable::as_raw(self), context.into().abi(), ::core::mem::transmute(location), verbose, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostMemory> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostMemory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostMemory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostMemory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostMemory> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostMemory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostMemory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostMemory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26247,36 +23571,7 @@ impl IDebugHostMemory2 {
         (::windows::core::Vtable::vtable(self).LinearizeLocation)(::windows::core::Vtable::as_raw(self), context.into().abi(), ::core::mem::transmute(location), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<Location>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostMemory2> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostMemory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostMemory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostMemory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostMemory2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostMemory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostMemory2> for IDebugHostMemory {
-    fn from(value: IDebugHostMemory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostMemory2> for &'a IDebugHostMemory {
-    fn from(value: &'a IDebugHostMemory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostMemory2> for IDebugHostMemory {
-    fn from(value: &IDebugHostMemory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostMemory2, ::windows::core::IUnknown, IDebugHostMemory);
 impl ::core::clone::Clone for IDebugHostMemory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26373,36 +23668,7 @@ impl IDebugHostModule {
         (::windows::core::Vtable::vtable(self).FindSymbolByName)(::windows::core::Vtable::as_raw(self), symbolname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugHostSymbol>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostModule> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostModule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostModule> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostModule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostModule> for IDebugHostSymbol {
-    fn from(value: IDebugHostModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostModule> for &'a IDebugHostSymbol {
-    fn from(value: &'a IDebugHostModule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostModule> for IDebugHostSymbol {
-    fn from(value: &IDebugHostModule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostModule, ::windows::core::IUnknown, IDebugHostSymbol);
 impl ::core::clone::Clone for IDebugHostModule {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26507,51 +23773,7 @@ impl IDebugHostModule2 {
         (::windows::core::Vtable::vtable(self).FindContainingSymbolByRVA)(::windows::core::Vtable::as_raw(self), rva, ::core::mem::transmute(symbol), ::core::mem::transmute(offset)).ok()
     }
 }
-impl ::core::convert::From<IDebugHostModule2> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostModule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostModule2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostModule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostModule2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostModule2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostModule2> for IDebugHostSymbol {
-    fn from(value: IDebugHostModule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostModule2> for &'a IDebugHostSymbol {
-    fn from(value: &'a IDebugHostModule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostModule2> for IDebugHostSymbol {
-    fn from(value: &IDebugHostModule2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostModule2> for IDebugHostModule {
-    fn from(value: IDebugHostModule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostModule2> for &'a IDebugHostModule {
-    fn from(value: &'a IDebugHostModule2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostModule2> for IDebugHostModule {
-    fn from(value: &IDebugHostModule2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostModule2, ::windows::core::IUnknown, IDebugHostSymbol, IDebugHostModule);
 impl ::core::clone::Clone for IDebugHostModule2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26592,21 +23814,7 @@ impl IDebugHostModuleSignature {
         (::windows::core::Vtable::vtable(self).IsMatch)(::windows::core::Vtable::as_raw(self), pmodule.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<bool>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostModuleSignature> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostModuleSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostModuleSignature> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostModuleSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostModuleSignature> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostModuleSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostModuleSignature, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostModuleSignature {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26682,36 +23890,7 @@ impl IDebugHostPublic {
         (::windows::core::Vtable::vtable(self).GetLocation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<Location>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostPublic> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostPublic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostPublic> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostPublic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostPublic> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostPublic) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostPublic> for IDebugHostSymbol {
-    fn from(value: IDebugHostPublic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostPublic> for &'a IDebugHostSymbol {
-    fn from(value: &'a IDebugHostPublic) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostPublic> for IDebugHostSymbol {
-    fn from(value: &IDebugHostPublic) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostPublic, ::windows::core::IUnknown, IDebugHostSymbol);
 impl ::core::clone::Clone for IDebugHostPublic {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26753,21 +23932,7 @@ impl IDebugHostScriptHost {
         (::windows::core::Vtable::vtable(self).CreateContext)(::windows::core::Vtable::as_raw(self), script.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDataModelScriptHostContext>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostScriptHost> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostScriptHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostScriptHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostScriptHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostScriptHost> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostScriptHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostScriptHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostScriptHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26805,21 +23970,7 @@ impl IDebugHostStatus {
         (::windows::core::Vtable::vtable(self).PollUserInterrupt)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<bool>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostStatus> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostStatus> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostStatus, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostStatus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26887,21 +24038,7 @@ impl IDebugHostSymbol {
         (::windows::core::Vtable::vtable(self).CompareAgainst)(::windows::core::Vtable::as_raw(self), pcomparisonsymbol.into().abi(), comparisonflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<bool>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostSymbol> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostSymbol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostSymbol> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostSymbol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostSymbol> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostSymbol) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostSymbol, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostSymbol {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26979,36 +24116,7 @@ impl IDebugHostSymbol2 {
         (::windows::core::Vtable::vtable(self).GetLanguage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<LanguageKind>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostSymbol2> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostSymbol2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostSymbol2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostSymbol2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostSymbol2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostSymbol2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostSymbol2> for IDebugHostSymbol {
-    fn from(value: IDebugHostSymbol2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostSymbol2> for &'a IDebugHostSymbol {
-    fn from(value: &'a IDebugHostSymbol2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostSymbol2> for IDebugHostSymbol {
-    fn from(value: &IDebugHostSymbol2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostSymbol2, ::windows::core::IUnknown, IDebugHostSymbol);
 impl ::core::clone::Clone for IDebugHostSymbol2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27049,21 +24157,7 @@ impl IDebugHostSymbolEnumerator {
         (::windows::core::Vtable::vtable(self).GetNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugHostSymbol>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostSymbolEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostSymbolEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostSymbolEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostSymbolEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostSymbolEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostSymbolEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostSymbolEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostSymbolEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27154,21 +24248,7 @@ impl IDebugHostSymbols {
         (::windows::core::Vtable::vtable(self).GetMostDerivedObject)(::windows::core::Vtable::as_raw(self), pcontext.into().abi(), ::core::mem::transmute(location), objecttype.into().abi(), ::core::mem::transmute(derivedlocation), ::core::mem::transmute(derivedtype)).ok()
     }
 }
-impl ::core::convert::From<IDebugHostSymbols> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostSymbols) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostSymbols> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostSymbols) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostSymbols> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostSymbols) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostSymbols, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostSymbols {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27315,36 +24395,7 @@ impl IDebugHostType {
         (::windows::core::Vtable::vtable(self).GetGenericArgumentAt)(::windows::core::Vtable::as_raw(self), i, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugHostSymbol>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostType> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostType> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostType> for IDebugHostSymbol {
-    fn from(value: IDebugHostType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostType> for &'a IDebugHostSymbol {
-    fn from(value: &'a IDebugHostType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostType> for IDebugHostSymbol {
-    fn from(value: &IDebugHostType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostType, ::windows::core::IUnknown, IDebugHostSymbol);
 impl ::core::clone::Clone for IDebugHostType {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27523,51 +24574,7 @@ impl IDebugHostType2 {
         (::windows::core::Vtable::vtable(self).GetFunctionInstancePointerType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugHostType2>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostType2> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostType2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostType2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostType2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostType2> for IDebugHostSymbol {
-    fn from(value: IDebugHostType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostType2> for &'a IDebugHostSymbol {
-    fn from(value: &'a IDebugHostType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostType2> for IDebugHostSymbol {
-    fn from(value: &IDebugHostType2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugHostType2> for IDebugHostType {
-    fn from(value: IDebugHostType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostType2> for &'a IDebugHostType {
-    fn from(value: &'a IDebugHostType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostType2> for IDebugHostType {
-    fn from(value: &IDebugHostType2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostType2, ::windows::core::IUnknown, IDebugHostSymbol, IDebugHostType);
 impl ::core::clone::Clone for IDebugHostType2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27622,21 +24629,7 @@ impl IDebugHostTypeSignature {
         (::windows::core::Vtable::vtable(self).CompareAgainst)(::windows::core::Vtable::as_raw(self), typesignature.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<SignatureComparison>(result__)
     }
 }
-impl ::core::convert::From<IDebugHostTypeSignature> for ::windows::core::IUnknown {
-    fn from(value: IDebugHostTypeSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugHostTypeSignature> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugHostTypeSignature) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugHostTypeSignature> for ::windows::core::IUnknown {
-    fn from(value: &IDebugHostTypeSignature) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugHostTypeSignature, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugHostTypeSignature {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27678,21 +24671,7 @@ impl IDebugInputCallbacks {
         (::windows::core::Vtable::vtable(self).EndInput)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDebugInputCallbacks> for ::windows::core::IUnknown {
-    fn from(value: IDebugInputCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugInputCallbacks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugInputCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugInputCallbacks> for ::windows::core::IUnknown {
-    fn from(value: &IDebugInputCallbacks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugInputCallbacks, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugInputCallbacks {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27733,21 +24712,7 @@ impl IDebugOutputCallbacks {
         (::windows::core::Vtable::vtable(self).Output)(::windows::core::Vtable::as_raw(self), mask, text.into()).ok()
     }
 }
-impl ::core::convert::From<IDebugOutputCallbacks> for ::windows::core::IUnknown {
-    fn from(value: IDebugOutputCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugOutputCallbacks> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugOutputCallbacks) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugOutputCallbacks> for ::windows::core::IUnknown {
-    fn from(value: &IDebugOutputCallbacks) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugOutputCallbacks, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugOutputCallbacks {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27797,21 +24762,7 @@ impl IDebugOutputCallbacks2 {
         (::windows::core::Vtable::vtable(self).Output2)(::windows::core::Vtable::as_raw(self), which, flags, arg, text.into()).ok()
     }
 }
-impl ::core::convert::From<IDebugOutputCallbacks2> for ::windows::core::IUnknown {
-    fn from(value: IDebugOutputCallbacks2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugOutputCallbacks2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugOutputCallbacks2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugOutputCallbacks2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugOutputCallbacks2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugOutputCallbacks2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugOutputCallbacks2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27853,21 +24804,7 @@ impl IDebugOutputCallbacksWide {
         (::windows::core::Vtable::vtable(self).Output)(::windows::core::Vtable::as_raw(self), mask, text.into()).ok()
     }
 }
-impl ::core::convert::From<IDebugOutputCallbacksWide> for ::windows::core::IUnknown {
-    fn from(value: IDebugOutputCallbacksWide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugOutputCallbacksWide> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugOutputCallbacksWide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugOutputCallbacksWide> for ::windows::core::IUnknown {
-    fn from(value: &IDebugOutputCallbacksWide) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugOutputCallbacksWide, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugOutputCallbacksWide {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27907,21 +24844,7 @@ impl IDebugOutputStream {
         (::windows::core::Vtable::vtable(self).Write)(::windows::core::Vtable::as_raw(self), psz.into()).ok()
     }
 }
-impl ::core::convert::From<IDebugOutputStream> for ::windows::core::IUnknown {
-    fn from(value: IDebugOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugOutputStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugOutputStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugOutputStream> for ::windows::core::IUnknown {
-    fn from(value: &IDebugOutputStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugOutputStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugOutputStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27963,21 +24886,7 @@ impl IDebugPlmClient {
         (::windows::core::Vtable::vtable(self).LaunchPlmPackageForDebugWide)(::windows::core::Vtable::as_raw(self), server, timeout, packagefullname.into(), appname.into(), arguments.into(), ::core::mem::transmute(processid), ::core::mem::transmute(threadid)).ok()
     }
 }
-impl ::core::convert::From<IDebugPlmClient> for ::windows::core::IUnknown {
-    fn from(value: IDebugPlmClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPlmClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugPlmClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPlmClient> for ::windows::core::IUnknown {
-    fn from(value: &IDebugPlmClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugPlmClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugPlmClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28026,21 +24935,7 @@ impl IDebugPlmClient2 {
         (::windows::core::Vtable::vtable(self).LaunchPlmBgTaskForDebugWide)(::windows::core::Vtable::as_raw(self), server, timeout, packagefullname.into(), backgroundtaskid.into(), ::core::mem::transmute(processid), ::core::mem::transmute(threadid)).ok()
     }
 }
-impl ::core::convert::From<IDebugPlmClient2> for ::windows::core::IUnknown {
-    fn from(value: IDebugPlmClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPlmClient2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugPlmClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPlmClient2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugPlmClient2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugPlmClient2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugPlmClient2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28148,21 +25043,7 @@ impl IDebugPlmClient3 {
         (::windows::core::Vtable::vtable(self).ActivateAndDebugPlmBgTaskWide)(::windows::core::Vtable::as_raw(self), server, packagefullname.into(), backgroundtaskid.into()).ok()
     }
 }
-impl ::core::convert::From<IDebugPlmClient3> for ::windows::core::IUnknown {
-    fn from(value: IDebugPlmClient3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPlmClient3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugPlmClient3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPlmClient3> for ::windows::core::IUnknown {
-    fn from(value: &IDebugPlmClient3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugPlmClient3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugPlmClient3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28230,21 +25111,7 @@ impl IDebugProperty {
         (::windows::core::Vtable::vtable(self).GetParent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugProperty>(result__)
     }
 }
-impl ::core::convert::From<IDebugProperty> for ::windows::core::IUnknown {
-    fn from(value: IDebugProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugProperty> for ::windows::core::IUnknown {
-    fn from(value: &IDebugProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugProperty, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28289,21 +25156,7 @@ impl IDebugPropertyEnumType_All {
         (::windows::core::Vtable::vtable(self).GetName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IDebugPropertyEnumType_All> for ::windows::core::IUnknown {
-    fn from(value: IDebugPropertyEnumType_All) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPropertyEnumType_All> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugPropertyEnumType_All) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPropertyEnumType_All> for ::windows::core::IUnknown {
-    fn from(value: &IDebugPropertyEnumType_All) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugPropertyEnumType_All, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugPropertyEnumType_All {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28341,36 +25194,7 @@ impl IDebugPropertyEnumType_Arguments {
         (::windows::core::Vtable::vtable(self).base__.GetName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IDebugPropertyEnumType_Arguments> for ::windows::core::IUnknown {
-    fn from(value: IDebugPropertyEnumType_Arguments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPropertyEnumType_Arguments> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugPropertyEnumType_Arguments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPropertyEnumType_Arguments> for ::windows::core::IUnknown {
-    fn from(value: &IDebugPropertyEnumType_Arguments) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugPropertyEnumType_Arguments> for IDebugPropertyEnumType_All {
-    fn from(value: IDebugPropertyEnumType_Arguments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPropertyEnumType_Arguments> for &'a IDebugPropertyEnumType_All {
-    fn from(value: &'a IDebugPropertyEnumType_Arguments) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPropertyEnumType_Arguments> for IDebugPropertyEnumType_All {
-    fn from(value: &IDebugPropertyEnumType_Arguments) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugPropertyEnumType_Arguments, ::windows::core::IUnknown, IDebugPropertyEnumType_All);
 impl ::core::clone::Clone for IDebugPropertyEnumType_Arguments {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28407,36 +25231,7 @@ impl IDebugPropertyEnumType_Locals {
         (::windows::core::Vtable::vtable(self).base__.GetName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IDebugPropertyEnumType_Locals> for ::windows::core::IUnknown {
-    fn from(value: IDebugPropertyEnumType_Locals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPropertyEnumType_Locals> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugPropertyEnumType_Locals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPropertyEnumType_Locals> for ::windows::core::IUnknown {
-    fn from(value: &IDebugPropertyEnumType_Locals) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugPropertyEnumType_Locals> for IDebugPropertyEnumType_All {
-    fn from(value: IDebugPropertyEnumType_Locals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPropertyEnumType_Locals> for &'a IDebugPropertyEnumType_All {
-    fn from(value: &'a IDebugPropertyEnumType_Locals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPropertyEnumType_Locals> for IDebugPropertyEnumType_All {
-    fn from(value: &IDebugPropertyEnumType_Locals) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugPropertyEnumType_Locals, ::windows::core::IUnknown, IDebugPropertyEnumType_All);
 impl ::core::clone::Clone for IDebugPropertyEnumType_Locals {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28473,36 +25268,7 @@ impl IDebugPropertyEnumType_LocalsPlusArgs {
         (::windows::core::Vtable::vtable(self).base__.GetName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IDebugPropertyEnumType_LocalsPlusArgs> for ::windows::core::IUnknown {
-    fn from(value: IDebugPropertyEnumType_LocalsPlusArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPropertyEnumType_LocalsPlusArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugPropertyEnumType_LocalsPlusArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPropertyEnumType_LocalsPlusArgs> for ::windows::core::IUnknown {
-    fn from(value: &IDebugPropertyEnumType_LocalsPlusArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugPropertyEnumType_LocalsPlusArgs> for IDebugPropertyEnumType_All {
-    fn from(value: IDebugPropertyEnumType_LocalsPlusArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPropertyEnumType_LocalsPlusArgs> for &'a IDebugPropertyEnumType_All {
-    fn from(value: &'a IDebugPropertyEnumType_LocalsPlusArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPropertyEnumType_LocalsPlusArgs> for IDebugPropertyEnumType_All {
-    fn from(value: &IDebugPropertyEnumType_LocalsPlusArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugPropertyEnumType_LocalsPlusArgs, ::windows::core::IUnknown, IDebugPropertyEnumType_All);
 impl ::core::clone::Clone for IDebugPropertyEnumType_LocalsPlusArgs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28539,36 +25305,7 @@ impl IDebugPropertyEnumType_Registers {
         (::windows::core::Vtable::vtable(self).base__.GetName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IDebugPropertyEnumType_Registers> for ::windows::core::IUnknown {
-    fn from(value: IDebugPropertyEnumType_Registers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPropertyEnumType_Registers> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugPropertyEnumType_Registers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPropertyEnumType_Registers> for ::windows::core::IUnknown {
-    fn from(value: &IDebugPropertyEnumType_Registers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugPropertyEnumType_Registers> for IDebugPropertyEnumType_All {
-    fn from(value: IDebugPropertyEnumType_Registers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugPropertyEnumType_Registers> for &'a IDebugPropertyEnumType_All {
-    fn from(value: &'a IDebugPropertyEnumType_Registers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugPropertyEnumType_Registers> for IDebugPropertyEnumType_All {
-    fn from(value: &IDebugPropertyEnumType_Registers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugPropertyEnumType_Registers, ::windows::core::IUnknown, IDebugPropertyEnumType_All);
 impl ::core::clone::Clone for IDebugPropertyEnumType_Registers {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28652,21 +25389,7 @@ impl IDebugRegisters {
         (::windows::core::Vtable::vtable(self).GetFrameOffset)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IDebugRegisters> for ::windows::core::IUnknown {
-    fn from(value: IDebugRegisters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugRegisters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugRegisters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugRegisters> for ::windows::core::IUnknown {
-    fn from(value: &IDebugRegisters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugRegisters, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugRegisters {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28844,21 +25567,7 @@ impl IDebugRegisters2 {
         (::windows::core::Vtable::vtable(self).GetFrameOffset2)(::windows::core::Vtable::as_raw(self), source, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IDebugRegisters2> for ::windows::core::IUnknown {
-    fn from(value: IDebugRegisters2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugRegisters2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugRegisters2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugRegisters2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugRegisters2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugRegisters2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugRegisters2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28947,21 +25656,7 @@ impl IDebugSessionProvider {
         (::windows::core::Vtable::vtable(self).StartDebugSession)(::windows::core::Vtable::as_raw(self), pda.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDebugSessionProvider> for ::windows::core::IUnknown {
-    fn from(value: IDebugSessionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSessionProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSessionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSessionProvider> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSessionProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSessionProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSessionProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29025,21 +25720,7 @@ impl IDebugStackFrame {
         (::windows::core::Vtable::vtable(self).GetDebugProperty)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugProperty>(result__)
     }
 }
-impl ::core::convert::From<IDebugStackFrame> for ::windows::core::IUnknown {
-    fn from(value: IDebugStackFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugStackFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugStackFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugStackFrame> for ::windows::core::IUnknown {
-    fn from(value: &IDebugStackFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugStackFrame, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugStackFrame {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29121,36 +25802,7 @@ impl IDebugStackFrame110 {
         (::windows::core::Vtable::vtable(self).GetScriptInvocationContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IScriptInvocationContext>(result__)
     }
 }
-impl ::core::convert::From<IDebugStackFrame110> for ::windows::core::IUnknown {
-    fn from(value: IDebugStackFrame110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugStackFrame110> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugStackFrame110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugStackFrame110> for ::windows::core::IUnknown {
-    fn from(value: &IDebugStackFrame110) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugStackFrame110> for IDebugStackFrame {
-    fn from(value: IDebugStackFrame110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugStackFrame110> for &'a IDebugStackFrame {
-    fn from(value: &'a IDebugStackFrame110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugStackFrame110> for IDebugStackFrame {
-    fn from(value: &IDebugStackFrame110) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugStackFrame110, ::windows::core::IUnknown, IDebugStackFrame);
 impl ::core::clone::Clone for IDebugStackFrame110 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29189,21 +25841,7 @@ impl IDebugStackFrameSniffer {
         (::windows::core::Vtable::vtable(self).EnumStackFrames)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugStackFrames>(result__)
     }
 }
-impl ::core::convert::From<IDebugStackFrameSniffer> for ::windows::core::IUnknown {
-    fn from(value: IDebugStackFrameSniffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugStackFrameSniffer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugStackFrameSniffer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugStackFrameSniffer> for ::windows::core::IUnknown {
-    fn from(value: &IDebugStackFrameSniffer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugStackFrameSniffer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugStackFrameSniffer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29245,36 +25883,7 @@ impl IDebugStackFrameSnifferEx32 {
         (::windows::core::Vtable::vtable(self).EnumStackFramesEx32)(::windows::core::Vtable::as_raw(self), dwspmin, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugStackFrames>(result__)
     }
 }
-impl ::core::convert::From<IDebugStackFrameSnifferEx32> for ::windows::core::IUnknown {
-    fn from(value: IDebugStackFrameSnifferEx32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugStackFrameSnifferEx32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugStackFrameSnifferEx32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugStackFrameSnifferEx32> for ::windows::core::IUnknown {
-    fn from(value: &IDebugStackFrameSnifferEx32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugStackFrameSnifferEx32> for IDebugStackFrameSniffer {
-    fn from(value: IDebugStackFrameSnifferEx32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugStackFrameSnifferEx32> for &'a IDebugStackFrameSniffer {
-    fn from(value: &'a IDebugStackFrameSnifferEx32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugStackFrameSnifferEx32> for IDebugStackFrameSniffer {
-    fn from(value: &IDebugStackFrameSnifferEx32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugStackFrameSnifferEx32, ::windows::core::IUnknown, IDebugStackFrameSniffer);
 impl ::core::clone::Clone for IDebugStackFrameSnifferEx32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29316,36 +25925,7 @@ impl IDebugStackFrameSnifferEx64 {
         (::windows::core::Vtable::vtable(self).EnumStackFramesEx64)(::windows::core::Vtable::as_raw(self), dwspmin, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugStackFrames64>(result__)
     }
 }
-impl ::core::convert::From<IDebugStackFrameSnifferEx64> for ::windows::core::IUnknown {
-    fn from(value: IDebugStackFrameSnifferEx64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugStackFrameSnifferEx64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugStackFrameSnifferEx64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugStackFrameSnifferEx64> for ::windows::core::IUnknown {
-    fn from(value: &IDebugStackFrameSnifferEx64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDebugStackFrameSnifferEx64> for IDebugStackFrameSniffer {
-    fn from(value: IDebugStackFrameSnifferEx64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugStackFrameSnifferEx64> for &'a IDebugStackFrameSniffer {
-    fn from(value: &'a IDebugStackFrameSnifferEx64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugStackFrameSnifferEx64> for IDebugStackFrameSniffer {
-    fn from(value: &IDebugStackFrameSnifferEx64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugStackFrameSnifferEx64, ::windows::core::IUnknown, IDebugStackFrameSniffer);
 impl ::core::clone::Clone for IDebugStackFrameSnifferEx64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29427,21 +26007,7 @@ impl IDebugSymbolGroup {
         (::windows::core::Vtable::vtable(self).OutputAsType)(::windows::core::Vtable::as_raw(self), index, r#type.into()).ok()
     }
 }
-impl ::core::convert::From<IDebugSymbolGroup> for ::windows::core::IUnknown {
-    fn from(value: IDebugSymbolGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSymbolGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSymbolGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSymbolGroup> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSymbolGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSymbolGroup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSymbolGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29590,21 +26156,7 @@ impl IDebugSymbolGroup2 {
         (::windows::core::Vtable::vtable(self).GetSymbolEntryInformation)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DEBUG_SYMBOL_ENTRY>(result__)
     }
 }
-impl ::core::convert::From<IDebugSymbolGroup2> for ::windows::core::IUnknown {
-    fn from(value: IDebugSymbolGroup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSymbolGroup2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSymbolGroup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSymbolGroup2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSymbolGroup2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSymbolGroup2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSymbolGroup2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29896,21 +26448,7 @@ impl IDebugSymbols {
         (::windows::core::Vtable::vtable(self).GetSourceFileLineOffsets)(::windows::core::Vtable::as_raw(self), file.into(), ::core::mem::transmute(buffer.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), buffer.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(filelines.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDebugSymbols> for ::windows::core::IUnknown {
-    fn from(value: IDebugSymbols) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSymbols> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSymbols) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSymbols> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSymbols) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSymbols, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSymbols {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30259,21 +26797,7 @@ impl IDebugSymbols2 {
         (::windows::core::Vtable::vtable(self).SetTypeOptions)(::windows::core::Vtable::as_raw(self), options).ok()
     }
 }
-impl ::core::convert::From<IDebugSymbols2> for ::windows::core::IUnknown {
-    fn from(value: IDebugSymbols2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSymbols2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSymbols2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSymbols2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSymbols2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSymbols2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSymbols2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30938,21 +27462,7 @@ impl IDebugSymbols3 {
         (::windows::core::Vtable::vtable(self).GetSourceEntryBySourceEntry)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(fromentry), flags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DEBUG_SYMBOL_SOURCE_ENTRY>(result__)
     }
 }
-impl ::core::convert::From<IDebugSymbols3> for ::windows::core::IUnknown {
-    fn from(value: IDebugSymbols3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSymbols3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSymbols3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSymbols3> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSymbols3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSymbols3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSymbols3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31708,21 +28218,7 @@ impl IDebugSymbols4 {
         (::windows::core::Vtable::vtable(self).OutputSymbolByInlineContext)(::windows::core::Vtable::as_raw(self), outputcontrol, flags, offset, inlinecontext).ok()
     }
 }
-impl ::core::convert::From<IDebugSymbols4> for ::windows::core::IUnknown {
-    fn from(value: IDebugSymbols4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSymbols4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSymbols4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSymbols4> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSymbols4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSymbols4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSymbols4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32498,21 +28994,7 @@ impl IDebugSymbols5 {
         (::windows::core::Vtable::vtable(self).SetScopeFrameByIndexEx)(::windows::core::Vtable::as_raw(self), flags, index).ok()
     }
 }
-impl ::core::convert::From<IDebugSymbols5> for ::windows::core::IUnknown {
-    fn from(value: IDebugSymbols5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSymbols5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSymbols5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSymbols5> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSymbols5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSymbols5, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSymbols5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32700,21 +29182,7 @@ impl IDebugSyncOperation {
         (::windows::core::Vtable::vtable(self).InProgressAbort)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDebugSyncOperation> for ::windows::core::IUnknown {
-    fn from(value: IDebugSyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSyncOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSyncOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSyncOperation> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSyncOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSyncOperation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSyncOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32860,21 +29328,7 @@ impl IDebugSystemObjects {
         (::windows::core::Vtable::vtable(self).GetCurrentProcessExecutableName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(buffer.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), buffer.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(exesize.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDebugSystemObjects> for ::windows::core::IUnknown {
-    fn from(value: IDebugSystemObjects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSystemObjects> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSystemObjects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSystemObjects> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSystemObjects) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSystemObjects, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSystemObjects {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33064,21 +29518,7 @@ impl IDebugSystemObjects2 {
         (::windows::core::Vtable::vtable(self).SetImplicitProcessDataOffset)(::windows::core::Vtable::as_raw(self), offset).ok()
     }
 }
-impl ::core::convert::From<IDebugSystemObjects2> for ::windows::core::IUnknown {
-    fn from(value: IDebugSystemObjects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSystemObjects2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSystemObjects2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSystemObjects2> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSystemObjects2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSystemObjects2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSystemObjects2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33305,21 +29745,7 @@ impl IDebugSystemObjects3 {
         (::windows::core::Vtable::vtable(self).GetCurrentSystemServerName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(buffer.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), buffer.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(namesize.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDebugSystemObjects3> for ::windows::core::IUnknown {
-    fn from(value: IDebugSystemObjects3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSystemObjects3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSystemObjects3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSystemObjects3> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSystemObjects3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSystemObjects3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSystemObjects3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33561,21 +29987,7 @@ impl IDebugSystemObjects4 {
         (::windows::core::Vtable::vtable(self).GetCurrentSystemServerNameWide)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(buffer.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), buffer.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(namesize.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDebugSystemObjects4> for ::windows::core::IUnknown {
-    fn from(value: IDebugSystemObjects4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugSystemObjects4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugSystemObjects4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugSystemObjects4> for ::windows::core::IUnknown {
-    fn from(value: &IDebugSystemObjects4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugSystemObjects4, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugSystemObjects4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33656,21 +30068,7 @@ impl IDebugThreadCall32 {
         (::windows::core::Vtable::vtable(self).ThreadCallHandler)(::windows::core::Vtable::as_raw(self), dwparam1, dwparam2, dwparam3).ok()
     }
 }
-impl ::core::convert::From<IDebugThreadCall32> for ::windows::core::IUnknown {
-    fn from(value: IDebugThreadCall32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugThreadCall32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugThreadCall32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugThreadCall32> for ::windows::core::IUnknown {
-    fn from(value: &IDebugThreadCall32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugThreadCall32, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugThreadCall32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33707,21 +30105,7 @@ impl IDebugThreadCall64 {
         (::windows::core::Vtable::vtable(self).ThreadCallHandler)(::windows::core::Vtable::as_raw(self), dwparam1, dwparam2, dwparam3).ok()
     }
 }
-impl ::core::convert::From<IDebugThreadCall64> for ::windows::core::IUnknown {
-    fn from(value: IDebugThreadCall64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDebugThreadCall64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDebugThreadCall64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDebugThreadCall64> for ::windows::core::IUnknown {
-    fn from(value: &IDebugThreadCall64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDebugThreadCall64, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDebugThreadCall64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33784,21 +30168,7 @@ impl IDynamicConceptProviderConcept {
         (::windows::core::Vtable::vtable(self).NotifyDestruct)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDynamicConceptProviderConcept> for ::windows::core::IUnknown {
-    fn from(value: IDynamicConceptProviderConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDynamicConceptProviderConcept> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDynamicConceptProviderConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDynamicConceptProviderConcept> for ::windows::core::IUnknown {
-    fn from(value: &IDynamicConceptProviderConcept) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDynamicConceptProviderConcept, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDynamicConceptProviderConcept {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33859,21 +30229,7 @@ impl IDynamicKeyProviderConcept {
         (::windows::core::Vtable::vtable(self).EnumerateKeys)(::windows::core::Vtable::as_raw(self), contextobject.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IKeyEnumerator>(result__)
     }
 }
-impl ::core::convert::From<IDynamicKeyProviderConcept> for ::windows::core::IUnknown {
-    fn from(value: IDynamicKeyProviderConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDynamicKeyProviderConcept> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDynamicKeyProviderConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDynamicKeyProviderConcept> for ::windows::core::IUnknown {
-    fn from(value: &IDynamicKeyProviderConcept) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDynamicKeyProviderConcept, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDynamicKeyProviderConcept {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33922,21 +30278,7 @@ impl IEnumDebugApplicationNodes {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugApplicationNodes>(result__)
     }
 }
-impl ::core::convert::From<IEnumDebugApplicationNodes> for ::windows::core::IUnknown {
-    fn from(value: IEnumDebugApplicationNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDebugApplicationNodes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDebugApplicationNodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDebugApplicationNodes> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDebugApplicationNodes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDebugApplicationNodes, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDebugApplicationNodes {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33986,21 +30328,7 @@ impl IEnumDebugCodeContexts {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugCodeContexts>(result__)
     }
 }
-impl ::core::convert::From<IEnumDebugCodeContexts> for ::windows::core::IUnknown {
-    fn from(value: IEnumDebugCodeContexts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDebugCodeContexts> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDebugCodeContexts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDebugCodeContexts> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDebugCodeContexts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDebugCodeContexts, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDebugCodeContexts {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34050,21 +30378,7 @@ impl IEnumDebugExpressionContexts {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugExpressionContexts>(result__)
     }
 }
-impl ::core::convert::From<IEnumDebugExpressionContexts> for ::windows::core::IUnknown {
-    fn from(value: IEnumDebugExpressionContexts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDebugExpressionContexts> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDebugExpressionContexts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDebugExpressionContexts> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDebugExpressionContexts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDebugExpressionContexts, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDebugExpressionContexts {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34120,21 +30434,7 @@ impl IEnumDebugExtendedPropertyInfo {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumDebugExtendedPropertyInfo> for ::windows::core::IUnknown {
-    fn from(value: IEnumDebugExtendedPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDebugExtendedPropertyInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDebugExtendedPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDebugExtendedPropertyInfo> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDebugExtendedPropertyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDebugExtendedPropertyInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDebugExtendedPropertyInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34192,21 +30492,7 @@ impl IEnumDebugPropertyInfo {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumDebugPropertyInfo> for ::windows::core::IUnknown {
-    fn from(value: IEnumDebugPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDebugPropertyInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDebugPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDebugPropertyInfo> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDebugPropertyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDebugPropertyInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDebugPropertyInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34259,21 +30545,7 @@ impl IEnumDebugStackFrames {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugStackFrames>(result__)
     }
 }
-impl ::core::convert::From<IEnumDebugStackFrames> for ::windows::core::IUnknown {
-    fn from(value: IEnumDebugStackFrames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDebugStackFrames> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDebugStackFrames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDebugStackFrames> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDebugStackFrames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDebugStackFrames, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumDebugStackFrames {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34333,36 +30605,7 @@ impl IEnumDebugStackFrames64 {
         (::windows::core::Vtable::vtable(self).Next64)(::windows::core::Vtable::as_raw(self), celt, ::core::mem::transmute(prgdsfd), ::core::mem::transmute(pceltfetched)).ok()
     }
 }
-impl ::core::convert::From<IEnumDebugStackFrames64> for ::windows::core::IUnknown {
-    fn from(value: IEnumDebugStackFrames64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDebugStackFrames64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumDebugStackFrames64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDebugStackFrames64> for ::windows::core::IUnknown {
-    fn from(value: &IEnumDebugStackFrames64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEnumDebugStackFrames64> for IEnumDebugStackFrames {
-    fn from(value: IEnumDebugStackFrames64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumDebugStackFrames64> for &'a IEnumDebugStackFrames {
-    fn from(value: &'a IEnumDebugStackFrames64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumDebugStackFrames64> for IEnumDebugStackFrames {
-    fn from(value: &IEnumDebugStackFrames64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumDebugStackFrames64, ::windows::core::IUnknown, IEnumDebugStackFrames);
 impl ::core::clone::Clone for IEnumDebugStackFrames64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34405,21 +30648,7 @@ impl IEnumJsStackFrames {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IEnumJsStackFrames> for ::windows::core::IUnknown {
-    fn from(value: IEnumJsStackFrames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumJsStackFrames> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumJsStackFrames) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumJsStackFrames> for ::windows::core::IUnknown {
-    fn from(value: &IEnumJsStackFrames) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumJsStackFrames, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumJsStackFrames {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34467,21 +30696,7 @@ impl IEnumRemoteDebugApplicationThreads {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumRemoteDebugApplicationThreads>(result__)
     }
 }
-impl ::core::convert::From<IEnumRemoteDebugApplicationThreads> for ::windows::core::IUnknown {
-    fn from(value: IEnumRemoteDebugApplicationThreads) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumRemoteDebugApplicationThreads> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumRemoteDebugApplicationThreads) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumRemoteDebugApplicationThreads> for ::windows::core::IUnknown {
-    fn from(value: &IEnumRemoteDebugApplicationThreads) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumRemoteDebugApplicationThreads, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumRemoteDebugApplicationThreads {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34531,21 +30746,7 @@ impl IEnumRemoteDebugApplications {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumRemoteDebugApplications>(result__)
     }
 }
-impl ::core::convert::From<IEnumRemoteDebugApplications> for ::windows::core::IUnknown {
-    fn from(value: IEnumRemoteDebugApplications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumRemoteDebugApplications> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumRemoteDebugApplications) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumRemoteDebugApplications> for ::windows::core::IUnknown {
-    fn from(value: &IEnumRemoteDebugApplications) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumRemoteDebugApplications, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumRemoteDebugApplications {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34590,21 +30791,7 @@ impl IEquatableConcept {
         (::windows::core::Vtable::vtable(self).AreObjectsEqual)(::windows::core::Vtable::as_raw(self), contextobject.into().abi(), otherobject.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<bool>(result__)
     }
 }
-impl ::core::convert::From<IEquatableConcept> for ::windows::core::IUnknown {
-    fn from(value: IEquatableConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEquatableConcept> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEquatableConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEquatableConcept> for ::windows::core::IUnknown {
-    fn from(value: &IEquatableConcept) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEquatableConcept, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEquatableConcept {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34641,21 +30828,7 @@ impl IHostDataModelAccess {
         (::windows::core::Vtable::vtable(self).GetDataModel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(manager), ::core::mem::transmute(host)).ok()
     }
 }
-impl ::core::convert::From<IHostDataModelAccess> for ::windows::core::IUnknown {
-    fn from(value: IHostDataModelAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHostDataModelAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHostDataModelAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHostDataModelAccess> for ::windows::core::IUnknown {
-    fn from(value: &IHostDataModelAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHostDataModelAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHostDataModelAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34709,21 +30882,7 @@ impl IIndexableConcept {
         (::windows::core::Vtable::vtable(self).SetAt)(::windows::core::Vtable::as_raw(self), contextobject.into().abi(), indexers.len() as _, ::core::mem::transmute(indexers.as_ptr()), value.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IIndexableConcept> for ::windows::core::IUnknown {
-    fn from(value: IIndexableConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIndexableConcept> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIndexableConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIndexableConcept> for ::windows::core::IUnknown {
-    fn from(value: &IIndexableConcept) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIndexableConcept, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IIndexableConcept {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34773,21 +30932,7 @@ impl IIterableConcept {
         (::windows::core::Vtable::vtable(self).GetIterator)(::windows::core::Vtable::as_raw(self), contextobject.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IModelIterator>(result__)
     }
 }
-impl ::core::convert::From<IIterableConcept> for ::windows::core::IUnknown {
-    fn from(value: IIterableConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIterableConcept> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIterableConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIterableConcept> for ::windows::core::IUnknown {
-    fn from(value: &IIterableConcept) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIterableConcept, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IIterableConcept {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34829,21 +30974,7 @@ impl IJsDebug {
         (::windows::core::Vtable::vtable(self).OpenVirtualProcess)(::windows::core::Vtable::as_raw(self), processid, runtimejsbaseaddress, pdatatarget.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IJsDebugProcess>(result__)
     }
 }
-impl ::core::convert::From<IJsDebug> for ::windows::core::IUnknown {
-    fn from(value: IJsDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IJsDebug> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IJsDebug) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IJsDebug> for ::windows::core::IUnknown {
-    fn from(value: &IJsDebug) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IJsDebug, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IJsDebug {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34895,21 +31026,7 @@ impl IJsDebugBreakPoint {
         (::windows::core::Vtable::vtable(self).GetDocumentPosition)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdocumentid), ::core::mem::transmute(pcharacteroffset), ::core::mem::transmute(pstatementcharcount)).ok()
     }
 }
-impl ::core::convert::From<IJsDebugBreakPoint> for ::windows::core::IUnknown {
-    fn from(value: IJsDebugBreakPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IJsDebugBreakPoint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IJsDebugBreakPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IJsDebugBreakPoint> for ::windows::core::IUnknown {
-    fn from(value: &IJsDebugBreakPoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IJsDebugBreakPoint, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IJsDebugBreakPoint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34982,21 +31099,7 @@ impl IJsDebugDataTarget {
         (::windows::core::Vtable::vtable(self).GetThreadContext)(::windows::core::Vtable::as_raw(self), threadid, contextflags, pcontext.len() as _, ::core::mem::transmute(pcontext.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IJsDebugDataTarget> for ::windows::core::IUnknown {
-    fn from(value: IJsDebugDataTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IJsDebugDataTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IJsDebugDataTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IJsDebugDataTarget> for ::windows::core::IUnknown {
-    fn from(value: &IJsDebugDataTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IJsDebugDataTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IJsDebugDataTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35065,21 +31168,7 @@ impl IJsDebugFrame {
         (::windows::core::Vtable::vtable(self).Evaluate)(::windows::core::Vtable::as_raw(self), pexpressiontext.into(), ::core::mem::transmute(ppdebugproperty), ::core::mem::transmute(perror)).ok()
     }
 }
-impl ::core::convert::From<IJsDebugFrame> for ::windows::core::IUnknown {
-    fn from(value: IJsDebugFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IJsDebugFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IJsDebugFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IJsDebugFrame> for ::windows::core::IUnknown {
-    fn from(value: &IJsDebugFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IJsDebugFrame, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IJsDebugFrame {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35139,21 +31228,7 @@ impl IJsDebugProcess {
         (::windows::core::Vtable::vtable(self).GetExternalStepAddress)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IJsDebugProcess> for ::windows::core::IUnknown {
-    fn from(value: IJsDebugProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IJsDebugProcess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IJsDebugProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IJsDebugProcess> for ::windows::core::IUnknown {
-    fn from(value: &IJsDebugProcess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IJsDebugProcess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IJsDebugProcess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35201,21 +31276,7 @@ impl IJsDebugProperty {
         (::windows::core::Vtable::vtable(self).GetMembers)(::windows::core::Vtable::as_raw(self), members, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IJsEnumDebugProperty>(result__)
     }
 }
-impl ::core::convert::From<IJsDebugProperty> for ::windows::core::IUnknown {
-    fn from(value: IJsDebugProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IJsDebugProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IJsDebugProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IJsDebugProperty> for ::windows::core::IUnknown {
-    fn from(value: &IJsDebugProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IJsDebugProperty, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IJsDebugProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35254,21 +31315,7 @@ impl IJsDebugStackWalker {
         (::windows::core::Vtable::vtable(self).GetNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IJsDebugFrame>(result__)
     }
 }
-impl ::core::convert::From<IJsDebugStackWalker> for ::windows::core::IUnknown {
-    fn from(value: IJsDebugStackWalker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IJsDebugStackWalker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IJsDebugStackWalker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IJsDebugStackWalker> for ::windows::core::IUnknown {
-    fn from(value: &IJsDebugStackWalker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IJsDebugStackWalker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IJsDebugStackWalker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35309,21 +31356,7 @@ impl IJsEnumDebugProperty {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IJsEnumDebugProperty> for ::windows::core::IUnknown {
-    fn from(value: IJsEnumDebugProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IJsEnumDebugProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IJsEnumDebugProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IJsEnumDebugProperty> for ::windows::core::IUnknown {
-    fn from(value: &IJsEnumDebugProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IJsEnumDebugProperty, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IJsEnumDebugProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35364,21 +31397,7 @@ impl IKeyEnumerator {
         (::windows::core::Vtable::vtable(self).GetNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(key), ::core::mem::transmute(value.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(metadata.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IKeyEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IKeyEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKeyEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKeyEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKeyEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IKeyEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKeyEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKeyEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35443,21 +31462,7 @@ impl IKeyStore {
         (::windows::core::Vtable::vtable(self).ClearKeys)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IKeyStore> for ::windows::core::IUnknown {
-    fn from(value: IKeyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKeyStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKeyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKeyStore> for ::windows::core::IUnknown {
-    fn from(value: &IKeyStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKeyStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKeyStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35509,21 +31514,7 @@ impl IMachineDebugManager {
         (::windows::core::Vtable::vtable(self).EnumApplications)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumRemoteDebugApplications>(result__)
     }
 }
-impl ::core::convert::From<IMachineDebugManager> for ::windows::core::IUnknown {
-    fn from(value: IMachineDebugManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMachineDebugManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMachineDebugManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMachineDebugManager> for ::windows::core::IUnknown {
-    fn from(value: &IMachineDebugManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMachineDebugManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMachineDebugManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35573,21 +31564,7 @@ impl IMachineDebugManagerCookie {
         (::windows::core::Vtable::vtable(self).EnumApplications)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumRemoteDebugApplications>(result__)
     }
 }
-impl ::core::convert::From<IMachineDebugManagerCookie> for ::windows::core::IUnknown {
-    fn from(value: IMachineDebugManagerCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMachineDebugManagerCookie> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMachineDebugManagerCookie) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMachineDebugManagerCookie> for ::windows::core::IUnknown {
-    fn from(value: &IMachineDebugManagerCookie) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMachineDebugManagerCookie, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMachineDebugManagerCookie {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35635,21 +31612,7 @@ impl IMachineDebugManagerEvents {
         (::windows::core::Vtable::vtable(self).onRemoveApplication)(::windows::core::Vtable::as_raw(self), pda.into().abi(), dwappcookie).ok()
     }
 }
-impl ::core::convert::From<IMachineDebugManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: IMachineDebugManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMachineDebugManagerEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMachineDebugManagerEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMachineDebugManagerEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMachineDebugManagerEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMachineDebugManagerEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMachineDebugManagerEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35690,21 +31653,7 @@ impl IModelIterator {
         (::windows::core::Vtable::vtable(self).GetNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(object), indexers.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(indexers.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ::core::mem::transmute(metadata.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IModelIterator> for ::windows::core::IUnknown {
-    fn from(value: IModelIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IModelIterator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IModelIterator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IModelIterator> for ::windows::core::IUnknown {
-    fn from(value: &IModelIterator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IModelIterator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IModelIterator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35770,21 +31719,7 @@ impl IModelKeyReference {
         (::windows::core::Vtable::vtable(self).SetKeyValue)(::windows::core::Vtable::as_raw(self), object.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IModelKeyReference> for ::windows::core::IUnknown {
-    fn from(value: IModelKeyReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IModelKeyReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IModelKeyReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IModelKeyReference> for ::windows::core::IUnknown {
-    fn from(value: &IModelKeyReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IModelKeyReference, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IModelKeyReference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35861,36 +31796,7 @@ impl IModelKeyReference2 {
         (::windows::core::Vtable::vtable(self).OverrideContextObject)(::windows::core::Vtable::as_raw(self), newcontextobject.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IModelKeyReference2> for ::windows::core::IUnknown {
-    fn from(value: IModelKeyReference2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IModelKeyReference2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IModelKeyReference2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IModelKeyReference2> for ::windows::core::IUnknown {
-    fn from(value: &IModelKeyReference2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IModelKeyReference2> for IModelKeyReference {
-    fn from(value: IModelKeyReference2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IModelKeyReference2> for &'a IModelKeyReference {
-    fn from(value: &'a IModelKeyReference2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IModelKeyReference2> for IModelKeyReference {
-    fn from(value: &IModelKeyReference2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IModelKeyReference2, ::windows::core::IUnknown, IModelKeyReference);
 impl ::core::clone::Clone for IModelKeyReference2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35930,21 +31836,7 @@ impl IModelMethod {
         (::windows::core::Vtable::vtable(self).Call)(::windows::core::Vtable::as_raw(self), pcontextobject.into().abi(), pparguments.len() as _, ::core::mem::transmute(pparguments.as_ptr()), ::core::mem::transmute(ppresult), ::core::mem::transmute(ppmetadata.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IModelMethod> for ::windows::core::IUnknown {
-    fn from(value: IModelMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IModelMethod> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IModelMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IModelMethod> for ::windows::core::IUnknown {
-    fn from(value: &IModelMethod) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IModelMethod, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IModelMethod {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36148,21 +32040,7 @@ impl IModelObject {
         (::windows::core::Vtable::vtable(self).IsEqualTo)(::windows::core::Vtable::as_raw(self), other.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<bool>(result__)
     }
 }
-impl ::core::convert::From<IModelObject> for ::windows::core::IUnknown {
-    fn from(value: IModelObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IModelObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IModelObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IModelObject> for ::windows::core::IUnknown {
-    fn from(value: &IModelObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IModelObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IModelObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36250,21 +32128,7 @@ impl IModelPropertyAccessor {
         (::windows::core::Vtable::vtable(self).SetValue)(::windows::core::Vtable::as_raw(self), key.into(), contextobject.into().abi(), value.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IModelPropertyAccessor> for ::windows::core::IUnknown {
-    fn from(value: IModelPropertyAccessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IModelPropertyAccessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IModelPropertyAccessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IModelPropertyAccessor> for ::windows::core::IUnknown {
-    fn from(value: &IModelPropertyAccessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IModelPropertyAccessor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IModelPropertyAccessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36305,21 +32169,7 @@ impl IObjectSafety {
         (::windows::core::Vtable::vtable(self).SetInterfaceSafetyOptions)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), dwoptionsetmask, dwenabledoptions).ok()
     }
 }
-impl ::core::convert::From<IObjectSafety> for ::windows::core::IUnknown {
-    fn from(value: IObjectSafety) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectSafety> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectSafety) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectSafety> for ::windows::core::IUnknown {
-    fn from(value: &IObjectSafety) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectSafety, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectSafety {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36370,21 +32220,7 @@ impl IPerPropertyBrowsing2 {
         (::windows::core::Vtable::vtable(self).SetPredefinedValue)(::windows::core::Vtable::as_raw(self), dispid, dwcookie).ok()
     }
 }
-impl ::core::convert::From<IPerPropertyBrowsing2> for ::windows::core::IUnknown {
-    fn from(value: IPerPropertyBrowsing2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPerPropertyBrowsing2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPerPropertyBrowsing2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPerPropertyBrowsing2> for ::windows::core::IUnknown {
-    fn from(value: &IPerPropertyBrowsing2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPerPropertyBrowsing2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPerPropertyBrowsing2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36431,21 +32267,7 @@ impl IPreferredRuntimeTypeConcept {
         (::windows::core::Vtable::vtable(self).CastToPreferredRuntimeType)(::windows::core::Vtable::as_raw(self), contextobject.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IModelObject>(result__)
     }
 }
-impl ::core::convert::From<IPreferredRuntimeTypeConcept> for ::windows::core::IUnknown {
-    fn from(value: IPreferredRuntimeTypeConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPreferredRuntimeTypeConcept> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPreferredRuntimeTypeConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPreferredRuntimeTypeConcept> for ::windows::core::IUnknown {
-    fn from(value: &IPreferredRuntimeTypeConcept) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPreferredRuntimeTypeConcept, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPreferredRuntimeTypeConcept {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36504,21 +32326,7 @@ impl IProcessDebugManager32 {
         (::windows::core::Vtable::vtable(self).CreateDebugDocumentHelper)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugDocumentHelper32>(result__)
     }
 }
-impl ::core::convert::From<IProcessDebugManager32> for ::windows::core::IUnknown {
-    fn from(value: IProcessDebugManager32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProcessDebugManager32> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProcessDebugManager32) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProcessDebugManager32> for ::windows::core::IUnknown {
-    fn from(value: &IProcessDebugManager32) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProcessDebugManager32, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProcessDebugManager32 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36581,21 +32389,7 @@ impl IProcessDebugManager64 {
         (::windows::core::Vtable::vtable(self).CreateDebugDocumentHelper)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDebugDocumentHelper64>(result__)
     }
 }
-impl ::core::convert::From<IProcessDebugManager64> for ::windows::core::IUnknown {
-    fn from(value: IProcessDebugManager64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProcessDebugManager64> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProcessDebugManager64) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProcessDebugManager64> for ::windows::core::IUnknown {
-    fn from(value: &IProcessDebugManager64) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProcessDebugManager64, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProcessDebugManager64 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36637,21 +32431,7 @@ impl IProvideExpressionContexts {
         (::windows::core::Vtable::vtable(self).EnumExpressionContexts)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugExpressionContexts>(result__)
     }
 }
-impl ::core::convert::From<IProvideExpressionContexts> for ::windows::core::IUnknown {
-    fn from(value: IProvideExpressionContexts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvideExpressionContexts> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvideExpressionContexts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvideExpressionContexts> for ::windows::core::IUnknown {
-    fn from(value: &IProvideExpressionContexts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvideExpressionContexts, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProvideExpressionContexts {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36691,21 +32471,7 @@ impl IRawEnumerator {
         (::windows::core::Vtable::vtable(self).GetNext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(name.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(kind.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(value.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IRawEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IRawEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IRawEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRawEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36788,21 +32554,7 @@ impl IRemoteDebugApplication {
         (::windows::core::Vtable::vtable(self).EnumGlobalExpressionContexts)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumDebugExpressionContexts>(result__)
     }
 }
-impl ::core::convert::From<IRemoteDebugApplication> for ::windows::core::IUnknown {
-    fn from(value: IRemoteDebugApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRemoteDebugApplication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteDebugApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRemoteDebugApplication> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteDebugApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteDebugApplication, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRemoteDebugApplication {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36857,21 +32609,7 @@ impl IRemoteDebugApplication110 {
         (::windows::core::Vtable::vtable(self).GetMainThread)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRemoteDebugApplicationThread>(result__)
     }
 }
-impl ::core::convert::From<IRemoteDebugApplication110> for ::windows::core::IUnknown {
-    fn from(value: IRemoteDebugApplication110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRemoteDebugApplication110> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteDebugApplication110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRemoteDebugApplication110> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteDebugApplication110) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteDebugApplication110, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRemoteDebugApplication110 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -36961,21 +32699,7 @@ impl IRemoteDebugApplicationEvents {
         (::windows::core::Vtable::vtable(self).OnBreakFlagChange)(::windows::core::Vtable::as_raw(self), abf, prdatsteppingthread.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IRemoteDebugApplicationEvents> for ::windows::core::IUnknown {
-    fn from(value: IRemoteDebugApplicationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRemoteDebugApplicationEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteDebugApplicationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRemoteDebugApplicationEvents> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteDebugApplicationEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteDebugApplicationEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRemoteDebugApplicationEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37056,21 +32780,7 @@ impl IRemoteDebugApplicationThread {
         (::windows::core::Vtable::vtable(self).GetSuspendCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IRemoteDebugApplicationThread> for ::windows::core::IUnknown {
-    fn from(value: IRemoteDebugApplicationThread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRemoteDebugApplicationThread> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteDebugApplicationThread) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRemoteDebugApplicationThread> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteDebugApplicationThread) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteDebugApplicationThread, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRemoteDebugApplicationThread {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37115,21 +32825,7 @@ impl IRemoteDebugCriticalErrorEvent110 {
         (::windows::core::Vtable::vtable(self).GetErrorInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbstrsource), ::core::mem::transmute(pmessageid), ::core::mem::transmute(pbstrmessage), ::core::mem::transmute(pplocation)).ok()
     }
 }
-impl ::core::convert::From<IRemoteDebugCriticalErrorEvent110> for ::windows::core::IUnknown {
-    fn from(value: IRemoteDebugCriticalErrorEvent110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRemoteDebugCriticalErrorEvent110> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteDebugCriticalErrorEvent110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRemoteDebugCriticalErrorEvent110> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteDebugCriticalErrorEvent110) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteDebugCriticalErrorEvent110, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRemoteDebugCriticalErrorEvent110 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37166,21 +32862,7 @@ impl IRemoteDebugInfoEvent110 {
         (::windows::core::Vtable::vtable(self).GetEventInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmessagetype), ::core::mem::transmute(pbstrmessage), ::core::mem::transmute(pbstrurl), ::core::mem::transmute(pplocation)).ok()
     }
 }
-impl ::core::convert::From<IRemoteDebugInfoEvent110> for ::windows::core::IUnknown {
-    fn from(value: IRemoteDebugInfoEvent110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRemoteDebugInfoEvent110> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteDebugInfoEvent110) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRemoteDebugInfoEvent110> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteDebugInfoEvent110) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteDebugInfoEvent110, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRemoteDebugInfoEvent110 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37319,36 +33001,7 @@ impl IScriptEntry {
         (::windows::core::Vtable::vtable(self).GetRange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pichmin), ::core::mem::transmute(pcch)).ok()
     }
 }
-impl ::core::convert::From<IScriptEntry> for ::windows::core::IUnknown {
-    fn from(value: IScriptEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScriptEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IScriptEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScriptEntry> for ::windows::core::IUnknown {
-    fn from(value: &IScriptEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IScriptEntry> for IScriptNode {
-    fn from(value: IScriptEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScriptEntry> for &'a IScriptNode {
-    fn from(value: &'a IScriptEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScriptEntry> for IScriptNode {
-    fn from(value: &IScriptEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IScriptEntry, ::windows::core::IUnknown, IScriptNode);
 impl ::core::clone::Clone for IScriptEntry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37410,21 +33063,7 @@ impl IScriptInvocationContext {
         (::windows::core::Vtable::vtable(self).GetContextObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IScriptInvocationContext> for ::windows::core::IUnknown {
-    fn from(value: IScriptInvocationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScriptInvocationContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IScriptInvocationContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScriptInvocationContext> for ::windows::core::IUnknown {
-    fn from(value: &IScriptInvocationContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IScriptInvocationContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IScriptInvocationContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37509,21 +33148,7 @@ impl IScriptNode {
         (::windows::core::Vtable::vtable(self).CreateChildHandler)(::windows::core::Vtable::as_raw(self), pszdefaultname.into(), ::core::mem::transmute(prgpsznames.as_ptr()), prgpsznames.len() as _, pszevent.into(), pszdelimiter.into(), ptisignature.into().abi(), imethodsignature, isn, dwcookie, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IScriptEntry>(result__)
     }
 }
-impl ::core::convert::From<IScriptNode> for ::windows::core::IUnknown {
-    fn from(value: IScriptNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScriptNode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IScriptNode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScriptNode> for ::windows::core::IUnknown {
-    fn from(value: &IScriptNode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IScriptNode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IScriptNode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37704,51 +33329,7 @@ impl IScriptScriptlet {
         (::windows::core::Vtable::vtable(self).SetSimpleEventName)(::windows::core::Vtable::as_raw(self), psz.into()).ok()
     }
 }
-impl ::core::convert::From<IScriptScriptlet> for ::windows::core::IUnknown {
-    fn from(value: IScriptScriptlet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScriptScriptlet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IScriptScriptlet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScriptScriptlet> for ::windows::core::IUnknown {
-    fn from(value: &IScriptScriptlet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IScriptScriptlet> for IScriptNode {
-    fn from(value: IScriptScriptlet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScriptScriptlet> for &'a IScriptNode {
-    fn from(value: &'a IScriptScriptlet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScriptScriptlet> for IScriptNode {
-    fn from(value: &IScriptScriptlet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IScriptScriptlet> for IScriptEntry {
-    fn from(value: IScriptScriptlet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScriptScriptlet> for &'a IScriptEntry {
-    fn from(value: &'a IScriptScriptlet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScriptScriptlet> for IScriptEntry {
-    fn from(value: &IScriptScriptlet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IScriptScriptlet, ::windows::core::IUnknown, IScriptNode, IScriptEntry);
 impl ::core::clone::Clone for IScriptScriptlet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37806,21 +33387,7 @@ impl ISimpleConnectionPoint {
         (::windows::core::Vtable::vtable(self).Unadvise)(::windows::core::Vtable::as_raw(self), dwcookie).ok()
     }
 }
-impl ::core::convert::From<ISimpleConnectionPoint> for ::windows::core::IUnknown {
-    fn from(value: ISimpleConnectionPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISimpleConnectionPoint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISimpleConnectionPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISimpleConnectionPoint> for ::windows::core::IUnknown {
-    fn from(value: &ISimpleConnectionPoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISimpleConnectionPoint, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISimpleConnectionPoint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37868,21 +33435,7 @@ impl IStringDisplayableConcept {
         (::windows::core::Vtable::vtable(self).ToDisplayString)(::windows::core::Vtable::as_raw(self), contextobject.into().abi(), metadata.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IStringDisplayableConcept> for ::windows::core::IUnknown {
-    fn from(value: IStringDisplayableConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStringDisplayableConcept> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStringDisplayableConcept) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStringDisplayableConcept> for ::windows::core::IUnknown {
-    fn from(value: &IStringDisplayableConcept) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStringDisplayableConcept, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStringDisplayableConcept {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37924,21 +33477,7 @@ impl ITridentEventSink {
         (::windows::core::Vtable::vtable(self).FireEvent)(::windows::core::Vtable::as_raw(self), pstrevent.into(), ::core::mem::transmute(pdp), ::core::mem::transmute(pvarres), ::core::mem::transmute(pei)).ok()
     }
 }
-impl ::core::convert::From<ITridentEventSink> for ::windows::core::IUnknown {
-    fn from(value: ITridentEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITridentEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITridentEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITridentEventSink> for ::windows::core::IUnknown {
-    fn from(value: &ITridentEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITridentEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITridentEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37984,21 +33523,7 @@ impl IWebAppDiagnosticsObjectInitialization {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), hpassedhandle.into(), pdebugapplication.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWebAppDiagnosticsObjectInitialization> for ::windows::core::IUnknown {
-    fn from(value: IWebAppDiagnosticsObjectInitialization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAppDiagnosticsObjectInitialization> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAppDiagnosticsObjectInitialization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAppDiagnosticsObjectInitialization> for ::windows::core::IUnknown {
-    fn from(value: &IWebAppDiagnosticsObjectInitialization) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAppDiagnosticsObjectInitialization, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWebAppDiagnosticsObjectInitialization {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -38042,21 +33567,7 @@ impl IWebAppDiagnosticsSetup {
         (::windows::core::Vtable::vtable(self).CreateObjectWithSiteAtWebApp)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid), dwclscontext, ::core::mem::transmute(riid), hpasstoobject).ok()
     }
 }
-impl ::core::convert::From<IWebAppDiagnosticsSetup> for ::windows::core::IUnknown {
-    fn from(value: IWebAppDiagnosticsSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAppDiagnosticsSetup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAppDiagnosticsSetup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAppDiagnosticsSetup> for ::windows::core::IUnknown {
-    fn from(value: &IWebAppDiagnosticsSetup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAppDiagnosticsSetup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWebAppDiagnosticsSetup {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
@@ -923,21 +923,7 @@ impl ITraceEvent {
         (::windows::core::Vtable::vtable(self).SetProviderId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(providerid)).ok()
     }
 }
-impl ::core::convert::From<ITraceEvent> for ::windows::core::IUnknown {
-    fn from(value: ITraceEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITraceEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITraceEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITraceEvent> for ::windows::core::IUnknown {
-    fn from(value: &ITraceEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITraceEvent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITraceEvent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1002,21 +988,7 @@ impl ITraceEventCallback {
         (::windows::core::Vtable::vtable(self).OnEvent)(::windows::core::Vtable::as_raw(self), event.into().abi(), relogger.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITraceEventCallback> for ::windows::core::IUnknown {
-    fn from(value: ITraceEventCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITraceEventCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITraceEventCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITraceEventCallback> for ::windows::core::IUnknown {
-    fn from(value: &ITraceEventCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITraceEventCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITraceEventCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1096,21 +1068,7 @@ impl ITraceRelogger {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITraceRelogger> for ::windows::core::IUnknown {
-    fn from(value: ITraceRelogger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITraceRelogger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITraceRelogger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITraceRelogger> for ::windows::core::IUnknown {
-    fn from(value: &ITraceRelogger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITraceRelogger, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITraceRelogger {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/mod.rs
@@ -61,21 +61,7 @@ impl IDtcLuConfigure {
         (::windows::core::Vtable::vtable(self).Delete)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(puclupair.as_ptr()), puclupair.len() as _).ok()
     }
 }
-impl ::core::convert::From<IDtcLuConfigure> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuConfigure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuConfigure> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuConfigure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuConfigure> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuConfigure) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuConfigure, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuConfigure {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -109,21 +95,7 @@ pub struct IDtcLuConfigure_Vtbl {
 #[repr(transparent)]
 pub struct IDtcLuRecovery(::windows::core::IUnknown);
 impl IDtcLuRecovery {}
-impl ::core::convert::From<IDtcLuRecovery> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuRecovery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuRecovery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuRecovery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuRecovery> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuRecovery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuRecovery, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuRecovery {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -160,21 +132,7 @@ impl IDtcLuRecoveryFactory {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(puclupair.as_ptr()), puclupair.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDtcLuRecovery>(result__)
     }
 }
-impl ::core::convert::From<IDtcLuRecoveryFactory> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuRecoveryFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuRecoveryFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuRecoveryFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuRecoveryFactory> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuRecoveryFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuRecoveryFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuRecoveryFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -211,21 +169,7 @@ impl IDtcLuRecoveryInitiatedByDtc {
         (::windows::core::Vtable::vtable(self).GetWork)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwork), ::core::mem::transmute(ppv)).ok()
     }
 }
-impl ::core::convert::From<IDtcLuRecoveryInitiatedByDtc> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuRecoveryInitiatedByDtc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuRecoveryInitiatedByDtc> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuRecoveryInitiatedByDtc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuRecoveryInitiatedByDtc> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuRecoveryInitiatedByDtc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuRecoveryInitiatedByDtc, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuRecoveryInitiatedByDtc {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -262,21 +206,7 @@ impl IDtcLuRecoveryInitiatedByDtcStatusWork {
         (::windows::core::Vtable::vtable(self).HandleCheckLuStatus)(::windows::core::Vtable::as_raw(self), lrecoveryseqnum).ok()
     }
 }
-impl ::core::convert::From<IDtcLuRecoveryInitiatedByDtcStatusWork> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuRecoveryInitiatedByDtcStatusWork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuRecoveryInitiatedByDtcStatusWork> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuRecoveryInitiatedByDtcStatusWork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuRecoveryInitiatedByDtcStatusWork> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuRecoveryInitiatedByDtcStatusWork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuRecoveryInitiatedByDtcStatusWork, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuRecoveryInitiatedByDtcStatusWork {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -351,21 +281,7 @@ impl IDtcLuRecoveryInitiatedByDtcTransWork {
         (::windows::core::Vtable::vtable(self).ObsoleteRecoverySeqNum)(::windows::core::Vtable::as_raw(self), lnewrecoveryseqnum).ok()
     }
 }
-impl ::core::convert::From<IDtcLuRecoveryInitiatedByDtcTransWork> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuRecoveryInitiatedByDtcTransWork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuRecoveryInitiatedByDtcTransWork> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuRecoveryInitiatedByDtcTransWork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuRecoveryInitiatedByDtcTransWork> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuRecoveryInitiatedByDtcTransWork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuRecoveryInitiatedByDtcTransWork, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuRecoveryInitiatedByDtcTransWork {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -418,21 +334,7 @@ impl IDtcLuRecoveryInitiatedByLu {
         (::windows::core::Vtable::vtable(self).GetObjectToHandleWorkFromLu)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDtcLuRecoveryInitiatedByLuWork>(result__)
     }
 }
-impl ::core::convert::From<IDtcLuRecoveryInitiatedByLu> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuRecoveryInitiatedByLu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuRecoveryInitiatedByLu> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuRecoveryInitiatedByLu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuRecoveryInitiatedByLu> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuRecoveryInitiatedByLu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuRecoveryInitiatedByLu, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuRecoveryInitiatedByLu {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -490,21 +392,7 @@ impl IDtcLuRecoveryInitiatedByLuWork {
         (::windows::core::Vtable::vtable(self).ConversationLost)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDtcLuRecoveryInitiatedByLuWork> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuRecoveryInitiatedByLuWork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuRecoveryInitiatedByLuWork> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuRecoveryInitiatedByLuWork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuRecoveryInitiatedByLuWork> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuRecoveryInitiatedByLuWork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuRecoveryInitiatedByLuWork, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuRecoveryInitiatedByLuWork {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -568,21 +456,7 @@ impl IDtcLuRmEnlistment {
         (::windows::core::Vtable::vtable(self).RequestCommit)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDtcLuRmEnlistment> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuRmEnlistment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuRmEnlistment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuRmEnlistment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuRmEnlistment> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuRmEnlistment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuRmEnlistment, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuRmEnlistment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -631,21 +505,7 @@ impl IDtcLuRmEnlistmentFactory {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(puclupair), cblupair, pitransaction.into().abi(), ::core::mem::transmute(ptransid), cbtransid, prmenlistmentsink.into().abi(), ::core::mem::transmute(pprmenlistment)).ok()
     }
 }
-impl ::core::convert::From<IDtcLuRmEnlistmentFactory> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuRmEnlistmentFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuRmEnlistmentFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuRmEnlistmentFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuRmEnlistmentFactory> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuRmEnlistmentFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuRmEnlistmentFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuRmEnlistmentFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -706,21 +566,7 @@ impl IDtcLuRmEnlistmentSink {
         (::windows::core::Vtable::vtable(self).RequestCommit)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDtcLuRmEnlistmentSink> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuRmEnlistmentSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuRmEnlistmentSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuRmEnlistmentSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuRmEnlistmentSink> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuRmEnlistmentSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuRmEnlistmentSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuRmEnlistmentSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -788,21 +634,7 @@ impl IDtcLuSubordinateDtc {
         (::windows::core::Vtable::vtable(self).RequestCommit)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDtcLuSubordinateDtc> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuSubordinateDtc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuSubordinateDtc> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuSubordinateDtc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuSubordinateDtc> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuSubordinateDtc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuSubordinateDtc, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuSubordinateDtc {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -853,21 +685,7 @@ impl IDtcLuSubordinateDtcFactory {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(puclupair), cblupair, punktransactionouter.into().abi(), isolevel, isoflags, poptions.into().abi(), ::core::mem::transmute(pptransaction), ::core::mem::transmute(ptransid), cbtransid, psubordinatedtcsink.into().abi(), ::core::mem::transmute(ppsubordinatedtc)).ok()
     }
 }
-impl ::core::convert::From<IDtcLuSubordinateDtcFactory> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuSubordinateDtcFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuSubordinateDtcFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuSubordinateDtcFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuSubordinateDtcFactory> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuSubordinateDtcFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuSubordinateDtcFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuSubordinateDtcFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -925,21 +743,7 @@ impl IDtcLuSubordinateDtcSink {
         (::windows::core::Vtable::vtable(self).RequestCommit)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDtcLuSubordinateDtcSink> for ::windows::core::IUnknown {
-    fn from(value: IDtcLuSubordinateDtcSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcLuSubordinateDtcSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcLuSubordinateDtcSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcLuSubordinateDtcSink> for ::windows::core::IUnknown {
-    fn from(value: &IDtcLuSubordinateDtcSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcLuSubordinateDtcSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcLuSubordinateDtcSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1067,21 +871,7 @@ impl IDtcNetworkAccessConfig {
         (::windows::core::Vtable::vtable(self).RestartDtcService)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDtcNetworkAccessConfig> for ::windows::core::IUnknown {
-    fn from(value: IDtcNetworkAccessConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcNetworkAccessConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcNetworkAccessConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcNetworkAccessConfig> for ::windows::core::IUnknown {
-    fn from(value: &IDtcNetworkAccessConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcNetworkAccessConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcNetworkAccessConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1285,36 +1075,7 @@ impl IDtcNetworkAccessConfig2 {
         (::windows::core::Vtable::vtable(self).SetAuthenticationLevel)(::windows::core::Vtable::as_raw(self), authlevel).ok()
     }
 }
-impl ::core::convert::From<IDtcNetworkAccessConfig2> for ::windows::core::IUnknown {
-    fn from(value: IDtcNetworkAccessConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcNetworkAccessConfig2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcNetworkAccessConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcNetworkAccessConfig2> for ::windows::core::IUnknown {
-    fn from(value: &IDtcNetworkAccessConfig2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDtcNetworkAccessConfig2> for IDtcNetworkAccessConfig {
-    fn from(value: IDtcNetworkAccessConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcNetworkAccessConfig2> for &'a IDtcNetworkAccessConfig {
-    fn from(value: &'a IDtcNetworkAccessConfig2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcNetworkAccessConfig2> for IDtcNetworkAccessConfig {
-    fn from(value: &IDtcNetworkAccessConfig2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcNetworkAccessConfig2, ::windows::core::IUnknown, IDtcNetworkAccessConfig);
 impl ::core::clone::Clone for IDtcNetworkAccessConfig2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1501,51 +1262,7 @@ impl IDtcNetworkAccessConfig3 {
         (::windows::core::Vtable::vtable(self).SetLUAccess)(::windows::core::Vtable::as_raw(self), bluaccess.into()).ok()
     }
 }
-impl ::core::convert::From<IDtcNetworkAccessConfig3> for ::windows::core::IUnknown {
-    fn from(value: IDtcNetworkAccessConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcNetworkAccessConfig3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcNetworkAccessConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcNetworkAccessConfig3> for ::windows::core::IUnknown {
-    fn from(value: &IDtcNetworkAccessConfig3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDtcNetworkAccessConfig3> for IDtcNetworkAccessConfig {
-    fn from(value: IDtcNetworkAccessConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcNetworkAccessConfig3> for &'a IDtcNetworkAccessConfig {
-    fn from(value: &'a IDtcNetworkAccessConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcNetworkAccessConfig3> for IDtcNetworkAccessConfig {
-    fn from(value: &IDtcNetworkAccessConfig3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDtcNetworkAccessConfig3> for IDtcNetworkAccessConfig2 {
-    fn from(value: IDtcNetworkAccessConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcNetworkAccessConfig3> for &'a IDtcNetworkAccessConfig2 {
-    fn from(value: &'a IDtcNetworkAccessConfig3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcNetworkAccessConfig3> for IDtcNetworkAccessConfig2 {
-    fn from(value: &IDtcNetworkAccessConfig3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcNetworkAccessConfig3, ::windows::core::IUnknown, IDtcNetworkAccessConfig, IDtcNetworkAccessConfig2);
 impl ::core::clone::Clone for IDtcNetworkAccessConfig3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1603,21 +1320,7 @@ impl IDtcToXaHelper {
         (::windows::core::Vtable::vtable(self).TranslateTridToXid)(::windows::core::Vtable::as_raw(self), pitransaction.into().abi(), ::core::mem::transmute(pguidbqual), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<XID>(result__)
     }
 }
-impl ::core::convert::From<IDtcToXaHelper> for ::windows::core::IUnknown {
-    fn from(value: IDtcToXaHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcToXaHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcToXaHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcToXaHelper> for ::windows::core::IUnknown {
-    fn from(value: &IDtcToXaHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcToXaHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcToXaHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1665,21 +1368,7 @@ impl IDtcToXaHelperFactory {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), pszdsn.into(), pszclientdllname.into(), ::core::mem::transmute(pguidrm), ::core::mem::transmute(ppxahelper)).ok()
     }
 }
-impl ::core::convert::From<IDtcToXaHelperFactory> for ::windows::core::IUnknown {
-    fn from(value: IDtcToXaHelperFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcToXaHelperFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcToXaHelperFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcToXaHelperFactory> for ::windows::core::IUnknown {
-    fn from(value: &IDtcToXaHelperFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcToXaHelperFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcToXaHelperFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1741,21 +1430,7 @@ impl IDtcToXaHelperSinglePipe {
         (::windows::core::Vtable::vtable(self).ReleaseRMCookie)(::windows::core::Vtable::as_raw(self), i_dwrmcookie, i_fnormal.into())
     }
 }
-impl ::core::convert::From<IDtcToXaHelperSinglePipe> for ::windows::core::IUnknown {
-    fn from(value: IDtcToXaHelperSinglePipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcToXaHelperSinglePipe> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcToXaHelperSinglePipe) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcToXaHelperSinglePipe> for ::windows::core::IUnknown {
-    fn from(value: &IDtcToXaHelperSinglePipe) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcToXaHelperSinglePipe, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcToXaHelperSinglePipe {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1816,21 +1491,7 @@ impl IDtcToXaMapper {
         (::windows::core::Vtable::vtable(self).ReleaseResourceManager)(::windows::core::Vtable::as_raw(self), dwrmcookie).ok()
     }
 }
-impl ::core::convert::From<IDtcToXaMapper> for ::windows::core::IUnknown {
-    fn from(value: IDtcToXaMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDtcToXaMapper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDtcToXaMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDtcToXaMapper> for ::windows::core::IUnknown {
-    fn from(value: &IDtcToXaMapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDtcToXaMapper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDtcToXaMapper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1873,21 +1534,7 @@ impl IGetDispenser {
         (::windows::core::Vtable::vtable(self).GetDispenser)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(iid), ::core::mem::transmute(ppvobject)).ok()
     }
 }
-impl ::core::convert::From<IGetDispenser> for ::windows::core::IUnknown {
-    fn from(value: IGetDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetDispenser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetDispenser> for ::windows::core::IUnknown {
-    fn from(value: &IGetDispenser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetDispenser, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetDispenser {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1927,21 +1574,7 @@ impl IKernelTransaction {
         (::windows::core::Vtable::vtable(self).GetHandle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::HANDLE>(result__)
     }
 }
-impl ::core::convert::From<IKernelTransaction> for ::windows::core::IUnknown {
-    fn from(value: IKernelTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKernelTransaction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKernelTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKernelTransaction> for ::windows::core::IUnknown {
-    fn from(value: &IKernelTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKernelTransaction, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKernelTransaction {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1984,21 +1617,7 @@ impl ILastResourceManager {
         (::windows::core::Vtable::vtable(self).RecoveryDone)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ILastResourceManager> for ::windows::core::IUnknown {
-    fn from(value: ILastResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILastResourceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILastResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILastResourceManager> for ::windows::core::IUnknown {
-    fn from(value: &ILastResourceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILastResourceManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILastResourceManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2039,21 +1658,7 @@ impl IPrepareInfo {
         (::windows::core::Vtable::vtable(self).GetPrepareInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pprepinfo)).ok()
     }
 }
-impl ::core::convert::From<IPrepareInfo> for ::windows::core::IUnknown {
-    fn from(value: IPrepareInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrepareInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrepareInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrepareInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPrepareInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrepareInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrepareInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2095,21 +1700,7 @@ impl IPrepareInfo2 {
         (::windows::core::Vtable::vtable(self).GetPrepareInfo)(::windows::core::Vtable::as_raw(self), pprepinfo.len() as _, ::core::mem::transmute(pprepinfo.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IPrepareInfo2> for ::windows::core::IUnknown {
-    fn from(value: IPrepareInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrepareInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrepareInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrepareInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IPrepareInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrepareInfo2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrepareInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2157,21 +1748,7 @@ impl IRMHelper {
         (::windows::core::Vtable::vtable(self).RMInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pxa_switch), fcdeclcallingconv.into(), pszopenstring.into(), pszclosestring.into(), ::core::mem::transmute(guidrmrecovery)).ok()
     }
 }
-impl ::core::convert::From<IRMHelper> for ::windows::core::IUnknown {
-    fn from(value: IRMHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRMHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRMHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRMHelper> for ::windows::core::IUnknown {
-    fn from(value: &IRMHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRMHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRMHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2226,21 +1803,7 @@ impl IResourceManager {
         (::windows::core::Vtable::vtable(self).GetDistributedTransactionManager)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(iid), ::core::mem::transmute(ppvobject)).ok()
     }
 }
-impl ::core::convert::From<IResourceManager> for ::windows::core::IUnknown {
-    fn from(value: IResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResourceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResourceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResourceManager> for ::windows::core::IUnknown {
-    fn from(value: &IResourceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResourceManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IResourceManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2309,36 +1872,7 @@ impl IResourceManager2 {
         (::windows::core::Vtable::vtable(self).Reenlist2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pxid), dwtimeout, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<XACTSTAT>(result__)
     }
 }
-impl ::core::convert::From<IResourceManager2> for ::windows::core::IUnknown {
-    fn from(value: IResourceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResourceManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResourceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResourceManager2> for ::windows::core::IUnknown {
-    fn from(value: &IResourceManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IResourceManager2> for IResourceManager {
-    fn from(value: IResourceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResourceManager2> for &'a IResourceManager {
-    fn from(value: &'a IResourceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResourceManager2> for IResourceManager {
-    fn from(value: &IResourceManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResourceManager2, ::windows::core::IUnknown, IResourceManager);
 impl ::core::clone::Clone for IResourceManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2387,21 +1921,7 @@ impl IResourceManagerFactory {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguidrm), pszrmname.into(), piresmgrsink.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IResourceManager>(result__)
     }
 }
-impl ::core::convert::From<IResourceManagerFactory> for ::windows::core::IUnknown {
-    fn from(value: IResourceManagerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResourceManagerFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResourceManagerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResourceManagerFactory> for ::windows::core::IUnknown {
-    fn from(value: &IResourceManagerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResourceManagerFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IResourceManagerFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2450,36 +1970,7 @@ impl IResourceManagerFactory2 {
         (::windows::core::Vtable::vtable(self).CreateEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguidrm), pszrmname.into(), piresmgrsink.into().abi(), ::core::mem::transmute(riidrequested), ::core::mem::transmute(ppvresmgr)).ok()
     }
 }
-impl ::core::convert::From<IResourceManagerFactory2> for ::windows::core::IUnknown {
-    fn from(value: IResourceManagerFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResourceManagerFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResourceManagerFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResourceManagerFactory2> for ::windows::core::IUnknown {
-    fn from(value: &IResourceManagerFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IResourceManagerFactory2> for IResourceManagerFactory {
-    fn from(value: IResourceManagerFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResourceManagerFactory2> for &'a IResourceManagerFactory {
-    fn from(value: &'a IResourceManagerFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResourceManagerFactory2> for IResourceManagerFactory {
-    fn from(value: &IResourceManagerFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResourceManagerFactory2, ::windows::core::IUnknown, IResourceManagerFactory);
 impl ::core::clone::Clone for IResourceManagerFactory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2549,51 +2040,7 @@ impl IResourceManagerRejoinable {
         (::windows::core::Vtable::vtable(self).Rejoin)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pprepinfo.as_ptr()), pprepinfo.len() as _, ltimeout, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<XACTSTAT>(result__)
     }
 }
-impl ::core::convert::From<IResourceManagerRejoinable> for ::windows::core::IUnknown {
-    fn from(value: IResourceManagerRejoinable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResourceManagerRejoinable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResourceManagerRejoinable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResourceManagerRejoinable> for ::windows::core::IUnknown {
-    fn from(value: &IResourceManagerRejoinable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IResourceManagerRejoinable> for IResourceManager {
-    fn from(value: IResourceManagerRejoinable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResourceManagerRejoinable> for &'a IResourceManager {
-    fn from(value: &'a IResourceManagerRejoinable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResourceManagerRejoinable> for IResourceManager {
-    fn from(value: &IResourceManagerRejoinable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IResourceManagerRejoinable> for IResourceManager2 {
-    fn from(value: IResourceManagerRejoinable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResourceManagerRejoinable> for &'a IResourceManager2 {
-    fn from(value: &'a IResourceManagerRejoinable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResourceManagerRejoinable> for IResourceManager2 {
-    fn from(value: &IResourceManagerRejoinable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResourceManagerRejoinable, ::windows::core::IUnknown, IResourceManager, IResourceManager2);
 impl ::core::clone::Clone for IResourceManagerRejoinable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2630,21 +2077,7 @@ impl IResourceManagerSink {
         (::windows::core::Vtable::vtable(self).TMDown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IResourceManagerSink> for ::windows::core::IUnknown {
-    fn from(value: IResourceManagerSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResourceManagerSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResourceManagerSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResourceManagerSink> for ::windows::core::IUnknown {
-    fn from(value: &IResourceManagerSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResourceManagerSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IResourceManagerSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2693,21 +2126,7 @@ impl ITipHelper {
         (::windows::core::Vtable::vtable(self).GetLocalTmUrl)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut u8>(result__)
     }
 }
-impl ::core::convert::From<ITipHelper> for ::windows::core::IUnknown {
-    fn from(value: ITipHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITipHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITipHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITipHelper> for ::windows::core::IUnknown {
-    fn from(value: &ITipHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITipHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITipHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2746,21 +2165,7 @@ impl ITipPullSink {
         (::windows::core::Vtable::vtable(self).PullComplete)(::windows::core::Vtable::as_raw(self), i_hrpull).ok()
     }
 }
-impl ::core::convert::From<ITipPullSink> for ::windows::core::IUnknown {
-    fn from(value: ITipPullSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITipPullSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITipPullSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITipPullSink> for ::windows::core::IUnknown {
-    fn from(value: &ITipPullSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITipPullSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITipPullSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2802,21 +2207,7 @@ impl ITipTransaction {
         (::windows::core::Vtable::vtable(self).GetTransactionUrl)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PSTR>(result__)
     }
 }
-impl ::core::convert::From<ITipTransaction> for ::windows::core::IUnknown {
-    fn from(value: ITipTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITipTransaction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITipTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITipTransaction> for ::windows::core::IUnknown {
-    fn from(value: &ITipTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITipTransaction, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITipTransaction {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2858,21 +2249,7 @@ impl ITmNodeName {
         (::windows::core::Vtable::vtable(self).GetNodeName)(::windows::core::Vtable::as_raw(self), cbnodenamebuffersize, ::core::mem::transmute(pnodenamebuffer)).ok()
     }
 }
-impl ::core::convert::From<ITmNodeName> for ::windows::core::IUnknown {
-    fn from(value: ITmNodeName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITmNodeName> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITmNodeName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITmNodeName> for ::windows::core::IUnknown {
-    fn from(value: &ITmNodeName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITmNodeName, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITmNodeName {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2928,21 +2305,7 @@ impl ITransaction {
         (::windows::core::Vtable::vtable(self).GetTransactionInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<XACTTRANSINFO>(result__)
     }
 }
-impl ::core::convert::From<ITransaction> for ::windows::core::IUnknown {
-    fn from(value: ITransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransaction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransaction> for ::windows::core::IUnknown {
-    fn from(value: &ITransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransaction, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransaction {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3013,51 +2376,7 @@ impl ITransaction2 {
         (::windows::core::Vtable::vtable(self).GetTransactionInfo2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<XACTTRANSINFO>(result__)
     }
 }
-impl ::core::convert::From<ITransaction2> for ::windows::core::IUnknown {
-    fn from(value: ITransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransaction2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransaction2> for ::windows::core::IUnknown {
-    fn from(value: &ITransaction2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITransaction2> for ITransaction {
-    fn from(value: ITransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransaction2> for &'a ITransaction {
-    fn from(value: &'a ITransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransaction2> for ITransaction {
-    fn from(value: &ITransaction2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITransaction2> for ITransactionCloner {
-    fn from(value: ITransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransaction2> for &'a ITransactionCloner {
-    fn from(value: &'a ITransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransaction2> for ITransactionCloner {
-    fn from(value: &ITransaction2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransaction2, ::windows::core::IUnknown, ITransaction, ITransactionCloner);
 impl ::core::clone::Clone for ITransaction2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3116,36 +2435,7 @@ impl ITransactionCloner {
         (::windows::core::Vtable::vtable(self).CloneWithCommitDisabled)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITransaction>(result__)
     }
 }
-impl ::core::convert::From<ITransactionCloner> for ::windows::core::IUnknown {
-    fn from(value: ITransactionCloner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionCloner> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionCloner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionCloner> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionCloner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITransactionCloner> for ITransaction {
-    fn from(value: ITransactionCloner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionCloner> for &'a ITransaction {
-    fn from(value: &'a ITransactionCloner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionCloner> for ITransaction {
-    fn from(value: &ITransactionCloner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionCloner, ::windows::core::IUnknown, ITransaction);
 impl ::core::clone::Clone for ITransactionCloner {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3191,21 +2481,7 @@ impl ITransactionDispenser {
         (::windows::core::Vtable::vtable(self).BeginTransaction)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), isolevel, isoflags, poptions.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITransaction>(result__)
     }
 }
-impl ::core::convert::From<ITransactionDispenser> for ::windows::core::IUnknown {
-    fn from(value: ITransactionDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionDispenser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionDispenser> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionDispenser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionDispenser, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionDispenser {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3254,21 +2530,7 @@ impl ITransactionEnlistmentAsync {
         (::windows::core::Vtable::vtable(self).AbortRequestDone)(::windows::core::Vtable::as_raw(self), hr).ok()
     }
 }
-impl ::core::convert::From<ITransactionEnlistmentAsync> for ::windows::core::IUnknown {
-    fn from(value: ITransactionEnlistmentAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionEnlistmentAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionEnlistmentAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionEnlistmentAsync> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionEnlistmentAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionEnlistmentAsync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionEnlistmentAsync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3320,21 +2582,7 @@ impl ITransactionExport {
         (::windows::core::Vtable::vtable(self).GetTransactionCookie)(::windows::core::Vtable::as_raw(self), punktransaction.into().abi(), rgbtransactioncookie.len() as _, ::core::mem::transmute(rgbtransactioncookie.as_ptr()), ::core::mem::transmute(pcbused)).ok()
     }
 }
-impl ::core::convert::From<ITransactionExport> for ::windows::core::IUnknown {
-    fn from(value: ITransactionExport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionExport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionExport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionExport> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionExport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionExport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionExport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3377,21 +2625,7 @@ impl ITransactionExportFactory {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), rgbwhereabouts.len() as _, ::core::mem::transmute(rgbwhereabouts.as_ptr()), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITransactionExport>(result__)
     }
 }
-impl ::core::convert::From<ITransactionExportFactory> for ::windows::core::IUnknown {
-    fn from(value: ITransactionExportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionExportFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionExportFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionExportFactory> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionExportFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionExportFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionExportFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3433,21 +2667,7 @@ impl ITransactionImport {
         (::windows::core::Vtable::vtable(self).Import)(::windows::core::Vtable::as_raw(self), rgbtransactioncookie.len() as _, ::core::mem::transmute(rgbtransactioncookie.as_ptr()), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ITransactionImport> for ::windows::core::IUnknown {
-    fn from(value: ITransactionImport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionImport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionImport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionImport> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionImport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionImport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionImport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3488,21 +2708,7 @@ impl ITransactionImportWhereabouts {
         (::windows::core::Vtable::vtable(self).GetWhereabouts)(::windows::core::Vtable::as_raw(self), rgbwhereabouts.len() as _, ::core::mem::transmute(rgbwhereabouts.as_ptr()), ::core::mem::transmute(pcbused)).ok()
     }
 }
-impl ::core::convert::From<ITransactionImportWhereabouts> for ::windows::core::IUnknown {
-    fn from(value: ITransactionImportWhereabouts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionImportWhereabouts> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionImportWhereabouts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionImportWhereabouts> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionImportWhereabouts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionImportWhereabouts, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionImportWhereabouts {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3540,21 +2746,7 @@ impl ITransactionLastEnlistmentAsync {
         (::windows::core::Vtable::vtable(self).TransactionOutcome)(::windows::core::Vtable::as_raw(self), xactstat, ::core::mem::transmute(pboidreason)).ok()
     }
 }
-impl ::core::convert::From<ITransactionLastEnlistmentAsync> for ::windows::core::IUnknown {
-    fn from(value: ITransactionLastEnlistmentAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionLastEnlistmentAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionLastEnlistmentAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionLastEnlistmentAsync> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionLastEnlistmentAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionLastEnlistmentAsync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionLastEnlistmentAsync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3594,21 +2786,7 @@ impl ITransactionLastResourceAsync {
         (::windows::core::Vtable::vtable(self).ForgetRequest)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pnewuow)).ok()
     }
 }
-impl ::core::convert::From<ITransactionLastResourceAsync> for ::windows::core::IUnknown {
-    fn from(value: ITransactionLastResourceAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionLastResourceAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionLastResourceAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionLastResourceAsync> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionLastResourceAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionLastResourceAsync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionLastResourceAsync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3649,21 +2827,7 @@ impl ITransactionOptions {
         (::windows::core::Vtable::vtable(self).GetOptions)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(poptions)).ok()
     }
 }
-impl ::core::convert::From<ITransactionOptions> for ::windows::core::IUnknown {
-    fn from(value: ITransactionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionOptions> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3720,21 +2884,7 @@ impl ITransactionOutcomeEvents {
         (::windows::core::Vtable::vtable(self).Indoubt)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITransactionOutcomeEvents> for ::windows::core::IUnknown {
-    fn from(value: ITransactionOutcomeEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionOutcomeEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionOutcomeEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionOutcomeEvents> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionOutcomeEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionOutcomeEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionOutcomeEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3793,21 +2943,7 @@ impl ITransactionPhase0EnlistmentAsync {
         (::windows::core::Vtable::vtable(self).GetTransaction)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITransaction>(result__)
     }
 }
-impl ::core::convert::From<ITransactionPhase0EnlistmentAsync> for ::windows::core::IUnknown {
-    fn from(value: ITransactionPhase0EnlistmentAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionPhase0EnlistmentAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionPhase0EnlistmentAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionPhase0EnlistmentAsync> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionPhase0EnlistmentAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionPhase0EnlistmentAsync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionPhase0EnlistmentAsync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3852,21 +2988,7 @@ impl ITransactionPhase0Factory {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), pphase0notify.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITransactionPhase0EnlistmentAsync>(result__)
     }
 }
-impl ::core::convert::From<ITransactionPhase0Factory> for ::windows::core::IUnknown {
-    fn from(value: ITransactionPhase0Factory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionPhase0Factory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionPhase0Factory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionPhase0Factory> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionPhase0Factory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionPhase0Factory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionPhase0Factory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3911,21 +3033,7 @@ impl ITransactionPhase0NotifyAsync {
         (::windows::core::Vtable::vtable(self).EnlistCompleted)(::windows::core::Vtable::as_raw(self), status).ok()
     }
 }
-impl ::core::convert::From<ITransactionPhase0NotifyAsync> for ::windows::core::IUnknown {
-    fn from(value: ITransactionPhase0NotifyAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionPhase0NotifyAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionPhase0NotifyAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionPhase0NotifyAsync> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionPhase0NotifyAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionPhase0NotifyAsync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionPhase0NotifyAsync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3977,21 +3085,7 @@ impl ITransactionReceiver {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITransactionReceiver> for ::windows::core::IUnknown {
-    fn from(value: ITransactionReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionReceiver> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionReceiver> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionReceiver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionReceiver, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionReceiver {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4032,21 +3126,7 @@ impl ITransactionReceiverFactory {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITransactionReceiver>(result__)
     }
 }
-impl ::core::convert::From<ITransactionReceiverFactory> for ::windows::core::IUnknown {
-    fn from(value: ITransactionReceiverFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionReceiverFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionReceiverFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionReceiverFactory> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionReceiverFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionReceiverFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionReceiverFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4104,21 +3184,7 @@ impl ITransactionResource {
         (::windows::core::Vtable::vtable(self).TMDown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITransactionResource> for ::windows::core::IUnknown {
-    fn from(value: ITransactionResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionResource> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionResource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4185,21 +3251,7 @@ impl ITransactionResourceAsync {
         (::windows::core::Vtable::vtable(self).TMDown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITransactionResourceAsync> for ::windows::core::IUnknown {
-    fn from(value: ITransactionResourceAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionResourceAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionResourceAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionResourceAsync> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionResourceAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionResourceAsync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionResourceAsync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4261,21 +3313,7 @@ impl ITransactionTransmitter {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITransactionTransmitter> for ::windows::core::IUnknown {
-    fn from(value: ITransactionTransmitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionTransmitter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionTransmitter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionTransmitter> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionTransmitter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionTransmitter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionTransmitter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4317,21 +3355,7 @@ impl ITransactionTransmitterFactory {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITransactionTransmitter>(result__)
     }
 }
-impl ::core::convert::From<ITransactionTransmitterFactory> for ::windows::core::IUnknown {
-    fn from(value: ITransactionTransmitterFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionTransmitterFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionTransmitterFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionTransmitterFactory> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionTransmitterFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionTransmitterFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionTransmitterFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4368,21 +3392,7 @@ impl ITransactionVoterBallotAsync2 {
         (::windows::core::Vtable::vtable(self).VoteRequestDone)(::windows::core::Vtable::as_raw(self), hr, ::core::mem::transmute(pboidreason.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<ITransactionVoterBallotAsync2> for ::windows::core::IUnknown {
-    fn from(value: ITransactionVoterBallotAsync2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionVoterBallotAsync2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionVoterBallotAsync2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionVoterBallotAsync2> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionVoterBallotAsync2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionVoterBallotAsync2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionVoterBallotAsync2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4424,21 +3434,7 @@ impl ITransactionVoterFactory2 {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), ptransaction.into().abi(), pvoternotify.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITransactionVoterBallotAsync2>(result__)
     }
 }
-impl ::core::convert::From<ITransactionVoterFactory2> for ::windows::core::IUnknown {
-    fn from(value: ITransactionVoterFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionVoterFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionVoterFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionVoterFactory2> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionVoterFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionVoterFactory2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionVoterFactory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4497,36 +3493,7 @@ impl ITransactionVoterNotifyAsync2 {
         (::windows::core::Vtable::vtable(self).VoteRequest)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITransactionVoterNotifyAsync2> for ::windows::core::IUnknown {
-    fn from(value: ITransactionVoterNotifyAsync2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionVoterNotifyAsync2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionVoterNotifyAsync2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionVoterNotifyAsync2> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionVoterNotifyAsync2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITransactionVoterNotifyAsync2> for ITransactionOutcomeEvents {
-    fn from(value: ITransactionVoterNotifyAsync2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionVoterNotifyAsync2> for &'a ITransactionOutcomeEvents {
-    fn from(value: &'a ITransactionVoterNotifyAsync2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionVoterNotifyAsync2> for ITransactionOutcomeEvents {
-    fn from(value: &ITransactionVoterNotifyAsync2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionVoterNotifyAsync2, ::windows::core::IUnknown, ITransactionOutcomeEvents);
 impl ::core::clone::Clone for ITransactionVoterNotifyAsync2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4566,21 +3533,7 @@ impl IXAConfig {
         (::windows::core::Vtable::vtable(self).Terminate)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IXAConfig> for ::windows::core::IUnknown {
-    fn from(value: IXAConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXAConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXAConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXAConfig> for ::windows::core::IUnknown {
-    fn from(value: &IXAConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXAConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXAConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4621,21 +3574,7 @@ impl IXAObtainRMInfo {
         (::windows::core::Vtable::vtable(self).ObtainRMInfo)(::windows::core::Vtable::as_raw(self), pirmhelper.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IXAObtainRMInfo> for ::windows::core::IUnknown {
-    fn from(value: IXAObtainRMInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXAObtainRMInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXAObtainRMInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXAObtainRMInfo> for ::windows::core::IUnknown {
-    fn from(value: &IXAObtainRMInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXAObtainRMInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXAObtainRMInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4673,21 +3612,7 @@ impl IXATransLookup {
         (::windows::core::Vtable::vtable(self).Lookup)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITransaction>(result__)
     }
 }
-impl ::core::convert::From<IXATransLookup> for ::windows::core::IUnknown {
-    fn from(value: IXATransLookup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXATransLookup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXATransLookup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXATransLookup> for ::windows::core::IUnknown {
-    fn from(value: &IXATransLookup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXATransLookup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXATransLookup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4727,21 +3652,7 @@ impl IXATransLookup2 {
         (::windows::core::Vtable::vtable(self).Lookup)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pxid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITransaction>(result__)
     }
 }
-impl ::core::convert::From<IXATransLookup2> for ::windows::core::IUnknown {
-    fn from(value: IXATransLookup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXATransLookup2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXATransLookup2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXATransLookup2> for ::windows::core::IUnknown {
-    fn from(value: &IXATransLookup2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXATransLookup2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXATransLookup2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/mod.rs
@@ -63,41 +63,7 @@ impl ISensLogon {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISensLogon> for ::windows::core::IUnknown {
-    fn from(value: ISensLogon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISensLogon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISensLogon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISensLogon> for ::windows::core::IUnknown {
-    fn from(value: &ISensLogon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISensLogon> for super::Com::IDispatch {
-    fn from(value: ISensLogon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISensLogon> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISensLogon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISensLogon> for super::Com::IDispatch {
-    fn from(value: &ISensLogon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISensLogon, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISensLogon {
     fn clone(&self) -> Self {
@@ -162,41 +128,7 @@ impl ISensLogon2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISensLogon2> for ::windows::core::IUnknown {
-    fn from(value: ISensLogon2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISensLogon2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISensLogon2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISensLogon2> for ::windows::core::IUnknown {
-    fn from(value: &ISensLogon2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISensLogon2> for super::Com::IDispatch {
-    fn from(value: ISensLogon2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISensLogon2> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISensLogon2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISensLogon2> for super::Com::IDispatch {
-    fn from(value: &ISensLogon2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISensLogon2, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISensLogon2 {
     fn clone(&self) -> Self {
@@ -259,41 +191,7 @@ impl ISensNetwork {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISensNetwork> for ::windows::core::IUnknown {
-    fn from(value: ISensNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISensNetwork> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISensNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISensNetwork> for ::windows::core::IUnknown {
-    fn from(value: &ISensNetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISensNetwork> for super::Com::IDispatch {
-    fn from(value: ISensNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISensNetwork> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISensNetwork) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISensNetwork> for super::Com::IDispatch {
-    fn from(value: &ISensNetwork) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISensNetwork, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISensNetwork {
     fn clone(&self) -> Self {
@@ -350,41 +248,7 @@ impl ISensOnNow {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISensOnNow> for ::windows::core::IUnknown {
-    fn from(value: ISensOnNow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISensOnNow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISensOnNow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISensOnNow> for ::windows::core::IUnknown {
-    fn from(value: &ISensOnNow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISensOnNow> for super::Com::IDispatch {
-    fn from(value: ISensOnNow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISensOnNow> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISensOnNow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISensOnNow> for super::Com::IDispatch {
-    fn from(value: &ISensOnNow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISensOnNow, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISensOnNow {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
@@ -451,21 +451,7 @@ impl IGPEInformation {
         (::windows::core::Vtable::vtable(self).PolicyChanged)(::windows::core::Vtable::as_raw(self), bmachine.into(), badd.into(), ::core::mem::transmute(pguidextension), ::core::mem::transmute(pguidsnapin)).ok()
     }
 }
-impl ::core::convert::From<IGPEInformation> for ::windows::core::IUnknown {
-    fn from(value: IGPEInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGPEInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPEInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGPEInformation> for ::windows::core::IUnknown {
-    fn from(value: &IGPEInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPEInformation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGPEInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -585,41 +571,7 @@ impl IGPM {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPM> for ::windows::core::IUnknown {
-    fn from(value: IGPM) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPM> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPM) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPM> for ::windows::core::IUnknown {
-    fn from(value: &IGPM) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPM> for super::Com::IDispatch {
-    fn from(value: IGPM) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPM> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPM) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPM> for super::Com::IDispatch {
-    fn from(value: &IGPM) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPM, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPM {
     fn clone(&self) -> Self {
@@ -785,59 +737,7 @@ impl IGPM2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPM2> for ::windows::core::IUnknown {
-    fn from(value: IGPM2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPM2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPM2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPM2> for ::windows::core::IUnknown {
-    fn from(value: &IGPM2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPM2> for super::Com::IDispatch {
-    fn from(value: IGPM2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPM2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPM2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPM2> for super::Com::IDispatch {
-    fn from(value: &IGPM2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPM2> for IGPM {
-    fn from(value: IGPM2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPM2> for &'a IGPM {
-    fn from(value: &'a IGPM2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPM2> for IGPM {
-    fn from(value: &IGPM2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPM2, ::windows::core::IUnknown, super::Com::IDispatch, IGPM);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPM2 {
     fn clone(&self) -> Self {
@@ -888,41 +788,7 @@ impl IGPMAsyncCancel {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMAsyncCancel> for ::windows::core::IUnknown {
-    fn from(value: IGPMAsyncCancel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMAsyncCancel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMAsyncCancel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMAsyncCancel> for ::windows::core::IUnknown {
-    fn from(value: &IGPMAsyncCancel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMAsyncCancel> for super::Com::IDispatch {
-    fn from(value: IGPMAsyncCancel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMAsyncCancel> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMAsyncCancel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMAsyncCancel> for super::Com::IDispatch {
-    fn from(value: &IGPMAsyncCancel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMAsyncCancel, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMAsyncCancel {
     fn clone(&self) -> Self {
@@ -974,41 +840,7 @@ impl IGPMAsyncProgress {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMAsyncProgress> for ::windows::core::IUnknown {
-    fn from(value: IGPMAsyncProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMAsyncProgress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMAsyncProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMAsyncProgress> for ::windows::core::IUnknown {
-    fn from(value: &IGPMAsyncProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMAsyncProgress> for super::Com::IDispatch {
-    fn from(value: IGPMAsyncProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMAsyncProgress> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMAsyncProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMAsyncProgress> for super::Com::IDispatch {
-    fn from(value: &IGPMAsyncProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMAsyncProgress, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMAsyncProgress {
     fn clone(&self) -> Self {
@@ -1097,41 +929,7 @@ impl IGPMBackup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMBackup> for ::windows::core::IUnknown {
-    fn from(value: IGPMBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMBackup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMBackup> for ::windows::core::IUnknown {
-    fn from(value: &IGPMBackup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMBackup> for super::Com::IDispatch {
-    fn from(value: IGPMBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMBackup> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMBackup> for super::Com::IDispatch {
-    fn from(value: &IGPMBackup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMBackup, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMBackup {
     fn clone(&self) -> Self {
@@ -1206,41 +1004,7 @@ impl IGPMBackupCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMBackupCollection> for ::windows::core::IUnknown {
-    fn from(value: IGPMBackupCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMBackupCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMBackupCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMBackupCollection> for ::windows::core::IUnknown {
-    fn from(value: &IGPMBackupCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMBackupCollection> for super::Com::IDispatch {
-    fn from(value: IGPMBackupCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMBackupCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMBackupCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMBackupCollection> for super::Com::IDispatch {
-    fn from(value: &IGPMBackupCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMBackupCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMBackupCollection {
     fn clone(&self) -> Self {
@@ -1311,41 +1075,7 @@ impl IGPMBackupDir {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMBackupDir> for ::windows::core::IUnknown {
-    fn from(value: IGPMBackupDir) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMBackupDir> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMBackupDir) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMBackupDir> for ::windows::core::IUnknown {
-    fn from(value: &IGPMBackupDir) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMBackupDir> for super::Com::IDispatch {
-    fn from(value: IGPMBackupDir) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMBackupDir> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMBackupDir) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMBackupDir> for super::Com::IDispatch {
-    fn from(value: &IGPMBackupDir) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMBackupDir, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMBackupDir {
     fn clone(&self) -> Self {
@@ -1420,41 +1150,7 @@ impl IGPMBackupDirEx {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMBackupDirEx> for ::windows::core::IUnknown {
-    fn from(value: IGPMBackupDirEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMBackupDirEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMBackupDirEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMBackupDirEx> for ::windows::core::IUnknown {
-    fn from(value: &IGPMBackupDirEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMBackupDirEx> for super::Com::IDispatch {
-    fn from(value: IGPMBackupDirEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMBackupDirEx> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMBackupDirEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMBackupDirEx> for super::Com::IDispatch {
-    fn from(value: &IGPMBackupDirEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMBackupDirEx, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMBackupDirEx {
     fn clone(&self) -> Self {
@@ -1523,41 +1219,7 @@ impl IGPMCSECollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMCSECollection> for ::windows::core::IUnknown {
-    fn from(value: IGPMCSECollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMCSECollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMCSECollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMCSECollection> for ::windows::core::IUnknown {
-    fn from(value: &IGPMCSECollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMCSECollection> for super::Com::IDispatch {
-    fn from(value: IGPMCSECollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMCSECollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMCSECollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMCSECollection> for super::Com::IDispatch {
-    fn from(value: &IGPMCSECollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMCSECollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMCSECollection {
     fn clone(&self) -> Self {
@@ -1625,41 +1287,7 @@ impl IGPMClientSideExtension {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMClientSideExtension> for ::windows::core::IUnknown {
-    fn from(value: IGPMClientSideExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMClientSideExtension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMClientSideExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMClientSideExtension> for ::windows::core::IUnknown {
-    fn from(value: &IGPMClientSideExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMClientSideExtension> for super::Com::IDispatch {
-    fn from(value: IGPMClientSideExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMClientSideExtension> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMClientSideExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMClientSideExtension> for super::Com::IDispatch {
-    fn from(value: &IGPMClientSideExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMClientSideExtension, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMClientSideExtension {
     fn clone(&self) -> Self {
@@ -1946,41 +1574,7 @@ impl IGPMConstants {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMConstants> for ::windows::core::IUnknown {
-    fn from(value: IGPMConstants) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMConstants> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMConstants) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMConstants> for ::windows::core::IUnknown {
-    fn from(value: &IGPMConstants) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMConstants> for super::Com::IDispatch {
-    fn from(value: IGPMConstants) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMConstants> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMConstants) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMConstants> for super::Com::IDispatch {
-    fn from(value: &IGPMConstants) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMConstants, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMConstants {
     fn clone(&self) -> Self {
@@ -2383,59 +1977,7 @@ impl IGPMConstants2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMConstants2> for ::windows::core::IUnknown {
-    fn from(value: IGPMConstants2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMConstants2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMConstants2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMConstants2> for ::windows::core::IUnknown {
-    fn from(value: &IGPMConstants2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMConstants2> for super::Com::IDispatch {
-    fn from(value: IGPMConstants2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMConstants2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMConstants2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMConstants2> for super::Com::IDispatch {
-    fn from(value: &IGPMConstants2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMConstants2> for IGPMConstants {
-    fn from(value: IGPMConstants2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMConstants2> for &'a IGPMConstants {
-    fn from(value: &'a IGPMConstants2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMConstants2> for IGPMConstants {
-    fn from(value: &IGPMConstants2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMConstants2, ::windows::core::IUnknown, super::Com::IDispatch, IGPMConstants);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMConstants2 {
     fn clone(&self) -> Self {
@@ -2560,41 +2102,7 @@ impl IGPMDomain {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMDomain> for ::windows::core::IUnknown {
-    fn from(value: IGPMDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMDomain> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMDomain> for ::windows::core::IUnknown {
-    fn from(value: &IGPMDomain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMDomain> for super::Com::IDispatch {
-    fn from(value: IGPMDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMDomain> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMDomain) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMDomain> for super::Com::IDispatch {
-    fn from(value: &IGPMDomain) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMDomain, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMDomain {
     fn clone(&self) -> Self {
@@ -2781,59 +2289,7 @@ impl IGPMDomain2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMDomain2> for ::windows::core::IUnknown {
-    fn from(value: IGPMDomain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMDomain2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMDomain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMDomain2> for ::windows::core::IUnknown {
-    fn from(value: &IGPMDomain2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMDomain2> for super::Com::IDispatch {
-    fn from(value: IGPMDomain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMDomain2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMDomain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMDomain2> for super::Com::IDispatch {
-    fn from(value: &IGPMDomain2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMDomain2> for IGPMDomain {
-    fn from(value: IGPMDomain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMDomain2> for &'a IGPMDomain {
-    fn from(value: &'a IGPMDomain2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMDomain2> for IGPMDomain {
-    fn from(value: &IGPMDomain2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMDomain2, ::windows::core::IUnknown, super::Com::IDispatch, IGPMDomain);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMDomain2 {
     fn clone(&self) -> Self {
@@ -3025,77 +2481,7 @@ impl IGPMDomain3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMDomain3> for ::windows::core::IUnknown {
-    fn from(value: IGPMDomain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMDomain3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMDomain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMDomain3> for ::windows::core::IUnknown {
-    fn from(value: &IGPMDomain3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMDomain3> for super::Com::IDispatch {
-    fn from(value: IGPMDomain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMDomain3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMDomain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMDomain3> for super::Com::IDispatch {
-    fn from(value: &IGPMDomain3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMDomain3> for IGPMDomain {
-    fn from(value: IGPMDomain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMDomain3> for &'a IGPMDomain {
-    fn from(value: &'a IGPMDomain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMDomain3> for IGPMDomain {
-    fn from(value: &IGPMDomain3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMDomain3> for IGPMDomain2 {
-    fn from(value: IGPMDomain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMDomain3> for &'a IGPMDomain2 {
-    fn from(value: &'a IGPMDomain3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMDomain3> for IGPMDomain2 {
-    fn from(value: &IGPMDomain3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMDomain3, ::windows::core::IUnknown, super::Com::IDispatch, IGPMDomain, IGPMDomain2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMDomain3 {
     fn clone(&self) -> Self {
@@ -3286,41 +2672,7 @@ impl IGPMGPO {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPO> for ::windows::core::IUnknown {
-    fn from(value: IGPMGPO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPO> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMGPO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPO> for ::windows::core::IUnknown {
-    fn from(value: &IGPMGPO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPO> for super::Com::IDispatch {
-    fn from(value: IGPMGPO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPO> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMGPO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPO> for super::Com::IDispatch {
-    fn from(value: &IGPMGPO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMGPO, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMGPO {
     fn clone(&self) -> Self {
@@ -3573,59 +2925,7 @@ impl IGPMGPO2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPO2> for ::windows::core::IUnknown {
-    fn from(value: IGPMGPO2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPO2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMGPO2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPO2> for ::windows::core::IUnknown {
-    fn from(value: &IGPMGPO2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPO2> for super::Com::IDispatch {
-    fn from(value: IGPMGPO2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPO2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMGPO2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPO2> for super::Com::IDispatch {
-    fn from(value: &IGPMGPO2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPO2> for IGPMGPO {
-    fn from(value: IGPMGPO2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPO2> for &'a IGPMGPO {
-    fn from(value: &'a IGPMGPO2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPO2> for IGPMGPO {
-    fn from(value: &IGPMGPO2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMGPO2, ::windows::core::IUnknown, super::Com::IDispatch, IGPMGPO);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMGPO2 {
     fn clone(&self) -> Self {
@@ -3828,77 +3128,7 @@ impl IGPMGPO3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPO3> for ::windows::core::IUnknown {
-    fn from(value: IGPMGPO3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPO3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMGPO3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPO3> for ::windows::core::IUnknown {
-    fn from(value: &IGPMGPO3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPO3> for super::Com::IDispatch {
-    fn from(value: IGPMGPO3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPO3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMGPO3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPO3> for super::Com::IDispatch {
-    fn from(value: &IGPMGPO3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPO3> for IGPMGPO {
-    fn from(value: IGPMGPO3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPO3> for &'a IGPMGPO {
-    fn from(value: &'a IGPMGPO3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPO3> for IGPMGPO {
-    fn from(value: &IGPMGPO3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPO3> for IGPMGPO2 {
-    fn from(value: IGPMGPO3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPO3> for &'a IGPMGPO2 {
-    fn from(value: &'a IGPMGPO3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPO3> for IGPMGPO2 {
-    fn from(value: &IGPMGPO3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMGPO3, ::windows::core::IUnknown, super::Com::IDispatch, IGPMGPO, IGPMGPO2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMGPO3 {
     fn clone(&self) -> Self {
@@ -3960,41 +3190,7 @@ impl IGPMGPOCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPOCollection> for ::windows::core::IUnknown {
-    fn from(value: IGPMGPOCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPOCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMGPOCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPOCollection> for ::windows::core::IUnknown {
-    fn from(value: &IGPMGPOCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPOCollection> for super::Com::IDispatch {
-    fn from(value: IGPMGPOCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPOCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMGPOCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPOCollection> for super::Com::IDispatch {
-    fn from(value: &IGPMGPOCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMGPOCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMGPOCollection {
     fn clone(&self) -> Self {
@@ -4081,41 +3277,7 @@ impl IGPMGPOLink {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPOLink> for ::windows::core::IUnknown {
-    fn from(value: IGPMGPOLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPOLink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMGPOLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPOLink> for ::windows::core::IUnknown {
-    fn from(value: &IGPMGPOLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPOLink> for super::Com::IDispatch {
-    fn from(value: IGPMGPOLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPOLink> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMGPOLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPOLink> for super::Com::IDispatch {
-    fn from(value: &IGPMGPOLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMGPOLink, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMGPOLink {
     fn clone(&self) -> Self {
@@ -4186,41 +3348,7 @@ impl IGPMGPOLinksCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPOLinksCollection> for ::windows::core::IUnknown {
-    fn from(value: IGPMGPOLinksCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPOLinksCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMGPOLinksCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPOLinksCollection> for ::windows::core::IUnknown {
-    fn from(value: &IGPMGPOLinksCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMGPOLinksCollection> for super::Com::IDispatch {
-    fn from(value: IGPMGPOLinksCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMGPOLinksCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMGPOLinksCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMGPOLinksCollection> for super::Com::IDispatch {
-    fn from(value: &IGPMGPOLinksCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMGPOLinksCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMGPOLinksCollection {
     fn clone(&self) -> Self {
@@ -4288,41 +3416,7 @@ impl IGPMMapEntry {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMMapEntry> for ::windows::core::IUnknown {
-    fn from(value: IGPMMapEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMMapEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMMapEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMMapEntry> for ::windows::core::IUnknown {
-    fn from(value: &IGPMMapEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMMapEntry> for super::Com::IDispatch {
-    fn from(value: IGPMMapEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMMapEntry> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMMapEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMMapEntry> for super::Com::IDispatch {
-    fn from(value: &IGPMMapEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMMapEntry, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMMapEntry {
     fn clone(&self) -> Self {
@@ -4385,41 +3479,7 @@ impl IGPMMapEntryCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMMapEntryCollection> for ::windows::core::IUnknown {
-    fn from(value: IGPMMapEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMMapEntryCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMMapEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMMapEntryCollection> for ::windows::core::IUnknown {
-    fn from(value: &IGPMMapEntryCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMMapEntryCollection> for super::Com::IDispatch {
-    fn from(value: IGPMMapEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMMapEntryCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMMapEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMMapEntryCollection> for super::Com::IDispatch {
-    fn from(value: &IGPMMapEntryCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMMapEntryCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMMapEntryCollection {
     fn clone(&self) -> Self {
@@ -4515,41 +3575,7 @@ impl IGPMMigrationTable {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMMigrationTable> for ::windows::core::IUnknown {
-    fn from(value: IGPMMigrationTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMMigrationTable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMMigrationTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMMigrationTable> for ::windows::core::IUnknown {
-    fn from(value: &IGPMMigrationTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMMigrationTable> for super::Com::IDispatch {
-    fn from(value: IGPMMigrationTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMMigrationTable> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMMigrationTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMMigrationTable> for super::Com::IDispatch {
-    fn from(value: &IGPMMigrationTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMMigrationTable, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMMigrationTable {
     fn clone(&self) -> Self {
@@ -4640,41 +3666,7 @@ impl IGPMPermission {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMPermission> for ::windows::core::IUnknown {
-    fn from(value: IGPMPermission) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMPermission> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMPermission) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMPermission> for ::windows::core::IUnknown {
-    fn from(value: &IGPMPermission) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMPermission> for super::Com::IDispatch {
-    fn from(value: IGPMPermission) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMPermission> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMPermission) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMPermission> for super::Com::IDispatch {
-    fn from(value: &IGPMPermission) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMPermission, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMPermission {
     fn clone(&self) -> Self {
@@ -4882,41 +3874,7 @@ impl IGPMRSOP {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMRSOP> for ::windows::core::IUnknown {
-    fn from(value: IGPMRSOP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMRSOP> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMRSOP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMRSOP> for ::windows::core::IUnknown {
-    fn from(value: &IGPMRSOP) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMRSOP> for super::Com::IDispatch {
-    fn from(value: IGPMRSOP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMRSOP> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMRSOP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMRSOP> for super::Com::IDispatch {
-    fn from(value: &IGPMRSOP) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMRSOP, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMRSOP {
     fn clone(&self) -> Self {
@@ -5042,41 +4000,7 @@ impl IGPMResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMResult> for ::windows::core::IUnknown {
-    fn from(value: IGPMResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMResult> for ::windows::core::IUnknown {
-    fn from(value: &IGPMResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMResult> for super::Com::IDispatch {
-    fn from(value: IGPMResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMResult> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMResult> for super::Com::IDispatch {
-    fn from(value: &IGPMResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMResult, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMResult {
     fn clone(&self) -> Self {
@@ -5182,41 +4106,7 @@ impl IGPMSOM {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMSOM> for ::windows::core::IUnknown {
-    fn from(value: IGPMSOM) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMSOM> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMSOM) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMSOM> for ::windows::core::IUnknown {
-    fn from(value: &IGPMSOM) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMSOM> for super::Com::IDispatch {
-    fn from(value: IGPMSOM) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMSOM> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMSOM) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMSOM> for super::Com::IDispatch {
-    fn from(value: &IGPMSOM) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMSOM, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMSOM {
     fn clone(&self) -> Self {
@@ -5300,41 +4190,7 @@ impl IGPMSOMCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMSOMCollection> for ::windows::core::IUnknown {
-    fn from(value: IGPMSOMCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMSOMCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMSOMCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMSOMCollection> for ::windows::core::IUnknown {
-    fn from(value: &IGPMSOMCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMSOMCollection> for super::Com::IDispatch {
-    fn from(value: IGPMSOMCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMSOMCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMSOMCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMSOMCollection> for super::Com::IDispatch {
-    fn from(value: &IGPMSOMCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMSOMCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMSOMCollection {
     fn clone(&self) -> Self {
@@ -5394,41 +4250,7 @@ impl IGPMSearchCriteria {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMSearchCriteria> for ::windows::core::IUnknown {
-    fn from(value: IGPMSearchCriteria) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMSearchCriteria> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMSearchCriteria) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMSearchCriteria> for ::windows::core::IUnknown {
-    fn from(value: &IGPMSearchCriteria) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMSearchCriteria> for super::Com::IDispatch {
-    fn from(value: IGPMSearchCriteria) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMSearchCriteria> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMSearchCriteria) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMSearchCriteria> for super::Com::IDispatch {
-    fn from(value: &IGPMSearchCriteria) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMSearchCriteria, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMSearchCriteria {
     fn clone(&self) -> Self {
@@ -5510,41 +4332,7 @@ impl IGPMSecurityInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMSecurityInfo> for ::windows::core::IUnknown {
-    fn from(value: IGPMSecurityInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMSecurityInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMSecurityInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMSecurityInfo> for ::windows::core::IUnknown {
-    fn from(value: &IGPMSecurityInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMSecurityInfo> for super::Com::IDispatch {
-    fn from(value: IGPMSecurityInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMSecurityInfo> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMSecurityInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMSecurityInfo> for super::Com::IDispatch {
-    fn from(value: &IGPMSecurityInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMSecurityInfo, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMSecurityInfo {
     fn clone(&self) -> Self {
@@ -5632,41 +4420,7 @@ impl IGPMSitesContainer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMSitesContainer> for ::windows::core::IUnknown {
-    fn from(value: IGPMSitesContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMSitesContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMSitesContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMSitesContainer> for ::windows::core::IUnknown {
-    fn from(value: &IGPMSitesContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMSitesContainer> for super::Com::IDispatch {
-    fn from(value: IGPMSitesContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMSitesContainer> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMSitesContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMSitesContainer> for super::Com::IDispatch {
-    fn from(value: &IGPMSitesContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMSitesContainer, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMSitesContainer {
     fn clone(&self) -> Self {
@@ -5815,41 +4569,7 @@ impl IGPMStarterGPO {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStarterGPO> for ::windows::core::IUnknown {
-    fn from(value: IGPMStarterGPO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStarterGPO> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMStarterGPO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStarterGPO> for ::windows::core::IUnknown {
-    fn from(value: &IGPMStarterGPO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStarterGPO> for super::Com::IDispatch {
-    fn from(value: IGPMStarterGPO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStarterGPO> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMStarterGPO) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStarterGPO> for super::Com::IDispatch {
-    fn from(value: &IGPMStarterGPO) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMStarterGPO, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMStarterGPO {
     fn clone(&self) -> Self {
@@ -5980,41 +4700,7 @@ impl IGPMStarterGPOBackup {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStarterGPOBackup> for ::windows::core::IUnknown {
-    fn from(value: IGPMStarterGPOBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStarterGPOBackup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMStarterGPOBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStarterGPOBackup> for ::windows::core::IUnknown {
-    fn from(value: &IGPMStarterGPOBackup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStarterGPOBackup> for super::Com::IDispatch {
-    fn from(value: IGPMStarterGPOBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStarterGPOBackup> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMStarterGPOBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStarterGPOBackup> for super::Com::IDispatch {
-    fn from(value: &IGPMStarterGPOBackup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMStarterGPOBackup, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMStarterGPOBackup {
     fn clone(&self) -> Self {
@@ -6090,41 +4776,7 @@ impl IGPMStarterGPOBackupCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStarterGPOBackupCollection> for ::windows::core::IUnknown {
-    fn from(value: IGPMStarterGPOBackupCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStarterGPOBackupCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMStarterGPOBackupCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStarterGPOBackupCollection> for ::windows::core::IUnknown {
-    fn from(value: &IGPMStarterGPOBackupCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStarterGPOBackupCollection> for super::Com::IDispatch {
-    fn from(value: IGPMStarterGPOBackupCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStarterGPOBackupCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMStarterGPOBackupCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStarterGPOBackupCollection> for super::Com::IDispatch {
-    fn from(value: &IGPMStarterGPOBackupCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMStarterGPOBackupCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMStarterGPOBackupCollection {
     fn clone(&self) -> Self {
@@ -6192,41 +4844,7 @@ impl IGPMStarterGPOCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStarterGPOCollection> for ::windows::core::IUnknown {
-    fn from(value: IGPMStarterGPOCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStarterGPOCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMStarterGPOCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStarterGPOCollection> for ::windows::core::IUnknown {
-    fn from(value: &IGPMStarterGPOCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStarterGPOCollection> for super::Com::IDispatch {
-    fn from(value: IGPMStarterGPOCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStarterGPOCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMStarterGPOCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStarterGPOCollection> for super::Com::IDispatch {
-    fn from(value: &IGPMStarterGPOCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMStarterGPOCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMStarterGPOCollection {
     fn clone(&self) -> Self {
@@ -6300,41 +4918,7 @@ impl IGPMStatusMessage {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStatusMessage> for ::windows::core::IUnknown {
-    fn from(value: IGPMStatusMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStatusMessage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMStatusMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStatusMessage> for ::windows::core::IUnknown {
-    fn from(value: &IGPMStatusMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStatusMessage> for super::Com::IDispatch {
-    fn from(value: IGPMStatusMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStatusMessage> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMStatusMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStatusMessage> for super::Com::IDispatch {
-    fn from(value: &IGPMStatusMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMStatusMessage, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMStatusMessage {
     fn clone(&self) -> Self {
@@ -6399,41 +4983,7 @@ impl IGPMStatusMsgCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStatusMsgCollection> for ::windows::core::IUnknown {
-    fn from(value: IGPMStatusMsgCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStatusMsgCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMStatusMsgCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStatusMsgCollection> for ::windows::core::IUnknown {
-    fn from(value: &IGPMStatusMsgCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMStatusMsgCollection> for super::Com::IDispatch {
-    fn from(value: IGPMStatusMsgCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMStatusMsgCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMStatusMsgCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMStatusMsgCollection> for super::Com::IDispatch {
-    fn from(value: &IGPMStatusMsgCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMStatusMsgCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMStatusMsgCollection {
     fn clone(&self) -> Self {
@@ -6505,41 +5055,7 @@ impl IGPMTrustee {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMTrustee> for ::windows::core::IUnknown {
-    fn from(value: IGPMTrustee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMTrustee> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMTrustee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMTrustee> for ::windows::core::IUnknown {
-    fn from(value: &IGPMTrustee) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMTrustee> for super::Com::IDispatch {
-    fn from(value: IGPMTrustee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMTrustee> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMTrustee) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMTrustee> for super::Com::IDispatch {
-    fn from(value: &IGPMTrustee) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMTrustee, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMTrustee {
     fn clone(&self) -> Self {
@@ -6625,41 +5141,7 @@ impl IGPMWMIFilter {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMWMIFilter> for ::windows::core::IUnknown {
-    fn from(value: IGPMWMIFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMWMIFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMWMIFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMWMIFilter> for ::windows::core::IUnknown {
-    fn from(value: &IGPMWMIFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMWMIFilter> for super::Com::IDispatch {
-    fn from(value: IGPMWMIFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMWMIFilter> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMWMIFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMWMIFilter> for super::Com::IDispatch {
-    fn from(value: &IGPMWMIFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMWMIFilter, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMWMIFilter {
     fn clone(&self) -> Self {
@@ -6735,41 +5217,7 @@ impl IGPMWMIFilterCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMWMIFilterCollection> for ::windows::core::IUnknown {
-    fn from(value: IGPMWMIFilterCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMWMIFilterCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGPMWMIFilterCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMWMIFilterCollection> for ::windows::core::IUnknown {
-    fn from(value: &IGPMWMIFilterCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IGPMWMIFilterCollection> for super::Com::IDispatch {
-    fn from(value: IGPMWMIFilterCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IGPMWMIFilterCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IGPMWMIFilterCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IGPMWMIFilterCollection> for super::Com::IDispatch {
-    fn from(value: &IGPMWMIFilterCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGPMWMIFilterCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IGPMWMIFilterCollection {
     fn clone(&self) -> Self {
@@ -6895,21 +5343,7 @@ impl IGroupPolicyObject {
         (::windows::core::Vtable::vtable(self).GetPropertySheetPages)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(hpages), ::core::mem::transmute(upagecount)).ok()
     }
 }
-impl ::core::convert::From<IGroupPolicyObject> for ::windows::core::IUnknown {
-    fn from(value: IGroupPolicyObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGroupPolicyObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGroupPolicyObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGroupPolicyObject> for ::windows::core::IUnknown {
-    fn from(value: &IGroupPolicyObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGroupPolicyObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGroupPolicyObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6984,21 +5418,7 @@ impl IRSOPInformation {
         (::windows::core::Vtable::vtable(self).GetEventLogEntryText)(::windows::core::Vtable::as_raw(self), pszeventsource.into(), pszeventlogname.into(), pszeventtime.into(), dweventid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IRSOPInformation> for ::windows::core::IUnknown {
-    fn from(value: IRSOPInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRSOPInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRSOPInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRSOPInformation> for ::windows::core::IUnknown {
-    fn from(value: &IRSOPInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRSOPInformation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRSOPInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
@@ -57,21 +57,7 @@ impl AsyncIFtpAuthenticationProvider {
         (::windows::core::Vtable::vtable(self).Finish_AuthenticateUser)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppszcanonicalusername), ::core::mem::transmute(pfauthenticated)).ok()
     }
 }
-impl ::core::convert::From<AsyncIFtpAuthenticationProvider> for ::windows::core::IUnknown {
-    fn from(value: AsyncIFtpAuthenticationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIFtpAuthenticationProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIFtpAuthenticationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIFtpAuthenticationProvider> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIFtpAuthenticationProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIFtpAuthenticationProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIFtpAuthenticationProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -122,21 +108,7 @@ impl AsyncIFtpAuthorizationProvider {
         (::windows::core::Vtable::vtable(self).Finish_GetUserAccessPermission)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<FTP_ACCESS>(result__)
     }
 }
-impl ::core::convert::From<AsyncIFtpAuthorizationProvider> for ::windows::core::IUnknown {
-    fn from(value: AsyncIFtpAuthorizationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIFtpAuthorizationProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIFtpAuthorizationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIFtpAuthorizationProvider> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIFtpAuthorizationProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIFtpAuthorizationProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIFtpAuthorizationProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -183,21 +155,7 @@ impl AsyncIFtpHomeDirectoryProvider {
         (::windows::core::Vtable::vtable(self).Finish_GetUserHomeDirectoryData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<AsyncIFtpHomeDirectoryProvider> for ::windows::core::IUnknown {
-    fn from(value: AsyncIFtpHomeDirectoryProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIFtpHomeDirectoryProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIFtpHomeDirectoryProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIFtpHomeDirectoryProvider> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIFtpHomeDirectoryProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIFtpHomeDirectoryProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIFtpHomeDirectoryProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -238,21 +196,7 @@ impl AsyncIFtpLogProvider {
         (::windows::core::Vtable::vtable(self).Finish_Log)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIFtpLogProvider> for ::windows::core::IUnknown {
-    fn from(value: AsyncIFtpLogProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIFtpLogProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIFtpLogProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIFtpLogProvider> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIFtpLogProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIFtpLogProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIFtpLogProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -296,21 +240,7 @@ impl AsyncIFtpPostprocessProvider {
         (::windows::core::Vtable::vtable(self).Finish_HandlePostprocess)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<FTP_PROCESS_STATUS>(result__)
     }
 }
-impl ::core::convert::From<AsyncIFtpPostprocessProvider> for ::windows::core::IUnknown {
-    fn from(value: AsyncIFtpPostprocessProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIFtpPostprocessProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIFtpPostprocessProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIFtpPostprocessProvider> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIFtpPostprocessProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIFtpPostprocessProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIFtpPostprocessProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -357,21 +287,7 @@ impl AsyncIFtpPreprocessProvider {
         (::windows::core::Vtable::vtable(self).Finish_HandlePreprocess)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<FTP_PROCESS_STATUS>(result__)
     }
 }
-impl ::core::convert::From<AsyncIFtpPreprocessProvider> for ::windows::core::IUnknown {
-    fn from(value: AsyncIFtpPreprocessProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIFtpPreprocessProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIFtpPreprocessProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIFtpPreprocessProvider> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIFtpPreprocessProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIFtpPreprocessProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIFtpPreprocessProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -424,21 +340,7 @@ impl AsyncIFtpRoleProvider {
         (::windows::core::Vtable::vtable(self).Finish_IsUserInRole)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<AsyncIFtpRoleProvider> for ::windows::core::IUnknown {
-    fn from(value: AsyncIFtpRoleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIFtpRoleProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIFtpRoleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIFtpRoleProvider> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIFtpRoleProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIFtpRoleProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIFtpRoleProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -488,21 +390,7 @@ impl AsyncIMSAdminBaseSinkW {
         (::windows::core::Vtable::vtable(self).Finish_ShutdownNotify)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<AsyncIMSAdminBaseSinkW> for ::windows::core::IUnknown {
-    fn from(value: AsyncIMSAdminBaseSinkW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a AsyncIMSAdminBaseSinkW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AsyncIMSAdminBaseSinkW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&AsyncIMSAdminBaseSinkW> for ::windows::core::IUnknown {
-    fn from(value: &AsyncIMSAdminBaseSinkW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AsyncIMSAdminBaseSinkW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for AsyncIMSAdminBaseSinkW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -548,21 +436,7 @@ impl IADMEXT {
         (::windows::core::Vtable::vtable(self).Terminate)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IADMEXT> for ::windows::core::IUnknown {
-    fn from(value: IADMEXT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IADMEXT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADMEXT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IADMEXT> for ::windows::core::IUnknown {
-    fn from(value: &IADMEXT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADMEXT, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IADMEXT {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -609,21 +483,7 @@ impl IFtpAuthenticationProvider {
         (::windows::core::Vtable::vtable(self).AuthenticateUser)(::windows::core::Vtable::as_raw(self), pszsessionid.into(), pszsitename.into(), pszusername.into(), pszpassword.into(), ::core::mem::transmute(ppszcanonicalusername), ::core::mem::transmute(pfauthenticated)).ok()
     }
 }
-impl ::core::convert::From<IFtpAuthenticationProvider> for ::windows::core::IUnknown {
-    fn from(value: IFtpAuthenticationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFtpAuthenticationProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFtpAuthenticationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFtpAuthenticationProvider> for ::windows::core::IUnknown {
-    fn from(value: &IFtpAuthenticationProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFtpAuthenticationProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFtpAuthenticationProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -670,21 +530,7 @@ impl IFtpAuthorizationProvider {
         (::windows::core::Vtable::vtable(self).GetUserAccessPermission)(::windows::core::Vtable::as_raw(self), pszsessionid.into(), pszsitename.into(), pszvirtualpath.into(), pszusername.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<FTP_ACCESS>(result__)
     }
 }
-impl ::core::convert::From<IFtpAuthorizationProvider> for ::windows::core::IUnknown {
-    fn from(value: IFtpAuthorizationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFtpAuthorizationProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFtpAuthorizationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFtpAuthorizationProvider> for ::windows::core::IUnknown {
-    fn from(value: &IFtpAuthorizationProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFtpAuthorizationProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFtpAuthorizationProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -727,21 +573,7 @@ impl IFtpHomeDirectoryProvider {
         (::windows::core::Vtable::vtable(self).GetUserHomeDirectoryData)(::windows::core::Vtable::as_raw(self), pszsessionid.into(), pszsitename.into(), pszusername.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IFtpHomeDirectoryProvider> for ::windows::core::IUnknown {
-    fn from(value: IFtpHomeDirectoryProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFtpHomeDirectoryProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFtpHomeDirectoryProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFtpHomeDirectoryProvider> for ::windows::core::IUnknown {
-    fn from(value: &IFtpHomeDirectoryProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFtpHomeDirectoryProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFtpHomeDirectoryProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -778,21 +610,7 @@ impl IFtpLogProvider {
         (::windows::core::Vtable::vtable(self).Log)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ploggingparameters)).ok()
     }
 }
-impl ::core::convert::From<IFtpLogProvider> for ::windows::core::IUnknown {
-    fn from(value: IFtpLogProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFtpLogProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFtpLogProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFtpLogProvider> for ::windows::core::IUnknown {
-    fn from(value: &IFtpLogProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFtpLogProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFtpLogProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -832,21 +650,7 @@ impl IFtpPostprocessProvider {
         (::windows::core::Vtable::vtable(self).HandlePostprocess)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppostprocessparameters), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<FTP_PROCESS_STATUS>(result__)
     }
 }
-impl ::core::convert::From<IFtpPostprocessProvider> for ::windows::core::IUnknown {
-    fn from(value: IFtpPostprocessProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFtpPostprocessProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFtpPostprocessProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFtpPostprocessProvider> for ::windows::core::IUnknown {
-    fn from(value: &IFtpPostprocessProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFtpPostprocessProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFtpPostprocessProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -889,21 +693,7 @@ impl IFtpPreprocessProvider {
         (::windows::core::Vtable::vtable(self).HandlePreprocess)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppreprocessparameters), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<FTP_PROCESS_STATUS>(result__)
     }
 }
-impl ::core::convert::From<IFtpPreprocessProvider> for ::windows::core::IUnknown {
-    fn from(value: IFtpPreprocessProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFtpPreprocessProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFtpPreprocessProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFtpPreprocessProvider> for ::windows::core::IUnknown {
-    fn from(value: &IFtpPreprocessProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFtpPreprocessProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFtpPreprocessProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -945,21 +735,7 @@ impl IFtpProviderConstruct {
         (::windows::core::Vtable::vtable(self).Construct)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(configurationentries)).ok()
     }
 }
-impl ::core::convert::From<IFtpProviderConstruct> for ::windows::core::IUnknown {
-    fn from(value: IFtpProviderConstruct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFtpProviderConstruct> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFtpProviderConstruct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFtpProviderConstruct> for ::windows::core::IUnknown {
-    fn from(value: &IFtpProviderConstruct) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFtpProviderConstruct, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFtpProviderConstruct {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1008,21 +784,7 @@ impl IFtpRoleProvider {
         (::windows::core::Vtable::vtable(self).IsUserInRole)(::windows::core::Vtable::as_raw(self), pszsessionid.into(), pszsitename.into(), pszusername.into(), pszrole.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IFtpRoleProvider> for ::windows::core::IUnknown {
-    fn from(value: IFtpRoleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFtpRoleProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFtpRoleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFtpRoleProvider> for ::windows::core::IUnknown {
-    fn from(value: &IFtpRoleProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFtpRoleProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFtpRoleProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1280,36 +1042,7 @@ impl IMSAdminBase2W {
         (::windows::core::Vtable::vtable(self).EnumHistory)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pszmdhistorylocation.as_ptr()), ::core::mem::transmute(pdwmdmajorversion), ::core::mem::transmute(pdwmdminorversion), ::core::mem::transmute(pftmdhistorytime), dwmdenumindex).ok()
     }
 }
-impl ::core::convert::From<IMSAdminBase2W> for ::windows::core::IUnknown {
-    fn from(value: IMSAdminBase2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMSAdminBase2W> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSAdminBase2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMSAdminBase2W> for ::windows::core::IUnknown {
-    fn from(value: &IMSAdminBase2W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMSAdminBase2W> for IMSAdminBaseW {
-    fn from(value: IMSAdminBase2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMSAdminBase2W> for &'a IMSAdminBaseW {
-    fn from(value: &'a IMSAdminBase2W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMSAdminBase2W> for IMSAdminBaseW {
-    fn from(value: &IMSAdminBase2W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSAdminBase2W, ::windows::core::IUnknown, IMSAdminBaseW);
 impl ::core::clone::Clone for IMSAdminBase2W {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1578,51 +1311,7 @@ impl IMSAdminBase3W {
         (::windows::core::Vtable::vtable(self).GetChildPaths)(::windows::core::Vtable::as_raw(self), hmdhandle, pszmdpath.into(), pszbuffer.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(pszbuffer.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ::core::mem::transmute(pcchmdrequiredbuffersize.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMSAdminBase3W> for ::windows::core::IUnknown {
-    fn from(value: IMSAdminBase3W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMSAdminBase3W> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSAdminBase3W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMSAdminBase3W> for ::windows::core::IUnknown {
-    fn from(value: &IMSAdminBase3W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMSAdminBase3W> for IMSAdminBaseW {
-    fn from(value: IMSAdminBase3W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMSAdminBase3W> for &'a IMSAdminBaseW {
-    fn from(value: &'a IMSAdminBase3W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMSAdminBase3W> for IMSAdminBaseW {
-    fn from(value: &IMSAdminBase3W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMSAdminBase3W> for IMSAdminBase2W {
-    fn from(value: IMSAdminBase3W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMSAdminBase3W> for &'a IMSAdminBase2W {
-    fn from(value: &'a IMSAdminBase3W) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMSAdminBase3W> for IMSAdminBase2W {
-    fn from(value: &IMSAdminBase3W) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSAdminBase3W, ::windows::core::IUnknown, IMSAdminBaseW, IMSAdminBase2W);
 impl ::core::clone::Clone for IMSAdminBase3W {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1662,21 +1351,7 @@ impl IMSAdminBaseSinkW {
         (::windows::core::Vtable::vtable(self).ShutdownNotify)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMSAdminBaseSinkW> for ::windows::core::IUnknown {
-    fn from(value: IMSAdminBaseSinkW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMSAdminBaseSinkW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSAdminBaseSinkW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMSAdminBaseSinkW> for ::windows::core::IUnknown {
-    fn from(value: &IMSAdminBaseSinkW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSAdminBaseSinkW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMSAdminBaseSinkW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1890,21 +1565,7 @@ impl IMSAdminBaseW {
         (::windows::core::Vtable::vtable(self).GetServerGuid)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMSAdminBaseW> for ::windows::core::IUnknown {
-    fn from(value: IMSAdminBaseW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMSAdminBaseW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSAdminBaseW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMSAdminBaseW> for ::windows::core::IUnknown {
-    fn from(value: &IMSAdminBaseW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSAdminBaseW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMSAdminBaseW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1990,21 +1651,7 @@ impl IMSImpExpHelpW {
         (::windows::core::Vtable::vtable(self).EnumeratePathsInFile)(::windows::core::Vtable::as_raw(self), pszfilename.into(), pszkeytype.into(), pszbuffer.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(pszbuffer.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ::core::mem::transmute(pdwmdrequiredbuffersize)).ok()
     }
 }
-impl ::core::convert::From<IMSImpExpHelpW> for ::windows::core::IUnknown {
-    fn from(value: IMSImpExpHelpW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMSImpExpHelpW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSImpExpHelpW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMSImpExpHelpW> for ::windows::core::IUnknown {
-    fn from(value: &IMSImpExpHelpW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSImpExpHelpW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMSImpExpHelpW {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/mod.rs
@@ -10,41 +10,7 @@ impl IMSMQApplication {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQApplication> for ::windows::core::IUnknown {
-    fn from(value: IMSMQApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQApplication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQApplication> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQApplication> for super::Com::IDispatch {
-    fn from(value: IMSMQApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQApplication> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQApplication> for super::Com::IDispatch {
-    fn from(value: &IMSMQApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQApplication, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQApplication {
     fn clone(&self) -> Self {
@@ -123,59 +89,7 @@ impl IMSMQApplication2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQApplication2> for ::windows::core::IUnknown {
-    fn from(value: IMSMQApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQApplication2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQApplication2> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQApplication2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQApplication2> for super::Com::IDispatch {
-    fn from(value: IMSMQApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQApplication2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQApplication2> for super::Com::IDispatch {
-    fn from(value: &IMSMQApplication2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQApplication2> for IMSMQApplication {
-    fn from(value: IMSMQApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQApplication2> for &'a IMSMQApplication {
-    fn from(value: &'a IMSMQApplication2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQApplication2> for IMSMQApplication {
-    fn from(value: &IMSMQApplication2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQApplication2, ::windows::core::IUnknown, super::Com::IDispatch, IMSMQApplication);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQApplication2 {
     fn clone(&self) -> Self {
@@ -308,77 +222,7 @@ impl IMSMQApplication3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQApplication3> for ::windows::core::IUnknown {
-    fn from(value: IMSMQApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQApplication3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQApplication3> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQApplication3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQApplication3> for super::Com::IDispatch {
-    fn from(value: IMSMQApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQApplication3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQApplication3> for super::Com::IDispatch {
-    fn from(value: &IMSMQApplication3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQApplication3> for IMSMQApplication {
-    fn from(value: IMSMQApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQApplication3> for &'a IMSMQApplication {
-    fn from(value: &'a IMSMQApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQApplication3> for IMSMQApplication {
-    fn from(value: &IMSMQApplication3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQApplication3> for IMSMQApplication2 {
-    fn from(value: IMSMQApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQApplication3> for &'a IMSMQApplication2 {
-    fn from(value: &'a IMSMQApplication3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQApplication3> for IMSMQApplication2 {
-    fn from(value: &IMSMQApplication3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQApplication3, ::windows::core::IUnknown, super::Com::IDispatch, IMSMQApplication, IMSMQApplication2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQApplication3 {
     fn clone(&self) -> Self {
@@ -454,41 +298,7 @@ impl IMSMQCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQCollection> for ::windows::core::IUnknown {
-    fn from(value: IMSMQCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQCollection> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQCollection> for super::Com::IDispatch {
-    fn from(value: IMSMQCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQCollection> for super::Com::IDispatch {
-    fn from(value: &IMSMQCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQCollection {
     fn clone(&self) -> Self {
@@ -543,41 +353,7 @@ impl IMSMQCoordinatedTransactionDispenser {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQCoordinatedTransactionDispenser> for ::windows::core::IUnknown {
-    fn from(value: IMSMQCoordinatedTransactionDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQCoordinatedTransactionDispenser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQCoordinatedTransactionDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQCoordinatedTransactionDispenser> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQCoordinatedTransactionDispenser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQCoordinatedTransactionDispenser> for super::Com::IDispatch {
-    fn from(value: IMSMQCoordinatedTransactionDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQCoordinatedTransactionDispenser> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQCoordinatedTransactionDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQCoordinatedTransactionDispenser> for super::Com::IDispatch {
-    fn from(value: &IMSMQCoordinatedTransactionDispenser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQCoordinatedTransactionDispenser, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQCoordinatedTransactionDispenser {
     fn clone(&self) -> Self {
@@ -636,41 +412,7 @@ impl IMSMQCoordinatedTransactionDispenser2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQCoordinatedTransactionDispenser2> for ::windows::core::IUnknown {
-    fn from(value: IMSMQCoordinatedTransactionDispenser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQCoordinatedTransactionDispenser2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQCoordinatedTransactionDispenser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQCoordinatedTransactionDispenser2> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQCoordinatedTransactionDispenser2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQCoordinatedTransactionDispenser2> for super::Com::IDispatch {
-    fn from(value: IMSMQCoordinatedTransactionDispenser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQCoordinatedTransactionDispenser2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQCoordinatedTransactionDispenser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQCoordinatedTransactionDispenser2> for super::Com::IDispatch {
-    fn from(value: &IMSMQCoordinatedTransactionDispenser2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQCoordinatedTransactionDispenser2, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQCoordinatedTransactionDispenser2 {
     fn clone(&self) -> Self {
@@ -733,41 +475,7 @@ impl IMSMQCoordinatedTransactionDispenser3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQCoordinatedTransactionDispenser3> for ::windows::core::IUnknown {
-    fn from(value: IMSMQCoordinatedTransactionDispenser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQCoordinatedTransactionDispenser3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQCoordinatedTransactionDispenser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQCoordinatedTransactionDispenser3> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQCoordinatedTransactionDispenser3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQCoordinatedTransactionDispenser3> for super::Com::IDispatch {
-    fn from(value: IMSMQCoordinatedTransactionDispenser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQCoordinatedTransactionDispenser3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQCoordinatedTransactionDispenser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQCoordinatedTransactionDispenser3> for super::Com::IDispatch {
-    fn from(value: &IMSMQCoordinatedTransactionDispenser3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQCoordinatedTransactionDispenser3, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQCoordinatedTransactionDispenser3 {
     fn clone(&self) -> Self {
@@ -883,41 +591,7 @@ impl IMSMQDestination {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQDestination> for ::windows::core::IUnknown {
-    fn from(value: IMSMQDestination) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQDestination> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQDestination) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQDestination> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQDestination) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQDestination> for super::Com::IDispatch {
-    fn from(value: IMSMQDestination) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQDestination> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQDestination) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQDestination> for super::Com::IDispatch {
-    fn from(value: &IMSMQDestination) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQDestination, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQDestination {
     fn clone(&self) -> Self {
@@ -988,41 +662,7 @@ pub struct IMSMQEvent(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IMSMQEvent {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQEvent> for ::windows::core::IUnknown {
-    fn from(value: IMSMQEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQEvent> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQEvent> for super::Com::IDispatch {
-    fn from(value: IMSMQEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQEvent> for super::Com::IDispatch {
-    fn from(value: &IMSMQEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQEvent {
     fn clone(&self) -> Self {
@@ -1071,59 +711,7 @@ impl IMSMQEvent2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQEvent2> for ::windows::core::IUnknown {
-    fn from(value: IMSMQEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQEvent2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQEvent2> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQEvent2> for super::Com::IDispatch {
-    fn from(value: IMSMQEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQEvent2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQEvent2> for super::Com::IDispatch {
-    fn from(value: &IMSMQEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQEvent2> for IMSMQEvent {
-    fn from(value: IMSMQEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQEvent2> for &'a IMSMQEvent {
-    fn from(value: &'a IMSMQEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQEvent2> for IMSMQEvent {
-    fn from(value: &IMSMQEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQEvent2, ::windows::core::IUnknown, super::Com::IDispatch, IMSMQEvent);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQEvent2 {
     fn clone(&self) -> Self {
@@ -1176,77 +764,7 @@ impl IMSMQEvent3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQEvent3> for ::windows::core::IUnknown {
-    fn from(value: IMSMQEvent3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQEvent3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQEvent3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQEvent3> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQEvent3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQEvent3> for super::Com::IDispatch {
-    fn from(value: IMSMQEvent3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQEvent3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQEvent3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQEvent3> for super::Com::IDispatch {
-    fn from(value: &IMSMQEvent3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQEvent3> for IMSMQEvent {
-    fn from(value: IMSMQEvent3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQEvent3> for &'a IMSMQEvent {
-    fn from(value: &'a IMSMQEvent3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQEvent3> for IMSMQEvent {
-    fn from(value: &IMSMQEvent3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQEvent3> for IMSMQEvent2 {
-    fn from(value: IMSMQEvent3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQEvent3> for &'a IMSMQEvent2 {
-    fn from(value: &'a IMSMQEvent3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQEvent3> for IMSMQEvent2 {
-    fn from(value: &IMSMQEvent3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQEvent3, ::windows::core::IUnknown, super::Com::IDispatch, IMSMQEvent, IMSMQEvent2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQEvent3 {
     fn clone(&self) -> Self {
@@ -1328,41 +846,7 @@ impl IMSMQManagement {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQManagement> for ::windows::core::IUnknown {
-    fn from(value: IMSMQManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQManagement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQManagement> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQManagement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQManagement> for super::Com::IDispatch {
-    fn from(value: IMSMQManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQManagement> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQManagement> for super::Com::IDispatch {
-    fn from(value: &IMSMQManagement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQManagement, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQManagement {
     fn clone(&self) -> Self {
@@ -1645,41 +1129,7 @@ impl IMSMQMessage {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQMessage> for ::windows::core::IUnknown {
-    fn from(value: IMSMQMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQMessage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQMessage> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQMessage> for super::Com::IDispatch {
-    fn from(value: IMSMQMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQMessage> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQMessage> for super::Com::IDispatch {
-    fn from(value: &IMSMQMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQMessage, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQMessage {
     fn clone(&self) -> Self {
@@ -2184,41 +1634,7 @@ impl IMSMQMessage2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQMessage2> for ::windows::core::IUnknown {
-    fn from(value: IMSMQMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQMessage2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQMessage2> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQMessage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQMessage2> for super::Com::IDispatch {
-    fn from(value: IMSMQMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQMessage2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQMessage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQMessage2> for super::Com::IDispatch {
-    fn from(value: &IMSMQMessage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQMessage2, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQMessage2 {
     fn clone(&self) -> Self {
@@ -2876,41 +2292,7 @@ impl IMSMQMessage3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQMessage3> for ::windows::core::IUnknown {
-    fn from(value: IMSMQMessage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQMessage3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQMessage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQMessage3> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQMessage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQMessage3> for super::Com::IDispatch {
-    fn from(value: IMSMQMessage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQMessage3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQMessage3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQMessage3> for super::Com::IDispatch {
-    fn from(value: &IMSMQMessage3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQMessage3, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQMessage3 {
     fn clone(&self) -> Self {
@@ -3611,41 +2993,7 @@ impl IMSMQMessage4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQMessage4> for ::windows::core::IUnknown {
-    fn from(value: IMSMQMessage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQMessage4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQMessage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQMessage4> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQMessage4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQMessage4> for super::Com::IDispatch {
-    fn from(value: IMSMQMessage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQMessage4> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQMessage4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQMessage4> for super::Com::IDispatch {
-    fn from(value: &IMSMQMessage4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQMessage4, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQMessage4 {
     fn clone(&self) -> Self {
@@ -3960,59 +3308,7 @@ impl IMSMQOutgoingQueueManagement {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQOutgoingQueueManagement> for ::windows::core::IUnknown {
-    fn from(value: IMSMQOutgoingQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQOutgoingQueueManagement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQOutgoingQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQOutgoingQueueManagement> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQOutgoingQueueManagement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQOutgoingQueueManagement> for super::Com::IDispatch {
-    fn from(value: IMSMQOutgoingQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQOutgoingQueueManagement> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQOutgoingQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQOutgoingQueueManagement> for super::Com::IDispatch {
-    fn from(value: &IMSMQOutgoingQueueManagement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQOutgoingQueueManagement> for IMSMQManagement {
-    fn from(value: IMSMQOutgoingQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQOutgoingQueueManagement> for &'a IMSMQManagement {
-    fn from(value: &'a IMSMQOutgoingQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQOutgoingQueueManagement> for IMSMQManagement {
-    fn from(value: &IMSMQOutgoingQueueManagement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQOutgoingQueueManagement, ::windows::core::IUnknown, super::Com::IDispatch, IMSMQManagement);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQOutgoingQueueManagement {
     fn clone(&self) -> Self {
@@ -4081,41 +3377,7 @@ impl IMSMQPrivateDestination {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQPrivateDestination> for ::windows::core::IUnknown {
-    fn from(value: IMSMQPrivateDestination) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQPrivateDestination> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQPrivateDestination) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQPrivateDestination> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQPrivateDestination) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQPrivateDestination> for super::Com::IDispatch {
-    fn from(value: IMSMQPrivateDestination) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQPrivateDestination> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQPrivateDestination) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQPrivateDestination> for super::Com::IDispatch {
-    fn from(value: &IMSMQPrivateDestination) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQPrivateDestination, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQPrivateDestination {
     fn clone(&self) -> Self {
@@ -4186,41 +3448,7 @@ impl IMSMQPrivateEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQPrivateEvent> for ::windows::core::IUnknown {
-    fn from(value: IMSMQPrivateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQPrivateEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQPrivateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQPrivateEvent> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQPrivateEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQPrivateEvent> for super::Com::IDispatch {
-    fn from(value: IMSMQPrivateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQPrivateEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQPrivateEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQPrivateEvent> for super::Com::IDispatch {
-    fn from(value: &IMSMQPrivateEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQPrivateEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQPrivateEvent {
     fn clone(&self) -> Self {
@@ -4278,41 +3506,7 @@ impl IMSMQQuery {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQuery> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQuery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQuery> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQuery> for super::Com::IDispatch {
-    fn from(value: IMSMQQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQuery> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQuery> for super::Com::IDispatch {
-    fn from(value: &IMSMQQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQuery, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQuery {
     fn clone(&self) -> Self {
@@ -4371,41 +3565,7 @@ impl IMSMQQuery2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQuery2> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQuery2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQuery2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQuery2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQuery2> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQuery2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQuery2> for super::Com::IDispatch {
-    fn from(value: IMSMQQuery2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQuery2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQuery2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQuery2> for super::Com::IDispatch {
-    fn from(value: &IMSMQQuery2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQuery2, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQuery2 {
     fn clone(&self) -> Self {
@@ -4489,41 +3649,7 @@ impl IMSMQQuery3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQuery3> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQuery3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQuery3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQuery3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQuery3> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQuery3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQuery3> for super::Com::IDispatch {
-    fn from(value: IMSMQQuery3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQuery3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQuery3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQuery3> for super::Com::IDispatch {
-    fn from(value: &IMSMQQuery3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQuery3, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQuery3 {
     fn clone(&self) -> Self {
@@ -4611,41 +3737,7 @@ impl IMSMQQuery4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQuery4> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQuery4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQuery4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQuery4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQuery4> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQuery4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQuery4> for super::Com::IDispatch {
-    fn from(value: IMSMQQuery4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQuery4> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQuery4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQuery4> for super::Com::IDispatch {
-    fn from(value: &IMSMQQuery4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQuery4, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQuery4 {
     fn clone(&self) -> Self {
@@ -4766,41 +3858,7 @@ impl IMSMQQueue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueue> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueue> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueue> for super::Com::IDispatch {
-    fn from(value: IMSMQQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueue> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueue> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueue, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueue {
     fn clone(&self) -> Self {
@@ -4979,41 +4037,7 @@ impl IMSMQQueue2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueue2> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueue2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueue2> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueue2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueue2> for super::Com::IDispatch {
-    fn from(value: IMSMQQueue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueue2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueue2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueue2> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueue2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueue2, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueue2 {
     fn clone(&self) -> Self {
@@ -5307,41 +4331,7 @@ impl IMSMQQueue3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueue3> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueue3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueue3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueue3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueue3> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueue3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueue3> for super::Com::IDispatch {
-    fn from(value: IMSMQQueue3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueue3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueue3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueue3> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueue3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueue3, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueue3 {
     fn clone(&self) -> Self {
@@ -5690,41 +4680,7 @@ impl IMSMQQueue4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueue4> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueue4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueue4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueue4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueue4> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueue4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueue4> for super::Com::IDispatch {
-    fn from(value: IMSMQQueue4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueue4> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueue4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueue4> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueue4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueue4, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueue4 {
     fn clone(&self) -> Self {
@@ -5989,41 +4945,7 @@ impl IMSMQQueueInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfo> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueueInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueueInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfo> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueueInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfo> for super::Com::IDispatch {
-    fn from(value: IMSMQQueueInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfo> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueueInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfo> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueueInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueueInfo, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueueInfo {
     fn clone(&self) -> Self {
@@ -6246,41 +5168,7 @@ impl IMSMQQueueInfo2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfo2> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueueInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueueInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueueInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfo2> for super::Com::IDispatch {
-    fn from(value: IMSMQQueueInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfo2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueueInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfo2> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueueInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueueInfo2, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueueInfo2 {
     fn clone(&self) -> Self {
@@ -6535,41 +5423,7 @@ impl IMSMQQueueInfo3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfo3> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueueInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfo3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueueInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfo3> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueueInfo3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfo3> for super::Com::IDispatch {
-    fn from(value: IMSMQQueueInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfo3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueueInfo3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfo3> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueueInfo3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueueInfo3, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueueInfo3 {
     fn clone(&self) -> Self {
@@ -6829,41 +5683,7 @@ impl IMSMQQueueInfo4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfo4> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueueInfo4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfo4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueueInfo4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfo4> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueueInfo4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfo4> for super::Com::IDispatch {
-    fn from(value: IMSMQQueueInfo4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfo4> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueueInfo4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfo4> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueueInfo4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueueInfo4, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueueInfo4 {
     fn clone(&self) -> Self {
@@ -6975,41 +5795,7 @@ impl IMSMQQueueInfos {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfos> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueueInfos) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfos> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueueInfos) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfos> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueueInfos) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfos> for super::Com::IDispatch {
-    fn from(value: IMSMQQueueInfos) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfos> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueueInfos) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfos> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueueInfos) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueueInfos, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueueInfos {
     fn clone(&self) -> Self {
@@ -7072,41 +5858,7 @@ impl IMSMQQueueInfos2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfos2> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueueInfos2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfos2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueueInfos2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfos2> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueueInfos2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfos2> for super::Com::IDispatch {
-    fn from(value: IMSMQQueueInfos2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfos2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueueInfos2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfos2> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueueInfos2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueueInfos2, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueueInfos2 {
     fn clone(&self) -> Self {
@@ -7173,41 +5925,7 @@ impl IMSMQQueueInfos3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfos3> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueueInfos3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfos3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueueInfos3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfos3> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueueInfos3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfos3> for super::Com::IDispatch {
-    fn from(value: IMSMQQueueInfos3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfos3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueueInfos3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfos3> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueueInfos3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueueInfos3, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueueInfos3 {
     fn clone(&self) -> Self {
@@ -7274,41 +5992,7 @@ impl IMSMQQueueInfos4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfos4> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueueInfos4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfos4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueueInfos4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfos4> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueueInfos4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueInfos4> for super::Com::IDispatch {
-    fn from(value: IMSMQQueueInfos4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueInfos4> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueueInfos4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueInfos4> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueueInfos4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueueInfos4, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueueInfos4 {
     fn clone(&self) -> Self {
@@ -7415,59 +6099,7 @@ impl IMSMQQueueManagement {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueManagement> for ::windows::core::IUnknown {
-    fn from(value: IMSMQQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueManagement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueManagement> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQQueueManagement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueManagement> for super::Com::IDispatch {
-    fn from(value: IMSMQQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueManagement> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueManagement> for super::Com::IDispatch {
-    fn from(value: &IMSMQQueueManagement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQQueueManagement> for IMSMQManagement {
-    fn from(value: IMSMQQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQQueueManagement> for &'a IMSMQManagement {
-    fn from(value: &'a IMSMQQueueManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQQueueManagement> for IMSMQManagement {
-    fn from(value: &IMSMQQueueManagement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQQueueManagement, ::windows::core::IUnknown, super::Com::IDispatch, IMSMQManagement);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQQueueManagement {
     fn clone(&self) -> Self {
@@ -7533,41 +6165,7 @@ impl IMSMQTransaction {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransaction> for ::windows::core::IUnknown {
-    fn from(value: IMSMQTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransaction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransaction> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransaction> for super::Com::IDispatch {
-    fn from(value: IMSMQTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransaction> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQTransaction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransaction> for super::Com::IDispatch {
-    fn from(value: &IMSMQTransaction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQTransaction, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQTransaction {
     fn clone(&self) -> Self {
@@ -7647,59 +6245,7 @@ impl IMSMQTransaction2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransaction2> for ::windows::core::IUnknown {
-    fn from(value: IMSMQTransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransaction2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQTransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransaction2> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQTransaction2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransaction2> for super::Com::IDispatch {
-    fn from(value: IMSMQTransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransaction2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQTransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransaction2> for super::Com::IDispatch {
-    fn from(value: &IMSMQTransaction2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransaction2> for IMSMQTransaction {
-    fn from(value: IMSMQTransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransaction2> for &'a IMSMQTransaction {
-    fn from(value: &'a IMSMQTransaction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransaction2> for IMSMQTransaction {
-    fn from(value: &IMSMQTransaction2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQTransaction2, ::windows::core::IUnknown, super::Com::IDispatch, IMSMQTransaction);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQTransaction2 {
     fn clone(&self) -> Self {
@@ -7784,77 +6330,7 @@ impl IMSMQTransaction3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransaction3> for ::windows::core::IUnknown {
-    fn from(value: IMSMQTransaction3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransaction3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQTransaction3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransaction3> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQTransaction3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransaction3> for super::Com::IDispatch {
-    fn from(value: IMSMQTransaction3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransaction3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQTransaction3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransaction3> for super::Com::IDispatch {
-    fn from(value: &IMSMQTransaction3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransaction3> for IMSMQTransaction {
-    fn from(value: IMSMQTransaction3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransaction3> for &'a IMSMQTransaction {
-    fn from(value: &'a IMSMQTransaction3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransaction3> for IMSMQTransaction {
-    fn from(value: &IMSMQTransaction3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransaction3> for IMSMQTransaction2 {
-    fn from(value: IMSMQTransaction3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransaction3> for &'a IMSMQTransaction2 {
-    fn from(value: &'a IMSMQTransaction3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransaction3> for IMSMQTransaction2 {
-    fn from(value: &IMSMQTransaction3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQTransaction3, ::windows::core::IUnknown, super::Com::IDispatch, IMSMQTransaction, IMSMQTransaction2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQTransaction3 {
     fn clone(&self) -> Self {
@@ -7907,41 +6383,7 @@ impl IMSMQTransactionDispenser {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransactionDispenser> for ::windows::core::IUnknown {
-    fn from(value: IMSMQTransactionDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransactionDispenser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQTransactionDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransactionDispenser> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQTransactionDispenser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransactionDispenser> for super::Com::IDispatch {
-    fn from(value: IMSMQTransactionDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransactionDispenser> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQTransactionDispenser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransactionDispenser> for super::Com::IDispatch {
-    fn from(value: &IMSMQTransactionDispenser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQTransactionDispenser, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQTransactionDispenser {
     fn clone(&self) -> Self {
@@ -8000,41 +6442,7 @@ impl IMSMQTransactionDispenser2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransactionDispenser2> for ::windows::core::IUnknown {
-    fn from(value: IMSMQTransactionDispenser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransactionDispenser2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQTransactionDispenser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransactionDispenser2> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQTransactionDispenser2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransactionDispenser2> for super::Com::IDispatch {
-    fn from(value: IMSMQTransactionDispenser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransactionDispenser2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQTransactionDispenser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransactionDispenser2> for super::Com::IDispatch {
-    fn from(value: &IMSMQTransactionDispenser2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQTransactionDispenser2, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQTransactionDispenser2 {
     fn clone(&self) -> Self {
@@ -8097,41 +6505,7 @@ impl IMSMQTransactionDispenser3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransactionDispenser3> for ::windows::core::IUnknown {
-    fn from(value: IMSMQTransactionDispenser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransactionDispenser3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMSMQTransactionDispenser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransactionDispenser3> for ::windows::core::IUnknown {
-    fn from(value: &IMSMQTransactionDispenser3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMSMQTransactionDispenser3> for super::Com::IDispatch {
-    fn from(value: IMSMQTransactionDispenser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMSMQTransactionDispenser3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMSMQTransactionDispenser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMSMQTransactionDispenser3> for super::Com::IDispatch {
-    fn from(value: &IMSMQTransactionDispenser3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMSMQTransactionDispenser3, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMSMQTransactionDispenser3 {
     fn clone(&self) -> Self {
@@ -8181,41 +6555,7 @@ pub struct _DMSMQEventEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _DMSMQEventEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_DMSMQEventEvents> for ::windows::core::IUnknown {
-    fn from(value: _DMSMQEventEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _DMSMQEventEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _DMSMQEventEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_DMSMQEventEvents> for ::windows::core::IUnknown {
-    fn from(value: &_DMSMQEventEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_DMSMQEventEvents> for super::Com::IDispatch {
-    fn from(value: _DMSMQEventEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _DMSMQEventEvents> for &'a super::Com::IDispatch {
-    fn from(value: &'a _DMSMQEventEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_DMSMQEventEvents> for super::Com::IDispatch {
-    fn from(value: &_DMSMQEventEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_DMSMQEventEvents, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _DMSMQEventEvents {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Mmc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Mmc/mod.rs
@@ -5,41 +5,7 @@ pub struct AppEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl AppEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<AppEvents> for ::windows::core::IUnknown {
-    fn from(value: AppEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a AppEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a AppEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&AppEvents> for ::windows::core::IUnknown {
-    fn from(value: &AppEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<AppEvents> for super::Com::IDispatch {
-    fn from(value: AppEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a AppEvents> for &'a super::Com::IDispatch {
-    fn from(value: &'a AppEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&AppEvents> for super::Com::IDispatch {
-    fn from(value: &AppEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(AppEvents, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for AppEvents {
     fn clone(&self) -> Self {
@@ -123,41 +89,7 @@ impl Column {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Column> for ::windows::core::IUnknown {
-    fn from(value: Column) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Column> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Column) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Column> for ::windows::core::IUnknown {
-    fn from(value: &Column) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Column> for super::Com::IDispatch {
-    fn from(value: Column) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Column> for &'a super::Com::IDispatch {
-    fn from(value: &'a Column) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Column> for super::Com::IDispatch {
-    fn from(value: &Column) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Column, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Column {
     fn clone(&self) -> Self {
@@ -232,41 +164,7 @@ impl Columns {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Columns> for ::windows::core::IUnknown {
-    fn from(value: Columns) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Columns> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Columns) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Columns> for ::windows::core::IUnknown {
-    fn from(value: &Columns) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Columns> for super::Com::IDispatch {
-    fn from(value: Columns) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Columns> for &'a super::Com::IDispatch {
-    fn from(value: &'a Columns) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Columns> for super::Com::IDispatch {
-    fn from(value: &Columns) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Columns, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Columns {
     fn clone(&self) -> Self {
@@ -332,41 +230,7 @@ impl ContextMenu {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ContextMenu> for ::windows::core::IUnknown {
-    fn from(value: ContextMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ContextMenu> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ContextMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ContextMenu> for ::windows::core::IUnknown {
-    fn from(value: &ContextMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ContextMenu> for super::Com::IDispatch {
-    fn from(value: ContextMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ContextMenu> for &'a super::Com::IDispatch {
-    fn from(value: &'a ContextMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ContextMenu> for super::Com::IDispatch {
-    fn from(value: &ContextMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ContextMenu, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ContextMenu {
     fn clone(&self) -> Self {
@@ -495,41 +359,7 @@ impl Document {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Document> for ::windows::core::IUnknown {
-    fn from(value: Document) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Document> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Document) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Document> for ::windows::core::IUnknown {
-    fn from(value: &Document) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Document> for super::Com::IDispatch {
-    fn from(value: Document) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Document> for &'a super::Com::IDispatch {
-    fn from(value: &'a Document) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Document> for super::Com::IDispatch {
-    fn from(value: &Document) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Document, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Document {
     fn clone(&self) -> Self {
@@ -653,41 +483,7 @@ impl Extension {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Extension> for ::windows::core::IUnknown {
-    fn from(value: Extension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Extension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Extension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Extension> for ::windows::core::IUnknown {
-    fn from(value: &Extension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Extension> for super::Com::IDispatch {
-    fn from(value: Extension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Extension> for &'a super::Com::IDispatch {
-    fn from(value: &'a Extension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Extension> for super::Com::IDispatch {
-    fn from(value: &Extension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Extension, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Extension {
     fn clone(&self) -> Self {
@@ -760,41 +556,7 @@ impl Extensions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Extensions> for ::windows::core::IUnknown {
-    fn from(value: Extensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Extensions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Extensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Extensions> for ::windows::core::IUnknown {
-    fn from(value: &Extensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Extensions> for super::Com::IDispatch {
-    fn from(value: Extensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Extensions> for &'a super::Com::IDispatch {
-    fn from(value: &'a Extensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Extensions> for super::Com::IDispatch {
-    fn from(value: &Extensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Extensions, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Extensions {
     fn clone(&self) -> Self {
@@ -880,41 +642,7 @@ impl Frame {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Frame> for ::windows::core::IUnknown {
-    fn from(value: Frame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Frame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Frame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Frame> for ::windows::core::IUnknown {
-    fn from(value: &Frame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Frame> for super::Com::IDispatch {
-    fn from(value: Frame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Frame> for &'a super::Com::IDispatch {
-    fn from(value: &'a Frame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Frame> for super::Com::IDispatch {
-    fn from(value: &Frame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Frame, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Frame {
     fn clone(&self) -> Self {
@@ -979,21 +707,7 @@ impl IColumnData {
         (::windows::core::Vtable::vtable(self).GetColumnSortData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcolid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut MMC_SORT_SET_DATA>(result__)
     }
 }
-impl ::core::convert::From<IColumnData> for ::windows::core::IUnknown {
-    fn from(value: IColumnData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IColumnData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IColumnData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IColumnData> for ::windows::core::IUnknown {
-    fn from(value: &IColumnData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IColumnData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IColumnData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1072,21 +786,7 @@ impl IComponent {
         (::windows::core::Vtable::vtable(self).CompareObjects)(::windows::core::Vtable::as_raw(self), lpdataobjecta.into().abi(), lpdataobjectb.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IComponent> for ::windows::core::IUnknown {
-    fn from(value: IComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComponent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComponent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComponent> for ::windows::core::IUnknown {
-    fn from(value: &IComponent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComponent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComponent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1192,36 +892,7 @@ impl IComponent2 {
         (::windows::core::Vtable::vtable(self).RestoreResultView)(::windows::core::Vtable::as_raw(self), cookie, ::core::mem::transmute(presultviewtype)).ok()
     }
 }
-impl ::core::convert::From<IComponent2> for ::windows::core::IUnknown {
-    fn from(value: IComponent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComponent2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComponent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComponent2> for ::windows::core::IUnknown {
-    fn from(value: &IComponent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IComponent2> for IComponent {
-    fn from(value: IComponent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComponent2> for &'a IComponent {
-    fn from(value: &'a IComponent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComponent2> for IComponent {
-    fn from(value: &IComponent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComponent2, ::windows::core::IUnknown, IComponent);
 impl ::core::clone::Clone for IComponent2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1303,21 +974,7 @@ impl IComponentData {
         (::windows::core::Vtable::vtable(self).CompareObjects)(::windows::core::Vtable::as_raw(self), lpdataobjecta.into().abi(), lpdataobjectb.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IComponentData> for ::windows::core::IUnknown {
-    fn from(value: IComponentData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComponentData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComponentData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComponentData> for ::windows::core::IUnknown {
-    fn from(value: &IComponentData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComponentData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComponentData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1418,36 +1075,7 @@ impl IComponentData2 {
         (::windows::core::Vtable::vtable(self).QueryDispatch)(::windows::core::Vtable::as_raw(self), cookie, r#type, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::IDispatch>(result__)
     }
 }
-impl ::core::convert::From<IComponentData2> for ::windows::core::IUnknown {
-    fn from(value: IComponentData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComponentData2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComponentData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComponentData2> for ::windows::core::IUnknown {
-    fn from(value: &IComponentData2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IComponentData2> for IComponentData {
-    fn from(value: IComponentData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComponentData2> for &'a IComponentData {
-    fn from(value: &'a IComponentData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComponentData2> for IComponentData {
-    fn from(value: &IComponentData2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComponentData2, ::windows::core::IUnknown, IComponentData);
 impl ::core::clone::Clone for IComponentData2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1541,21 +1169,7 @@ impl IConsole {
         (::windows::core::Vtable::vtable(self).NewWindow)(::windows::core::Vtable::as_raw(self), hscopeitem, loptions).ok()
     }
 }
-impl ::core::convert::From<IConsole> for ::windows::core::IUnknown {
-    fn from(value: IConsole) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsole> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConsole) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsole> for ::windows::core::IUnknown {
-    fn from(value: &IConsole) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConsole, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConsole {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1679,36 +1293,7 @@ impl IConsole2 {
         (::windows::core::Vtable::vtable(self).SetStatusText)(::windows::core::Vtable::as_raw(self), pszstatustext.into()).ok()
     }
 }
-impl ::core::convert::From<IConsole2> for ::windows::core::IUnknown {
-    fn from(value: IConsole2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsole2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConsole2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsole2> for ::windows::core::IUnknown {
-    fn from(value: &IConsole2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IConsole2> for IConsole {
-    fn from(value: IConsole2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsole2> for &'a IConsole {
-    fn from(value: &'a IConsole2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsole2> for IConsole {
-    fn from(value: &IConsole2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConsole2, ::windows::core::IUnknown, IConsole);
 impl ::core::clone::Clone for IConsole2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1824,51 +1409,7 @@ impl IConsole3 {
         (::windows::core::Vtable::vtable(self).RenameScopeItem)(::windows::core::Vtable::as_raw(self), hscopeitem).ok()
     }
 }
-impl ::core::convert::From<IConsole3> for ::windows::core::IUnknown {
-    fn from(value: IConsole3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsole3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConsole3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsole3> for ::windows::core::IUnknown {
-    fn from(value: &IConsole3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IConsole3> for IConsole {
-    fn from(value: IConsole3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsole3> for &'a IConsole {
-    fn from(value: &'a IConsole3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsole3> for IConsole {
-    fn from(value: &IConsole3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IConsole3> for IConsole2 {
-    fn from(value: IConsole3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsole3> for &'a IConsole2 {
-    fn from(value: &'a IConsole3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsole3> for IConsole2 {
-    fn from(value: &IConsole3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConsole3, ::windows::core::IUnknown, IConsole, IConsole2);
 impl ::core::clone::Clone for IConsole3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1929,21 +1470,7 @@ impl IConsoleNameSpace {
         (::windows::core::Vtable::vtable(self).GetParentItem)(::windows::core::Vtable::as_raw(self), item, ::core::mem::transmute(pitemparent), ::core::mem::transmute(pcookie)).ok()
     }
 }
-impl ::core::convert::From<IConsoleNameSpace> for ::windows::core::IUnknown {
-    fn from(value: IConsoleNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsoleNameSpace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConsoleNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsoleNameSpace> for ::windows::core::IUnknown {
-    fn from(value: &IConsoleNameSpace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConsoleNameSpace, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConsoleNameSpace {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2025,36 +1552,7 @@ impl IConsoleNameSpace2 {
         (::windows::core::Vtable::vtable(self).AddExtension)(::windows::core::Vtable::as_raw(self), hitem, ::core::mem::transmute(lpclsid)).ok()
     }
 }
-impl ::core::convert::From<IConsoleNameSpace2> for ::windows::core::IUnknown {
-    fn from(value: IConsoleNameSpace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsoleNameSpace2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConsoleNameSpace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsoleNameSpace2> for ::windows::core::IUnknown {
-    fn from(value: &IConsoleNameSpace2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IConsoleNameSpace2> for IConsoleNameSpace {
-    fn from(value: IConsoleNameSpace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsoleNameSpace2> for &'a IConsoleNameSpace {
-    fn from(value: &'a IConsoleNameSpace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsoleNameSpace2> for IConsoleNameSpace {
-    fn from(value: &IConsoleNameSpace2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConsoleNameSpace2, ::windows::core::IUnknown, IConsoleNameSpace);
 impl ::core::clone::Clone for IConsoleNameSpace2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2095,21 +1593,7 @@ impl IConsolePower {
         (::windows::core::Vtable::vtable(self).ResetIdleTimer)(::windows::core::Vtable::as_raw(self), dwflags).ok()
     }
 }
-impl ::core::convert::From<IConsolePower> for ::windows::core::IUnknown {
-    fn from(value: IConsolePower) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsolePower> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConsolePower) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsolePower> for ::windows::core::IUnknown {
-    fn from(value: &IConsolePower) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConsolePower, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConsolePower {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2153,21 +1637,7 @@ impl IConsolePowerSink {
         (::windows::core::Vtable::vtable(self).OnPowerBroadcast)(::windows::core::Vtable::as_raw(self), nevent, lparam.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::LRESULT>(result__)
     }
 }
-impl ::core::convert::From<IConsolePowerSink> for ::windows::core::IUnknown {
-    fn from(value: IConsolePowerSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsolePowerSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConsolePowerSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsolePowerSink> for ::windows::core::IUnknown {
-    fn from(value: &IConsolePowerSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConsolePowerSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConsolePowerSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2225,21 +1695,7 @@ impl IConsoleVerb {
         (::windows::core::Vtable::vtable(self).GetDefaultVerb)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MMC_CONSOLE_VERB>(result__)
     }
 }
-impl ::core::convert::From<IConsoleVerb> for ::windows::core::IUnknown {
-    fn from(value: IConsoleVerb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConsoleVerb> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConsoleVerb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConsoleVerb> for ::windows::core::IUnknown {
-    fn from(value: &IConsoleVerb) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConsoleVerb, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConsoleVerb {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2285,21 +1741,7 @@ impl IContextMenuCallback {
         (::windows::core::Vtable::vtable(self).AddItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pitem)).ok()
     }
 }
-impl ::core::convert::From<IContextMenuCallback> for ::windows::core::IUnknown {
-    fn from(value: IContextMenuCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenuCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextMenuCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenuCallback> for ::windows::core::IUnknown {
-    fn from(value: &IContextMenuCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextMenuCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContextMenuCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2336,21 +1778,7 @@ impl IContextMenuCallback2 {
         (::windows::core::Vtable::vtable(self).AddItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pitem)).ok()
     }
 }
-impl ::core::convert::From<IContextMenuCallback2> for ::windows::core::IUnknown {
-    fn from(value: IContextMenuCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenuCallback2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextMenuCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenuCallback2> for ::windows::core::IUnknown {
-    fn from(value: &IContextMenuCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextMenuCallback2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContextMenuCallback2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2416,36 +1844,7 @@ impl IContextMenuProvider {
         (::windows::core::Vtable::vtable(self).ShowContextMenu)(::windows::core::Vtable::as_raw(self), hwndparent.into(), xpos, ypos, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IContextMenuProvider> for ::windows::core::IUnknown {
-    fn from(value: IContextMenuProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenuProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextMenuProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenuProvider> for ::windows::core::IUnknown {
-    fn from(value: &IContextMenuProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContextMenuProvider> for IContextMenuCallback {
-    fn from(value: IContextMenuProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenuProvider> for &'a IContextMenuCallback {
-    fn from(value: &'a IContextMenuProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenuProvider> for IContextMenuCallback {
-    fn from(value: &IContextMenuProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextMenuProvider, ::windows::core::IUnknown, IContextMenuCallback);
 impl ::core::clone::Clone for IContextMenuProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2510,21 +1909,7 @@ impl IControlbar {
         (::windows::core::Vtable::vtable(self).Detach)(::windows::core::Vtable::as_raw(self), lpunknown.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IControlbar> for ::windows::core::IUnknown {
-    fn from(value: IControlbar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IControlbar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IControlbar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IControlbar> for ::windows::core::IUnknown {
-    fn from(value: &IControlbar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IControlbar, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IControlbar {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2566,21 +1951,7 @@ impl IDisplayHelp {
         (::windows::core::Vtable::vtable(self).ShowTopic)(::windows::core::Vtable::as_raw(self), pszhelptopic.into()).ok()
     }
 }
-impl ::core::convert::From<IDisplayHelp> for ::windows::core::IUnknown {
-    fn from(value: IDisplayHelp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDisplayHelp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDisplayHelp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDisplayHelp> for ::windows::core::IUnknown {
-    fn from(value: &IDisplayHelp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDisplayHelp, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDisplayHelp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2627,21 +1998,7 @@ impl IEnumTASK {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumTASK>(result__)
     }
 }
-impl ::core::convert::From<IEnumTASK> for ::windows::core::IUnknown {
-    fn from(value: IEnumTASK) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTASK> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTASK) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTASK> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTASK) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTASK, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTASK {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2695,21 +2052,7 @@ impl IExtendContextMenu {
         (::windows::core::Vtable::vtable(self).Command)(::windows::core::Vtable::as_raw(self), lcommandid, pidataobject.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IExtendContextMenu> for ::windows::core::IUnknown {
-    fn from(value: IExtendContextMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtendContextMenu> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExtendContextMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtendContextMenu> for ::windows::core::IUnknown {
-    fn from(value: &IExtendContextMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExtendContextMenu, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExtendContextMenu {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2765,21 +2108,7 @@ impl IExtendControlbar {
         (::windows::core::Vtable::vtable(self).ControlbarNotify)(::windows::core::Vtable::as_raw(self), event, arg.into(), param2.into()).ok()
     }
 }
-impl ::core::convert::From<IExtendControlbar> for ::windows::core::IUnknown {
-    fn from(value: IExtendControlbar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtendControlbar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExtendControlbar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtendControlbar> for ::windows::core::IUnknown {
-    fn from(value: &IExtendControlbar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExtendControlbar, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExtendControlbar {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2834,21 +2163,7 @@ impl IExtendPropertySheet {
         (::windows::core::Vtable::vtable(self).QueryPagesFor)(::windows::core::Vtable::as_raw(self), lpdataobject.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IExtendPropertySheet> for ::windows::core::IUnknown {
-    fn from(value: IExtendPropertySheet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtendPropertySheet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExtendPropertySheet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtendPropertySheet> for ::windows::core::IUnknown {
-    fn from(value: &IExtendPropertySheet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExtendPropertySheet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExtendPropertySheet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2914,36 +2229,7 @@ impl IExtendPropertySheet2 {
         (::windows::core::Vtable::vtable(self).GetWatermarks)(::windows::core::Vtable::as_raw(self), lpidataobject.into().abi(), ::core::mem::transmute(lphwatermark), ::core::mem::transmute(lphheader), ::core::mem::transmute(lphpalette), ::core::mem::transmute(bstretch)).ok()
     }
 }
-impl ::core::convert::From<IExtendPropertySheet2> for ::windows::core::IUnknown {
-    fn from(value: IExtendPropertySheet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtendPropertySheet2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExtendPropertySheet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtendPropertySheet2> for ::windows::core::IUnknown {
-    fn from(value: &IExtendPropertySheet2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IExtendPropertySheet2> for IExtendPropertySheet {
-    fn from(value: IExtendPropertySheet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtendPropertySheet2> for &'a IExtendPropertySheet {
-    fn from(value: &'a IExtendPropertySheet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtendPropertySheet2> for IExtendPropertySheet {
-    fn from(value: &IExtendPropertySheet2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExtendPropertySheet2, ::windows::core::IUnknown, IExtendPropertySheet);
 impl ::core::clone::Clone for IExtendPropertySheet2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3026,21 +2312,7 @@ impl IExtendTaskPad {
         (::windows::core::Vtable::vtable(self).GetListPadInfo)(::windows::core::Vtable::as_raw(self), pszgroup.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<MMC_LISTPAD_INFO>(result__)
     }
 }
-impl ::core::convert::From<IExtendTaskPad> for ::windows::core::IUnknown {
-    fn from(value: IExtendTaskPad) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtendTaskPad> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExtendTaskPad) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtendTaskPad> for ::windows::core::IUnknown {
-    fn from(value: &IExtendTaskPad) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExtendTaskPad, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExtendTaskPad {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3094,21 +2366,7 @@ impl IExtendView {
         (::windows::core::Vtable::vtable(self).GetViews)(::windows::core::Vtable::as_raw(self), pdataobject.into().abi(), pviewextensioncallback.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IExtendView> for ::windows::core::IUnknown {
-    fn from(value: IExtendView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtendView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExtendView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtendView> for ::windows::core::IUnknown {
-    fn from(value: &IExtendView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExtendView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExtendView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3171,21 +2429,7 @@ impl IHeaderCtrl {
         (::windows::core::Vtable::vtable(self).GetColumnWidth)(::windows::core::Vtable::as_raw(self), ncol, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IHeaderCtrl> for ::windows::core::IUnknown {
-    fn from(value: IHeaderCtrl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHeaderCtrl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHeaderCtrl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHeaderCtrl> for ::windows::core::IUnknown {
-    fn from(value: &IHeaderCtrl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHeaderCtrl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHeaderCtrl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3259,36 +2503,7 @@ impl IHeaderCtrl2 {
         (::windows::core::Vtable::vtable(self).GetColumnFilter)(::windows::core::Vtable::as_raw(self), ncolumn, ::core::mem::transmute(pdwtype), ::core::mem::transmute(pfilterdata)).ok()
     }
 }
-impl ::core::convert::From<IHeaderCtrl2> for ::windows::core::IUnknown {
-    fn from(value: IHeaderCtrl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHeaderCtrl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHeaderCtrl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHeaderCtrl2> for ::windows::core::IUnknown {
-    fn from(value: &IHeaderCtrl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHeaderCtrl2> for IHeaderCtrl {
-    fn from(value: IHeaderCtrl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHeaderCtrl2> for &'a IHeaderCtrl {
-    fn from(value: &'a IHeaderCtrl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHeaderCtrl2> for IHeaderCtrl {
-    fn from(value: &IHeaderCtrl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHeaderCtrl2, ::windows::core::IUnknown, IHeaderCtrl);
 impl ::core::clone::Clone for IHeaderCtrl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3335,21 +2550,7 @@ impl IImageList {
         (::windows::core::Vtable::vtable(self).ImageListSetStrip)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbmapsm), ::core::mem::transmute(pbmaplg), nstartloc, cmask.into()).ok()
     }
 }
-impl ::core::convert::From<IImageList> for ::windows::core::IUnknown {
-    fn from(value: IImageList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImageList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImageList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImageList> for ::windows::core::IUnknown {
-    fn from(value: &IImageList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImageList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IImageList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3390,21 +2591,7 @@ impl IMMCVersionInfo {
         (::windows::core::Vtable::vtable(self).GetMMCVersion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pversionmajor), ::core::mem::transmute(pversionminor)).ok()
     }
 }
-impl ::core::convert::From<IMMCVersionInfo> for ::windows::core::IUnknown {
-    fn from(value: IMMCVersionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMMCVersionInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMMCVersionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMMCVersionInfo> for ::windows::core::IUnknown {
-    fn from(value: &IMMCVersionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMMCVersionInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMMCVersionInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3460,21 +2647,7 @@ impl IMenuButton {
         (::windows::core::Vtable::vtable(self).SetButtonState)(::windows::core::Vtable::as_raw(self), idcommand, nstate, bstate.into()).ok()
     }
 }
-impl ::core::convert::From<IMenuButton> for ::windows::core::IUnknown {
-    fn from(value: IMenuButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMenuButton> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMenuButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMenuButton> for ::windows::core::IUnknown {
-    fn from(value: &IMenuButton) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMenuButton, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMenuButton {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3531,21 +2704,7 @@ impl IMessageView {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMessageView> for ::windows::core::IUnknown {
-    fn from(value: IMessageView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMessageView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMessageView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMessageView> for ::windows::core::IUnknown {
-    fn from(value: &IMessageView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMessageView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMessageView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3591,21 +2750,7 @@ impl INodeProperties {
         (::windows::core::Vtable::vtable(self).GetProperty)(::windows::core::Vtable::as_raw(self), pdataobject.into().abi(), ::core::mem::transmute_copy(szpropertyname), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut u16>(result__)
     }
 }
-impl ::core::convert::From<INodeProperties> for ::windows::core::IUnknown {
-    fn from(value: INodeProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INodeProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INodeProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INodeProperties> for ::windows::core::IUnknown {
-    fn from(value: &INodeProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INodeProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INodeProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3658,21 +2803,7 @@ impl IPropertySheetCallback {
         (::windows::core::Vtable::vtable(self).RemovePage)(::windows::core::Vtable::as_raw(self), hpage.into()).ok()
     }
 }
-impl ::core::convert::From<IPropertySheetCallback> for ::windows::core::IUnknown {
-    fn from(value: IPropertySheetCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertySheetCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertySheetCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertySheetCallback> for ::windows::core::IUnknown {
-    fn from(value: &IPropertySheetCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertySheetCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertySheetCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3748,21 +2879,7 @@ impl IPropertySheetProvider {
         (::windows::core::Vtable::vtable(self).Show)(::windows::core::Vtable::as_raw(self), window, page).ok()
     }
 }
-impl ::core::convert::From<IPropertySheetProvider> for ::windows::core::IUnknown {
-    fn from(value: IPropertySheetProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertySheetProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertySheetProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertySheetProvider> for ::windows::core::IUnknown {
-    fn from(value: &IPropertySheetProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertySheetProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertySheetProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3820,21 +2937,7 @@ impl IRequiredExtensions {
         (::windows::core::Vtable::vtable(self).GetNextExtension)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IRequiredExtensions> for ::windows::core::IUnknown {
-    fn from(value: IRequiredExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRequiredExtensions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRequiredExtensions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRequiredExtensions> for ::windows::core::IUnknown {
-    fn from(value: &IRequiredExtensions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRequiredExtensions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRequiredExtensions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3938,21 +3041,7 @@ impl IResultData {
         (::windows::core::Vtable::vtable(self).SetItemCount)(::windows::core::Vtable::as_raw(self), nitemcount, dwoptions).ok()
     }
 }
-impl ::core::convert::From<IResultData> for ::windows::core::IUnknown {
-    fn from(value: IResultData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResultData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResultData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResultData> for ::windows::core::IUnknown {
-    fn from(value: &IResultData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResultData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IResultData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4089,36 +3178,7 @@ impl IResultData2 {
         (::windows::core::Vtable::vtable(self).RenameResultItem)(::windows::core::Vtable::as_raw(self), itemid).ok()
     }
 }
-impl ::core::convert::From<IResultData2> for ::windows::core::IUnknown {
-    fn from(value: IResultData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResultData2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResultData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResultData2> for ::windows::core::IUnknown {
-    fn from(value: &IResultData2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IResultData2> for IResultData {
-    fn from(value: IResultData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResultData2> for &'a IResultData {
-    fn from(value: &'a IResultData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResultData2> for IResultData {
-    fn from(value: &IResultData2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResultData2, ::windows::core::IUnknown, IResultData);
 impl ::core::clone::Clone for IResultData2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4160,21 +3220,7 @@ impl IResultDataCompare {
         (::windows::core::Vtable::vtable(self).Compare)(::windows::core::Vtable::as_raw(self), luserparam.into(), cookiea, cookieb, ::core::mem::transmute(pnresult)).ok()
     }
 }
-impl ::core::convert::From<IResultDataCompare> for ::windows::core::IUnknown {
-    fn from(value: IResultDataCompare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResultDataCompare> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResultDataCompare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResultDataCompare> for ::windows::core::IUnknown {
-    fn from(value: &IResultDataCompare) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResultDataCompare, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IResultDataCompare {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4217,21 +3263,7 @@ impl IResultDataCompareEx {
         (::windows::core::Vtable::vtable(self).Compare)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prdc), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IResultDataCompareEx> for ::windows::core::IUnknown {
-    fn from(value: IResultDataCompareEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResultDataCompareEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResultDataCompareEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResultDataCompareEx> for ::windows::core::IUnknown {
-    fn from(value: &IResultDataCompareEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResultDataCompareEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IResultDataCompareEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4283,21 +3315,7 @@ impl IResultOwnerData {
         (::windows::core::Vtable::vtable(self).SortItems)(::windows::core::Vtable::as_raw(self), ncolumn, dwsortoptions, luserparam.into()).ok()
     }
 }
-impl ::core::convert::From<IResultOwnerData> for ::windows::core::IUnknown {
-    fn from(value: IResultOwnerData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResultOwnerData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResultOwnerData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResultOwnerData> for ::windows::core::IUnknown {
-    fn from(value: &IResultOwnerData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResultOwnerData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IResultOwnerData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4359,21 +3377,7 @@ impl ISnapinAbout {
         (::windows::core::Vtable::vtable(self).GetStaticFolderImage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(hsmallimage), ::core::mem::transmute(hsmallimageopen), ::core::mem::transmute(hlargeimage), ::core::mem::transmute(cmask)).ok()
     }
 }
-impl ::core::convert::From<ISnapinAbout> for ::windows::core::IUnknown {
-    fn from(value: ISnapinAbout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISnapinAbout> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISnapinAbout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISnapinAbout> for ::windows::core::IUnknown {
-    fn from(value: &ISnapinAbout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISnapinAbout, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISnapinAbout {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4421,21 +3425,7 @@ impl ISnapinHelp {
         (::windows::core::Vtable::vtable(self).GetHelpTopic)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ISnapinHelp> for ::windows::core::IUnknown {
-    fn from(value: ISnapinHelp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISnapinHelp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISnapinHelp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISnapinHelp> for ::windows::core::IUnknown {
-    fn from(value: &ISnapinHelp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISnapinHelp, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISnapinHelp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4477,36 +3467,7 @@ impl ISnapinHelp2 {
         (::windows::core::Vtable::vtable(self).GetLinkedTopics)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ISnapinHelp2> for ::windows::core::IUnknown {
-    fn from(value: ISnapinHelp2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISnapinHelp2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISnapinHelp2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISnapinHelp2> for ::windows::core::IUnknown {
-    fn from(value: &ISnapinHelp2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISnapinHelp2> for ISnapinHelp {
-    fn from(value: ISnapinHelp2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISnapinHelp2> for &'a ISnapinHelp {
-    fn from(value: &'a ISnapinHelp2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISnapinHelp2> for ISnapinHelp {
-    fn from(value: &ISnapinHelp2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISnapinHelp2, ::windows::core::IUnknown, ISnapinHelp);
 impl ::core::clone::Clone for ISnapinHelp2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4559,21 +3520,7 @@ impl ISnapinProperties {
         (::windows::core::Vtable::vtable(self).PropertiesChanged)(::windows::core::Vtable::as_raw(self), pproperties.len() as _, ::core::mem::transmute(pproperties.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<ISnapinProperties> for ::windows::core::IUnknown {
-    fn from(value: ISnapinProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISnapinProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISnapinProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISnapinProperties> for ::windows::core::IUnknown {
-    fn from(value: &ISnapinProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISnapinProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISnapinProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4621,21 +3568,7 @@ impl ISnapinPropertiesCallback {
         (::windows::core::Vtable::vtable(self).AddPropertyName)(::windows::core::Vtable::as_raw(self), pszpropname.into(), dwflags).ok()
     }
 }
-impl ::core::convert::From<ISnapinPropertiesCallback> for ::windows::core::IUnknown {
-    fn from(value: ISnapinPropertiesCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISnapinPropertiesCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISnapinPropertiesCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISnapinPropertiesCallback> for ::windows::core::IUnknown {
-    fn from(value: &ISnapinPropertiesCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISnapinPropertiesCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISnapinPropertiesCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4702,21 +3635,7 @@ impl IStringTable {
         (::windows::core::Vtable::vtable(self).Enumerate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::IEnumString>(result__)
     }
 }
-impl ::core::convert::From<IStringTable> for ::windows::core::IUnknown {
-    fn from(value: IStringTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStringTable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStringTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStringTable> for ::windows::core::IUnknown {
-    fn from(value: &IStringTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStringTable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStringTable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4791,21 +3710,7 @@ impl IToolbar {
         (::windows::core::Vtable::vtable(self).SetButtonState)(::windows::core::Vtable::as_raw(self), idcommand, nstate, bstate.into()).ok()
     }
 }
-impl ::core::convert::From<IToolbar> for ::windows::core::IUnknown {
-    fn from(value: IToolbar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IToolbar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IToolbar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IToolbar> for ::windows::core::IUnknown {
-    fn from(value: &IToolbar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IToolbar, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IToolbar {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4858,21 +3763,7 @@ impl IViewExtensionCallback {
         (::windows::core::Vtable::vtable(self).AddView)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pextviewdata)).ok()
     }
 }
-impl ::core::convert::From<IViewExtensionCallback> for ::windows::core::IUnknown {
-    fn from(value: IViewExtensionCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewExtensionCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IViewExtensionCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewExtensionCallback> for ::windows::core::IUnknown {
-    fn from(value: &IViewExtensionCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IViewExtensionCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IViewExtensionCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4937,41 +3828,7 @@ impl MenuItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<MenuItem> for ::windows::core::IUnknown {
-    fn from(value: MenuItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a MenuItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a MenuItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&MenuItem> for ::windows::core::IUnknown {
-    fn from(value: &MenuItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<MenuItem> for super::Com::IDispatch {
-    fn from(value: MenuItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a MenuItem> for &'a super::Com::IDispatch {
-    fn from(value: &'a MenuItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&MenuItem> for super::Com::IDispatch {
-    fn from(value: &MenuItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(MenuItem, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for MenuItem {
     fn clone(&self) -> Self {
@@ -5045,41 +3902,7 @@ impl Node {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Node> for ::windows::core::IUnknown {
-    fn from(value: Node) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Node> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Node) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Node> for ::windows::core::IUnknown {
-    fn from(value: &Node) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Node> for super::Com::IDispatch {
-    fn from(value: Node) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Node> for &'a super::Com::IDispatch {
-    fn from(value: &'a Node) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Node> for super::Com::IDispatch {
-    fn from(value: &Node) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Node, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Node {
     fn clone(&self) -> Self {
@@ -5144,41 +3967,7 @@ impl Nodes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Nodes> for ::windows::core::IUnknown {
-    fn from(value: Nodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Nodes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Nodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Nodes> for ::windows::core::IUnknown {
-    fn from(value: &Nodes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Nodes> for super::Com::IDispatch {
-    fn from(value: Nodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Nodes> for &'a super::Com::IDispatch {
-    fn from(value: &'a Nodes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Nodes> for super::Com::IDispatch {
-    fn from(value: &Nodes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Nodes, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Nodes {
     fn clone(&self) -> Self {
@@ -5244,41 +4033,7 @@ impl Properties {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Properties> for ::windows::core::IUnknown {
-    fn from(value: Properties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Properties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Properties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Properties> for ::windows::core::IUnknown {
-    fn from(value: &Properties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Properties> for super::Com::IDispatch {
-    fn from(value: Properties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Properties> for &'a super::Com::IDispatch {
-    fn from(value: &'a Properties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Properties> for super::Com::IDispatch {
-    fn from(value: &Properties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Properties, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Properties {
     fn clone(&self) -> Self {
@@ -5346,41 +4101,7 @@ impl Property {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Property> for ::windows::core::IUnknown {
-    fn from(value: Property) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Property> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Property) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Property> for ::windows::core::IUnknown {
-    fn from(value: &Property) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Property> for super::Com::IDispatch {
-    fn from(value: Property) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Property> for &'a super::Com::IDispatch {
-    fn from(value: &'a Property) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Property> for super::Com::IDispatch {
-    fn from(value: &Property) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Property, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Property {
     fn clone(&self) -> Self {
@@ -5473,41 +4194,7 @@ impl ScopeNamespace {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ScopeNamespace> for ::windows::core::IUnknown {
-    fn from(value: ScopeNamespace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ScopeNamespace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ScopeNamespace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ScopeNamespace> for ::windows::core::IUnknown {
-    fn from(value: &ScopeNamespace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ScopeNamespace> for super::Com::IDispatch {
-    fn from(value: ScopeNamespace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ScopeNamespace> for &'a super::Com::IDispatch {
-    fn from(value: &'a ScopeNamespace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ScopeNamespace> for super::Com::IDispatch {
-    fn from(value: &ScopeNamespace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ScopeNamespace, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ScopeNamespace {
     fn clone(&self) -> Self {
@@ -5606,41 +4293,7 @@ impl SnapIn {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<SnapIn> for ::windows::core::IUnknown {
-    fn from(value: SnapIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a SnapIn> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a SnapIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&SnapIn> for ::windows::core::IUnknown {
-    fn from(value: &SnapIn) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<SnapIn> for super::Com::IDispatch {
-    fn from(value: SnapIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a SnapIn> for &'a super::Com::IDispatch {
-    fn from(value: &'a SnapIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&SnapIn> for super::Com::IDispatch {
-    fn from(value: &SnapIn) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(SnapIn, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for SnapIn {
     fn clone(&self) -> Self {
@@ -5731,41 +4384,7 @@ impl SnapIns {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<SnapIns> for ::windows::core::IUnknown {
-    fn from(value: SnapIns) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a SnapIns> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a SnapIns) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&SnapIns> for ::windows::core::IUnknown {
-    fn from(value: &SnapIns) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<SnapIns> for super::Com::IDispatch {
-    fn from(value: SnapIns) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a SnapIns> for &'a super::Com::IDispatch {
-    fn from(value: &'a SnapIns) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&SnapIns> for super::Com::IDispatch {
-    fn from(value: &SnapIns) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(SnapIns, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for SnapIns {
     fn clone(&self) -> Self {
@@ -6060,41 +4679,7 @@ impl View {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<View> for ::windows::core::IUnknown {
-    fn from(value: View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a View> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&View> for ::windows::core::IUnknown {
-    fn from(value: &View) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<View> for super::Com::IDispatch {
-    fn from(value: View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a View> for &'a super::Com::IDispatch {
-    fn from(value: &'a View) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&View> for super::Com::IDispatch {
-    fn from(value: &View) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(View, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for View {
     fn clone(&self) -> Self {
@@ -6276,41 +4861,7 @@ impl Views {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Views> for ::windows::core::IUnknown {
-    fn from(value: Views) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Views> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Views) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Views> for ::windows::core::IUnknown {
-    fn from(value: &Views) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Views> for super::Com::IDispatch {
-    fn from(value: Views) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Views> for &'a super::Com::IDispatch {
-    fn from(value: &'a Views) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Views> for super::Com::IDispatch {
-    fn from(value: &Views) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Views, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Views {
     fn clone(&self) -> Self {
@@ -6459,41 +5010,7 @@ impl _AppEvents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_AppEvents> for ::windows::core::IUnknown {
-    fn from(value: _AppEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _AppEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _AppEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_AppEvents> for ::windows::core::IUnknown {
-    fn from(value: &_AppEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_AppEvents> for super::Com::IDispatch {
-    fn from(value: _AppEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _AppEvents> for &'a super::Com::IDispatch {
-    fn from(value: &'a _AppEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_AppEvents> for super::Com::IDispatch {
-    fn from(value: &_AppEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_AppEvents, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _AppEvents {
     fn clone(&self) -> Self {
@@ -6636,41 +5153,7 @@ impl _Application {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_Application> for ::windows::core::IUnknown {
-    fn from(value: _Application) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _Application> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _Application) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_Application> for ::windows::core::IUnknown {
-    fn from(value: &_Application) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_Application> for super::Com::IDispatch {
-    fn from(value: _Application) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _Application> for &'a super::Com::IDispatch {
-    fn from(value: &'a _Application) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_Application> for super::Com::IDispatch {
-    fn from(value: &_Application) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_Application, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _Application {
     fn clone(&self) -> Self {
@@ -6751,41 +5234,7 @@ impl _EventConnector {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_EventConnector> for ::windows::core::IUnknown {
-    fn from(value: _EventConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _EventConnector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _EventConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_EventConnector> for ::windows::core::IUnknown {
-    fn from(value: &_EventConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_EventConnector> for super::Com::IDispatch {
-    fn from(value: _EventConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _EventConnector> for &'a super::Com::IDispatch {
-    fn from(value: &'a _EventConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_EventConnector> for super::Com::IDispatch {
-    fn from(value: &_EventConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_EventConnector, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _EventConnector {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
@@ -5134,41 +5134,7 @@ impl IAdviseSinkEx {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAdviseSinkEx> for ::windows::core::IUnknown {
-    fn from(value: IAdviseSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAdviseSinkEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAdviseSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAdviseSinkEx> for ::windows::core::IUnknown {
-    fn from(value: &IAdviseSinkEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAdviseSinkEx> for super::Com::IAdviseSink {
-    fn from(value: IAdviseSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAdviseSinkEx> for &'a super::Com::IAdviseSink {
-    fn from(value: &'a IAdviseSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAdviseSinkEx> for super::Com::IAdviseSink {
-    fn from(value: &IAdviseSinkEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAdviseSinkEx, ::windows::core::IUnknown, super::Com::IAdviseSink);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAdviseSinkEx {
     fn clone(&self) -> Self {
@@ -5214,21 +5180,7 @@ impl ICanHandleException {
         (::windows::core::Vtable::vtable(self).CanHandleException)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pexcepinfo), ::core::mem::transmute(pvar)).ok()
     }
 }
-impl ::core::convert::From<ICanHandleException> for ::windows::core::IUnknown {
-    fn from(value: ICanHandleException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICanHandleException> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICanHandleException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICanHandleException> for ::windows::core::IUnknown {
-    fn from(value: &ICanHandleException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICanHandleException, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICanHandleException {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5304,41 +5256,7 @@ impl IClassFactory2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IClassFactory2> for ::windows::core::IUnknown {
-    fn from(value: IClassFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IClassFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IClassFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IClassFactory2> for ::windows::core::IUnknown {
-    fn from(value: &IClassFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IClassFactory2> for super::Com::IClassFactory {
-    fn from(value: IClassFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IClassFactory2> for &'a super::Com::IClassFactory {
-    fn from(value: &'a IClassFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IClassFactory2> for super::Com::IClassFactory {
-    fn from(value: &IClassFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IClassFactory2, ::windows::core::IUnknown, super::Com::IClassFactory);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IClassFactory2 {
     fn clone(&self) -> Self {
@@ -5387,21 +5305,7 @@ impl IContinue {
         (::windows::core::Vtable::vtable(self).FContinue)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IContinue> for ::windows::core::IUnknown {
-    fn from(value: IContinue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContinue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContinue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContinue> for ::windows::core::IUnknown {
-    fn from(value: &IContinue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContinue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContinue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5444,21 +5348,7 @@ impl IContinueCallback {
         (::windows::core::Vtable::vtable(self).FContinuePrinting)(::windows::core::Vtable::as_raw(self), ncntprinted, ncurpage, pwszprintstatus.into()).ok()
     }
 }
-impl ::core::convert::From<IContinueCallback> for ::windows::core::IUnknown {
-    fn from(value: IContinueCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContinueCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContinueCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContinueCallback> for ::windows::core::IUnknown {
-    fn from(value: &IContinueCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContinueCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContinueCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5517,21 +5407,7 @@ impl ICreateErrorInfo {
         (::windows::core::Vtable::vtable(self).SetHelpContext)(::windows::core::Vtable::as_raw(self), dwhelpcontext).ok()
     }
 }
-impl ::core::convert::From<ICreateErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: ICreateErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &ICreateErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateErrorInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICreateErrorInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5670,21 +5546,7 @@ impl ICreateTypeInfo {
         (::windows::core::Vtable::vtable(self).LayOut)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ICreateTypeInfo> for ::windows::core::IUnknown {
-    fn from(value: ICreateTypeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateTypeInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateTypeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateTypeInfo> for ::windows::core::IUnknown {
-    fn from(value: &ICreateTypeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateTypeInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICreateTypeInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5916,36 +5778,7 @@ impl ICreateTypeInfo2 {
         (::windows::core::Vtable::vtable(self).SetName)(::windows::core::Vtable::as_raw(self), szname.into()).ok()
     }
 }
-impl ::core::convert::From<ICreateTypeInfo2> for ::windows::core::IUnknown {
-    fn from(value: ICreateTypeInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateTypeInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateTypeInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateTypeInfo2> for ::windows::core::IUnknown {
-    fn from(value: &ICreateTypeInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICreateTypeInfo2> for ICreateTypeInfo {
-    fn from(value: ICreateTypeInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateTypeInfo2> for &'a ICreateTypeInfo {
-    fn from(value: &'a ICreateTypeInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateTypeInfo2> for ICreateTypeInfo {
-    fn from(value: &ICreateTypeInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateTypeInfo2, ::windows::core::IUnknown, ICreateTypeInfo);
 impl ::core::clone::Clone for ICreateTypeInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6056,21 +5889,7 @@ impl ICreateTypeLib {
         (::windows::core::Vtable::vtable(self).SaveAllChanges)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ICreateTypeLib> for ::windows::core::IUnknown {
-    fn from(value: ICreateTypeLib) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateTypeLib> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateTypeLib) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateTypeLib> for ::windows::core::IUnknown {
-    fn from(value: &ICreateTypeLib) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateTypeLib, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICreateTypeLib {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6181,36 +6000,7 @@ impl ICreateTypeLib2 {
         (::windows::core::Vtable::vtable(self).SetHelpStringDll)(::windows::core::Vtable::as_raw(self), szfilename.into()).ok()
     }
 }
-impl ::core::convert::From<ICreateTypeLib2> for ::windows::core::IUnknown {
-    fn from(value: ICreateTypeLib2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateTypeLib2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateTypeLib2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateTypeLib2> for ::windows::core::IUnknown {
-    fn from(value: &ICreateTypeLib2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICreateTypeLib2> for ICreateTypeLib {
-    fn from(value: ICreateTypeLib2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateTypeLib2> for &'a ICreateTypeLib {
-    fn from(value: &'a ICreateTypeLib2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateTypeLib2> for ICreateTypeLib {
-    fn from(value: &ICreateTypeLib2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateTypeLib2, ::windows::core::IUnknown, ICreateTypeLib);
 impl ::core::clone::Clone for ICreateTypeLib2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6273,21 +6063,7 @@ impl IDispError {
         (::windows::core::Vtable::vtable(self).GetDescription)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IDispError> for ::windows::core::IUnknown {
-    fn from(value: IDispError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDispError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDispError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDispError> for ::windows::core::IUnknown {
-    fn from(value: &IDispError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDispError, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDispError {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6363,41 +6139,7 @@ impl IDispatchEx {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDispatchEx> for ::windows::core::IUnknown {
-    fn from(value: IDispatchEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDispatchEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDispatchEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDispatchEx> for ::windows::core::IUnknown {
-    fn from(value: &IDispatchEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDispatchEx> for super::Com::IDispatch {
-    fn from(value: IDispatchEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDispatchEx> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDispatchEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDispatchEx> for super::Com::IDispatch {
-    fn from(value: &IDispatchEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDispatchEx, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDispatchEx {
     fn clone(&self) -> Self {
@@ -6459,21 +6201,7 @@ impl IDropSource {
         (::windows::core::Vtable::vtable(self).GiveFeedback)(::windows::core::Vtable::as_raw(self), dweffect).ok()
     }
 }
-impl ::core::convert::From<IDropSource> for ::windows::core::IUnknown {
-    fn from(value: IDropSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDropSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDropSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDropSource> for ::windows::core::IUnknown {
-    fn from(value: &IDropSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDropSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDropSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6522,21 +6250,7 @@ impl IDropSourceNotify {
         (::windows::core::Vtable::vtable(self).DragLeaveTarget)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDropSourceNotify> for ::windows::core::IUnknown {
-    fn from(value: IDropSourceNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDropSourceNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDropSourceNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDropSourceNotify> for ::windows::core::IUnknown {
-    fn from(value: &IDropSourceNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDropSourceNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDropSourceNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6598,21 +6312,7 @@ impl IDropTarget {
         (::windows::core::Vtable::vtable(self).Drop)(::windows::core::Vtable::as_raw(self), pdataobj.into().abi(), grfkeystate, ::core::mem::transmute(pt), ::core::mem::transmute(pdweffect)).ok()
     }
 }
-impl ::core::convert::From<IDropTarget> for ::windows::core::IUnknown {
-    fn from(value: IDropTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDropTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDropTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDropTarget> for ::windows::core::IUnknown {
-    fn from(value: &IDropTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDropTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDropTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6670,21 +6370,7 @@ impl IEnterpriseDropTarget {
         (::windows::core::Vtable::vtable(self).IsEvaluatingEdpPolicy)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IEnterpriseDropTarget> for ::windows::core::IUnknown {
-    fn from(value: IEnterpriseDropTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnterpriseDropTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnterpriseDropTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnterpriseDropTarget> for ::windows::core::IUnknown {
-    fn from(value: &IEnterpriseDropTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnterpriseDropTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnterpriseDropTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6737,21 +6423,7 @@ impl IEnumOLEVERB {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumOLEVERB>(result__)
     }
 }
-impl ::core::convert::From<IEnumOLEVERB> for ::windows::core::IUnknown {
-    fn from(value: IEnumOLEVERB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumOLEVERB> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumOLEVERB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumOLEVERB> for ::windows::core::IUnknown {
-    fn from(value: &IEnumOLEVERB) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumOLEVERB, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumOLEVERB {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6804,21 +6476,7 @@ impl IEnumOleDocumentViews {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumOleDocumentViews>(result__)
     }
 }
-impl ::core::convert::From<IEnumOleDocumentViews> for ::windows::core::IUnknown {
-    fn from(value: IEnumOleDocumentViews) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumOleDocumentViews> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumOleDocumentViews) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumOleDocumentViews> for ::windows::core::IUnknown {
-    fn from(value: &IEnumOleDocumentViews) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumOleDocumentViews, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumOleDocumentViews {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6868,21 +6526,7 @@ impl IEnumOleUndoUnits {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumOleUndoUnits>(result__)
     }
 }
-impl ::core::convert::From<IEnumOleUndoUnits> for ::windows::core::IUnknown {
-    fn from(value: IEnumOleUndoUnits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumOleUndoUnits> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumOleUndoUnits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumOleUndoUnits> for ::windows::core::IUnknown {
-    fn from(value: &IEnumOleUndoUnits) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumOleUndoUnits, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumOleUndoUnits {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6934,21 +6578,7 @@ impl IEnumVARIANT {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumVARIANT>(result__)
     }
 }
-impl ::core::convert::From<IEnumVARIANT> for ::windows::core::IUnknown {
-    fn from(value: IEnumVARIANT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumVARIANT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumVARIANT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumVARIANT> for ::windows::core::IUnknown {
-    fn from(value: &IEnumVARIANT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumVARIANT, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumVARIANT {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7125,21 +6755,7 @@ impl IFont {
         (::windows::core::Vtable::vtable(self).SetHdc)(::windows::core::Vtable::as_raw(self), hdc.into()).ok()
     }
 }
-impl ::core::convert::From<IFont> for ::windows::core::IUnknown {
-    fn from(value: IFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFont> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFont> for ::windows::core::IUnknown {
-    fn from(value: &IFont) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFont, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFont {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7243,41 +6859,7 @@ pub struct IFontDisp(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IFontDisp {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFontDisp> for ::windows::core::IUnknown {
-    fn from(value: IFontDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFontDisp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFontDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFontDisp> for ::windows::core::IUnknown {
-    fn from(value: &IFontDisp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFontDisp> for super::Com::IDispatch {
-    fn from(value: IFontDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFontDisp> for &'a super::Com::IDispatch {
-    fn from(value: &'a IFontDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFontDisp> for super::Com::IDispatch {
-    fn from(value: &IFontDisp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFontDisp, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFontDisp {
     fn clone(&self) -> Self {
@@ -7319,41 +6901,7 @@ pub struct IFontEventsDisp(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IFontEventsDisp {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFontEventsDisp> for ::windows::core::IUnknown {
-    fn from(value: IFontEventsDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFontEventsDisp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFontEventsDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFontEventsDisp> for ::windows::core::IUnknown {
-    fn from(value: &IFontEventsDisp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFontEventsDisp> for super::Com::IDispatch {
-    fn from(value: IFontEventsDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFontEventsDisp> for &'a super::Com::IDispatch {
-    fn from(value: &'a IFontEventsDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFontEventsDisp> for super::Com::IDispatch {
-    fn from(value: &IFontEventsDisp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFontEventsDisp, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFontEventsDisp {
     fn clone(&self) -> Self {
@@ -7396,21 +6944,7 @@ impl IGetOleObject {
         (::windows::core::Vtable::vtable(self).GetOleObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(ppvobj)).ok()
     }
 }
-impl ::core::convert::From<IGetOleObject> for ::windows::core::IUnknown {
-    fn from(value: IGetOleObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetOleObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetOleObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetOleObject> for ::windows::core::IUnknown {
-    fn from(value: &IGetOleObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetOleObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetOleObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7447,21 +6981,7 @@ impl IGetVBAObject {
         (::windows::core::Vtable::vtable(self).GetObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(ppvobj), dwreserved).ok()
     }
 }
-impl ::core::convert::From<IGetVBAObject> for ::windows::core::IUnknown {
-    fn from(value: IGetVBAObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetVBAObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetVBAObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetVBAObject> for ::windows::core::IUnknown {
-    fn from(value: &IGetVBAObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetVBAObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetVBAObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7501,21 +7021,7 @@ impl IObjectIdentity {
         (::windows::core::Vtable::vtable(self).IsEqualObject)(::windows::core::Vtable::as_raw(self), punk.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IObjectIdentity> for ::windows::core::IUnknown {
-    fn from(value: IObjectIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectIdentity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectIdentity> for ::windows::core::IUnknown {
-    fn from(value: &IObjectIdentity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectIdentity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectIdentity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7562,21 +7068,7 @@ impl IObjectWithSite {
         (::windows::core::Vtable::vtable(self).GetSite)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IObjectWithSite> for ::windows::core::IUnknown {
-    fn from(value: IObjectWithSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectWithSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectWithSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectWithSite> for ::windows::core::IUnknown {
-    fn from(value: &IObjectWithSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectWithSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectWithSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7643,21 +7135,7 @@ impl IOleAdviseHolder {
         (::windows::core::Vtable::vtable(self).SendOnClose)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IOleAdviseHolder> for ::windows::core::IUnknown {
-    fn from(value: IOleAdviseHolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleAdviseHolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleAdviseHolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleAdviseHolder> for ::windows::core::IUnknown {
-    fn from(value: &IOleAdviseHolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleAdviseHolder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleAdviseHolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7736,21 +7214,7 @@ impl IOleCache {
         (::windows::core::Vtable::vtable(self).SetData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pformatetc), ::core::mem::transmute(pmedium), frelease.into()).ok()
     }
 }
-impl ::core::convert::From<IOleCache> for ::windows::core::IUnknown {
-    fn from(value: IOleCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleCache> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleCache> for ::windows::core::IUnknown {
-    fn from(value: &IOleCache) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleCache, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleCache {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7842,36 +7306,7 @@ impl IOleCache2 {
         (::windows::core::Vtable::vtable(self).DiscardCache)(::windows::core::Vtable::as_raw(self), dwdiscardoptions).ok()
     }
 }
-impl ::core::convert::From<IOleCache2> for ::windows::core::IUnknown {
-    fn from(value: IOleCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleCache2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleCache2> for ::windows::core::IUnknown {
-    fn from(value: &IOleCache2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleCache2> for IOleCache {
-    fn from(value: IOleCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleCache2> for &'a IOleCache {
-    fn from(value: &'a IOleCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleCache2> for IOleCache {
-    fn from(value: &IOleCache2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleCache2, ::windows::core::IUnknown, IOleCache);
 impl ::core::clone::Clone for IOleCache2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7920,21 +7355,7 @@ impl IOleCacheControl {
         (::windows::core::Vtable::vtable(self).OnStop)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IOleCacheControl> for ::windows::core::IUnknown {
-    fn from(value: IOleCacheControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleCacheControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleCacheControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleCacheControl> for ::windows::core::IUnknown {
-    fn from(value: &IOleCacheControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleCacheControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleCacheControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7999,21 +7420,7 @@ impl IOleClientSite {
         (::windows::core::Vtable::vtable(self).RequestNewObjectLayout)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IOleClientSite> for ::windows::core::IUnknown {
-    fn from(value: IOleClientSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleClientSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleClientSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleClientSite> for ::windows::core::IUnknown {
-    fn from(value: &IOleClientSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleClientSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleClientSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8066,21 +7473,7 @@ impl IOleCommandTarget {
         (::windows::core::Vtable::vtable(self).Exec)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguidcmdgroup), ncmdid, ncmdexecopt, ::core::mem::transmute(pvain), ::core::mem::transmute(pvaout)).ok()
     }
 }
-impl ::core::convert::From<IOleCommandTarget> for ::windows::core::IUnknown {
-    fn from(value: IOleCommandTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleCommandTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleCommandTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleCommandTarget> for ::windows::core::IUnknown {
-    fn from(value: &IOleCommandTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleCommandTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleCommandTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8141,36 +7534,7 @@ impl IOleContainer {
         (::windows::core::Vtable::vtable(self).LockContainer)(::windows::core::Vtable::as_raw(self), flock.into()).ok()
     }
 }
-impl ::core::convert::From<IOleContainer> for ::windows::core::IUnknown {
-    fn from(value: IOleContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleContainer> for ::windows::core::IUnknown {
-    fn from(value: &IOleContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleContainer> for IParseDisplayName {
-    fn from(value: IOleContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleContainer> for &'a IParseDisplayName {
-    fn from(value: &'a IOleContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleContainer> for IParseDisplayName {
-    fn from(value: &IOleContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleContainer, ::windows::core::IUnknown, IParseDisplayName);
 impl ::core::clone::Clone for IOleContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8232,21 +7596,7 @@ impl IOleControl {
         (::windows::core::Vtable::vtable(self).FreezeEvents)(::windows::core::Vtable::as_raw(self), bfreeze.into()).ok()
     }
 }
-impl ::core::convert::From<IOleControl> for ::windows::core::IUnknown {
-    fn from(value: IOleControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleControl> for ::windows::core::IUnknown {
-    fn from(value: &IOleControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8330,21 +7680,7 @@ impl IOleControlSite {
         (::windows::core::Vtable::vtable(self).ShowPropertyFrame)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IOleControlSite> for ::windows::core::IUnknown {
-    fn from(value: IOleControlSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleControlSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleControlSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleControlSite> for ::windows::core::IUnknown {
-    fn from(value: &IOleControlSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleControlSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleControlSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8416,21 +7752,7 @@ impl IOleDocument {
         (::windows::core::Vtable::vtable(self).EnumViews)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppenum), ::core::mem::transmute(ppview)).ok()
     }
 }
-impl ::core::convert::From<IOleDocument> for ::windows::core::IUnknown {
-    fn from(value: IOleDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleDocument> for ::windows::core::IUnknown {
-    fn from(value: &IOleDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleDocument, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleDocument {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8475,21 +7797,7 @@ impl IOleDocumentSite {
         (::windows::core::Vtable::vtable(self).ActivateMe)(::windows::core::Vtable::as_raw(self), pviewtoactivate.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IOleDocumentSite> for ::windows::core::IUnknown {
-    fn from(value: IOleDocumentSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleDocumentSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleDocumentSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleDocumentSite> for ::windows::core::IUnknown {
-    fn from(value: &IOleDocumentSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleDocumentSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleDocumentSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8598,21 +7906,7 @@ impl IOleDocumentView {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), pipsitenew.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IOleDocumentView>(result__)
     }
 }
-impl ::core::convert::From<IOleDocumentView> for ::windows::core::IUnknown {
-    fn from(value: IOleDocumentView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleDocumentView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleDocumentView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleDocumentView> for ::windows::core::IUnknown {
-    fn from(value: &IOleDocumentView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleDocumentView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleDocumentView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8731,36 +8025,7 @@ impl IOleInPlaceActiveObject {
         (::windows::core::Vtable::vtable(self).EnableModeless)(::windows::core::Vtable::as_raw(self), fenable.into()).ok()
     }
 }
-impl ::core::convert::From<IOleInPlaceActiveObject> for ::windows::core::IUnknown {
-    fn from(value: IOleInPlaceActiveObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceActiveObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleInPlaceActiveObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceActiveObject> for ::windows::core::IUnknown {
-    fn from(value: &IOleInPlaceActiveObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceActiveObject> for IOleWindow {
-    fn from(value: IOleInPlaceActiveObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceActiveObject> for &'a IOleWindow {
-    fn from(value: &'a IOleInPlaceActiveObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceActiveObject> for IOleWindow {
-    fn from(value: &IOleInPlaceActiveObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleInPlaceActiveObject, ::windows::core::IUnknown, IOleWindow);
 impl ::core::clone::Clone for IOleInPlaceActiveObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8894,51 +8159,7 @@ impl IOleInPlaceFrame {
         (::windows::core::Vtable::vtable(self).TranslateAccelerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lpmsg), wid).ok()
     }
 }
-impl ::core::convert::From<IOleInPlaceFrame> for ::windows::core::IUnknown {
-    fn from(value: IOleInPlaceFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleInPlaceFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceFrame> for ::windows::core::IUnknown {
-    fn from(value: &IOleInPlaceFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceFrame> for IOleWindow {
-    fn from(value: IOleInPlaceFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceFrame> for &'a IOleWindow {
-    fn from(value: &'a IOleInPlaceFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceFrame> for IOleWindow {
-    fn from(value: &IOleInPlaceFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceFrame> for IOleInPlaceUIWindow {
-    fn from(value: IOleInPlaceFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceFrame> for &'a IOleInPlaceUIWindow {
-    fn from(value: &'a IOleInPlaceFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceFrame> for IOleInPlaceUIWindow {
-    fn from(value: &IOleInPlaceFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleInPlaceFrame, ::windows::core::IUnknown, IOleWindow, IOleInPlaceUIWindow);
 impl ::core::clone::Clone for IOleInPlaceFrame {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9020,36 +8241,7 @@ impl IOleInPlaceObject {
         (::windows::core::Vtable::vtable(self).ReactivateAndUndo)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IOleInPlaceObject> for ::windows::core::IUnknown {
-    fn from(value: IOleInPlaceObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleInPlaceObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceObject> for ::windows::core::IUnknown {
-    fn from(value: &IOleInPlaceObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceObject> for IOleWindow {
-    fn from(value: IOleInPlaceObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceObject> for &'a IOleWindow {
-    fn from(value: &'a IOleInPlaceObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceObject> for IOleWindow {
-    fn from(value: &IOleInPlaceObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleInPlaceObject, ::windows::core::IUnknown, IOleWindow);
 impl ::core::clone::Clone for IOleInPlaceObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9131,51 +8323,7 @@ impl IOleInPlaceObjectWindowless {
         (::windows::core::Vtable::vtable(self).GetDropTarget)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IDropTarget>(result__)
     }
 }
-impl ::core::convert::From<IOleInPlaceObjectWindowless> for ::windows::core::IUnknown {
-    fn from(value: IOleInPlaceObjectWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceObjectWindowless> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleInPlaceObjectWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceObjectWindowless> for ::windows::core::IUnknown {
-    fn from(value: &IOleInPlaceObjectWindowless) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceObjectWindowless> for IOleWindow {
-    fn from(value: IOleInPlaceObjectWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceObjectWindowless> for &'a IOleWindow {
-    fn from(value: &'a IOleInPlaceObjectWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceObjectWindowless> for IOleWindow {
-    fn from(value: &IOleInPlaceObjectWindowless) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceObjectWindowless> for IOleInPlaceObject {
-    fn from(value: IOleInPlaceObjectWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceObjectWindowless> for &'a IOleInPlaceObject {
-    fn from(value: &'a IOleInPlaceObjectWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceObjectWindowless> for IOleInPlaceObject {
-    fn from(value: &IOleInPlaceObjectWindowless) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleInPlaceObjectWindowless, ::windows::core::IUnknown, IOleWindow, IOleInPlaceObject);
 impl ::core::clone::Clone for IOleInPlaceObjectWindowless {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9268,36 +8416,7 @@ impl IOleInPlaceSite {
         (::windows::core::Vtable::vtable(self).OnPosRectChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lprcposrect)).ok()
     }
 }
-impl ::core::convert::From<IOleInPlaceSite> for ::windows::core::IUnknown {
-    fn from(value: IOleInPlaceSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleInPlaceSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceSite> for ::windows::core::IUnknown {
-    fn from(value: &IOleInPlaceSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceSite> for IOleWindow {
-    fn from(value: IOleInPlaceSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceSite> for &'a IOleWindow {
-    fn from(value: &'a IOleInPlaceSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceSite> for IOleWindow {
-    fn from(value: &IOleInPlaceSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleInPlaceSite, ::windows::core::IUnknown, IOleWindow);
 impl ::core::clone::Clone for IOleInPlaceSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9423,51 +8542,7 @@ impl IOleInPlaceSiteEx {
         (::windows::core::Vtable::vtable(self).RequestUIActivate)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IOleInPlaceSiteEx> for ::windows::core::IUnknown {
-    fn from(value: IOleInPlaceSiteEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceSiteEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleInPlaceSiteEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceSiteEx> for ::windows::core::IUnknown {
-    fn from(value: &IOleInPlaceSiteEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceSiteEx> for IOleWindow {
-    fn from(value: IOleInPlaceSiteEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceSiteEx> for &'a IOleWindow {
-    fn from(value: &'a IOleInPlaceSiteEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceSiteEx> for IOleWindow {
-    fn from(value: &IOleInPlaceSiteEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceSiteEx> for IOleInPlaceSite {
-    fn from(value: IOleInPlaceSiteEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceSiteEx> for &'a IOleInPlaceSite {
-    fn from(value: &'a IOleInPlaceSiteEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceSiteEx> for IOleInPlaceSite {
-    fn from(value: &IOleInPlaceSiteEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleInPlaceSiteEx, ::windows::core::IUnknown, IOleWindow, IOleInPlaceSite);
 impl ::core::clone::Clone for IOleInPlaceSiteEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9656,66 +8731,7 @@ impl IOleInPlaceSiteWindowless {
         (::windows::core::Vtable::vtable(self).OnDefWindowMessage)(::windows::core::Vtable::as_raw(self), msg, wparam.into(), lparam.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::LRESULT>(result__)
     }
 }
-impl ::core::convert::From<IOleInPlaceSiteWindowless> for ::windows::core::IUnknown {
-    fn from(value: IOleInPlaceSiteWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceSiteWindowless> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleInPlaceSiteWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceSiteWindowless> for ::windows::core::IUnknown {
-    fn from(value: &IOleInPlaceSiteWindowless) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceSiteWindowless> for IOleWindow {
-    fn from(value: IOleInPlaceSiteWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceSiteWindowless> for &'a IOleWindow {
-    fn from(value: &'a IOleInPlaceSiteWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceSiteWindowless> for IOleWindow {
-    fn from(value: &IOleInPlaceSiteWindowless) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceSiteWindowless> for IOleInPlaceSite {
-    fn from(value: IOleInPlaceSiteWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceSiteWindowless> for &'a IOleInPlaceSite {
-    fn from(value: &'a IOleInPlaceSiteWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceSiteWindowless> for IOleInPlaceSite {
-    fn from(value: &IOleInPlaceSiteWindowless) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceSiteWindowless> for IOleInPlaceSiteEx {
-    fn from(value: IOleInPlaceSiteWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceSiteWindowless> for &'a IOleInPlaceSiteEx {
-    fn from(value: &'a IOleInPlaceSiteWindowless) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceSiteWindowless> for IOleInPlaceSiteEx {
-    fn from(value: &IOleInPlaceSiteWindowless) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleInPlaceSiteWindowless, ::windows::core::IUnknown, IOleWindow, IOleInPlaceSite, IOleInPlaceSiteEx);
 impl ::core::clone::Clone for IOleInPlaceSiteWindowless {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9824,36 +8840,7 @@ impl IOleInPlaceUIWindow {
         (::windows::core::Vtable::vtable(self).SetActiveObject)(::windows::core::Vtable::as_raw(self), pactiveobject.into().abi(), pszobjname.into()).ok()
     }
 }
-impl ::core::convert::From<IOleInPlaceUIWindow> for ::windows::core::IUnknown {
-    fn from(value: IOleInPlaceUIWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceUIWindow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleInPlaceUIWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceUIWindow> for ::windows::core::IUnknown {
-    fn from(value: &IOleInPlaceUIWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleInPlaceUIWindow> for IOleWindow {
-    fn from(value: IOleInPlaceUIWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleInPlaceUIWindow> for &'a IOleWindow {
-    fn from(value: &'a IOleInPlaceUIWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleInPlaceUIWindow> for IOleWindow {
-    fn from(value: &IOleInPlaceUIWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleInPlaceUIWindow, ::windows::core::IUnknown, IOleWindow);
 impl ::core::clone::Clone for IOleInPlaceUIWindow {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9950,51 +8937,7 @@ impl IOleItemContainer {
         (::windows::core::Vtable::vtable(self).IsRunning)(::windows::core::Vtable::as_raw(self), pszitem.into()).ok()
     }
 }
-impl ::core::convert::From<IOleItemContainer> for ::windows::core::IUnknown {
-    fn from(value: IOleItemContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleItemContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleItemContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleItemContainer> for ::windows::core::IUnknown {
-    fn from(value: &IOleItemContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleItemContainer> for IParseDisplayName {
-    fn from(value: IOleItemContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleItemContainer> for &'a IParseDisplayName {
-    fn from(value: &'a IOleItemContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleItemContainer> for IParseDisplayName {
-    fn from(value: &IOleItemContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleItemContainer> for IOleContainer {
-    fn from(value: IOleItemContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleItemContainer> for &'a IOleContainer {
-    fn from(value: &'a IOleItemContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleItemContainer> for IOleContainer {
-    fn from(value: &IOleItemContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleItemContainer, ::windows::core::IUnknown, IParseDisplayName, IOleContainer);
 impl ::core::clone::Clone for IOleItemContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10093,21 +9036,7 @@ impl IOleLink {
         (::windows::core::Vtable::vtable(self).Update)(::windows::core::Vtable::as_raw(self), pbc.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IOleLink> for ::windows::core::IUnknown {
-    fn from(value: IOleLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleLink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleLink> for ::windows::core::IUnknown {
-    fn from(value: &IOleLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleLink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleLink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10279,21 +9208,7 @@ impl IOleObject {
         (::windows::core::Vtable::vtable(self).SetColorScheme)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(plogpal)).ok()
     }
 }
-impl ::core::convert::From<IOleObject> for ::windows::core::IUnknown {
-    fn from(value: IOleObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleObject> for ::windows::core::IUnknown {
-    fn from(value: &IOleObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10427,36 +9342,7 @@ impl IOleParentUndoUnit {
         (::windows::core::Vtable::vtable(self).GetParentState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IOleParentUndoUnit> for ::windows::core::IUnknown {
-    fn from(value: IOleParentUndoUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleParentUndoUnit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleParentUndoUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleParentUndoUnit> for ::windows::core::IUnknown {
-    fn from(value: &IOleParentUndoUnit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleParentUndoUnit> for IOleUndoUnit {
-    fn from(value: IOleParentUndoUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleParentUndoUnit> for &'a IOleUndoUnit {
-    fn from(value: &'a IOleParentUndoUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleParentUndoUnit> for IOleUndoUnit {
-    fn from(value: &IOleParentUndoUnit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleParentUndoUnit, ::windows::core::IUnknown, IOleUndoUnit);
 impl ::core::clone::Clone for IOleParentUndoUnit {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10536,21 +9422,7 @@ impl IOleUILinkContainerA {
         (::windows::core::Vtable::vtable(self).CancelLink)(::windows::core::Vtable::as_raw(self), dwlink).ok()
     }
 }
-impl ::core::convert::From<IOleUILinkContainerA> for ::windows::core::IUnknown {
-    fn from(value: IOleUILinkContainerA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleUILinkContainerA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleUILinkContainerA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleUILinkContainerA> for ::windows::core::IUnknown {
-    fn from(value: &IOleUILinkContainerA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleUILinkContainerA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleUILinkContainerA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10639,21 +9511,7 @@ impl IOleUILinkContainerW {
         (::windows::core::Vtable::vtable(self).CancelLink)(::windows::core::Vtable::as_raw(self), dwlink).ok()
     }
 }
-impl ::core::convert::From<IOleUILinkContainerW> for ::windows::core::IUnknown {
-    fn from(value: IOleUILinkContainerW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleUILinkContainerW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleUILinkContainerW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleUILinkContainerW> for ::windows::core::IUnknown {
-    fn from(value: &IOleUILinkContainerW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleUILinkContainerW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleUILinkContainerW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10748,36 +9606,7 @@ impl IOleUILinkInfoA {
         (::windows::core::Vtable::vtable(self).GetLastUpdate)(::windows::core::Vtable::as_raw(self), dwlink, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::FILETIME>(result__)
     }
 }
-impl ::core::convert::From<IOleUILinkInfoA> for ::windows::core::IUnknown {
-    fn from(value: IOleUILinkInfoA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleUILinkInfoA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleUILinkInfoA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleUILinkInfoA> for ::windows::core::IUnknown {
-    fn from(value: &IOleUILinkInfoA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleUILinkInfoA> for IOleUILinkContainerA {
-    fn from(value: IOleUILinkInfoA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleUILinkInfoA> for &'a IOleUILinkContainerA {
-    fn from(value: &'a IOleUILinkInfoA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleUILinkInfoA> for IOleUILinkContainerA {
-    fn from(value: &IOleUILinkInfoA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleUILinkInfoA, ::windows::core::IUnknown, IOleUILinkContainerA);
 impl ::core::clone::Clone for IOleUILinkInfoA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10859,36 +9688,7 @@ impl IOleUILinkInfoW {
         (::windows::core::Vtable::vtable(self).GetLastUpdate)(::windows::core::Vtable::as_raw(self), dwlink, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::FILETIME>(result__)
     }
 }
-impl ::core::convert::From<IOleUILinkInfoW> for ::windows::core::IUnknown {
-    fn from(value: IOleUILinkInfoW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleUILinkInfoW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleUILinkInfoW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleUILinkInfoW> for ::windows::core::IUnknown {
-    fn from(value: &IOleUILinkInfoW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IOleUILinkInfoW> for IOleUILinkContainerW {
-    fn from(value: IOleUILinkInfoW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleUILinkInfoW> for &'a IOleUILinkContainerW {
-    fn from(value: &'a IOleUILinkInfoW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleUILinkInfoW> for IOleUILinkContainerW {
-    fn from(value: &IOleUILinkInfoW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleUILinkInfoW, ::windows::core::IUnknown, IOleUILinkContainerW);
 impl ::core::clone::Clone for IOleUILinkInfoW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10945,21 +9745,7 @@ impl IOleUIObjInfoA {
         (::windows::core::Vtable::vtable(self).SetViewInfo)(::windows::core::Vtable::as_raw(self), dwobject, hmetapict, dvaspect, ncurrentscale, brelativetoorig.into()).ok()
     }
 }
-impl ::core::convert::From<IOleUIObjInfoA> for ::windows::core::IUnknown {
-    fn from(value: IOleUIObjInfoA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleUIObjInfoA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleUIObjInfoA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleUIObjInfoA> for ::windows::core::IUnknown {
-    fn from(value: &IOleUIObjInfoA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleUIObjInfoA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleUIObjInfoA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11020,21 +9806,7 @@ impl IOleUIObjInfoW {
         (::windows::core::Vtable::vtable(self).SetViewInfo)(::windows::core::Vtable::as_raw(self), dwobject, hmetapict, dvaspect, ncurrentscale, brelativetoorig.into()).ok()
     }
 }
-impl ::core::convert::From<IOleUIObjInfoW> for ::windows::core::IUnknown {
-    fn from(value: IOleUIObjInfoW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleUIObjInfoW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleUIObjInfoW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleUIObjInfoW> for ::windows::core::IUnknown {
-    fn from(value: &IOleUIObjInfoW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleUIObjInfoW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleUIObjInfoW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11142,21 +9914,7 @@ impl IOleUndoManager {
         (::windows::core::Vtable::vtable(self).Enable)(::windows::core::Vtable::as_raw(self), fenable.into()).ok()
     }
 }
-impl ::core::convert::From<IOleUndoManager> for ::windows::core::IUnknown {
-    fn from(value: IOleUndoManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleUndoManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleUndoManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleUndoManager> for ::windows::core::IUnknown {
-    fn from(value: &IOleUndoManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleUndoManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleUndoManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11223,21 +9981,7 @@ impl IOleUndoUnit {
         (::windows::core::Vtable::vtable(self).OnNextAdd)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IOleUndoUnit> for ::windows::core::IUnknown {
-    fn from(value: IOleUndoUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleUndoUnit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleUndoUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleUndoUnit> for ::windows::core::IUnknown {
-    fn from(value: &IOleUndoUnit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleUndoUnit, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleUndoUnit {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11288,21 +10032,7 @@ impl IOleWindow {
         (::windows::core::Vtable::vtable(self).ContextSensitiveHelp)(::windows::core::Vtable::as_raw(self), fentermode.into()).ok()
     }
 }
-impl ::core::convert::From<IOleWindow> for ::windows::core::IUnknown {
-    fn from(value: IOleWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOleWindow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOleWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOleWindow> for ::windows::core::IUnknown {
-    fn from(value: &IOleWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOleWindow, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOleWindow {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11352,21 +10082,7 @@ impl IParseDisplayName {
         (::windows::core::Vtable::vtable(self).ParseDisplayName)(::windows::core::Vtable::as_raw(self), pbc.into().abi(), pszdisplayname.into(), ::core::mem::transmute(pcheaten), ::core::mem::transmute(ppmkout)).ok()
     }
 }
-impl ::core::convert::From<IParseDisplayName> for ::windows::core::IUnknown {
-    fn from(value: IParseDisplayName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IParseDisplayName> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IParseDisplayName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IParseDisplayName> for ::windows::core::IUnknown {
-    fn from(value: &IParseDisplayName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IParseDisplayName, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IParseDisplayName {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11420,21 +10136,7 @@ impl IPerPropertyBrowsing {
         (::windows::core::Vtable::vtable(self).GetPredefinedValue)(::windows::core::Vtable::as_raw(self), dispid, dwcookie, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<IPerPropertyBrowsing> for ::windows::core::IUnknown {
-    fn from(value: IPerPropertyBrowsing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPerPropertyBrowsing> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPerPropertyBrowsing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPerPropertyBrowsing> for ::windows::core::IUnknown {
-    fn from(value: &IPerPropertyBrowsing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPerPropertyBrowsing, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPerPropertyBrowsing {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11505,41 +10207,7 @@ impl IPersistPropertyBag {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistPropertyBag> for ::windows::core::IUnknown {
-    fn from(value: IPersistPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistPropertyBag> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistPropertyBag> for ::windows::core::IUnknown {
-    fn from(value: &IPersistPropertyBag) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistPropertyBag> for super::Com::IPersist {
-    fn from(value: IPersistPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistPropertyBag> for &'a super::Com::IPersist {
-    fn from(value: &'a IPersistPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistPropertyBag> for super::Com::IPersist {
-    fn from(value: &IPersistPropertyBag) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistPropertyBag, ::windows::core::IUnknown, super::Com::IPersist);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPersistPropertyBag {
     fn clone(&self) -> Self {
@@ -11622,41 +10290,7 @@ impl IPersistPropertyBag2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistPropertyBag2> for ::windows::core::IUnknown {
-    fn from(value: IPersistPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistPropertyBag2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistPropertyBag2> for ::windows::core::IUnknown {
-    fn from(value: &IPersistPropertyBag2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistPropertyBag2> for super::Com::IPersist {
-    fn from(value: IPersistPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistPropertyBag2> for &'a super::Com::IPersist {
-    fn from(value: &'a IPersistPropertyBag2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistPropertyBag2> for super::Com::IPersist {
-    fn from(value: &IPersistPropertyBag2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistPropertyBag2, ::windows::core::IUnknown, super::Com::IPersist);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPersistPropertyBag2 {
     fn clone(&self) -> Self {
@@ -11782,21 +10416,7 @@ impl IPicture {
         (::windows::core::Vtable::vtable(self).Attributes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IPicture> for ::windows::core::IUnknown {
-    fn from(value: IPicture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPicture> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPicture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPicture> for ::windows::core::IUnknown {
-    fn from(value: &IPicture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPicture, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPicture {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11937,21 +10557,7 @@ impl IPicture2 {
         (::windows::core::Vtable::vtable(self).Attributes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IPicture2> for ::windows::core::IUnknown {
-    fn from(value: IPicture2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPicture2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPicture2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPicture2> for ::windows::core::IUnknown {
-    fn from(value: &IPicture2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPicture2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPicture2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12018,41 +10624,7 @@ pub struct IPictureDisp(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IPictureDisp {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPictureDisp> for ::windows::core::IUnknown {
-    fn from(value: IPictureDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPictureDisp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPictureDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPictureDisp> for ::windows::core::IUnknown {
-    fn from(value: &IPictureDisp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPictureDisp> for super::Com::IDispatch {
-    fn from(value: IPictureDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPictureDisp> for &'a super::Com::IDispatch {
-    fn from(value: &'a IPictureDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPictureDisp> for super::Com::IDispatch {
-    fn from(value: &IPictureDisp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPictureDisp, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPictureDisp {
     fn clone(&self) -> Self {
@@ -12109,21 +10681,7 @@ impl IPointerInactive {
         (::windows::core::Vtable::vtable(self).OnInactiveSetCursor)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prectbounds), x, y, dwmousemsg, fsetalways.into()).ok()
     }
 }
-impl ::core::convert::From<IPointerInactive> for ::windows::core::IUnknown {
-    fn from(value: IPointerInactive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPointerInactive> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPointerInactive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPointerInactive> for ::windows::core::IUnknown {
-    fn from(value: &IPointerInactive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPointerInactive, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPointerInactive {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12179,21 +10737,7 @@ impl IPrint {
         (::windows::core::Vtable::vtable(self).Print)(::windows::core::Vtable::as_raw(self), grfflags, ::core::mem::transmute(pptd), ::core::mem::transmute(pppageset), ::core::mem::transmute(pstgmoptions), pcallback.into().abi(), nfirstpage, ::core::mem::transmute(pcpagesprinted), ::core::mem::transmute(pnlastpage)).ok()
     }
 }
-impl ::core::convert::From<IPrint> for ::windows::core::IUnknown {
-    fn from(value: IPrint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrint> for ::windows::core::IUnknown {
-    fn from(value: &IPrint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrint, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12238,21 +10782,7 @@ impl IPropertyNotifySink {
         (::windows::core::Vtable::vtable(self).OnRequestEdit)(::windows::core::Vtable::as_raw(self), dispid).ok()
     }
 }
-impl ::core::convert::From<IPropertyNotifySink> for ::windows::core::IUnknown {
-    fn from(value: IPropertyNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyNotifySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12339,21 +10869,7 @@ impl IPropertyPage {
         (::windows::core::Vtable::vtable(self).TranslateAccelerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg)).ok()
     }
 }
-impl ::core::convert::From<IPropertyPage> for ::windows::core::IUnknown {
-    fn from(value: IPropertyPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyPage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyPage> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyPage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyPage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyPage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12464,36 +10980,7 @@ impl IPropertyPage2 {
         (::windows::core::Vtable::vtable(self).EditProperty)(::windows::core::Vtable::as_raw(self), dispid).ok()
     }
 }
-impl ::core::convert::From<IPropertyPage2> for ::windows::core::IUnknown {
-    fn from(value: IPropertyPage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyPage2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyPage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyPage2> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyPage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertyPage2> for IPropertyPage {
-    fn from(value: IPropertyPage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyPage2> for &'a IPropertyPage {
-    fn from(value: &'a IPropertyPage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyPage2> for IPropertyPage {
-    fn from(value: &IPropertyPage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyPage2, ::windows::core::IUnknown, IPropertyPage);
 impl ::core::clone::Clone for IPropertyPage2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12543,21 +11030,7 @@ impl IPropertyPageSite {
         (::windows::core::Vtable::vtable(self).TranslateAccelerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg)).ok()
     }
 }
-impl ::core::convert::From<IPropertyPageSite> for ::windows::core::IUnknown {
-    fn from(value: IPropertyPageSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyPageSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyPageSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyPageSite> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyPageSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyPageSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyPageSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12603,21 +11076,7 @@ impl IProtectFocus {
         (::windows::core::Vtable::vtable(self).AllowFocusChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IProtectFocus> for ::windows::core::IUnknown {
-    fn from(value: IProtectFocus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtectFocus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProtectFocus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtectFocus> for ::windows::core::IUnknown {
-    fn from(value: &IProtectFocus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProtectFocus, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProtectFocus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12679,21 +11138,7 @@ impl IProtectedModeMenuServices {
         (::windows::core::Vtable::vtable(self).LoadMenuID)(::windows::core::Vtable::as_raw(self), pszmodulename.into(), wresourceid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::UI::WindowsAndMessaging::HMENU>(result__)
     }
 }
-impl ::core::convert::From<IProtectedModeMenuServices> for ::windows::core::IUnknown {
-    fn from(value: IProtectedModeMenuServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtectedModeMenuServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProtectedModeMenuServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtectedModeMenuServices> for ::windows::core::IUnknown {
-    fn from(value: &IProtectedModeMenuServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProtectedModeMenuServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProtectedModeMenuServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12744,21 +11189,7 @@ impl IProvideClassInfo {
         (::windows::core::Vtable::vtable(self).GetClassInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::ITypeInfo>(result__)
     }
 }
-impl ::core::convert::From<IProvideClassInfo> for ::windows::core::IUnknown {
-    fn from(value: IProvideClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvideClassInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvideClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvideClassInfo> for ::windows::core::IUnknown {
-    fn from(value: &IProvideClassInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvideClassInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProvideClassInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12805,36 +11236,7 @@ impl IProvideClassInfo2 {
         (::windows::core::Vtable::vtable(self).GetGUID)(::windows::core::Vtable::as_raw(self), dwguidkind, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IProvideClassInfo2> for ::windows::core::IUnknown {
-    fn from(value: IProvideClassInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvideClassInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvideClassInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvideClassInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IProvideClassInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IProvideClassInfo2> for IProvideClassInfo {
-    fn from(value: IProvideClassInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvideClassInfo2> for &'a IProvideClassInfo {
-    fn from(value: &'a IProvideClassInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvideClassInfo2> for IProvideClassInfo {
-    fn from(value: &IProvideClassInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvideClassInfo2, ::windows::core::IUnknown, IProvideClassInfo);
 impl ::core::clone::Clone for IProvideClassInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12887,51 +11289,7 @@ impl IProvideMultipleClassInfo {
         (::windows::core::Vtable::vtable(self).GetInfoOfIndex)(::windows::core::Vtable::as_raw(self), iti, dwflags, ::core::mem::transmute(ppticoclass), ::core::mem::transmute(pdwtiflags), ::core::mem::transmute(pcdispidreserved), ::core::mem::transmute(piidprimary), ::core::mem::transmute(piidsource)).ok()
     }
 }
-impl ::core::convert::From<IProvideMultipleClassInfo> for ::windows::core::IUnknown {
-    fn from(value: IProvideMultipleClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvideMultipleClassInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvideMultipleClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvideMultipleClassInfo> for ::windows::core::IUnknown {
-    fn from(value: &IProvideMultipleClassInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IProvideMultipleClassInfo> for IProvideClassInfo {
-    fn from(value: IProvideMultipleClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvideMultipleClassInfo> for &'a IProvideClassInfo {
-    fn from(value: &'a IProvideMultipleClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvideMultipleClassInfo> for IProvideClassInfo {
-    fn from(value: &IProvideMultipleClassInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IProvideMultipleClassInfo> for IProvideClassInfo2 {
-    fn from(value: IProvideMultipleClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvideMultipleClassInfo> for &'a IProvideClassInfo2 {
-    fn from(value: &'a IProvideMultipleClassInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvideMultipleClassInfo> for IProvideClassInfo2 {
-    fn from(value: &IProvideMultipleClassInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvideMultipleClassInfo, ::windows::core::IUnknown, IProvideClassInfo, IProvideClassInfo2);
 impl ::core::clone::Clone for IProvideMultipleClassInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12972,21 +11330,7 @@ impl IProvideRuntimeContext {
         (::windows::core::Vtable::vtable(self).GetCurrentSourceContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwcontext), ::core::mem::transmute(pfexecutingglobalcode)).ok()
     }
 }
-impl ::core::convert::From<IProvideRuntimeContext> for ::windows::core::IUnknown {
-    fn from(value: IProvideRuntimeContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvideRuntimeContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvideRuntimeContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvideRuntimeContext> for ::windows::core::IUnknown {
-    fn from(value: &IProvideRuntimeContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvideRuntimeContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProvideRuntimeContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13036,21 +11380,7 @@ impl IQuickActivate {
         (::windows::core::Vtable::vtable(self).GetContentExtent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::SIZE>(result__)
     }
 }
-impl ::core::convert::From<IQuickActivate> for ::windows::core::IUnknown {
-    fn from(value: IQuickActivate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQuickActivate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQuickActivate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQuickActivate> for ::windows::core::IUnknown {
-    fn from(value: &IQuickActivate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQuickActivate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IQuickActivate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13175,21 +11505,7 @@ impl IRecordInfo {
         (::windows::core::Vtable::vtable(self).RecordDestroy)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvrecord)).ok()
     }
 }
-impl ::core::convert::From<IRecordInfo> for ::windows::core::IUnknown {
-    fn from(value: IRecordInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRecordInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRecordInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRecordInfo> for ::windows::core::IUnknown {
-    fn from(value: &IRecordInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRecordInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRecordInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13276,21 +11592,7 @@ impl ISimpleFrameSite {
         (::windows::core::Vtable::vtable(self).PostMessageFilter)(::windows::core::Vtable::as_raw(self), hwnd.into(), msg, wp.into(), lp.into(), ::core::mem::transmute(plresult), dwcookie).ok()
     }
 }
-impl ::core::convert::From<ISimpleFrameSite> for ::windows::core::IUnknown {
-    fn from(value: ISimpleFrameSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISimpleFrameSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISimpleFrameSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISimpleFrameSite> for ::windows::core::IUnknown {
-    fn from(value: &ISimpleFrameSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISimpleFrameSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISimpleFrameSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13335,21 +11637,7 @@ impl ISpecifyPropertyPages {
         (::windows::core::Vtable::vtable(self).GetPages)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<CAUUID>(result__)
     }
 }
-impl ::core::convert::From<ISpecifyPropertyPages> for ::windows::core::IUnknown {
-    fn from(value: ISpecifyPropertyPages) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpecifyPropertyPages> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpecifyPropertyPages) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpecifyPropertyPages> for ::windows::core::IUnknown {
-    fn from(value: &ISpecifyPropertyPages) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpecifyPropertyPages, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpecifyPropertyPages {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13402,21 +11690,7 @@ impl ITypeChangeEvents {
         (::windows::core::Vtable::vtable(self).AfterTypeChange)(::windows::core::Vtable::as_raw(self), changekind, ptinfoafter.into().abi(), pstrname.into()).ok()
     }
 }
-impl ::core::convert::From<ITypeChangeEvents> for ::windows::core::IUnknown {
-    fn from(value: ITypeChangeEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeChangeEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITypeChangeEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeChangeEvents> for ::windows::core::IUnknown {
-    fn from(value: &ITypeChangeEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITypeChangeEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITypeChangeEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13466,21 +11740,7 @@ impl ITypeFactory {
         (::windows::core::Vtable::vtable(self).CreateFromTypeInfo)(::windows::core::Vtable::as_raw(self), ptypeinfo.into().abi(), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<ITypeFactory> for ::windows::core::IUnknown {
-    fn from(value: ITypeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITypeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeFactory> for ::windows::core::IUnknown {
-    fn from(value: &ITypeFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITypeFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITypeFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13530,21 +11790,7 @@ impl ITypeMarshal {
         (::windows::core::Vtable::vtable(self).Free)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvtype)).ok()
     }
 }
-impl ::core::convert::From<ITypeMarshal> for ::windows::core::IUnknown {
-    fn from(value: ITypeMarshal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITypeMarshal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITypeMarshal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITypeMarshal> for ::windows::core::IUnknown {
-    fn from(value: &ITypeMarshal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITypeMarshal, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITypeMarshal {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13586,21 +11832,7 @@ impl IVBFormat {
         (::windows::core::Vtable::vtable(self).Format)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(vdata), ::core::mem::transmute_copy(bstrformat), ::core::mem::transmute(lpbuffer), cb, lcid, sfirstdayofweek, sfirstweekofyear, ::core::mem::transmute(rcb)).ok()
     }
 }
-impl ::core::convert::From<IVBFormat> for ::windows::core::IUnknown {
-    fn from(value: IVBFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVBFormat> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBFormat) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVBFormat> for ::windows::core::IUnknown {
-    fn from(value: &IVBFormat) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBFormat, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVBFormat {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13643,21 +11875,7 @@ impl IVBGetControl {
         (::windows::core::Vtable::vtable(self).EnumControls)(::windows::core::Vtable::as_raw(self), dwolecontf, dwwhich, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::IEnumUnknown>(result__)
     }
 }
-impl ::core::convert::From<IVBGetControl> for ::windows::core::IUnknown {
-    fn from(value: IVBGetControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVBGetControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVBGetControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVBGetControl> for ::windows::core::IUnknown {
-    fn from(value: &IVBGetControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVBGetControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVBGetControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13699,21 +11917,7 @@ impl IVariantChangeType {
         (::windows::core::Vtable::vtable(self).ChangeType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvardst), ::core::mem::transmute(pvarsrc), lcid, vtnew).ok()
     }
 }
-impl ::core::convert::From<IVariantChangeType> for ::windows::core::IUnknown {
-    fn from(value: IVariantChangeType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVariantChangeType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVariantChangeType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVariantChangeType> for ::windows::core::IUnknown {
-    fn from(value: &IVariantChangeType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVariantChangeType, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVariantChangeType {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13788,21 +11992,7 @@ impl IViewObject {
         (::windows::core::Vtable::vtable(self).GetAdvise)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(paspects.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(padvf.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ppadvsink)).ok()
     }
 }
-impl ::core::convert::From<IViewObject> for ::windows::core::IUnknown {
-    fn from(value: IViewObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IViewObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewObject> for ::windows::core::IUnknown {
-    fn from(value: &IViewObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IViewObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IViewObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13900,36 +12090,7 @@ impl IViewObject2 {
         (::windows::core::Vtable::vtable(self).GetExtent)(::windows::core::Vtable::as_raw(self), dwdrawaspect, lindex, ::core::mem::transmute(ptd), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::SIZE>(result__)
     }
 }
-impl ::core::convert::From<IViewObject2> for ::windows::core::IUnknown {
-    fn from(value: IViewObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewObject2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IViewObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewObject2> for ::windows::core::IUnknown {
-    fn from(value: &IViewObject2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IViewObject2> for IViewObject {
-    fn from(value: IViewObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewObject2> for &'a IViewObject {
-    fn from(value: &'a IViewObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewObject2> for IViewObject {
-    fn from(value: &IViewObject2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IViewObject2, ::windows::core::IUnknown, IViewObject);
 impl ::core::clone::Clone for IViewObject2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14041,51 +12202,7 @@ impl IViewObjectEx {
         (::windows::core::Vtable::vtable(self).GetNaturalExtent)(::windows::core::Vtable::as_raw(self), dwaspect, lindex, ::core::mem::transmute(ptd), hictargetdev.into(), ::core::mem::transmute(pextentinfo), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::SIZE>(result__)
     }
 }
-impl ::core::convert::From<IViewObjectEx> for ::windows::core::IUnknown {
-    fn from(value: IViewObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewObjectEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IViewObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewObjectEx> for ::windows::core::IUnknown {
-    fn from(value: &IViewObjectEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IViewObjectEx> for IViewObject {
-    fn from(value: IViewObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewObjectEx> for &'a IViewObject {
-    fn from(value: &'a IViewObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewObjectEx> for IViewObject {
-    fn from(value: &IViewObjectEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IViewObjectEx> for IViewObject2 {
-    fn from(value: IViewObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewObjectEx> for &'a IViewObject2 {
-    fn from(value: &'a IViewObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewObjectEx> for IViewObject2 {
-    fn from(value: &IViewObjectEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IViewObjectEx, ::windows::core::IUnknown, IViewObject, IViewObject2);
 impl ::core::clone::Clone for IViewObjectEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14138,21 +12255,7 @@ impl IZoomEvents {
         (::windows::core::Vtable::vtable(self).OnZoomPercentChanged)(::windows::core::Vtable::as_raw(self), ulzoompercent).ok()
     }
 }
-impl ::core::convert::From<IZoomEvents> for ::windows::core::IUnknown {
-    fn from(value: IZoomEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IZoomEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IZoomEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IZoomEvents> for ::windows::core::IUnknown {
-    fn from(value: &IZoomEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IZoomEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IZoomEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/ParentalControls/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ParentalControls/mod.rs
@@ -23,36 +23,7 @@ impl IWPCGamesSettings {
         (::windows::core::Vtable::vtable(self).IsBlocked)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidappid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IWPCGamesSettings> for ::windows::core::IUnknown {
-    fn from(value: IWPCGamesSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWPCGamesSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWPCGamesSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWPCGamesSettings> for ::windows::core::IUnknown {
-    fn from(value: &IWPCGamesSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWPCGamesSettings> for IWPCSettings {
-    fn from(value: IWPCGamesSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWPCGamesSettings> for &'a IWPCSettings {
-    fn from(value: &'a IWPCGamesSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWPCGamesSettings> for IWPCSettings {
-    fn from(value: &IWPCGamesSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWPCGamesSettings, ::windows::core::IUnknown, IWPCSettings);
 impl ::core::clone::Clone for IWPCGamesSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -106,21 +77,7 @@ impl IWPCProviderConfig {
         (::windows::core::Vtable::vtable(self).RequestOverride)(::windows::core::Vtable::as_raw(self), hwnd.into(), ::core::mem::transmute_copy(bstrpath), dwflags).ok()
     }
 }
-impl ::core::convert::From<IWPCProviderConfig> for ::windows::core::IUnknown {
-    fn from(value: IWPCProviderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWPCProviderConfig> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWPCProviderConfig) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWPCProviderConfig> for ::windows::core::IUnknown {
-    fn from(value: &IWPCProviderConfig) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWPCProviderConfig, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWPCProviderConfig {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -168,21 +125,7 @@ impl IWPCProviderState {
         (::windows::core::Vtable::vtable(self).Disable)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWPCProviderState> for ::windows::core::IUnknown {
-    fn from(value: IWPCProviderState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWPCProviderState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWPCProviderState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWPCProviderState> for ::windows::core::IUnknown {
-    fn from(value: &IWPCProviderState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWPCProviderState, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWPCProviderState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -221,21 +164,7 @@ impl IWPCProviderSupport {
         (::windows::core::Vtable::vtable(self).GetCurrent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IWPCProviderSupport> for ::windows::core::IUnknown {
-    fn from(value: IWPCProviderSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWPCProviderSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWPCProviderSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWPCProviderSupport> for ::windows::core::IUnknown {
-    fn from(value: &IWPCProviderSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWPCProviderSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWPCProviderSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -285,21 +214,7 @@ impl IWPCSettings {
         (::windows::core::Vtable::vtable(self).GetRestrictions)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WPCFLAG_RESTRICTION>(result__)
     }
 }
-impl ::core::convert::From<IWPCSettings> for ::windows::core::IUnknown {
-    fn from(value: IWPCSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWPCSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWPCSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWPCSettings> for ::windows::core::IUnknown {
-    fn from(value: &IWPCSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWPCSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWPCSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -371,36 +286,7 @@ impl IWPCWebSettings {
         (::windows::core::Vtable::vtable(self).RequestURLOverride)(::windows::core::Vtable::as_raw(self), hwnd.into(), pcszurl.into(), ppcszsuburls.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(ppcszsuburls.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWPCWebSettings> for ::windows::core::IUnknown {
-    fn from(value: IWPCWebSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWPCWebSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWPCWebSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWPCWebSettings> for ::windows::core::IUnknown {
-    fn from(value: &IWPCWebSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWPCWebSettings> for IWPCSettings {
-    fn from(value: IWPCWebSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWPCWebSettings> for &'a IWPCSettings {
-    fn from(value: &'a IWPCWebSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWPCWebSettings> for IWPCSettings {
-    fn from(value: &IWPCWebSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWPCWebSettings, ::windows::core::IUnknown, IWPCSettings);
 impl ::core::clone::Clone for IWPCWebSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -466,36 +352,7 @@ impl IWindowsParentalControls {
         (::windows::core::Vtable::vtable(self).GetGamesSettings)(::windows::core::Vtable::as_raw(self), pcszsid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWPCGamesSettings>(result__)
     }
 }
-impl ::core::convert::From<IWindowsParentalControls> for ::windows::core::IUnknown {
-    fn from(value: IWindowsParentalControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsParentalControls> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsParentalControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsParentalControls> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsParentalControls) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWindowsParentalControls> for IWindowsParentalControlsCore {
-    fn from(value: IWindowsParentalControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsParentalControls> for &'a IWindowsParentalControlsCore {
-    fn from(value: &'a IWindowsParentalControls) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsParentalControls> for IWindowsParentalControlsCore {
-    fn from(value: &IWindowsParentalControls) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsParentalControls, ::windows::core::IUnknown, IWindowsParentalControlsCore);
 impl ::core::clone::Clone for IWindowsParentalControls {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -550,21 +407,7 @@ impl IWindowsParentalControlsCore {
         (::windows::core::Vtable::vtable(self).GetWebFilterInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguidid), ::core::mem::transmute(ppszname.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IWindowsParentalControlsCore> for ::windows::core::IUnknown {
-    fn from(value: IWindowsParentalControlsCore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsParentalControlsCore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsParentalControlsCore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsParentalControlsCore> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsParentalControlsCore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsParentalControlsCore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWindowsParentalControlsCore {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Performance/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Performance/mod.rs
@@ -1590,41 +1590,7 @@ pub struct DICounterItem(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DICounterItem {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DICounterItem> for ::windows::core::IUnknown {
-    fn from(value: DICounterItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DICounterItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DICounterItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DICounterItem> for ::windows::core::IUnknown {
-    fn from(value: &DICounterItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DICounterItem> for super::Com::IDispatch {
-    fn from(value: DICounterItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DICounterItem> for &'a super::Com::IDispatch {
-    fn from(value: &'a DICounterItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DICounterItem> for super::Com::IDispatch {
-    fn from(value: &DICounterItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DICounterItem, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DICounterItem {
     fn clone(&self) -> Self {
@@ -1666,41 +1632,7 @@ pub struct DILogFileItem(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DILogFileItem {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DILogFileItem> for ::windows::core::IUnknown {
-    fn from(value: DILogFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DILogFileItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DILogFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DILogFileItem> for ::windows::core::IUnknown {
-    fn from(value: &DILogFileItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DILogFileItem> for super::Com::IDispatch {
-    fn from(value: DILogFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DILogFileItem> for &'a super::Com::IDispatch {
-    fn from(value: &'a DILogFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DILogFileItem> for super::Com::IDispatch {
-    fn from(value: &DILogFileItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DILogFileItem, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DILogFileItem {
     fn clone(&self) -> Self {
@@ -1742,41 +1674,7 @@ pub struct DISystemMonitor(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DISystemMonitor {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DISystemMonitor> for ::windows::core::IUnknown {
-    fn from(value: DISystemMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DISystemMonitor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DISystemMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DISystemMonitor> for ::windows::core::IUnknown {
-    fn from(value: &DISystemMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DISystemMonitor> for super::Com::IDispatch {
-    fn from(value: DISystemMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DISystemMonitor> for &'a super::Com::IDispatch {
-    fn from(value: &'a DISystemMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DISystemMonitor> for super::Com::IDispatch {
-    fn from(value: &DISystemMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DISystemMonitor, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DISystemMonitor {
     fn clone(&self) -> Self {
@@ -1818,41 +1716,7 @@ pub struct DISystemMonitorEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DISystemMonitorEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DISystemMonitorEvents> for ::windows::core::IUnknown {
-    fn from(value: DISystemMonitorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DISystemMonitorEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DISystemMonitorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DISystemMonitorEvents> for ::windows::core::IUnknown {
-    fn from(value: &DISystemMonitorEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DISystemMonitorEvents> for super::Com::IDispatch {
-    fn from(value: DISystemMonitorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DISystemMonitorEvents> for &'a super::Com::IDispatch {
-    fn from(value: &'a DISystemMonitorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DISystemMonitorEvents> for super::Com::IDispatch {
-    fn from(value: &DISystemMonitorEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DISystemMonitorEvents, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DISystemMonitorEvents {
     fn clone(&self) -> Self {
@@ -1894,41 +1758,7 @@ pub struct DISystemMonitorInternal(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DISystemMonitorInternal {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DISystemMonitorInternal> for ::windows::core::IUnknown {
-    fn from(value: DISystemMonitorInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DISystemMonitorInternal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DISystemMonitorInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DISystemMonitorInternal> for ::windows::core::IUnknown {
-    fn from(value: &DISystemMonitorInternal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DISystemMonitorInternal> for super::Com::IDispatch {
-    fn from(value: DISystemMonitorInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DISystemMonitorInternal> for &'a super::Com::IDispatch {
-    fn from(value: &'a DISystemMonitorInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DISystemMonitorInternal> for super::Com::IDispatch {
-    fn from(value: &DISystemMonitorInternal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DISystemMonitorInternal, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DISystemMonitorInternal {
     fn clone(&self) -> Self {
@@ -2130,59 +1960,7 @@ impl IAlertDataCollector {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAlertDataCollector> for ::windows::core::IUnknown {
-    fn from(value: IAlertDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAlertDataCollector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAlertDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAlertDataCollector> for ::windows::core::IUnknown {
-    fn from(value: &IAlertDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAlertDataCollector> for super::Com::IDispatch {
-    fn from(value: IAlertDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAlertDataCollector> for &'a super::Com::IDispatch {
-    fn from(value: &'a IAlertDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAlertDataCollector> for super::Com::IDispatch {
-    fn from(value: &IAlertDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAlertDataCollector> for IDataCollector {
-    fn from(value: IAlertDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAlertDataCollector> for &'a IDataCollector {
-    fn from(value: &'a IAlertDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAlertDataCollector> for IDataCollector {
-    fn from(value: &IAlertDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAlertDataCollector, ::windows::core::IUnknown, super::Com::IDispatch, IDataCollector);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAlertDataCollector {
     fn clone(&self) -> Self {
@@ -2407,59 +2185,7 @@ impl IApiTracingDataCollector {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IApiTracingDataCollector> for ::windows::core::IUnknown {
-    fn from(value: IApiTracingDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IApiTracingDataCollector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApiTracingDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IApiTracingDataCollector> for ::windows::core::IUnknown {
-    fn from(value: &IApiTracingDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IApiTracingDataCollector> for super::Com::IDispatch {
-    fn from(value: IApiTracingDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IApiTracingDataCollector> for &'a super::Com::IDispatch {
-    fn from(value: &'a IApiTracingDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IApiTracingDataCollector> for super::Com::IDispatch {
-    fn from(value: &IApiTracingDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IApiTracingDataCollector> for IDataCollector {
-    fn from(value: IApiTracingDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IApiTracingDataCollector> for &'a IDataCollector {
-    fn from(value: &'a IApiTracingDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IApiTracingDataCollector> for IDataCollector {
-    fn from(value: &IApiTracingDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApiTracingDataCollector, ::windows::core::IUnknown, super::Com::IDispatch, IDataCollector);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IApiTracingDataCollector {
     fn clone(&self) -> Self {
@@ -2708,59 +2434,7 @@ impl IConfigurationDataCollector {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IConfigurationDataCollector> for ::windows::core::IUnknown {
-    fn from(value: IConfigurationDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IConfigurationDataCollector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConfigurationDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IConfigurationDataCollector> for ::windows::core::IUnknown {
-    fn from(value: &IConfigurationDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IConfigurationDataCollector> for super::Com::IDispatch {
-    fn from(value: IConfigurationDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IConfigurationDataCollector> for &'a super::Com::IDispatch {
-    fn from(value: &'a IConfigurationDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IConfigurationDataCollector> for super::Com::IDispatch {
-    fn from(value: &IConfigurationDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IConfigurationDataCollector> for IDataCollector {
-    fn from(value: IConfigurationDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IConfigurationDataCollector> for &'a IDataCollector {
-    fn from(value: &'a IConfigurationDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IConfigurationDataCollector> for IDataCollector {
-    fn from(value: &IConfigurationDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConfigurationDataCollector, ::windows::core::IUnknown, super::Com::IDispatch, IDataCollector);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IConfigurationDataCollector {
     fn clone(&self) -> Self {
@@ -2878,21 +2552,7 @@ impl ICounterItem {
         (::windows::core::Vtable::vtable(self).GetStatistics)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(max), ::core::mem::transmute(min), ::core::mem::transmute(avg), ::core::mem::transmute(status)).ok()
     }
 }
-impl ::core::convert::From<ICounterItem> for ::windows::core::IUnknown {
-    fn from(value: ICounterItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICounterItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICounterItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICounterItem> for ::windows::core::IUnknown {
-    fn from(value: &ICounterItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICounterItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICounterItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2999,36 +2659,7 @@ impl ICounterItem2 {
         (::windows::core::Vtable::vtable(self).GetDataAt)(::windows::core::Vtable::as_raw(self), iindex, iwhich, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<ICounterItem2> for ::windows::core::IUnknown {
-    fn from(value: ICounterItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICounterItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICounterItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICounterItem2> for ::windows::core::IUnknown {
-    fn from(value: &ICounterItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICounterItem2> for ICounterItem {
-    fn from(value: ICounterItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICounterItem2> for &'a ICounterItem {
-    fn from(value: &'a ICounterItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICounterItem2> for ICounterItem {
-    fn from(value: &ICounterItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICounterItem2, ::windows::core::IUnknown, ICounterItem);
 impl ::core::clone::Clone for ICounterItem2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3103,41 +2734,7 @@ impl ICounters {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICounters> for ::windows::core::IUnknown {
-    fn from(value: ICounters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICounters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICounters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICounters> for ::windows::core::IUnknown {
-    fn from(value: &ICounters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICounters> for super::Com::IDispatch {
-    fn from(value: ICounters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICounters> for &'a super::Com::IDispatch {
-    fn from(value: &'a ICounters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICounters> for super::Com::IDispatch {
-    fn from(value: &ICounters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICounters, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICounters {
     fn clone(&self) -> Self {
@@ -3293,41 +2890,7 @@ impl IDataCollector {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataCollector> for ::windows::core::IUnknown {
-    fn from(value: IDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataCollector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataCollector> for ::windows::core::IUnknown {
-    fn from(value: &IDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataCollector> for super::Com::IDispatch {
-    fn from(value: IDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataCollector> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataCollector> for super::Com::IDispatch {
-    fn from(value: &IDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataCollector, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDataCollector {
     fn clone(&self) -> Self {
@@ -3459,41 +3022,7 @@ impl IDataCollectorCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataCollectorCollection> for ::windows::core::IUnknown {
-    fn from(value: IDataCollectorCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataCollectorCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataCollectorCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataCollectorCollection> for ::windows::core::IUnknown {
-    fn from(value: &IDataCollectorCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataCollectorCollection> for super::Com::IDispatch {
-    fn from(value: IDataCollectorCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataCollectorCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDataCollectorCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataCollectorCollection> for super::Com::IDispatch {
-    fn from(value: &IDataCollectorCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataCollectorCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDataCollectorCollection {
     fn clone(&self) -> Self {
@@ -3791,41 +3320,7 @@ impl IDataCollectorSet {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataCollectorSet> for ::windows::core::IUnknown {
-    fn from(value: IDataCollectorSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataCollectorSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataCollectorSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataCollectorSet> for ::windows::core::IUnknown {
-    fn from(value: &IDataCollectorSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataCollectorSet> for super::Com::IDispatch {
-    fn from(value: IDataCollectorSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataCollectorSet> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDataCollectorSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataCollectorSet> for super::Com::IDispatch {
-    fn from(value: &IDataCollectorSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataCollectorSet, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDataCollectorSet {
     fn clone(&self) -> Self {
@@ -3996,41 +3491,7 @@ impl IDataCollectorSetCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataCollectorSetCollection> for ::windows::core::IUnknown {
-    fn from(value: IDataCollectorSetCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataCollectorSetCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataCollectorSetCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataCollectorSetCollection> for ::windows::core::IUnknown {
-    fn from(value: &IDataCollectorSetCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataCollectorSetCollection> for super::Com::IDispatch {
-    fn from(value: IDataCollectorSetCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataCollectorSetCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDataCollectorSetCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataCollectorSetCollection> for super::Com::IDispatch {
-    fn from(value: &IDataCollectorSetCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataCollectorSetCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDataCollectorSetCollection {
     fn clone(&self) -> Self {
@@ -4185,41 +3646,7 @@ impl IDataManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataManager> for ::windows::core::IUnknown {
-    fn from(value: IDataManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataManager> for ::windows::core::IUnknown {
-    fn from(value: &IDataManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataManager> for super::Com::IDispatch {
-    fn from(value: IDataManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDataManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataManager> for super::Com::IDispatch {
-    fn from(value: &IDataManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDataManager {
     fn clone(&self) -> Self {
@@ -4321,41 +3748,7 @@ impl IFolderAction {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFolderAction> for ::windows::core::IUnknown {
-    fn from(value: IFolderAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFolderAction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFolderAction> for ::windows::core::IUnknown {
-    fn from(value: &IFolderAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFolderAction> for super::Com::IDispatch {
-    fn from(value: IFolderAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFolderAction> for &'a super::Com::IDispatch {
-    fn from(value: &'a IFolderAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFolderAction> for super::Com::IDispatch {
-    fn from(value: &IFolderAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderAction, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFolderAction {
     fn clone(&self) -> Self {
@@ -4456,41 +3849,7 @@ impl IFolderActionCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFolderActionCollection> for ::windows::core::IUnknown {
-    fn from(value: IFolderActionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFolderActionCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderActionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFolderActionCollection> for ::windows::core::IUnknown {
-    fn from(value: &IFolderActionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFolderActionCollection> for super::Com::IDispatch {
-    fn from(value: IFolderActionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFolderActionCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IFolderActionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFolderActionCollection> for super::Com::IDispatch {
-    fn from(value: &IFolderActionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderActionCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFolderActionCollection {
     fn clone(&self) -> Self {
@@ -4557,21 +3916,7 @@ impl ILogFileItem {
         (::windows::core::Vtable::vtable(self).Path)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ILogFileItem> for ::windows::core::IUnknown {
-    fn from(value: ILogFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILogFileItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILogFileItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILogFileItem> for ::windows::core::IUnknown {
-    fn from(value: &ILogFileItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILogFileItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILogFileItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4639,41 +3984,7 @@ impl ILogFiles {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ILogFiles> for ::windows::core::IUnknown {
-    fn from(value: ILogFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ILogFiles> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILogFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ILogFiles> for ::windows::core::IUnknown {
-    fn from(value: &ILogFiles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ILogFiles> for super::Com::IDispatch {
-    fn from(value: ILogFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ILogFiles> for &'a super::Com::IDispatch {
-    fn from(value: &'a ILogFiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ILogFiles> for super::Com::IDispatch {
-    fn from(value: &ILogFiles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILogFiles, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ILogFiles {
     fn clone(&self) -> Self {
@@ -4868,59 +4179,7 @@ impl IPerformanceCounterDataCollector {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPerformanceCounterDataCollector> for ::windows::core::IUnknown {
-    fn from(value: IPerformanceCounterDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPerformanceCounterDataCollector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPerformanceCounterDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPerformanceCounterDataCollector> for ::windows::core::IUnknown {
-    fn from(value: &IPerformanceCounterDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPerformanceCounterDataCollector> for super::Com::IDispatch {
-    fn from(value: IPerformanceCounterDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPerformanceCounterDataCollector> for &'a super::Com::IDispatch {
-    fn from(value: &'a IPerformanceCounterDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPerformanceCounterDataCollector> for super::Com::IDispatch {
-    fn from(value: &IPerformanceCounterDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPerformanceCounterDataCollector> for IDataCollector {
-    fn from(value: IPerformanceCounterDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPerformanceCounterDataCollector> for &'a IDataCollector {
-    fn from(value: &'a IPerformanceCounterDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPerformanceCounterDataCollector> for IDataCollector {
-    fn from(value: &IPerformanceCounterDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPerformanceCounterDataCollector, ::windows::core::IUnknown, super::Com::IDispatch, IDataCollector);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPerformanceCounterDataCollector {
     fn clone(&self) -> Self {
@@ -5028,41 +4287,7 @@ impl ISchedule {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchedule> for ::windows::core::IUnknown {
-    fn from(value: ISchedule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchedule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchedule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchedule> for ::windows::core::IUnknown {
-    fn from(value: &ISchedule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISchedule> for super::Com::IDispatch {
-    fn from(value: ISchedule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISchedule> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISchedule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISchedule> for super::Com::IDispatch {
-    fn from(value: &ISchedule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchedule, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISchedule {
     fn clone(&self) -> Self {
@@ -5181,41 +4406,7 @@ impl IScheduleCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IScheduleCollection> for ::windows::core::IUnknown {
-    fn from(value: IScheduleCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IScheduleCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IScheduleCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IScheduleCollection> for ::windows::core::IUnknown {
-    fn from(value: &IScheduleCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IScheduleCollection> for super::Com::IDispatch {
-    fn from(value: IScheduleCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IScheduleCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IScheduleCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IScheduleCollection> for super::Com::IDispatch {
-    fn from(value: &IScheduleCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IScheduleCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IScheduleCollection {
     fn clone(&self) -> Self {
@@ -5556,21 +4747,7 @@ impl ISystemMonitor {
         (::windows::core::Vtable::vtable(self).SqlLogSetName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ISystemMonitor> for ::windows::core::IUnknown {
-    fn from(value: ISystemMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISystemMonitor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISystemMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISystemMonitor> for ::windows::core::IUnknown {
-    fn from(value: &ISystemMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISystemMonitor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISystemMonitor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6036,36 +5213,7 @@ impl ISystemMonitor2 {
         (::windows::core::Vtable::vtable(self).LoadSettings)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrsettingfilename)).ok()
     }
 }
-impl ::core::convert::From<ISystemMonitor2> for ::windows::core::IUnknown {
-    fn from(value: ISystemMonitor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISystemMonitor2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISystemMonitor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISystemMonitor2> for ::windows::core::IUnknown {
-    fn from(value: &ISystemMonitor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISystemMonitor2> for ISystemMonitor {
-    fn from(value: ISystemMonitor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISystemMonitor2> for &'a ISystemMonitor {
-    fn from(value: &'a ISystemMonitor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISystemMonitor2> for ISystemMonitor {
-    fn from(value: &ISystemMonitor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISystemMonitor2, ::windows::core::IUnknown, ISystemMonitor);
 impl ::core::clone::Clone for ISystemMonitor2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6133,21 +5281,7 @@ impl ISystemMonitorEvents {
         (::windows::core::Vtable::vtable(self).OnDblClick)(::windows::core::Vtable::as_raw(self), index)
     }
 }
-impl ::core::convert::From<ISystemMonitorEvents> for ::windows::core::IUnknown {
-    fn from(value: ISystemMonitorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISystemMonitorEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISystemMonitorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISystemMonitorEvents> for ::windows::core::IUnknown {
-    fn from(value: &ISystemMonitorEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISystemMonitorEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISystemMonitorEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6430,59 +5564,7 @@ impl ITraceDataCollector {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITraceDataCollector> for ::windows::core::IUnknown {
-    fn from(value: ITraceDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITraceDataCollector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITraceDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITraceDataCollector> for ::windows::core::IUnknown {
-    fn from(value: &ITraceDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITraceDataCollector> for super::Com::IDispatch {
-    fn from(value: ITraceDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITraceDataCollector> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITraceDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITraceDataCollector> for super::Com::IDispatch {
-    fn from(value: &ITraceDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITraceDataCollector> for IDataCollector {
-    fn from(value: ITraceDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITraceDataCollector> for &'a IDataCollector {
-    fn from(value: &'a ITraceDataCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITraceDataCollector> for IDataCollector {
-    fn from(value: &ITraceDataCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITraceDataCollector, ::windows::core::IUnknown, super::Com::IDispatch, IDataCollector);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITraceDataCollector {
     fn clone(&self) -> Self {
@@ -6655,41 +5737,7 @@ impl ITraceDataProvider {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITraceDataProvider> for ::windows::core::IUnknown {
-    fn from(value: ITraceDataProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITraceDataProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITraceDataProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITraceDataProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITraceDataProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITraceDataProvider> for super::Com::IDispatch {
-    fn from(value: ITraceDataProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITraceDataProvider> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITraceDataProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITraceDataProvider> for super::Com::IDispatch {
-    fn from(value: &ITraceDataProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITraceDataProvider, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITraceDataProvider {
     fn clone(&self) -> Self {
@@ -6831,41 +5879,7 @@ impl ITraceDataProviderCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITraceDataProviderCollection> for ::windows::core::IUnknown {
-    fn from(value: ITraceDataProviderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITraceDataProviderCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITraceDataProviderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITraceDataProviderCollection> for ::windows::core::IUnknown {
-    fn from(value: &ITraceDataProviderCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITraceDataProviderCollection> for super::Com::IDispatch {
-    fn from(value: ITraceDataProviderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITraceDataProviderCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITraceDataProviderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITraceDataProviderCollection> for super::Com::IDispatch {
-    fn from(value: &ITraceDataProviderCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITraceDataProviderCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITraceDataProviderCollection {
     fn clone(&self) -> Self {
@@ -7011,41 +6025,7 @@ impl IValueMap {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IValueMap> for ::windows::core::IUnknown {
-    fn from(value: IValueMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IValueMap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IValueMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IValueMap> for ::windows::core::IUnknown {
-    fn from(value: &IValueMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IValueMap> for super::Com::IDispatch {
-    fn from(value: IValueMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IValueMap> for &'a super::Com::IDispatch {
-    fn from(value: &'a IValueMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IValueMap> for super::Com::IDispatch {
-    fn from(value: &IValueMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IValueMap, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IValueMap {
     fn clone(&self) -> Self {
@@ -7165,41 +6145,7 @@ impl IValueMapItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IValueMapItem> for ::windows::core::IUnknown {
-    fn from(value: IValueMapItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IValueMapItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IValueMapItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IValueMapItem> for ::windows::core::IUnknown {
-    fn from(value: &IValueMapItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IValueMapItem> for super::Com::IDispatch {
-    fn from(value: IValueMapItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IValueMapItem> for &'a super::Com::IDispatch {
-    fn from(value: &'a IValueMapItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IValueMapItem> for super::Com::IDispatch {
-    fn from(value: &IValueMapItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IValueMapItem, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IValueMapItem {
     fn clone(&self) -> Self {
@@ -7317,21 +6263,7 @@ impl _ICounterItemUnion {
         (::windows::core::Vtable::vtable(self).GetDataAt)(::windows::core::Vtable::as_raw(self), iindex, iwhich, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<_ICounterItemUnion> for ::windows::core::IUnknown {
-    fn from(value: _ICounterItemUnion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a _ICounterItemUnion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _ICounterItemUnion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&_ICounterItemUnion> for ::windows::core::IUnknown {
-    fn from(value: &_ICounterItemUnion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_ICounterItemUnion, ::windows::core::IUnknown);
 impl ::core::clone::Clone for _ICounterItemUnion {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7729,21 +6661,7 @@ impl _ISystemMonitorUnion {
         (::windows::core::Vtable::vtable(self).LoadSettings)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrsettingfilename)).ok()
     }
 }
-impl ::core::convert::From<_ISystemMonitorUnion> for ::windows::core::IUnknown {
-    fn from(value: _ISystemMonitorUnion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a _ISystemMonitorUnion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _ISystemMonitorUnion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&_ISystemMonitorUnion> for ::windows::core::IUnknown {
-    fn from(value: &_ISystemMonitorUnion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_ISystemMonitorUnion, ::windows::core::IUnknown);
 impl ::core::clone::Clone for _ISystemMonitorUnion {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/mod.rs
@@ -13,21 +13,7 @@ impl INetworkTransportSettings {
         (::windows::core::Vtable::vtable(self).QuerySetting)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(settingid), valuein.len() as _, ::core::mem::transmute(valuein.as_ptr()), ::core::mem::transmute(lengthout), ::core::mem::transmute(valueout)).ok()
     }
 }
-impl ::core::convert::From<INetworkTransportSettings> for ::windows::core::IUnknown {
-    fn from(value: INetworkTransportSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetworkTransportSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkTransportSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetworkTransportSettings> for ::windows::core::IUnknown {
-    fn from(value: &INetworkTransportSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkTransportSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetworkTransportSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -74,21 +60,7 @@ impl INotificationTransportSync {
         (::windows::core::Vtable::vtable(self).Flush)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<INotificationTransportSync> for ::windows::core::IUnknown {
-    fn from(value: INotificationTransportSync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INotificationTransportSync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INotificationTransportSync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INotificationTransportSync> for ::windows::core::IUnknown {
-    fn from(value: &INotificationTransportSync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INotificationTransportSync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INotificationTransportSync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -159,36 +131,7 @@ impl IRTCBuddy {
         (::windows::core::Vtable::vtable(self).Notes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IRTCBuddy> for ::windows::core::IUnknown {
-    fn from(value: IRTCBuddy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCBuddy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCBuddy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCBuddy> for ::windows::core::IUnknown {
-    fn from(value: &IRTCBuddy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRTCBuddy> for IRTCPresenceContact {
-    fn from(value: IRTCBuddy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCBuddy> for &'a IRTCPresenceContact {
-    fn from(value: &'a IRTCBuddy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCBuddy> for IRTCPresenceContact {
-    fn from(value: &IRTCBuddy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCBuddy, ::windows::core::IUnknown, IRTCPresenceContact);
 impl ::core::clone::Clone for IRTCBuddy {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -294,51 +237,7 @@ impl IRTCBuddy2 {
         (::windows::core::Vtable::vtable(self).SubscriptionType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<RTC_BUDDY_SUBSCRIPTION_TYPE>(result__)
     }
 }
-impl ::core::convert::From<IRTCBuddy2> for ::windows::core::IUnknown {
-    fn from(value: IRTCBuddy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCBuddy2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCBuddy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCBuddy2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCBuddy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRTCBuddy2> for IRTCPresenceContact {
-    fn from(value: IRTCBuddy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCBuddy2> for &'a IRTCPresenceContact {
-    fn from(value: &'a IRTCBuddy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCBuddy2> for IRTCPresenceContact {
-    fn from(value: &IRTCBuddy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRTCBuddy2> for IRTCBuddy {
-    fn from(value: IRTCBuddy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCBuddy2> for &'a IRTCBuddy {
-    fn from(value: &'a IRTCBuddy2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCBuddy2> for IRTCBuddy {
-    fn from(value: &IRTCBuddy2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCBuddy2, ::windows::core::IUnknown, IRTCPresenceContact, IRTCBuddy);
 impl ::core::clone::Clone for IRTCBuddy2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -392,41 +291,7 @@ impl IRTCBuddyEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCBuddyEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCBuddyEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCBuddyEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCBuddyEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCBuddyEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCBuddyEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCBuddyEvent> for super::Com::IDispatch {
-    fn from(value: IRTCBuddyEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCBuddyEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCBuddyEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCBuddyEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCBuddyEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCBuddyEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCBuddyEvent {
     fn clone(&self) -> Self {
@@ -486,59 +351,7 @@ impl IRTCBuddyEvent2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCBuddyEvent2> for ::windows::core::IUnknown {
-    fn from(value: IRTCBuddyEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCBuddyEvent2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCBuddyEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCBuddyEvent2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCBuddyEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCBuddyEvent2> for super::Com::IDispatch {
-    fn from(value: IRTCBuddyEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCBuddyEvent2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCBuddyEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCBuddyEvent2> for super::Com::IDispatch {
-    fn from(value: &IRTCBuddyEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCBuddyEvent2> for IRTCBuddyEvent {
-    fn from(value: IRTCBuddyEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCBuddyEvent2> for &'a IRTCBuddyEvent {
-    fn from(value: &'a IRTCBuddyEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCBuddyEvent2> for IRTCBuddyEvent {
-    fn from(value: &IRTCBuddyEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCBuddyEvent2, ::windows::core::IUnknown, super::Com::IDispatch, IRTCBuddyEvent);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCBuddyEvent2 {
     fn clone(&self) -> Self {
@@ -621,21 +434,7 @@ impl IRTCBuddyGroup {
         (::windows::core::Vtable::vtable(self).Profile)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRTCProfile2>(result__)
     }
 }
-impl ::core::convert::From<IRTCBuddyGroup> for ::windows::core::IUnknown {
-    fn from(value: IRTCBuddyGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCBuddyGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCBuddyGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCBuddyGroup> for ::windows::core::IUnknown {
-    fn from(value: &IRTCBuddyGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCBuddyGroup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCBuddyGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -699,41 +498,7 @@ impl IRTCBuddyGroupEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCBuddyGroupEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCBuddyGroupEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCBuddyGroupEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCBuddyGroupEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCBuddyGroupEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCBuddyGroupEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCBuddyGroupEvent> for super::Com::IDispatch {
-    fn from(value: IRTCBuddyGroupEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCBuddyGroupEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCBuddyGroupEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCBuddyGroupEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCBuddyGroupEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCBuddyGroupEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCBuddyGroupEvent {
     fn clone(&self) -> Self {
@@ -931,21 +696,7 @@ impl IRTCClient {
         (::windows::core::Vtable::vtable(self).IsTuned)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i16>(result__)
     }
 }
-impl ::core::convert::From<IRTCClient> for ::windows::core::IUnknown {
-    fn from(value: IRTCClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCClient> for ::windows::core::IUnknown {
-    fn from(value: &IRTCClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1230,36 +981,7 @@ impl IRTCClient2 {
         (::windows::core::Vtable::vtable(self).get_AllowedPorts)(::windows::core::Vtable::as_raw(self), ltransport, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<RTC_LISTEN_MODE>(result__)
     }
 }
-impl ::core::convert::From<IRTCClient2> for ::windows::core::IUnknown {
-    fn from(value: IRTCClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCClient2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCClient2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCClient2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRTCClient2> for IRTCClient {
-    fn from(value: IRTCClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCClient2> for &'a IRTCClient {
-    fn from(value: &'a IRTCClient2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCClient2> for IRTCClient {
-    fn from(value: &IRTCClient2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCClient2, ::windows::core::IUnknown, IRTCClient);
 impl ::core::clone::Clone for IRTCClient2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1316,41 +1038,7 @@ impl IRTCClientEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCClientEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCClientEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCClientEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCClientEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCClientEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCClientEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCClientEvent> for super::Com::IDispatch {
-    fn from(value: IRTCClientEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCClientEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCClientEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCClientEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCClientEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCClientEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCClientEvent {
     fn clone(&self) -> Self {
@@ -1401,21 +1089,7 @@ impl IRTCClientPortManagement {
         (::windows::core::Vtable::vtable(self).GetPortRange)(::windows::core::Vtable::as_raw(self), enporttype, ::core::mem::transmute(plminvalue), ::core::mem::transmute(plmaxvalue)).ok()
     }
 }
-impl ::core::convert::From<IRTCClientPortManagement> for ::windows::core::IUnknown {
-    fn from(value: IRTCClientPortManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCClientPortManagement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCClientPortManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCClientPortManagement> for ::windows::core::IUnknown {
-    fn from(value: &IRTCClientPortManagement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCClientPortManagement, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCClientPortManagement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1543,21 +1217,7 @@ impl IRTCClientPresence {
         (::windows::core::Vtable::vtable(self).SetPrivacyMode)(::windows::core::Vtable::as_raw(self), enmode).ok()
     }
 }
-impl ::core::convert::From<IRTCClientPresence> for ::windows::core::IUnknown {
-    fn from(value: IRTCClientPresence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCClientPresence> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCClientPresence) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCClientPresence> for ::windows::core::IUnknown {
-    fn from(value: &IRTCClientPresence) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCClientPresence, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCClientPresence {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1788,36 +1448,7 @@ impl IRTCClientPresence2 {
         (::windows::core::Vtable::vtable(self).AddBuddyEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrpresentityuri), ::core::mem::transmute_copy(bstrusername), ::core::mem::transmute_copy(bstrdata), fpersistent, ensubscriptiontype, pprofile.into().abi(), lflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRTCBuddy2>(result__)
     }
 }
-impl ::core::convert::From<IRTCClientPresence2> for ::windows::core::IUnknown {
-    fn from(value: IRTCClientPresence2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCClientPresence2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCClientPresence2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCClientPresence2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCClientPresence2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRTCClientPresence2> for IRTCClientPresence {
-    fn from(value: IRTCClientPresence2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCClientPresence2> for &'a IRTCClientPresence {
-    fn from(value: &'a IRTCClientPresence2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCClientPresence2> for IRTCClientPresence {
-    fn from(value: &IRTCClientPresence2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCClientPresence2, ::windows::core::IUnknown, IRTCClientPresence);
 impl ::core::clone::Clone for IRTCClientPresence2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1904,21 +1535,7 @@ impl IRTCClientProvisioning {
         (::windows::core::Vtable::vtable(self).SessionCapabilities)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IRTCClientProvisioning> for ::windows::core::IUnknown {
-    fn from(value: IRTCClientProvisioning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCClientProvisioning> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCClientProvisioning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCClientProvisioning> for ::windows::core::IUnknown {
-    fn from(value: &IRTCClientProvisioning) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCClientProvisioning, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCClientProvisioning {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2000,36 +1617,7 @@ impl IRTCClientProvisioning2 {
         (::windows::core::Vtable::vtable(self).EnableProfileEx)(::windows::core::Vtable::as_raw(self), pprofile.into().abi(), lregisterflags, lroamingflags).ok()
     }
 }
-impl ::core::convert::From<IRTCClientProvisioning2> for ::windows::core::IUnknown {
-    fn from(value: IRTCClientProvisioning2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCClientProvisioning2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCClientProvisioning2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCClientProvisioning2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCClientProvisioning2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRTCClientProvisioning2> for IRTCClientProvisioning {
-    fn from(value: IRTCClientProvisioning2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCClientProvisioning2> for &'a IRTCClientProvisioning {
-    fn from(value: &'a IRTCClientProvisioning2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCClientProvisioning2> for IRTCClientProvisioning {
-    fn from(value: &IRTCClientProvisioning2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCClientProvisioning2, ::windows::core::IUnknown, IRTCClientProvisioning);
 impl ::core::clone::Clone for IRTCClientProvisioning2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2080,41 +1668,7 @@ impl IRTCCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCCollection> for ::windows::core::IUnknown {
-    fn from(value: IRTCCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCCollection> for ::windows::core::IUnknown {
-    fn from(value: &IRTCCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCCollection> for super::Com::IDispatch {
-    fn from(value: IRTCCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCCollection> for super::Com::IDispatch {
-    fn from(value: &IRTCCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCCollection {
     fn clone(&self) -> Self {
@@ -2162,41 +1716,7 @@ pub struct IRTCDispatchEventNotification(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IRTCDispatchEventNotification {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCDispatchEventNotification> for ::windows::core::IUnknown {
-    fn from(value: IRTCDispatchEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCDispatchEventNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCDispatchEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCDispatchEventNotification> for ::windows::core::IUnknown {
-    fn from(value: &IRTCDispatchEventNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCDispatchEventNotification> for super::Com::IDispatch {
-    fn from(value: IRTCDispatchEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCDispatchEventNotification> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCDispatchEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCDispatchEventNotification> for super::Com::IDispatch {
-    fn from(value: &IRTCDispatchEventNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCDispatchEventNotification, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCDispatchEventNotification {
     fn clone(&self) -> Self {
@@ -2249,21 +1769,7 @@ impl IRTCEnumBuddies {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRTCEnumBuddies>(result__)
     }
 }
-impl ::core::convert::From<IRTCEnumBuddies> for ::windows::core::IUnknown {
-    fn from(value: IRTCEnumBuddies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCEnumBuddies> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCEnumBuddies) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCEnumBuddies> for ::windows::core::IUnknown {
-    fn from(value: &IRTCEnumBuddies) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCEnumBuddies, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCEnumBuddies {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2313,21 +1819,7 @@ impl IRTCEnumGroups {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRTCEnumGroups>(result__)
     }
 }
-impl ::core::convert::From<IRTCEnumGroups> for ::windows::core::IUnknown {
-    fn from(value: IRTCEnumGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCEnumGroups> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCEnumGroups) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCEnumGroups> for ::windows::core::IUnknown {
-    fn from(value: &IRTCEnumGroups) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCEnumGroups, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCEnumGroups {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2377,21 +1869,7 @@ impl IRTCEnumParticipants {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRTCEnumParticipants>(result__)
     }
 }
-impl ::core::convert::From<IRTCEnumParticipants> for ::windows::core::IUnknown {
-    fn from(value: IRTCEnumParticipants) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCEnumParticipants> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCEnumParticipants) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCEnumParticipants> for ::windows::core::IUnknown {
-    fn from(value: &IRTCEnumParticipants) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCEnumParticipants, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCEnumParticipants {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2441,21 +1919,7 @@ impl IRTCEnumPresenceDevices {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRTCEnumPresenceDevices>(result__)
     }
 }
-impl ::core::convert::From<IRTCEnumPresenceDevices> for ::windows::core::IUnknown {
-    fn from(value: IRTCEnumPresenceDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCEnumPresenceDevices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCEnumPresenceDevices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCEnumPresenceDevices> for ::windows::core::IUnknown {
-    fn from(value: &IRTCEnumPresenceDevices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCEnumPresenceDevices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCEnumPresenceDevices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2505,21 +1969,7 @@ impl IRTCEnumProfiles {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRTCEnumProfiles>(result__)
     }
 }
-impl ::core::convert::From<IRTCEnumProfiles> for ::windows::core::IUnknown {
-    fn from(value: IRTCEnumProfiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCEnumProfiles> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCEnumProfiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCEnumProfiles> for ::windows::core::IUnknown {
-    fn from(value: &IRTCEnumProfiles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCEnumProfiles, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCEnumProfiles {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2569,21 +2019,7 @@ impl IRTCEnumUserSearchResults {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRTCEnumUserSearchResults>(result__)
     }
 }
-impl ::core::convert::From<IRTCEnumUserSearchResults> for ::windows::core::IUnknown {
-    fn from(value: IRTCEnumUserSearchResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCEnumUserSearchResults> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCEnumUserSearchResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCEnumUserSearchResults> for ::windows::core::IUnknown {
-    fn from(value: &IRTCEnumUserSearchResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCEnumUserSearchResults, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCEnumUserSearchResults {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2633,21 +2069,7 @@ impl IRTCEnumWatchers {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRTCEnumWatchers>(result__)
     }
 }
-impl ::core::convert::From<IRTCEnumWatchers> for ::windows::core::IUnknown {
-    fn from(value: IRTCEnumWatchers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCEnumWatchers> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCEnumWatchers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCEnumWatchers> for ::windows::core::IUnknown {
-    fn from(value: &IRTCEnumWatchers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCEnumWatchers, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCEnumWatchers {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2692,21 +2114,7 @@ impl IRTCEventNotification {
         (::windows::core::Vtable::vtable(self).Event)(::windows::core::Vtable::as_raw(self), rtcevent, pevent.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IRTCEventNotification> for ::windows::core::IUnknown {
-    fn from(value: IRTCEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCEventNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCEventNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCEventNotification> for ::windows::core::IUnknown {
-    fn from(value: &IRTCEventNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCEventNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCEventNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2762,41 +2170,7 @@ impl IRTCInfoEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCInfoEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCInfoEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCInfoEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCInfoEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCInfoEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCInfoEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCInfoEvent> for super::Com::IDispatch {
-    fn from(value: IRTCInfoEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCInfoEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCInfoEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCInfoEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCInfoEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCInfoEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCInfoEvent {
     fn clone(&self) -> Self {
@@ -2859,41 +2233,7 @@ impl IRTCIntensityEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCIntensityEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCIntensityEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCIntensityEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCIntensityEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCIntensityEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCIntensityEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCIntensityEvent> for super::Com::IDispatch {
-    fn from(value: IRTCIntensityEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCIntensityEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCIntensityEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCIntensityEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCIntensityEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCIntensityEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCIntensityEvent {
     fn clone(&self) -> Self {
@@ -2952,41 +2292,7 @@ impl IRTCMediaEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCMediaEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCMediaEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCMediaEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCMediaEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCMediaEvent> for super::Com::IDispatch {
-    fn from(value: IRTCMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCMediaEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCMediaEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCMediaEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCMediaEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCMediaEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCMediaEvent {
     fn clone(&self) -> Self {
@@ -3058,41 +2364,7 @@ impl IRTCMediaRequestEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCMediaRequestEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCMediaRequestEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCMediaRequestEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCMediaRequestEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCMediaRequestEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCMediaRequestEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCMediaRequestEvent> for super::Com::IDispatch {
-    fn from(value: IRTCMediaRequestEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCMediaRequestEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCMediaRequestEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCMediaRequestEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCMediaRequestEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCMediaRequestEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCMediaRequestEvent {
     fn clone(&self) -> Self {
@@ -3166,41 +2438,7 @@ impl IRTCMessagingEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCMessagingEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCMessagingEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCMessagingEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCMessagingEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCMessagingEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCMessagingEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCMessagingEvent> for super::Com::IDispatch {
-    fn from(value: IRTCMessagingEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCMessagingEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCMessagingEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCMessagingEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCMessagingEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCMessagingEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCMessagingEvent {
     fn clone(&self) -> Self {
@@ -3266,21 +2504,7 @@ impl IRTCParticipant {
         (::windows::core::Vtable::vtable(self).Session)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRTCSession>(result__)
     }
 }
-impl ::core::convert::From<IRTCParticipant> for ::windows::core::IUnknown {
-    fn from(value: IRTCParticipant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCParticipant> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCParticipant) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCParticipant> for ::windows::core::IUnknown {
-    fn from(value: &IRTCParticipant) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCParticipant, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCParticipant {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3333,41 +2557,7 @@ impl IRTCParticipantStateChangeEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCParticipantStateChangeEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCParticipantStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCParticipantStateChangeEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCParticipantStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCParticipantStateChangeEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCParticipantStateChangeEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCParticipantStateChangeEvent> for super::Com::IDispatch {
-    fn from(value: IRTCParticipantStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCParticipantStateChangeEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCParticipantStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCParticipantStateChangeEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCParticipantStateChangeEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCParticipantStateChangeEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCParticipantStateChangeEvent {
     fn clone(&self) -> Self {
@@ -3419,21 +2609,7 @@ impl IRTCPortManager {
         (::windows::core::Vtable::vtable(self).ReleaseMapping)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrinternallocaladdress), linternallocalport, ::core::mem::transmute_copy(bstrexternallocaladdress), lexternallocaladdress).ok()
     }
 }
-impl ::core::convert::From<IRTCPortManager> for ::windows::core::IUnknown {
-    fn from(value: IRTCPortManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCPortManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCPortManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCPortManager> for ::windows::core::IUnknown {
-    fn from(value: &IRTCPortManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCPortManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCPortManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3497,21 +2673,7 @@ impl IRTCPresenceContact {
         (::windows::core::Vtable::vtable(self).SetPersistent)(::windows::core::Vtable::as_raw(self), fpersistent).ok()
     }
 }
-impl ::core::convert::From<IRTCPresenceContact> for ::windows::core::IUnknown {
-    fn from(value: IRTCPresenceContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCPresenceContact> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCPresenceContact) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCPresenceContact> for ::windows::core::IUnknown {
-    fn from(value: &IRTCPresenceContact) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCPresenceContact, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCPresenceContact {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3566,41 +2728,7 @@ impl IRTCPresenceDataEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCPresenceDataEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCPresenceDataEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCPresenceDataEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCPresenceDataEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCPresenceDataEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCPresenceDataEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCPresenceDataEvent> for super::Com::IDispatch {
-    fn from(value: IRTCPresenceDataEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCPresenceDataEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCPresenceDataEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCPresenceDataEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCPresenceDataEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCPresenceDataEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCPresenceDataEvent {
     fn clone(&self) -> Self {
@@ -3658,21 +2786,7 @@ impl IRTCPresenceDevice {
         (::windows::core::Vtable::vtable(self).GetPresenceData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbstrnamespace), ::core::mem::transmute(pbstrdata)).ok()
     }
 }
-impl ::core::convert::From<IRTCPresenceDevice> for ::windows::core::IUnknown {
-    fn from(value: IRTCPresenceDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCPresenceDevice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCPresenceDevice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCPresenceDevice> for ::windows::core::IUnknown {
-    fn from(value: &IRTCPresenceDevice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCPresenceDevice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCPresenceDevice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3728,41 +2842,7 @@ impl IRTCPresencePropertyEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCPresencePropertyEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCPresencePropertyEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCPresencePropertyEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCPresencePropertyEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCPresencePropertyEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCPresencePropertyEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCPresencePropertyEvent> for super::Com::IDispatch {
-    fn from(value: IRTCPresencePropertyEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCPresencePropertyEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCPresencePropertyEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCPresencePropertyEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCPresencePropertyEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCPresencePropertyEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCPresencePropertyEvent {
     fn clone(&self) -> Self {
@@ -3820,41 +2900,7 @@ impl IRTCPresenceStatusEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCPresenceStatusEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCPresenceStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCPresenceStatusEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCPresenceStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCPresenceStatusEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCPresenceStatusEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCPresenceStatusEvent> for super::Com::IDispatch {
-    fn from(value: IRTCPresenceStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCPresenceStatusEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCPresenceStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCPresenceStatusEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCPresenceStatusEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCPresenceStatusEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCPresenceStatusEvent {
     fn clone(&self) -> Self {
@@ -3968,21 +3014,7 @@ impl IRTCProfile {
         (::windows::core::Vtable::vtable(self).State)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<RTC_REGISTRATION_STATE>(result__)
     }
 }
-impl ::core::convert::From<IRTCProfile> for ::windows::core::IUnknown {
-    fn from(value: IRTCProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCProfile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCProfile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCProfile> for ::windows::core::IUnknown {
-    fn from(value: &IRTCProfile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCProfile, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCProfile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4118,36 +3150,7 @@ impl IRTCProfile2 {
         (::windows::core::Vtable::vtable(self).SetAllowedAuth)(::windows::core::Vtable::as_raw(self), lallowedauth).ok()
     }
 }
-impl ::core::convert::From<IRTCProfile2> for ::windows::core::IUnknown {
-    fn from(value: IRTCProfile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCProfile2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCProfile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCProfile2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCProfile2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRTCProfile2> for IRTCProfile {
-    fn from(value: IRTCProfile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCProfile2> for &'a IRTCProfile {
-    fn from(value: &'a IRTCProfile2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCProfile2> for IRTCProfile {
-    fn from(value: &IRTCProfile2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCProfile2, ::windows::core::IUnknown, IRTCProfile);
 impl ::core::clone::Clone for IRTCProfile2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4199,41 +3202,7 @@ impl IRTCProfileEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCProfileEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCProfileEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCProfileEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCProfileEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCProfileEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCProfileEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCProfileEvent> for super::Com::IDispatch {
-    fn from(value: IRTCProfileEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCProfileEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCProfileEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCProfileEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCProfileEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCProfileEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCProfileEvent {
     fn clone(&self) -> Self {
@@ -4295,59 +3264,7 @@ impl IRTCProfileEvent2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCProfileEvent2> for ::windows::core::IUnknown {
-    fn from(value: IRTCProfileEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCProfileEvent2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCProfileEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCProfileEvent2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCProfileEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCProfileEvent2> for super::Com::IDispatch {
-    fn from(value: IRTCProfileEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCProfileEvent2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCProfileEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCProfileEvent2> for super::Com::IDispatch {
-    fn from(value: &IRTCProfileEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCProfileEvent2> for IRTCProfileEvent {
-    fn from(value: IRTCProfileEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCProfileEvent2> for &'a IRTCProfileEvent {
-    fn from(value: &'a IRTCProfileEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCProfileEvent2> for IRTCProfileEvent {
-    fn from(value: &IRTCProfileEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCProfileEvent2, ::windows::core::IUnknown, super::Com::IDispatch, IRTCProfileEvent);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCProfileEvent2 {
     fn clone(&self) -> Self {
@@ -4408,41 +3325,7 @@ impl IRTCReInviteEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCReInviteEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCReInviteEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCReInviteEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCReInviteEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCReInviteEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCReInviteEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCReInviteEvent> for super::Com::IDispatch {
-    fn from(value: IRTCReInviteEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCReInviteEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCReInviteEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCReInviteEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCReInviteEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCReInviteEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCReInviteEvent {
     fn clone(&self) -> Self {
@@ -4506,41 +3389,7 @@ impl IRTCRegistrationStateChangeEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCRegistrationStateChangeEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCRegistrationStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCRegistrationStateChangeEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCRegistrationStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCRegistrationStateChangeEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCRegistrationStateChangeEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCRegistrationStateChangeEvent> for super::Com::IDispatch {
-    fn from(value: IRTCRegistrationStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCRegistrationStateChangeEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCRegistrationStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCRegistrationStateChangeEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCRegistrationStateChangeEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCRegistrationStateChangeEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCRegistrationStateChangeEvent {
     fn clone(&self) -> Self {
@@ -4603,41 +3452,7 @@ impl IRTCRoamingEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCRoamingEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCRoamingEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCRoamingEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCRoamingEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCRoamingEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCRoamingEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCRoamingEvent> for super::Com::IDispatch {
-    fn from(value: IRTCRoamingEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCRoamingEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCRoamingEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCRoamingEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCRoamingEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCRoamingEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCRoamingEvent {
     fn clone(&self) -> Self {
@@ -4759,21 +3574,7 @@ impl IRTCSession {
         (::windows::core::Vtable::vtable(self).put_EncryptionKey)(::windows::core::Vtable::as_raw(self), lmediatype, ::core::mem::transmute_copy(encryptionkey)).ok()
     }
 }
-impl ::core::convert::From<IRTCSession> for ::windows::core::IUnknown {
-    fn from(value: IRTCSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCSession> for ::windows::core::IUnknown {
-    fn from(value: &IRTCSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4927,36 +3728,7 @@ impl IRTCSession2 {
         (::windows::core::Vtable::vtable(self).ReInviteWithSessionDescription)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrcontenttype), ::core::mem::transmute_copy(bstrsessiondescription), lcookie).ok()
     }
 }
-impl ::core::convert::From<IRTCSession2> for ::windows::core::IUnknown {
-    fn from(value: IRTCSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCSession2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCSession2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCSession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRTCSession2> for IRTCSession {
-    fn from(value: IRTCSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCSession2> for &'a IRTCSession {
-    fn from(value: &'a IRTCSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCSession2> for IRTCSession {
-    fn from(value: &IRTCSession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCSession2, ::windows::core::IUnknown, IRTCSession);
 impl ::core::clone::Clone for IRTCSession2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5025,21 +3797,7 @@ impl IRTCSessionCallControl {
         (::windows::core::Vtable::vtable(self).IsReferred)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i16>(result__)
     }
 }
-impl ::core::convert::From<IRTCSessionCallControl> for ::windows::core::IUnknown {
-    fn from(value: IRTCSessionCallControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCSessionCallControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCSessionCallControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCSessionCallControl> for ::windows::core::IUnknown {
-    fn from(value: &IRTCSessionCallControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCSessionCallControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCSessionCallControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5084,21 +3842,7 @@ impl IRTCSessionDescriptionManager {
         (::windows::core::Vtable::vtable(self).EvaluateSessionDescription)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrcontenttype), ::core::mem::transmute_copy(bstrsessiondescription), ::core::mem::transmute(pfapplicationsession)).ok()
     }
 }
-impl ::core::convert::From<IRTCSessionDescriptionManager> for ::windows::core::IUnknown {
-    fn from(value: IRTCSessionDescriptionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCSessionDescriptionManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCSessionDescriptionManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCSessionDescriptionManager> for ::windows::core::IUnknown {
-    fn from(value: &IRTCSessionDescriptionManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCSessionDescriptionManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCSessionDescriptionManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5151,41 +3895,7 @@ impl IRTCSessionOperationCompleteEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionOperationCompleteEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCSessionOperationCompleteEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionOperationCompleteEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCSessionOperationCompleteEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionOperationCompleteEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCSessionOperationCompleteEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionOperationCompleteEvent> for super::Com::IDispatch {
-    fn from(value: IRTCSessionOperationCompleteEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionOperationCompleteEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCSessionOperationCompleteEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionOperationCompleteEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCSessionOperationCompleteEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCSessionOperationCompleteEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCSessionOperationCompleteEvent {
     fn clone(&self) -> Self {
@@ -5255,59 +3965,7 @@ impl IRTCSessionOperationCompleteEvent2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionOperationCompleteEvent2> for ::windows::core::IUnknown {
-    fn from(value: IRTCSessionOperationCompleteEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionOperationCompleteEvent2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCSessionOperationCompleteEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionOperationCompleteEvent2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCSessionOperationCompleteEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionOperationCompleteEvent2> for super::Com::IDispatch {
-    fn from(value: IRTCSessionOperationCompleteEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionOperationCompleteEvent2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCSessionOperationCompleteEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionOperationCompleteEvent2> for super::Com::IDispatch {
-    fn from(value: &IRTCSessionOperationCompleteEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionOperationCompleteEvent2> for IRTCSessionOperationCompleteEvent {
-    fn from(value: IRTCSessionOperationCompleteEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionOperationCompleteEvent2> for &'a IRTCSessionOperationCompleteEvent {
-    fn from(value: &'a IRTCSessionOperationCompleteEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionOperationCompleteEvent2> for IRTCSessionOperationCompleteEvent {
-    fn from(value: &IRTCSessionOperationCompleteEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCSessionOperationCompleteEvent2, ::windows::core::IUnknown, super::Com::IDispatch, IRTCSessionOperationCompleteEvent);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCSessionOperationCompleteEvent2 {
     fn clone(&self) -> Self {
@@ -5355,21 +4013,7 @@ impl IRTCSessionPortManagement {
         (::windows::core::Vtable::vtable(self).SetPortManager)(::windows::core::Vtable::as_raw(self), pportmanager.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IRTCSessionPortManagement> for ::windows::core::IUnknown {
-    fn from(value: IRTCSessionPortManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCSessionPortManagement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCSessionPortManagement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCSessionPortManagement> for ::windows::core::IUnknown {
-    fn from(value: &IRTCSessionPortManagement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCSessionPortManagement, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCSessionPortManagement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5422,41 +4066,7 @@ impl IRTCSessionReferStatusEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionReferStatusEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCSessionReferStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionReferStatusEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCSessionReferStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionReferStatusEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCSessionReferStatusEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionReferStatusEvent> for super::Com::IDispatch {
-    fn from(value: IRTCSessionReferStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionReferStatusEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCSessionReferStatusEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionReferStatusEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCSessionReferStatusEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCSessionReferStatusEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCSessionReferStatusEvent {
     fn clone(&self) -> Self {
@@ -5528,41 +4138,7 @@ impl IRTCSessionReferredEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionReferredEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCSessionReferredEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionReferredEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCSessionReferredEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionReferredEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCSessionReferredEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionReferredEvent> for super::Com::IDispatch {
-    fn from(value: IRTCSessionReferredEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionReferredEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCSessionReferredEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionReferredEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCSessionReferredEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCSessionReferredEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCSessionReferredEvent {
     fn clone(&self) -> Self {
@@ -5628,41 +4204,7 @@ impl IRTCSessionStateChangeEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionStateChangeEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCSessionStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionStateChangeEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCSessionStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionStateChangeEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCSessionStateChangeEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionStateChangeEvent> for super::Com::IDispatch {
-    fn from(value: IRTCSessionStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionStateChangeEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCSessionStateChangeEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionStateChangeEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCSessionStateChangeEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCSessionStateChangeEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCSessionStateChangeEvent {
     fn clone(&self) -> Self {
@@ -5740,59 +4282,7 @@ impl IRTCSessionStateChangeEvent2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionStateChangeEvent2> for ::windows::core::IUnknown {
-    fn from(value: IRTCSessionStateChangeEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionStateChangeEvent2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCSessionStateChangeEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionStateChangeEvent2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCSessionStateChangeEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionStateChangeEvent2> for super::Com::IDispatch {
-    fn from(value: IRTCSessionStateChangeEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionStateChangeEvent2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCSessionStateChangeEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionStateChangeEvent2> for super::Com::IDispatch {
-    fn from(value: &IRTCSessionStateChangeEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCSessionStateChangeEvent2> for IRTCSessionStateChangeEvent {
-    fn from(value: IRTCSessionStateChangeEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCSessionStateChangeEvent2> for &'a IRTCSessionStateChangeEvent {
-    fn from(value: &'a IRTCSessionStateChangeEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCSessionStateChangeEvent2> for IRTCSessionStateChangeEvent {
-    fn from(value: &IRTCSessionStateChangeEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCSessionStateChangeEvent2, ::windows::core::IUnknown, super::Com::IDispatch, IRTCSessionStateChangeEvent);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCSessionStateChangeEvent2 {
     fn clone(&self) -> Self {
@@ -5847,21 +4337,7 @@ impl IRTCUserSearch {
         (::windows::core::Vtable::vtable(self).ExecuteSearch)(::windows::core::Vtable::as_raw(self), pquery.into().abi(), pprofile.into().abi(), lcookie).ok()
     }
 }
-impl ::core::convert::From<IRTCUserSearch> for ::windows::core::IUnknown {
-    fn from(value: IRTCUserSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCUserSearch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCUserSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCUserSearch> for ::windows::core::IUnknown {
-    fn from(value: &IRTCUserSearch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCUserSearch, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCUserSearch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5921,21 +4397,7 @@ impl IRTCUserSearchQuery {
         (::windows::core::Vtable::vtable(self).SearchDomain)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IRTCUserSearchQuery> for ::windows::core::IUnknown {
-    fn from(value: IRTCUserSearchQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCUserSearchQuery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCUserSearchQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCUserSearchQuery> for ::windows::core::IUnknown {
-    fn from(value: &IRTCUserSearchQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCUserSearchQuery, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCUserSearchQuery {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5979,21 +4441,7 @@ impl IRTCUserSearchResult {
         (::windows::core::Vtable::vtable(self).get_Value)(::windows::core::Vtable::as_raw(self), encolumn, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IRTCUserSearchResult> for ::windows::core::IUnknown {
-    fn from(value: IRTCUserSearchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCUserSearchResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCUserSearchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCUserSearchResult> for ::windows::core::IUnknown {
-    fn from(value: &IRTCUserSearchResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCUserSearchResult, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRTCUserSearchResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6060,41 +4508,7 @@ impl IRTCUserSearchResultsEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCUserSearchResultsEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCUserSearchResultsEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCUserSearchResultsEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCUserSearchResultsEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCUserSearchResultsEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCUserSearchResultsEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCUserSearchResultsEvent> for super::Com::IDispatch {
-    fn from(value: IRTCUserSearchResultsEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCUserSearchResultsEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCUserSearchResultsEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCUserSearchResultsEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCUserSearchResultsEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCUserSearchResultsEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCUserSearchResultsEvent {
     fn clone(&self) -> Self {
@@ -6179,36 +4593,7 @@ impl IRTCWatcher {
         (::windows::core::Vtable::vtable(self).SetState)(::windows::core::Vtable::as_raw(self), enstate).ok()
     }
 }
-impl ::core::convert::From<IRTCWatcher> for ::windows::core::IUnknown {
-    fn from(value: IRTCWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCWatcher> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCWatcher> for ::windows::core::IUnknown {
-    fn from(value: &IRTCWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRTCWatcher> for IRTCPresenceContact {
-    fn from(value: IRTCWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCWatcher> for &'a IRTCPresenceContact {
-    fn from(value: &'a IRTCWatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCWatcher> for IRTCPresenceContact {
-    fn from(value: &IRTCWatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCWatcher, ::windows::core::IUnknown, IRTCPresenceContact);
 impl ::core::clone::Clone for IRTCWatcher {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6286,51 +4671,7 @@ impl IRTCWatcher2 {
         (::windows::core::Vtable::vtable(self).Scope)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<RTC_ACE_SCOPE>(result__)
     }
 }
-impl ::core::convert::From<IRTCWatcher2> for ::windows::core::IUnknown {
-    fn from(value: IRTCWatcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCWatcher2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCWatcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCWatcher2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCWatcher2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRTCWatcher2> for IRTCPresenceContact {
-    fn from(value: IRTCWatcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCWatcher2> for &'a IRTCPresenceContact {
-    fn from(value: &'a IRTCWatcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCWatcher2> for IRTCPresenceContact {
-    fn from(value: &IRTCWatcher2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRTCWatcher2> for IRTCWatcher {
-    fn from(value: IRTCWatcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRTCWatcher2> for &'a IRTCWatcher {
-    fn from(value: &'a IRTCWatcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRTCWatcher2> for IRTCWatcher {
-    fn from(value: &IRTCWatcher2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCWatcher2, ::windows::core::IUnknown, IRTCPresenceContact, IRTCWatcher);
 impl ::core::clone::Clone for IRTCWatcher2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6372,41 +4713,7 @@ impl IRTCWatcherEvent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCWatcherEvent> for ::windows::core::IUnknown {
-    fn from(value: IRTCWatcherEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCWatcherEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCWatcherEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCWatcherEvent> for ::windows::core::IUnknown {
-    fn from(value: &IRTCWatcherEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCWatcherEvent> for super::Com::IDispatch {
-    fn from(value: IRTCWatcherEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCWatcherEvent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCWatcherEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCWatcherEvent> for super::Com::IDispatch {
-    fn from(value: &IRTCWatcherEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCWatcherEvent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCWatcherEvent {
     fn clone(&self) -> Self {
@@ -6462,59 +4769,7 @@ impl IRTCWatcherEvent2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCWatcherEvent2> for ::windows::core::IUnknown {
-    fn from(value: IRTCWatcherEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCWatcherEvent2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRTCWatcherEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCWatcherEvent2> for ::windows::core::IUnknown {
-    fn from(value: &IRTCWatcherEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCWatcherEvent2> for super::Com::IDispatch {
-    fn from(value: IRTCWatcherEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCWatcherEvent2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRTCWatcherEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCWatcherEvent2> for super::Com::IDispatch {
-    fn from(value: &IRTCWatcherEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRTCWatcherEvent2> for IRTCWatcherEvent {
-    fn from(value: IRTCWatcherEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRTCWatcherEvent2> for &'a IRTCWatcherEvent {
-    fn from(value: &'a IRTCWatcherEvent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRTCWatcherEvent2> for IRTCWatcherEvent {
-    fn from(value: &IRTCWatcherEvent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRTCWatcherEvent2, ::windows::core::IUnknown, super::Com::IDispatch, IRTCWatcherEvent);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRTCWatcherEvent2 {
     fn clone(&self) -> Self {
@@ -6566,21 +4821,7 @@ impl ITransportSettingsInternal {
         (::windows::core::Vtable::vtable(self).QuerySetting)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(setting)).ok()
     }
 }
-impl ::core::convert::From<ITransportSettingsInternal> for ::windows::core::IUnknown {
-    fn from(value: ITransportSettingsInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransportSettingsInternal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransportSettingsInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransportSettingsInternal> for ::windows::core::IUnknown {
-    fn from(value: &ITransportSettingsInternal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransportSettingsInternal, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransportSettingsInternal {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/mod.rs
@@ -5,41 +5,7 @@ pub struct DRendezvousSessionEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DRendezvousSessionEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DRendezvousSessionEvents> for ::windows::core::IUnknown {
-    fn from(value: DRendezvousSessionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DRendezvousSessionEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DRendezvousSessionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DRendezvousSessionEvents> for ::windows::core::IUnknown {
-    fn from(value: &DRendezvousSessionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DRendezvousSessionEvents> for super::Com::IDispatch {
-    fn from(value: DRendezvousSessionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DRendezvousSessionEvents> for &'a super::Com::IDispatch {
-    fn from(value: &'a DRendezvousSessionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DRendezvousSessionEvents> for super::Com::IDispatch {
-    fn from(value: &DRendezvousSessionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DRendezvousSessionEvents, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DRendezvousSessionEvents {
     fn clone(&self) -> Self {
@@ -85,21 +51,7 @@ impl IRendezvousApplication {
         (::windows::core::Vtable::vtable(self).SetRendezvousSession)(::windows::core::Vtable::as_raw(self), prendezvoussession.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IRendezvousApplication> for ::windows::core::IUnknown {
-    fn from(value: IRendezvousApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRendezvousApplication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRendezvousApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRendezvousApplication> for ::windows::core::IUnknown {
-    fn from(value: &IRendezvousApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRendezvousApplication, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRendezvousApplication {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -151,21 +103,7 @@ impl IRendezvousSession {
         (::windows::core::Vtable::vtable(self).Terminate)(::windows::core::Vtable::as_raw(self), hr, ::core::mem::transmute_copy(bstrappdata)).ok()
     }
 }
-impl ::core::convert::From<IRendezvousSession> for ::windows::core::IUnknown {
-    fn from(value: IRendezvousSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRendezvousSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRendezvousSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRendezvousSession> for ::windows::core::IUnknown {
-    fn from(value: &IRendezvousSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRendezvousSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRendezvousSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
@@ -954,41 +954,7 @@ impl IADsTSUserEx {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsTSUserEx> for ::windows::core::IUnknown {
-    fn from(value: IADsTSUserEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsTSUserEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADsTSUserEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsTSUserEx> for ::windows::core::IUnknown {
-    fn from(value: &IADsTSUserEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IADsTSUserEx> for super::Com::IDispatch {
-    fn from(value: IADsTSUserEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IADsTSUserEx> for &'a super::Com::IDispatch {
-    fn from(value: &'a IADsTSUserEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IADsTSUserEx> for super::Com::IDispatch {
-    fn from(value: &IADsTSUserEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADsTSUserEx, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IADsTSUserEx {
     fn clone(&self) -> Self {
@@ -1076,21 +1042,7 @@ impl IAudioDeviceEndpoint {
         (::windows::core::Vtable::vtable(self).WriteExclusiveModeParametersToSharedMemory)(::windows::core::Vtable::as_raw(self), htargetprocess, hnsperiod, hnsbufferduration, u32latencycoefficient, ::core::mem::transmute(pu32sharedmemorysize), ::core::mem::transmute(phsharedmemory)).ok()
     }
 }
-impl ::core::convert::From<IAudioDeviceEndpoint> for ::windows::core::IUnknown {
-    fn from(value: IAudioDeviceEndpoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioDeviceEndpoint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioDeviceEndpoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioDeviceEndpoint> for ::windows::core::IUnknown {
-    fn from(value: &IAudioDeviceEndpoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioDeviceEndpoint, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioDeviceEndpoint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1158,21 +1110,7 @@ impl IAudioEndpoint {
         (::windows::core::Vtable::vtable(self).SetEventHandle)(::windows::core::Vtable::as_raw(self), eventhandle.into()).ok()
     }
 }
-impl ::core::convert::From<IAudioEndpoint> for ::windows::core::IUnknown {
-    fn from(value: IAudioEndpoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpoint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEndpoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpoint> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEndpoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEndpoint, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEndpoint {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1225,21 +1163,7 @@ impl IAudioEndpointControl {
         (::windows::core::Vtable::vtable(self).Stop)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAudioEndpointControl> for ::windows::core::IUnknown {
-    fn from(value: IAudioEndpointControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpointControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEndpointControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpointControl> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEndpointControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEndpointControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEndpointControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1287,21 +1211,7 @@ impl IAudioEndpointRT {
         (::windows::core::Vtable::vtable(self).SetPinActive)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAudioEndpointRT> for ::windows::core::IUnknown {
-    fn from(value: IAudioEndpointRT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioEndpointRT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioEndpointRT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioEndpointRT> for ::windows::core::IUnknown {
-    fn from(value: &IAudioEndpointRT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioEndpointRT, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioEndpointRT {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1349,21 +1259,7 @@ impl IAudioInputEndpointRT {
         (::windows::core::Vtable::vtable(self).PulseEndpoint)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IAudioInputEndpointRT> for ::windows::core::IUnknown {
-    fn from(value: IAudioInputEndpointRT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioInputEndpointRT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioInputEndpointRT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioInputEndpointRT> for ::windows::core::IUnknown {
-    fn from(value: &IAudioInputEndpointRT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioInputEndpointRT, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioInputEndpointRT {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1413,21 +1309,7 @@ impl IAudioOutputEndpointRT {
         (::windows::core::Vtable::vtable(self).PulseEndpoint)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IAudioOutputEndpointRT> for ::windows::core::IUnknown {
-    fn from(value: IAudioOutputEndpointRT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioOutputEndpointRT> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioOutputEndpointRT) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioOutputEndpointRT> for ::windows::core::IUnknown {
-    fn from(value: &IAudioOutputEndpointRT) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioOutputEndpointRT, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAudioOutputEndpointRT {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1518,41 +1400,7 @@ impl IRemoteDesktopClient {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRemoteDesktopClient> for ::windows::core::IUnknown {
-    fn from(value: IRemoteDesktopClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRemoteDesktopClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteDesktopClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRemoteDesktopClient> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteDesktopClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRemoteDesktopClient> for super::Com::IDispatch {
-    fn from(value: IRemoteDesktopClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRemoteDesktopClient> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRemoteDesktopClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRemoteDesktopClient> for super::Com::IDispatch {
-    fn from(value: &IRemoteDesktopClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteDesktopClient, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRemoteDesktopClient {
     fn clone(&self) -> Self {
@@ -1633,41 +1481,7 @@ impl IRemoteDesktopClientActions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRemoteDesktopClientActions> for ::windows::core::IUnknown {
-    fn from(value: IRemoteDesktopClientActions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRemoteDesktopClientActions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteDesktopClientActions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRemoteDesktopClientActions> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteDesktopClientActions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRemoteDesktopClientActions> for super::Com::IDispatch {
-    fn from(value: IRemoteDesktopClientActions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRemoteDesktopClientActions> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRemoteDesktopClientActions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRemoteDesktopClientActions> for super::Com::IDispatch {
-    fn from(value: &IRemoteDesktopClientActions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteDesktopClientActions, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRemoteDesktopClientActions {
     fn clone(&self) -> Self {
@@ -1735,41 +1549,7 @@ impl IRemoteDesktopClientSettings {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRemoteDesktopClientSettings> for ::windows::core::IUnknown {
-    fn from(value: IRemoteDesktopClientSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRemoteDesktopClientSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteDesktopClientSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRemoteDesktopClientSettings> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteDesktopClientSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRemoteDesktopClientSettings> for super::Com::IDispatch {
-    fn from(value: IRemoteDesktopClientSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRemoteDesktopClientSettings> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRemoteDesktopClientSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRemoteDesktopClientSettings> for super::Com::IDispatch {
-    fn from(value: &IRemoteDesktopClientSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteDesktopClientSettings, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRemoteDesktopClientSettings {
     fn clone(&self) -> Self {
@@ -1843,41 +1623,7 @@ impl IRemoteDesktopClientTouchPointer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRemoteDesktopClientTouchPointer> for ::windows::core::IUnknown {
-    fn from(value: IRemoteDesktopClientTouchPointer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRemoteDesktopClientTouchPointer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteDesktopClientTouchPointer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRemoteDesktopClientTouchPointer> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteDesktopClientTouchPointer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRemoteDesktopClientTouchPointer> for super::Com::IDispatch {
-    fn from(value: IRemoteDesktopClientTouchPointer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRemoteDesktopClientTouchPointer> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRemoteDesktopClientTouchPointer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRemoteDesktopClientTouchPointer> for super::Com::IDispatch {
-    fn from(value: &IRemoteDesktopClientTouchPointer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteDesktopClientTouchPointer, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRemoteDesktopClientTouchPointer {
     fn clone(&self) -> Self {
@@ -1930,21 +1676,7 @@ impl IRemoteSystemAdditionalInfoProvider {
         (::windows::core::Vtable::vtable(self).GetAdditionalInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(deduplicationid), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IRemoteSystemAdditionalInfoProvider> for ::windows::core::IUnknown {
-    fn from(value: IRemoteSystemAdditionalInfoProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRemoteSystemAdditionalInfoProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteSystemAdditionalInfoProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRemoteSystemAdditionalInfoProvider> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteSystemAdditionalInfoProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteSystemAdditionalInfoProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRemoteSystemAdditionalInfoProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1984,21 +1716,7 @@ impl ITSGAccountingEngine {
         (::windows::core::Vtable::vtable(self).DoAccounting)(::windows::core::Vtable::as_raw(self), accountingdatatype, accountingdata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITSGAccountingEngine> for ::windows::core::IUnknown {
-    fn from(value: ITSGAccountingEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITSGAccountingEngine> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITSGAccountingEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITSGAccountingEngine> for ::windows::core::IUnknown {
-    fn from(value: &ITSGAccountingEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITSGAccountingEngine, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITSGAccountingEngine {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2049,21 +1767,7 @@ impl ITSGAuthenticateUserSink {
         (::windows::core::Vtable::vtable(self).DisconnectUser)(::windows::core::Vtable::as_raw(self), context).ok()
     }
 }
-impl ::core::convert::From<ITSGAuthenticateUserSink> for ::windows::core::IUnknown {
-    fn from(value: ITSGAuthenticateUserSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITSGAuthenticateUserSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITSGAuthenticateUserSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITSGAuthenticateUserSink> for ::windows::core::IUnknown {
-    fn from(value: &ITSGAuthenticateUserSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITSGAuthenticateUserSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITSGAuthenticateUserSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2112,21 +1816,7 @@ impl ITSGAuthenticationEngine {
         (::windows::core::Vtable::vtable(self).CancelAuthentication)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(mainsessionid), context).ok()
     }
 }
-impl ::core::convert::From<ITSGAuthenticationEngine> for ::windows::core::IUnknown {
-    fn from(value: ITSGAuthenticationEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITSGAuthenticationEngine> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITSGAuthenticationEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITSGAuthenticationEngine> for ::windows::core::IUnknown {
-    fn from(value: &ITSGAuthenticationEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITSGAuthenticationEngine, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITSGAuthenticationEngine {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2164,21 +1854,7 @@ impl ITSGAuthorizeConnectionSink {
         (::windows::core::Vtable::vtable(self).OnConnectionAuthorized)(::windows::core::Vtable::as_raw(self), hrin, ::core::mem::transmute(mainsessionid), pbsohresponse.len() as _, ::core::mem::transmute(pbsohresponse.as_ptr()), idletimeout, sessiontimeout, sessiontimeoutaction, trustclass, ::core::mem::transmute(policyattributes)).ok()
     }
 }
-impl ::core::convert::From<ITSGAuthorizeConnectionSink> for ::windows::core::IUnknown {
-    fn from(value: ITSGAuthorizeConnectionSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITSGAuthorizeConnectionSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITSGAuthorizeConnectionSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITSGAuthorizeConnectionSink> for ::windows::core::IUnknown {
-    fn from(value: &ITSGAuthorizeConnectionSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITSGAuthorizeConnectionSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITSGAuthorizeConnectionSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2215,21 +1891,7 @@ impl ITSGAuthorizeResourceSink {
         (::windows::core::Vtable::vtable(self).OnChannelAuthorized)(::windows::core::Vtable::as_raw(self), hrin, ::core::mem::transmute(mainsessionid), subsessionid, ::core::mem::transmute(allowedresourcenames.as_ptr()), allowedresourcenames.len() as _, ::core::mem::transmute(failedresourcenames.as_ptr()), failedresourcenames.len() as _).ok()
     }
 }
-impl ::core::convert::From<ITSGAuthorizeResourceSink> for ::windows::core::IUnknown {
-    fn from(value: ITSGAuthorizeResourceSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITSGAuthorizeResourceSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITSGAuthorizeResourceSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITSGAuthorizeResourceSink> for ::windows::core::IUnknown {
-    fn from(value: &ITSGAuthorizeResourceSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITSGAuthorizeResourceSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITSGAuthorizeResourceSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2287,21 +1949,7 @@ impl ITSGPolicyEngine {
         (::windows::core::Vtable::vtable(self).IsQuarantineEnabled)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITSGPolicyEngine> for ::windows::core::IUnknown {
-    fn from(value: ITSGPolicyEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITSGPolicyEngine> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITSGPolicyEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITSGPolicyEngine> for ::windows::core::IUnknown {
-    fn from(value: &ITSGPolicyEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITSGPolicyEngine, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITSGPolicyEngine {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2350,21 +1998,7 @@ impl ITsSbBaseNotifySink {
         (::windows::core::Vtable::vtable(self).OnReportStatus)(::windows::core::Vtable::as_raw(self), messagetype, messageid).ok()
     }
 }
-impl ::core::convert::From<ITsSbBaseNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITsSbBaseNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbBaseNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbBaseNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbBaseNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbBaseNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbBaseNotifySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbBaseNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2469,21 +2103,7 @@ impl ITsSbClientConnection {
         (::windows::core::Vtable::vtable(self).GetDisconnectedSession)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITsSbSession>(result__)
     }
 }
-impl ::core::convert::From<ITsSbClientConnection> for ::windows::core::IUnknown {
-    fn from(value: ITsSbClientConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbClientConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbClientConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbClientConnection> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbClientConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbClientConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbClientConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2563,59 +2183,7 @@ impl ITsSbClientConnectionPropertySet {
     }
 }
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbClientConnectionPropertySet> for ::windows::core::IUnknown {
-    fn from(value: ITsSbClientConnectionPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbClientConnectionPropertySet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbClientConnectionPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbClientConnectionPropertySet> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbClientConnectionPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbClientConnectionPropertySet> for super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: ITsSbClientConnectionPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbClientConnectionPropertySet> for &'a super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: &'a ITsSbClientConnectionPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbClientConnectionPropertySet> for super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: &ITsSbClientConnectionPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbClientConnectionPropertySet> for ITsSbPropertySet {
-    fn from(value: ITsSbClientConnectionPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbClientConnectionPropertySet> for &'a ITsSbPropertySet {
-    fn from(value: &'a ITsSbClientConnectionPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbClientConnectionPropertySet> for ITsSbPropertySet {
-    fn from(value: &ITsSbClientConnectionPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbClientConnectionPropertySet, ::windows::core::IUnknown, super::Com::StructuredStorage::IPropertyBag, ITsSbPropertySet);
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ::core::clone::Clone for ITsSbClientConnectionPropertySet {
     fn clone(&self) -> Self {
@@ -2677,21 +2245,7 @@ impl ITsSbEnvironment {
         (::windows::core::Vtable::vtable(self).SetEnvironmentPropertySet)(::windows::core::Vtable::as_raw(self), pval.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITsSbEnvironment> for ::windows::core::IUnknown {
-    fn from(value: ITsSbEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbEnvironment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbEnvironment> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbEnvironment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbEnvironment, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbEnvironment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2754,59 +2308,7 @@ impl ITsSbEnvironmentPropertySet {
     }
 }
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbEnvironmentPropertySet> for ::windows::core::IUnknown {
-    fn from(value: ITsSbEnvironmentPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbEnvironmentPropertySet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbEnvironmentPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbEnvironmentPropertySet> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbEnvironmentPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbEnvironmentPropertySet> for super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: ITsSbEnvironmentPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbEnvironmentPropertySet> for &'a super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: &'a ITsSbEnvironmentPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbEnvironmentPropertySet> for super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: &ITsSbEnvironmentPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbEnvironmentPropertySet> for ITsSbPropertySet {
-    fn from(value: ITsSbEnvironmentPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbEnvironmentPropertySet> for &'a ITsSbPropertySet {
-    fn from(value: &'a ITsSbEnvironmentPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbEnvironmentPropertySet> for ITsSbPropertySet {
-    fn from(value: &ITsSbEnvironmentPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbEnvironmentPropertySet, ::windows::core::IUnknown, super::Com::StructuredStorage::IPropertyBag, ITsSbPropertySet);
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ::core::clone::Clone for ITsSbEnvironmentPropertySet {
     fn clone(&self) -> Self {
@@ -2863,21 +2365,7 @@ impl ITsSbFilterPluginStore {
         (::windows::core::Vtable::vtable(self).DeleteProperties)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(propertyname)).ok()
     }
 }
-impl ::core::convert::From<ITsSbFilterPluginStore> for ::windows::core::IUnknown {
-    fn from(value: ITsSbFilterPluginStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbFilterPluginStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbFilterPluginStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbFilterPluginStore> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbFilterPluginStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbFilterPluginStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbFilterPluginStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2928,21 +2416,7 @@ impl ITsSbGenericNotifySink {
         (::windows::core::Vtable::vtable(self).GetWaitTimeout)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::FILETIME>(result__)
     }
 }
-impl ::core::convert::From<ITsSbGenericNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITsSbGenericNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbGenericNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbGenericNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbGenericNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbGenericNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbGenericNotifySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbGenericNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3007,21 +2481,7 @@ impl ITsSbGlobalStore {
         (::windows::core::Vtable::vtable(self).GetFarmProperty)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(farmname), ::core::mem::transmute_copy(propertyname), ::core::mem::transmute(pvarvalue)).ok()
     }
 }
-impl ::core::convert::From<ITsSbGlobalStore> for ::windows::core::IUnknown {
-    fn from(value: ITsSbGlobalStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbGlobalStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbGlobalStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbGlobalStore> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbGlobalStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbGlobalStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbGlobalStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3071,21 +2531,7 @@ impl ITsSbLoadBalanceResult {
         (::windows::core::Vtable::vtable(self).TargetName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITsSbLoadBalanceResult> for ::windows::core::IUnknown {
-    fn from(value: ITsSbLoadBalanceResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbLoadBalanceResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbLoadBalanceResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbLoadBalanceResult> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbLoadBalanceResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbLoadBalanceResult, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbLoadBalanceResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3139,36 +2585,7 @@ impl ITsSbLoadBalancing {
         (::windows::core::Vtable::vtable(self).GetMostSuitableTarget)(::windows::core::Vtable::as_raw(self), pconnection.into().abi(), plbsink.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITsSbLoadBalancing> for ::windows::core::IUnknown {
-    fn from(value: ITsSbLoadBalancing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbLoadBalancing> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbLoadBalancing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbLoadBalancing> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbLoadBalancing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITsSbLoadBalancing> for ITsSbPlugin {
-    fn from(value: ITsSbLoadBalancing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbLoadBalancing> for &'a ITsSbPlugin {
-    fn from(value: &'a ITsSbLoadBalancing) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbLoadBalancing> for ITsSbPlugin {
-    fn from(value: &ITsSbLoadBalancing) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbLoadBalancing, ::windows::core::IUnknown, ITsSbPlugin);
 impl ::core::clone::Clone for ITsSbLoadBalancing {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3217,36 +2634,7 @@ impl ITsSbLoadBalancingNotifySink {
         (::windows::core::Vtable::vtable(self).OnGetMostSuitableTarget)(::windows::core::Vtable::as_raw(self), plbresult.into().abi(), fisnewconnection.into()).ok()
     }
 }
-impl ::core::convert::From<ITsSbLoadBalancingNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITsSbLoadBalancingNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbLoadBalancingNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbLoadBalancingNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbLoadBalancingNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbLoadBalancingNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITsSbLoadBalancingNotifySink> for ITsSbBaseNotifySink {
-    fn from(value: ITsSbLoadBalancingNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbLoadBalancingNotifySink> for &'a ITsSbBaseNotifySink {
-    fn from(value: &'a ITsSbLoadBalancingNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbLoadBalancingNotifySink> for ITsSbBaseNotifySink {
-    fn from(value: &ITsSbLoadBalancingNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbLoadBalancingNotifySink, ::windows::core::IUnknown, ITsSbBaseNotifySink);
 impl ::core::clone::Clone for ITsSbLoadBalancingNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3303,36 +2691,7 @@ impl ITsSbOrchestration {
         (::windows::core::Vtable::vtable(self).PrepareTargetForConnect)(::windows::core::Vtable::as_raw(self), pconnection.into().abi(), porchestrationnotifysink.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITsSbOrchestration> for ::windows::core::IUnknown {
-    fn from(value: ITsSbOrchestration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbOrchestration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbOrchestration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbOrchestration> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbOrchestration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITsSbOrchestration> for ITsSbPlugin {
-    fn from(value: ITsSbOrchestration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbOrchestration> for &'a ITsSbPlugin {
-    fn from(value: &'a ITsSbOrchestration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbOrchestration> for ITsSbPlugin {
-    fn from(value: &ITsSbOrchestration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbOrchestration, ::windows::core::IUnknown, ITsSbPlugin);
 impl ::core::clone::Clone for ITsSbOrchestration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3378,36 +2737,7 @@ impl ITsSbOrchestrationNotifySink {
         (::windows::core::Vtable::vtable(self).OnReadyToConnect)(::windows::core::Vtable::as_raw(self), ptarget.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITsSbOrchestrationNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITsSbOrchestrationNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbOrchestrationNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbOrchestrationNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbOrchestrationNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbOrchestrationNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITsSbOrchestrationNotifySink> for ITsSbBaseNotifySink {
-    fn from(value: ITsSbOrchestrationNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbOrchestrationNotifySink> for &'a ITsSbBaseNotifySink {
-    fn from(value: &'a ITsSbOrchestrationNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbOrchestrationNotifySink> for ITsSbBaseNotifySink {
-    fn from(value: &ITsSbOrchestrationNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbOrchestrationNotifySink, ::windows::core::IUnknown, ITsSbBaseNotifySink);
 impl ::core::clone::Clone for ITsSbOrchestrationNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3461,36 +2791,7 @@ impl ITsSbPlacement {
         (::windows::core::Vtable::vtable(self).QueryEnvironmentForTarget)(::windows::core::Vtable::as_raw(self), pconnection.into().abi(), pplacementsink.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITsSbPlacement> for ::windows::core::IUnknown {
-    fn from(value: ITsSbPlacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbPlacement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbPlacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbPlacement> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbPlacement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITsSbPlacement> for ITsSbPlugin {
-    fn from(value: ITsSbPlacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbPlacement> for &'a ITsSbPlugin {
-    fn from(value: &'a ITsSbPlacement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbPlacement> for ITsSbPlugin {
-    fn from(value: &ITsSbPlacement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbPlacement, ::windows::core::IUnknown, ITsSbPlugin);
 impl ::core::clone::Clone for ITsSbPlacement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3536,36 +2837,7 @@ impl ITsSbPlacementNotifySink {
         (::windows::core::Vtable::vtable(self).OnQueryEnvironmentCompleted)(::windows::core::Vtable::as_raw(self), penvironment.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITsSbPlacementNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITsSbPlacementNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbPlacementNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbPlacementNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbPlacementNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbPlacementNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITsSbPlacementNotifySink> for ITsSbBaseNotifySink {
-    fn from(value: ITsSbPlacementNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbPlacementNotifySink> for &'a ITsSbBaseNotifySink {
-    fn from(value: &'a ITsSbPlacementNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbPlacementNotifySink> for ITsSbBaseNotifySink {
-    fn from(value: &ITsSbPlacementNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbPlacementNotifySink, ::windows::core::IUnknown, ITsSbBaseNotifySink);
 impl ::core::clone::Clone for ITsSbPlacementNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3612,21 +2884,7 @@ impl ITsSbPlugin {
         (::windows::core::Vtable::vtable(self).Terminate)(::windows::core::Vtable::as_raw(self), hr).ok()
     }
 }
-impl ::core::convert::From<ITsSbPlugin> for ::windows::core::IUnknown {
-    fn from(value: ITsSbPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbPlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbPlugin> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbPlugin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbPlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3676,36 +2934,7 @@ impl ITsSbPluginNotifySink {
         (::windows::core::Vtable::vtable(self).OnTerminated)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITsSbPluginNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITsSbPluginNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbPluginNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbPluginNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbPluginNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbPluginNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITsSbPluginNotifySink> for ITsSbBaseNotifySink {
-    fn from(value: ITsSbPluginNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbPluginNotifySink> for &'a ITsSbBaseNotifySink {
-    fn from(value: &'a ITsSbPluginNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbPluginNotifySink> for ITsSbBaseNotifySink {
-    fn from(value: &ITsSbPluginNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbPluginNotifySink, ::windows::core::IUnknown, ITsSbBaseNotifySink);
 impl ::core::clone::Clone for ITsSbPluginNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3760,59 +2989,7 @@ impl ITsSbPluginPropertySet {
     }
 }
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbPluginPropertySet> for ::windows::core::IUnknown {
-    fn from(value: ITsSbPluginPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbPluginPropertySet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbPluginPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbPluginPropertySet> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbPluginPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbPluginPropertySet> for super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: ITsSbPluginPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbPluginPropertySet> for &'a super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: &'a ITsSbPluginPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbPluginPropertySet> for super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: &ITsSbPluginPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbPluginPropertySet> for ITsSbPropertySet {
-    fn from(value: ITsSbPluginPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbPluginPropertySet> for &'a ITsSbPropertySet {
-    fn from(value: &'a ITsSbPluginPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbPluginPropertySet> for ITsSbPropertySet {
-    fn from(value: &ITsSbPluginPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbPluginPropertySet, ::windows::core::IUnknown, super::Com::StructuredStorage::IPropertyBag, ITsSbPropertySet);
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ::core::clone::Clone for ITsSbPluginPropertySet {
     fn clone(&self) -> Self {
@@ -3872,41 +3049,7 @@ impl ITsSbPropertySet {
     }
 }
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbPropertySet> for ::windows::core::IUnknown {
-    fn from(value: ITsSbPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbPropertySet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbPropertySet> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbPropertySet> for super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: ITsSbPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbPropertySet> for &'a super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: &'a ITsSbPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbPropertySet> for super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: &ITsSbPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbPropertySet, ::windows::core::IUnknown, super::Com::StructuredStorage::IPropertyBag);
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ::core::clone::Clone for ITsSbPropertySet {
     fn clone(&self) -> Self {
@@ -4001,21 +3144,7 @@ impl ITsSbProvider {
         (::windows::core::Vtable::vtable(self).CreateEnvironmentPropertySetObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITsSbEnvironmentPropertySet>(result__)
     }
 }
-impl ::core::convert::From<ITsSbProvider> for ::windows::core::IUnknown {
-    fn from(value: ITsSbProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4103,36 +3232,7 @@ impl ITsSbProvisioning {
         (::windows::core::Vtable::vtable(self).CancelJob)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(jobguid)).ok()
     }
 }
-impl ::core::convert::From<ITsSbProvisioning> for ::windows::core::IUnknown {
-    fn from(value: ITsSbProvisioning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbProvisioning> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbProvisioning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbProvisioning> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbProvisioning) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITsSbProvisioning> for ITsSbPlugin {
-    fn from(value: ITsSbProvisioning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbProvisioning> for &'a ITsSbPlugin {
-    fn from(value: &'a ITsSbProvisioning) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbProvisioning> for ITsSbPlugin {
-    fn from(value: &ITsSbProvisioning) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbProvisioning, ::windows::core::IUnknown, ITsSbPlugin);
 impl ::core::clone::Clone for ITsSbProvisioning {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4187,21 +3287,7 @@ impl ITsSbProvisioningPluginNotifySink {
         (::windows::core::Vtable::vtable(self).OnVirtualMachineHostStatusChanged)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(vmhost), vmhostnotifystatus, errorcode, ::core::mem::transmute_copy(errordescr)).ok()
     }
 }
-impl ::core::convert::From<ITsSbProvisioningPluginNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITsSbProvisioningPluginNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbProvisioningPluginNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbProvisioningPluginNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbProvisioningPluginNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbProvisioningPluginNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbProvisioningPluginNotifySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbProvisioningPluginNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4258,21 +3344,7 @@ impl ITsSbResourceNotification {
         (::windows::core::Vtable::vtable(self).NotifyClientConnectionStateChange)(::windows::core::Vtable::as_raw(self), changetype, pconnection.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITsSbResourceNotification> for ::windows::core::IUnknown {
-    fn from(value: ITsSbResourceNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbResourceNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbResourceNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbResourceNotification> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbResourceNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbResourceNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbResourceNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4317,21 +3389,7 @@ impl ITsSbResourceNotificationEx {
         (::windows::core::Vtable::vtable(self).NotifyClientConnectionStateChangeEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(username), ::core::mem::transmute_copy(domain), ::core::mem::transmute_copy(initialprogram), ::core::mem::transmute_copy(poolname), ::core::mem::transmute_copy(targetname), connectionchangetype).ok()
     }
 }
-impl ::core::convert::From<ITsSbResourceNotificationEx> for ::windows::core::IUnknown {
-    fn from(value: ITsSbResourceNotificationEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbResourceNotificationEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbResourceNotificationEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbResourceNotificationEx> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbResourceNotificationEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbResourceNotificationEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbResourceNotificationEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4380,36 +3438,7 @@ impl ITsSbResourcePlugin {
         (::windows::core::Vtable::vtable(self).base__.Terminate)(::windows::core::Vtable::as_raw(self), hr).ok()
     }
 }
-impl ::core::convert::From<ITsSbResourcePlugin> for ::windows::core::IUnknown {
-    fn from(value: ITsSbResourcePlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbResourcePlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbResourcePlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbResourcePlugin> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbResourcePlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITsSbResourcePlugin> for ITsSbPlugin {
-    fn from(value: ITsSbResourcePlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbResourcePlugin> for &'a ITsSbPlugin {
-    fn from(value: &'a ITsSbResourcePlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbResourcePlugin> for ITsSbPlugin {
-    fn from(value: &ITsSbResourcePlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbResourcePlugin, ::windows::core::IUnknown, ITsSbPlugin);
 impl ::core::clone::Clone for ITsSbResourcePlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4586,21 +3615,7 @@ impl ITsSbResourcePluginStore {
         (::windows::core::Vtable::vtable(self).SetServerDrainMode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(serverfqdn), drainmode).ok()
     }
 }
-impl ::core::convert::From<ITsSbResourcePluginStore> for ::windows::core::IUnknown {
-    fn from(value: ITsSbResourcePluginStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbResourcePluginStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbResourcePluginStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbResourcePluginStore> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbResourcePluginStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbResourcePluginStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbResourcePluginStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4694,21 +3709,7 @@ impl ITsSbServiceNotification {
         (::windows::core::Vtable::vtable(self).NotifyServiceSuccess)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITsSbServiceNotification> for ::windows::core::IUnknown {
-    fn from(value: ITsSbServiceNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbServiceNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbServiceNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbServiceNotification> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbServiceNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbServiceNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbServiceNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4812,21 +3813,7 @@ impl ITsSbSession {
         (::windows::core::Vtable::vtable(self).SetProtocolType)(::windows::core::Vtable::as_raw(self), val).ok()
     }
 }
-impl ::core::convert::From<ITsSbSession> for ::windows::core::IUnknown {
-    fn from(value: ITsSbSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbSession> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4962,21 +3949,7 @@ impl ITsSbTarget {
         (::windows::core::Vtable::vtable(self).TargetLoad)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ITsSbTarget> for ::windows::core::IUnknown {
-    fn from(value: ITsSbTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbTarget> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5054,59 +4027,7 @@ impl ITsSbTargetPropertySet {
     }
 }
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbTargetPropertySet> for ::windows::core::IUnknown {
-    fn from(value: ITsSbTargetPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbTargetPropertySet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbTargetPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbTargetPropertySet> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbTargetPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbTargetPropertySet> for super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: ITsSbTargetPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbTargetPropertySet> for &'a super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: &'a ITsSbTargetPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbTargetPropertySet> for super::Com::StructuredStorage::IPropertyBag {
-    fn from(value: &ITsSbTargetPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<ITsSbTargetPropertySet> for ITsSbPropertySet {
-    fn from(value: ITsSbTargetPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl<'a> ::core::convert::From<&'a ITsSbTargetPropertySet> for &'a ITsSbPropertySet {
-    fn from(value: &'a ITsSbTargetPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl ::core::convert::From<&ITsSbTargetPropertySet> for ITsSbPropertySet {
-    fn from(value: &ITsSbTargetPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbTargetPropertySet, ::windows::core::IUnknown, super::Com::StructuredStorage::IPropertyBag, ITsSbPropertySet);
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ::core::clone::Clone for ITsSbTargetPropertySet {
     fn clone(&self) -> Self {
@@ -5190,21 +4111,7 @@ impl ITsSbTaskInfo {
         (::windows::core::Vtable::vtable(self).Status)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<RDV_TASK_STATUS>(result__)
     }
 }
-impl ::core::convert::From<ITsSbTaskInfo> for ::windows::core::IUnknown {
-    fn from(value: ITsSbTaskInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbTaskInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbTaskInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbTaskInfo> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbTaskInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbTaskInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITsSbTaskInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5280,36 +4187,7 @@ impl ITsSbTaskPlugin {
         (::windows::core::Vtable::vtable(self).SetTaskQueue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(pszhostname), pitssbtaskinfo.len() as _, ::core::mem::transmute(pitssbtaskinfo.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<ITsSbTaskPlugin> for ::windows::core::IUnknown {
-    fn from(value: ITsSbTaskPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbTaskPlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbTaskPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbTaskPlugin> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbTaskPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITsSbTaskPlugin> for ITsSbPlugin {
-    fn from(value: ITsSbTaskPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbTaskPlugin> for &'a ITsSbPlugin {
-    fn from(value: &'a ITsSbTaskPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbTaskPlugin> for ITsSbPlugin {
-    fn from(value: &ITsSbTaskPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbTaskPlugin, ::windows::core::IUnknown, ITsSbPlugin);
 impl ::core::clone::Clone for ITsSbTaskPlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5364,36 +4242,7 @@ impl ITsSbTaskPluginNotifySink {
         (::windows::core::Vtable::vtable(self).OnReportTasks)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(szhostname)).ok()
     }
 }
-impl ::core::convert::From<ITsSbTaskPluginNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITsSbTaskPluginNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbTaskPluginNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITsSbTaskPluginNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbTaskPluginNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITsSbTaskPluginNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITsSbTaskPluginNotifySink> for ITsSbBaseNotifySink {
-    fn from(value: ITsSbTaskPluginNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITsSbTaskPluginNotifySink> for &'a ITsSbBaseNotifySink {
-    fn from(value: &'a ITsSbTaskPluginNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITsSbTaskPluginNotifySink> for ITsSbBaseNotifySink {
-    fn from(value: &ITsSbTaskPluginNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITsSbTaskPluginNotifySink, ::windows::core::IUnknown, ITsSbBaseNotifySink);
 impl ::core::clone::Clone for ITsSbTaskPluginNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5437,21 +4286,7 @@ impl IWRdsEnhancedFastReconnectArbitrator {
         (::windows::core::Vtable::vtable(self).GetSessionForEnhancedFastReconnect)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(psessionidarray), dwsessioncount, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IWRdsEnhancedFastReconnectArbitrator> for ::windows::core::IUnknown {
-    fn from(value: IWRdsEnhancedFastReconnectArbitrator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsEnhancedFastReconnectArbitrator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsEnhancedFastReconnectArbitrator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsEnhancedFastReconnectArbitrator> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsEnhancedFastReconnectArbitrator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsEnhancedFastReconnectArbitrator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsEnhancedFastReconnectArbitrator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5501,21 +4336,7 @@ impl IWRdsGraphicsChannel {
         (::windows::core::Vtable::vtable(self).Open)(::windows::core::Vtable::as_raw(self), pchannelevents.into().abi(), popencontext.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWRdsGraphicsChannel> for ::windows::core::IUnknown {
-    fn from(value: IWRdsGraphicsChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsGraphicsChannel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsGraphicsChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsGraphicsChannel> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsGraphicsChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsGraphicsChannel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsGraphicsChannel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5575,21 +4396,7 @@ impl IWRdsGraphicsChannelEvents {
         (::windows::core::Vtable::vtable(self).OnMetricsUpdate)(::windows::core::Vtable::as_raw(self), bandwidth, rtt, lastsentbyteindex).ok()
     }
 }
-impl ::core::convert::From<IWRdsGraphicsChannelEvents> for ::windows::core::IUnknown {
-    fn from(value: IWRdsGraphicsChannelEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsGraphicsChannelEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsGraphicsChannelEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsGraphicsChannelEvents> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsGraphicsChannelEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsGraphicsChannelEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsGraphicsChannelEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5634,21 +4441,7 @@ impl IWRdsGraphicsChannelManager {
         (::windows::core::Vtable::vtable(self).CreateChannel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pszchannelname), channeltype, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWRdsGraphicsChannel>(result__)
     }
 }
-impl ::core::convert::From<IWRdsGraphicsChannelManager> for ::windows::core::IUnknown {
-    fn from(value: IWRdsGraphicsChannelManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsGraphicsChannelManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsGraphicsChannelManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsGraphicsChannelManager> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsGraphicsChannelManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsGraphicsChannelManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsGraphicsChannelManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5801,21 +4594,7 @@ impl IWRdsProtocolConnection {
         (::windows::core::Vtable::vtable(self).NotifyCommandProcessCreated)(::windows::core::Vtable::as_raw(self), sessionid).ok()
     }
 }
-impl ::core::convert::From<IWRdsProtocolConnection> for ::windows::core::IUnknown {
-    fn from(value: IWRdsProtocolConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsProtocolConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsProtocolConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsProtocolConnection> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsProtocolConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsProtocolConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsProtocolConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5912,21 +4691,7 @@ impl IWRdsProtocolConnectionCallback {
         (::windows::core::Vtable::vtable(self).GetConnectionId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IWRdsProtocolConnectionCallback> for ::windows::core::IUnknown {
-    fn from(value: IWRdsProtocolConnectionCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsProtocolConnectionCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsProtocolConnectionCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsProtocolConnectionCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsProtocolConnectionCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsProtocolConnectionCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsProtocolConnectionCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5971,21 +4736,7 @@ impl IWRdsProtocolConnectionSettings {
         (::windows::core::Vtable::vtable(self).GetConnectionSetting)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(propertyid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WTS_PROPERTY_VALUE>(result__)
     }
 }
-impl ::core::convert::From<IWRdsProtocolConnectionSettings> for ::windows::core::IUnknown {
-    fn from(value: IWRdsProtocolConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsProtocolConnectionSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsProtocolConnectionSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsProtocolConnectionSettings> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsProtocolConnectionSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsProtocolConnectionSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsProtocolConnectionSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6034,21 +4785,7 @@ impl IWRdsProtocolLicenseConnection {
         (::windows::core::Vtable::vtable(self).ProtocolComplete)(::windows::core::Vtable::as_raw(self), ulcomplete).ok()
     }
 }
-impl ::core::convert::From<IWRdsProtocolLicenseConnection> for ::windows::core::IUnknown {
-    fn from(value: IWRdsProtocolLicenseConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsProtocolLicenseConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsProtocolLicenseConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsProtocolLicenseConnection> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsProtocolLicenseConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsProtocolLicenseConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsProtocolLicenseConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6101,21 +4838,7 @@ impl IWRdsProtocolListener {
         (::windows::core::Vtable::vtable(self).StopListen)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWRdsProtocolListener> for ::windows::core::IUnknown {
-    fn from(value: IWRdsProtocolListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsProtocolListener> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsProtocolListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsProtocolListener> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsProtocolListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsProtocolListener, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsProtocolListener {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6160,21 +4883,7 @@ impl IWRdsProtocolListenerCallback {
         (::windows::core::Vtable::vtable(self).OnConnected)(::windows::core::Vtable::as_raw(self), pconnection.into().abi(), ::core::mem::transmute(pwrdsconnectionsettings), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWRdsProtocolConnectionCallback>(result__)
     }
 }
-impl ::core::convert::From<IWRdsProtocolListenerCallback> for ::windows::core::IUnknown {
-    fn from(value: IWRdsProtocolListenerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsProtocolListenerCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsProtocolListenerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsProtocolListenerCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsProtocolListenerCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsProtocolListenerCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsProtocolListenerCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6237,21 +4946,7 @@ impl IWRdsProtocolLogonErrorRedirector {
         (::windows::core::Vtable::vtable(self).RedirectLogonError)(::windows::core::Vtable::as_raw(self), ntsstatus, ntssubstatus, pszcaption.into(), pszmessage.into(), utype, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WTS_LOGON_ERROR_REDIRECTOR_RESPONSE>(result__)
     }
 }
-impl ::core::convert::From<IWRdsProtocolLogonErrorRedirector> for ::windows::core::IUnknown {
-    fn from(value: IWRdsProtocolLogonErrorRedirector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsProtocolLogonErrorRedirector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsProtocolLogonErrorRedirector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsProtocolLogonErrorRedirector> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsProtocolLogonErrorRedirector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsProtocolLogonErrorRedirector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsProtocolLogonErrorRedirector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6323,21 +5018,7 @@ impl IWRdsProtocolManager {
         (::windows::core::Vtable::vtable(self).Uninitialize)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWRdsProtocolManager> for ::windows::core::IUnknown {
-    fn from(value: IWRdsProtocolManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsProtocolManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsProtocolManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsProtocolManager> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsProtocolManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsProtocolManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsProtocolManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6395,21 +5076,7 @@ impl IWRdsProtocolSettings {
         (::windows::core::Vtable::vtable(self).MergeSettings)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwrdssettings), wrdsconnectionsettinglevel, ::core::mem::transmute(pwrdsconnectionsettings)).ok()
     }
 }
-impl ::core::convert::From<IWRdsProtocolSettings> for ::windows::core::IUnknown {
-    fn from(value: IWRdsProtocolSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsProtocolSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsProtocolSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsProtocolSettings> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsProtocolSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsProtocolSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsProtocolSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6460,21 +5127,7 @@ impl IWRdsProtocolShadowCallback {
         (::windows::core::Vtable::vtable(self).InvokeTargetShadow)(::windows::core::Vtable::as_raw(self), ptargetservername.into(), targetsessionid, ::core::mem::transmute(pparam1.as_ptr()), pparam1.len() as _, ::core::mem::transmute(pparam2.as_ptr()), pparam2.len() as _, ::core::mem::transmute(pparam3.as_ptr()), pparam3.len() as _, ::core::mem::transmute(pparam4.as_ptr()), pparam4.len() as _, pclientname.into()).ok()
     }
 }
-impl ::core::convert::From<IWRdsProtocolShadowCallback> for ::windows::core::IUnknown {
-    fn from(value: IWRdsProtocolShadowCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsProtocolShadowCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsProtocolShadowCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsProtocolShadowCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsProtocolShadowCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsProtocolShadowCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsProtocolShadowCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6525,21 +5178,7 @@ impl IWRdsProtocolShadowConnection {
         (::windows::core::Vtable::vtable(self).DoTarget)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pparam1.as_ptr()), pparam1.len() as _, ::core::mem::transmute(pparam2.as_ptr()), pparam2.len() as _, ::core::mem::transmute(pparam3.as_ptr()), pparam3.len() as _, ::core::mem::transmute(pparam4.as_ptr()), pparam4.len() as _, pclientname.into()).ok()
     }
 }
-impl ::core::convert::From<IWRdsProtocolShadowConnection> for ::windows::core::IUnknown {
-    fn from(value: IWRdsProtocolShadowConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsProtocolShadowConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsProtocolShadowConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsProtocolShadowConnection> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsProtocolShadowConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsProtocolShadowConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsProtocolShadowConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6597,21 +5236,7 @@ impl IWRdsWddmIddProps {
         (::windows::core::Vtable::vtable(self).EnableWddmIdd)(::windows::core::Vtable::as_raw(self), enabled.into()).ok()
     }
 }
-impl ::core::convert::From<IWRdsWddmIddProps> for ::windows::core::IUnknown {
-    fn from(value: IWRdsWddmIddProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWRdsWddmIddProps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWRdsWddmIddProps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWRdsWddmIddProps> for ::windows::core::IUnknown {
-    fn from(value: &IWRdsWddmIddProps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWRdsWddmIddProps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWRdsWddmIddProps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6661,21 +5286,7 @@ impl IWTSBitmapRenderService {
         (::windows::core::Vtable::vtable(self).GetMappedRenderer)(::windows::core::Vtable::as_raw(self), mappingid, pmappedrenderercallback.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWTSBitmapRenderer>(result__)
     }
 }
-impl ::core::convert::From<IWTSBitmapRenderService> for ::windows::core::IUnknown {
-    fn from(value: IWTSBitmapRenderService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSBitmapRenderService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSBitmapRenderService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSBitmapRenderService> for ::windows::core::IUnknown {
-    fn from(value: &IWTSBitmapRenderService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSBitmapRenderService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSBitmapRenderService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6719,21 +5330,7 @@ impl IWTSBitmapRenderer {
         (::windows::core::Vtable::vtable(self).RemoveMapping)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWTSBitmapRenderer> for ::windows::core::IUnknown {
-    fn from(value: IWTSBitmapRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSBitmapRenderer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSBitmapRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSBitmapRenderer> for ::windows::core::IUnknown {
-    fn from(value: &IWTSBitmapRenderer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSBitmapRenderer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSBitmapRenderer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6774,21 +5371,7 @@ impl IWTSBitmapRendererCallback {
         (::windows::core::Vtable::vtable(self).OnTargetSizeChanged)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rcnewsize)).ok()
     }
 }
-impl ::core::convert::From<IWTSBitmapRendererCallback> for ::windows::core::IUnknown {
-    fn from(value: IWTSBitmapRendererCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSBitmapRendererCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSBitmapRendererCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSBitmapRendererCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWTSBitmapRendererCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSBitmapRendererCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSBitmapRendererCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6831,21 +5414,7 @@ impl IWTSListener {
         (::windows::core::Vtable::vtable(self).GetConfiguration)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::StructuredStorage::IPropertyBag>(result__)
     }
 }
-impl ::core::convert::From<IWTSListener> for ::windows::core::IUnknown {
-    fn from(value: IWTSListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSListener> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSListener> for ::windows::core::IUnknown {
-    fn from(value: &IWTSListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSListener, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSListener {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6890,21 +5459,7 @@ impl IWTSListenerCallback {
         (::windows::core::Vtable::vtable(self).OnNewChannelConnection)(::windows::core::Vtable::as_raw(self), pchannel.into().abi(), ::core::mem::transmute_copy(data), ::core::mem::transmute(pbaccept), ::core::mem::transmute(ppcallback)).ok()
     }
 }
-impl ::core::convert::From<IWTSListenerCallback> for ::windows::core::IUnknown {
-    fn from(value: IWTSListenerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSListenerCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSListenerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSListenerCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWTSListenerCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSListenerCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSListenerCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6956,21 +5511,7 @@ impl IWTSPlugin {
         (::windows::core::Vtable::vtable(self).Terminated)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWTSPlugin> for ::windows::core::IUnknown {
-    fn from(value: IWTSPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSPlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSPlugin> for ::windows::core::IUnknown {
-    fn from(value: &IWTSPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSPlugin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSPlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7011,21 +5552,7 @@ impl IWTSPluginServiceProvider {
         (::windows::core::Vtable::vtable(self).GetService)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(serviceid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IWTSPluginServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: IWTSPluginServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSPluginServiceProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSPluginServiceProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSPluginServiceProvider> for ::windows::core::IUnknown {
-    fn from(value: &IWTSPluginServiceProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSPluginServiceProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSPluginServiceProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7171,21 +5698,7 @@ impl IWTSProtocolConnection {
         (::windows::core::Vtable::vtable(self).GetShadowConnection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWTSProtocolShadowConnection>(result__)
     }
 }
-impl ::core::convert::From<IWTSProtocolConnection> for ::windows::core::IUnknown {
-    fn from(value: IWTSProtocolConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSProtocolConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSProtocolConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSProtocolConnection> for ::windows::core::IUnknown {
-    fn from(value: &IWTSProtocolConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSProtocolConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSProtocolConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7280,21 +5793,7 @@ impl IWTSProtocolConnectionCallback {
         (::windows::core::Vtable::vtable(self).DisplayIOCtl)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(displayioctl)).ok()
     }
 }
-impl ::core::convert::From<IWTSProtocolConnectionCallback> for ::windows::core::IUnknown {
-    fn from(value: IWTSProtocolConnectionCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSProtocolConnectionCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSProtocolConnectionCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSProtocolConnectionCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWTSProtocolConnectionCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSProtocolConnectionCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSProtocolConnectionCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7346,21 +5845,7 @@ impl IWTSProtocolLicenseConnection {
         (::windows::core::Vtable::vtable(self).ProtocolComplete)(::windows::core::Vtable::as_raw(self), ulcomplete).ok()
     }
 }
-impl ::core::convert::From<IWTSProtocolLicenseConnection> for ::windows::core::IUnknown {
-    fn from(value: IWTSProtocolLicenseConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSProtocolLicenseConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSProtocolLicenseConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSProtocolLicenseConnection> for ::windows::core::IUnknown {
-    fn from(value: &IWTSProtocolLicenseConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSProtocolLicenseConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSProtocolLicenseConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7409,21 +5894,7 @@ impl IWTSProtocolListener {
         (::windows::core::Vtable::vtable(self).StopListen)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWTSProtocolListener> for ::windows::core::IUnknown {
-    fn from(value: IWTSProtocolListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSProtocolListener> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSProtocolListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSProtocolListener> for ::windows::core::IUnknown {
-    fn from(value: &IWTSProtocolListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSProtocolListener, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSProtocolListener {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7465,21 +5936,7 @@ impl IWTSProtocolListenerCallback {
         (::windows::core::Vtable::vtable(self).OnConnected)(::windows::core::Vtable::as_raw(self), pconnection.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWTSProtocolConnectionCallback>(result__)
     }
 }
-impl ::core::convert::From<IWTSProtocolListenerCallback> for ::windows::core::IUnknown {
-    fn from(value: IWTSProtocolListenerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSProtocolListenerCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSProtocolListenerCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSProtocolListenerCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWTSProtocolListenerCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSProtocolListenerCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSProtocolListenerCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7539,21 +5996,7 @@ impl IWTSProtocolLogonErrorRedirector {
         (::windows::core::Vtable::vtable(self).RedirectLogonError)(::windows::core::Vtable::as_raw(self), ntsstatus, ntssubstatus, pszcaption.into(), pszmessage.into(), utype, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WTS_LOGON_ERROR_REDIRECTOR_RESPONSE>(result__)
     }
 }
-impl ::core::convert::From<IWTSProtocolLogonErrorRedirector> for ::windows::core::IUnknown {
-    fn from(value: IWTSProtocolLogonErrorRedirector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSProtocolLogonErrorRedirector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSProtocolLogonErrorRedirector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSProtocolLogonErrorRedirector> for ::windows::core::IUnknown {
-    fn from(value: &IWTSProtocolLogonErrorRedirector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSProtocolLogonErrorRedirector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSProtocolLogonErrorRedirector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7609,21 +6052,7 @@ impl IWTSProtocolManager {
         (::windows::core::Vtable::vtable(self).NotifySessionStateChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(sessionid), eventid).ok()
     }
 }
-impl ::core::convert::From<IWTSProtocolManager> for ::windows::core::IUnknown {
-    fn from(value: IWTSProtocolManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSProtocolManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSProtocolManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSProtocolManager> for ::windows::core::IUnknown {
-    fn from(value: &IWTSProtocolManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSProtocolManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSProtocolManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7671,21 +6100,7 @@ impl IWTSProtocolShadowCallback {
         (::windows::core::Vtable::vtable(self).InvokeTargetShadow)(::windows::core::Vtable::as_raw(self), ptargetservername.into(), targetsessionid, ::core::mem::transmute(pparam1.as_ptr()), pparam1.len() as _, ::core::mem::transmute(pparam2.as_ptr()), pparam2.len() as _, ::core::mem::transmute(pparam3.as_ptr()), pparam3.len() as _, ::core::mem::transmute(pparam4.as_ptr()), pparam4.len() as _, pclientname.into()).ok()
     }
 }
-impl ::core::convert::From<IWTSProtocolShadowCallback> for ::windows::core::IUnknown {
-    fn from(value: IWTSProtocolShadowCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSProtocolShadowCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSProtocolShadowCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSProtocolShadowCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWTSProtocolShadowCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSProtocolShadowCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSProtocolShadowCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7736,21 +6151,7 @@ impl IWTSProtocolShadowConnection {
         (::windows::core::Vtable::vtable(self).DoTarget)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pparam1.as_ptr()), pparam1.len() as _, ::core::mem::transmute(pparam2.as_ptr()), pparam2.len() as _, ::core::mem::transmute(pparam3.as_ptr()), pparam3.len() as _, ::core::mem::transmute(pparam4.as_ptr()), pparam4.len() as _, pclientname.into()).ok()
     }
 }
-impl ::core::convert::From<IWTSProtocolShadowConnection> for ::windows::core::IUnknown {
-    fn from(value: IWTSProtocolShadowConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSProtocolShadowConnection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSProtocolShadowConnection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSProtocolShadowConnection> for ::windows::core::IUnknown {
-    fn from(value: &IWTSProtocolShadowConnection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSProtocolShadowConnection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSProtocolShadowConnection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7818,21 +6219,7 @@ impl IWTSSBPlugin {
         (::windows::core::Vtable::vtable(self).WTSSBX_GetUserExternalSession)(::windows::core::Vtable::as_raw(self), username.into(), domainname.into(), applicationtype.into(), ::core::mem::transmute(redirectorinternalip), ::core::mem::transmute(psessionid), ::core::mem::transmute(pmachineconnectinfo)).ok()
     }
 }
-impl ::core::convert::From<IWTSSBPlugin> for ::windows::core::IUnknown {
-    fn from(value: IWTSSBPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSSBPlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSSBPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSSBPlugin> for ::windows::core::IUnknown {
-    fn from(value: &IWTSSBPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSSBPlugin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSSBPlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7883,21 +6270,7 @@ impl IWTSVirtualChannel {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWTSVirtualChannel> for ::windows::core::IUnknown {
-    fn from(value: IWTSVirtualChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSVirtualChannel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSVirtualChannel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSVirtualChannel> for ::windows::core::IUnknown {
-    fn from(value: &IWTSVirtualChannel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSVirtualChannel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSVirtualChannel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7938,21 +6311,7 @@ impl IWTSVirtualChannelCallback {
         (::windows::core::Vtable::vtable(self).OnClose)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWTSVirtualChannelCallback> for ::windows::core::IUnknown {
-    fn from(value: IWTSVirtualChannelCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSVirtualChannelCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSVirtualChannelCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSVirtualChannelCallback> for ::windows::core::IUnknown {
-    fn from(value: &IWTSVirtualChannelCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSVirtualChannelCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSVirtualChannelCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7994,21 +6353,7 @@ impl IWTSVirtualChannelManager {
         (::windows::core::Vtable::vtable(self).CreateListener)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pszchannelname), uflags, plistenercallback.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWTSListener>(result__)
     }
 }
-impl ::core::convert::From<IWTSVirtualChannelManager> for ::windows::core::IUnknown {
-    fn from(value: IWTSVirtualChannelManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWTSVirtualChannelManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWTSVirtualChannelManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWTSVirtualChannelManager> for ::windows::core::IUnknown {
-    fn from(value: &IWTSVirtualChannelManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWTSVirtualChannelManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWTSVirtualChannelManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8057,21 +6402,7 @@ impl IWorkspace {
         (::windows::core::Vtable::vtable(self).GetProcessId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IWorkspace> for ::windows::core::IUnknown {
-    fn from(value: IWorkspace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWorkspace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWorkspace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWorkspace> for ::windows::core::IUnknown {
-    fn from(value: &IWorkspace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWorkspace, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWorkspace {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8133,36 +6464,7 @@ impl IWorkspace2 {
         (::windows::core::Vtable::vtable(self).StartRemoteApplicationEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrworkspaceid), ::core::mem::transmute_copy(bstrrequestingappid), ::core::mem::transmute_copy(bstrrequestingappfamilyname), blaunchintoimmersiveclient, ::core::mem::transmute_copy(bstrimmersiveclientactivationcontext), ::core::mem::transmute(psaparams)).ok()
     }
 }
-impl ::core::convert::From<IWorkspace2> for ::windows::core::IUnknown {
-    fn from(value: IWorkspace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWorkspace2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWorkspace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWorkspace2> for ::windows::core::IUnknown {
-    fn from(value: &IWorkspace2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWorkspace2> for IWorkspace {
-    fn from(value: IWorkspace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWorkspace2> for &'a IWorkspace {
-    fn from(value: &'a IWorkspace2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWorkspace2> for IWorkspace {
-    fn from(value: &IWorkspace2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWorkspace2, ::windows::core::IUnknown, IWorkspace);
 impl ::core::clone::Clone for IWorkspace2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8228,51 +6530,7 @@ impl IWorkspace3 {
         (::windows::core::Vtable::vtable(self).SetClaimsToken)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstraccesstoken), ullaccesstokenexpiration, ::core::mem::transmute_copy(bstrrefreshtoken)).ok()
     }
 }
-impl ::core::convert::From<IWorkspace3> for ::windows::core::IUnknown {
-    fn from(value: IWorkspace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWorkspace3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWorkspace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWorkspace3> for ::windows::core::IUnknown {
-    fn from(value: &IWorkspace3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWorkspace3> for IWorkspace {
-    fn from(value: IWorkspace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWorkspace3> for &'a IWorkspace {
-    fn from(value: &'a IWorkspace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWorkspace3> for IWorkspace {
-    fn from(value: &IWorkspace3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWorkspace3> for IWorkspace2 {
-    fn from(value: IWorkspace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWorkspace3> for &'a IWorkspace2 {
-    fn from(value: &'a IWorkspace3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWorkspace3> for IWorkspace2 {
-    fn from(value: &IWorkspace3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWorkspace3, ::windows::core::IUnknown, IWorkspace, IWorkspace2);
 impl ::core::clone::Clone for IWorkspace3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8321,21 +6579,7 @@ impl IWorkspaceClientExt {
         (::windows::core::Vtable::vtable(self).IssueDisconnect)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWorkspaceClientExt> for ::windows::core::IUnknown {
-    fn from(value: IWorkspaceClientExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWorkspaceClientExt> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWorkspaceClientExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWorkspaceClientExt> for ::windows::core::IUnknown {
-    fn from(value: &IWorkspaceClientExt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWorkspaceClientExt, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWorkspaceClientExt {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8381,21 +6625,7 @@ impl IWorkspaceRegistration {
         (::windows::core::Vtable::vtable(self).RemoveResource)(::windows::core::Vtable::as_raw(self), dwcookieconnection).ok()
     }
 }
-impl ::core::convert::From<IWorkspaceRegistration> for ::windows::core::IUnknown {
-    fn from(value: IWorkspaceRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWorkspaceRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWorkspaceRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWorkspaceRegistration> for ::windows::core::IUnknown {
-    fn from(value: &IWorkspaceRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWorkspaceRegistration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWorkspaceRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8449,36 +6679,7 @@ impl IWorkspaceRegistration2 {
         (::windows::core::Vtable::vtable(self).RemoveResourceEx)(::windows::core::Vtable::as_raw(self), dwcookieconnection, ::core::mem::transmute(correlationid)).ok()
     }
 }
-impl ::core::convert::From<IWorkspaceRegistration2> for ::windows::core::IUnknown {
-    fn from(value: IWorkspaceRegistration2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWorkspaceRegistration2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWorkspaceRegistration2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWorkspaceRegistration2> for ::windows::core::IUnknown {
-    fn from(value: &IWorkspaceRegistration2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWorkspaceRegistration2> for IWorkspaceRegistration {
-    fn from(value: IWorkspaceRegistration2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWorkspaceRegistration2> for &'a IWorkspaceRegistration {
-    fn from(value: &'a IWorkspaceRegistration2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWorkspaceRegistration2> for IWorkspaceRegistration {
-    fn from(value: &IWorkspaceRegistration2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWorkspaceRegistration2, ::windows::core::IUnknown, IWorkspaceRegistration);
 impl ::core::clone::Clone for IWorkspaceRegistration2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8523,21 +6724,7 @@ impl IWorkspaceReportMessage {
         (::windows::core::Vtable::vtable(self).RegisterErrorEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrwkspid), dwerrortype, ::core::mem::transmute_copy(bstrerrormessagetype), dwerrorcode).ok()
     }
 }
-impl ::core::convert::From<IWorkspaceReportMessage> for ::windows::core::IUnknown {
-    fn from(value: IWorkspaceReportMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWorkspaceReportMessage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWorkspaceReportMessage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWorkspaceReportMessage> for ::windows::core::IUnknown {
-    fn from(value: &IWorkspaceReportMessage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWorkspaceReportMessage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWorkspaceReportMessage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8595,41 +6782,7 @@ impl IWorkspaceResTypeRegistry {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWorkspaceResTypeRegistry> for ::windows::core::IUnknown {
-    fn from(value: IWorkspaceResTypeRegistry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWorkspaceResTypeRegistry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWorkspaceResTypeRegistry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWorkspaceResTypeRegistry> for ::windows::core::IUnknown {
-    fn from(value: &IWorkspaceResTypeRegistry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWorkspaceResTypeRegistry> for super::Com::IDispatch {
-    fn from(value: IWorkspaceResTypeRegistry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWorkspaceResTypeRegistry> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWorkspaceResTypeRegistry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWorkspaceResTypeRegistry> for super::Com::IDispatch {
-    fn from(value: &IWorkspaceResTypeRegistry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWorkspaceResTypeRegistry, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWorkspaceResTypeRegistry {
     fn clone(&self) -> Self {
@@ -8703,41 +6856,7 @@ impl IWorkspaceScriptable {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWorkspaceScriptable> for ::windows::core::IUnknown {
-    fn from(value: IWorkspaceScriptable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWorkspaceScriptable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWorkspaceScriptable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWorkspaceScriptable> for ::windows::core::IUnknown {
-    fn from(value: &IWorkspaceScriptable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWorkspaceScriptable> for super::Com::IDispatch {
-    fn from(value: IWorkspaceScriptable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWorkspaceScriptable> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWorkspaceScriptable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWorkspaceScriptable> for super::Com::IDispatch {
-    fn from(value: &IWorkspaceScriptable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWorkspaceScriptable, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWorkspaceScriptable {
     fn clone(&self) -> Self {
@@ -8816,59 +6935,7 @@ impl IWorkspaceScriptable2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWorkspaceScriptable2> for ::windows::core::IUnknown {
-    fn from(value: IWorkspaceScriptable2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWorkspaceScriptable2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWorkspaceScriptable2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWorkspaceScriptable2> for ::windows::core::IUnknown {
-    fn from(value: &IWorkspaceScriptable2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWorkspaceScriptable2> for super::Com::IDispatch {
-    fn from(value: IWorkspaceScriptable2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWorkspaceScriptable2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWorkspaceScriptable2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWorkspaceScriptable2> for super::Com::IDispatch {
-    fn from(value: &IWorkspaceScriptable2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWorkspaceScriptable2> for IWorkspaceScriptable {
-    fn from(value: IWorkspaceScriptable2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWorkspaceScriptable2> for &'a IWorkspaceScriptable {
-    fn from(value: &'a IWorkspaceScriptable2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWorkspaceScriptable2> for IWorkspaceScriptable {
-    fn from(value: &IWorkspaceScriptable2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWorkspaceScriptable2, ::windows::core::IUnknown, super::Com::IDispatch, IWorkspaceScriptable);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWorkspaceScriptable2 {
     fn clone(&self) -> Self {
@@ -8959,77 +7026,7 @@ impl IWorkspaceScriptable3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWorkspaceScriptable3> for ::windows::core::IUnknown {
-    fn from(value: IWorkspaceScriptable3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWorkspaceScriptable3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWorkspaceScriptable3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWorkspaceScriptable3> for ::windows::core::IUnknown {
-    fn from(value: &IWorkspaceScriptable3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWorkspaceScriptable3> for super::Com::IDispatch {
-    fn from(value: IWorkspaceScriptable3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWorkspaceScriptable3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWorkspaceScriptable3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWorkspaceScriptable3> for super::Com::IDispatch {
-    fn from(value: &IWorkspaceScriptable3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWorkspaceScriptable3> for IWorkspaceScriptable {
-    fn from(value: IWorkspaceScriptable3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWorkspaceScriptable3> for &'a IWorkspaceScriptable {
-    fn from(value: &'a IWorkspaceScriptable3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWorkspaceScriptable3> for IWorkspaceScriptable {
-    fn from(value: &IWorkspaceScriptable3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWorkspaceScriptable3> for IWorkspaceScriptable2 {
-    fn from(value: IWorkspaceScriptable3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWorkspaceScriptable3> for &'a IWorkspaceScriptable2 {
-    fn from(value: &'a IWorkspaceScriptable3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWorkspaceScriptable3> for IWorkspaceScriptable2 {
-    fn from(value: &IWorkspaceScriptable3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWorkspaceScriptable3, ::windows::core::IUnknown, super::Com::IDispatch, IWorkspaceScriptable, IWorkspaceScriptable2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWorkspaceScriptable3 {
     fn clone(&self) -> Self {
@@ -9102,21 +7099,7 @@ impl ItsPubPlugin {
         (::windows::core::Vtable::vtable(self).ResolveResource)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(resourcetype), ::core::mem::transmute(resourcelocation), ::core::mem::transmute(endpointname), userid.into(), alias.into()).ok()
     }
 }
-impl ::core::convert::From<ItsPubPlugin> for ::windows::core::IUnknown {
-    fn from(value: ItsPubPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ItsPubPlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ItsPubPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ItsPubPlugin> for ::windows::core::IUnknown {
-    fn from(value: &ItsPubPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ItsPubPlugin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ItsPubPlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9215,36 +7198,7 @@ impl ItsPubPlugin2 {
         (::windows::core::Vtable::vtable(self).DeletePersonalDesktopAssignment)(::windows::core::Vtable::as_raw(self), userid.into(), poolid.into(), endpointname.into()).ok()
     }
 }
-impl ::core::convert::From<ItsPubPlugin2> for ::windows::core::IUnknown {
-    fn from(value: ItsPubPlugin2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ItsPubPlugin2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ItsPubPlugin2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ItsPubPlugin2> for ::windows::core::IUnknown {
-    fn from(value: &ItsPubPlugin2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ItsPubPlugin2> for ItsPubPlugin {
-    fn from(value: ItsPubPlugin2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ItsPubPlugin2> for &'a ItsPubPlugin {
-    fn from(value: &'a ItsPubPlugin2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ItsPubPlugin2> for ItsPubPlugin {
-    fn from(value: &ItsPubPlugin2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ItsPubPlugin2, ::windows::core::IUnknown, ItsPubPlugin);
 impl ::core::clone::Clone for ItsPubPlugin2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9283,41 +7237,7 @@ pub struct _ITSWkspEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _ITSWkspEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_ITSWkspEvents> for ::windows::core::IUnknown {
-    fn from(value: _ITSWkspEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _ITSWkspEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _ITSWkspEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_ITSWkspEvents> for ::windows::core::IUnknown {
-    fn from(value: &_ITSWkspEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_ITSWkspEvents> for super::Com::IDispatch {
-    fn from(value: _ITSWkspEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _ITSWkspEvents> for &'a super::Com::IDispatch {
-    fn from(value: &'a _ITSWkspEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_ITSWkspEvents> for super::Com::IDispatch {
-    fn from(value: &_ITSWkspEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_ITSWkspEvents, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _ITSWkspEvents {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
@@ -393,41 +393,7 @@ impl IWSMan {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSMan> for ::windows::core::IUnknown {
-    fn from(value: IWSMan) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSMan> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSMan) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSMan> for ::windows::core::IUnknown {
-    fn from(value: &IWSMan) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSMan> for super::Com::IDispatch {
-    fn from(value: IWSMan) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSMan> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSMan) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSMan> for super::Com::IDispatch {
-    fn from(value: &IWSMan) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSMan, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSMan {
     fn clone(&self) -> Self {
@@ -490,41 +456,7 @@ impl IWSManConnectionOptions {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManConnectionOptions> for ::windows::core::IUnknown {
-    fn from(value: IWSManConnectionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManConnectionOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSManConnectionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManConnectionOptions> for ::windows::core::IUnknown {
-    fn from(value: &IWSManConnectionOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManConnectionOptions> for super::Com::IDispatch {
-    fn from(value: IWSManConnectionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManConnectionOptions> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSManConnectionOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManConnectionOptions> for super::Com::IDispatch {
-    fn from(value: &IWSManConnectionOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSManConnectionOptions, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSManConnectionOptions {
     fn clone(&self) -> Self {
@@ -587,59 +519,7 @@ impl IWSManConnectionOptionsEx {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManConnectionOptionsEx> for ::windows::core::IUnknown {
-    fn from(value: IWSManConnectionOptionsEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManConnectionOptionsEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSManConnectionOptionsEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManConnectionOptionsEx> for ::windows::core::IUnknown {
-    fn from(value: &IWSManConnectionOptionsEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManConnectionOptionsEx> for super::Com::IDispatch {
-    fn from(value: IWSManConnectionOptionsEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManConnectionOptionsEx> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSManConnectionOptionsEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManConnectionOptionsEx> for super::Com::IDispatch {
-    fn from(value: &IWSManConnectionOptionsEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManConnectionOptionsEx> for IWSManConnectionOptions {
-    fn from(value: IWSManConnectionOptionsEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManConnectionOptionsEx> for &'a IWSManConnectionOptions {
-    fn from(value: &'a IWSManConnectionOptionsEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManConnectionOptionsEx> for IWSManConnectionOptions {
-    fn from(value: &IWSManConnectionOptionsEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSManConnectionOptionsEx, ::windows::core::IUnknown, super::Com::IDispatch, IWSManConnectionOptions);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSManConnectionOptionsEx {
     fn clone(&self) -> Self {
@@ -732,77 +612,7 @@ impl IWSManConnectionOptionsEx2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManConnectionOptionsEx2> for ::windows::core::IUnknown {
-    fn from(value: IWSManConnectionOptionsEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManConnectionOptionsEx2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSManConnectionOptionsEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManConnectionOptionsEx2> for ::windows::core::IUnknown {
-    fn from(value: &IWSManConnectionOptionsEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManConnectionOptionsEx2> for super::Com::IDispatch {
-    fn from(value: IWSManConnectionOptionsEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManConnectionOptionsEx2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSManConnectionOptionsEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManConnectionOptionsEx2> for super::Com::IDispatch {
-    fn from(value: &IWSManConnectionOptionsEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManConnectionOptionsEx2> for IWSManConnectionOptions {
-    fn from(value: IWSManConnectionOptionsEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManConnectionOptionsEx2> for &'a IWSManConnectionOptions {
-    fn from(value: &'a IWSManConnectionOptionsEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManConnectionOptionsEx2> for IWSManConnectionOptions {
-    fn from(value: &IWSManConnectionOptionsEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManConnectionOptionsEx2> for IWSManConnectionOptionsEx {
-    fn from(value: IWSManConnectionOptionsEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManConnectionOptionsEx2> for &'a IWSManConnectionOptionsEx {
-    fn from(value: &'a IWSManConnectionOptionsEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManConnectionOptionsEx2> for IWSManConnectionOptionsEx {
-    fn from(value: &IWSManConnectionOptionsEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSManConnectionOptionsEx2, ::windows::core::IUnknown, super::Com::IDispatch, IWSManConnectionOptions, IWSManConnectionOptionsEx);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSManConnectionOptionsEx2 {
     fn clone(&self) -> Self {
@@ -865,41 +675,7 @@ impl IWSManEnumerator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IWSManEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSManEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IWSManEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEnumerator> for super::Com::IDispatch {
-    fn from(value: IWSManEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEnumerator> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSManEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEnumerator> for super::Com::IDispatch {
-    fn from(value: &IWSManEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSManEnumerator, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSManEnumerator {
     fn clone(&self) -> Self {
@@ -1050,59 +826,7 @@ impl IWSManEx {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx> for ::windows::core::IUnknown {
-    fn from(value: IWSManEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSManEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx> for ::windows::core::IUnknown {
-    fn from(value: &IWSManEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx> for super::Com::IDispatch {
-    fn from(value: IWSManEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSManEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx> for super::Com::IDispatch {
-    fn from(value: &IWSManEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx> for IWSMan {
-    fn from(value: IWSManEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx> for &'a IWSMan {
-    fn from(value: &'a IWSManEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx> for IWSMan {
-    fn from(value: &IWSManEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSManEx, ::windows::core::IUnknown, super::Com::IDispatch, IWSMan);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSManEx {
     fn clone(&self) -> Self {
@@ -1277,77 +1001,7 @@ impl IWSManEx2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx2> for ::windows::core::IUnknown {
-    fn from(value: IWSManEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSManEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx2> for ::windows::core::IUnknown {
-    fn from(value: &IWSManEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx2> for super::Com::IDispatch {
-    fn from(value: IWSManEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSManEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx2> for super::Com::IDispatch {
-    fn from(value: &IWSManEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx2> for IWSMan {
-    fn from(value: IWSManEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx2> for &'a IWSMan {
-    fn from(value: &'a IWSManEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx2> for IWSMan {
-    fn from(value: &IWSManEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx2> for IWSManEx {
-    fn from(value: IWSManEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx2> for &'a IWSManEx {
-    fn from(value: &'a IWSManEx2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx2> for IWSManEx {
-    fn from(value: &IWSManEx2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSManEx2, ::windows::core::IUnknown, super::Com::IDispatch, IWSMan, IWSManEx);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSManEx2 {
     fn clone(&self) -> Self {
@@ -1528,95 +1182,7 @@ impl IWSManEx3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx3> for ::windows::core::IUnknown {
-    fn from(value: IWSManEx3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSManEx3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx3> for ::windows::core::IUnknown {
-    fn from(value: &IWSManEx3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx3> for super::Com::IDispatch {
-    fn from(value: IWSManEx3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSManEx3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx3> for super::Com::IDispatch {
-    fn from(value: &IWSManEx3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx3> for IWSMan {
-    fn from(value: IWSManEx3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx3> for &'a IWSMan {
-    fn from(value: &'a IWSManEx3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx3> for IWSMan {
-    fn from(value: &IWSManEx3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx3> for IWSManEx {
-    fn from(value: IWSManEx3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx3> for &'a IWSManEx {
-    fn from(value: &'a IWSManEx3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx3> for IWSManEx {
-    fn from(value: &IWSManEx3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManEx3> for IWSManEx2 {
-    fn from(value: IWSManEx3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManEx3> for &'a IWSManEx2 {
-    fn from(value: &'a IWSManEx3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManEx3> for IWSManEx2 {
-    fn from(value: &IWSManEx3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSManEx3, ::windows::core::IUnknown, super::Com::IDispatch, IWSMan, IWSManEx, IWSManEx2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSManEx3 {
     fn clone(&self) -> Self {
@@ -1676,41 +1242,7 @@ impl IWSManInternal {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManInternal> for ::windows::core::IUnknown {
-    fn from(value: IWSManInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManInternal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSManInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManInternal> for ::windows::core::IUnknown {
-    fn from(value: &IWSManInternal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManInternal> for super::Com::IDispatch {
-    fn from(value: IWSManInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManInternal> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSManInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManInternal> for super::Com::IDispatch {
-    fn from(value: &IWSManInternal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSManInternal, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSManInternal {
     fn clone(&self) -> Self {
@@ -1819,41 +1351,7 @@ impl IWSManResourceLocator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManResourceLocator> for ::windows::core::IUnknown {
-    fn from(value: IWSManResourceLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManResourceLocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSManResourceLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManResourceLocator> for ::windows::core::IUnknown {
-    fn from(value: &IWSManResourceLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManResourceLocator> for super::Com::IDispatch {
-    fn from(value: IWSManResourceLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManResourceLocator> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSManResourceLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManResourceLocator> for super::Com::IDispatch {
-    fn from(value: &IWSManResourceLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSManResourceLocator, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSManResourceLocator {
     fn clone(&self) -> Self {
@@ -1917,21 +1415,7 @@ pub struct IWSManResourceLocator_Vtbl {
 #[repr(transparent)]
 pub struct IWSManResourceLocatorInternal(::windows::core::IUnknown);
 impl IWSManResourceLocatorInternal {}
-impl ::core::convert::From<IWSManResourceLocatorInternal> for ::windows::core::IUnknown {
-    fn from(value: IWSManResourceLocatorInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWSManResourceLocatorInternal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSManResourceLocatorInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWSManResourceLocatorInternal> for ::windows::core::IUnknown {
-    fn from(value: &IWSManResourceLocatorInternal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSManResourceLocatorInternal, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWSManResourceLocatorInternal {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2042,41 +1526,7 @@ impl IWSManSession {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManSession> for ::windows::core::IUnknown {
-    fn from(value: IWSManSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSManSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManSession> for ::windows::core::IUnknown {
-    fn from(value: &IWSManSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSManSession> for super::Com::IDispatch {
-    fn from(value: IWSManSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSManSession> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSManSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSManSession> for super::Com::IDispatch {
-    fn from(value: &IWSManSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSManSession, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSManSession {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -2504,21 +2504,7 @@ impl DataSource {
         (::windows::core::Vtable::vtable(self).removeDataSourceListener)(::windows::core::Vtable::as_raw(self), pdsl.into().abi()).ok()
     }
 }
-impl ::core::convert::From<DataSource> for ::windows::core::IUnknown {
-    fn from(value: DataSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a DataSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DataSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataSource> for ::windows::core::IUnknown {
-    fn from(value: &DataSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DataSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for DataSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2565,21 +2551,7 @@ impl DataSourceListener {
         (::windows::core::Vtable::vtable(self).dataMemberRemoved)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(bstrdm)).ok()
     }
 }
-impl ::core::convert::From<DataSourceListener> for ::windows::core::IUnknown {
-    fn from(value: DataSourceListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a DataSourceListener> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DataSourceListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&DataSourceListener> for ::windows::core::IUnknown {
-    fn from(value: &DataSourceListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DataSourceListener, ::windows::core::IUnknown);
 impl ::core::clone::Clone for DataSourceListener {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2617,41 +2589,7 @@ pub struct DataSourceObject(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DataSourceObject {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DataSourceObject> for ::windows::core::IUnknown {
-    fn from(value: DataSourceObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DataSourceObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DataSourceObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DataSourceObject> for ::windows::core::IUnknown {
-    fn from(value: &DataSourceObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DataSourceObject> for super::Com::IDispatch {
-    fn from(value: DataSourceObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DataSourceObject> for &'a super::Com::IDispatch {
-    fn from(value: &'a DataSourceObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DataSourceObject> for super::Com::IDispatch {
-    fn from(value: &DataSourceObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DataSourceObject, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DataSourceObject {
     fn clone(&self) -> Self {
@@ -2718,21 +2656,7 @@ impl IAccessor {
         (::windows::core::Vtable::vtable(self).ReleaseAccessor)(::windows::core::Vtable::as_raw(self), haccessor.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAccessor> for ::windows::core::IUnknown {
-    fn from(value: IAccessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccessor> for ::windows::core::IUnknown {
-    fn from(value: &IAccessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccessor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2780,21 +2704,7 @@ impl IAlterIndex {
         (::windows::core::Vtable::vtable(self).AlterIndex)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptableid), ::core::mem::transmute(pindexid), ::core::mem::transmute(pnewindexid), cpropertysets, ::core::mem::transmute(rgpropertysets)).ok()
     }
 }
-impl ::core::convert::From<IAlterIndex> for ::windows::core::IUnknown {
-    fn from(value: IAlterIndex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAlterIndex> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAlterIndex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAlterIndex> for ::windows::core::IUnknown {
-    fn from(value: &IAlterIndex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAlterIndex, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAlterIndex {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2841,21 +2751,7 @@ impl IAlterTable {
         (::windows::core::Vtable::vtable(self).AlterTable)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptableid), ::core::mem::transmute(pnewtableid), cpropertysets, ::core::mem::transmute(rgpropertysets)).ok()
     }
 }
-impl ::core::convert::From<IAlterTable> for ::windows::core::IUnknown {
-    fn from(value: IAlterTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAlterTable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAlterTable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAlterTable> for ::windows::core::IUnknown {
-    fn from(value: &IAlterTable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAlterTable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAlterTable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2906,21 +2802,7 @@ impl IBindResource {
         (::windows::core::Vtable::vtable(self).Bind)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), pwszurl.into(), dwbindurlflags, ::core::mem::transmute(rguid), ::core::mem::transmute(riid), pauthenticate.into().abi(), ::core::mem::transmute(pimplsession.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pdwbindstatus.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ppunk)).ok()
     }
 }
-impl ::core::convert::From<IBindResource> for ::windows::core::IUnknown {
-    fn from(value: IBindResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBindResource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBindResource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBindResource> for ::windows::core::IUnknown {
-    fn from(value: &IBindResource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBindResource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBindResource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2965,21 +2847,7 @@ impl IChapteredRowset {
         (::windows::core::Vtable::vtable(self).ReleaseChapter)(::windows::core::Vtable::as_raw(self), hchapter, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IChapteredRowset> for ::windows::core::IUnknown {
-    fn from(value: IChapteredRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IChapteredRowset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IChapteredRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IChapteredRowset> for ::windows::core::IUnknown {
-    fn from(value: &IChapteredRowset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IChapteredRowset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IChapteredRowset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3035,21 +2903,7 @@ impl IColumnMapper {
         (::windows::core::Vtable::vtable(self).IsMapUpToDate)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IColumnMapper> for ::windows::core::IUnknown {
-    fn from(value: IColumnMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IColumnMapper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IColumnMapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IColumnMapper> for ::windows::core::IUnknown {
-    fn from(value: &IColumnMapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IColumnMapper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IColumnMapper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3103,21 +2957,7 @@ impl IColumnMapperCreator {
         (::windows::core::Vtable::vtable(self).GetColumnMapper)(::windows::core::Vtable::as_raw(self), wcsmachinename.into(), wcscatalogname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IColumnMapper>(result__)
     }
 }
-impl ::core::convert::From<IColumnMapperCreator> for ::windows::core::IUnknown {
-    fn from(value: IColumnMapperCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IColumnMapperCreator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IColumnMapperCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IColumnMapperCreator> for ::windows::core::IUnknown {
-    fn from(value: &IColumnMapperCreator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IColumnMapperCreator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IColumnMapperCreator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3162,21 +3002,7 @@ impl IColumnsInfo {
         (::windows::core::Vtable::vtable(self).MapColumnIDs)(::windows::core::Vtable::as_raw(self), ccolumnids, ::core::mem::transmute(rgcolumnids.unwrap_or(::std::ptr::null())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<usize>(result__)
     }
 }
-impl ::core::convert::From<IColumnsInfo> for ::windows::core::IUnknown {
-    fn from(value: IColumnsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IColumnsInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IColumnsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IColumnsInfo> for ::windows::core::IUnknown {
-    fn from(value: &IColumnsInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IColumnsInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IColumnsInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3233,36 +3059,7 @@ impl IColumnsInfo2 {
         (::windows::core::Vtable::vtable(self).GetRestrictedColumnInfo)(::windows::core::Vtable::as_raw(self), rgcolumnidmasks.len() as _, ::core::mem::transmute(rgcolumnidmasks.as_ptr()), dwflags, ::core::mem::transmute(pccolumns), ::core::mem::transmute(prgcolumnids), ::core::mem::transmute(prgcolumninfo), ::core::mem::transmute(ppstringsbuffer.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IColumnsInfo2> for ::windows::core::IUnknown {
-    fn from(value: IColumnsInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IColumnsInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IColumnsInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IColumnsInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IColumnsInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IColumnsInfo2> for IColumnsInfo {
-    fn from(value: IColumnsInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IColumnsInfo2> for &'a IColumnsInfo {
-    fn from(value: &'a IColumnsInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IColumnsInfo2> for IColumnsInfo {
-    fn from(value: &IColumnsInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IColumnsInfo2, ::windows::core::IUnknown, IColumnsInfo);
 impl ::core::clone::Clone for IColumnsInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3312,21 +3109,7 @@ impl IColumnsRowset {
         (::windows::core::Vtable::vtable(self).GetColumnsRowset)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), rgoptcolumns.len() as _, ::core::mem::transmute(rgoptcolumns.as_ptr()), ::core::mem::transmute(riid), rgpropertysets.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(rgpropertysets.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ::core::mem::transmute(ppcolrowset)).ok()
     }
 }
-impl ::core::convert::From<IColumnsRowset> for ::windows::core::IUnknown {
-    fn from(value: IColumnsRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IColumnsRowset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IColumnsRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IColumnsRowset> for ::windows::core::IUnknown {
-    fn from(value: &IColumnsRowset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IColumnsRowset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IColumnsRowset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3380,21 +3163,7 @@ impl ICommand {
         (::windows::core::Vtable::vtable(self).GetDBSession)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<ICommand> for ::windows::core::IUnknown {
-    fn from(value: ICommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommand> for ::windows::core::IUnknown {
-    fn from(value: &ICommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommand, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICommand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3466,21 +3235,7 @@ impl ICommandCost {
         (::windows::core::Vtable::vtable(self).SetCostLimits)(::windows::core::Vtable::as_raw(self), pwszrowsetname.into(), ccostlimits, ::core::mem::transmute(prgcostlimits), dwexecutionflags).ok()
     }
 }
-impl ::core::convert::From<ICommandCost> for ::windows::core::IUnknown {
-    fn from(value: ICommandCost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommandCost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommandCost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommandCost> for ::windows::core::IUnknown {
-    fn from(value: &ICommandCost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommandCost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICommandCost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3539,21 +3294,7 @@ impl ICommandPersist {
         (::windows::core::Vtable::vtable(self).SaveCommand)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcommandid), dwflags).ok()
     }
 }
-impl ::core::convert::From<ICommandPersist> for ::windows::core::IUnknown {
-    fn from(value: ICommandPersist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommandPersist> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommandPersist) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommandPersist> for ::windows::core::IUnknown {
-    fn from(value: &ICommandPersist) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommandPersist, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICommandPersist {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3608,21 +3349,7 @@ impl ICommandPrepare {
         (::windows::core::Vtable::vtable(self).Unprepare)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ICommandPrepare> for ::windows::core::IUnknown {
-    fn from(value: ICommandPrepare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommandPrepare> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommandPrepare) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommandPrepare> for ::windows::core::IUnknown {
-    fn from(value: &ICommandPrepare) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommandPrepare, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICommandPrepare {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3667,21 +3394,7 @@ impl ICommandProperties {
         (::windows::core::Vtable::vtable(self).SetProperties)(::windows::core::Vtable::as_raw(self), rgpropertysets.len() as _, ::core::mem::transmute(rgpropertysets.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<ICommandProperties> for ::windows::core::IUnknown {
-    fn from(value: ICommandProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommandProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommandProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommandProperties> for ::windows::core::IUnknown {
-    fn from(value: &ICommandProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommandProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICommandProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3731,21 +3444,7 @@ impl ICommandStream {
         (::windows::core::Vtable::vtable(self).SetCommandStream)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(rguiddialect), pcommandstream.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ICommandStream> for ::windows::core::IUnknown {
-    fn from(value: ICommandStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommandStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommandStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommandStream> for ::windows::core::IUnknown {
-    fn from(value: &ICommandStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommandStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICommandStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3802,36 +3501,7 @@ impl ICommandText {
         (::windows::core::Vtable::vtable(self).SetCommandText)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rguiddialect), pwszcommand.into()).ok()
     }
 }
-impl ::core::convert::From<ICommandText> for ::windows::core::IUnknown {
-    fn from(value: ICommandText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommandText> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommandText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommandText> for ::windows::core::IUnknown {
-    fn from(value: &ICommandText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICommandText> for ICommand {
-    fn from(value: ICommandText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommandText> for &'a ICommand {
-    fn from(value: &'a ICommandText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommandText> for ICommand {
-    fn from(value: &ICommandText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommandText, ::windows::core::IUnknown, ICommand);
 impl ::core::clone::Clone for ICommandText {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3872,21 +3542,7 @@ impl ICommandValidate {
         (::windows::core::Vtable::vtable(self).ValidateSyntax)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ICommandValidate> for ::windows::core::IUnknown {
-    fn from(value: ICommandValidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommandValidate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommandValidate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommandValidate> for ::windows::core::IUnknown {
-    fn from(value: &ICommandValidate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommandValidate, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICommandValidate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3933,21 +3589,7 @@ impl ICommandWithParameters {
         (::windows::core::Vtable::vtable(self).SetParameterInfo)(::windows::core::Vtable::as_raw(self), cparams, ::core::mem::transmute(rgparamordinals.unwrap_or(::std::ptr::null())), ::core::mem::transmute(rgparambindinfo.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<ICommandWithParameters> for ::windows::core::IUnknown {
-    fn from(value: ICommandWithParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommandWithParameters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommandWithParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommandWithParameters> for ::windows::core::IUnknown {
-    fn from(value: &ICommandWithParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommandWithParameters, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICommandWithParameters {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4058,59 +3700,7 @@ impl ICondition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICondition> for ::windows::core::IUnknown {
-    fn from(value: ICondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICondition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICondition> for ::windows::core::IUnknown {
-    fn from(value: &ICondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICondition> for super::Com::IPersist {
-    fn from(value: ICondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICondition> for &'a super::Com::IPersist {
-    fn from(value: &'a ICondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICondition> for super::Com::IPersist {
-    fn from(value: &ICondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICondition> for super::Com::IPersistStream {
-    fn from(value: ICondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICondition> for &'a super::Com::IPersistStream {
-    fn from(value: &'a ICondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICondition> for super::Com::IPersistStream {
-    fn from(value: &ICondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICondition, ::windows::core::IUnknown, super::Com::IPersist, super::Com::IPersistStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICondition {
     fn clone(&self) -> Self {
@@ -4247,77 +3837,7 @@ impl ICondition2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICondition2> for ::windows::core::IUnknown {
-    fn from(value: ICondition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICondition2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICondition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICondition2> for ::windows::core::IUnknown {
-    fn from(value: &ICondition2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICondition2> for super::Com::IPersist {
-    fn from(value: ICondition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICondition2> for &'a super::Com::IPersist {
-    fn from(value: &'a ICondition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICondition2> for super::Com::IPersist {
-    fn from(value: &ICondition2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICondition2> for super::Com::IPersistStream {
-    fn from(value: ICondition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICondition2> for &'a super::Com::IPersistStream {
-    fn from(value: &'a ICondition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICondition2> for super::Com::IPersistStream {
-    fn from(value: &ICondition2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICondition2> for ICondition {
-    fn from(value: ICondition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICondition2> for &'a ICondition {
-    fn from(value: &'a ICondition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICondition2> for ICondition {
-    fn from(value: &ICondition2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICondition2, ::windows::core::IUnknown, super::Com::IPersist, super::Com::IPersistStream, ICondition);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICondition2 {
     fn clone(&self) -> Self {
@@ -4405,21 +3925,7 @@ impl IConditionFactory {
         (::windows::core::Vtable::vtable(self).Resolve)(::windows::core::Vtable::as_raw(self), pc.into().abi(), sqro, ::core::mem::transmute(pstreferencetime.unwrap_or(::std::ptr::null())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ICondition>(result__)
     }
 }
-impl ::core::convert::From<IConditionFactory> for ::windows::core::IUnknown {
-    fn from(value: IConditionFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConditionFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConditionFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConditionFactory> for ::windows::core::IUnknown {
-    fn from(value: &IConditionFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConditionFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConditionFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4604,36 +4110,7 @@ impl IConditionFactory2 {
         (::windows::core::Vtable::vtable(self).ResolveCondition)(::windows::core::Vtable::as_raw(self), pc.into().abi(), sqro, ::core::mem::transmute(pstreferencetime.unwrap_or(::std::ptr::null())), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IConditionFactory2> for ::windows::core::IUnknown {
-    fn from(value: IConditionFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConditionFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConditionFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConditionFactory2> for ::windows::core::IUnknown {
-    fn from(value: &IConditionFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IConditionFactory2> for IConditionFactory {
-    fn from(value: IConditionFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConditionFactory2> for &'a IConditionFactory {
-    fn from(value: &'a IConditionFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConditionFactory2> for IConditionFactory {
-    fn from(value: &IConditionFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConditionFactory2, ::windows::core::IUnknown, IConditionFactory);
 impl ::core::clone::Clone for IConditionFactory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4742,21 +4219,7 @@ impl IConditionGenerator {
         (::windows::core::Vtable::vtable(self).DefaultPhrase)(::windows::core::Vtable::as_raw(self), pszvaluetype.into(), ::core::mem::transmute(ppropvar), fuseenglish.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IConditionGenerator> for ::windows::core::IUnknown {
-    fn from(value: IConditionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConditionGenerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConditionGenerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConditionGenerator> for ::windows::core::IUnknown {
-    fn from(value: &IConditionGenerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConditionGenerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConditionGenerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4802,21 +4265,7 @@ impl IConvertType {
         (::windows::core::Vtable::vtable(self).CanConvert)(::windows::core::Vtable::as_raw(self), wfromtype, wtotype, dwconvertflags).ok()
     }
 }
-impl ::core::convert::From<IConvertType> for ::windows::core::IUnknown {
-    fn from(value: IConvertType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConvertType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConvertType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConvertType> for ::windows::core::IUnknown {
-    fn from(value: &IConvertType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConvertType, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConvertType {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4860,21 +4309,7 @@ impl ICreateRow {
         (::windows::core::Vtable::vtable(self).CreateRow)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), pwszurl.into(), dwbindurlflags, ::core::mem::transmute(rguid), ::core::mem::transmute(riid), pauthenticate.into().abi(), ::core::mem::transmute(pimplsession.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pdwbindstatus), ::core::mem::transmute(ppwsznewurl.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ppunk)).ok()
     }
 }
-impl ::core::convert::From<ICreateRow> for ::windows::core::IUnknown {
-    fn from(value: ICreateRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateRow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateRow> for ::windows::core::IUnknown {
-    fn from(value: &ICreateRow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateRow, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICreateRow {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4926,21 +4361,7 @@ impl IDBAsynchNotify {
         (::windows::core::Vtable::vtable(self).OnStop)(::windows::core::Vtable::as_raw(self), hchapter, eoperation, hrstatus, pwszstatustext.into()).ok()
     }
 }
-impl ::core::convert::From<IDBAsynchNotify> for ::windows::core::IUnknown {
-    fn from(value: IDBAsynchNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBAsynchNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBAsynchNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBAsynchNotify> for ::windows::core::IUnknown {
-    fn from(value: &IDBAsynchNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBAsynchNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDBAsynchNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4982,21 +4403,7 @@ impl IDBAsynchStatus {
         (::windows::core::Vtable::vtable(self).GetStatus)(::windows::core::Vtable::as_raw(self), hchapter, eoperation, ::core::mem::transmute(pulprogress.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pulprogressmax.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(peasynchphase), ::core::mem::transmute(ppwszstatustext.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDBAsynchStatus> for ::windows::core::IUnknown {
-    fn from(value: IDBAsynchStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBAsynchStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBAsynchStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBAsynchStatus> for ::windows::core::IUnknown {
-    fn from(value: &IDBAsynchStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBAsynchStatus, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDBAsynchStatus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5049,36 +4456,7 @@ impl IDBBinderProperties {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDBBinderProperties> for ::windows::core::IUnknown {
-    fn from(value: IDBBinderProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBBinderProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBBinderProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBBinderProperties> for ::windows::core::IUnknown {
-    fn from(value: &IDBBinderProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDBBinderProperties> for IDBProperties {
-    fn from(value: IDBBinderProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBBinderProperties> for &'a IDBProperties {
-    fn from(value: &'a IDBBinderProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBBinderProperties> for IDBProperties {
-    fn from(value: &IDBBinderProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBBinderProperties, ::windows::core::IUnknown, IDBProperties);
 impl ::core::clone::Clone for IDBBinderProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5119,21 +4497,7 @@ impl IDBCreateCommand {
         (::windows::core::Vtable::vtable(self).CreateCommand)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IDBCreateCommand> for ::windows::core::IUnknown {
-    fn from(value: IDBCreateCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBCreateCommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBCreateCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBCreateCommand> for ::windows::core::IUnknown {
-    fn from(value: &IDBCreateCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBCreateCommand, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDBCreateCommand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5174,21 +4538,7 @@ impl IDBCreateSession {
         (::windows::core::Vtable::vtable(self).CreateSession)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IDBCreateSession> for ::windows::core::IUnknown {
-    fn from(value: IDBCreateSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBCreateSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBCreateSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBCreateSession> for ::windows::core::IUnknown {
-    fn from(value: &IDBCreateSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBCreateSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDBCreateSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5243,21 +4593,7 @@ impl IDBDataSourceAdmin {
         (::windows::core::Vtable::vtable(self).ModifyDataSource)(::windows::core::Vtable::as_raw(self), rgpropertysets.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(rgpropertysets.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr()))).ok()
     }
 }
-impl ::core::convert::From<IDBDataSourceAdmin> for ::windows::core::IUnknown {
-    fn from(value: IDBDataSourceAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBDataSourceAdmin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBDataSourceAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBDataSourceAdmin> for ::windows::core::IUnknown {
-    fn from(value: &IDBDataSourceAdmin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBDataSourceAdmin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDBDataSourceAdmin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5312,21 +4648,7 @@ impl IDBInfo {
         (::windows::core::Vtable::vtable(self).GetLiteralInfo)(::windows::core::Vtable::as_raw(self), rgliterals.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(rgliterals.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ::core::mem::transmute(pcliteralinfo), ::core::mem::transmute(prgliteralinfo), ::core::mem::transmute(ppcharbuffer)).ok()
     }
 }
-impl ::core::convert::From<IDBInfo> for ::windows::core::IUnknown {
-    fn from(value: IDBInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBInfo> for ::windows::core::IUnknown {
-    fn from(value: &IDBInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDBInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5370,21 +4692,7 @@ impl IDBInitialize {
         (::windows::core::Vtable::vtable(self).Uninitialize)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IDBInitialize> for ::windows::core::IUnknown {
-    fn from(value: IDBInitialize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBInitialize> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBInitialize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBInitialize> for ::windows::core::IUnknown {
-    fn from(value: &IDBInitialize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBInitialize, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDBInitialize {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5440,21 +4748,7 @@ impl IDBPromptInitialize {
         (::windows::core::Vtable::vtable(self).PromptFileName)(::windows::core::Vtable::as_raw(self), hwndparent.into(), dwpromptoptions, pwszinitialdirectory.into(), pwszinitialfile.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IDBPromptInitialize> for ::windows::core::IUnknown {
-    fn from(value: IDBPromptInitialize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBPromptInitialize> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBPromptInitialize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBPromptInitialize> for ::windows::core::IUnknown {
-    fn from(value: &IDBPromptInitialize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBPromptInitialize, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDBPromptInitialize {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5510,21 +4804,7 @@ impl IDBProperties {
         (::windows::core::Vtable::vtable(self).SetProperties)(::windows::core::Vtable::as_raw(self), rgpropertysets.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(rgpropertysets.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr()))).ok()
     }
 }
-impl ::core::convert::From<IDBProperties> for ::windows::core::IUnknown {
-    fn from(value: IDBProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBProperties> for ::windows::core::IUnknown {
-    fn from(value: &IDBProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDBProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5579,21 +4859,7 @@ impl IDBSchemaCommand {
         (::windows::core::Vtable::vtable(self).GetSchemas)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcschemas), ::core::mem::transmute(prgschemas)).ok()
     }
 }
-impl ::core::convert::From<IDBSchemaCommand> for ::windows::core::IUnknown {
-    fn from(value: IDBSchemaCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBSchemaCommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBSchemaCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBSchemaCommand> for ::windows::core::IUnknown {
-    fn from(value: &IDBSchemaCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBSchemaCommand, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDBSchemaCommand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5650,21 +4916,7 @@ impl IDBSchemaRowset {
         (::windows::core::Vtable::vtable(self).GetSchemas)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcschemas), ::core::mem::transmute(prgschemas.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(prgrestrictionsupport.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IDBSchemaRowset> for ::windows::core::IUnknown {
-    fn from(value: IDBSchemaRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDBSchemaRowset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDBSchemaRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDBSchemaRowset> for ::windows::core::IUnknown {
-    fn from(value: &IDBSchemaRowset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDBSchemaRowset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDBSchemaRowset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5713,21 +4965,7 @@ impl IDCInfo {
         (::windows::core::Vtable::vtable(self).SetInfo)(::windows::core::Vtable::as_raw(self), rginfo.len() as _, ::core::mem::transmute(rginfo.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IDCInfo> for ::windows::core::IUnknown {
-    fn from(value: IDCInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDCInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDCInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDCInfo> for ::windows::core::IUnknown {
-    fn from(value: &IDCInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDCInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDCInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5777,21 +5015,7 @@ impl IDataConvert {
         (::windows::core::Vtable::vtable(self).GetConversionSize)(::windows::core::Vtable::as_raw(self), wsrctype, wdsttype, ::core::mem::transmute(pcbsrclength.unwrap_or(::std::ptr::null())), ::core::mem::transmute(pcbdstlength.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(psrc.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IDataConvert> for ::windows::core::IUnknown {
-    fn from(value: IDataConvert) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataConvert> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataConvert) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataConvert> for ::windows::core::IUnknown {
-    fn from(value: &IDataConvert) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataConvert, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataConvert {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5872,21 +5096,7 @@ impl IDataInitialize {
         (::windows::core::Vtable::vtable(self).WriteStringToStorage)(::windows::core::Vtable::as_raw(self), pwszfilename.into(), pwszinitializationstring.into(), dwcreationdisposition).ok()
     }
 }
-impl ::core::convert::From<IDataInitialize> for ::windows::core::IUnknown {
-    fn from(value: IDataInitialize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataInitialize> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataInitialize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataInitialize> for ::windows::core::IUnknown {
-    fn from(value: &IDataInitialize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataInitialize, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataInitialize {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5956,41 +5166,7 @@ impl IDataSourceLocator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataSourceLocator> for ::windows::core::IUnknown {
-    fn from(value: IDataSourceLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataSourceLocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataSourceLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataSourceLocator> for ::windows::core::IUnknown {
-    fn from(value: &IDataSourceLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDataSourceLocator> for super::Com::IDispatch {
-    fn from(value: IDataSourceLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDataSourceLocator> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDataSourceLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDataSourceLocator> for super::Com::IDispatch {
-    fn from(value: &IDataSourceLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataSourceLocator, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDataSourceLocator {
     fn clone(&self) -> Self {
@@ -6093,21 +5269,7 @@ impl IEntity {
         (::windows::core::Vtable::vtable(self).DefaultPhrase)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IEntity> for ::windows::core::IUnknown {
-    fn from(value: IEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEntity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEntity> for ::windows::core::IUnknown {
-    fn from(value: &IEntity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEntity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEntity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6167,21 +5329,7 @@ impl IEnumItemProperties {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumItemProperties> for ::windows::core::IUnknown {
-    fn from(value: IEnumItemProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumItemProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumItemProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumItemProperties> for ::windows::core::IUnknown {
-    fn from(value: &IEnumItemProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumItemProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumItemProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6235,21 +5383,7 @@ impl IEnumSearchRoots {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSearchRoots>(result__)
     }
 }
-impl ::core::convert::From<IEnumSearchRoots> for ::windows::core::IUnknown {
-    fn from(value: IEnumSearchRoots) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSearchRoots> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSearchRoots) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSearchRoots> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSearchRoots) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSearchRoots, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSearchRoots {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6299,21 +5433,7 @@ impl IEnumSearchScopeRules {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSearchScopeRules>(result__)
     }
 }
-impl ::core::convert::From<IEnumSearchScopeRules> for ::windows::core::IUnknown {
-    fn from(value: IEnumSearchScopeRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSearchScopeRules> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSearchScopeRules) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSearchScopeRules> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSearchScopeRules) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSearchScopeRules, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSearchScopeRules {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6367,21 +5487,7 @@ impl IEnumSubscription {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IEnumSubscription> for ::windows::core::IUnknown {
-    fn from(value: IEnumSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSubscription> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSubscription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSubscription> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSubscription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSubscription, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSubscription {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6430,21 +5536,7 @@ impl IErrorLookup {
         (::windows::core::Vtable::vtable(self).ReleaseErrors)(::windows::core::Vtable::as_raw(self), dwdynamicerrorid).ok()
     }
 }
-impl ::core::convert::From<IErrorLookup> for ::windows::core::IUnknown {
-    fn from(value: IErrorLookup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IErrorLookup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IErrorLookup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IErrorLookup> for ::windows::core::IUnknown {
-    fn from(value: &IErrorLookup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IErrorLookup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IErrorLookup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6515,21 +5607,7 @@ impl IErrorRecords {
         (::windows::core::Vtable::vtable(self).GetRecordCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IErrorRecords> for ::windows::core::IUnknown {
-    fn from(value: IErrorRecords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IErrorRecords> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IErrorRecords) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IErrorRecords> for ::windows::core::IUnknown {
-    fn from(value: &IErrorRecords) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IErrorRecords, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IErrorRecords {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6581,21 +5659,7 @@ impl IGetDataSource {
         (::windows::core::Vtable::vtable(self).GetDataSource)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IGetDataSource> for ::windows::core::IUnknown {
-    fn from(value: IGetDataSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetDataSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetDataSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetDataSource> for ::windows::core::IUnknown {
-    fn from(value: &IGetDataSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetDataSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetDataSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6640,21 +5704,7 @@ impl IGetRow {
         (::windows::core::Vtable::vtable(self).GetURLFromHROW)(::windows::core::Vtable::as_raw(self), hrow, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IGetRow> for ::windows::core::IUnknown {
-    fn from(value: IGetRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetRow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetRow> for ::windows::core::IUnknown {
-    fn from(value: &IGetRow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetRow, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetRow {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6693,21 +5743,7 @@ impl IGetSession {
         (::windows::core::Vtable::vtable(self).GetSession)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IGetSession> for ::windows::core::IUnknown {
-    fn from(value: IGetSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetSession> for ::windows::core::IUnknown {
-    fn from(value: &IGetSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6745,21 +5781,7 @@ impl IGetSourceRow {
         (::windows::core::Vtable::vtable(self).GetSourceRow)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IGetSourceRow> for ::windows::core::IUnknown {
-    fn from(value: IGetSourceRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetSourceRow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetSourceRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetSourceRow> for ::windows::core::IUnknown {
-    fn from(value: &IGetSourceRow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetSourceRow, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetSourceRow {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6803,21 +5825,7 @@ impl IIndexDefinition {
         (::windows::core::Vtable::vtable(self).DropIndex)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptableid), ::core::mem::transmute(pindexid.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IIndexDefinition> for ::windows::core::IUnknown {
-    fn from(value: IIndexDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIndexDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIndexDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIndexDefinition> for ::windows::core::IUnknown {
-    fn from(value: &IIndexDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIndexDefinition, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IIndexDefinition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6863,21 +5871,7 @@ impl IInterval {
         (::windows::core::Vtable::vtable(self).GetLimits)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pilklower), ::core::mem::transmute(ppropvarlower), ::core::mem::transmute(pilkupper), ::core::mem::transmute(ppropvarupper)).ok()
     }
 }
-impl ::core::convert::From<IInterval> for ::windows::core::IUnknown {
-    fn from(value: IInterval) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInterval> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInterval) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInterval> for ::windows::core::IUnknown {
-    fn from(value: &IInterval) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInterval, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInterval {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6945,21 +5939,7 @@ impl ILoadFilter {
         (::windows::core::Vtable::vtable(self).LoadIFilterFromStream)(::windows::core::Vtable::as_raw(self), pstm.into().abi(), ::core::mem::transmute(pfilteredsources), punkouter.into().abi(), fusedefault.into(), ::core::mem::transmute(pfilterclsid), ::core::mem::transmute(searchdecsize), ::core::mem::transmute(pwcssearchdesc), ::core::mem::transmute(ppifilt)).ok()
     }
 }
-impl ::core::convert::From<ILoadFilter> for ::windows::core::IUnknown {
-    fn from(value: ILoadFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILoadFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILoadFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILoadFilter> for ::windows::core::IUnknown {
-    fn from(value: &ILoadFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILoadFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILoadFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7043,36 +6023,7 @@ impl ILoadFilterWithPrivateComActivation {
         (::windows::core::Vtable::vtable(self).LoadIFilterWithPrivateComActivation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(filteredsources), usedefault.into(), ::core::mem::transmute(filterclsid), ::core::mem::transmute(isfilterprivatecomactivated), ::core::mem::transmute(filterobj)).ok()
     }
 }
-impl ::core::convert::From<ILoadFilterWithPrivateComActivation> for ::windows::core::IUnknown {
-    fn from(value: ILoadFilterWithPrivateComActivation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILoadFilterWithPrivateComActivation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILoadFilterWithPrivateComActivation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILoadFilterWithPrivateComActivation> for ::windows::core::IUnknown {
-    fn from(value: &ILoadFilterWithPrivateComActivation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILoadFilterWithPrivateComActivation> for ILoadFilter {
-    fn from(value: ILoadFilterWithPrivateComActivation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILoadFilterWithPrivateComActivation> for &'a ILoadFilter {
-    fn from(value: &'a ILoadFilterWithPrivateComActivation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILoadFilterWithPrivateComActivation> for ILoadFilter {
-    fn from(value: &ILoadFilterWithPrivateComActivation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILoadFilterWithPrivateComActivation, ::windows::core::IUnknown, ILoadFilter);
 impl ::core::clone::Clone for ILoadFilterWithPrivateComActivation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7133,21 +6084,7 @@ impl IMDDataset {
         (::windows::core::Vtable::vtable(self).GetSpecification)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IMDDataset> for ::windows::core::IUnknown {
-    fn from(value: IMDDataset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDDataset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDDataset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDDataset> for ::windows::core::IUnknown {
-    fn from(value: &IMDDataset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDDataset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDDataset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7194,21 +6131,7 @@ impl IMDFind {
         (::windows::core::Vtable::vtable(self).FindTuple)(::windows::core::Vtable::as_raw(self), ulaxisidentifier, ulstartingordinal, cmembers, ::core::mem::transmute(rgpwszmember), ::core::mem::transmute(pultupleordinal)).ok()
     }
 }
-impl ::core::convert::From<IMDFind> for ::windows::core::IUnknown {
-    fn from(value: IMDFind) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDFind> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDFind) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDFind> for ::windows::core::IUnknown {
-    fn from(value: &IMDFind) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDFind, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDFind {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7251,21 +6174,7 @@ impl IMDRangeRowset {
         (::windows::core::Vtable::vtable(self).GetRangeRowset)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), ulstartcell, ulendcell, ::core::mem::transmute(riid), cpropertysets, ::core::mem::transmute(rgpropertysets), ::core::mem::transmute(pprowset)).ok()
     }
 }
-impl ::core::convert::From<IMDRangeRowset> for ::windows::core::IUnknown {
-    fn from(value: IMDRangeRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMDRangeRowset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMDRangeRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMDRangeRowset> for ::windows::core::IUnknown {
-    fn from(value: &IMDRangeRowset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMDRangeRowset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMDRangeRowset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7305,21 +6214,7 @@ impl IMetaData {
         (::windows::core::Vtable::vtable(self).GetData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppszkey.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ppszvalue.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMetaData> for ::windows::core::IUnknown {
-    fn from(value: IMetaData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMetaData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMetaData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMetaData> for ::windows::core::IUnknown {
-    fn from(value: &IMetaData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMetaData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMetaData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7359,21 +6254,7 @@ impl IMultipleResults {
         (::windows::core::Vtable::vtable(self).GetResult)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), lresultflag, ::core::mem::transmute(riid), ::core::mem::transmute(pcrowsaffected.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pprowset.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IMultipleResults> for ::windows::core::IUnknown {
-    fn from(value: IMultipleResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMultipleResults> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultipleResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMultipleResults> for ::windows::core::IUnknown {
-    fn from(value: &IMultipleResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultipleResults, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMultipleResults {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7415,21 +6296,7 @@ impl INamedEntity {
         (::windows::core::Vtable::vtable(self).DefaultPhrase)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<INamedEntity> for ::windows::core::IUnknown {
-    fn from(value: INamedEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INamedEntity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INamedEntity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INamedEntity> for ::windows::core::IUnknown {
-    fn from(value: &INamedEntity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INamedEntity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INamedEntity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7471,21 +6338,7 @@ impl INamedEntityCollector {
         (::windows::core::Vtable::vtable(self).Add)(::windows::core::Vtable::as_raw(self), beginspan, endspan, beginactual, endactual, ptype.into().abi(), pszvalue.into(), certainty).ok()
     }
 }
-impl ::core::convert::From<INamedEntityCollector> for ::windows::core::IUnknown {
-    fn from(value: INamedEntityCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INamedEntityCollector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INamedEntityCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INamedEntityCollector> for ::windows::core::IUnknown {
-    fn from(value: &INamedEntityCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INamedEntityCollector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INamedEntityCollector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7544,21 +6397,7 @@ impl IObjectAccessControl {
         (::windows::core::Vtable::vtable(self).SetObjectOwner)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pobject), ::core::mem::transmute(powner)).ok()
     }
 }
-impl ::core::convert::From<IObjectAccessControl> for ::windows::core::IUnknown {
-    fn from(value: IObjectAccessControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectAccessControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectAccessControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectAccessControl> for ::windows::core::IUnknown {
-    fn from(value: &IObjectAccessControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectAccessControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectAccessControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7629,21 +6468,7 @@ impl IOpLockStatus {
         (::windows::core::Vtable::vtable(self).GetOplockEventHandle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::HANDLE>(result__)
     }
 }
-impl ::core::convert::From<IOpLockStatus> for ::windows::core::IUnknown {
-    fn from(value: IOpLockStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpLockStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpLockStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpLockStatus> for ::windows::core::IUnknown {
-    fn from(value: &IOpLockStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpLockStatus, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpLockStatus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7696,21 +6521,7 @@ impl IOpenRowset {
         (::windows::core::Vtable::vtable(self).OpenRowset)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), ::core::mem::transmute(ptableid.unwrap_or(::std::ptr::null())), ::core::mem::transmute(pindexid.unwrap_or(::std::ptr::null())), ::core::mem::transmute(riid), rgpropertysets.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(rgpropertysets.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ::core::mem::transmute(pprowset.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IOpenRowset> for ::windows::core::IUnknown {
-    fn from(value: IOpenRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpenRowset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpenRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpenRowset> for ::windows::core::IUnknown {
-    fn from(value: &IOpenRowset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpenRowset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpenRowset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7754,21 +6565,7 @@ impl IParentRowset {
         (::windows::core::Vtable::vtable(self).GetChildRowset)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), iordinal, ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IParentRowset> for ::windows::core::IUnknown {
-    fn from(value: IParentRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IParentRowset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IParentRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IParentRowset> for ::windows::core::IUnknown {
-    fn from(value: &IParentRowset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IParentRowset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IParentRowset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7811,21 +6608,7 @@ impl IProtocolHandlerSite {
         (::windows::core::Vtable::vtable(self).GetFilter)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pclsidobj), pcwszcontenttype.into(), pcwszextension.into(), ::core::mem::transmute(ppfilter)).ok()
     }
 }
-impl ::core::convert::From<IProtocolHandlerSite> for ::windows::core::IUnknown {
-    fn from(value: IProtocolHandlerSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProtocolHandlerSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProtocolHandlerSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProtocolHandlerSite> for ::windows::core::IUnknown {
-    fn from(value: &IProtocolHandlerSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProtocolHandlerSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProtocolHandlerSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7868,21 +6651,7 @@ impl IProvideMoniker {
         (::windows::core::Vtable::vtable(self).GetMoniker)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::IMoniker>(result__)
     }
 }
-impl ::core::convert::From<IProvideMoniker> for ::windows::core::IUnknown {
-    fn from(value: IProvideMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvideMoniker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvideMoniker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvideMoniker> for ::windows::core::IUnknown {
-    fn from(value: &IProvideMoniker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvideMoniker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProvideMoniker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7979,21 +6748,7 @@ impl IQueryParser {
         (::windows::core::Vtable::vtable(self).RestatePropertyValueToString)(::windows::core::Vtable::as_raw(self), pcondition.into().abi(), fuseenglish.into(), ::core::mem::transmute(ppszpropertyname), ::core::mem::transmute(ppszquerystring)).ok()
     }
 }
-impl ::core::convert::From<IQueryParser> for ::windows::core::IUnknown {
-    fn from(value: IQueryParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQueryParser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryParser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQueryParser> for ::windows::core::IUnknown {
-    fn from(value: &IQueryParser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryParser, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IQueryParser {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8075,21 +6830,7 @@ impl IQueryParserManager {
         (::windows::core::Vtable::vtable(self).SetOption)(::windows::core::Vtable::as_raw(self), option, ::core::mem::transmute(poptionvalue)).ok()
     }
 }
-impl ::core::convert::From<IQueryParserManager> for ::windows::core::IUnknown {
-    fn from(value: IQueryParserManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQueryParserManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryParserManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQueryParserManager> for ::windows::core::IUnknown {
-    fn from(value: &IQueryParserManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryParserManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IQueryParserManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8189,36 +6930,7 @@ impl IQuerySolution {
         (::windows::core::Vtable::vtable(self).GetLexicalData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppszinputstring.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pptokens.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(plcid.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ppwordbreaker.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IQuerySolution> for ::windows::core::IUnknown {
-    fn from(value: IQuerySolution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQuerySolution> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQuerySolution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQuerySolution> for ::windows::core::IUnknown {
-    fn from(value: &IQuerySolution) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IQuerySolution> for IConditionFactory {
-    fn from(value: IQuerySolution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQuerySolution> for &'a IConditionFactory {
-    fn from(value: &'a IQuerySolution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQuerySolution> for IConditionFactory {
-    fn from(value: &IQuerySolution) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQuerySolution, ::windows::core::IUnknown, IConditionFactory);
 impl ::core::clone::Clone for IQuerySolution {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8266,21 +6978,7 @@ impl IReadData {
         (::windows::core::Vtable::vtable(self).ReleaseChapter)(::windows::core::Vtable::as_raw(self), hchapter).ok()
     }
 }
-impl ::core::convert::From<IReadData> for ::windows::core::IUnknown {
-    fn from(value: IReadData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IReadData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IReadData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IReadData> for ::windows::core::IUnknown {
-    fn from(value: &IReadData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IReadData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IReadData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8334,21 +7032,7 @@ impl IRegisterProvider {
         (::windows::core::Vtable::vtable(self).UnregisterProvider)(::windows::core::Vtable::as_raw(self), pwszurl.into(), dwreserved, ::core::mem::transmute(rclsidprovider.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IRegisterProvider> for ::windows::core::IUnknown {
-    fn from(value: IRegisterProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRegisterProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRegisterProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRegisterProvider> for ::windows::core::IUnknown {
-    fn from(value: &IRegisterProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRegisterProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRegisterProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8409,21 +7093,7 @@ impl IRelationship {
         (::windows::core::Vtable::vtable(self).DefaultPhrase)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IRelationship> for ::windows::core::IUnknown {
-    fn from(value: IRelationship) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRelationship> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRelationship) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRelationship> for ::windows::core::IUnknown {
-    fn from(value: &IRelationship) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRelationship, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRelationship {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8469,21 +7139,7 @@ impl IRichChunk {
         (::windows::core::Vtable::vtable(self).GetData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfirstpos.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(plength.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ppsz.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pvalue.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IRichChunk> for ::windows::core::IUnknown {
-    fn from(value: IRichChunk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRichChunk> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRichChunk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRichChunk> for ::windows::core::IUnknown {
-    fn from(value: &IRichChunk) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRichChunk, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRichChunk {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8537,21 +7193,7 @@ impl IRow {
         (::windows::core::Vtable::vtable(self).Open)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), ::core::mem::transmute(pcolumnid), ::core::mem::transmute(rguidcolumntype), dwbindflags, ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IRow> for ::windows::core::IUnknown {
-    fn from(value: IRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRow> for ::windows::core::IUnknown {
-    fn from(value: &IRow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRow, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRow {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8598,21 +7240,7 @@ impl IRowChange {
         (::windows::core::Vtable::vtable(self).SetColumns)(::windows::core::Vtable::as_raw(self), rgcolumns.len() as _, ::core::mem::transmute(rgcolumns.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IRowChange> for ::windows::core::IUnknown {
-    fn from(value: IRowChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowChange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowChange> for ::windows::core::IUnknown {
-    fn from(value: &IRowChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowChange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowChange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8668,21 +7296,7 @@ impl IRowPosition {
         (::windows::core::Vtable::vtable(self).SetRowPosition)(::windows::core::Vtable::as_raw(self), hchapter, hrow, dwpositionflags).ok()
     }
 }
-impl ::core::convert::From<IRowPosition> for ::windows::core::IUnknown {
-    fn from(value: IRowPosition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowPosition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowPosition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowPosition> for ::windows::core::IUnknown {
-    fn from(value: &IRowPosition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowPosition, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowPosition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8728,21 +7342,7 @@ impl IRowPositionChange {
         (::windows::core::Vtable::vtable(self).OnRowPositionChange)(::windows::core::Vtable::as_raw(self), ereason, ephase, fcantdeny.into()).ok()
     }
 }
-impl ::core::convert::From<IRowPositionChange> for ::windows::core::IUnknown {
-    fn from(value: IRowPositionChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowPositionChange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowPositionChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowPositionChange> for ::windows::core::IUnknown {
-    fn from(value: &IRowPositionChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowPositionChange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowPositionChange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8794,36 +7394,7 @@ impl IRowSchemaChange {
         (::windows::core::Vtable::vtable(self).AddColumns)(::windows::core::Vtable::as_raw(self), ccolumns, ::core::mem::transmute(rgnewcolumninfo), ::core::mem::transmute(rgcolumns)).ok()
     }
 }
-impl ::core::convert::From<IRowSchemaChange> for ::windows::core::IUnknown {
-    fn from(value: IRowSchemaChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowSchemaChange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowSchemaChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowSchemaChange> for ::windows::core::IUnknown {
-    fn from(value: &IRowSchemaChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRowSchemaChange> for IRowChange {
-    fn from(value: IRowSchemaChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowSchemaChange> for &'a IRowChange {
-    fn from(value: &'a IRowSchemaChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowSchemaChange> for IRowChange {
-    fn from(value: &IRowSchemaChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowSchemaChange, ::windows::core::IUnknown, IRowChange);
 impl ::core::clone::Clone for IRowSchemaChange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8882,21 +7453,7 @@ impl IRowset {
         (::windows::core::Vtable::vtable(self).RestartPosition)(::windows::core::Vtable::as_raw(self), hreserved).ok()
     }
 }
-impl ::core::convert::From<IRowset> for ::windows::core::IUnknown {
-    fn from(value: IRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowset> for ::windows::core::IUnknown {
-    fn from(value: &IRowset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8942,21 +7499,7 @@ impl IRowsetAsynch {
         (::windows::core::Vtable::vtable(self).Stop)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IRowsetAsynch> for ::windows::core::IUnknown {
-    fn from(value: IRowsetAsynch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetAsynch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetAsynch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetAsynch> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetAsynch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetAsynch, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetAsynch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8997,21 +7540,7 @@ impl IRowsetBookmark {
         (::windows::core::Vtable::vtable(self).PositionOnBookmark)(::windows::core::Vtable::as_raw(self), hchapter, pbookmark.len() as _, ::core::mem::transmute(pbookmark.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IRowsetBookmark> for ::windows::core::IUnknown {
-    fn from(value: IRowsetBookmark) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetBookmark> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetBookmark) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetBookmark> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetBookmark) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetBookmark, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetBookmark {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9060,21 +7589,7 @@ impl IRowsetChange {
         (::windows::core::Vtable::vtable(self).InsertRow)(::windows::core::Vtable::as_raw(self), hreserved, haccessor.into(), ::core::mem::transmute(pdata), ::core::mem::transmute(phrow)).ok()
     }
 }
-impl ::core::convert::From<IRowsetChange> for ::windows::core::IUnknown {
-    fn from(value: IRowsetChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetChange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetChange> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetChange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetChange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9116,21 +7631,7 @@ impl IRowsetChangeExtInfo {
         (::windows::core::Vtable::vtable(self).GetPendingColumns)(::windows::core::Vtable::as_raw(self), hreserved, hrow, ccolumnordinals, ::core::mem::transmute(rgiordinals), ::core::mem::transmute(rgcolumnstatus)).ok()
     }
 }
-impl ::core::convert::From<IRowsetChangeExtInfo> for ::windows::core::IUnknown {
-    fn from(value: IRowsetChangeExtInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetChangeExtInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetChangeExtInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetChangeExtInfo> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetChangeExtInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetChangeExtInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetChangeExtInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9168,21 +7669,7 @@ impl IRowsetChapterMember {
         (::windows::core::Vtable::vtable(self).IsRowInChapter)(::windows::core::Vtable::as_raw(self), hchapter, hrow).ok()
     }
 }
-impl ::core::convert::From<IRowsetChapterMember> for ::windows::core::IUnknown {
-    fn from(value: IRowsetChapterMember) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetChapterMember> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetChapterMember) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetChapterMember> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetChapterMember) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetChapterMember, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetChapterMember {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9231,21 +7718,7 @@ impl IRowsetCopyRows {
         (::windows::core::Vtable::vtable(self).DefineSource)(::windows::core::Vtable::as_raw(self), prowsetsource.into().abi(), ccolids, ::core::mem::transmute(rgsourcecolumns), ::core::mem::transmute(rgtargetcolumns), ::core::mem::transmute(phsourceid)).ok()
     }
 }
-impl ::core::convert::From<IRowsetCopyRows> for ::windows::core::IUnknown {
-    fn from(value: IRowsetCopyRows) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetCopyRows> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetCopyRows) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetCopyRows> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetCopyRows) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetCopyRows, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetCopyRows {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9309,36 +7782,7 @@ impl IRowsetCurrentIndex {
         (::windows::core::Vtable::vtable(self).SetIndex)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pindexid)).ok()
     }
 }
-impl ::core::convert::From<IRowsetCurrentIndex> for ::windows::core::IUnknown {
-    fn from(value: IRowsetCurrentIndex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetCurrentIndex> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetCurrentIndex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetCurrentIndex> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetCurrentIndex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRowsetCurrentIndex> for IRowsetIndex {
-    fn from(value: IRowsetCurrentIndex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetCurrentIndex> for &'a IRowsetIndex {
-    fn from(value: &'a IRowsetCurrentIndex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetCurrentIndex> for IRowsetIndex {
-    fn from(value: &IRowsetCurrentIndex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetCurrentIndex, ::windows::core::IUnknown, IRowsetIndex);
 impl ::core::clone::Clone for IRowsetCurrentIndex {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9399,21 +7843,7 @@ impl IRowsetEvents {
         (::windows::core::Vtable::vtable(self).OnRowsetEvent)(::windows::core::Vtable::as_raw(self), eventtype, ::core::mem::transmute(eventdata)).ok()
     }
 }
-impl ::core::convert::From<IRowsetEvents> for ::windows::core::IUnknown {
-    fn from(value: IRowsetEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetEvents> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9476,21 +7906,7 @@ impl IRowsetFastLoad {
         (::windows::core::Vtable::vtable(self).Commit)(::windows::core::Vtable::as_raw(self), fdone.into()).ok()
     }
 }
-impl ::core::convert::From<IRowsetFastLoad> for ::windows::core::IUnknown {
-    fn from(value: IRowsetFastLoad) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetFastLoad> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetFastLoad) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetFastLoad> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetFastLoad) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetFastLoad, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetFastLoad {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9534,21 +7950,7 @@ impl IRowsetFind {
         (::windows::core::Vtable::vtable(self).FindNextRow)(::windows::core::Vtable::as_raw(self), hchapter, haccessor.into(), ::core::mem::transmute(pfindvalue), compareop, cbbookmark, ::core::mem::transmute(pbookmark), lrowsoffset, crows, ::core::mem::transmute(pcrowsobtained), ::core::mem::transmute(prghrows)).ok()
     }
 }
-impl ::core::convert::From<IRowsetFind> for ::windows::core::IUnknown {
-    fn from(value: IRowsetFind) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetFind> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetFind) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetFind> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetFind) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetFind, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetFind {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9585,21 +7987,7 @@ impl IRowsetIdentity {
         (::windows::core::Vtable::vtable(self).IsSameRow)(::windows::core::Vtable::as_raw(self), hthisrow, hthatrow).ok()
     }
 }
-impl ::core::convert::From<IRowsetIdentity> for ::windows::core::IUnknown {
-    fn from(value: IRowsetIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetIdentity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetIdentity> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetIdentity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetIdentity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetIdentity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9650,21 +8038,7 @@ impl IRowsetIndex {
         (::windows::core::Vtable::vtable(self).SetRange)(::windows::core::Vtable::as_raw(self), haccessor.into(), cstartkeycolumns, ::core::mem::transmute(pstartdata), cendkeycolumns, ::core::mem::transmute(penddata), dwrangeoptions).ok()
     }
 }
-impl ::core::convert::From<IRowsetIndex> for ::windows::core::IUnknown {
-    fn from(value: IRowsetIndex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetIndex> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetIndex) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetIndex> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetIndex) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetIndex, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetIndex {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9716,21 +8090,7 @@ impl IRowsetInfo {
         (::windows::core::Vtable::vtable(self).GetSpecification)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IRowsetInfo> for ::windows::core::IUnknown {
-    fn from(value: IRowsetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetInfo> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9772,21 +8132,7 @@ impl IRowsetKeys {
         (::windows::core::Vtable::vtable(self).ListKeys)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pccolumns), ::core::mem::transmute(prgcolumns)).ok()
     }
 }
-impl ::core::convert::From<IRowsetKeys> for ::windows::core::IUnknown {
-    fn from(value: IRowsetKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetKeys> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetKeys) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetKeys> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetKeys) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetKeys, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetKeys {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9850,36 +8196,7 @@ impl IRowsetLocate {
         (::windows::core::Vtable::vtable(self).Hash)(::windows::core::Vtable::as_raw(self), hreserved, cbookmarks, ::core::mem::transmute(rgcbbookmarks), ::core::mem::transmute(rgpbookmarks), ::core::mem::transmute(rghashedvalues), ::core::mem::transmute(rgbookmarkstatus)).ok()
     }
 }
-impl ::core::convert::From<IRowsetLocate> for ::windows::core::IUnknown {
-    fn from(value: IRowsetLocate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetLocate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetLocate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetLocate> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetLocate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRowsetLocate> for IRowset {
-    fn from(value: IRowsetLocate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetLocate> for &'a IRowset {
-    fn from(value: &'a IRowsetLocate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetLocate> for IRowset {
-    fn from(value: &IRowsetLocate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetLocate, ::windows::core::IUnknown, IRowset);
 impl ::core::clone::Clone for IRowsetLocate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9922,21 +8239,7 @@ impl IRowsetNewRowAfter {
         (::windows::core::Vtable::vtable(self).SetNewDataAfter)(::windows::core::Vtable::as_raw(self), hchapter, cbbmprevious, ::core::mem::transmute(pbmprevious), haccessor.into(), ::core::mem::transmute(pdata), ::core::mem::transmute(phrow)).ok()
     }
 }
-impl ::core::convert::From<IRowsetNewRowAfter> for ::windows::core::IUnknown {
-    fn from(value: IRowsetNewRowAfter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetNewRowAfter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetNewRowAfter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetNewRowAfter> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetNewRowAfter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetNewRowAfter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetNewRowAfter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9977,21 +8280,7 @@ impl IRowsetNextRowset {
         (::windows::core::Vtable::vtable(self).GetNextRowset)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IRowsetNextRowset> for ::windows::core::IUnknown {
-    fn from(value: IRowsetNextRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetNextRowset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetNextRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetNextRowset> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetNextRowset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetNextRowset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetNextRowset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10052,21 +8341,7 @@ impl IRowsetNotify {
         (::windows::core::Vtable::vtable(self).OnRowsetChange)(::windows::core::Vtable::as_raw(self), prowset.into().abi(), ereason, ephase, fcantdeny.into()).ok()
     }
 }
-impl ::core::convert::From<IRowsetNotify> for ::windows::core::IUnknown {
-    fn from(value: IRowsetNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetNotify> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10120,21 +8395,7 @@ impl IRowsetPrioritization {
         (::windows::core::Vtable::vtable(self).GetScopeStatistics)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(indexeddocumentcount), ::core::mem::transmute(oustandingaddcount), ::core::mem::transmute(oustandingmodifycount)).ok()
     }
 }
-impl ::core::convert::From<IRowsetPrioritization> for ::windows::core::IUnknown {
-    fn from(value: IRowsetPrioritization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetPrioritization> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetPrioritization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetPrioritization> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetPrioritization) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetPrioritization, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetPrioritization {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10176,21 +8437,7 @@ impl IRowsetQueryStatus {
         (::windows::core::Vtable::vtable(self).GetStatusEx)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwstatus), ::core::mem::transmute(pcfiltereddocuments), ::core::mem::transmute(pcdocumentstofilter), ::core::mem::transmute(pdwratiofinisheddenominator), ::core::mem::transmute(pdwratiofinishednumerator), cbbmk, ::core::mem::transmute(pbmk), ::core::mem::transmute(pirowbmk), ::core::mem::transmute(pcrowstotal)).ok()
     }
 }
-impl ::core::convert::From<IRowsetQueryStatus> for ::windows::core::IUnknown {
-    fn from(value: IRowsetQueryStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetQueryStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetQueryStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetQueryStatus> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetQueryStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetQueryStatus, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetQueryStatus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10239,21 +8486,7 @@ impl IRowsetRefresh {
         (::windows::core::Vtable::vtable(self).GetLastVisibleData)(::windows::core::Vtable::as_raw(self), hrow, haccessor.into(), ::core::mem::transmute(pdata)).ok()
     }
 }
-impl ::core::convert::From<IRowsetRefresh> for ::windows::core::IUnknown {
-    fn from(value: IRowsetRefresh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetRefresh> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetRefresh) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetRefresh> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetRefresh) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetRefresh, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetRefresh {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10300,21 +8533,7 @@ impl IRowsetResynch {
         (::windows::core::Vtable::vtable(self).ResynchRows)(::windows::core::Vtable::as_raw(self), crows, ::core::mem::transmute(rghrows), ::core::mem::transmute(pcrowsresynched), ::core::mem::transmute(prghrowsresynched), ::core::mem::transmute(prgrowstatus)).ok()
     }
 }
-impl ::core::convert::From<IRowsetResynch> for ::windows::core::IUnknown {
-    fn from(value: IRowsetResynch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetResynch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetResynch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetResynch> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetResynch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetResynch, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetResynch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10385,51 +8604,7 @@ impl IRowsetScroll {
         (::windows::core::Vtable::vtable(self).GetRowsAtRatio)(::windows::core::Vtable::as_raw(self), hreserved1, hreserved2, ulnumerator, uldenominator, crows, ::core::mem::transmute(pcrowsobtained), ::core::mem::transmute(prghrows)).ok()
     }
 }
-impl ::core::convert::From<IRowsetScroll> for ::windows::core::IUnknown {
-    fn from(value: IRowsetScroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetScroll> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetScroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetScroll> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetScroll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRowsetScroll> for IRowset {
-    fn from(value: IRowsetScroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetScroll> for &'a IRowset {
-    fn from(value: &'a IRowsetScroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetScroll> for IRowset {
-    fn from(value: &IRowsetScroll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRowsetScroll> for IRowsetLocate {
-    fn from(value: IRowsetScroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetScroll> for &'a IRowsetLocate {
-    fn from(value: &'a IRowsetScroll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetScroll> for IRowsetLocate {
-    fn from(value: &IRowsetScroll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetScroll, ::windows::core::IUnknown, IRowset, IRowsetLocate);
 impl ::core::clone::Clone for IRowsetScroll {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10497,36 +8672,7 @@ impl IRowsetUpdate {
         (::windows::core::Vtable::vtable(self).Update)(::windows::core::Vtable::as_raw(self), hreserved, crows, ::core::mem::transmute(rghrows), ::core::mem::transmute(pcrows), ::core::mem::transmute(prgrows), ::core::mem::transmute(prgrowstatus)).ok()
     }
 }
-impl ::core::convert::From<IRowsetUpdate> for ::windows::core::IUnknown {
-    fn from(value: IRowsetUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetUpdate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetUpdate> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRowsetUpdate> for IRowsetChange {
-    fn from(value: IRowsetUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetUpdate> for &'a IRowsetChange {
-    fn from(value: &'a IRowsetUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetUpdate> for IRowsetChange {
-    fn from(value: &IRowsetUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetUpdate, ::windows::core::IUnknown, IRowsetChange);
 impl ::core::clone::Clone for IRowsetUpdate {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10574,21 +8720,7 @@ impl IRowsetView {
         (::windows::core::Vtable::vtable(self).GetView)(::windows::core::Vtable::as_raw(self), hchapter, ::core::mem::transmute(riid), ::core::mem::transmute(phchaptersource), ::core::mem::transmute(ppview)).ok()
     }
 }
-impl ::core::convert::From<IRowsetView> for ::windows::core::IUnknown {
-    fn from(value: IRowsetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetView> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10632,21 +8764,7 @@ impl IRowsetWatchAll {
         (::windows::core::Vtable::vtable(self).StopWatching)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IRowsetWatchAll> for ::windows::core::IUnknown {
-    fn from(value: IRowsetWatchAll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetWatchAll> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetWatchAll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetWatchAll> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetWatchAll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetWatchAll, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetWatchAll {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10688,21 +8806,7 @@ impl IRowsetWatchNotify {
         (::windows::core::Vtable::vtable(self).OnChange)(::windows::core::Vtable::as_raw(self), prowset.into().abi(), echangereason).ok()
     }
 }
-impl ::core::convert::From<IRowsetWatchNotify> for ::windows::core::IUnknown {
-    fn from(value: IRowsetWatchNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetWatchNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetWatchNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetWatchNotify> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetWatchNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetWatchNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetWatchNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10763,36 +8867,7 @@ impl IRowsetWatchRegion {
         (::windows::core::Vtable::vtable(self).ShrinkWatchRegion)(::windows::core::Vtable::as_raw(self), hregion, hchapter, cbbookmark, ::core::mem::transmute(pbookmark), crows).ok()
     }
 }
-impl ::core::convert::From<IRowsetWatchRegion> for ::windows::core::IUnknown {
-    fn from(value: IRowsetWatchRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetWatchRegion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetWatchRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetWatchRegion> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetWatchRegion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRowsetWatchRegion> for IRowsetWatchAll {
-    fn from(value: IRowsetWatchRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetWatchRegion> for &'a IRowsetWatchAll {
-    fn from(value: &'a IRowsetWatchRegion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetWatchRegion> for IRowsetWatchAll {
-    fn from(value: &IRowsetWatchRegion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetWatchRegion, ::windows::core::IUnknown, IRowsetWatchAll);
 impl ::core::clone::Clone for IRowsetWatchRegion {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10839,21 +8914,7 @@ impl IRowsetWithParameters {
         (::windows::core::Vtable::vtable(self).Requery)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pparams), ::core::mem::transmute(pulerrorparam), ::core::mem::transmute(phreserved)).ok()
     }
 }
-impl ::core::convert::From<IRowsetWithParameters> for ::windows::core::IUnknown {
-    fn from(value: IRowsetWithParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRowsetWithParameters> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRowsetWithParameters) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRowsetWithParameters> for ::windows::core::IUnknown {
-    fn from(value: &IRowsetWithParameters) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRowsetWithParameters, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRowsetWithParameters {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10894,21 +8955,7 @@ impl ISQLErrorInfo {
         (::windows::core::Vtable::vtable(self).GetSQLInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbstrsqlstate), ::core::mem::transmute(plnativeerror)).ok()
     }
 }
-impl ::core::convert::From<ISQLErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: ISQLErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISQLErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISQLErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISQLErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISQLErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISQLErrorInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISQLErrorInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10947,21 +8994,7 @@ impl ISQLGetDiagField {
         (::windows::core::Vtable::vtable(self).GetDiagField)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdiaginfo.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<ISQLGetDiagField> for ::windows::core::IUnknown {
-    fn from(value: ISQLGetDiagField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISQLGetDiagField> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISQLGetDiagField) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISQLGetDiagField> for ::windows::core::IUnknown {
-    fn from(value: &ISQLGetDiagField) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISQLGetDiagField, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISQLGetDiagField {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11003,21 +9036,7 @@ impl ISQLRequestDiagFields {
         (::windows::core::Vtable::vtable(self).RequestDiagFields)(::windows::core::Vtable::as_raw(self), rgdiagfields.len() as _, ::core::mem::transmute(rgdiagfields.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<ISQLRequestDiagFields> for ::windows::core::IUnknown {
-    fn from(value: ISQLRequestDiagFields) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISQLRequestDiagFields> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISQLRequestDiagFields) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISQLRequestDiagFields> for ::windows::core::IUnknown {
-    fn from(value: &ISQLRequestDiagFields) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISQLRequestDiagFields, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISQLRequestDiagFields {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11057,21 +9076,7 @@ impl ISQLServerErrorInfo {
         (::windows::core::Vtable::vtable(self).GetErrorInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pperrorinfo), ::core::mem::transmute(ppstringsbuffer)).ok()
     }
 }
-impl ::core::convert::From<ISQLServerErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: ISQLServerErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISQLServerErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISQLServerErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISQLServerErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISQLServerErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISQLServerErrorInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISQLServerErrorInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11112,21 +9117,7 @@ impl ISchemaLocalizerSupport {
         (::windows::core::Vtable::vtable(self).Localize)(::windows::core::Vtable::as_raw(self), pszglobalstring.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ISchemaLocalizerSupport> for ::windows::core::IUnknown {
-    fn from(value: ISchemaLocalizerSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISchemaLocalizerSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaLocalizerSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISchemaLocalizerSupport> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaLocalizerSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaLocalizerSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISchemaLocalizerSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11173,21 +9164,7 @@ impl ISchemaLock {
         (::windows::core::Vtable::vtable(self).ReleaseSchemaLock)(::windows::core::Vtable::as_raw(self), hlockhandle.into()).ok()
     }
 }
-impl ::core::convert::From<ISchemaLock> for ::windows::core::IUnknown {
-    fn from(value: ISchemaLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISchemaLock> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaLock) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISchemaLock> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaLock) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaLock, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISchemaLock {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11273,21 +9250,7 @@ impl ISchemaProvider {
         (::windows::core::Vtable::vtable(self).LookupAuthoredNamedEntity)(::windows::core::Vtable::as_raw(self), pentity.into().abi(), pszinputstring.into(), ptokencollection.into().abi(), ctokensbegin, ::core::mem::transmute(pctokenslength), ::core::mem::transmute(ppszvalue)).ok()
     }
 }
-impl ::core::convert::From<ISchemaProvider> for ::windows::core::IUnknown {
-    fn from(value: ISchemaProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISchemaProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISchemaProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISchemaProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISchemaProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISchemaProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISchemaProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11365,36 +9328,7 @@ impl IScopedOperations {
         (::windows::core::Vtable::vtable(self).OpenRowset)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), ::core::mem::transmute(ptableid.unwrap_or(::std::ptr::null())), ::core::mem::transmute(pindexid.unwrap_or(::std::ptr::null())), ::core::mem::transmute(riid), rgpropertysets.len() as _, ::core::mem::transmute(rgpropertysets.as_ptr()), ::core::mem::transmute(pprowset.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IScopedOperations> for ::windows::core::IUnknown {
-    fn from(value: IScopedOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScopedOperations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IScopedOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScopedOperations> for ::windows::core::IUnknown {
-    fn from(value: &IScopedOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IScopedOperations> for IBindResource {
-    fn from(value: IScopedOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScopedOperations> for &'a IBindResource {
-    fn from(value: &'a IScopedOperations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScopedOperations> for IBindResource {
-    fn from(value: &IScopedOperations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IScopedOperations, ::windows::core::IUnknown, IBindResource);
 impl ::core::clone::Clone for IScopedOperations {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11572,21 +9506,7 @@ impl ISearchCatalogManager {
         (::windows::core::Vtable::vtable(self).GetCrawlScopeManager)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISearchCrawlScopeManager>(result__)
     }
 }
-impl ::core::convert::From<ISearchCatalogManager> for ::windows::core::IUnknown {
-    fn from(value: ISearchCatalogManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchCatalogManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchCatalogManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchCatalogManager> for ::windows::core::IUnknown {
-    fn from(value: &ISearchCatalogManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchCatalogManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchCatalogManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11801,36 +9721,7 @@ impl ISearchCatalogManager2 {
         (::windows::core::Vtable::vtable(self).PrioritizeMatchingURLs)(::windows::core::Vtable::as_raw(self), pszpattern.into(), dwprioritizeflags).ok()
     }
 }
-impl ::core::convert::From<ISearchCatalogManager2> for ::windows::core::IUnknown {
-    fn from(value: ISearchCatalogManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchCatalogManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchCatalogManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchCatalogManager2> for ::windows::core::IUnknown {
-    fn from(value: &ISearchCatalogManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISearchCatalogManager2> for ISearchCatalogManager {
-    fn from(value: ISearchCatalogManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchCatalogManager2> for &'a ISearchCatalogManager {
-    fn from(value: &'a ISearchCatalogManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchCatalogManager2> for ISearchCatalogManager {
-    fn from(value: &ISearchCatalogManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchCatalogManager2, ::windows::core::IUnknown, ISearchCatalogManager);
 impl ::core::clone::Clone for ISearchCatalogManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11974,21 +9865,7 @@ impl ISearchCrawlScopeManager {
         (::windows::core::Vtable::vtable(self).RemoveDefaultScopeRule)(::windows::core::Vtable::as_raw(self), pszurl.into()).ok()
     }
 }
-impl ::core::convert::From<ISearchCrawlScopeManager> for ::windows::core::IUnknown {
-    fn from(value: ISearchCrawlScopeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchCrawlScopeManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchCrawlScopeManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchCrawlScopeManager> for ::windows::core::IUnknown {
-    fn from(value: &ISearchCrawlScopeManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchCrawlScopeManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchCrawlScopeManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12173,36 +10050,7 @@ impl ISearchCrawlScopeManager2 {
         (::windows::core::Vtable::vtable(self).GetVersion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(plversion), ::core::mem::transmute(phfilemapping)).ok()
     }
 }
-impl ::core::convert::From<ISearchCrawlScopeManager2> for ::windows::core::IUnknown {
-    fn from(value: ISearchCrawlScopeManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchCrawlScopeManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchCrawlScopeManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchCrawlScopeManager2> for ::windows::core::IUnknown {
-    fn from(value: &ISearchCrawlScopeManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISearchCrawlScopeManager2> for ISearchCrawlScopeManager {
-    fn from(value: ISearchCrawlScopeManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchCrawlScopeManager2> for &'a ISearchCrawlScopeManager {
-    fn from(value: &'a ISearchCrawlScopeManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchCrawlScopeManager2> for ISearchCrawlScopeManager {
-    fn from(value: &ISearchCrawlScopeManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchCrawlScopeManager2, ::windows::core::IUnknown, ISearchCrawlScopeManager);
 impl ::core::clone::Clone for ISearchCrawlScopeManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12256,21 +10104,7 @@ impl ISearchItemsChangedSink {
         (::windows::core::Vtable::vtable(self).OnItemsChanged)(::windows::core::Vtable::as_raw(self), dwnumberofchanges, ::core::mem::transmute(rgdatachangeentries), ::core::mem::transmute(rgdwdocids), ::core::mem::transmute(rghrcompletioncodes)).ok()
     }
 }
-impl ::core::convert::From<ISearchItemsChangedSink> for ::windows::core::IUnknown {
-    fn from(value: ISearchItemsChangedSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchItemsChangedSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchItemsChangedSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchItemsChangedSink> for ::windows::core::IUnknown {
-    fn from(value: &ISearchItemsChangedSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchItemsChangedSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchItemsChangedSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12333,21 +10167,7 @@ impl ISearchLanguageSupport {
         (::windows::core::Vtable::vtable(self).IsPrefixNormalized)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwcsquerytoken.as_ptr()), pwcsquerytoken.len() as _, ::core::mem::transmute(pwcsdocumenttoken.as_ptr()), pwcsdocumenttoken.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ISearchLanguageSupport> for ::windows::core::IUnknown {
-    fn from(value: ISearchLanguageSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchLanguageSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchLanguageSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchLanguageSupport> for ::windows::core::IUnknown {
-    fn from(value: &ISearchLanguageSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchLanguageSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchLanguageSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12464,21 +10284,7 @@ impl ISearchManager {
         (::windows::core::Vtable::vtable(self).PortNumber)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ISearchManager> for ::windows::core::IUnknown {
-    fn from(value: ISearchManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchManager> for ::windows::core::IUnknown {
-    fn from(value: &ISearchManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12622,36 +10428,7 @@ impl ISearchManager2 {
         (::windows::core::Vtable::vtable(self).DeleteCatalog)(::windows::core::Vtable::as_raw(self), pszcatalog.into()).ok()
     }
 }
-impl ::core::convert::From<ISearchManager2> for ::windows::core::IUnknown {
-    fn from(value: ISearchManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchManager2> for ::windows::core::IUnknown {
-    fn from(value: &ISearchManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISearchManager2> for ISearchManager {
-    fn from(value: ISearchManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchManager2> for &'a ISearchManager {
-    fn from(value: &'a ISearchManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchManager2> for ISearchManager {
-    fn from(value: &ISearchManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchManager2, ::windows::core::IUnknown, ISearchManager);
 impl ::core::clone::Clone for ISearchManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12692,21 +10469,7 @@ impl ISearchNotifyInlineSite {
         (::windows::core::Vtable::vtable(self).OnCatalogStatusChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidcatalogresetsignature), ::core::mem::transmute(guidcheckpointsignature), dwlastcheckpointnumber).ok()
     }
 }
-impl ::core::convert::From<ISearchNotifyInlineSite> for ::windows::core::IUnknown {
-    fn from(value: ISearchNotifyInlineSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchNotifyInlineSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchNotifyInlineSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchNotifyInlineSite> for ::windows::core::IUnknown {
-    fn from(value: &ISearchNotifyInlineSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchNotifyInlineSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchNotifyInlineSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12757,21 +10520,7 @@ impl ISearchPersistentItemsChangedSink {
         (::windows::core::Vtable::vtable(self).OnItemsChanged)(::windows::core::Vtable::as_raw(self), dwnumberofchanges, ::core::mem::transmute(datachangeentries), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::HRESULT>(result__)
     }
 }
-impl ::core::convert::From<ISearchPersistentItemsChangedSink> for ::windows::core::IUnknown {
-    fn from(value: ISearchPersistentItemsChangedSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchPersistentItemsChangedSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchPersistentItemsChangedSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchPersistentItemsChangedSink> for ::windows::core::IUnknown {
-    fn from(value: &ISearchPersistentItemsChangedSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchPersistentItemsChangedSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchPersistentItemsChangedSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12832,21 +10581,7 @@ impl ISearchProtocol {
         (::windows::core::Vtable::vtable(self).ShutDown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISearchProtocol> for ::windows::core::IUnknown {
-    fn from(value: ISearchProtocol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchProtocol> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchProtocol) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchProtocol> for ::windows::core::IUnknown {
-    fn from(value: &ISearchProtocol) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchProtocol, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchProtocol {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12922,36 +10657,7 @@ impl ISearchProtocol2 {
         (::windows::core::Vtable::vtable(self).CreateAccessorEx)(::windows::core::Vtable::as_raw(self), pcwszurl.into(), ::core::mem::transmute(pauthenticationinfo), ::core::mem::transmute(pincrementalaccessinfo), ::core::mem::transmute(piteminfo), ::core::mem::transmute(puserdata), ::core::mem::transmute(ppaccessor)).ok()
     }
 }
-impl ::core::convert::From<ISearchProtocol2> for ::windows::core::IUnknown {
-    fn from(value: ISearchProtocol2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchProtocol2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchProtocol2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchProtocol2> for ::windows::core::IUnknown {
-    fn from(value: &ISearchProtocol2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISearchProtocol2> for ISearchProtocol {
-    fn from(value: ISearchProtocol2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchProtocol2> for &'a ISearchProtocol {
-    fn from(value: &'a ISearchProtocol2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchProtocol2> for ISearchProtocol {
-    fn from(value: &ISearchProtocol2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchProtocol2, ::windows::core::IUnknown, ISearchProtocol);
 impl ::core::clone::Clone for ISearchProtocol2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12997,21 +10703,7 @@ impl ISearchProtocolThreadContext {
         (::windows::core::Vtable::vtable(self).ThreadIdle)(::windows::core::Vtable::as_raw(self), dwtimeelaspedsincelastcallinms).ok()
     }
 }
-impl ::core::convert::From<ISearchProtocolThreadContext> for ::windows::core::IUnknown {
-    fn from(value: ISearchProtocolThreadContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchProtocolThreadContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchProtocolThreadContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchProtocolThreadContext> for ::windows::core::IUnknown {
-    fn from(value: &ISearchProtocolThreadContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchProtocolThreadContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchProtocolThreadContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13138,21 +10830,7 @@ impl ISearchQueryHelper {
         (::windows::core::Vtable::vtable(self).QueryMaxResults)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<ISearchQueryHelper> for ::windows::core::IUnknown {
-    fn from(value: ISearchQueryHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchQueryHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchQueryHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchQueryHelper> for ::windows::core::IUnknown {
-    fn from(value: &ISearchQueryHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchQueryHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchQueryHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13227,21 +10905,7 @@ impl ISearchQueryHits {
         (::windows::core::Vtable::vtable(self).NextHitOffset)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcregion), ::core::mem::transmute(paregion))
     }
 }
-impl ::core::convert::From<ISearchQueryHits> for ::windows::core::IUnknown {
-    fn from(value: ISearchQueryHits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchQueryHits> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchQueryHits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchQueryHits> for ::windows::core::IUnknown {
-    fn from(value: &ISearchQueryHits) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchQueryHits, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchQueryHits {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13403,21 +11067,7 @@ impl ISearchRoot {
         (::windows::core::Vtable::vtable(self).Password)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ISearchRoot> for ::windows::core::IUnknown {
-    fn from(value: ISearchRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchRoot> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchRoot> for ::windows::core::IUnknown {
-    fn from(value: &ISearchRoot) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchRoot, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchRoot {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13516,21 +11166,7 @@ impl ISearchScopeRule {
         (::windows::core::Vtable::vtable(self).FollowFlags)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ISearchScopeRule> for ::windows::core::IUnknown {
-    fn from(value: ISearchScopeRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchScopeRule> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchScopeRule) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchScopeRule> for ::windows::core::IUnknown {
-    fn from(value: &ISearchScopeRule) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchScopeRule, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchScopeRule {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13578,21 +11214,7 @@ impl ISearchViewChangedSink {
         (::windows::core::Vtable::vtable(self).OnChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwdocid), ::core::mem::transmute(pchange), ::core::mem::transmute(pfinview)).ok()
     }
 }
-impl ::core::convert::From<ISearchViewChangedSink> for ::windows::core::IUnknown {
-    fn from(value: ISearchViewChangedSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchViewChangedSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchViewChangedSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchViewChangedSink> for ::windows::core::IUnknown {
-    fn from(value: &ISearchViewChangedSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchViewChangedSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchViewChangedSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13640,21 +11262,7 @@ impl ISecurityInfo {
         (::windows::core::Vtable::vtable(self).GetPermissions)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(objecttype), ::core::mem::transmute(ppermissions)).ok()
     }
 }
-impl ::core::convert::From<ISecurityInfo> for ::windows::core::IUnknown {
-    fn from(value: ISecurityInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISecurityInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISecurityInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISecurityInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISecurityInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISecurityInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISecurityInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13699,21 +11307,7 @@ impl IService {
         (::windows::core::Vtable::vtable(self).InvokeService)(::windows::core::Vtable::as_raw(self), punkinner.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IService> for ::windows::core::IUnknown {
-    fn from(value: IService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IService> for ::windows::core::IUnknown {
-    fn from(value: &IService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13757,21 +11351,7 @@ impl ISessionProperties {
         (::windows::core::Vtable::vtable(self).SetProperties)(::windows::core::Vtable::as_raw(self), rgpropertysets.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(rgpropertysets.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr()))).ok()
     }
 }
-impl ::core::convert::From<ISessionProperties> for ::windows::core::IUnknown {
-    fn from(value: ISessionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISessionProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISessionProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISessionProperties> for ::windows::core::IUnknown {
-    fn from(value: &ISessionProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISessionProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISessionProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13831,21 +11411,7 @@ impl ISimpleCommandCreator {
         (::windows::core::Vtable::vtable(self).GetDefaultCatalog)(::windows::core::Vtable::as_raw(self), pwszcatalogname.into(), cwcin, ::core::mem::transmute(pcwcout)).ok()
     }
 }
-impl ::core::convert::From<ISimpleCommandCreator> for ::windows::core::IUnknown {
-    fn from(value: ISimpleCommandCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISimpleCommandCreator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISimpleCommandCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISimpleCommandCreator> for ::windows::core::IUnknown {
-    fn from(value: &ISimpleCommandCreator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISimpleCommandCreator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISimpleCommandCreator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13889,21 +11455,7 @@ impl ISourcesRowset {
         (::windows::core::Vtable::vtable(self).GetSourcesRowset)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), ::core::mem::transmute(riid), rgproperties.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(rgproperties.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ::core::mem::transmute(ppsourcesrowset)).ok()
     }
 }
-impl ::core::convert::From<ISourcesRowset> for ::windows::core::IUnknown {
-    fn from(value: ISourcesRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISourcesRowset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISourcesRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISourcesRowset> for ::windows::core::IUnknown {
-    fn from(value: &ISourcesRowset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISourcesRowset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISourcesRowset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13955,21 +11507,7 @@ impl IStemmer {
         (::windows::core::Vtable::vtable(self).GetLicenseToUse)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppwcslicense)).ok()
     }
 }
-impl ::core::convert::From<IStemmer> for ::windows::core::IUnknown {
-    fn from(value: IStemmer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStemmer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStemmer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStemmer> for ::windows::core::IUnknown {
-    fn from(value: &IStemmer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStemmer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStemmer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14037,21 +11575,7 @@ impl ISubscriptionItem {
         (::windows::core::Vtable::vtable(self).NotifyChanged)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISubscriptionItem> for ::windows::core::IUnknown {
-    fn from(value: ISubscriptionItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISubscriptionItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISubscriptionItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISubscriptionItem> for ::windows::core::IUnknown {
-    fn from(value: &ISubscriptionItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISubscriptionItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISubscriptionItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14158,21 +11682,7 @@ impl ISubscriptionMgr {
         (::windows::core::Vtable::vtable(self).CreateSubscription)(::windows::core::Vtable::as_raw(self), hwnd.into(), pwszurl.into(), pwszfriendlyname.into(), dwflags, substype, ::core::mem::transmute(pinfo)).ok()
     }
 }
-impl ::core::convert::From<ISubscriptionMgr> for ::windows::core::IUnknown {
-    fn from(value: ISubscriptionMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISubscriptionMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISubscriptionMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISubscriptionMgr> for ::windows::core::IUnknown {
-    fn from(value: &ISubscriptionMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISubscriptionMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISubscriptionMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14320,36 +11830,7 @@ impl ISubscriptionMgr2 {
         (::windows::core::Vtable::vtable(self).AbortAll)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISubscriptionMgr2> for ::windows::core::IUnknown {
-    fn from(value: ISubscriptionMgr2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISubscriptionMgr2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISubscriptionMgr2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISubscriptionMgr2> for ::windows::core::IUnknown {
-    fn from(value: &ISubscriptionMgr2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISubscriptionMgr2> for ISubscriptionMgr {
-    fn from(value: ISubscriptionMgr2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISubscriptionMgr2> for &'a ISubscriptionMgr {
-    fn from(value: &'a ISubscriptionMgr2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISubscriptionMgr2> for ISubscriptionMgr {
-    fn from(value: &ISubscriptionMgr2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISubscriptionMgr2, ::windows::core::IUnknown, ISubscriptionMgr);
 impl ::core::clone::Clone for ISubscriptionMgr2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14441,36 +11922,7 @@ impl ITableCreation {
         .ok()
     }
 }
-impl ::core::convert::From<ITableCreation> for ::windows::core::IUnknown {
-    fn from(value: ITableCreation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITableCreation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITableCreation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITableCreation> for ::windows::core::IUnknown {
-    fn from(value: &ITableCreation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITableCreation> for ITableDefinition {
-    fn from(value: ITableCreation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITableCreation> for &'a ITableDefinition {
-    fn from(value: &'a ITableCreation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITableCreation> for ITableDefinition {
-    fn from(value: &ITableCreation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITableCreation, ::windows::core::IUnknown, ITableDefinition);
 impl ::core::clone::Clone for ITableCreation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14543,21 +11995,7 @@ impl ITableDefinition {
         (::windows::core::Vtable::vtable(self).DropColumn)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptableid), ::core::mem::transmute(pcolumnid)).ok()
     }
 }
-impl ::core::convert::From<ITableDefinition> for ::windows::core::IUnknown {
-    fn from(value: ITableDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITableDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITableDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITableDefinition> for ::windows::core::IUnknown {
-    fn from(value: &ITableDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITableDefinition, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITableDefinition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14676,51 +12114,7 @@ impl ITableDefinitionWithConstraints {
         (::windows::core::Vtable::vtable(self).DropConstraint)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptableid), ::core::mem::transmute(pconstraintid)).ok()
     }
 }
-impl ::core::convert::From<ITableDefinitionWithConstraints> for ::windows::core::IUnknown {
-    fn from(value: ITableDefinitionWithConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITableDefinitionWithConstraints> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITableDefinitionWithConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITableDefinitionWithConstraints> for ::windows::core::IUnknown {
-    fn from(value: &ITableDefinitionWithConstraints) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITableDefinitionWithConstraints> for ITableDefinition {
-    fn from(value: ITableDefinitionWithConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITableDefinitionWithConstraints> for &'a ITableDefinition {
-    fn from(value: &'a ITableDefinitionWithConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITableDefinitionWithConstraints> for ITableDefinition {
-    fn from(value: &ITableDefinitionWithConstraints) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITableDefinitionWithConstraints> for ITableCreation {
-    fn from(value: ITableDefinitionWithConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITableDefinitionWithConstraints> for &'a ITableCreation {
-    fn from(value: &'a ITableDefinitionWithConstraints) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITableDefinitionWithConstraints> for ITableCreation {
-    fn from(value: &ITableDefinitionWithConstraints) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITableDefinitionWithConstraints, ::windows::core::IUnknown, ITableDefinition, ITableCreation);
 impl ::core::clone::Clone for ITableDefinitionWithConstraints {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14775,21 +12169,7 @@ impl ITableRename {
         (::windows::core::Vtable::vtable(self).RenameTable)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(poldtableid), ::core::mem::transmute(poldindexid), ::core::mem::transmute(pnewtableid), ::core::mem::transmute(pnewindexid)).ok()
     }
 }
-impl ::core::convert::From<ITableRename> for ::windows::core::IUnknown {
-    fn from(value: ITableRename) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITableRename> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITableRename) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITableRename> for ::windows::core::IUnknown {
-    fn from(value: &ITableRename) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITableRename, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITableRename {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14836,21 +12216,7 @@ impl ITokenCollection {
         (::windows::core::Vtable::vtable(self).GetToken)(::windows::core::Vtable::as_raw(self), i, ::core::mem::transmute(pbegin.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(plength.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ppsz.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<ITokenCollection> for ::windows::core::IUnknown {
-    fn from(value: ITokenCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITokenCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITokenCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITokenCollection> for ::windows::core::IUnknown {
-    fn from(value: &ITokenCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITokenCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITokenCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14900,21 +12266,7 @@ impl ITransactionJoin {
         (::windows::core::Vtable::vtable(self).JoinTransaction)(::windows::core::Vtable::as_raw(self), punktransactioncoord.into().abi(), isolevel, isoflags, potheroptions.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITransactionJoin> for ::windows::core::IUnknown {
-    fn from(value: ITransactionJoin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionJoin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionJoin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionJoin> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionJoin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionJoin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionJoin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14996,41 +12348,7 @@ impl ITransactionLocal {
     }
 }
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
-impl ::core::convert::From<ITransactionLocal> for ::windows::core::IUnknown {
-    fn from(value: ITransactionLocal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
-impl<'a> ::core::convert::From<&'a ITransactionLocal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionLocal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
-impl ::core::convert::From<&ITransactionLocal> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionLocal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
-impl ::core::convert::From<ITransactionLocal> for super::DistributedTransactionCoordinator::ITransaction {
-    fn from(value: ITransactionLocal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
-impl<'a> ::core::convert::From<&'a ITransactionLocal> for &'a super::DistributedTransactionCoordinator::ITransaction {
-    fn from(value: &'a ITransactionLocal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
-impl ::core::convert::From<&ITransactionLocal> for super::DistributedTransactionCoordinator::ITransaction {
-    fn from(value: &ITransactionLocal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionLocal, ::windows::core::IUnknown, super::DistributedTransactionCoordinator::ITransaction);
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
 impl ::core::clone::Clone for ITransactionLocal {
     fn clone(&self) -> Self {
@@ -15084,21 +12402,7 @@ impl ITransactionObject {
         (::windows::core::Vtable::vtable(self).GetTransactionObject)(::windows::core::Vtable::as_raw(self), ultransactionlevel, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::DistributedTransactionCoordinator::ITransaction>(result__)
     }
 }
-impl ::core::convert::From<ITransactionObject> for ::windows::core::IUnknown {
-    fn from(value: ITransactionObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransactionObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransactionObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransactionObject> for ::windows::core::IUnknown {
-    fn from(value: &ITransactionObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransactionObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransactionObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15160,21 +12464,7 @@ impl ITrusteeAdmin {
         (::windows::core::Vtable::vtable(self).GetTrusteeProperties)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptrustee), cpropertyidsets, ::core::mem::transmute(rgpropertyidsets), ::core::mem::transmute(pcpropertysets), ::core::mem::transmute(prgpropertysets)).ok()
     }
 }
-impl ::core::convert::From<ITrusteeAdmin> for ::windows::core::IUnknown {
-    fn from(value: ITrusteeAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITrusteeAdmin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITrusteeAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITrusteeAdmin> for ::windows::core::IUnknown {
-    fn from(value: &ITrusteeAdmin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITrusteeAdmin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITrusteeAdmin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15252,21 +12542,7 @@ impl ITrusteeGroupAdmin {
         (::windows::core::Vtable::vtable(self).GetMemberships)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptrustee), ::core::mem::transmute(pcmemberships), ::core::mem::transmute(prgmemberships)).ok()
     }
 }
-impl ::core::convert::From<ITrusteeGroupAdmin> for ::windows::core::IUnknown {
-    fn from(value: ITrusteeGroupAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITrusteeGroupAdmin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITrusteeGroupAdmin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITrusteeGroupAdmin> for ::windows::core::IUnknown {
-    fn from(value: &ITrusteeGroupAdmin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITrusteeGroupAdmin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITrusteeGroupAdmin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15384,21 +12660,7 @@ impl IUMSInitialize {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pums)).ok()
     }
 }
-impl ::core::convert::From<IUMSInitialize> for ::windows::core::IUnknown {
-    fn from(value: IUMSInitialize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUMSInitialize> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUMSInitialize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUMSInitialize> for ::windows::core::IUnknown {
-    fn from(value: &IUMSInitialize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUMSInitialize, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUMSInitialize {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15485,21 +12747,7 @@ impl IUrlAccessor {
         (::windows::core::Vtable::vtable(self).BindToFilter)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Storage::IndexServer::IFilter>(result__)
     }
 }
-impl ::core::convert::From<IUrlAccessor> for ::windows::core::IUnknown {
-    fn from(value: IUrlAccessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUrlAccessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUrlAccessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUrlAccessor> for ::windows::core::IUnknown {
-    fn from(value: &IUrlAccessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUrlAccessor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUrlAccessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15619,36 +12867,7 @@ impl IUrlAccessor2 {
         (::windows::core::Vtable::vtable(self).GetCodePage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(wszcodepage), dwsize, ::core::mem::transmute(pdwlength)).ok()
     }
 }
-impl ::core::convert::From<IUrlAccessor2> for ::windows::core::IUnknown {
-    fn from(value: IUrlAccessor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUrlAccessor2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUrlAccessor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUrlAccessor2> for ::windows::core::IUnknown {
-    fn from(value: &IUrlAccessor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUrlAccessor2> for IUrlAccessor {
-    fn from(value: IUrlAccessor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUrlAccessor2> for &'a IUrlAccessor {
-    fn from(value: &'a IUrlAccessor2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUrlAccessor2> for IUrlAccessor {
-    fn from(value: &IUrlAccessor2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUrlAccessor2, ::windows::core::IUnknown, IUrlAccessor);
 impl ::core::clone::Clone for IUrlAccessor2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15754,51 +12973,7 @@ impl IUrlAccessor3 {
         (::windows::core::Vtable::vtable(self).GetImpersonationSidBlobs)(::windows::core::Vtable::as_raw(self), pcwszurl.into(), ::core::mem::transmute(pcsidcount), ::core::mem::transmute(ppsidblobs)).ok()
     }
 }
-impl ::core::convert::From<IUrlAccessor3> for ::windows::core::IUnknown {
-    fn from(value: IUrlAccessor3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUrlAccessor3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUrlAccessor3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUrlAccessor3> for ::windows::core::IUnknown {
-    fn from(value: &IUrlAccessor3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUrlAccessor3> for IUrlAccessor {
-    fn from(value: IUrlAccessor3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUrlAccessor3> for &'a IUrlAccessor {
-    fn from(value: &'a IUrlAccessor3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUrlAccessor3> for IUrlAccessor {
-    fn from(value: &IUrlAccessor3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUrlAccessor3> for IUrlAccessor2 {
-    fn from(value: IUrlAccessor3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUrlAccessor3> for &'a IUrlAccessor2 {
-    fn from(value: &'a IUrlAccessor3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUrlAccessor3> for IUrlAccessor2 {
-    fn from(value: &IUrlAccessor3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUrlAccessor3, ::windows::core::IUnknown, IUrlAccessor, IUrlAccessor2);
 impl ::core::clone::Clone for IUrlAccessor3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15917,66 +13092,7 @@ impl IUrlAccessor4 {
         (::windows::core::Vtable::vtable(self).ShouldIndexProperty)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(key), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IUrlAccessor4> for ::windows::core::IUnknown {
-    fn from(value: IUrlAccessor4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUrlAccessor4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUrlAccessor4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUrlAccessor4> for ::windows::core::IUnknown {
-    fn from(value: &IUrlAccessor4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUrlAccessor4> for IUrlAccessor {
-    fn from(value: IUrlAccessor4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUrlAccessor4> for &'a IUrlAccessor {
-    fn from(value: &'a IUrlAccessor4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUrlAccessor4> for IUrlAccessor {
-    fn from(value: &IUrlAccessor4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUrlAccessor4> for IUrlAccessor2 {
-    fn from(value: IUrlAccessor4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUrlAccessor4> for &'a IUrlAccessor2 {
-    fn from(value: &'a IUrlAccessor4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUrlAccessor4> for IUrlAccessor2 {
-    fn from(value: &IUrlAccessor4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUrlAccessor4> for IUrlAccessor3 {
-    fn from(value: IUrlAccessor4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUrlAccessor4> for &'a IUrlAccessor3 {
-    fn from(value: &'a IUrlAccessor4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUrlAccessor4> for IUrlAccessor3 {
-    fn from(value: &IUrlAccessor4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUrlAccessor4, ::windows::core::IUnknown, IUrlAccessor, IUrlAccessor2, IUrlAccessor3);
 impl ::core::clone::Clone for IUrlAccessor4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16025,21 +13141,7 @@ impl IViewChapter {
         (::windows::core::Vtable::vtable(self).OpenViewChapter)(::windows::core::Vtable::as_raw(self), hsource, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<usize>(result__)
     }
 }
-impl ::core::convert::From<IViewChapter> for ::windows::core::IUnknown {
-    fn from(value: IViewChapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewChapter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IViewChapter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewChapter> for ::windows::core::IUnknown {
-    fn from(value: &IViewChapter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IViewChapter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IViewChapter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16091,21 +13193,7 @@ impl IViewFilter {
         (::windows::core::Vtable::vtable(self).SetFilter)(::windows::core::Vtable::as_raw(self), haccessor.into(), compareops.len() as _, ::core::mem::transmute(compareops.as_ptr()), ::core::mem::transmute(pcriteriadata)).ok()
     }
 }
-impl ::core::convert::From<IViewFilter> for ::windows::core::IUnknown {
-    fn from(value: IViewFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IViewFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewFilter> for ::windows::core::IUnknown {
-    fn from(value: &IViewFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IViewFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IViewFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16155,21 +13243,7 @@ impl IViewRowset {
         (::windows::core::Vtable::vtable(self).OpenViewRowset)(::windows::core::Vtable::as_raw(self), punkouter.into().abi(), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IViewRowset> for ::windows::core::IUnknown {
-    fn from(value: IViewRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewRowset> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IViewRowset) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewRowset> for ::windows::core::IUnknown {
-    fn from(value: &IViewRowset) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IViewRowset, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IViewRowset {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16210,21 +13284,7 @@ impl IViewSort {
         (::windows::core::Vtable::vtable(self).SetSortOrder)(::windows::core::Vtable::as_raw(self), cvalues, ::core::mem::transmute(rgcolumns), ::core::mem::transmute(rgorders)).ok()
     }
 }
-impl ::core::convert::From<IViewSort> for ::windows::core::IUnknown {
-    fn from(value: IViewSort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewSort> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IViewSort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewSort> for ::windows::core::IUnknown {
-    fn from(value: &IViewSort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IViewSort, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IViewSort {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16287,21 +13347,7 @@ impl IWordBreaker {
         (::windows::core::Vtable::vtable(self).GetLicenseToUse)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppwcslicense)).ok()
     }
 }
-impl ::core::convert::From<IWordBreaker> for ::windows::core::IUnknown {
-    fn from(value: IWordBreaker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWordBreaker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWordBreaker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWordBreaker> for ::windows::core::IUnknown {
-    fn from(value: &IWordBreaker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWordBreaker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWordBreaker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16356,21 +13402,7 @@ impl IWordFormSink {
         (::windows::core::Vtable::vtable(self).PutWord)(::windows::core::Vtable::as_raw(self), pwcinbuf.into(), cwc).ok()
     }
 }
-impl ::core::convert::From<IWordFormSink> for ::windows::core::IUnknown {
-    fn from(value: IWordFormSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWordFormSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWordFormSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWordFormSink> for ::windows::core::IUnknown {
-    fn from(value: &IWordFormSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWordFormSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWordFormSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16428,21 +13460,7 @@ impl IWordSink {
         (::windows::core::Vtable::vtable(self).PutBreak)(::windows::core::Vtable::as_raw(self), breaktype).ok()
     }
 }
-impl ::core::convert::From<IWordSink> for ::windows::core::IUnknown {
-    fn from(value: IWordSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWordSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWordSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWordSink> for ::windows::core::IUnknown {
-    fn from(value: &IWordSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWordSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWordSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16555,21 +13573,7 @@ impl OLEDBSimpleProvider {
         (::windows::core::Vtable::vtable(self).stopTransfer)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<OLEDBSimpleProvider> for ::windows::core::IUnknown {
-    fn from(value: OLEDBSimpleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a OLEDBSimpleProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a OLEDBSimpleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OLEDBSimpleProvider> for ::windows::core::IUnknown {
-    fn from(value: &OLEDBSimpleProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(OLEDBSimpleProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for OLEDBSimpleProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16652,21 +13656,7 @@ impl OLEDBSimpleProviderListener {
         (::windows::core::Vtable::vtable(self).transferComplete)(::windows::core::Vtable::as_raw(self), xfer).ok()
     }
 }
-impl ::core::convert::From<OLEDBSimpleProviderListener> for ::windows::core::IUnknown {
-    fn from(value: OLEDBSimpleProviderListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a OLEDBSimpleProviderListener> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a OLEDBSimpleProviderListener) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&OLEDBSimpleProviderListener> for ::windows::core::IUnknown {
-    fn from(value: &OLEDBSimpleProviderListener) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(OLEDBSimpleProviderListener, ::windows::core::IUnknown);
 impl ::core::clone::Clone for OLEDBSimpleProviderListener {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/SecurityCenter/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SecurityCenter/mod.rs
@@ -69,41 +69,7 @@ impl IWSCDefaultProduct {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSCDefaultProduct> for ::windows::core::IUnknown {
-    fn from(value: IWSCDefaultProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSCDefaultProduct> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSCDefaultProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSCDefaultProduct> for ::windows::core::IUnknown {
-    fn from(value: &IWSCDefaultProduct) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSCDefaultProduct> for super::Com::IDispatch {
-    fn from(value: IWSCDefaultProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSCDefaultProduct> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSCDefaultProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSCDefaultProduct> for super::Com::IDispatch {
-    fn from(value: &IWSCDefaultProduct) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSCDefaultProduct, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSCDefaultProduct {
     fn clone(&self) -> Self {
@@ -160,41 +126,7 @@ impl IWSCProductList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSCProductList> for ::windows::core::IUnknown {
-    fn from(value: IWSCProductList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSCProductList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWSCProductList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSCProductList> for ::windows::core::IUnknown {
-    fn from(value: &IWSCProductList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWSCProductList> for super::Com::IDispatch {
-    fn from(value: IWSCProductList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWSCProductList> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWSCProductList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWSCProductList> for super::Com::IDispatch {
-    fn from(value: &IWSCProductList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWSCProductList, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWSCProductList {
     fn clone(&self) -> Self {
@@ -273,41 +205,7 @@ impl IWscProduct {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWscProduct> for ::windows::core::IUnknown {
-    fn from(value: IWscProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWscProduct> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWscProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWscProduct> for ::windows::core::IUnknown {
-    fn from(value: &IWscProduct) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWscProduct> for super::Com::IDispatch {
-    fn from(value: IWscProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWscProduct> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWscProduct) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWscProduct> for super::Com::IDispatch {
-    fn from(value: &IWscProduct) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWscProduct, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWscProduct {
     fn clone(&self) -> Self {
@@ -414,59 +312,7 @@ impl IWscProduct2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWscProduct2> for ::windows::core::IUnknown {
-    fn from(value: IWscProduct2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWscProduct2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWscProduct2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWscProduct2> for ::windows::core::IUnknown {
-    fn from(value: &IWscProduct2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWscProduct2> for super::Com::IDispatch {
-    fn from(value: IWscProduct2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWscProduct2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWscProduct2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWscProduct2> for super::Com::IDispatch {
-    fn from(value: &IWscProduct2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWscProduct2> for IWscProduct {
-    fn from(value: IWscProduct2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWscProduct2> for &'a IWscProduct {
-    fn from(value: &'a IWscProduct2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWscProduct2> for IWscProduct {
-    fn from(value: &IWscProduct2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWscProduct2, ::windows::core::IUnknown, super::Com::IDispatch, IWscProduct);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWscProduct2 {
     fn clone(&self) -> Self {
@@ -573,77 +419,7 @@ impl IWscProduct3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWscProduct3> for ::windows::core::IUnknown {
-    fn from(value: IWscProduct3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWscProduct3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWscProduct3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWscProduct3> for ::windows::core::IUnknown {
-    fn from(value: &IWscProduct3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWscProduct3> for super::Com::IDispatch {
-    fn from(value: IWscProduct3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWscProduct3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWscProduct3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWscProduct3> for super::Com::IDispatch {
-    fn from(value: &IWscProduct3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWscProduct3> for IWscProduct {
-    fn from(value: IWscProduct3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWscProduct3> for &'a IWscProduct {
-    fn from(value: &'a IWscProduct3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWscProduct3> for IWscProduct {
-    fn from(value: &IWscProduct3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWscProduct3> for IWscProduct2 {
-    fn from(value: IWscProduct3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWscProduct3> for &'a IWscProduct2 {
-    fn from(value: &'a IWscProduct3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWscProduct3> for IWscProduct2 {
-    fn from(value: &IWscProduct3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWscProduct3, ::windows::core::IUnknown, super::Com::IDispatch, IWscProduct, IWscProduct2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWscProduct3 {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/ServerBackup/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ServerBackup/mod.rs
@@ -10,21 +10,7 @@ impl IWsbApplicationAsync {
         (::windows::core::Vtable::vtable(self).Abort)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWsbApplicationAsync> for ::windows::core::IUnknown {
-    fn from(value: IWsbApplicationAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWsbApplicationAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWsbApplicationAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWsbApplicationAsync> for ::windows::core::IUnknown {
-    fn from(value: &IWsbApplicationAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWsbApplicationAsync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWsbApplicationAsync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -68,21 +54,7 @@ impl IWsbApplicationBackupSupport {
         (::windows::core::Vtable::vtable(self).CheckConsistency)(::windows::core::Vtable::as_raw(self), wszwritermetadata.into(), wszcomponentname.into(), wszcomponentlogicalpath.into(), cvolumes, ::core::mem::transmute(rgwszsourcevolumepath), ::core::mem::transmute(rgwszsnapshotvolumepath), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWsbApplicationAsync>(result__)
     }
 }
-impl ::core::convert::From<IWsbApplicationBackupSupport> for ::windows::core::IUnknown {
-    fn from(value: IWsbApplicationBackupSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWsbApplicationBackupSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWsbApplicationBackupSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWsbApplicationBackupSupport> for ::windows::core::IUnknown {
-    fn from(value: &IWsbApplicationBackupSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWsbApplicationBackupSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWsbApplicationBackupSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -145,21 +117,7 @@ impl IWsbApplicationRestoreSupport {
         (::windows::core::Vtable::vtable(self).IsRollForwardSupported)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u8>(result__)
     }
 }
-impl ::core::convert::From<IWsbApplicationRestoreSupport> for ::windows::core::IUnknown {
-    fn from(value: IWsbApplicationRestoreSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWsbApplicationRestoreSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWsbApplicationRestoreSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWsbApplicationRestoreSupport> for ::windows::core::IUnknown {
-    fn from(value: &IWsbApplicationRestoreSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWsbApplicationRestoreSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWsbApplicationRestoreSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/mod.rs
@@ -18,21 +18,7 @@ impl IItemEnumerator {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IItemEnumerator> for ::windows::core::IUnknown {
-    fn from(value: IItemEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IItemEnumerator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IItemEnumerator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IItemEnumerator> for ::windows::core::IUnknown {
-    fn from(value: &IItemEnumerator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IItemEnumerator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IItemEnumerator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -116,21 +102,7 @@ impl ISettingsContext {
         (::windows::core::Vtable::vtable(self).RevertSetting)(::windows::core::Vtable::as_raw(self), pidentity.into().abi(), pwzsetting.into()).ok()
     }
 }
-impl ::core::convert::From<ISettingsContext> for ::windows::core::IUnknown {
-    fn from(value: ISettingsContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISettingsContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISettingsContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISettingsContext> for ::windows::core::IUnknown {
-    fn from(value: &ISettingsContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISettingsContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISettingsContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -259,21 +231,7 @@ impl ISettingsEngine {
         (::windows::core::Vtable::vtable(self).GetSettingsContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISettingsContext>(result__)
     }
 }
-impl ::core::convert::From<ISettingsEngine> for ::windows::core::IUnknown {
-    fn from(value: ISettingsEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISettingsEngine> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISettingsEngine) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISettingsEngine> for ::windows::core::IUnknown {
-    fn from(value: &ISettingsEngine) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISettingsEngine, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISettingsEngine {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -349,21 +307,7 @@ impl ISettingsIdentity {
         (::windows::core::Vtable::vtable(self).SetFlags)(::windows::core::Vtable::as_raw(self), flags).ok()
     }
 }
-impl ::core::convert::From<ISettingsIdentity> for ::windows::core::IUnknown {
-    fn from(value: ISettingsIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISettingsIdentity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISettingsIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISettingsIdentity> for ::windows::core::IUnknown {
-    fn from(value: &ISettingsIdentity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISettingsIdentity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISettingsIdentity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -514,21 +458,7 @@ impl ISettingsItem {
         (::windows::core::Vtable::vtable(self).GetKeyValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<ISettingsItem> for ::windows::core::IUnknown {
-    fn from(value: ISettingsItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISettingsItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISettingsItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISettingsItem> for ::windows::core::IUnknown {
-    fn from(value: &ISettingsItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISettingsItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISettingsItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -650,21 +580,7 @@ impl ISettingsNamespace {
         (::windows::core::Vtable::vtable(self).GetAttribute)(::windows::core::Vtable::as_raw(self), name.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<ISettingsNamespace> for ::windows::core::IUnknown {
-    fn from(value: ISettingsNamespace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISettingsNamespace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISettingsNamespace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISettingsNamespace> for ::windows::core::IUnknown {
-    fn from(value: &ISettingsNamespace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISettingsNamespace, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISettingsNamespace {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -734,21 +650,7 @@ impl ISettingsResult {
         (::windows::core::Vtable::vtable(self).GetSource)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ISettingsResult> for ::windows::core::IUnknown {
-    fn from(value: ISettingsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISettingsResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISettingsResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISettingsResult> for ::windows::core::IUnknown {
-    fn from(value: &ISettingsResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISettingsResult, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISettingsResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -915,21 +817,7 @@ impl ITargetInfo {
         (::windows::core::Vtable::vtable(self).GetSchemaHiveMountName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITargetInfo> for ::windows::core::IUnknown {
-    fn from(value: ITargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITargetInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITargetInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITargetInfo> for ::windows::core::IUnknown {
-    fn from(value: &ITargetInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITargetInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITargetInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/SideShow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SideShow/mod.rs
@@ -14,36 +14,7 @@ impl ISideShowBulkCapabilities {
         (::windows::core::Vtable::vtable(self).GetCapabilities)(::windows::core::Vtable::as_raw(self), in_keycollection.into().abi(), ::core::mem::transmute(inout_pvalues)).ok()
     }
 }
-impl ::core::convert::From<ISideShowBulkCapabilities> for ::windows::core::IUnknown {
-    fn from(value: ISideShowBulkCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowBulkCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISideShowBulkCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowBulkCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &ISideShowBulkCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISideShowBulkCapabilities> for ISideShowCapabilities {
-    fn from(value: ISideShowBulkCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowBulkCapabilities> for &'a ISideShowCapabilities {
-    fn from(value: &'a ISideShowBulkCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowBulkCapabilities> for ISideShowCapabilities {
-    fn from(value: &ISideShowBulkCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISideShowBulkCapabilities, ::windows::core::IUnknown, ISideShowCapabilities);
 impl ::core::clone::Clone for ISideShowBulkCapabilities {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -82,21 +53,7 @@ impl ISideShowCapabilities {
         (::windows::core::Vtable::vtable(self).GetCapability)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(in_keycapability), ::core::mem::transmute(inout_pvalue)).ok()
     }
 }
-impl ::core::convert::From<ISideShowCapabilities> for ::windows::core::IUnknown {
-    fn from(value: ISideShowCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISideShowCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &ISideShowCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISideShowCapabilities, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISideShowCapabilities {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -141,21 +98,7 @@ impl ISideShowCapabilitiesCollection {
         (::windows::core::Vtable::vtable(self).GetAt)(::windows::core::Vtable::as_raw(self), in_dwindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISideShowCapabilities>(result__)
     }
 }
-impl ::core::convert::From<ISideShowCapabilitiesCollection> for ::windows::core::IUnknown {
-    fn from(value: ISideShowCapabilitiesCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowCapabilitiesCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISideShowCapabilitiesCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowCapabilitiesCollection> for ::windows::core::IUnknown {
-    fn from(value: &ISideShowCapabilitiesCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISideShowCapabilitiesCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISideShowCapabilitiesCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -206,21 +149,7 @@ impl ISideShowContent {
         (::windows::core::Vtable::vtable(self).DifferentiateContent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ISideShowContent> for ::windows::core::IUnknown {
-    fn from(value: ISideShowContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowContent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISideShowContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowContent> for ::windows::core::IUnknown {
-    fn from(value: &ISideShowContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISideShowContent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISideShowContent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -281,21 +210,7 @@ impl ISideShowContentManager {
         (::windows::core::Vtable::vtable(self).GetDeviceCapabilities)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISideShowCapabilitiesCollection>(result__)
     }
 }
-impl ::core::convert::From<ISideShowContentManager> for ::windows::core::IUnknown {
-    fn from(value: ISideShowContentManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowContentManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISideShowContentManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowContentManager> for ::windows::core::IUnknown {
-    fn from(value: &ISideShowContentManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISideShowContentManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISideShowContentManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -355,21 +270,7 @@ impl ISideShowEvents {
         (::windows::core::Vtable::vtable(self).DeviceRemoved)(::windows::core::Vtable::as_raw(self), in_pidevice.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISideShowEvents> for ::windows::core::IUnknown {
-    fn from(value: ISideShowEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISideShowEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowEvents> for ::windows::core::IUnknown {
-    fn from(value: &ISideShowEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISideShowEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISideShowEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -425,21 +326,7 @@ impl ISideShowKeyCollection {
         (::windows::core::Vtable::vtable(self).RemoveAt)(::windows::core::Vtable::as_raw(self), dwindex).ok()
     }
 }
-impl ::core::convert::From<ISideShowKeyCollection> for ::windows::core::IUnknown {
-    fn from(value: ISideShowKeyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowKeyCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISideShowKeyCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowKeyCollection> for ::windows::core::IUnknown {
-    fn from(value: &ISideShowKeyCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISideShowKeyCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISideShowKeyCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -535,21 +422,7 @@ impl ISideShowNotification {
         (::windows::core::Vtable::vtable(self).SetExpirationTime)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(in_ptime.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<ISideShowNotification> for ::windows::core::IUnknown {
-    fn from(value: ISideShowNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISideShowNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowNotification> for ::windows::core::IUnknown {
-    fn from(value: &ISideShowNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISideShowNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISideShowNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -616,21 +489,7 @@ impl ISideShowNotificationManager {
         (::windows::core::Vtable::vtable(self).RevokeAll)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISideShowNotificationManager> for ::windows::core::IUnknown {
-    fn from(value: ISideShowNotificationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowNotificationManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISideShowNotificationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowNotificationManager> for ::windows::core::IUnknown {
-    fn from(value: &ISideShowNotificationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISideShowNotificationManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISideShowNotificationManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -685,21 +544,7 @@ impl ISideShowPropVariantCollection {
         (::windows::core::Vtable::vtable(self).RemoveAt)(::windows::core::Vtable::as_raw(self), dwindex).ok()
     }
 }
-impl ::core::convert::From<ISideShowPropVariantCollection> for ::windows::core::IUnknown {
-    fn from(value: ISideShowPropVariantCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowPropVariantCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISideShowPropVariantCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowPropVariantCollection> for ::windows::core::IUnknown {
-    fn from(value: &ISideShowPropVariantCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISideShowPropVariantCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISideShowPropVariantCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -751,21 +596,7 @@ impl ISideShowSession {
         (::windows::core::Vtable::vtable(self).RegisterNotifications)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(in_applicationid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISideShowNotificationManager>(result__)
     }
 }
-impl ::core::convert::From<ISideShowSession> for ::windows::core::IUnknown {
-    fn from(value: ISideShowSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISideShowSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISideShowSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISideShowSession> for ::windows::core::IUnknown {
-    fn from(value: &ISideShowSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISideShowSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISideShowSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/mod.rs
@@ -15,41 +15,7 @@ impl IAction {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAction> for ::windows::core::IUnknown {
-    fn from(value: IAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAction> for ::windows::core::IUnknown {
-    fn from(value: &IAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAction> for super::Com::IDispatch {
-    fn from(value: IAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAction> for &'a super::Com::IDispatch {
-    fn from(value: &'a IAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAction> for super::Com::IDispatch {
-    fn from(value: &IAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAction, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAction {
     fn clone(&self) -> Self {
@@ -137,41 +103,7 @@ impl IActionCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IActionCollection> for ::windows::core::IUnknown {
-    fn from(value: IActionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IActionCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IActionCollection> for ::windows::core::IUnknown {
-    fn from(value: &IActionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IActionCollection> for super::Com::IDispatch {
-    fn from(value: IActionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IActionCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IActionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IActionCollection> for super::Com::IDispatch {
-    fn from(value: &IActionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActionCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IActionCollection {
     fn clone(&self) -> Self {
@@ -286,59 +218,7 @@ impl IBootTrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBootTrigger> for ::windows::core::IUnknown {
-    fn from(value: IBootTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBootTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBootTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBootTrigger> for ::windows::core::IUnknown {
-    fn from(value: &IBootTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBootTrigger> for super::Com::IDispatch {
-    fn from(value: IBootTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBootTrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a IBootTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBootTrigger> for super::Com::IDispatch {
-    fn from(value: &IBootTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IBootTrigger> for ITrigger {
-    fn from(value: IBootTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IBootTrigger> for &'a ITrigger {
-    fn from(value: &'a IBootTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IBootTrigger> for ITrigger {
-    fn from(value: &IBootTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBootTrigger, ::windows::core::IUnknown, super::Com::IDispatch, ITrigger);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IBootTrigger {
     fn clone(&self) -> Self {
@@ -404,59 +284,7 @@ impl IComHandlerAction {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IComHandlerAction> for ::windows::core::IUnknown {
-    fn from(value: IComHandlerAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IComHandlerAction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComHandlerAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IComHandlerAction> for ::windows::core::IUnknown {
-    fn from(value: &IComHandlerAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IComHandlerAction> for super::Com::IDispatch {
-    fn from(value: IComHandlerAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IComHandlerAction> for &'a super::Com::IDispatch {
-    fn from(value: &'a IComHandlerAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IComHandlerAction> for super::Com::IDispatch {
-    fn from(value: &IComHandlerAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IComHandlerAction> for IAction {
-    fn from(value: IComHandlerAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IComHandlerAction> for &'a IAction {
-    fn from(value: &'a IComHandlerAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IComHandlerAction> for IAction {
-    fn from(value: &IComHandlerAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComHandlerAction, ::windows::core::IUnknown, super::Com::IDispatch, IAction);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IComHandlerAction {
     fn clone(&self) -> Self {
@@ -562,59 +390,7 @@ impl IDailyTrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDailyTrigger> for ::windows::core::IUnknown {
-    fn from(value: IDailyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDailyTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDailyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDailyTrigger> for ::windows::core::IUnknown {
-    fn from(value: &IDailyTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDailyTrigger> for super::Com::IDispatch {
-    fn from(value: IDailyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDailyTrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDailyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDailyTrigger> for super::Com::IDispatch {
-    fn from(value: &IDailyTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDailyTrigger> for ITrigger {
-    fn from(value: IDailyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDailyTrigger> for &'a ITrigger {
-    fn from(value: &'a IDailyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDailyTrigger> for ITrigger {
-    fn from(value: &IDailyTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDailyTrigger, ::windows::core::IUnknown, super::Com::IDispatch, ITrigger);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDailyTrigger {
     fn clone(&self) -> Self {
@@ -742,59 +518,7 @@ impl IEmailAction {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEmailAction> for ::windows::core::IUnknown {
-    fn from(value: IEmailAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEmailAction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEmailAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEmailAction> for ::windows::core::IUnknown {
-    fn from(value: &IEmailAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEmailAction> for super::Com::IDispatch {
-    fn from(value: IEmailAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEmailAction> for &'a super::Com::IDispatch {
-    fn from(value: &'a IEmailAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEmailAction> for super::Com::IDispatch {
-    fn from(value: &IEmailAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEmailAction> for IAction {
-    fn from(value: IEmailAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEmailAction> for &'a IAction {
-    fn from(value: &'a IEmailAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEmailAction> for IAction {
-    fn from(value: &IEmailAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEmailAction, ::windows::core::IUnknown, super::Com::IDispatch, IAction);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IEmailAction {
     fn clone(&self) -> Self {
@@ -879,21 +603,7 @@ impl IEnumWorkItems {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumWorkItems>(result__)
     }
 }
-impl ::core::convert::From<IEnumWorkItems> for ::windows::core::IUnknown {
-    fn from(value: IEnumWorkItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumWorkItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumWorkItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumWorkItems> for ::windows::core::IUnknown {
-    fn from(value: &IEnumWorkItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumWorkItems, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumWorkItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1006,59 +716,7 @@ impl IEventTrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEventTrigger> for ::windows::core::IUnknown {
-    fn from(value: IEventTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEventTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEventTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEventTrigger> for ::windows::core::IUnknown {
-    fn from(value: &IEventTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEventTrigger> for super::Com::IDispatch {
-    fn from(value: IEventTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEventTrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a IEventTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEventTrigger> for super::Com::IDispatch {
-    fn from(value: &IEventTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEventTrigger> for ITrigger {
-    fn from(value: IEventTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEventTrigger> for &'a ITrigger {
-    fn from(value: &'a IEventTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEventTrigger> for ITrigger {
-    fn from(value: &IEventTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEventTrigger, ::windows::core::IUnknown, super::Com::IDispatch, ITrigger);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IEventTrigger {
     fn clone(&self) -> Self {
@@ -1140,59 +798,7 @@ impl IExecAction {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IExecAction> for ::windows::core::IUnknown {
-    fn from(value: IExecAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IExecAction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExecAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IExecAction> for ::windows::core::IUnknown {
-    fn from(value: &IExecAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IExecAction> for super::Com::IDispatch {
-    fn from(value: IExecAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IExecAction> for &'a super::Com::IDispatch {
-    fn from(value: &'a IExecAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IExecAction> for super::Com::IDispatch {
-    fn from(value: &IExecAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IExecAction> for IAction {
-    fn from(value: IExecAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IExecAction> for &'a IAction {
-    fn from(value: &'a IExecAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IExecAction> for IAction {
-    fn from(value: &IExecAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExecAction, ::windows::core::IUnknown, super::Com::IDispatch, IAction);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IExecAction {
     fn clone(&self) -> Self {
@@ -1274,77 +880,7 @@ impl IExecAction2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IExecAction2> for ::windows::core::IUnknown {
-    fn from(value: IExecAction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IExecAction2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExecAction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IExecAction2> for ::windows::core::IUnknown {
-    fn from(value: &IExecAction2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IExecAction2> for super::Com::IDispatch {
-    fn from(value: IExecAction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IExecAction2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IExecAction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IExecAction2> for super::Com::IDispatch {
-    fn from(value: &IExecAction2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IExecAction2> for IAction {
-    fn from(value: IExecAction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IExecAction2> for &'a IAction {
-    fn from(value: &'a IExecAction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IExecAction2> for IAction {
-    fn from(value: &IExecAction2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IExecAction2> for IExecAction {
-    fn from(value: IExecAction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IExecAction2> for &'a IExecAction {
-    fn from(value: &'a IExecAction2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IExecAction2> for IExecAction {
-    fn from(value: &IExecAction2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExecAction2, ::windows::core::IUnknown, super::Com::IDispatch, IAction, IExecAction);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IExecAction2 {
     fn clone(&self) -> Self {
@@ -1413,41 +949,7 @@ impl IIdleSettings {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IIdleSettings> for ::windows::core::IUnknown {
-    fn from(value: IIdleSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IIdleSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIdleSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IIdleSettings> for ::windows::core::IUnknown {
-    fn from(value: &IIdleSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IIdleSettings> for super::Com::IDispatch {
-    fn from(value: IIdleSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IIdleSettings> for &'a super::Com::IDispatch {
-    fn from(value: &'a IIdleSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IIdleSettings> for super::Com::IDispatch {
-    fn from(value: &IIdleSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIdleSettings, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IIdleSettings {
     fn clone(&self) -> Self {
@@ -1545,59 +1047,7 @@ impl IIdleTrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IIdleTrigger> for ::windows::core::IUnknown {
-    fn from(value: IIdleTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IIdleTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIdleTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IIdleTrigger> for ::windows::core::IUnknown {
-    fn from(value: &IIdleTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IIdleTrigger> for super::Com::IDispatch {
-    fn from(value: IIdleTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IIdleTrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a IIdleTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IIdleTrigger> for super::Com::IDispatch {
-    fn from(value: &IIdleTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IIdleTrigger> for ITrigger {
-    fn from(value: IIdleTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IIdleTrigger> for &'a ITrigger {
-    fn from(value: &'a IIdleTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IIdleTrigger> for ITrigger {
-    fn from(value: &IIdleTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIdleTrigger, ::windows::core::IUnknown, super::Com::IDispatch, ITrigger);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IIdleTrigger {
     fn clone(&self) -> Self {
@@ -1699,59 +1149,7 @@ impl ILogonTrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ILogonTrigger> for ::windows::core::IUnknown {
-    fn from(value: ILogonTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ILogonTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILogonTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ILogonTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ILogonTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ILogonTrigger> for super::Com::IDispatch {
-    fn from(value: ILogonTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ILogonTrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a ILogonTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ILogonTrigger> for super::Com::IDispatch {
-    fn from(value: &ILogonTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ILogonTrigger> for ITrigger {
-    fn from(value: ILogonTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ILogonTrigger> for &'a ITrigger {
-    fn from(value: &'a ILogonTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ILogonTrigger> for ITrigger {
-    fn from(value: &ILogonTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILogonTrigger, ::windows::core::IUnknown, super::Com::IDispatch, ITrigger);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ILogonTrigger {
     fn clone(&self) -> Self {
@@ -1816,41 +1214,7 @@ impl IMaintenanceSettings {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMaintenanceSettings> for ::windows::core::IUnknown {
-    fn from(value: IMaintenanceSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMaintenanceSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMaintenanceSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMaintenanceSettings> for ::windows::core::IUnknown {
-    fn from(value: &IMaintenanceSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMaintenanceSettings> for super::Com::IDispatch {
-    fn from(value: IMaintenanceSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMaintenanceSettings> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMaintenanceSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMaintenanceSettings> for super::Com::IDispatch {
-    fn from(value: &IMaintenanceSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMaintenanceSettings, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMaintenanceSettings {
     fn clone(&self) -> Self {
@@ -1976,59 +1340,7 @@ impl IMonthlyDOWTrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMonthlyDOWTrigger> for ::windows::core::IUnknown {
-    fn from(value: IMonthlyDOWTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMonthlyDOWTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMonthlyDOWTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMonthlyDOWTrigger> for ::windows::core::IUnknown {
-    fn from(value: &IMonthlyDOWTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMonthlyDOWTrigger> for super::Com::IDispatch {
-    fn from(value: IMonthlyDOWTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMonthlyDOWTrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMonthlyDOWTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMonthlyDOWTrigger> for super::Com::IDispatch {
-    fn from(value: &IMonthlyDOWTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMonthlyDOWTrigger> for ITrigger {
-    fn from(value: IMonthlyDOWTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMonthlyDOWTrigger> for &'a ITrigger {
-    fn from(value: &'a IMonthlyDOWTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMonthlyDOWTrigger> for ITrigger {
-    fn from(value: &IMonthlyDOWTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMonthlyDOWTrigger, ::windows::core::IUnknown, super::Com::IDispatch, ITrigger);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMonthlyDOWTrigger {
     fn clone(&self) -> Self {
@@ -2152,59 +1464,7 @@ impl IMonthlyTrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMonthlyTrigger> for ::windows::core::IUnknown {
-    fn from(value: IMonthlyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMonthlyTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMonthlyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMonthlyTrigger> for ::windows::core::IUnknown {
-    fn from(value: &IMonthlyTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMonthlyTrigger> for super::Com::IDispatch {
-    fn from(value: IMonthlyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMonthlyTrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a IMonthlyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMonthlyTrigger> for super::Com::IDispatch {
-    fn from(value: &IMonthlyTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMonthlyTrigger> for ITrigger {
-    fn from(value: IMonthlyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMonthlyTrigger> for &'a ITrigger {
-    fn from(value: &'a IMonthlyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMonthlyTrigger> for ITrigger {
-    fn from(value: &IMonthlyTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMonthlyTrigger, ::windows::core::IUnknown, super::Com::IDispatch, ITrigger);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMonthlyTrigger {
     fn clone(&self) -> Self {
@@ -2267,41 +1527,7 @@ impl INetworkSettings {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetworkSettings> for ::windows::core::IUnknown {
-    fn from(value: INetworkSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetworkSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetworkSettings> for ::windows::core::IUnknown {
-    fn from(value: &INetworkSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INetworkSettings> for super::Com::IDispatch {
-    fn from(value: INetworkSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INetworkSettings> for &'a super::Com::IDispatch {
-    fn from(value: &'a INetworkSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INetworkSettings> for super::Com::IDispatch {
-    fn from(value: &INetworkSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkSettings, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INetworkSettings {
     fn clone(&self) -> Self {
@@ -2384,41 +1610,7 @@ impl IPrincipal {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrincipal> for ::windows::core::IUnknown {
-    fn from(value: IPrincipal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrincipal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrincipal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrincipal> for ::windows::core::IUnknown {
-    fn from(value: &IPrincipal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrincipal> for super::Com::IDispatch {
-    fn from(value: IPrincipal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrincipal> for &'a super::Com::IDispatch {
-    fn from(value: &'a IPrincipal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrincipal> for super::Com::IDispatch {
-    fn from(value: &IPrincipal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrincipal, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrincipal {
     fn clone(&self) -> Self {
@@ -2488,41 +1680,7 @@ impl IPrincipal2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrincipal2> for ::windows::core::IUnknown {
-    fn from(value: IPrincipal2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrincipal2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrincipal2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrincipal2> for ::windows::core::IUnknown {
-    fn from(value: &IPrincipal2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPrincipal2> for super::Com::IDispatch {
-    fn from(value: IPrincipal2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPrincipal2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IPrincipal2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPrincipal2> for super::Com::IDispatch {
-    fn from(value: &IPrincipal2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrincipal2, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPrincipal2 {
     fn clone(&self) -> Self {
@@ -2576,21 +1734,7 @@ impl IProvideTaskPage {
         (::windows::core::Vtable::vtable(self).GetPage)(::windows::core::Vtable::as_raw(self), tptype, fpersistchanges.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::UI::Controls::HPROPSHEETPAGE>(result__)
     }
 }
-impl ::core::convert::From<IProvideTaskPage> for ::windows::core::IUnknown {
-    fn from(value: IProvideTaskPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProvideTaskPage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProvideTaskPage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProvideTaskPage> for ::windows::core::IUnknown {
-    fn from(value: &IProvideTaskPage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProvideTaskPage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProvideTaskPage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2714,41 +1858,7 @@ impl IRegisteredTask {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRegisteredTask> for ::windows::core::IUnknown {
-    fn from(value: IRegisteredTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRegisteredTask> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRegisteredTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRegisteredTask> for ::windows::core::IUnknown {
-    fn from(value: &IRegisteredTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRegisteredTask> for super::Com::IDispatch {
-    fn from(value: IRegisteredTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRegisteredTask> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRegisteredTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRegisteredTask> for super::Com::IDispatch {
-    fn from(value: &IRegisteredTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRegisteredTask, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRegisteredTask {
     fn clone(&self) -> Self {
@@ -2841,41 +1951,7 @@ impl IRegisteredTaskCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRegisteredTaskCollection> for ::windows::core::IUnknown {
-    fn from(value: IRegisteredTaskCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRegisteredTaskCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRegisteredTaskCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRegisteredTaskCollection> for ::windows::core::IUnknown {
-    fn from(value: &IRegisteredTaskCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRegisteredTaskCollection> for super::Com::IDispatch {
-    fn from(value: IRegisteredTaskCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRegisteredTaskCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRegisteredTaskCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRegisteredTaskCollection> for super::Com::IDispatch {
-    fn from(value: &IRegisteredTaskCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRegisteredTaskCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRegisteredTaskCollection {
     fn clone(&self) -> Self {
@@ -2985,41 +2061,7 @@ impl IRegistrationInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRegistrationInfo> for ::windows::core::IUnknown {
-    fn from(value: IRegistrationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRegistrationInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRegistrationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRegistrationInfo> for ::windows::core::IUnknown {
-    fn from(value: &IRegistrationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRegistrationInfo> for super::Com::IDispatch {
-    fn from(value: IRegistrationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRegistrationInfo> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRegistrationInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRegistrationInfo> for super::Com::IDispatch {
-    fn from(value: &IRegistrationInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRegistrationInfo, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRegistrationInfo {
     fn clone(&self) -> Self {
@@ -3139,59 +2181,7 @@ impl IRegistrationTrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRegistrationTrigger> for ::windows::core::IUnknown {
-    fn from(value: IRegistrationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRegistrationTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRegistrationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRegistrationTrigger> for ::windows::core::IUnknown {
-    fn from(value: &IRegistrationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRegistrationTrigger> for super::Com::IDispatch {
-    fn from(value: IRegistrationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRegistrationTrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRegistrationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRegistrationTrigger> for super::Com::IDispatch {
-    fn from(value: &IRegistrationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRegistrationTrigger> for ITrigger {
-    fn from(value: IRegistrationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRegistrationTrigger> for &'a ITrigger {
-    fn from(value: &'a IRegistrationTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRegistrationTrigger> for ITrigger {
-    fn from(value: &IRegistrationTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRegistrationTrigger, ::windows::core::IUnknown, super::Com::IDispatch, ITrigger);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRegistrationTrigger {
     fn clone(&self) -> Self {
@@ -3254,41 +2244,7 @@ impl IRepetitionPattern {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRepetitionPattern> for ::windows::core::IUnknown {
-    fn from(value: IRepetitionPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRepetitionPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRepetitionPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRepetitionPattern> for ::windows::core::IUnknown {
-    fn from(value: &IRepetitionPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRepetitionPattern> for super::Com::IDispatch {
-    fn from(value: IRepetitionPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRepetitionPattern> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRepetitionPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRepetitionPattern> for super::Com::IDispatch {
-    fn from(value: &IRepetitionPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRepetitionPattern, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRepetitionPattern {
     fn clone(&self) -> Self {
@@ -3367,41 +2323,7 @@ impl IRunningTask {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRunningTask> for ::windows::core::IUnknown {
-    fn from(value: IRunningTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRunningTask> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRunningTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRunningTask> for ::windows::core::IUnknown {
-    fn from(value: &IRunningTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRunningTask> for super::Com::IDispatch {
-    fn from(value: IRunningTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRunningTask> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRunningTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRunningTask> for super::Com::IDispatch {
-    fn from(value: &IRunningTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRunningTask, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRunningTask {
     fn clone(&self) -> Self {
@@ -3469,41 +2391,7 @@ impl IRunningTaskCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRunningTaskCollection> for ::windows::core::IUnknown {
-    fn from(value: IRunningTaskCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRunningTaskCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRunningTaskCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRunningTaskCollection> for ::windows::core::IUnknown {
-    fn from(value: &IRunningTaskCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRunningTaskCollection> for super::Com::IDispatch {
-    fn from(value: IRunningTaskCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRunningTaskCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRunningTaskCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRunningTaskCollection> for super::Com::IDispatch {
-    fn from(value: &IRunningTaskCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRunningTaskCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRunningTaskCollection {
     fn clone(&self) -> Self {
@@ -3669,21 +2557,7 @@ impl IScheduledWorkItem {
         (::windows::core::Vtable::vtable(self).GetAccountInformation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IScheduledWorkItem> for ::windows::core::IUnknown {
-    fn from(value: IScheduledWorkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScheduledWorkItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IScheduledWorkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScheduledWorkItem> for ::windows::core::IUnknown {
-    fn from(value: &IScheduledWorkItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IScheduledWorkItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IScheduledWorkItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3825,59 +2699,7 @@ impl ISessionStateChangeTrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISessionStateChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: ISessionStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISessionStateChangeTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISessionStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISessionStateChangeTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ISessionStateChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISessionStateChangeTrigger> for super::Com::IDispatch {
-    fn from(value: ISessionStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISessionStateChangeTrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISessionStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISessionStateChangeTrigger> for super::Com::IDispatch {
-    fn from(value: &ISessionStateChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISessionStateChangeTrigger> for ITrigger {
-    fn from(value: ISessionStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISessionStateChangeTrigger> for &'a ITrigger {
-    fn from(value: &'a ISessionStateChangeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISessionStateChangeTrigger> for ITrigger {
-    fn from(value: &ISessionStateChangeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISessionStateChangeTrigger, ::windows::core::IUnknown, super::Com::IDispatch, ITrigger);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISessionStateChangeTrigger {
     fn clone(&self) -> Self {
@@ -3947,59 +2769,7 @@ impl IShowMessageAction {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShowMessageAction> for ::windows::core::IUnknown {
-    fn from(value: IShowMessageAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShowMessageAction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShowMessageAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShowMessageAction> for ::windows::core::IUnknown {
-    fn from(value: &IShowMessageAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShowMessageAction> for super::Com::IDispatch {
-    fn from(value: IShowMessageAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShowMessageAction> for &'a super::Com::IDispatch {
-    fn from(value: &'a IShowMessageAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShowMessageAction> for super::Com::IDispatch {
-    fn from(value: &IShowMessageAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShowMessageAction> for IAction {
-    fn from(value: IShowMessageAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShowMessageAction> for &'a IAction {
-    fn from(value: &'a IShowMessageAction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShowMessageAction> for IAction {
-    fn from(value: &IShowMessageAction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShowMessageAction, ::windows::core::IUnknown, super::Com::IDispatch, IAction);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShowMessageAction {
     fn clone(&self) -> Self {
@@ -4214,36 +2984,7 @@ impl ITask {
         (::windows::core::Vtable::vtable(self).GetMaxRunTime)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ITask> for ::windows::core::IUnknown {
-    fn from(value: ITask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITask> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITask> for ::windows::core::IUnknown {
-    fn from(value: &ITask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITask> for IScheduledWorkItem {
-    fn from(value: ITask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITask> for &'a IScheduledWorkItem {
-    fn from(value: &'a ITask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITask> for IScheduledWorkItem {
-    fn from(value: &ITask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITask, ::windows::core::IUnknown, IScheduledWorkItem);
 impl ::core::clone::Clone for ITask {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4373,41 +3114,7 @@ impl ITaskDefinition {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskDefinition> for ::windows::core::IUnknown {
-    fn from(value: ITaskDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskDefinition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskDefinition> for ::windows::core::IUnknown {
-    fn from(value: &ITaskDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskDefinition> for super::Com::IDispatch {
-    fn from(value: ITaskDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskDefinition> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITaskDefinition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskDefinition> for super::Com::IDispatch {
-    fn from(value: &ITaskDefinition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskDefinition, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITaskDefinition {
     fn clone(&self) -> Self {
@@ -4571,41 +3278,7 @@ impl ITaskFolder {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskFolder> for ::windows::core::IUnknown {
-    fn from(value: ITaskFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskFolder> for ::windows::core::IUnknown {
-    fn from(value: &ITaskFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskFolder> for super::Com::IDispatch {
-    fn from(value: ITaskFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskFolder> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITaskFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskFolder> for super::Com::IDispatch {
-    fn from(value: &ITaskFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskFolder, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITaskFolder {
     fn clone(&self) -> Self {
@@ -4699,41 +3372,7 @@ impl ITaskFolderCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskFolderCollection> for ::windows::core::IUnknown {
-    fn from(value: ITaskFolderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskFolderCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskFolderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskFolderCollection> for ::windows::core::IUnknown {
-    fn from(value: &ITaskFolderCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskFolderCollection> for super::Com::IDispatch {
-    fn from(value: ITaskFolderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskFolderCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITaskFolderCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskFolderCollection> for super::Com::IDispatch {
-    fn from(value: &ITaskFolderCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskFolderCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITaskFolderCollection {
     fn clone(&self) -> Self {
@@ -4795,21 +3434,7 @@ impl ITaskHandler {
         (::windows::core::Vtable::vtable(self).Resume)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITaskHandler> for ::windows::core::IUnknown {
-    fn from(value: ITaskHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskHandler> for ::windows::core::IUnknown {
-    fn from(value: &ITaskHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITaskHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4852,21 +3477,7 @@ impl ITaskHandlerStatus {
         (::windows::core::Vtable::vtable(self).TaskCompleted)(::windows::core::Vtable::as_raw(self), taskerrcode).ok()
     }
 }
-impl ::core::convert::From<ITaskHandlerStatus> for ::windows::core::IUnknown {
-    fn from(value: ITaskHandlerStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskHandlerStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskHandlerStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskHandlerStatus> for ::windows::core::IUnknown {
-    fn from(value: &ITaskHandlerStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskHandlerStatus, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITaskHandlerStatus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4929,41 +3540,7 @@ impl ITaskNamedValueCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskNamedValueCollection> for ::windows::core::IUnknown {
-    fn from(value: ITaskNamedValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskNamedValueCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskNamedValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskNamedValueCollection> for ::windows::core::IUnknown {
-    fn from(value: &ITaskNamedValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskNamedValueCollection> for super::Com::IDispatch {
-    fn from(value: ITaskNamedValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskNamedValueCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITaskNamedValueCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskNamedValueCollection> for super::Com::IDispatch {
-    fn from(value: &ITaskNamedValueCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskNamedValueCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITaskNamedValueCollection {
     fn clone(&self) -> Self {
@@ -5030,41 +3607,7 @@ impl ITaskNamedValuePair {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskNamedValuePair> for ::windows::core::IUnknown {
-    fn from(value: ITaskNamedValuePair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskNamedValuePair> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskNamedValuePair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskNamedValuePair> for ::windows::core::IUnknown {
-    fn from(value: &ITaskNamedValuePair) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskNamedValuePair> for super::Com::IDispatch {
-    fn from(value: ITaskNamedValuePair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskNamedValuePair> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITaskNamedValuePair) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskNamedValuePair> for super::Com::IDispatch {
-    fn from(value: &ITaskNamedValuePair) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskNamedValuePair, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITaskNamedValuePair {
     fn clone(&self) -> Self {
@@ -5155,21 +3698,7 @@ impl ITaskScheduler {
         (::windows::core::Vtable::vtable(self).IsOfType)(::windows::core::Vtable::as_raw(self), pwszname.into(), ::core::mem::transmute(riid)).ok()
     }
 }
-impl ::core::convert::From<ITaskScheduler> for ::windows::core::IUnknown {
-    fn from(value: ITaskScheduler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskScheduler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskScheduler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskScheduler> for ::windows::core::IUnknown {
-    fn from(value: &ITaskScheduler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskScheduler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITaskScheduler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5262,41 +3791,7 @@ impl ITaskService {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskService> for ::windows::core::IUnknown {
-    fn from(value: ITaskService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskService> for ::windows::core::IUnknown {
-    fn from(value: &ITaskService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskService> for super::Com::IDispatch {
-    fn from(value: ITaskService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskService> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITaskService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskService> for super::Com::IDispatch {
-    fn from(value: &ITaskService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskService, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITaskService {
     fn clone(&self) -> Self {
@@ -5496,41 +3991,7 @@ impl ITaskSettings {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskSettings> for ::windows::core::IUnknown {
-    fn from(value: ITaskSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskSettings> for ::windows::core::IUnknown {
-    fn from(value: &ITaskSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskSettings> for super::Com::IDispatch {
-    fn from(value: ITaskSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskSettings> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITaskSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskSettings> for super::Com::IDispatch {
-    fn from(value: &ITaskSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskSettings, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITaskSettings {
     fn clone(&self) -> Self {
@@ -5637,41 +4098,7 @@ impl ITaskSettings2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskSettings2> for ::windows::core::IUnknown {
-    fn from(value: ITaskSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskSettings2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskSettings2> for ::windows::core::IUnknown {
-    fn from(value: &ITaskSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskSettings2> for super::Com::IDispatch {
-    fn from(value: ITaskSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskSettings2> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITaskSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskSettings2> for super::Com::IDispatch {
-    fn from(value: &ITaskSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskSettings2, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITaskSettings2 {
     fn clone(&self) -> Self {
@@ -5892,59 +4319,7 @@ impl ITaskSettings3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskSettings3> for ::windows::core::IUnknown {
-    fn from(value: ITaskSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskSettings3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskSettings3> for ::windows::core::IUnknown {
-    fn from(value: &ITaskSettings3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskSettings3> for super::Com::IDispatch {
-    fn from(value: ITaskSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskSettings3> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITaskSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskSettings3> for super::Com::IDispatch {
-    fn from(value: &ITaskSettings3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITaskSettings3> for ITaskSettings {
-    fn from(value: ITaskSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITaskSettings3> for &'a ITaskSettings {
-    fn from(value: &'a ITaskSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITaskSettings3> for ITaskSettings {
-    fn from(value: &ITaskSettings3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskSettings3, ::windows::core::IUnknown, super::Com::IDispatch, ITaskSettings);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITaskSettings3 {
     fn clone(&self) -> Self {
@@ -6013,21 +4388,7 @@ impl ITaskTrigger {
         (::windows::core::Vtable::vtable(self).GetTriggerString)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ITaskTrigger> for ::windows::core::IUnknown {
-    fn from(value: ITaskTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ITaskTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskTrigger, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITaskTrigger {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6074,21 +4435,7 @@ impl ITaskVariables {
         (::windows::core::Vtable::vtable(self).GetContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITaskVariables> for ::windows::core::IUnknown {
-    fn from(value: ITaskVariables) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskVariables> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskVariables) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskVariables> for ::windows::core::IUnknown {
-    fn from(value: &ITaskVariables) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskVariables, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITaskVariables {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6180,59 +4527,7 @@ impl ITimeTrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITimeTrigger> for ::windows::core::IUnknown {
-    fn from(value: ITimeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITimeTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITimeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITimeTrigger> for ::windows::core::IUnknown {
-    fn from(value: &ITimeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITimeTrigger> for super::Com::IDispatch {
-    fn from(value: ITimeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITimeTrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITimeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITimeTrigger> for super::Com::IDispatch {
-    fn from(value: &ITimeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITimeTrigger> for ITrigger {
-    fn from(value: ITimeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITimeTrigger> for &'a ITrigger {
-    fn from(value: &'a ITimeTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITimeTrigger> for ITrigger {
-    fn from(value: &ITimeTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITimeTrigger, ::windows::core::IUnknown, super::Com::IDispatch, ITrigger);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITimeTrigger {
     fn clone(&self) -> Self {
@@ -6324,41 +4619,7 @@ impl ITrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITrigger> for ::windows::core::IUnknown {
-    fn from(value: ITrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITrigger> for ::windows::core::IUnknown {
-    fn from(value: &ITrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITrigger> for super::Com::IDispatch {
-    fn from(value: ITrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITrigger> for super::Com::IDispatch {
-    fn from(value: &ITrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITrigger, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITrigger {
     fn clone(&self) -> Self {
@@ -6450,41 +4711,7 @@ impl ITriggerCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITriggerCollection> for ::windows::core::IUnknown {
-    fn from(value: ITriggerCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITriggerCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITriggerCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITriggerCollection> for ::windows::core::IUnknown {
-    fn from(value: &ITriggerCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITriggerCollection> for super::Com::IDispatch {
-    fn from(value: ITriggerCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITriggerCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a ITriggerCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITriggerCollection> for super::Com::IDispatch {
-    fn from(value: &ITriggerCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITriggerCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITriggerCollection {
     fn clone(&self) -> Self {
@@ -6607,59 +4834,7 @@ impl IWeeklyTrigger {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWeeklyTrigger> for ::windows::core::IUnknown {
-    fn from(value: IWeeklyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWeeklyTrigger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWeeklyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWeeklyTrigger> for ::windows::core::IUnknown {
-    fn from(value: &IWeeklyTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWeeklyTrigger> for super::Com::IDispatch {
-    fn from(value: IWeeklyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWeeklyTrigger> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWeeklyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWeeklyTrigger> for super::Com::IDispatch {
-    fn from(value: &IWeeklyTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWeeklyTrigger> for ITrigger {
-    fn from(value: IWeeklyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWeeklyTrigger> for &'a ITrigger {
-    fn from(value: &'a IWeeklyTrigger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWeeklyTrigger> for ITrigger {
-    fn from(value: &IWeeklyTrigger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWeeklyTrigger, ::windows::core::IUnknown, super::Com::IDispatch, ITrigger);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWeeklyTrigger {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/TransactionServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TransactionServer/mod.rs
@@ -24,41 +24,7 @@ impl ICatalog {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICatalog> for ::windows::core::IUnknown {
-    fn from(value: ICatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICatalog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICatalog> for ::windows::core::IUnknown {
-    fn from(value: &ICatalog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICatalog> for super::Com::IDispatch {
-    fn from(value: ICatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICatalog> for &'a super::Com::IDispatch {
-    fn from(value: &'a ICatalog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICatalog> for super::Com::IDispatch {
-    fn from(value: &ICatalog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICatalog, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICatalog {
     fn clone(&self) -> Self {
@@ -125,41 +91,7 @@ impl IComponentUtil {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IComponentUtil> for ::windows::core::IUnknown {
-    fn from(value: IComponentUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IComponentUtil> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComponentUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IComponentUtil> for ::windows::core::IUnknown {
-    fn from(value: &IComponentUtil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IComponentUtil> for super::Com::IDispatch {
-    fn from(value: IComponentUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IComponentUtil> for &'a super::Com::IDispatch {
-    fn from(value: &'a IComponentUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IComponentUtil> for super::Com::IDispatch {
-    fn from(value: &IComponentUtil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComponentUtil, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IComponentUtil {
     fn clone(&self) -> Self {
@@ -218,41 +150,7 @@ impl IPackageUtil {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPackageUtil> for ::windows::core::IUnknown {
-    fn from(value: IPackageUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPackageUtil> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPackageUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPackageUtil> for ::windows::core::IUnknown {
-    fn from(value: &IPackageUtil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPackageUtil> for super::Com::IDispatch {
-    fn from(value: IPackageUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPackageUtil> for &'a super::Com::IDispatch {
-    fn from(value: &'a IPackageUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPackageUtil> for super::Com::IDispatch {
-    fn from(value: &IPackageUtil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPackageUtil, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPackageUtil {
     fn clone(&self) -> Self {
@@ -304,41 +202,7 @@ impl IRemoteComponentUtil {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRemoteComponentUtil> for ::windows::core::IUnknown {
-    fn from(value: IRemoteComponentUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRemoteComponentUtil> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteComponentUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRemoteComponentUtil> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteComponentUtil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRemoteComponentUtil> for super::Com::IDispatch {
-    fn from(value: IRemoteComponentUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRemoteComponentUtil> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRemoteComponentUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRemoteComponentUtil> for super::Com::IDispatch {
-    fn from(value: &IRemoteComponentUtil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteComponentUtil, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRemoteComponentUtil {
     fn clone(&self) -> Self {
@@ -389,41 +253,7 @@ impl IRoleAssociationUtil {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRoleAssociationUtil> for ::windows::core::IUnknown {
-    fn from(value: IRoleAssociationUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRoleAssociationUtil> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRoleAssociationUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRoleAssociationUtil> for ::windows::core::IUnknown {
-    fn from(value: &IRoleAssociationUtil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IRoleAssociationUtil> for super::Com::IDispatch {
-    fn from(value: IRoleAssociationUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IRoleAssociationUtil> for &'a super::Com::IDispatch {
-    fn from(value: &'a IRoleAssociationUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IRoleAssociationUtil> for super::Com::IDispatch {
-    fn from(value: &IRoleAssociationUtil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRoleAssociationUtil, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IRoleAssociationUtil {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/mod.rs
@@ -31,41 +31,7 @@ impl IAutomaticUpdates {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdates> for ::windows::core::IUnknown {
-    fn from(value: IAutomaticUpdates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdates> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAutomaticUpdates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdates> for ::windows::core::IUnknown {
-    fn from(value: &IAutomaticUpdates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdates> for super::Com::IDispatch {
-    fn from(value: IAutomaticUpdates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdates> for &'a super::Com::IDispatch {
-    fn from(value: &'a IAutomaticUpdates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdates> for super::Com::IDispatch {
-    fn from(value: &IAutomaticUpdates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAutomaticUpdates, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAutomaticUpdates {
     fn clone(&self) -> Self {
@@ -149,59 +115,7 @@ impl IAutomaticUpdates2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdates2> for ::windows::core::IUnknown {
-    fn from(value: IAutomaticUpdates2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdates2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAutomaticUpdates2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdates2> for ::windows::core::IUnknown {
-    fn from(value: &IAutomaticUpdates2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdates2> for super::Com::IDispatch {
-    fn from(value: IAutomaticUpdates2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdates2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IAutomaticUpdates2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdates2> for super::Com::IDispatch {
-    fn from(value: &IAutomaticUpdates2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdates2> for IAutomaticUpdates {
-    fn from(value: IAutomaticUpdates2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdates2> for &'a IAutomaticUpdates {
-    fn from(value: &'a IAutomaticUpdates2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdates2> for IAutomaticUpdates {
-    fn from(value: &IAutomaticUpdates2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAutomaticUpdates2, ::windows::core::IUnknown, super::Com::IDispatch, IAutomaticUpdates);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAutomaticUpdates2 {
     fn clone(&self) -> Self {
@@ -260,41 +174,7 @@ impl IAutomaticUpdatesResults {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdatesResults> for ::windows::core::IUnknown {
-    fn from(value: IAutomaticUpdatesResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdatesResults> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAutomaticUpdatesResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdatesResults> for ::windows::core::IUnknown {
-    fn from(value: &IAutomaticUpdatesResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdatesResults> for super::Com::IDispatch {
-    fn from(value: IAutomaticUpdatesResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdatesResults> for &'a super::Com::IDispatch {
-    fn from(value: &'a IAutomaticUpdatesResults) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdatesResults> for super::Com::IDispatch {
-    fn from(value: &IAutomaticUpdatesResults) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAutomaticUpdatesResults, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAutomaticUpdatesResults {
     fn clone(&self) -> Self {
@@ -380,41 +260,7 @@ impl IAutomaticUpdatesSettings {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdatesSettings> for ::windows::core::IUnknown {
-    fn from(value: IAutomaticUpdatesSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdatesSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAutomaticUpdatesSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdatesSettings> for ::windows::core::IUnknown {
-    fn from(value: &IAutomaticUpdatesSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdatesSettings> for super::Com::IDispatch {
-    fn from(value: IAutomaticUpdatesSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdatesSettings> for &'a super::Com::IDispatch {
-    fn from(value: &'a IAutomaticUpdatesSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdatesSettings> for super::Com::IDispatch {
-    fn from(value: &IAutomaticUpdatesSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAutomaticUpdatesSettings, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAutomaticUpdatesSettings {
     fn clone(&self) -> Self {
@@ -513,59 +359,7 @@ impl IAutomaticUpdatesSettings2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdatesSettings2> for ::windows::core::IUnknown {
-    fn from(value: IAutomaticUpdatesSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdatesSettings2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAutomaticUpdatesSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdatesSettings2> for ::windows::core::IUnknown {
-    fn from(value: &IAutomaticUpdatesSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdatesSettings2> for super::Com::IDispatch {
-    fn from(value: IAutomaticUpdatesSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdatesSettings2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IAutomaticUpdatesSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdatesSettings2> for super::Com::IDispatch {
-    fn from(value: &IAutomaticUpdatesSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdatesSettings2> for IAutomaticUpdatesSettings {
-    fn from(value: IAutomaticUpdatesSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdatesSettings2> for &'a IAutomaticUpdatesSettings {
-    fn from(value: &'a IAutomaticUpdatesSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdatesSettings2> for IAutomaticUpdatesSettings {
-    fn from(value: &IAutomaticUpdatesSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAutomaticUpdatesSettings2, ::windows::core::IUnknown, super::Com::IDispatch, IAutomaticUpdatesSettings);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAutomaticUpdatesSettings2 {
     fn clone(&self) -> Self {
@@ -671,77 +465,7 @@ impl IAutomaticUpdatesSettings3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdatesSettings3> for ::windows::core::IUnknown {
-    fn from(value: IAutomaticUpdatesSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdatesSettings3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAutomaticUpdatesSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdatesSettings3> for ::windows::core::IUnknown {
-    fn from(value: &IAutomaticUpdatesSettings3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdatesSettings3> for super::Com::IDispatch {
-    fn from(value: IAutomaticUpdatesSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdatesSettings3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IAutomaticUpdatesSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdatesSettings3> for super::Com::IDispatch {
-    fn from(value: &IAutomaticUpdatesSettings3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdatesSettings3> for IAutomaticUpdatesSettings {
-    fn from(value: IAutomaticUpdatesSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdatesSettings3> for &'a IAutomaticUpdatesSettings {
-    fn from(value: &'a IAutomaticUpdatesSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdatesSettings3> for IAutomaticUpdatesSettings {
-    fn from(value: &IAutomaticUpdatesSettings3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAutomaticUpdatesSettings3> for IAutomaticUpdatesSettings2 {
-    fn from(value: IAutomaticUpdatesSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAutomaticUpdatesSettings3> for &'a IAutomaticUpdatesSettings2 {
-    fn from(value: &'a IAutomaticUpdatesSettings3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAutomaticUpdatesSettings3> for IAutomaticUpdatesSettings2 {
-    fn from(value: &IAutomaticUpdatesSettings3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAutomaticUpdatesSettings3, ::windows::core::IUnknown, super::Com::IDispatch, IAutomaticUpdatesSettings, IAutomaticUpdatesSettings2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAutomaticUpdatesSettings3 {
     fn clone(&self) -> Self {
@@ -832,41 +556,7 @@ impl ICategory {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICategory> for ::windows::core::IUnknown {
-    fn from(value: ICategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICategory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICategory> for ::windows::core::IUnknown {
-    fn from(value: &ICategory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICategory> for super::Com::IDispatch {
-    fn from(value: ICategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICategory> for &'a super::Com::IDispatch {
-    fn from(value: &'a ICategory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICategory> for super::Com::IDispatch {
-    fn from(value: &ICategory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICategory, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICategory {
     fn clone(&self) -> Self {
@@ -944,41 +634,7 @@ impl ICategoryCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICategoryCollection> for ::windows::core::IUnknown {
-    fn from(value: ICategoryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICategoryCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICategoryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICategoryCollection> for ::windows::core::IUnknown {
-    fn from(value: &ICategoryCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ICategoryCollection> for super::Com::IDispatch {
-    fn from(value: ICategoryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ICategoryCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a ICategoryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ICategoryCollection> for super::Com::IDispatch {
-    fn from(value: &ICategoryCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICategoryCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ICategoryCollection {
     fn clone(&self) -> Self {
@@ -1033,21 +689,7 @@ impl IDownloadCompletedCallback {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self), downloadjob.into().abi(), callbackargs.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDownloadCompletedCallback> for ::windows::core::IUnknown {
-    fn from(value: IDownloadCompletedCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDownloadCompletedCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDownloadCompletedCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDownloadCompletedCallback> for ::windows::core::IUnknown {
-    fn from(value: &IDownloadCompletedCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDownloadCompletedCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDownloadCompletedCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1086,41 +728,7 @@ pub struct IDownloadCompletedCallbackArgs(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IDownloadCompletedCallbackArgs {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDownloadCompletedCallbackArgs> for ::windows::core::IUnknown {
-    fn from(value: IDownloadCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDownloadCompletedCallbackArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDownloadCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDownloadCompletedCallbackArgs> for ::windows::core::IUnknown {
-    fn from(value: &IDownloadCompletedCallbackArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDownloadCompletedCallbackArgs> for super::Com::IDispatch {
-    fn from(value: IDownloadCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDownloadCompletedCallbackArgs> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDownloadCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDownloadCompletedCallbackArgs> for super::Com::IDispatch {
-    fn from(value: &IDownloadCompletedCallbackArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDownloadCompletedCallbackArgs, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDownloadCompletedCallbackArgs {
     fn clone(&self) -> Self {
@@ -1191,41 +799,7 @@ impl IDownloadJob {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDownloadJob> for ::windows::core::IUnknown {
-    fn from(value: IDownloadJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDownloadJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDownloadJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDownloadJob> for ::windows::core::IUnknown {
-    fn from(value: &IDownloadJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDownloadJob> for super::Com::IDispatch {
-    fn from(value: IDownloadJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDownloadJob> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDownloadJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDownloadJob> for super::Com::IDispatch {
-    fn from(value: &IDownloadJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDownloadJob, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDownloadJob {
     fn clone(&self) -> Self {
@@ -1329,41 +903,7 @@ impl IDownloadProgress {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDownloadProgress> for ::windows::core::IUnknown {
-    fn from(value: IDownloadProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDownloadProgress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDownloadProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDownloadProgress> for ::windows::core::IUnknown {
-    fn from(value: &IDownloadProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDownloadProgress> for super::Com::IDispatch {
-    fn from(value: IDownloadProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDownloadProgress> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDownloadProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDownloadProgress> for super::Com::IDispatch {
-    fn from(value: &IDownloadProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDownloadProgress, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDownloadProgress {
     fn clone(&self) -> Self {
@@ -1436,21 +976,7 @@ impl IDownloadProgressChangedCallback {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self), downloadjob.into().abi(), callbackargs.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDownloadProgressChangedCallback> for ::windows::core::IUnknown {
-    fn from(value: IDownloadProgressChangedCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDownloadProgressChangedCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDownloadProgressChangedCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDownloadProgressChangedCallback> for ::windows::core::IUnknown {
-    fn from(value: &IDownloadProgressChangedCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDownloadProgressChangedCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDownloadProgressChangedCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1496,41 +1022,7 @@ impl IDownloadProgressChangedCallbackArgs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDownloadProgressChangedCallbackArgs> for ::windows::core::IUnknown {
-    fn from(value: IDownloadProgressChangedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDownloadProgressChangedCallbackArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDownloadProgressChangedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDownloadProgressChangedCallbackArgs> for ::windows::core::IUnknown {
-    fn from(value: &IDownloadProgressChangedCallbackArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDownloadProgressChangedCallbackArgs> for super::Com::IDispatch {
-    fn from(value: IDownloadProgressChangedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDownloadProgressChangedCallbackArgs> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDownloadProgressChangedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDownloadProgressChangedCallbackArgs> for super::Com::IDispatch {
-    fn from(value: &IDownloadProgressChangedCallbackArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDownloadProgressChangedCallbackArgs, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDownloadProgressChangedCallbackArgs {
     fn clone(&self) -> Self {
@@ -1591,41 +1083,7 @@ impl IDownloadResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDownloadResult> for ::windows::core::IUnknown {
-    fn from(value: IDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDownloadResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDownloadResult> for ::windows::core::IUnknown {
-    fn from(value: &IDownloadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IDownloadResult> for super::Com::IDispatch {
-    fn from(value: IDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IDownloadResult> for &'a super::Com::IDispatch {
-    fn from(value: &'a IDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IDownloadResult> for super::Com::IDispatch {
-    fn from(value: &IDownloadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDownloadResult, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IDownloadResult {
     fn clone(&self) -> Self {
@@ -1690,41 +1148,7 @@ impl IImageInformation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IImageInformation> for ::windows::core::IUnknown {
-    fn from(value: IImageInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IImageInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImageInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IImageInformation> for ::windows::core::IUnknown {
-    fn from(value: &IImageInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IImageInformation> for super::Com::IDispatch {
-    fn from(value: IImageInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IImageInformation> for &'a super::Com::IDispatch {
-    fn from(value: &'a IImageInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IImageInformation> for super::Com::IDispatch {
-    fn from(value: &IImageInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImageInformation, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IImageInformation {
     fn clone(&self) -> Self {
@@ -1779,41 +1203,7 @@ impl IInstallationAgent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationAgent> for ::windows::core::IUnknown {
-    fn from(value: IInstallationAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationAgent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInstallationAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationAgent> for ::windows::core::IUnknown {
-    fn from(value: &IInstallationAgent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationAgent> for super::Com::IDispatch {
-    fn from(value: IInstallationAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationAgent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IInstallationAgent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationAgent> for super::Com::IDispatch {
-    fn from(value: &IInstallationAgent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInstallationAgent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInstallationAgent {
     fn clone(&self) -> Self {
@@ -1876,41 +1266,7 @@ impl IInstallationBehavior {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationBehavior> for ::windows::core::IUnknown {
-    fn from(value: IInstallationBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationBehavior> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInstallationBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationBehavior> for ::windows::core::IUnknown {
-    fn from(value: &IInstallationBehavior) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationBehavior> for super::Com::IDispatch {
-    fn from(value: IInstallationBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationBehavior> for &'a super::Com::IDispatch {
-    fn from(value: &'a IInstallationBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationBehavior> for super::Com::IDispatch {
-    fn from(value: &IInstallationBehavior) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInstallationBehavior, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInstallationBehavior {
     fn clone(&self) -> Self {
@@ -1963,21 +1319,7 @@ impl IInstallationCompletedCallback {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self), installationjob.into().abi(), callbackargs.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IInstallationCompletedCallback> for ::windows::core::IUnknown {
-    fn from(value: IInstallationCompletedCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInstallationCompletedCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInstallationCompletedCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInstallationCompletedCallback> for ::windows::core::IUnknown {
-    fn from(value: &IInstallationCompletedCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInstallationCompletedCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInstallationCompletedCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2016,41 +1358,7 @@ pub struct IInstallationCompletedCallbackArgs(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IInstallationCompletedCallbackArgs {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationCompletedCallbackArgs> for ::windows::core::IUnknown {
-    fn from(value: IInstallationCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationCompletedCallbackArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInstallationCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationCompletedCallbackArgs> for ::windows::core::IUnknown {
-    fn from(value: &IInstallationCompletedCallbackArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationCompletedCallbackArgs> for super::Com::IDispatch {
-    fn from(value: IInstallationCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationCompletedCallbackArgs> for &'a super::Com::IDispatch {
-    fn from(value: &'a IInstallationCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationCompletedCallbackArgs> for super::Com::IDispatch {
-    fn from(value: &IInstallationCompletedCallbackArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInstallationCompletedCallbackArgs, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInstallationCompletedCallbackArgs {
     fn clone(&self) -> Self {
@@ -2121,41 +1429,7 @@ impl IInstallationJob {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationJob> for ::windows::core::IUnknown {
-    fn from(value: IInstallationJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInstallationJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationJob> for ::windows::core::IUnknown {
-    fn from(value: &IInstallationJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationJob> for super::Com::IDispatch {
-    fn from(value: IInstallationJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationJob> for &'a super::Com::IDispatch {
-    fn from(value: &'a IInstallationJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationJob> for super::Com::IDispatch {
-    fn from(value: &IInstallationJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInstallationJob, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInstallationJob {
     fn clone(&self) -> Self {
@@ -2231,41 +1505,7 @@ impl IInstallationProgress {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationProgress> for ::windows::core::IUnknown {
-    fn from(value: IInstallationProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationProgress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInstallationProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationProgress> for ::windows::core::IUnknown {
-    fn from(value: &IInstallationProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationProgress> for super::Com::IDispatch {
-    fn from(value: IInstallationProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationProgress> for &'a super::Com::IDispatch {
-    fn from(value: &'a IInstallationProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationProgress> for super::Com::IDispatch {
-    fn from(value: &IInstallationProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInstallationProgress, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInstallationProgress {
     fn clone(&self) -> Self {
@@ -2321,21 +1561,7 @@ impl IInstallationProgressChangedCallback {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self), installationjob.into().abi(), callbackargs.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IInstallationProgressChangedCallback> for ::windows::core::IUnknown {
-    fn from(value: IInstallationProgressChangedCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInstallationProgressChangedCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInstallationProgressChangedCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInstallationProgressChangedCallback> for ::windows::core::IUnknown {
-    fn from(value: &IInstallationProgressChangedCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInstallationProgressChangedCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInstallationProgressChangedCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2381,41 +1607,7 @@ impl IInstallationProgressChangedCallbackArgs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationProgressChangedCallbackArgs> for ::windows::core::IUnknown {
-    fn from(value: IInstallationProgressChangedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationProgressChangedCallbackArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInstallationProgressChangedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationProgressChangedCallbackArgs> for ::windows::core::IUnknown {
-    fn from(value: &IInstallationProgressChangedCallbackArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationProgressChangedCallbackArgs> for super::Com::IDispatch {
-    fn from(value: IInstallationProgressChangedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationProgressChangedCallbackArgs> for &'a super::Com::IDispatch {
-    fn from(value: &'a IInstallationProgressChangedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationProgressChangedCallbackArgs> for super::Com::IDispatch {
-    fn from(value: &IInstallationProgressChangedCallbackArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInstallationProgressChangedCallbackArgs, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInstallationProgressChangedCallbackArgs {
     fn clone(&self) -> Self {
@@ -2480,41 +1672,7 @@ impl IInstallationResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationResult> for ::windows::core::IUnknown {
-    fn from(value: IInstallationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInstallationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationResult> for ::windows::core::IUnknown {
-    fn from(value: &IInstallationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInstallationResult> for super::Com::IDispatch {
-    fn from(value: IInstallationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInstallationResult> for &'a super::Com::IDispatch {
-    fn from(value: &'a IInstallationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInstallationResult> for super::Com::IDispatch {
-    fn from(value: &IInstallationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInstallationResult, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInstallationResult {
     fn clone(&self) -> Self {
@@ -2580,59 +1738,7 @@ impl IInvalidProductLicenseException {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInvalidProductLicenseException> for ::windows::core::IUnknown {
-    fn from(value: IInvalidProductLicenseException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInvalidProductLicenseException> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInvalidProductLicenseException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInvalidProductLicenseException> for ::windows::core::IUnknown {
-    fn from(value: &IInvalidProductLicenseException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInvalidProductLicenseException> for super::Com::IDispatch {
-    fn from(value: IInvalidProductLicenseException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInvalidProductLicenseException> for &'a super::Com::IDispatch {
-    fn from(value: &'a IInvalidProductLicenseException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInvalidProductLicenseException> for super::Com::IDispatch {
-    fn from(value: &IInvalidProductLicenseException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInvalidProductLicenseException> for IUpdateException {
-    fn from(value: IInvalidProductLicenseException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInvalidProductLicenseException> for &'a IUpdateException {
-    fn from(value: &'a IInvalidProductLicenseException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInvalidProductLicenseException> for IUpdateException {
-    fn from(value: &IInvalidProductLicenseException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInvalidProductLicenseException, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateException);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInvalidProductLicenseException {
     fn clone(&self) -> Self {
@@ -2682,21 +1788,7 @@ impl ISearchCompletedCallback {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self), searchjob.into().abi(), callbackargs.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISearchCompletedCallback> for ::windows::core::IUnknown {
-    fn from(value: ISearchCompletedCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchCompletedCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchCompletedCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchCompletedCallback> for ::windows::core::IUnknown {
-    fn from(value: &ISearchCompletedCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchCompletedCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchCompletedCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2735,41 +1827,7 @@ pub struct ISearchCompletedCallbackArgs(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl ISearchCompletedCallbackArgs {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISearchCompletedCallbackArgs> for ::windows::core::IUnknown {
-    fn from(value: ISearchCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISearchCompletedCallbackArgs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISearchCompletedCallbackArgs> for ::windows::core::IUnknown {
-    fn from(value: &ISearchCompletedCallbackArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISearchCompletedCallbackArgs> for super::Com::IDispatch {
-    fn from(value: ISearchCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISearchCompletedCallbackArgs> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISearchCompletedCallbackArgs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISearchCompletedCallbackArgs> for super::Com::IDispatch {
-    fn from(value: &ISearchCompletedCallbackArgs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchCompletedCallbackArgs, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISearchCompletedCallbackArgs {
     fn clone(&self) -> Self {
@@ -2828,41 +1886,7 @@ impl ISearchJob {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISearchJob> for ::windows::core::IUnknown {
-    fn from(value: ISearchJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISearchJob> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISearchJob> for ::windows::core::IUnknown {
-    fn from(value: &ISearchJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISearchJob> for super::Com::IDispatch {
-    fn from(value: ISearchJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISearchJob> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISearchJob) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISearchJob> for super::Com::IDispatch {
-    fn from(value: &ISearchJob) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchJob, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISearchJob {
     fn clone(&self) -> Self {
@@ -2934,41 +1958,7 @@ impl ISearchResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISearchResult> for ::windows::core::IUnknown {
-    fn from(value: ISearchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISearchResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISearchResult> for ::windows::core::IUnknown {
-    fn from(value: &ISearchResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISearchResult> for super::Com::IDispatch {
-    fn from(value: ISearchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISearchResult> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISearchResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISearchResult> for super::Com::IDispatch {
-    fn from(value: &ISearchResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchResult, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISearchResult {
     fn clone(&self) -> Self {
@@ -3062,41 +2052,7 @@ impl IStringCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStringCollection> for ::windows::core::IUnknown {
-    fn from(value: IStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStringCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStringCollection> for ::windows::core::IUnknown {
-    fn from(value: &IStringCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStringCollection> for super::Com::IDispatch {
-    fn from(value: IStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStringCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IStringCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStringCollection> for super::Com::IDispatch {
-    fn from(value: &IStringCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStringCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IStringCollection {
     fn clone(&self) -> Self {
@@ -3160,41 +2116,7 @@ impl ISystemInformation {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISystemInformation> for ::windows::core::IUnknown {
-    fn from(value: ISystemInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISystemInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISystemInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISystemInformation> for ::windows::core::IUnknown {
-    fn from(value: &ISystemInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISystemInformation> for super::Com::IDispatch {
-    fn from(value: ISystemInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISystemInformation> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISystemInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISystemInformation> for super::Com::IDispatch {
-    fn from(value: &ISystemInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISystemInformation, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISystemInformation {
     fn clone(&self) -> Self {
@@ -3448,41 +2370,7 @@ impl IUpdate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate> for ::windows::core::IUnknown {
-    fn from(value: IUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate> for ::windows::core::IUnknown {
-    fn from(value: &IUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate> for super::Com::IDispatch {
-    fn from(value: IUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate> for super::Com::IDispatch {
-    fn from(value: &IUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdate, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdate {
     fn clone(&self) -> Self {
@@ -3849,59 +2737,7 @@ impl IUpdate2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate2> for ::windows::core::IUnknown {
-    fn from(value: IUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate2> for ::windows::core::IUnknown {
-    fn from(value: &IUpdate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate2> for super::Com::IDispatch {
-    fn from(value: IUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate2> for super::Com::IDispatch {
-    fn from(value: &IUpdate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate2> for IUpdate {
-    fn from(value: IUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate2> for &'a IUpdate {
-    fn from(value: &'a IUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate2> for IUpdate {
-    fn from(value: &IUpdate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdate2, ::windows::core::IUnknown, super::Com::IDispatch, IUpdate);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdate2 {
     fn clone(&self) -> Self {
@@ -4189,77 +3025,7 @@ impl IUpdate3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate3> for ::windows::core::IUnknown {
-    fn from(value: IUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate3> for ::windows::core::IUnknown {
-    fn from(value: &IUpdate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate3> for super::Com::IDispatch {
-    fn from(value: IUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate3> for super::Com::IDispatch {
-    fn from(value: &IUpdate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate3> for IUpdate {
-    fn from(value: IUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate3> for &'a IUpdate {
-    fn from(value: &'a IUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate3> for IUpdate {
-    fn from(value: &IUpdate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate3> for IUpdate2 {
-    fn from(value: IUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate3> for &'a IUpdate2 {
-    fn from(value: &'a IUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate3> for IUpdate2 {
-    fn from(value: &IUpdate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdate3, ::windows::core::IUnknown, super::Com::IDispatch, IUpdate, IUpdate2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdate3 {
     fn clone(&self) -> Self {
@@ -4542,95 +3308,7 @@ impl IUpdate4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate4> for ::windows::core::IUnknown {
-    fn from(value: IUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate4> for ::windows::core::IUnknown {
-    fn from(value: &IUpdate4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate4> for super::Com::IDispatch {
-    fn from(value: IUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate4> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate4> for super::Com::IDispatch {
-    fn from(value: &IUpdate4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate4> for IUpdate {
-    fn from(value: IUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate4> for &'a IUpdate {
-    fn from(value: &'a IUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate4> for IUpdate {
-    fn from(value: &IUpdate4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate4> for IUpdate2 {
-    fn from(value: IUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate4> for &'a IUpdate2 {
-    fn from(value: &'a IUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate4> for IUpdate2 {
-    fn from(value: &IUpdate4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate4> for IUpdate3 {
-    fn from(value: IUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate4> for &'a IUpdate3 {
-    fn from(value: &'a IUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate4> for IUpdate3 {
-    fn from(value: &IUpdate4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdate4, ::windows::core::IUnknown, super::Com::IDispatch, IUpdate, IUpdate2, IUpdate3);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdate4 {
     fn clone(&self) -> Self {
@@ -4921,113 +3599,7 @@ impl IUpdate5 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate5> for ::windows::core::IUnknown {
-    fn from(value: IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate5> for ::windows::core::IUnknown {
-    fn from(value: &IUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate5> for super::Com::IDispatch {
-    fn from(value: IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate5> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate5> for super::Com::IDispatch {
-    fn from(value: &IUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate5> for IUpdate {
-    fn from(value: IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate5> for &'a IUpdate {
-    fn from(value: &'a IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate5> for IUpdate {
-    fn from(value: &IUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate5> for IUpdate2 {
-    fn from(value: IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate5> for &'a IUpdate2 {
-    fn from(value: &'a IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate5> for IUpdate2 {
-    fn from(value: &IUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate5> for IUpdate3 {
-    fn from(value: IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate5> for &'a IUpdate3 {
-    fn from(value: &'a IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate5> for IUpdate3 {
-    fn from(value: &IUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdate5> for IUpdate4 {
-    fn from(value: IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdate5> for &'a IUpdate4 {
-    fn from(value: &'a IUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdate5> for IUpdate4 {
-    fn from(value: &IUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdate5, ::windows::core::IUnknown, super::Com::IDispatch, IUpdate, IUpdate2, IUpdate3, IUpdate4);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdate5 {
     fn clone(&self) -> Self {
@@ -5127,41 +3699,7 @@ impl IUpdateCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateCollection> for ::windows::core::IUnknown {
-    fn from(value: IUpdateCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateCollection> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateCollection> for super::Com::IDispatch {
-    fn from(value: IUpdateCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateCollection> for super::Com::IDispatch {
-    fn from(value: &IUpdateCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateCollection {
     fn clone(&self) -> Self {
@@ -5233,41 +3771,7 @@ impl IUpdateDownloadContent {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateDownloadContent> for ::windows::core::IUnknown {
-    fn from(value: IUpdateDownloadContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateDownloadContent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateDownloadContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateDownloadContent> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateDownloadContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateDownloadContent> for super::Com::IDispatch {
-    fn from(value: IUpdateDownloadContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateDownloadContent> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateDownloadContent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateDownloadContent> for super::Com::IDispatch {
-    fn from(value: &IUpdateDownloadContent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateDownloadContent, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateDownloadContent {
     fn clone(&self) -> Self {
@@ -5319,59 +3823,7 @@ impl IUpdateDownloadContent2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateDownloadContent2> for ::windows::core::IUnknown {
-    fn from(value: IUpdateDownloadContent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateDownloadContent2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateDownloadContent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateDownloadContent2> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateDownloadContent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateDownloadContent2> for super::Com::IDispatch {
-    fn from(value: IUpdateDownloadContent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateDownloadContent2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateDownloadContent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateDownloadContent2> for super::Com::IDispatch {
-    fn from(value: &IUpdateDownloadContent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateDownloadContent2> for IUpdateDownloadContent {
-    fn from(value: IUpdateDownloadContent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateDownloadContent2> for &'a IUpdateDownloadContent {
-    fn from(value: &'a IUpdateDownloadContent2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateDownloadContent2> for IUpdateDownloadContent {
-    fn from(value: &IUpdateDownloadContent2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateDownloadContent2, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateDownloadContent);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateDownloadContent2 {
     fn clone(&self) -> Self {
@@ -5429,41 +3881,7 @@ impl IUpdateDownloadContentCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateDownloadContentCollection> for ::windows::core::IUnknown {
-    fn from(value: IUpdateDownloadContentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateDownloadContentCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateDownloadContentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateDownloadContentCollection> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateDownloadContentCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateDownloadContentCollection> for super::Com::IDispatch {
-    fn from(value: IUpdateDownloadContentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateDownloadContentCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateDownloadContentCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateDownloadContentCollection> for super::Com::IDispatch {
-    fn from(value: &IUpdateDownloadContentCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateDownloadContentCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateDownloadContentCollection {
     fn clone(&self) -> Self {
@@ -5520,41 +3938,7 @@ impl IUpdateDownloadResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateDownloadResult> for ::windows::core::IUnknown {
-    fn from(value: IUpdateDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateDownloadResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateDownloadResult> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateDownloadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateDownloadResult> for super::Com::IDispatch {
-    fn from(value: IUpdateDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateDownloadResult> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateDownloadResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateDownloadResult> for super::Com::IDispatch {
-    fn from(value: &IUpdateDownloadResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateDownloadResult, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateDownloadResult {
     fn clone(&self) -> Self {
@@ -5660,41 +4044,7 @@ impl IUpdateDownloader {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateDownloader> for ::windows::core::IUnknown {
-    fn from(value: IUpdateDownloader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateDownloader> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateDownloader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateDownloader> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateDownloader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateDownloader> for super::Com::IDispatch {
-    fn from(value: IUpdateDownloader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateDownloader> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateDownloader) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateDownloader> for super::Com::IDispatch {
-    fn from(value: &IUpdateDownloader) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateDownloader, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateDownloader {
     fn clone(&self) -> Self {
@@ -5775,41 +4125,7 @@ impl IUpdateException {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateException> for ::windows::core::IUnknown {
-    fn from(value: IUpdateException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateException> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateException> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateException> for super::Com::IDispatch {
-    fn from(value: IUpdateException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateException> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateException> for super::Com::IDispatch {
-    fn from(value: &IUpdateException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateException, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateException {
     fn clone(&self) -> Self {
@@ -5869,41 +4185,7 @@ impl IUpdateExceptionCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateExceptionCollection> for ::windows::core::IUnknown {
-    fn from(value: IUpdateExceptionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateExceptionCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateExceptionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateExceptionCollection> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateExceptionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateExceptionCollection> for super::Com::IDispatch {
-    fn from(value: IUpdateExceptionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateExceptionCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateExceptionCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateExceptionCollection> for super::Com::IDispatch {
-    fn from(value: &IUpdateExceptionCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateExceptionCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateExceptionCollection {
     fn clone(&self) -> Self {
@@ -6012,41 +4294,7 @@ impl IUpdateHistoryEntry {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateHistoryEntry> for ::windows::core::IUnknown {
-    fn from(value: IUpdateHistoryEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateHistoryEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateHistoryEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateHistoryEntry> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateHistoryEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateHistoryEntry> for super::Com::IDispatch {
-    fn from(value: IUpdateHistoryEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateHistoryEntry> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateHistoryEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateHistoryEntry> for super::Com::IDispatch {
-    fn from(value: &IUpdateHistoryEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateHistoryEntry, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateHistoryEntry {
     fn clone(&self) -> Self {
@@ -6175,59 +4423,7 @@ impl IUpdateHistoryEntry2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateHistoryEntry2> for ::windows::core::IUnknown {
-    fn from(value: IUpdateHistoryEntry2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateHistoryEntry2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateHistoryEntry2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateHistoryEntry2> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateHistoryEntry2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateHistoryEntry2> for super::Com::IDispatch {
-    fn from(value: IUpdateHistoryEntry2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateHistoryEntry2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateHistoryEntry2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateHistoryEntry2> for super::Com::IDispatch {
-    fn from(value: &IUpdateHistoryEntry2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateHistoryEntry2> for IUpdateHistoryEntry {
-    fn from(value: IUpdateHistoryEntry2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateHistoryEntry2> for &'a IUpdateHistoryEntry {
-    fn from(value: &'a IUpdateHistoryEntry2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateHistoryEntry2> for IUpdateHistoryEntry {
-    fn from(value: &IUpdateHistoryEntry2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateHistoryEntry2, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateHistoryEntry);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateHistoryEntry2 {
     fn clone(&self) -> Self {
@@ -6288,41 +4484,7 @@ impl IUpdateHistoryEntryCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateHistoryEntryCollection> for ::windows::core::IUnknown {
-    fn from(value: IUpdateHistoryEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateHistoryEntryCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateHistoryEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateHistoryEntryCollection> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateHistoryEntryCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateHistoryEntryCollection> for super::Com::IDispatch {
-    fn from(value: IUpdateHistoryEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateHistoryEntryCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateHistoryEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateHistoryEntryCollection> for super::Com::IDispatch {
-    fn from(value: &IUpdateHistoryEntryCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateHistoryEntryCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateHistoryEntryCollection {
     fn clone(&self) -> Self {
@@ -6379,41 +4541,7 @@ impl IUpdateIdentity {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateIdentity> for ::windows::core::IUnknown {
-    fn from(value: IUpdateIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateIdentity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateIdentity> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateIdentity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateIdentity> for super::Com::IDispatch {
-    fn from(value: IUpdateIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateIdentity> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateIdentity> for super::Com::IDispatch {
-    fn from(value: &IUpdateIdentity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateIdentity, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateIdentity {
     fn clone(&self) -> Self {
@@ -6470,41 +4598,7 @@ impl IUpdateInstallationResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstallationResult> for ::windows::core::IUnknown {
-    fn from(value: IUpdateInstallationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstallationResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateInstallationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstallationResult> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateInstallationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstallationResult> for super::Com::IDispatch {
-    fn from(value: IUpdateInstallationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstallationResult> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateInstallationResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstallationResult> for super::Com::IDispatch {
-    fn from(value: &IUpdateInstallationResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateInstallationResult, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateInstallationResult {
     fn clone(&self) -> Self {
@@ -6675,41 +4769,7 @@ impl IUpdateInstaller {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller> for ::windows::core::IUnknown {
-    fn from(value: IUpdateInstaller) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateInstaller) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateInstaller) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller> for super::Com::IDispatch {
-    fn from(value: IUpdateInstaller) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateInstaller) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller> for super::Com::IDispatch {
-    fn from(value: &IUpdateInstaller) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateInstaller, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateInstaller {
     fn clone(&self) -> Self {
@@ -6938,59 +4998,7 @@ impl IUpdateInstaller2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller2> for ::windows::core::IUnknown {
-    fn from(value: IUpdateInstaller2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateInstaller2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller2> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateInstaller2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller2> for super::Com::IDispatch {
-    fn from(value: IUpdateInstaller2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateInstaller2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller2> for super::Com::IDispatch {
-    fn from(value: &IUpdateInstaller2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller2> for IUpdateInstaller {
-    fn from(value: IUpdateInstaller2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller2> for &'a IUpdateInstaller {
-    fn from(value: &'a IUpdateInstaller2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller2> for IUpdateInstaller {
-    fn from(value: &IUpdateInstaller2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateInstaller2, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateInstaller);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateInstaller2 {
     fn clone(&self) -> Self {
@@ -7174,77 +5182,7 @@ impl IUpdateInstaller3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller3> for ::windows::core::IUnknown {
-    fn from(value: IUpdateInstaller3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateInstaller3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller3> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateInstaller3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller3> for super::Com::IDispatch {
-    fn from(value: IUpdateInstaller3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateInstaller3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller3> for super::Com::IDispatch {
-    fn from(value: &IUpdateInstaller3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller3> for IUpdateInstaller {
-    fn from(value: IUpdateInstaller3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller3> for &'a IUpdateInstaller {
-    fn from(value: &'a IUpdateInstaller3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller3> for IUpdateInstaller {
-    fn from(value: &IUpdateInstaller3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller3> for IUpdateInstaller2 {
-    fn from(value: IUpdateInstaller3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller3> for &'a IUpdateInstaller2 {
-    fn from(value: &'a IUpdateInstaller3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller3> for IUpdateInstaller2 {
-    fn from(value: &IUpdateInstaller3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateInstaller3, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateInstaller, IUpdateInstaller2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateInstaller3 {
     fn clone(&self) -> Self {
@@ -7431,95 +5369,7 @@ impl IUpdateInstaller4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller4> for ::windows::core::IUnknown {
-    fn from(value: IUpdateInstaller4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateInstaller4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller4> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateInstaller4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller4> for super::Com::IDispatch {
-    fn from(value: IUpdateInstaller4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller4> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateInstaller4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller4> for super::Com::IDispatch {
-    fn from(value: &IUpdateInstaller4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller4> for IUpdateInstaller {
-    fn from(value: IUpdateInstaller4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller4> for &'a IUpdateInstaller {
-    fn from(value: &'a IUpdateInstaller4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller4> for IUpdateInstaller {
-    fn from(value: &IUpdateInstaller4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller4> for IUpdateInstaller2 {
-    fn from(value: IUpdateInstaller4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller4> for &'a IUpdateInstaller2 {
-    fn from(value: &'a IUpdateInstaller4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller4> for IUpdateInstaller2 {
-    fn from(value: &IUpdateInstaller4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateInstaller4> for IUpdateInstaller3 {
-    fn from(value: IUpdateInstaller4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateInstaller4> for &'a IUpdateInstaller3 {
-    fn from(value: &'a IUpdateInstaller4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateInstaller4> for IUpdateInstaller3 {
-    fn from(value: &IUpdateInstaller4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateInstaller4, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateInstaller, IUpdateInstaller2, IUpdateInstaller3);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateInstaller4 {
     fn clone(&self) -> Self {
@@ -7563,21 +5413,7 @@ impl IUpdateLockdown {
         (::windows::core::Vtable::vtable(self).LockDown)(::windows::core::Vtable::as_raw(self), flags).ok()
     }
 }
-impl ::core::convert::From<IUpdateLockdown> for ::windows::core::IUnknown {
-    fn from(value: IUpdateLockdown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUpdateLockdown> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateLockdown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUpdateLockdown> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateLockdown) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateLockdown, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUpdateLockdown {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7695,41 +5531,7 @@ impl IUpdateSearcher {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSearcher> for ::windows::core::IUnknown {
-    fn from(value: IUpdateSearcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSearcher> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateSearcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSearcher> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateSearcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSearcher> for super::Com::IDispatch {
-    fn from(value: IUpdateSearcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSearcher> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateSearcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSearcher> for super::Com::IDispatch {
-    fn from(value: &IUpdateSearcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateSearcher, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateSearcher {
     fn clone(&self) -> Self {
@@ -7890,59 +5692,7 @@ impl IUpdateSearcher2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSearcher2> for ::windows::core::IUnknown {
-    fn from(value: IUpdateSearcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSearcher2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateSearcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSearcher2> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateSearcher2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSearcher2> for super::Com::IDispatch {
-    fn from(value: IUpdateSearcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSearcher2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateSearcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSearcher2> for super::Com::IDispatch {
-    fn from(value: &IUpdateSearcher2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSearcher2> for IUpdateSearcher {
-    fn from(value: IUpdateSearcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSearcher2> for &'a IUpdateSearcher {
-    fn from(value: &'a IUpdateSearcher2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSearcher2> for IUpdateSearcher {
-    fn from(value: &IUpdateSearcher2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateSearcher2, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateSearcher);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateSearcher2 {
     fn clone(&self) -> Self {
@@ -8082,77 +5832,7 @@ impl IUpdateSearcher3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSearcher3> for ::windows::core::IUnknown {
-    fn from(value: IUpdateSearcher3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSearcher3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateSearcher3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSearcher3> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateSearcher3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSearcher3> for super::Com::IDispatch {
-    fn from(value: IUpdateSearcher3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSearcher3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateSearcher3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSearcher3> for super::Com::IDispatch {
-    fn from(value: &IUpdateSearcher3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSearcher3> for IUpdateSearcher {
-    fn from(value: IUpdateSearcher3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSearcher3> for &'a IUpdateSearcher {
-    fn from(value: &'a IUpdateSearcher3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSearcher3> for IUpdateSearcher {
-    fn from(value: &IUpdateSearcher3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSearcher3> for IUpdateSearcher2 {
-    fn from(value: IUpdateSearcher3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSearcher3> for &'a IUpdateSearcher2 {
-    fn from(value: &'a IUpdateSearcher3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSearcher3> for IUpdateSearcher2 {
-    fn from(value: &IUpdateSearcher3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateSearcher3, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateSearcher, IUpdateSearcher2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateSearcher3 {
     fn clone(&self) -> Self {
@@ -8253,41 +5933,7 @@ impl IUpdateService {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateService> for ::windows::core::IUnknown {
-    fn from(value: IUpdateService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateService> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateService> for super::Com::IDispatch {
-    fn from(value: IUpdateService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateService> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateService> for super::Com::IDispatch {
-    fn from(value: &IUpdateService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateService, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateService {
     fn clone(&self) -> Self {
@@ -8409,59 +6055,7 @@ impl IUpdateService2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateService2> for ::windows::core::IUnknown {
-    fn from(value: IUpdateService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateService2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateService2> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateService2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateService2> for super::Com::IDispatch {
-    fn from(value: IUpdateService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateService2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateService2> for super::Com::IDispatch {
-    fn from(value: &IUpdateService2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateService2> for IUpdateService {
-    fn from(value: IUpdateService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateService2> for &'a IUpdateService {
-    fn from(value: &'a IUpdateService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateService2> for IUpdateService {
-    fn from(value: &IUpdateService2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateService2, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateService);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateService2 {
     fn clone(&self) -> Self {
@@ -8519,41 +6113,7 @@ impl IUpdateServiceCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateServiceCollection> for ::windows::core::IUnknown {
-    fn from(value: IUpdateServiceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateServiceCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateServiceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateServiceCollection> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateServiceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateServiceCollection> for super::Com::IDispatch {
-    fn from(value: IUpdateServiceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateServiceCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateServiceCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateServiceCollection> for super::Com::IDispatch {
-    fn from(value: &IUpdateServiceCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateServiceCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateServiceCollection {
     fn clone(&self) -> Self {
@@ -8637,41 +6197,7 @@ impl IUpdateServiceManager {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateServiceManager> for ::windows::core::IUnknown {
-    fn from(value: IUpdateServiceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateServiceManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateServiceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateServiceManager> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateServiceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateServiceManager> for super::Com::IDispatch {
-    fn from(value: IUpdateServiceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateServiceManager> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateServiceManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateServiceManager> for super::Com::IDispatch {
-    fn from(value: &IUpdateServiceManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateServiceManager, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateServiceManager {
     fn clone(&self) -> Self {
@@ -8787,59 +6313,7 @@ impl IUpdateServiceManager2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateServiceManager2> for ::windows::core::IUnknown {
-    fn from(value: IUpdateServiceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateServiceManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateServiceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateServiceManager2> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateServiceManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateServiceManager2> for super::Com::IDispatch {
-    fn from(value: IUpdateServiceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateServiceManager2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateServiceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateServiceManager2> for super::Com::IDispatch {
-    fn from(value: &IUpdateServiceManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateServiceManager2> for IUpdateServiceManager {
-    fn from(value: IUpdateServiceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateServiceManager2> for &'a IUpdateServiceManager {
-    fn from(value: &'a IUpdateServiceManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateServiceManager2> for IUpdateServiceManager {
-    fn from(value: &IUpdateServiceManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateServiceManager2, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateServiceManager);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateServiceManager2 {
     fn clone(&self) -> Self {
@@ -8910,41 +6384,7 @@ impl IUpdateServiceRegistration {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateServiceRegistration> for ::windows::core::IUnknown {
-    fn from(value: IUpdateServiceRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateServiceRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateServiceRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateServiceRegistration> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateServiceRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateServiceRegistration> for super::Com::IDispatch {
-    fn from(value: IUpdateServiceRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateServiceRegistration> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateServiceRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateServiceRegistration> for super::Com::IDispatch {
-    fn from(value: &IUpdateServiceRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateServiceRegistration, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateServiceRegistration {
     fn clone(&self) -> Self {
@@ -9037,41 +6477,7 @@ impl IUpdateSession {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSession> for ::windows::core::IUnknown {
-    fn from(value: IUpdateSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSession> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSession> for super::Com::IDispatch {
-    fn from(value: IUpdateSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSession> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSession> for super::Com::IDispatch {
-    fn from(value: &IUpdateSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateSession, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateSession {
     fn clone(&self) -> Self {
@@ -9187,59 +6593,7 @@ impl IUpdateSession2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSession2> for ::windows::core::IUnknown {
-    fn from(value: IUpdateSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSession2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSession2> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateSession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSession2> for super::Com::IDispatch {
-    fn from(value: IUpdateSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSession2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSession2> for super::Com::IDispatch {
-    fn from(value: &IUpdateSession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSession2> for IUpdateSession {
-    fn from(value: IUpdateSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSession2> for &'a IUpdateSession {
-    fn from(value: &'a IUpdateSession2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSession2> for IUpdateSession {
-    fn from(value: &IUpdateSession2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateSession2, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateSession);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateSession2 {
     fn clone(&self) -> Self {
@@ -9346,77 +6700,7 @@ impl IUpdateSession3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSession3> for ::windows::core::IUnknown {
-    fn from(value: IUpdateSession3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSession3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateSession3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSession3> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateSession3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSession3> for super::Com::IDispatch {
-    fn from(value: IUpdateSession3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSession3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IUpdateSession3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSession3> for super::Com::IDispatch {
-    fn from(value: &IUpdateSession3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSession3> for IUpdateSession {
-    fn from(value: IUpdateSession3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSession3> for &'a IUpdateSession {
-    fn from(value: &'a IUpdateSession3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSession3> for IUpdateSession {
-    fn from(value: &IUpdateSession3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IUpdateSession3> for IUpdateSession2 {
-    fn from(value: IUpdateSession3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IUpdateSession3> for &'a IUpdateSession2 {
-    fn from(value: &'a IUpdateSession3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IUpdateSession3> for IUpdateSession2 {
-    fn from(value: &IUpdateSession3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateSession3, ::windows::core::IUnknown, super::Com::IDispatch, IUpdateSession, IUpdateSession2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IUpdateSession3 {
     fn clone(&self) -> Self {
@@ -9530,41 +6814,7 @@ impl IWebProxy {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebProxy> for ::windows::core::IUnknown {
-    fn from(value: IWebProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebProxy> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebProxy> for ::windows::core::IUnknown {
-    fn from(value: &IWebProxy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebProxy> for super::Com::IDispatch {
-    fn from(value: IWebProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebProxy> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWebProxy) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebProxy> for super::Com::IDispatch {
-    fn from(value: &IWebProxy) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebProxy, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWebProxy {
     fn clone(&self) -> Self {
@@ -9871,59 +7121,7 @@ impl IWindowsDriverUpdate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate> for ::windows::core::IUnknown {
-    fn from(value: IWindowsDriverUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsDriverUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsDriverUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate> for super::Com::IDispatch {
-    fn from(value: IWindowsDriverUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWindowsDriverUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate> for super::Com::IDispatch {
-    fn from(value: &IWindowsDriverUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate> for IUpdate {
-    fn from(value: IWindowsDriverUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate> for &'a IUpdate {
-    fn from(value: &'a IWindowsDriverUpdate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate> for IUpdate {
-    fn from(value: &IWindowsDriverUpdate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsDriverUpdate, ::windows::core::IUnknown, super::Com::IDispatch, IUpdate);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsDriverUpdate {
     fn clone(&self) -> Self {
@@ -10237,77 +7435,7 @@ impl IWindowsDriverUpdate2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate2> for ::windows::core::IUnknown {
-    fn from(value: IWindowsDriverUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsDriverUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate2> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsDriverUpdate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate2> for super::Com::IDispatch {
-    fn from(value: IWindowsDriverUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate2> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWindowsDriverUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate2> for super::Com::IDispatch {
-    fn from(value: &IWindowsDriverUpdate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate2> for IUpdate {
-    fn from(value: IWindowsDriverUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate2> for &'a IUpdate {
-    fn from(value: &'a IWindowsDriverUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate2> for IUpdate {
-    fn from(value: &IWindowsDriverUpdate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate2> for IWindowsDriverUpdate {
-    fn from(value: IWindowsDriverUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate2> for &'a IWindowsDriverUpdate {
-    fn from(value: &'a IWindowsDriverUpdate2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate2> for IWindowsDriverUpdate {
-    fn from(value: &IWindowsDriverUpdate2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsDriverUpdate2, ::windows::core::IUnknown, super::Com::IDispatch, IUpdate, IWindowsDriverUpdate);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsDriverUpdate2 {
     fn clone(&self) -> Self {
@@ -10627,95 +7755,7 @@ impl IWindowsDriverUpdate3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate3> for ::windows::core::IUnknown {
-    fn from(value: IWindowsDriverUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsDriverUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate3> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsDriverUpdate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate3> for super::Com::IDispatch {
-    fn from(value: IWindowsDriverUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate3> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWindowsDriverUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate3> for super::Com::IDispatch {
-    fn from(value: &IWindowsDriverUpdate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate3> for IUpdate {
-    fn from(value: IWindowsDriverUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate3> for &'a IUpdate {
-    fn from(value: &'a IWindowsDriverUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate3> for IUpdate {
-    fn from(value: &IWindowsDriverUpdate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate3> for IWindowsDriverUpdate {
-    fn from(value: IWindowsDriverUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate3> for &'a IWindowsDriverUpdate {
-    fn from(value: &'a IWindowsDriverUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate3> for IWindowsDriverUpdate {
-    fn from(value: &IWindowsDriverUpdate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate3> for IWindowsDriverUpdate2 {
-    fn from(value: IWindowsDriverUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate3> for &'a IWindowsDriverUpdate2 {
-    fn from(value: &'a IWindowsDriverUpdate3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate3> for IWindowsDriverUpdate2 {
-    fn from(value: &IWindowsDriverUpdate3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsDriverUpdate3, ::windows::core::IUnknown, super::Com::IDispatch, IUpdate, IWindowsDriverUpdate, IWindowsDriverUpdate2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsDriverUpdate3 {
     fn clone(&self) -> Self {
@@ -11036,113 +8076,7 @@ impl IWindowsDriverUpdate4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate4> for ::windows::core::IUnknown {
-    fn from(value: IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate4> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsDriverUpdate4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate4> for super::Com::IDispatch {
-    fn from(value: IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate4> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate4> for super::Com::IDispatch {
-    fn from(value: &IWindowsDriverUpdate4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate4> for IUpdate {
-    fn from(value: IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate4> for &'a IUpdate {
-    fn from(value: &'a IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate4> for IUpdate {
-    fn from(value: &IWindowsDriverUpdate4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate4> for IWindowsDriverUpdate {
-    fn from(value: IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate4> for &'a IWindowsDriverUpdate {
-    fn from(value: &'a IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate4> for IWindowsDriverUpdate {
-    fn from(value: &IWindowsDriverUpdate4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate4> for IWindowsDriverUpdate2 {
-    fn from(value: IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate4> for &'a IWindowsDriverUpdate2 {
-    fn from(value: &'a IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate4> for IWindowsDriverUpdate2 {
-    fn from(value: &IWindowsDriverUpdate4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate4> for IWindowsDriverUpdate3 {
-    fn from(value: IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate4> for &'a IWindowsDriverUpdate3 {
-    fn from(value: &'a IWindowsDriverUpdate4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate4> for IWindowsDriverUpdate3 {
-    fn from(value: &IWindowsDriverUpdate4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsDriverUpdate4, ::windows::core::IUnknown, super::Com::IDispatch, IUpdate, IWindowsDriverUpdate, IWindowsDriverUpdate2, IWindowsDriverUpdate3);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsDriverUpdate4 {
     fn clone(&self) -> Self {
@@ -11475,131 +8409,7 @@ impl IWindowsDriverUpdate5 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate5> for ::windows::core::IUnknown {
-    fn from(value: IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate5> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsDriverUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate5> for super::Com::IDispatch {
-    fn from(value: IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate5> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate5> for super::Com::IDispatch {
-    fn from(value: &IWindowsDriverUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate5> for IUpdate {
-    fn from(value: IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate5> for &'a IUpdate {
-    fn from(value: &'a IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate5> for IUpdate {
-    fn from(value: &IWindowsDriverUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate5> for IWindowsDriverUpdate {
-    fn from(value: IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate5> for &'a IWindowsDriverUpdate {
-    fn from(value: &'a IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate5> for IWindowsDriverUpdate {
-    fn from(value: &IWindowsDriverUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate5> for IWindowsDriverUpdate2 {
-    fn from(value: IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate5> for &'a IWindowsDriverUpdate2 {
-    fn from(value: &'a IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate5> for IWindowsDriverUpdate2 {
-    fn from(value: &IWindowsDriverUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate5> for IWindowsDriverUpdate3 {
-    fn from(value: IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate5> for &'a IWindowsDriverUpdate3 {
-    fn from(value: &'a IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate5> for IWindowsDriverUpdate3 {
-    fn from(value: &IWindowsDriverUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdate5> for IWindowsDriverUpdate4 {
-    fn from(value: IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdate5> for &'a IWindowsDriverUpdate4 {
-    fn from(value: &'a IWindowsDriverUpdate5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdate5> for IWindowsDriverUpdate4 {
-    fn from(value: &IWindowsDriverUpdate5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsDriverUpdate5, ::windows::core::IUnknown, super::Com::IDispatch, IUpdate, IWindowsDriverUpdate, IWindowsDriverUpdate2, IWindowsDriverUpdate3, IWindowsDriverUpdate4);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsDriverUpdate5 {
     fn clone(&self) -> Self {
@@ -11676,41 +8486,7 @@ impl IWindowsDriverUpdateEntry {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdateEntry> for ::windows::core::IUnknown {
-    fn from(value: IWindowsDriverUpdateEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdateEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsDriverUpdateEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdateEntry> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsDriverUpdateEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdateEntry> for super::Com::IDispatch {
-    fn from(value: IWindowsDriverUpdateEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdateEntry> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWindowsDriverUpdateEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdateEntry> for super::Com::IDispatch {
-    fn from(value: &IWindowsDriverUpdateEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsDriverUpdateEntry, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsDriverUpdateEntry {
     fn clone(&self) -> Self {
@@ -11775,41 +8551,7 @@ impl IWindowsDriverUpdateEntryCollection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdateEntryCollection> for ::windows::core::IUnknown {
-    fn from(value: IWindowsDriverUpdateEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdateEntryCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsDriverUpdateEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdateEntryCollection> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsDriverUpdateEntryCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsDriverUpdateEntryCollection> for super::Com::IDispatch {
-    fn from(value: IWindowsDriverUpdateEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsDriverUpdateEntryCollection> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWindowsDriverUpdateEntryCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsDriverUpdateEntryCollection> for super::Com::IDispatch {
-    fn from(value: &IWindowsDriverUpdateEntryCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsDriverUpdateEntryCollection, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsDriverUpdateEntryCollection {
     fn clone(&self) -> Self {
@@ -11867,41 +8609,7 @@ impl IWindowsUpdateAgentInfo {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsUpdateAgentInfo> for ::windows::core::IUnknown {
-    fn from(value: IWindowsUpdateAgentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsUpdateAgentInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsUpdateAgentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsUpdateAgentInfo> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsUpdateAgentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWindowsUpdateAgentInfo> for super::Com::IDispatch {
-    fn from(value: IWindowsUpdateAgentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWindowsUpdateAgentInfo> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWindowsUpdateAgentInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWindowsUpdateAgentInfo> for super::Com::IDispatch {
-    fn from(value: &IWindowsUpdateAgentInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsUpdateAgentInfo, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWindowsUpdateAgentInfo {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/mod.rs
@@ -9,21 +9,7 @@ impl IWaaSAssessor {
         (::windows::core::Vtable::vtable(self).GetOSUpdateAssessment)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<OSUpdateAssessment>(result__)
     }
 }
-impl ::core::convert::From<IWaaSAssessor> for ::windows::core::IUnknown {
-    fn from(value: IWaaSAssessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWaaSAssessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWaaSAssessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWaaSAssessor> for ::windows::core::IUnknown {
-    fn from(value: &IWaaSAssessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWaaSAssessor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWaaSAssessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/AllJoyn/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/AllJoyn/mod.rs
@@ -10,36 +10,7 @@ impl IWindowsDevicesAllJoynBusAttachmentFactoryInterop {
         (::windows::core::Vtable::vtable(self).CreateFromWin32Handle)(::windows::core::Vtable::as_raw(self), win32handle, enableaboutdata, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IWindowsDevicesAllJoynBusAttachmentFactoryInterop> for ::windows::core::IUnknown {
-    fn from(value: IWindowsDevicesAllJoynBusAttachmentFactoryInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsDevicesAllJoynBusAttachmentFactoryInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsDevicesAllJoynBusAttachmentFactoryInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsDevicesAllJoynBusAttachmentFactoryInterop> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsDevicesAllJoynBusAttachmentFactoryInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWindowsDevicesAllJoynBusAttachmentFactoryInterop> for ::windows::core::IInspectable {
-    fn from(value: IWindowsDevicesAllJoynBusAttachmentFactoryInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsDevicesAllJoynBusAttachmentFactoryInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWindowsDevicesAllJoynBusAttachmentFactoryInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsDevicesAllJoynBusAttachmentFactoryInterop> for ::windows::core::IInspectable {
-    fn from(value: &IWindowsDevicesAllJoynBusAttachmentFactoryInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsDevicesAllJoynBusAttachmentFactoryInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWindowsDevicesAllJoynBusAttachmentFactoryInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -77,36 +48,7 @@ impl IWindowsDevicesAllJoynBusAttachmentInterop {
         (::windows::core::Vtable::vtable(self).Win32Handle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IWindowsDevicesAllJoynBusAttachmentInterop> for ::windows::core::IUnknown {
-    fn from(value: IWindowsDevicesAllJoynBusAttachmentInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsDevicesAllJoynBusAttachmentInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsDevicesAllJoynBusAttachmentInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsDevicesAllJoynBusAttachmentInterop> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsDevicesAllJoynBusAttachmentInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWindowsDevicesAllJoynBusAttachmentInterop> for ::windows::core::IInspectable {
-    fn from(value: IWindowsDevicesAllJoynBusAttachmentInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsDevicesAllJoynBusAttachmentInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWindowsDevicesAllJoynBusAttachmentInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsDevicesAllJoynBusAttachmentInterop> for ::windows::core::IInspectable {
-    fn from(value: &IWindowsDevicesAllJoynBusAttachmentInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsDevicesAllJoynBusAttachmentInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWindowsDevicesAllJoynBusAttachmentInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -147,36 +89,7 @@ impl IWindowsDevicesAllJoynBusObjectFactoryInterop {
         (::windows::core::Vtable::vtable(self).CreateFromWin32Handle)(::windows::core::Vtable::as_raw(self), win32handle, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IWindowsDevicesAllJoynBusObjectFactoryInterop> for ::windows::core::IUnknown {
-    fn from(value: IWindowsDevicesAllJoynBusObjectFactoryInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsDevicesAllJoynBusObjectFactoryInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsDevicesAllJoynBusObjectFactoryInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsDevicesAllJoynBusObjectFactoryInterop> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsDevicesAllJoynBusObjectFactoryInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWindowsDevicesAllJoynBusObjectFactoryInterop> for ::windows::core::IInspectable {
-    fn from(value: IWindowsDevicesAllJoynBusObjectFactoryInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsDevicesAllJoynBusObjectFactoryInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWindowsDevicesAllJoynBusObjectFactoryInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsDevicesAllJoynBusObjectFactoryInterop> for ::windows::core::IInspectable {
-    fn from(value: &IWindowsDevicesAllJoynBusObjectFactoryInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsDevicesAllJoynBusObjectFactoryInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWindowsDevicesAllJoynBusObjectFactoryInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -220,36 +133,7 @@ impl IWindowsDevicesAllJoynBusObjectInterop {
         (::windows::core::Vtable::vtable(self).Win32Handle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u64>(result__)
     }
 }
-impl ::core::convert::From<IWindowsDevicesAllJoynBusObjectInterop> for ::windows::core::IUnknown {
-    fn from(value: IWindowsDevicesAllJoynBusObjectInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsDevicesAllJoynBusObjectInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsDevicesAllJoynBusObjectInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsDevicesAllJoynBusObjectInterop> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsDevicesAllJoynBusObjectInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWindowsDevicesAllJoynBusObjectInterop> for ::windows::core::IInspectable {
-    fn from(value: IWindowsDevicesAllJoynBusObjectInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsDevicesAllJoynBusObjectInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWindowsDevicesAllJoynBusObjectInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsDevicesAllJoynBusObjectInterop> for ::windows::core::IInspectable {
-    fn from(value: &IWindowsDevicesAllJoynBusObjectInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsDevicesAllJoynBusObjectInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWindowsDevicesAllJoynBusObjectInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/mod.rs
@@ -12,36 +12,7 @@ impl ICompositionCapabilitiesInteropFactory {
         (::windows::core::Vtable::vtable(self).GetForWindow)(::windows::core::Vtable::as_raw(self), hwnd.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::super::UI::Composition::CompositionCapabilities>(result__)
     }
 }
-impl ::core::convert::From<ICompositionCapabilitiesInteropFactory> for ::windows::core::IUnknown {
-    fn from(value: ICompositionCapabilitiesInteropFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionCapabilitiesInteropFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositionCapabilitiesInteropFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionCapabilitiesInteropFactory> for ::windows::core::IUnknown {
-    fn from(value: &ICompositionCapabilitiesInteropFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICompositionCapabilitiesInteropFactory> for ::windows::core::IInspectable {
-    fn from(value: ICompositionCapabilitiesInteropFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionCapabilitiesInteropFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICompositionCapabilitiesInteropFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionCapabilitiesInteropFactory> for ::windows::core::IInspectable {
-    fn from(value: &ICompositionCapabilitiesInteropFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositionCapabilitiesInteropFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICompositionCapabilitiesInteropFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -106,21 +77,7 @@ impl ICompositionDrawingSurfaceInterop {
         (::windows::core::Vtable::vtable(self).SuspendDraw)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ICompositionDrawingSurfaceInterop> for ::windows::core::IUnknown {
-    fn from(value: ICompositionDrawingSurfaceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionDrawingSurfaceInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositionDrawingSurfaceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionDrawingSurfaceInterop> for ::windows::core::IUnknown {
-    fn from(value: &ICompositionDrawingSurfaceInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositionDrawingSurfaceInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICompositionDrawingSurfaceInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -204,36 +161,7 @@ impl ICompositionDrawingSurfaceInterop2 {
         (::windows::core::Vtable::vtable(self).CopySurface)(::windows::core::Vtable::as_raw(self), destinationresource.into().abi(), destinationoffsetx, destinationoffsety, ::core::mem::transmute(sourcerectangle.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<ICompositionDrawingSurfaceInterop2> for ::windows::core::IUnknown {
-    fn from(value: ICompositionDrawingSurfaceInterop2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionDrawingSurfaceInterop2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositionDrawingSurfaceInterop2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionDrawingSurfaceInterop2> for ::windows::core::IUnknown {
-    fn from(value: &ICompositionDrawingSurfaceInterop2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICompositionDrawingSurfaceInterop2> for ICompositionDrawingSurfaceInterop {
-    fn from(value: ICompositionDrawingSurfaceInterop2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionDrawingSurfaceInterop2> for &'a ICompositionDrawingSurfaceInterop {
-    fn from(value: &'a ICompositionDrawingSurfaceInterop2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionDrawingSurfaceInterop2> for ICompositionDrawingSurfaceInterop {
-    fn from(value: &ICompositionDrawingSurfaceInterop2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositionDrawingSurfaceInterop2, ::windows::core::IUnknown, ICompositionDrawingSurfaceInterop);
 impl ::core::clone::Clone for ICompositionDrawingSurfaceInterop2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -280,21 +208,7 @@ impl ICompositionGraphicsDeviceInterop {
         (::windows::core::Vtable::vtable(self).SetRenderingDevice)(::windows::core::Vtable::as_raw(self), value.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ICompositionGraphicsDeviceInterop> for ::windows::core::IUnknown {
-    fn from(value: ICompositionGraphicsDeviceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositionGraphicsDeviceInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositionGraphicsDeviceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositionGraphicsDeviceInterop> for ::windows::core::IUnknown {
-    fn from(value: &ICompositionGraphicsDeviceInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositionGraphicsDeviceInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICompositionGraphicsDeviceInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -342,21 +256,7 @@ impl ICompositorDesktopInterop {
         (::windows::core::Vtable::vtable(self).EnsureOnThread)(::windows::core::Vtable::as_raw(self), threadid).ok()
     }
 }
-impl ::core::convert::From<ICompositorDesktopInterop> for ::windows::core::IUnknown {
-    fn from(value: ICompositorDesktopInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositorDesktopInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositorDesktopInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositorDesktopInterop> for ::windows::core::IUnknown {
-    fn from(value: &ICompositorDesktopInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositorDesktopInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICompositorDesktopInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -421,21 +321,7 @@ impl ICompositorInterop {
         (::windows::core::Vtable::vtable(self).CreateGraphicsDevice)(::windows::core::Vtable::as_raw(self), renderingdevice.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::super::UI::Composition::CompositionGraphicsDevice>(result__)
     }
 }
-impl ::core::convert::From<ICompositorInterop> for ::windows::core::IUnknown {
-    fn from(value: ICompositorInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICompositorInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICompositorInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICompositorInterop> for ::windows::core::IUnknown {
-    fn from(value: &ICompositorInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICompositorInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICompositorInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -486,21 +372,7 @@ impl IDesktopWindowTargetInterop {
         (::windows::core::Vtable::vtable(self).Hwnd)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::HWND>(result__)
     }
 }
-impl ::core::convert::From<IDesktopWindowTargetInterop> for ::windows::core::IUnknown {
-    fn from(value: IDesktopWindowTargetInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDesktopWindowTargetInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDesktopWindowTargetInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDesktopWindowTargetInterop> for ::windows::core::IUnknown {
-    fn from(value: &IDesktopWindowTargetInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDesktopWindowTargetInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDesktopWindowTargetInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -543,21 +415,7 @@ impl ISwapChainInterop {
         (::windows::core::Vtable::vtable(self).SetSwapChain)(::windows::core::Vtable::as_raw(self), swapchain.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISwapChainInterop> for ::windows::core::IUnknown {
-    fn from(value: ISwapChainInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISwapChainInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISwapChainInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISwapChainInterop> for ::windows::core::IUnknown {
-    fn from(value: &ISwapChainInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISwapChainInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISwapChainInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -596,21 +454,7 @@ impl IVisualInteractionSourceInterop {
         (::windows::core::Vtable::vtable(self).TryRedirectForManipulation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pointerinfo)).ok()
     }
 }
-impl ::core::convert::From<IVisualInteractionSourceInterop> for ::windows::core::IUnknown {
-    fn from(value: IVisualInteractionSourceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualInteractionSourceInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVisualInteractionSourceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualInteractionSourceInterop> for ::windows::core::IUnknown {
-    fn from(value: &IVisualInteractionSourceInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVisualInteractionSourceInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVisualInteractionSourceInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/CoreInputView/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/CoreInputView/mod.rs
@@ -13,36 +13,7 @@ impl ICoreFrameworkInputViewInterop {
         (::windows::core::Vtable::vtable(self).GetForWindow)(::windows::core::Vtable::as_raw(self), appwindow.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ICoreFrameworkInputViewInterop> for ::windows::core::IUnknown {
-    fn from(value: ICoreFrameworkInputViewInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreFrameworkInputViewInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreFrameworkInputViewInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreFrameworkInputViewInterop> for ::windows::core::IUnknown {
-    fn from(value: &ICoreFrameworkInputViewInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICoreFrameworkInputViewInterop> for ::windows::core::IInspectable {
-    fn from(value: ICoreFrameworkInputViewInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreFrameworkInputViewInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICoreFrameworkInputViewInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreFrameworkInputViewInterop> for ::windows::core::IInspectable {
-    fn from(value: &ICoreFrameworkInputViewInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreFrameworkInputViewInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICoreFrameworkInputViewInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Direct3D11/mod.rs
@@ -38,21 +38,7 @@ impl IDirect3DDxgiInterfaceAccess {
         (::windows::core::Vtable::vtable(self).GetInterface)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDirect3DDxgiInterfaceAccess> for ::windows::core::IUnknown {
-    fn from(value: IDirect3DDxgiInterfaceAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDirect3DDxgiInterfaceAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDirect3DDxgiInterfaceAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDirect3DDxgiInterfaceAccess> for ::windows::core::IUnknown {
-    fn from(value: &IDirect3DDxgiInterfaceAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDirect3DDxgiInterfaceAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDirect3DDxgiInterfaceAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/mod.rs
@@ -21,21 +21,7 @@ impl IDisplayDeviceInterop {
         (::windows::core::Vtable::vtable(self).OpenSharedHandle)(::windows::core::Vtable::as_raw(self), nthandle.into(), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut ::core::ffi::c_void>(result__)
     }
 }
-impl ::core::convert::From<IDisplayDeviceInterop> for ::windows::core::IUnknown {
-    fn from(value: IDisplayDeviceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDisplayDeviceInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDisplayDeviceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDisplayDeviceInterop> for ::windows::core::IUnknown {
-    fn from(value: &IDisplayDeviceInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDisplayDeviceInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDisplayDeviceInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -86,21 +72,7 @@ impl IDisplayPathInterop {
         (::windows::core::Vtable::vtable(self).GetSourceId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IDisplayPathInterop> for ::windows::core::IUnknown {
-    fn from(value: IDisplayPathInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDisplayPathInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDisplayPathInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDisplayPathInterop> for ::windows::core::IUnknown {
-    fn from(value: &IDisplayPathInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDisplayPathInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDisplayPathInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Capture/mod.rs
@@ -23,21 +23,7 @@ impl IGraphicsCaptureItemInterop {
         (::windows::core::Vtable::vtable(self).CreateForMonitor)(::windows::core::Vtable::as_raw(self), monitor.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IGraphicsCaptureItemInterop> for ::windows::core::IUnknown {
-    fn from(value: IGraphicsCaptureItemInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGraphicsCaptureItemInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGraphicsCaptureItemInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGraphicsCaptureItemInterop> for ::windows::core::IUnknown {
-    fn from(value: &IGraphicsCaptureItemInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGraphicsCaptureItemInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGraphicsCaptureItemInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/mod.rs
@@ -18,21 +18,7 @@ impl IGeometrySource2DInterop {
         (::windows::core::Vtable::vtable(self).TryGetGeometryUsingFactory)(::windows::core::Vtable::as_raw(self), factory.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::super::Graphics::Direct2D::ID2D1Geometry>(result__)
     }
 }
-impl ::core::convert::From<IGeometrySource2DInterop> for ::windows::core::IUnknown {
-    fn from(value: IGeometrySource2DInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGeometrySource2DInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGeometrySource2DInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGeometrySource2DInterop> for ::windows::core::IUnknown {
-    fn from(value: &IGeometrySource2DInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGeometrySource2DInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGeometrySource2DInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -103,21 +89,7 @@ impl IGraphicsEffectD2D1Interop {
         (::windows::core::Vtable::vtable(self).GetSourceCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IGraphicsEffectD2D1Interop> for ::windows::core::IUnknown {
-    fn from(value: IGraphicsEffectD2D1Interop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGraphicsEffectD2D1Interop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGraphicsEffectD2D1Interop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGraphicsEffectD2D1Interop> for ::windows::core::IUnknown {
-    fn from(value: &IGraphicsEffectD2D1Interop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGraphicsEffectD2D1Interop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGraphicsEffectD2D1Interop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Imaging/mod.rs
@@ -10,36 +10,7 @@ impl ISoftwareBitmapNative {
         (::windows::core::Vtable::vtable(self).GetData)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ISoftwareBitmapNative> for ::windows::core::IUnknown {
-    fn from(value: ISoftwareBitmapNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISoftwareBitmapNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISoftwareBitmapNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISoftwareBitmapNative> for ::windows::core::IUnknown {
-    fn from(value: &ISoftwareBitmapNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISoftwareBitmapNative> for ::windows::core::IInspectable {
-    fn from(value: ISoftwareBitmapNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISoftwareBitmapNative> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISoftwareBitmapNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISoftwareBitmapNative> for ::windows::core::IInspectable {
-    fn from(value: &ISoftwareBitmapNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISoftwareBitmapNative, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISoftwareBitmapNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -95,36 +66,7 @@ impl ISoftwareBitmapNativeFactory {
         (::windows::core::Vtable::vtable(self).CreateFromMF2DBuffer2)(::windows::core::Vtable::as_raw(self), data.into().abi(), ::core::mem::transmute(subtype), width, height, forcereadonly.into(), ::core::mem::transmute(mindisplayaperture.unwrap_or(::std::ptr::null())), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ISoftwareBitmapNativeFactory> for ::windows::core::IUnknown {
-    fn from(value: ISoftwareBitmapNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISoftwareBitmapNativeFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISoftwareBitmapNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISoftwareBitmapNativeFactory> for ::windows::core::IUnknown {
-    fn from(value: &ISoftwareBitmapNativeFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISoftwareBitmapNativeFactory> for ::windows::core::IInspectable {
-    fn from(value: ISoftwareBitmapNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISoftwareBitmapNativeFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISoftwareBitmapNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISoftwareBitmapNativeFactory> for ::windows::core::IInspectable {
-    fn from(value: &ISoftwareBitmapNativeFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISoftwareBitmapNativeFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISoftwareBitmapNativeFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Holographic/mod.rs
@@ -48,36 +48,7 @@ impl IHolographicCameraInterop {
         (::windows::core::Vtable::vtable(self).UnacquireDirect3D12BufferResource)(::windows::core::Vtable::as_raw(self), presourcetounacquire.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IHolographicCameraInterop> for ::windows::core::IUnknown {
-    fn from(value: IHolographicCameraInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHolographicCameraInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHolographicCameraInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHolographicCameraInterop> for ::windows::core::IUnknown {
-    fn from(value: &IHolographicCameraInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHolographicCameraInterop> for ::windows::core::IInspectable {
-    fn from(value: IHolographicCameraInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHolographicCameraInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IHolographicCameraInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHolographicCameraInterop> for ::windows::core::IInspectable {
-    fn from(value: &IHolographicCameraInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHolographicCameraInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IHolographicCameraInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -150,36 +121,7 @@ impl IHolographicCameraRenderingParametersInterop {
         (::windows::core::Vtable::vtable(self).CommitDirect3D12ResourceWithDepthData)(::windows::core::Vtable::as_raw(self), pcolorresourcetocommit.into().abi(), pcolorresourcefence.into().abi(), colorresourcefencesignalvalue, pdepthresourcetocommit.into().abi(), pdepthresourcefence.into().abi(), depthresourcefencesignalvalue).ok()
     }
 }
-impl ::core::convert::From<IHolographicCameraRenderingParametersInterop> for ::windows::core::IUnknown {
-    fn from(value: IHolographicCameraRenderingParametersInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHolographicCameraRenderingParametersInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHolographicCameraRenderingParametersInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHolographicCameraRenderingParametersInterop> for ::windows::core::IUnknown {
-    fn from(value: &IHolographicCameraRenderingParametersInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHolographicCameraRenderingParametersInterop> for ::windows::core::IInspectable {
-    fn from(value: IHolographicCameraRenderingParametersInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHolographicCameraRenderingParametersInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IHolographicCameraRenderingParametersInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHolographicCameraRenderingParametersInterop> for ::windows::core::IInspectable {
-    fn from(value: &IHolographicCameraRenderingParametersInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHolographicCameraRenderingParametersInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IHolographicCameraRenderingParametersInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -265,36 +207,7 @@ impl IHolographicQuadLayerInterop {
         (::windows::core::Vtable::vtable(self).UnacquireDirect3D12BufferResource)(::windows::core::Vtable::as_raw(self), presourcetounacquire.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IHolographicQuadLayerInterop> for ::windows::core::IUnknown {
-    fn from(value: IHolographicQuadLayerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHolographicQuadLayerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHolographicQuadLayerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHolographicQuadLayerInterop> for ::windows::core::IUnknown {
-    fn from(value: &IHolographicQuadLayerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHolographicQuadLayerInterop> for ::windows::core::IInspectable {
-    fn from(value: IHolographicQuadLayerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHolographicQuadLayerInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IHolographicQuadLayerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHolographicQuadLayerInterop> for ::windows::core::IInspectable {
-    fn from(value: &IHolographicQuadLayerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHolographicQuadLayerInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IHolographicQuadLayerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -356,36 +269,7 @@ impl IHolographicQuadLayerUpdateParametersInterop {
         (::windows::core::Vtable::vtable(self).CommitDirect3D12Resource)(::windows::core::Vtable::as_raw(self), pcolorresourcetocommit.into().abi(), pcolorresourcefence.into().abi(), colorresourcefencesignalvalue).ok()
     }
 }
-impl ::core::convert::From<IHolographicQuadLayerUpdateParametersInterop> for ::windows::core::IUnknown {
-    fn from(value: IHolographicQuadLayerUpdateParametersInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHolographicQuadLayerUpdateParametersInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHolographicQuadLayerUpdateParametersInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHolographicQuadLayerUpdateParametersInterop> for ::windows::core::IUnknown {
-    fn from(value: &IHolographicQuadLayerUpdateParametersInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHolographicQuadLayerUpdateParametersInterop> for ::windows::core::IInspectable {
-    fn from(value: IHolographicQuadLayerUpdateParametersInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHolographicQuadLayerUpdateParametersInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IHolographicQuadLayerUpdateParametersInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHolographicQuadLayerUpdateParametersInterop> for ::windows::core::IInspectable {
-    fn from(value: &IHolographicQuadLayerUpdateParametersInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHolographicQuadLayerUpdateParametersInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IHolographicQuadLayerUpdateParametersInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/mod.rs
@@ -12,21 +12,7 @@ impl IIsolatedEnvironmentInterop {
         (::windows::core::Vtable::vtable(self).GetHostHwndInterop)(::windows::core::Vtable::as_raw(self), containerhwnd.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::HWND>(result__)
     }
 }
-impl ::core::convert::From<IIsolatedEnvironmentInterop> for ::windows::core::IUnknown {
-    fn from(value: IIsolatedEnvironmentInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIsolatedEnvironmentInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIsolatedEnvironmentInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIsolatedEnvironmentInterop> for ::windows::core::IUnknown {
-    fn from(value: &IIsolatedEnvironmentInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIsolatedEnvironmentInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IIsolatedEnvironmentInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/mod.rs
@@ -12,21 +12,7 @@ impl ILearningModelDeviceFactoryNative {
         (::windows::core::Vtable::vtable(self).CreateFromD3D12CommandQueue)(::windows::core::Vtable::as_raw(self), value.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<ILearningModelDeviceFactoryNative> for ::windows::core::IUnknown {
-    fn from(value: ILearningModelDeviceFactoryNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILearningModelDeviceFactoryNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILearningModelDeviceFactoryNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILearningModelDeviceFactoryNative> for ::windows::core::IUnknown {
-    fn from(value: &ILearningModelDeviceFactoryNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILearningModelDeviceFactoryNative, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILearningModelDeviceFactoryNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -69,21 +55,7 @@ impl ILearningModelOperatorProviderNative {
         (::windows::core::Vtable::vtable(self).GetRegistry)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::AI::MachineLearning::WinML::IMLOperatorRegistry>(result__)
     }
 }
-impl ::core::convert::From<ILearningModelOperatorProviderNative> for ::windows::core::IUnknown {
-    fn from(value: ILearningModelOperatorProviderNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILearningModelOperatorProviderNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILearningModelOperatorProviderNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILearningModelOperatorProviderNative> for ::windows::core::IUnknown {
-    fn from(value: &ILearningModelOperatorProviderNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILearningModelOperatorProviderNative, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILearningModelOperatorProviderNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -123,21 +95,7 @@ impl ILearningModelSessionOptionsNative {
         (::windows::core::Vtable::vtable(self).SetIntraOpNumThreadsOverride)(::windows::core::Vtable::as_raw(self), intraopnumthreads).ok()
     }
 }
-impl ::core::convert::From<ILearningModelSessionOptionsNative> for ::windows::core::IUnknown {
-    fn from(value: ILearningModelSessionOptionsNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILearningModelSessionOptionsNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILearningModelSessionOptionsNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILearningModelSessionOptionsNative> for ::windows::core::IUnknown {
-    fn from(value: &ILearningModelSessionOptionsNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILearningModelSessionOptionsNative, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILearningModelSessionOptionsNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -180,21 +138,7 @@ impl ITensorNative {
         (::windows::core::Vtable::vtable(self).GetD3D12Resource)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Graphics::Direct3D12::ID3D12Resource>(result__)
     }
 }
-impl ::core::convert::From<ITensorNative> for ::windows::core::IUnknown {
-    fn from(value: ITensorNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITensorNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITensorNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITensorNative> for ::windows::core::IUnknown {
-    fn from(value: &ITensorNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITensorNative, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITensorNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -240,21 +184,7 @@ impl ITensorStaticsNative {
         (::windows::core::Vtable::vtable(self).CreateFromD3D12Resource)(::windows::core::Vtable::as_raw(self), value.into().abi(), ::core::mem::transmute(shape), shapecount, ::core::mem::transmute(result)).ok()
     }
 }
-impl ::core::convert::From<ITensorStaticsNative> for ::windows::core::IUnknown {
-    fn from(value: ITensorStaticsNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITensorStaticsNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITensorStaticsNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITensorStaticsNative> for ::windows::core::IUnknown {
-    fn from(value: &ITensorStaticsNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITensorStaticsNative, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITensorStaticsNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Media/mod.rs
@@ -10,36 +10,7 @@ impl IAudioFrameNative {
         (::windows::core::Vtable::vtable(self).GetData)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IAudioFrameNative> for ::windows::core::IUnknown {
-    fn from(value: IAudioFrameNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioFrameNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioFrameNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioFrameNative> for ::windows::core::IUnknown {
-    fn from(value: &IAudioFrameNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioFrameNative> for ::windows::core::IInspectable {
-    fn from(value: IAudioFrameNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioFrameNative> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAudioFrameNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioFrameNative> for ::windows::core::IInspectable {
-    fn from(value: &IAudioFrameNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioFrameNative, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAudioFrameNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -84,36 +55,7 @@ impl IAudioFrameNativeFactory {
         (::windows::core::Vtable::vtable(self).CreateFromMFSample)(::windows::core::Vtable::as_raw(self), data.into().abi(), forcereadonly.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IAudioFrameNativeFactory> for ::windows::core::IUnknown {
-    fn from(value: IAudioFrameNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioFrameNativeFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAudioFrameNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioFrameNativeFactory> for ::windows::core::IUnknown {
-    fn from(value: &IAudioFrameNativeFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAudioFrameNativeFactory> for ::windows::core::IInspectable {
-    fn from(value: IAudioFrameNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAudioFrameNativeFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAudioFrameNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAudioFrameNativeFactory> for ::windows::core::IInspectable {
-    fn from(value: &IAudioFrameNativeFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAudioFrameNativeFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAudioFrameNativeFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -164,36 +106,7 @@ impl IVideoFrameNative {
         (::windows::core::Vtable::vtable(self).GetDevice)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IVideoFrameNative> for ::windows::core::IUnknown {
-    fn from(value: IVideoFrameNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVideoFrameNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVideoFrameNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVideoFrameNative> for ::windows::core::IUnknown {
-    fn from(value: &IVideoFrameNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVideoFrameNative> for ::windows::core::IInspectable {
-    fn from(value: IVideoFrameNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVideoFrameNative> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVideoFrameNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVideoFrameNative> for ::windows::core::IInspectable {
-    fn from(value: &IVideoFrameNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVideoFrameNative, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVideoFrameNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -240,36 +153,7 @@ impl IVideoFrameNativeFactory {
         (::windows::core::Vtable::vtable(self).CreateFromMFSample)(::windows::core::Vtable::as_raw(self), data.into().abi(), ::core::mem::transmute(subtype), width, height, forcereadonly.into(), ::core::mem::transmute(mindisplayaperture.unwrap_or(::std::ptr::null())), device.into().abi(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IVideoFrameNativeFactory> for ::windows::core::IUnknown {
-    fn from(value: IVideoFrameNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVideoFrameNativeFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVideoFrameNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVideoFrameNativeFactory> for ::windows::core::IUnknown {
-    fn from(value: &IVideoFrameNativeFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVideoFrameNativeFactory> for ::windows::core::IInspectable {
-    fn from(value: IVideoFrameNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVideoFrameNativeFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IVideoFrameNativeFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVideoFrameNativeFactory> for ::windows::core::IInspectable {
-    fn from(value: &IVideoFrameNativeFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVideoFrameNativeFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IVideoFrameNativeFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/mod.rs
@@ -35,21 +35,7 @@ impl IPdfRendererNative {
         (::windows::core::Vtable::vtable(self).RenderPageToDeviceContext)(::windows::core::Vtable::as_raw(self), pdfpage.into().abi(), pd2ddevicecontext.into().abi(), ::core::mem::transmute(prenderparams.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IPdfRendererNative> for ::windows::core::IUnknown {
-    fn from(value: IPdfRendererNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPdfRendererNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPdfRendererNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPdfRendererNative> for ::windows::core::IUnknown {
-    fn from(value: &IPdfRendererNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPdfRendererNative, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPdfRendererNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/mod.rs
@@ -23,36 +23,7 @@ impl IPrintManagerInterop {
         (::windows::core::Vtable::vtable(self).ShowPrintUIForWindowAsync)(::windows::core::Vtable::as_raw(self), appwindow.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IPrintManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: IPrintManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintManagerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: &IPrintManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: IPrintManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintManagerInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrintManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: &IPrintManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintManagerInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPrintManagerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -111,21 +82,7 @@ impl IPrintWorkflowConfigurationNative {
         (::windows::core::Vtable::vtable(self).UserProperties)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Graphics::Printing::IPrinterPropertyBag>(result__)
     }
 }
-impl ::core::convert::From<IPrintWorkflowConfigurationNative> for ::windows::core::IUnknown {
-    fn from(value: IPrintWorkflowConfigurationNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintWorkflowConfigurationNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintWorkflowConfigurationNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintWorkflowConfigurationNative> for ::windows::core::IUnknown {
-    fn from(value: &IPrintWorkflowConfigurationNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintWorkflowConfigurationNative, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintWorkflowConfigurationNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -182,21 +139,7 @@ impl IPrintWorkflowObjectModelSourceFileContentNative {
         (::windows::core::Vtable::vtable(self).ObjectFactory)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Storage::Xps::IXpsOMObjectFactory1>(result__)
     }
 }
-impl ::core::convert::From<IPrintWorkflowObjectModelSourceFileContentNative> for ::windows::core::IUnknown {
-    fn from(value: IPrintWorkflowObjectModelSourceFileContentNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintWorkflowObjectModelSourceFileContentNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintWorkflowObjectModelSourceFileContentNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintWorkflowObjectModelSourceFileContentNative> for ::windows::core::IUnknown {
-    fn from(value: &IPrintWorkflowObjectModelSourceFileContentNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintWorkflowObjectModelSourceFileContentNative, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintWorkflowObjectModelSourceFileContentNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -240,21 +183,7 @@ impl IPrintWorkflowXpsObjectModelTargetPackageNative {
         (::windows::core::Vtable::vtable(self).DocumentPackageTarget)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Storage::Xps::IXpsDocumentPackageTarget>(result__)
     }
 }
-impl ::core::convert::From<IPrintWorkflowXpsObjectModelTargetPackageNative> for ::windows::core::IUnknown {
-    fn from(value: IPrintWorkflowXpsObjectModelTargetPackageNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintWorkflowXpsObjectModelTargetPackageNative> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintWorkflowXpsObjectModelTargetPackageNative) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintWorkflowXpsObjectModelTargetPackageNative> for ::windows::core::IUnknown {
-    fn from(value: &IPrintWorkflowXpsObjectModelTargetPackageNative) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintWorkflowXpsObjectModelTargetPackageNative, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintWorkflowXpsObjectModelTargetPackageNative {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -326,21 +255,7 @@ impl IPrintWorkflowXpsReceiver {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPrintWorkflowXpsReceiver> for ::windows::core::IUnknown {
-    fn from(value: IPrintWorkflowXpsReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintWorkflowXpsReceiver> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintWorkflowXpsReceiver) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintWorkflowXpsReceiver> for ::windows::core::IUnknown {
-    fn from(value: &IPrintWorkflowXpsReceiver) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintWorkflowXpsReceiver, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintWorkflowXpsReceiver {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -425,36 +340,7 @@ impl IPrintWorkflowXpsReceiver2 {
         (::windows::core::Vtable::vtable(self).Failed)(::windows::core::Vtable::as_raw(self), xpserror).ok()
     }
 }
-impl ::core::convert::From<IPrintWorkflowXpsReceiver2> for ::windows::core::IUnknown {
-    fn from(value: IPrintWorkflowXpsReceiver2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintWorkflowXpsReceiver2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintWorkflowXpsReceiver2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintWorkflowXpsReceiver2> for ::windows::core::IUnknown {
-    fn from(value: &IPrintWorkflowXpsReceiver2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrintWorkflowXpsReceiver2> for IPrintWorkflowXpsReceiver {
-    fn from(value: IPrintWorkflowXpsReceiver2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintWorkflowXpsReceiver2> for &'a IPrintWorkflowXpsReceiver {
-    fn from(value: &'a IPrintWorkflowXpsReceiver2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintWorkflowXpsReceiver2> for IPrintWorkflowXpsReceiver {
-    fn from(value: &IPrintWorkflowXpsReceiver2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintWorkflowXpsReceiver2, ::windows::core::IUnknown, IPrintWorkflowXpsReceiver);
 impl ::core::clone::Clone for IPrintWorkflowXpsReceiver2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -508,36 +394,7 @@ impl IPrinting3DManagerInterop {
         (::windows::core::Vtable::vtable(self).ShowPrintUIForWindowAsync)(::windows::core::Vtable::as_raw(self), appwindow.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IPrinting3DManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: IPrinting3DManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrinting3DManagerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrinting3DManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrinting3DManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: &IPrinting3DManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPrinting3DManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: IPrinting3DManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrinting3DManagerInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPrinting3DManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrinting3DManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: &IPrinting3DManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrinting3DManagerInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPrinting3DManagerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Shell/mod.rs
@@ -18,21 +18,7 @@ impl IDDEInitializer {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), fileextensionorprotocol.into(), method, currentdirectory.into(), exectarget.into().abi(), site.into().abi(), application.into(), targetfile.into(), arguments.into(), verb.into()).ok()
     }
 }
-impl ::core::convert::From<IDDEInitializer> for ::windows::core::IUnknown {
-    fn from(value: IDDEInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDDEInitializer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDDEInitializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDDEInitializer> for ::windows::core::IUnknown {
-    fn from(value: &IDDEInitializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDDEInitializer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDDEInitializer {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/mod.rs
@@ -6,21 +6,7 @@ impl IOplockBreakingHandler {
         (::windows::core::Vtable::vtable(self).OplockBreaking)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IOplockBreakingHandler> for ::windows::core::IUnknown {
-    fn from(value: IOplockBreakingHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOplockBreakingHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOplockBreakingHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOplockBreakingHandler> for ::windows::core::IUnknown {
-    fn from(value: &IOplockBreakingHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOplockBreakingHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOplockBreakingHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -58,21 +44,7 @@ impl IRandomAccessStreamFileAccessMode {
         (::windows::core::Vtable::vtable(self).GetMode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IRandomAccessStreamFileAccessMode> for ::windows::core::IUnknown {
-    fn from(value: IRandomAccessStreamFileAccessMode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRandomAccessStreamFileAccessMode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRandomAccessStreamFileAccessMode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRandomAccessStreamFileAccessMode> for ::windows::core::IUnknown {
-    fn from(value: &IRandomAccessStreamFileAccessMode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRandomAccessStreamFileAccessMode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRandomAccessStreamFileAccessMode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -116,21 +88,7 @@ impl IStorageFolderHandleAccess {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), filename.into(), creationoptions, accessoptions, sharingoptions, options, oplockbreakinghandler.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::HANDLE>(result__)
     }
 }
-impl ::core::convert::From<IStorageFolderHandleAccess> for ::windows::core::IUnknown {
-    fn from(value: IStorageFolderHandleAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageFolderHandleAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageFolderHandleAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageFolderHandleAccess> for ::windows::core::IUnknown {
-    fn from(value: &IStorageFolderHandleAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageFolderHandleAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStorageFolderHandleAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -176,21 +134,7 @@ impl IStorageItemHandleAccess {
         (::windows::core::Vtable::vtable(self).Create)(::windows::core::Vtable::as_raw(self), accessoptions, sharingoptions, options, oplockbreakinghandler.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::Foundation::HANDLE>(result__)
     }
 }
-impl ::core::convert::From<IStorageItemHandleAccess> for ::windows::core::IUnknown {
-    fn from(value: IStorageItemHandleAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageItemHandleAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageItemHandleAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageItemHandleAccess> for ::windows::core::IUnknown {
-    fn from(value: &IStorageItemHandleAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageItemHandleAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStorageItemHandleAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -230,21 +174,7 @@ impl IUnbufferedFileHandleOplockCallback {
         (::windows::core::Vtable::vtable(self).OnBrokenCallback)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUnbufferedFileHandleOplockCallback> for ::windows::core::IUnknown {
-    fn from(value: IUnbufferedFileHandleOplockCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUnbufferedFileHandleOplockCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUnbufferedFileHandleOplockCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUnbufferedFileHandleOplockCallback> for ::windows::core::IUnknown {
-    fn from(value: &IUnbufferedFileHandleOplockCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUnbufferedFileHandleOplockCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUnbufferedFileHandleOplockCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -288,21 +218,7 @@ impl IUnbufferedFileHandleProvider {
         (::windows::core::Vtable::vtable(self).CloseUnbufferedFileHandle)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUnbufferedFileHandleProvider> for ::windows::core::IUnknown {
-    fn from(value: IUnbufferedFileHandleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUnbufferedFileHandleProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUnbufferedFileHandleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUnbufferedFileHandleProvider> for ::windows::core::IUnknown {
-    fn from(value: &IUnbufferedFileHandleProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUnbufferedFileHandleProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUnbufferedFileHandleProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -796,36 +796,7 @@ impl IAccountsSettingsPaneInterop {
         (::windows::core::Vtable::vtable(self).ShowAddAccountForWindowAsync)(::windows::core::Vtable::as_raw(self), appwindow.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IAccountsSettingsPaneInterop> for ::windows::core::IUnknown {
-    fn from(value: IAccountsSettingsPaneInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccountsSettingsPaneInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccountsSettingsPaneInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccountsSettingsPaneInterop> for ::windows::core::IUnknown {
-    fn from(value: &IAccountsSettingsPaneInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAccountsSettingsPaneInterop> for ::windows::core::IInspectable {
-    fn from(value: IAccountsSettingsPaneInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccountsSettingsPaneInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IAccountsSettingsPaneInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccountsSettingsPaneInterop> for ::windows::core::IInspectable {
-    fn from(value: &IAccountsSettingsPaneInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccountsSettingsPaneInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IAccountsSettingsPaneInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -874,36 +845,7 @@ impl IActivationFactory {
         (::windows::core::Vtable::vtable(self).ActivateInstance)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IInspectable>(result__)
     }
 }
-impl ::core::convert::From<IActivationFactory> for ::windows::core::IUnknown {
-    fn from(value: IActivationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActivationFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActivationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActivationFactory> for ::windows::core::IUnknown {
-    fn from(value: &IActivationFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActivationFactory> for ::windows::core::IInspectable {
-    fn from(value: IActivationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActivationFactory> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IActivationFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActivationFactory> for ::windows::core::IInspectable {
-    fn from(value: &IActivationFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActivationFactory, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IActivationFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -944,21 +886,7 @@ impl IAgileReference {
         (::windows::core::Vtable::vtable(self).Resolve)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IAgileReference> for ::windows::core::IUnknown {
-    fn from(value: IAgileReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAgileReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAgileReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAgileReference> for ::windows::core::IUnknown {
-    fn from(value: &IAgileReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAgileReference, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAgileReference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -995,21 +923,7 @@ impl IApartmentShutdown {
         (::windows::core::Vtable::vtable(self).OnUninitialize)(::windows::core::Vtable::as_raw(self), ui64apartmentidentifier)
     }
 }
-impl ::core::convert::From<IApartmentShutdown> for ::windows::core::IUnknown {
-    fn from(value: IApartmentShutdown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApartmentShutdown> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApartmentShutdown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApartmentShutdown> for ::windows::core::IUnknown {
-    fn from(value: &IApartmentShutdown) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApartmentShutdown, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApartmentShutdown {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1050,21 +964,7 @@ impl IAppServiceConnectionExtendedExecution {
         (::windows::core::Vtable::vtable(self).OpenForExtendedExecutionAsync)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IAppServiceConnectionExtendedExecution> for ::windows::core::IUnknown {
-    fn from(value: IAppServiceConnectionExtendedExecution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppServiceConnectionExtendedExecution> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppServiceConnectionExtendedExecution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppServiceConnectionExtendedExecution> for ::windows::core::IUnknown {
-    fn from(value: &IAppServiceConnectionExtendedExecution) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppServiceConnectionExtendedExecution, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppServiceConnectionExtendedExecution {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1102,21 +1002,7 @@ impl IBufferByteAccess {
         (::windows::core::Vtable::vtable(self).Buffer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut u8>(result__)
     }
 }
-impl ::core::convert::From<IBufferByteAccess> for ::windows::core::IUnknown {
-    fn from(value: IBufferByteAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBufferByteAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBufferByteAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBufferByteAccess> for ::windows::core::IUnknown {
-    fn from(value: &IBufferByteAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBufferByteAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBufferByteAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1173,21 +1059,7 @@ impl ICastingController {
         (::windows::core::Vtable::vtable(self).UnAdvise)(::windows::core::Vtable::as_raw(self), cookie).ok()
     }
 }
-impl ::core::convert::From<ICastingController> for ::windows::core::IUnknown {
-    fn from(value: ICastingController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICastingController> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICastingController) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICastingController> for ::windows::core::IUnknown {
-    fn from(value: &ICastingController) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICastingController, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICastingController {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1234,21 +1106,7 @@ impl ICastingEventHandler {
         (::windows::core::Vtable::vtable(self).OnError)(::windows::core::Vtable::as_raw(self), errorstatus, errormessage.into()).ok()
     }
 }
-impl ::core::convert::From<ICastingEventHandler> for ::windows::core::IUnknown {
-    fn from(value: ICastingEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICastingEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICastingEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICastingEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &ICastingEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICastingEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICastingEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1293,21 +1151,7 @@ impl ICastingSourceInfo {
         (::windows::core::Vtable::vtable(self).GetProperties)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::UI::Shell::PropertiesSystem::INamedPropertyStore>(result__)
     }
 }
-impl ::core::convert::From<ICastingSourceInfo> for ::windows::core::IUnknown {
-    fn from(value: ICastingSourceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICastingSourceInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICastingSourceInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICastingSourceInfo> for ::windows::core::IUnknown {
-    fn from(value: &ICastingSourceInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICastingSourceInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICastingSourceInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1354,21 +1198,7 @@ impl ICoreInputInterop {
         (::windows::core::Vtable::vtable(self).SetMessageHandled)(::windows::core::Vtable::as_raw(self), value).ok()
     }
 }
-impl ::core::convert::From<ICoreInputInterop> for ::windows::core::IUnknown {
-    fn from(value: ICoreInputInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreInputInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreInputInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreInputInterop> for ::windows::core::IUnknown {
-    fn from(value: &ICoreInputInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreInputInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICoreInputInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1437,36 +1267,7 @@ impl ICoreWindowAdapterInterop {
         (::windows::core::Vtable::vtable(self).SetWindowClientAdapter)(::windows::core::Vtable::as_raw(self), value.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ICoreWindowAdapterInterop> for ::windows::core::IUnknown {
-    fn from(value: ICoreWindowAdapterInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreWindowAdapterInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreWindowAdapterInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreWindowAdapterInterop> for ::windows::core::IUnknown {
-    fn from(value: &ICoreWindowAdapterInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICoreWindowAdapterInterop> for ::windows::core::IInspectable {
-    fn from(value: ICoreWindowAdapterInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreWindowAdapterInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICoreWindowAdapterInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreWindowAdapterInterop> for ::windows::core::IInspectable {
-    fn from(value: &ICoreWindowAdapterInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreWindowAdapterInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICoreWindowAdapterInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1520,21 +1321,7 @@ impl ICoreWindowComponentInterop {
         (::windows::core::Vtable::vtable(self).GetViewInstanceId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ICoreWindowComponentInterop> for ::windows::core::IUnknown {
-    fn from(value: ICoreWindowComponentInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreWindowComponentInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreWindowComponentInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreWindowComponentInterop> for ::windows::core::IUnknown {
-    fn from(value: &ICoreWindowComponentInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreWindowComponentInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICoreWindowComponentInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1581,21 +1368,7 @@ impl ICoreWindowInterop {
         (::windows::core::Vtable::vtable(self).SetMessageHandled)(::windows::core::Vtable::as_raw(self), value).ok()
     }
 }
-impl ::core::convert::From<ICoreWindowInterop> for ::windows::core::IUnknown {
-    fn from(value: ICoreWindowInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreWindowInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreWindowInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreWindowInterop> for ::windows::core::IUnknown {
-    fn from(value: &ICoreWindowInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreWindowInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICoreWindowInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1644,36 +1417,7 @@ impl ICorrelationVectorInformation {
         (::windows::core::Vtable::vtable(self).SetNextCorrelationVectorForThread)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(cv)).ok()
     }
 }
-impl ::core::convert::From<ICorrelationVectorInformation> for ::windows::core::IUnknown {
-    fn from(value: ICorrelationVectorInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICorrelationVectorInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICorrelationVectorInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICorrelationVectorInformation> for ::windows::core::IUnknown {
-    fn from(value: &ICorrelationVectorInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICorrelationVectorInformation> for ::windows::core::IInspectable {
-    fn from(value: ICorrelationVectorInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICorrelationVectorInformation> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ICorrelationVectorInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICorrelationVectorInformation> for ::windows::core::IInspectable {
-    fn from(value: &ICorrelationVectorInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICorrelationVectorInformation, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ICorrelationVectorInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1713,21 +1457,7 @@ impl ICorrelationVectorSource {
         (::windows::core::Vtable::vtable(self).CorrelationVector)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::HSTRING>(result__)
     }
 }
-impl ::core::convert::From<ICorrelationVectorSource> for ::windows::core::IUnknown {
-    fn from(value: ICorrelationVectorSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICorrelationVectorSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICorrelationVectorSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICorrelationVectorSource> for ::windows::core::IUnknown {
-    fn from(value: &ICorrelationVectorSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICorrelationVectorSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICorrelationVectorSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1771,36 +1501,7 @@ impl IDragDropManagerInterop {
         (::windows::core::Vtable::vtable(self).GetForWindow)(::windows::core::Vtable::as_raw(self), hwnd.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDragDropManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: IDragDropManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDragDropManagerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDragDropManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDragDropManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: &IDragDropManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDragDropManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: IDragDropManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDragDropManagerInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IDragDropManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDragDropManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: &IDragDropManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDragDropManagerInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IDragDropManagerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1847,36 +1548,7 @@ impl IHolographicSpaceInterop {
         (::windows::core::Vtable::vtable(self).CreateForWindow)(::windows::core::Vtable::as_raw(self), window.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IHolographicSpaceInterop> for ::windows::core::IUnknown {
-    fn from(value: IHolographicSpaceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHolographicSpaceInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHolographicSpaceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHolographicSpaceInterop> for ::windows::core::IUnknown {
-    fn from(value: &IHolographicSpaceInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHolographicSpaceInterop> for ::windows::core::IInspectable {
-    fn from(value: IHolographicSpaceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHolographicSpaceInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IHolographicSpaceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHolographicSpaceInterop> for ::windows::core::IInspectable {
-    fn from(value: &IHolographicSpaceInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHolographicSpaceInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IHolographicSpaceInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1923,36 +1595,7 @@ impl IInputPaneInterop {
         (::windows::core::Vtable::vtable(self).GetForWindow)(::windows::core::Vtable::as_raw(self), appwindow.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IInputPaneInterop> for ::windows::core::IUnknown {
-    fn from(value: IInputPaneInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputPaneInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInputPaneInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputPaneInterop> for ::windows::core::IUnknown {
-    fn from(value: &IInputPaneInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInputPaneInterop> for ::windows::core::IInspectable {
-    fn from(value: IInputPaneInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputPaneInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IInputPaneInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputPaneInterop> for ::windows::core::IInspectable {
-    fn from(value: &IInputPaneInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInputPaneInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IInputPaneInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1993,21 +1636,7 @@ impl ILanguageExceptionErrorInfo {
         (::windows::core::Vtable::vtable(self).GetLanguageException)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<ILanguageExceptionErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: ILanguageExceptionErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILanguageExceptionErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILanguageExceptionErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILanguageExceptionErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &ILanguageExceptionErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILanguageExceptionErrorInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILanguageExceptionErrorInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2059,36 +1688,7 @@ impl ILanguageExceptionErrorInfo2 {
         (::windows::core::Vtable::vtable(self).GetPropagationContextHead)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ILanguageExceptionErrorInfo2>(result__)
     }
 }
-impl ::core::convert::From<ILanguageExceptionErrorInfo2> for ::windows::core::IUnknown {
-    fn from(value: ILanguageExceptionErrorInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILanguageExceptionErrorInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILanguageExceptionErrorInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILanguageExceptionErrorInfo2> for ::windows::core::IUnknown {
-    fn from(value: &ILanguageExceptionErrorInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ILanguageExceptionErrorInfo2> for ILanguageExceptionErrorInfo {
-    fn from(value: ILanguageExceptionErrorInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILanguageExceptionErrorInfo2> for &'a ILanguageExceptionErrorInfo {
-    fn from(value: &'a ILanguageExceptionErrorInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILanguageExceptionErrorInfo2> for ILanguageExceptionErrorInfo {
-    fn from(value: &ILanguageExceptionErrorInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILanguageExceptionErrorInfo2, ::windows::core::IUnknown, ILanguageExceptionErrorInfo);
 impl ::core::clone::Clone for ILanguageExceptionErrorInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2127,21 +1727,7 @@ impl ILanguageExceptionStackBackTrace {
         (::windows::core::Vtable::vtable(self).GetStackBackTrace)(::windows::core::Vtable::as_raw(self), maxframestocapture, ::core::mem::transmute(stackbacktrace), ::core::mem::transmute(framescaptured)).ok()
     }
 }
-impl ::core::convert::From<ILanguageExceptionStackBackTrace> for ::windows::core::IUnknown {
-    fn from(value: ILanguageExceptionStackBackTrace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILanguageExceptionStackBackTrace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILanguageExceptionStackBackTrace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILanguageExceptionStackBackTrace> for ::windows::core::IUnknown {
-    fn from(value: &ILanguageExceptionStackBackTrace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILanguageExceptionStackBackTrace, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILanguageExceptionStackBackTrace {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2179,21 +1765,7 @@ impl ILanguageExceptionTransform {
         (::windows::core::Vtable::vtable(self).GetTransformedRestrictedErrorInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRestrictedErrorInfo>(result__)
     }
 }
-impl ::core::convert::From<ILanguageExceptionTransform> for ::windows::core::IUnknown {
-    fn from(value: ILanguageExceptionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILanguageExceptionTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILanguageExceptionTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILanguageExceptionTransform> for ::windows::core::IUnknown {
-    fn from(value: &ILanguageExceptionTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILanguageExceptionTransform, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILanguageExceptionTransform {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2230,21 +1802,7 @@ impl IMemoryBufferByteAccess {
         (::windows::core::Vtable::vtable(self).GetBuffer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(value), ::core::mem::transmute(capacity)).ok()
     }
 }
-impl ::core::convert::From<IMemoryBufferByteAccess> for ::windows::core::IUnknown {
-    fn from(value: IMemoryBufferByteAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMemoryBufferByteAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMemoryBufferByteAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMemoryBufferByteAccess> for ::windows::core::IUnknown {
-    fn from(value: &IMemoryBufferByteAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMemoryBufferByteAccess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMemoryBufferByteAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2281,36 +1839,7 @@ impl IMessageDispatcher {
         (::windows::core::Vtable::vtable(self).PumpMessages)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IMessageDispatcher> for ::windows::core::IUnknown {
-    fn from(value: IMessageDispatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMessageDispatcher> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMessageDispatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMessageDispatcher> for ::windows::core::IUnknown {
-    fn from(value: &IMessageDispatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMessageDispatcher> for ::windows::core::IInspectable {
-    fn from(value: IMessageDispatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMessageDispatcher> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IMessageDispatcher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMessageDispatcher> for ::windows::core::IInspectable {
-    fn from(value: &IMessageDispatcher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMessageDispatcher, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IMessageDispatcher {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2362,36 +1891,7 @@ impl IPlayToManagerInterop {
         (::windows::core::Vtable::vtable(self).ShowPlayToUIForWindow)(::windows::core::Vtable::as_raw(self), appwindow.into()).ok()
     }
 }
-impl ::core::convert::From<IPlayToManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: IPlayToManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayToManagerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPlayToManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayToManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: &IPlayToManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPlayToManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: IPlayToManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPlayToManagerInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IPlayToManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPlayToManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: &IPlayToManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPlayToManagerInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IPlayToManagerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2439,21 +1939,7 @@ impl IRestrictedErrorInfo {
         (::windows::core::Vtable::vtable(self).GetReference)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IRestrictedErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: IRestrictedErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRestrictedErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRestrictedErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRestrictedErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &IRestrictedErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRestrictedErrorInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRestrictedErrorInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2639,21 +2125,7 @@ impl IShareWindowCommandEventArgsInterop {
         (::windows::core::Vtable::vtable(self).GetWindow)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::HWND>(result__)
     }
 }
-impl ::core::convert::From<IShareWindowCommandEventArgsInterop> for ::windows::core::IUnknown {
-    fn from(value: IShareWindowCommandEventArgsInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShareWindowCommandEventArgsInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShareWindowCommandEventArgsInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShareWindowCommandEventArgsInterop> for ::windows::core::IUnknown {
-    fn from(value: &IShareWindowCommandEventArgsInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShareWindowCommandEventArgsInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShareWindowCommandEventArgsInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2700,21 +2172,7 @@ impl IShareWindowCommandSourceInterop {
         (::windows::core::Vtable::vtable(self).GetForWindow)(::windows::core::Vtable::as_raw(self), appwindow.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IShareWindowCommandSourceInterop> for ::windows::core::IUnknown {
-    fn from(value: IShareWindowCommandSourceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShareWindowCommandSourceInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShareWindowCommandSourceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShareWindowCommandSourceInterop> for ::windows::core::IUnknown {
-    fn from(value: &IShareWindowCommandSourceInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShareWindowCommandSourceInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShareWindowCommandSourceInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2761,36 +2219,7 @@ impl ISpatialInteractionManagerInterop {
         (::windows::core::Vtable::vtable(self).GetForWindow)(::windows::core::Vtable::as_raw(self), window.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ISpatialInteractionManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: ISpatialInteractionManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialInteractionManagerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpatialInteractionManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialInteractionManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: &ISpatialInteractionManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISpatialInteractionManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: ISpatialInteractionManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpatialInteractionManagerInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISpatialInteractionManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpatialInteractionManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: &ISpatialInteractionManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpatialInteractionManagerInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISpatialInteractionManagerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2837,36 +2266,7 @@ impl ISystemMediaTransportControlsInterop {
         (::windows::core::Vtable::vtable(self).GetForWindow)(::windows::core::Vtable::as_raw(self), appwindow.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ISystemMediaTransportControlsInterop> for ::windows::core::IUnknown {
-    fn from(value: ISystemMediaTransportControlsInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISystemMediaTransportControlsInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISystemMediaTransportControlsInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISystemMediaTransportControlsInterop> for ::windows::core::IUnknown {
-    fn from(value: &ISystemMediaTransportControlsInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISystemMediaTransportControlsInterop> for ::windows::core::IInspectable {
-    fn from(value: ISystemMediaTransportControlsInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISystemMediaTransportControlsInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a ISystemMediaTransportControlsInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISystemMediaTransportControlsInterop> for ::windows::core::IInspectable {
-    fn from(value: &ISystemMediaTransportControlsInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISystemMediaTransportControlsInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for ISystemMediaTransportControlsInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2913,36 +2313,7 @@ impl IUIViewSettingsInterop {
         (::windows::core::Vtable::vtable(self).GetForWindow)(::windows::core::Vtable::as_raw(self), hwnd.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IUIViewSettingsInterop> for ::windows::core::IUnknown {
-    fn from(value: IUIViewSettingsInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIViewSettingsInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIViewSettingsInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIViewSettingsInterop> for ::windows::core::IUnknown {
-    fn from(value: &IUIViewSettingsInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIViewSettingsInterop> for ::windows::core::IInspectable {
-    fn from(value: IUIViewSettingsInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIViewSettingsInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IUIViewSettingsInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIViewSettingsInterop> for ::windows::core::IInspectable {
-    fn from(value: &IUIViewSettingsInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIViewSettingsInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IUIViewSettingsInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2989,36 +2360,7 @@ impl IUserActivityInterop {
         (::windows::core::Vtable::vtable(self).CreateSessionForWindow)(::windows::core::Vtable::as_raw(self), window.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IUserActivityInterop> for ::windows::core::IUnknown {
-    fn from(value: IUserActivityInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserActivityInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserActivityInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserActivityInterop> for ::windows::core::IUnknown {
-    fn from(value: &IUserActivityInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUserActivityInterop> for ::windows::core::IInspectable {
-    fn from(value: IUserActivityInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserActivityInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IUserActivityInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserActivityInterop> for ::windows::core::IInspectable {
-    fn from(value: &IUserActivityInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserActivityInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IUserActivityInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3065,36 +2407,7 @@ impl IUserActivityRequestManagerInterop {
         (::windows::core::Vtable::vtable(self).GetForWindow)(::windows::core::Vtable::as_raw(self), window.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IUserActivityRequestManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: IUserActivityRequestManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserActivityRequestManagerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserActivityRequestManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserActivityRequestManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: &IUserActivityRequestManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUserActivityRequestManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: IUserActivityRequestManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserActivityRequestManagerInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IUserActivityRequestManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserActivityRequestManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: &IUserActivityRequestManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserActivityRequestManagerInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IUserActivityRequestManagerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3134,36 +2447,7 @@ impl IUserActivitySourceHostInterop {
         (::windows::core::Vtable::vtable(self).SetActivitySourceHost)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(activitysourcehost)).ok()
     }
 }
-impl ::core::convert::From<IUserActivitySourceHostInterop> for ::windows::core::IUnknown {
-    fn from(value: IUserActivitySourceHostInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserActivitySourceHostInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserActivitySourceHostInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserActivitySourceHostInterop> for ::windows::core::IUnknown {
-    fn from(value: &IUserActivitySourceHostInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUserActivitySourceHostInterop> for ::windows::core::IInspectable {
-    fn from(value: IUserActivitySourceHostInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserActivitySourceHostInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IUserActivitySourceHostInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserActivitySourceHostInterop> for ::windows::core::IInspectable {
-    fn from(value: &IUserActivitySourceHostInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserActivitySourceHostInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IUserActivitySourceHostInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3207,36 +2491,7 @@ impl IUserConsentVerifierInterop {
         (::windows::core::Vtable::vtable(self).RequestVerificationForWindowAsync)(::windows::core::Vtable::as_raw(self), appwindow.into(), ::core::mem::transmute_copy(message), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IUserConsentVerifierInterop> for ::windows::core::IUnknown {
-    fn from(value: IUserConsentVerifierInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserConsentVerifierInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserConsentVerifierInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserConsentVerifierInterop> for ::windows::core::IUnknown {
-    fn from(value: &IUserConsentVerifierInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUserConsentVerifierInterop> for ::windows::core::IInspectable {
-    fn from(value: IUserConsentVerifierInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserConsentVerifierInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IUserConsentVerifierInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserConsentVerifierInterop> for ::windows::core::IInspectable {
-    fn from(value: &IUserConsentVerifierInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserConsentVerifierInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IUserConsentVerifierInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3280,21 +2535,7 @@ impl IWeakReference {
         (::windows::core::Vtable::vtable(self).Resolve)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IWeakReference> for ::windows::core::IUnknown {
-    fn from(value: IWeakReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWeakReference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWeakReference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWeakReference> for ::windows::core::IUnknown {
-    fn from(value: &IWeakReference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWeakReference, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWeakReference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3332,21 +2573,7 @@ impl IWeakReferenceSource {
         (::windows::core::Vtable::vtable(self).GetWeakReference)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWeakReference>(result__)
     }
 }
-impl ::core::convert::From<IWeakReferenceSource> for ::windows::core::IUnknown {
-    fn from(value: IWeakReferenceSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWeakReferenceSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWeakReferenceSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWeakReferenceSource> for ::windows::core::IUnknown {
-    fn from(value: &IWeakReferenceSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWeakReferenceSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWeakReferenceSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3403,36 +2630,7 @@ impl IWebAuthenticationCoreManagerInterop {
         (::windows::core::Vtable::vtable(self).RequestTokenWithWebAccountForWindowAsync)(::windows::core::Vtable::as_raw(self), appwindow.into(), request.into().abi(), webaccount.into().abi(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IWebAuthenticationCoreManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: IWebAuthenticationCoreManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAuthenticationCoreManagerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebAuthenticationCoreManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAuthenticationCoreManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: &IWebAuthenticationCoreManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebAuthenticationCoreManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: IWebAuthenticationCoreManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebAuthenticationCoreManagerInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IWebAuthenticationCoreManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebAuthenticationCoreManagerInterop> for ::windows::core::IInspectable {
-    fn from(value: &IWebAuthenticationCoreManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebAuthenticationCoreManagerInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IWebAuthenticationCoreManagerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
@@ -2837,21 +2837,7 @@ impl ICameraUIControl {
         (::windows::core::Vtable::vtable(self).RemoveCapturedItem)(::windows::core::Vtable::as_raw(self), pszpath.into()).ok()
     }
 }
-impl ::core::convert::From<ICameraUIControl> for ::windows::core::IUnknown {
-    fn from(value: ICameraUIControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICameraUIControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICameraUIControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICameraUIControl> for ::windows::core::IUnknown {
-    fn from(value: &ICameraUIControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICameraUIControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICameraUIControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2922,21 +2908,7 @@ impl ICameraUIControlEventCallback {
         (::windows::core::Vtable::vtable(self).OnClosed)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<ICameraUIControlEventCallback> for ::windows::core::IUnknown {
-    fn from(value: ICameraUIControlEventCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICameraUIControlEventCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICameraUIControlEventCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICameraUIControlEventCallback> for ::windows::core::IUnknown {
-    fn from(value: &ICameraUIControlEventCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICameraUIControlEventCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICameraUIControlEventCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2977,21 +2949,7 @@ impl IClipServiceNotificationHelper {
         (::windows::core::Vtable::vtable(self).ShowToast)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(titletext), ::core::mem::transmute_copy(bodytext), ::core::mem::transmute_copy(packagename), ::core::mem::transmute_copy(appid), ::core::mem::transmute_copy(launchcommand)).ok()
     }
 }
-impl ::core::convert::From<IClipServiceNotificationHelper> for ::windows::core::IUnknown {
-    fn from(value: IClipServiceNotificationHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IClipServiceNotificationHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IClipServiceNotificationHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IClipServiceNotificationHelper> for ::windows::core::IUnknown {
-    fn from(value: &IClipServiceNotificationHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IClipServiceNotificationHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IClipServiceNotificationHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3029,21 +2987,7 @@ impl IContainerActivationHelper {
         (::windows::core::Vtable::vtable(self).CanActivateClientVM)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i16>(result__)
     }
 }
-impl ::core::convert::From<IContainerActivationHelper> for ::windows::core::IUnknown {
-    fn from(value: IContainerActivationHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContainerActivationHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContainerActivationHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContainerActivationHelper> for ::windows::core::IUnknown {
-    fn from(value: &IContainerActivationHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContainerActivationHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContainerActivationHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3082,21 +3026,7 @@ impl IDefaultBrowserSyncSettings {
         (::windows::core::Vtable::vtable(self).IsEnabled)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IDefaultBrowserSyncSettings> for ::windows::core::IUnknown {
-    fn from(value: IDefaultBrowserSyncSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDefaultBrowserSyncSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDefaultBrowserSyncSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDefaultBrowserSyncSettings> for ::windows::core::IUnknown {
-    fn from(value: &IDefaultBrowserSyncSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDefaultBrowserSyncSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDefaultBrowserSyncSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3136,21 +3066,7 @@ impl IDeleteBrowsingHistory {
         (::windows::core::Vtable::vtable(self).DeleteBrowsingHistory)(::windows::core::Vtable::as_raw(self), dwflags).ok()
     }
 }
-impl ::core::convert::From<IDeleteBrowsingHistory> for ::windows::core::IUnknown {
-    fn from(value: IDeleteBrowsingHistory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDeleteBrowsingHistory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeleteBrowsingHistory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDeleteBrowsingHistory> for ::windows::core::IUnknown {
-    fn from(value: &IDeleteBrowsingHistory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeleteBrowsingHistory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDeleteBrowsingHistory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3196,21 +3112,7 @@ impl IEditionUpgradeBroker {
         (::windows::core::Vtable::vtable(self).CanUpgrade)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IEditionUpgradeBroker> for ::windows::core::IUnknown {
-    fn from(value: IEditionUpgradeBroker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEditionUpgradeBroker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEditionUpgradeBroker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEditionUpgradeBroker> for ::windows::core::IUnknown {
-    fn from(value: &IEditionUpgradeBroker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEditionUpgradeBroker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEditionUpgradeBroker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3272,21 +3174,7 @@ impl IEditionUpgradeHelper {
         (::windows::core::Vtable::vtable(self).GetGenuineLocalStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IEditionUpgradeHelper> for ::windows::core::IUnknown {
-    fn from(value: IEditionUpgradeHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEditionUpgradeHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEditionUpgradeHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEditionUpgradeHelper> for ::windows::core::IUnknown {
-    fn from(value: &IEditionUpgradeHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEditionUpgradeHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEditionUpgradeHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3336,21 +3224,7 @@ impl IWindowsLockModeHelper {
         (::windows::core::Vtable::vtable(self).GetSMode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWindowsLockModeHelper> for ::windows::core::IUnknown {
-    fn from(value: IWindowsLockModeHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowsLockModeHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowsLockModeHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowsLockModeHelper> for ::windows::core::IUnknown {
-    fn from(value: &IWindowsLockModeHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowsLockModeHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWindowsLockModeHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsSync/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsSync/mod.rs
@@ -26,21 +26,7 @@ impl IAsynchronousDataRetriever {
         (::windows::core::Vtable::vtable(self).LoadChangeData)(::windows::core::Vtable::as_raw(self), ploadchangecontext.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAsynchronousDataRetriever> for ::windows::core::IUnknown {
-    fn from(value: IAsynchronousDataRetriever) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAsynchronousDataRetriever> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAsynchronousDataRetriever) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAsynchronousDataRetriever> for ::windows::core::IUnknown {
-    fn from(value: &IAsynchronousDataRetriever) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAsynchronousDataRetriever, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAsynchronousDataRetriever {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -114,21 +100,7 @@ impl IChangeConflict {
         (::windows::core::Vtable::vtable(self).SetResolveActionForChangeUnit)(::windows::core::Vtable::as_raw(self), pchangeunit.into().abi(), resolveaction).ok()
     }
 }
-impl ::core::convert::From<IChangeConflict> for ::windows::core::IUnknown {
-    fn from(value: IChangeConflict) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IChangeConflict> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IChangeConflict) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IChangeConflict> for ::windows::core::IUnknown {
-    fn from(value: &IChangeConflict) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IChangeConflict, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IChangeConflict {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -178,21 +150,7 @@ impl IChangeUnitException {
         (::windows::core::Vtable::vtable(self).GetClockVector)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(ppunk)).ok()
     }
 }
-impl ::core::convert::From<IChangeUnitException> for ::windows::core::IUnknown {
-    fn from(value: IChangeUnitException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IChangeUnitException> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IChangeUnitException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IChangeUnitException> for ::windows::core::IUnknown {
-    fn from(value: &IChangeUnitException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IChangeUnitException, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IChangeUnitException {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -240,36 +198,7 @@ impl IChangeUnitListFilterInfo {
         (::windows::core::Vtable::vtable(self).GetChangeUnitId)(::windows::core::Vtable::as_raw(self), dwchangeunitidindex, ::core::mem::transmute(pbchangeunitid), ::core::mem::transmute(pcbidsize)).ok()
     }
 }
-impl ::core::convert::From<IChangeUnitListFilterInfo> for ::windows::core::IUnknown {
-    fn from(value: IChangeUnitListFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IChangeUnitListFilterInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IChangeUnitListFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IChangeUnitListFilterInfo> for ::windows::core::IUnknown {
-    fn from(value: &IChangeUnitListFilterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IChangeUnitListFilterInfo> for ISyncFilterInfo {
-    fn from(value: IChangeUnitListFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IChangeUnitListFilterInfo> for &'a ISyncFilterInfo {
-    fn from(value: &'a IChangeUnitListFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IChangeUnitListFilterInfo> for ISyncFilterInfo {
-    fn from(value: &IChangeUnitListFilterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IChangeUnitListFilterInfo, ::windows::core::IUnknown, ISyncFilterInfo);
 impl ::core::clone::Clone for IChangeUnitListFilterInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -311,21 +240,7 @@ impl IClockVector {
         (::windows::core::Vtable::vtable(self).GetClockVectorElementCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwcount)).ok()
     }
 }
-impl ::core::convert::From<IClockVector> for ::windows::core::IUnknown {
-    fn from(value: IClockVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IClockVector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IClockVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IClockVector> for ::windows::core::IUnknown {
-    fn from(value: &IClockVector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IClockVector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IClockVector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -366,21 +281,7 @@ impl IClockVectorElement {
         (::windows::core::Vtable::vtable(self).GetTickCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pulltickcount)).ok()
     }
 }
-impl ::core::convert::From<IClockVectorElement> for ::windows::core::IUnknown {
-    fn from(value: IClockVectorElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IClockVectorElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IClockVectorElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IClockVectorElement> for ::windows::core::IUnknown {
-    fn from(value: &IClockVectorElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IClockVectorElement, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IClockVectorElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -428,36 +329,7 @@ impl ICombinedFilterInfo {
         (::windows::core::Vtable::vtable(self).GetFilterCombinationType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfiltercombinationtype)).ok()
     }
 }
-impl ::core::convert::From<ICombinedFilterInfo> for ::windows::core::IUnknown {
-    fn from(value: ICombinedFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICombinedFilterInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICombinedFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICombinedFilterInfo> for ::windows::core::IUnknown {
-    fn from(value: &ICombinedFilterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICombinedFilterInfo> for ISyncFilterInfo {
-    fn from(value: ICombinedFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICombinedFilterInfo> for &'a ISyncFilterInfo {
-    fn from(value: &'a ICombinedFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICombinedFilterInfo> for ISyncFilterInfo {
-    fn from(value: &ICombinedFilterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICombinedFilterInfo, ::windows::core::IUnknown, ISyncFilterInfo);
 impl ::core::clone::Clone for ICombinedFilterInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -541,21 +413,7 @@ impl IConstraintConflict {
         (::windows::core::Vtable::vtable(self).IsTemporary)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IConstraintConflict> for ::windows::core::IUnknown {
-    fn from(value: IConstraintConflict) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConstraintConflict> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConstraintConflict) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConstraintConflict> for ::windows::core::IUnknown {
-    fn from(value: &IConstraintConflict) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConstraintConflict, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConstraintConflict {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -603,21 +461,7 @@ impl IConstructReplicaKeyMap {
         (::windows::core::Vtable::vtable(self).FindOrAddReplica)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbreplicaid), ::core::mem::transmute(pdwreplicakey)).ok()
     }
 }
-impl ::core::convert::From<IConstructReplicaKeyMap> for ::windows::core::IUnknown {
-    fn from(value: IConstructReplicaKeyMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConstructReplicaKeyMap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConstructReplicaKeyMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConstructReplicaKeyMap> for ::windows::core::IUnknown {
-    fn from(value: &IConstructReplicaKeyMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConstructReplicaKeyMap, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IConstructReplicaKeyMap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -666,21 +510,7 @@ impl ICoreFragment {
         (::windows::core::Vtable::vtable(self).GetRangeCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prangecount)).ok()
     }
 }
-impl ::core::convert::From<ICoreFragment> for ::windows::core::IUnknown {
-    fn from(value: ICoreFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreFragment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreFragment> for ::windows::core::IUnknown {
-    fn from(value: &ICoreFragment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreFragment, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICoreFragment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -724,21 +554,7 @@ impl ICoreFragmentInspector {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ICoreFragmentInspector> for ::windows::core::IUnknown {
-    fn from(value: ICoreFragmentInspector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoreFragmentInspector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoreFragmentInspector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoreFragmentInspector> for ::windows::core::IUnknown {
-    fn from(value: &ICoreFragmentInspector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoreFragmentInspector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICoreFragmentInspector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -780,36 +596,7 @@ impl ICustomFilterInfo {
         (::windows::core::Vtable::vtable(self).GetSyncFilter)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncFilter>(result__)
     }
 }
-impl ::core::convert::From<ICustomFilterInfo> for ::windows::core::IUnknown {
-    fn from(value: ICustomFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICustomFilterInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICustomFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICustomFilterInfo> for ::windows::core::IUnknown {
-    fn from(value: &ICustomFilterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICustomFilterInfo> for ISyncFilterInfo {
-    fn from(value: ICustomFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICustomFilterInfo> for &'a ISyncFilterInfo {
-    fn from(value: &'a ICustomFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICustomFilterInfo> for ISyncFilterInfo {
-    fn from(value: &ICustomFilterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICustomFilterInfo, ::windows::core::IUnknown, ISyncFilterInfo);
 impl ::core::clone::Clone for ICustomFilterInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -852,21 +639,7 @@ impl IDataRetrieverCallback {
         (::windows::core::Vtable::vtable(self).LoadChangeDataError)(::windows::core::Vtable::as_raw(self), hrerror).ok()
     }
 }
-impl ::core::convert::From<IDataRetrieverCallback> for ::windows::core::IUnknown {
-    fn from(value: IDataRetrieverCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataRetrieverCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataRetrieverCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataRetrieverCallback> for ::windows::core::IUnknown {
-    fn from(value: &IDataRetrieverCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataRetrieverCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataRetrieverCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -914,21 +687,7 @@ impl IEnumChangeUnitExceptions {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumChangeUnitExceptions>(result__)
     }
 }
-impl ::core::convert::From<IEnumChangeUnitExceptions> for ::windows::core::IUnknown {
-    fn from(value: IEnumChangeUnitExceptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumChangeUnitExceptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumChangeUnitExceptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumChangeUnitExceptions> for ::windows::core::IUnknown {
-    fn from(value: &IEnumChangeUnitExceptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumChangeUnitExceptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumChangeUnitExceptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -978,21 +737,7 @@ impl IEnumClockVector {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumClockVector>(result__)
     }
 }
-impl ::core::convert::From<IEnumClockVector> for ::windows::core::IUnknown {
-    fn from(value: IEnumClockVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumClockVector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumClockVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumClockVector> for ::windows::core::IUnknown {
-    fn from(value: &IEnumClockVector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumClockVector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumClockVector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1042,21 +787,7 @@ impl IEnumFeedClockVector {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumFeedClockVector>(result__)
     }
 }
-impl ::core::convert::From<IEnumFeedClockVector> for ::windows::core::IUnknown {
-    fn from(value: IEnumFeedClockVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumFeedClockVector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumFeedClockVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumFeedClockVector> for ::windows::core::IUnknown {
-    fn from(value: &IEnumFeedClockVector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumFeedClockVector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumFeedClockVector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1096,21 +827,7 @@ impl IEnumItemIds {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbitemid), ::core::mem::transmute(pcbitemidsize)).ok()
     }
 }
-impl ::core::convert::From<IEnumItemIds> for ::windows::core::IUnknown {
-    fn from(value: IEnumItemIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumItemIds> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumItemIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumItemIds> for ::windows::core::IUnknown {
-    fn from(value: &IEnumItemIds) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumItemIds, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumItemIds {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1157,21 +874,7 @@ impl IEnumRangeExceptions {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumRangeExceptions>(result__)
     }
 }
-impl ::core::convert::From<IEnumRangeExceptions> for ::windows::core::IUnknown {
-    fn from(value: IEnumRangeExceptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumRangeExceptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumRangeExceptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumRangeExceptions> for ::windows::core::IUnknown {
-    fn from(value: &IEnumRangeExceptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumRangeExceptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumRangeExceptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1221,21 +924,7 @@ impl IEnumSingleItemExceptions {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSingleItemExceptions>(result__)
     }
 }
-impl ::core::convert::From<IEnumSingleItemExceptions> for ::windows::core::IUnknown {
-    fn from(value: IEnumSingleItemExceptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSingleItemExceptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSingleItemExceptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSingleItemExceptions> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSingleItemExceptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSingleItemExceptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSingleItemExceptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1285,21 +974,7 @@ impl IEnumSyncChangeUnits {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSyncChangeUnits>(result__)
     }
 }
-impl ::core::convert::From<IEnumSyncChangeUnits> for ::windows::core::IUnknown {
-    fn from(value: IEnumSyncChangeUnits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSyncChangeUnits> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSyncChangeUnits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSyncChangeUnits> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSyncChangeUnits) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSyncChangeUnits, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSyncChangeUnits {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1349,21 +1024,7 @@ impl IEnumSyncChanges {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSyncChanges>(result__)
     }
 }
-impl ::core::convert::From<IEnumSyncChanges> for ::windows::core::IUnknown {
-    fn from(value: IEnumSyncChanges) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSyncChanges> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSyncChanges) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSyncChanges> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSyncChanges) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSyncChanges, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSyncChanges {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1415,21 +1076,7 @@ impl IEnumSyncProviderConfigUIInfos {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSyncProviderConfigUIInfos>(result__)
     }
 }
-impl ::core::convert::From<IEnumSyncProviderConfigUIInfos> for ::windows::core::IUnknown {
-    fn from(value: IEnumSyncProviderConfigUIInfos) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSyncProviderConfigUIInfos> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSyncProviderConfigUIInfos) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSyncProviderConfigUIInfos> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSyncProviderConfigUIInfos) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSyncProviderConfigUIInfos, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSyncProviderConfigUIInfos {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1484,21 +1131,7 @@ impl IEnumSyncProviderInfos {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSyncProviderInfos>(result__)
     }
 }
-impl ::core::convert::From<IEnumSyncProviderInfos> for ::windows::core::IUnknown {
-    fn from(value: IEnumSyncProviderInfos) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSyncProviderInfos> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSyncProviderInfos) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSyncProviderInfos> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSyncProviderInfos) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSyncProviderInfos, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSyncProviderInfos {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1552,36 +1185,7 @@ impl IFeedClockVector {
         (::windows::core::Vtable::vtable(self).IsNoConflictsSpecified)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfisnoconflictsspecified)).ok()
     }
 }
-impl ::core::convert::From<IFeedClockVector> for ::windows::core::IUnknown {
-    fn from(value: IFeedClockVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFeedClockVector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeedClockVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFeedClockVector> for ::windows::core::IUnknown {
-    fn from(value: &IFeedClockVector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFeedClockVector> for IClockVector {
-    fn from(value: IFeedClockVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFeedClockVector> for &'a IClockVector {
-    fn from(value: &'a IFeedClockVector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFeedClockVector> for IClockVector {
-    fn from(value: &IFeedClockVector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeedClockVector, ::windows::core::IUnknown, IClockVector);
 impl ::core::clone::Clone for IFeedClockVector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1631,36 +1235,7 @@ impl IFeedClockVectorElement {
         (::windows::core::Vtable::vtable(self).GetFlags)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbflags)).ok()
     }
 }
-impl ::core::convert::From<IFeedClockVectorElement> for ::windows::core::IUnknown {
-    fn from(value: IFeedClockVectorElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFeedClockVectorElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFeedClockVectorElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFeedClockVectorElement> for ::windows::core::IUnknown {
-    fn from(value: &IFeedClockVectorElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFeedClockVectorElement> for IClockVectorElement {
-    fn from(value: IFeedClockVectorElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFeedClockVectorElement> for &'a IClockVectorElement {
-    fn from(value: &'a IFeedClockVectorElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFeedClockVectorElement> for IClockVectorElement {
-    fn from(value: &IFeedClockVectorElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFeedClockVectorElement, ::windows::core::IUnknown, IClockVectorElement);
 impl ::core::clone::Clone for IFeedClockVectorElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1711,21 +1286,7 @@ impl IFilterKeyMap {
         (::windows::core::Vtable::vtable(self).Serialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbfilterkeymap), ::core::mem::transmute(pcbfilterkeymap)).ok()
     }
 }
-impl ::core::convert::From<IFilterKeyMap> for ::windows::core::IUnknown {
-    fn from(value: IFilterKeyMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFilterKeyMap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFilterKeyMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFilterKeyMap> for ::windows::core::IUnknown {
-    fn from(value: &IFilterKeyMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFilterKeyMap, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFilterKeyMap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1768,21 +1329,7 @@ impl IFilterRequestCallback {
         (::windows::core::Vtable::vtable(self).RequestFilter)(::windows::core::Vtable::as_raw(self), pfilter.into().abi(), filteringtype).ok()
     }
 }
-impl ::core::convert::From<IFilterRequestCallback> for ::windows::core::IUnknown {
-    fn from(value: IFilterRequestCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFilterRequestCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFilterRequestCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFilterRequestCallback> for ::windows::core::IUnknown {
-    fn from(value: &IFilterRequestCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFilterRequestCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFilterRequestCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1828,21 +1375,7 @@ impl IFilterTrackingProvider {
         (::windows::core::Vtable::vtable(self).AddTrackedFilter)(::windows::core::Vtable::as_raw(self), pfilter.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IFilterTrackingProvider> for ::windows::core::IUnknown {
-    fn from(value: IFilterTrackingProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFilterTrackingProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFilterTrackingProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFilterTrackingProvider> for ::windows::core::IUnknown {
-    fn from(value: &IFilterTrackingProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFilterTrackingProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFilterTrackingProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1883,21 +1416,7 @@ impl IFilterTrackingRequestCallback {
         (::windows::core::Vtable::vtable(self).RequestTrackedFilter)(::windows::core::Vtable::as_raw(self), pfilter.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IFilterTrackingRequestCallback> for ::windows::core::IUnknown {
-    fn from(value: IFilterTrackingRequestCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFilterTrackingRequestCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFilterTrackingRequestCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFilterTrackingRequestCallback> for ::windows::core::IUnknown {
-    fn from(value: &IFilterTrackingRequestCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFilterTrackingRequestCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFilterTrackingRequestCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1939,21 +1458,7 @@ impl IFilterTrackingSyncChangeBuilder {
         (::windows::core::Vtable::vtable(self).SetAllChangeUnitsPresentFlag)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IFilterTrackingSyncChangeBuilder> for ::windows::core::IUnknown {
-    fn from(value: IFilterTrackingSyncChangeBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFilterTrackingSyncChangeBuilder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFilterTrackingSyncChangeBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFilterTrackingSyncChangeBuilder> for ::windows::core::IUnknown {
-    fn from(value: &IFilterTrackingSyncChangeBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFilterTrackingSyncChangeBuilder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFilterTrackingSyncChangeBuilder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2092,36 +1597,7 @@ impl IForgottenKnowledge {
         (::windows::core::Vtable::vtable(self).ForgetToVersion)(::windows::core::Vtable::as_raw(self), pknowledge.into().abi(), ::core::mem::transmute(pversion)).ok()
     }
 }
-impl ::core::convert::From<IForgottenKnowledge> for ::windows::core::IUnknown {
-    fn from(value: IForgottenKnowledge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IForgottenKnowledge> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IForgottenKnowledge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IForgottenKnowledge> for ::windows::core::IUnknown {
-    fn from(value: &IForgottenKnowledge) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IForgottenKnowledge> for ISyncKnowledge {
-    fn from(value: IForgottenKnowledge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IForgottenKnowledge> for &'a ISyncKnowledge {
-    fn from(value: &'a IForgottenKnowledge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IForgottenKnowledge> for ISyncKnowledge {
-    fn from(value: &IForgottenKnowledge) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IForgottenKnowledge, ::windows::core::IUnknown, ISyncKnowledge);
 impl ::core::clone::Clone for IForgottenKnowledge {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2203,36 +1679,7 @@ impl IKnowledgeSyncProvider {
         (::windows::core::Vtable::vtable(self).EndSession)(::windows::core::Vtable::as_raw(self), psessionstate.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IKnowledgeSyncProvider> for ::windows::core::IUnknown {
-    fn from(value: IKnowledgeSyncProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKnowledgeSyncProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKnowledgeSyncProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKnowledgeSyncProvider> for ::windows::core::IUnknown {
-    fn from(value: &IKnowledgeSyncProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IKnowledgeSyncProvider> for ISyncProvider {
-    fn from(value: IKnowledgeSyncProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKnowledgeSyncProvider> for &'a ISyncProvider {
-    fn from(value: &'a IKnowledgeSyncProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKnowledgeSyncProvider> for ISyncProvider {
-    fn from(value: &IKnowledgeSyncProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKnowledgeSyncProvider, ::windows::core::IUnknown, ISyncProvider);
 impl ::core::clone::Clone for IKnowledgeSyncProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2289,21 +1736,7 @@ impl ILoadChangeContext {
         (::windows::core::Vtable::vtable(self).SetRecoverableErrorOnChangeUnit)(::windows::core::Vtable::as_raw(self), hrerror, pchangeunit.into().abi(), perrordata.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ILoadChangeContext> for ::windows::core::IUnknown {
-    fn from(value: ILoadChangeContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILoadChangeContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILoadChangeContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILoadChangeContext> for ::windows::core::IUnknown {
-    fn from(value: &ILoadChangeContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILoadChangeContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILoadChangeContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2345,21 +1778,7 @@ impl IProviderConverter {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pisyncprovider.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IProviderConverter> for ::windows::core::IUnknown {
-    fn from(value: IProviderConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProviderConverter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProviderConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProviderConverter> for ::windows::core::IUnknown {
-    fn from(value: &IProviderConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProviderConverter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProviderConverter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2402,21 +1821,7 @@ impl IRangeException {
         (::windows::core::Vtable::vtable(self).GetClockVector)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(ppunk)).ok()
     }
 }
-impl ::core::convert::From<IRangeException> for ::windows::core::IUnknown {
-    fn from(value: IRangeException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRangeException> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRangeException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRangeException> for ::windows::core::IUnknown {
-    fn from(value: &IRangeException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRangeException, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRangeException {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2471,21 +1876,7 @@ impl IRecoverableError {
         (::windows::core::Vtable::vtable(self).GetRecoverableErrorDataForChangeUnit)(::windows::core::Vtable::as_raw(self), pchangeunit.into().abi(), ::core::mem::transmute(phrerror), ::core::mem::transmute(pperrordata)).ok()
     }
 }
-impl ::core::convert::From<IRecoverableError> for ::windows::core::IUnknown {
-    fn from(value: IRecoverableError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRecoverableError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRecoverableError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRecoverableError> for ::windows::core::IUnknown {
-    fn from(value: &IRecoverableError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRecoverableError, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRecoverableError {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2542,21 +1933,7 @@ impl IRecoverableErrorData {
         (::windows::core::Vtable::vtable(self).GetErrorDescription)(::windows::core::Vtable::as_raw(self), pszerrordescription.into(), ::core::mem::transmute(pccherrordescription)).ok()
     }
 }
-impl ::core::convert::From<IRecoverableErrorData> for ::windows::core::IUnknown {
-    fn from(value: IRecoverableErrorData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRecoverableErrorData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRecoverableErrorData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRecoverableErrorData> for ::windows::core::IUnknown {
-    fn from(value: &IRecoverableErrorData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRecoverableErrorData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRecoverableErrorData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2607,21 +1984,7 @@ impl IRegisteredSyncProvider {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IRegisteredSyncProvider> for ::windows::core::IUnknown {
-    fn from(value: IRegisteredSyncProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRegisteredSyncProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRegisteredSyncProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRegisteredSyncProvider> for ::windows::core::IUnknown {
-    fn from(value: &IRegisteredSyncProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRegisteredSyncProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRegisteredSyncProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2669,21 +2032,7 @@ impl IReplicaKeyMap {
         (::windows::core::Vtable::vtable(self).Serialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbreplicakeymap), ::core::mem::transmute(pcbreplicakeymap)).ok()
     }
 }
-impl ::core::convert::From<IReplicaKeyMap> for ::windows::core::IUnknown {
-    fn from(value: IReplicaKeyMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IReplicaKeyMap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IReplicaKeyMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IReplicaKeyMap> for ::windows::core::IUnknown {
-    fn from(value: &IReplicaKeyMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IReplicaKeyMap, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IReplicaKeyMap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2725,21 +2074,7 @@ impl IRequestFilteredSync {
         (::windows::core::Vtable::vtable(self).SpecifyFilter)(::windows::core::Vtable::as_raw(self), pcallback.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IRequestFilteredSync> for ::windows::core::IUnknown {
-    fn from(value: IRequestFilteredSync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRequestFilteredSync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRequestFilteredSync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRequestFilteredSync> for ::windows::core::IUnknown {
-    fn from(value: &IRequestFilteredSync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRequestFilteredSync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRequestFilteredSync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2779,21 +2114,7 @@ impl ISingleItemException {
         (::windows::core::Vtable::vtable(self).GetClockVector)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(ppunk)).ok()
     }
 }
-impl ::core::convert::From<ISingleItemException> for ::windows::core::IUnknown {
-    fn from(value: ISingleItemException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISingleItemException> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISingleItemException) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISingleItemException> for ::windows::core::IUnknown {
-    fn from(value: &ISingleItemException) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISingleItemException, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISingleItemException {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2834,21 +2155,7 @@ impl ISupportFilteredSync {
         (::windows::core::Vtable::vtable(self).AddFilter)(::windows::core::Vtable::as_raw(self), pfilter.into().abi(), filteringtype).ok()
     }
 }
-impl ::core::convert::From<ISupportFilteredSync> for ::windows::core::IUnknown {
-    fn from(value: ISupportFilteredSync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISupportFilteredSync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISupportFilteredSync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISupportFilteredSync> for ::windows::core::IUnknown {
-    fn from(value: &ISupportFilteredSync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISupportFilteredSync, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISupportFilteredSync {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2888,21 +2195,7 @@ impl ISupportLastWriteTime {
         (::windows::core::Vtable::vtable(self).GetChangeUnitChangeTime)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbitemid), ::core::mem::transmute(pbchangeunitid), ::core::mem::transmute(pulltimestamp)).ok()
     }
 }
-impl ::core::convert::From<ISupportLastWriteTime> for ::windows::core::IUnknown {
-    fn from(value: ISupportLastWriteTime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISupportLastWriteTime> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISupportLastWriteTime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISupportLastWriteTime> for ::windows::core::IUnknown {
-    fn from(value: &ISupportLastWriteTime) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISupportLastWriteTime, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISupportLastWriteTime {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2961,21 +2254,7 @@ impl ISyncCallback {
         (::windows::core::Vtable::vtable(self).OnRecoverableError)(::windows::core::Vtable::as_raw(self), precoverableerror.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISyncCallback> for ::windows::core::IUnknown {
-    fn from(value: ISyncCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncCallback> for ::windows::core::IUnknown {
-    fn from(value: &ISyncCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3043,36 +2322,7 @@ impl ISyncCallback2 {
         (::windows::core::Vtable::vtable(self).OnChangeFailed)(::windows::core::Vtable::as_raw(self), dwchangesapplied, dwchangesfailed).ok()
     }
 }
-impl ::core::convert::From<ISyncCallback2> for ::windows::core::IUnknown {
-    fn from(value: ISyncCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncCallback2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncCallback2> for ::windows::core::IUnknown {
-    fn from(value: &ISyncCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncCallback2> for ISyncCallback {
-    fn from(value: ISyncCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncCallback2> for &'a ISyncCallback {
-    fn from(value: &'a ISyncCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncCallback2> for ISyncCallback {
-    fn from(value: &ISyncCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncCallback2, ::windows::core::IUnknown, ISyncCallback);
 impl ::core::clone::Clone for ISyncCallback2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3140,21 +2390,7 @@ impl ISyncChange {
         (::windows::core::Vtable::vtable(self).SetWorkEstimate)(::windows::core::Vtable::as_raw(self), dwwork).ok()
     }
 }
-impl ::core::convert::From<ISyncChange> for ::windows::core::IUnknown {
-    fn from(value: ISyncChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChange> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncChange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3268,36 +2504,7 @@ impl ISyncChangeBatch {
         (::windows::core::Vtable::vtable(self).AddLoggedConflict)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbownerreplicaid), ::core::mem::transmute(pbitemid), ::core::mem::transmute(pchangeversion), ::core::mem::transmute(pcreationversion), dwflags, dwworkforchange, pconflictknowledge.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncChangeBuilder>(result__)
     }
 }
-impl ::core::convert::From<ISyncChangeBatch> for ::windows::core::IUnknown {
-    fn from(value: ISyncChangeBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChangeBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatch> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChangeBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncChangeBatch> for ISyncChangeBatchBase {
-    fn from(value: ISyncChangeBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatch> for &'a ISyncChangeBatchBase {
-    fn from(value: &'a ISyncChangeBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatch> for ISyncChangeBatchBase {
-    fn from(value: &ISyncChangeBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChangeBatch, ::windows::core::IUnknown, ISyncChangeBatchBase);
 impl ::core::clone::Clone for ISyncChangeBatch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3418,51 +2625,7 @@ impl ISyncChangeBatch2 {
         (::windows::core::Vtable::vtable(self).AddMergeTombstoneLoggedConflict)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbownerreplicaid), ::core::mem::transmute(pbwinneritemid), ::core::mem::transmute(pbitemid), ::core::mem::transmute(pchangeversion), ::core::mem::transmute(pcreationversion), dwworkforchange, pconflictknowledge.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncChangeBuilder>(result__)
     }
 }
-impl ::core::convert::From<ISyncChangeBatch2> for ::windows::core::IUnknown {
-    fn from(value: ISyncChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatch2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatch2> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChangeBatch2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncChangeBatch2> for ISyncChangeBatchBase {
-    fn from(value: ISyncChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatch2> for &'a ISyncChangeBatchBase {
-    fn from(value: &'a ISyncChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatch2> for ISyncChangeBatchBase {
-    fn from(value: &ISyncChangeBatch2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncChangeBatch2> for ISyncChangeBatch {
-    fn from(value: ISyncChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatch2> for &'a ISyncChangeBatch {
-    fn from(value: &'a ISyncChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatch2> for ISyncChangeBatch {
-    fn from(value: &ISyncChangeBatch2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChangeBatch2, ::windows::core::IUnknown, ISyncChangeBatchBase, ISyncChangeBatch);
 impl ::core::clone::Clone for ISyncChangeBatch2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3513,21 +2676,7 @@ impl ISyncChangeBatchAdvanced {
         (::windows::core::Vtable::vtable(self).GetBatchLevelKnowledgeShouldBeApplied)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pfbatchknowledgeshouldbeapplied)).ok()
     }
 }
-impl ::core::convert::From<ISyncChangeBatchAdvanced> for ::windows::core::IUnknown {
-    fn from(value: ISyncChangeBatchAdvanced) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatchAdvanced> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChangeBatchAdvanced) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatchAdvanced> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChangeBatchAdvanced) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChangeBatchAdvanced, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncChangeBatchAdvanced {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3619,21 +2768,7 @@ impl ISyncChangeBatchBase {
         (::windows::core::Vtable::vtable(self).Serialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbchangebatch), ::core::mem::transmute(pcbchangebatch)).ok()
     }
 }
-impl ::core::convert::From<ISyncChangeBatchBase> for ::windows::core::IUnknown {
-    fn from(value: ISyncChangeBatchBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatchBase> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChangeBatchBase) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatchBase> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChangeBatchBase) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChangeBatchBase, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncChangeBatchBase {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3738,36 +2873,7 @@ impl ISyncChangeBatchBase2 {
         (::windows::core::Vtable::vtable(self).SerializeWithOptions)(::windows::core::Vtable::as_raw(self), targetformatversion, dwflags, ::core::mem::transmute(pbbuffer), ::core::mem::transmute(pdwserializedsize)).ok()
     }
 }
-impl ::core::convert::From<ISyncChangeBatchBase2> for ::windows::core::IUnknown {
-    fn from(value: ISyncChangeBatchBase2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatchBase2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChangeBatchBase2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatchBase2> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChangeBatchBase2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncChangeBatchBase2> for ISyncChangeBatchBase {
-    fn from(value: ISyncChangeBatchBase2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatchBase2> for &'a ISyncChangeBatchBase {
-    fn from(value: &'a ISyncChangeBatchBase2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatchBase2> for ISyncChangeBatchBase {
-    fn from(value: &ISyncChangeBatchBase2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChangeBatchBase2, ::windows::core::IUnknown, ISyncChangeBatchBase);
 impl ::core::clone::Clone for ISyncChangeBatchBase2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3857,21 +2963,7 @@ impl ISyncChangeBatchWithFilterKeyMap {
         (::windows::core::Vtable::vtable(self).GetLearnedFilterForgottenKnowledgeAfterRecoveryComplete)(::windows::core::Vtable::as_raw(self), pdestinationknowledge.into().abi(), pnewmoveins.into().abi(), dwfilterkey, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncKnowledge>(result__)
     }
 }
-impl ::core::convert::From<ISyncChangeBatchWithFilterKeyMap> for ::windows::core::IUnknown {
-    fn from(value: ISyncChangeBatchWithFilterKeyMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatchWithFilterKeyMap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChangeBatchWithFilterKeyMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatchWithFilterKeyMap> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChangeBatchWithFilterKeyMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChangeBatchWithFilterKeyMap, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncChangeBatchWithFilterKeyMap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3981,36 +3073,7 @@ impl ISyncChangeBatchWithPrerequisite {
         (::windows::core::Vtable::vtable(self).GetLearnedForgottenKnowledge)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IForgottenKnowledge>(result__)
     }
 }
-impl ::core::convert::From<ISyncChangeBatchWithPrerequisite> for ::windows::core::IUnknown {
-    fn from(value: ISyncChangeBatchWithPrerequisite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatchWithPrerequisite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChangeBatchWithPrerequisite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatchWithPrerequisite> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChangeBatchWithPrerequisite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncChangeBatchWithPrerequisite> for ISyncChangeBatchBase {
-    fn from(value: ISyncChangeBatchWithPrerequisite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBatchWithPrerequisite> for &'a ISyncChangeBatchBase {
-    fn from(value: &'a ISyncChangeBatchWithPrerequisite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBatchWithPrerequisite> for ISyncChangeBatchBase {
-    fn from(value: &ISyncChangeBatchWithPrerequisite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChangeBatchWithPrerequisite, ::windows::core::IUnknown, ISyncChangeBatchBase);
 impl ::core::clone::Clone for ISyncChangeBatchWithPrerequisite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4049,21 +3112,7 @@ impl ISyncChangeBuilder {
         (::windows::core::Vtable::vtable(self).AddChangeUnitMetadata)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbchangeunitid), ::core::mem::transmute(pchangeunitversion)).ok()
     }
 }
-impl ::core::convert::From<ISyncChangeBuilder> for ::windows::core::IUnknown {
-    fn from(value: ISyncChangeBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeBuilder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChangeBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeBuilder> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChangeBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChangeBuilder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncChangeBuilder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4107,21 +3156,7 @@ impl ISyncChangeUnit {
         (::windows::core::Vtable::vtable(self).GetChangeUnitVersion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbcurrentreplicaid), ::core::mem::transmute(pversion)).ok()
     }
 }
-impl ::core::convert::From<ISyncChangeUnit> for ::windows::core::IUnknown {
-    fn from(value: ISyncChangeUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeUnit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChangeUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeUnit> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChangeUnit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChangeUnit, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncChangeUnit {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4214,21 +3249,7 @@ impl ISyncChangeWithFilterKeyMap {
         (::windows::core::Vtable::vtable(self).GetLearnedFilterForgottenKnowledgeAfterRecoveryComplete)(::windows::core::Vtable::as_raw(self), pdestinationknowledge.into().abi(), pnewmoveins.into().abi(), dwfilterkey, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncKnowledge>(result__)
     }
 }
-impl ::core::convert::From<ISyncChangeWithFilterKeyMap> for ::windows::core::IUnknown {
-    fn from(value: ISyncChangeWithFilterKeyMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeWithFilterKeyMap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChangeWithFilterKeyMap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeWithFilterKeyMap> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChangeWithFilterKeyMap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChangeWithFilterKeyMap, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncChangeWithFilterKeyMap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4287,21 +3308,7 @@ impl ISyncChangeWithPrerequisite {
         (::windows::core::Vtable::vtable(self).GetLearnedKnowledgeWithPrerequisite)(::windows::core::Vtable::as_raw(self), pdestinationknowledge.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncKnowledge>(result__)
     }
 }
-impl ::core::convert::From<ISyncChangeWithPrerequisite> for ::windows::core::IUnknown {
-    fn from(value: ISyncChangeWithPrerequisite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncChangeWithPrerequisite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncChangeWithPrerequisite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncChangeWithPrerequisite> for ::windows::core::IUnknown {
-    fn from(value: &ISyncChangeWithPrerequisite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncChangeWithPrerequisite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncChangeWithPrerequisite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4342,21 +3349,7 @@ impl ISyncConstraintCallback {
         (::windows::core::Vtable::vtable(self).OnConstraintConflict)(::windows::core::Vtable::as_raw(self), pconflict.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISyncConstraintCallback> for ::windows::core::IUnknown {
-    fn from(value: ISyncConstraintCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncConstraintCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncConstraintCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncConstraintCallback> for ::windows::core::IUnknown {
-    fn from(value: &ISyncConstraintCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncConstraintCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncConstraintCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4422,21 +3415,7 @@ impl ISyncDataConverter {
         (::windows::core::Vtable::vtable(self).ConvertDataToProviderFormat)(::windows::core::Vtable::as_raw(self), pdatacontext.into().abi(), punkdataout.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<ISyncDataConverter> for ::windows::core::IUnknown {
-    fn from(value: ISyncDataConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncDataConverter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncDataConverter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncDataConverter> for ::windows::core::IUnknown {
-    fn from(value: &ISyncDataConverter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncDataConverter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncDataConverter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4482,21 +3461,7 @@ impl ISyncFilter {
         (::windows::core::Vtable::vtable(self).Serialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbsyncfilter), ::core::mem::transmute(pcbsyncfilter)).ok()
     }
 }
-impl ::core::convert::From<ISyncFilter> for ::windows::core::IUnknown {
-    fn from(value: ISyncFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncFilter> for ::windows::core::IUnknown {
-    fn from(value: &ISyncFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4535,21 +3500,7 @@ impl ISyncFilterDeserializer {
         (::windows::core::Vtable::vtable(self).DeserializeSyncFilter)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbsyncfilter), dwcbsyncfilter, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncFilter>(result__)
     }
 }
-impl ::core::convert::From<ISyncFilterDeserializer> for ::windows::core::IUnknown {
-    fn from(value: ISyncFilterDeserializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncFilterDeserializer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncFilterDeserializer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncFilterDeserializer> for ::windows::core::IUnknown {
-    fn from(value: &ISyncFilterDeserializer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncFilterDeserializer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncFilterDeserializer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4586,21 +3537,7 @@ impl ISyncFilterInfo {
         (::windows::core::Vtable::vtable(self).Serialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbbuffer), ::core::mem::transmute(pcbbuffer)).ok()
     }
 }
-impl ::core::convert::From<ISyncFilterInfo> for ::windows::core::IUnknown {
-    fn from(value: ISyncFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncFilterInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncFilterInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncFilterInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISyncFilterInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncFilterInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncFilterInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4640,36 +3577,7 @@ impl ISyncFilterInfo2 {
         (::windows::core::Vtable::vtable(self).GetFlags)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwflags)).ok()
     }
 }
-impl ::core::convert::From<ISyncFilterInfo2> for ::windows::core::IUnknown {
-    fn from(value: ISyncFilterInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncFilterInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncFilterInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncFilterInfo2> for ::windows::core::IUnknown {
-    fn from(value: &ISyncFilterInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncFilterInfo2> for ISyncFilterInfo {
-    fn from(value: ISyncFilterInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncFilterInfo2> for &'a ISyncFilterInfo {
-    fn from(value: &'a ISyncFilterInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncFilterInfo2> for ISyncFilterInfo {
-    fn from(value: &ISyncFilterInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncFilterInfo2, ::windows::core::IUnknown, ISyncFilterInfo);
 impl ::core::clone::Clone for ISyncFilterInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4711,21 +3619,7 @@ impl ISyncFullEnumerationChange {
         (::windows::core::Vtable::vtable(self).GetLearnedForgottenKnowledge)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IForgottenKnowledge>(result__)
     }
 }
-impl ::core::convert::From<ISyncFullEnumerationChange> for ::windows::core::IUnknown {
-    fn from(value: ISyncFullEnumerationChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncFullEnumerationChange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncFullEnumerationChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncFullEnumerationChange> for ::windows::core::IUnknown {
-    fn from(value: &ISyncFullEnumerationChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncFullEnumerationChange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncFullEnumerationChange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4822,36 +3716,7 @@ impl ISyncFullEnumerationChangeBatch {
         (::windows::core::Vtable::vtable(self).GetClosedUpperBoundItemId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbclosedupperbounditemid), ::core::mem::transmute(pcbidsize)).ok()
     }
 }
-impl ::core::convert::From<ISyncFullEnumerationChangeBatch> for ::windows::core::IUnknown {
-    fn from(value: ISyncFullEnumerationChangeBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncFullEnumerationChangeBatch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncFullEnumerationChangeBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncFullEnumerationChangeBatch> for ::windows::core::IUnknown {
-    fn from(value: &ISyncFullEnumerationChangeBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncFullEnumerationChangeBatch> for ISyncChangeBatchBase {
-    fn from(value: ISyncFullEnumerationChangeBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncFullEnumerationChangeBatch> for &'a ISyncChangeBatchBase {
-    fn from(value: &'a ISyncFullEnumerationChangeBatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncFullEnumerationChangeBatch> for ISyncChangeBatchBase {
-    fn from(value: &ISyncFullEnumerationChangeBatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncFullEnumerationChangeBatch, ::windows::core::IUnknown, ISyncChangeBatchBase);
 impl ::core::clone::Clone for ISyncFullEnumerationChangeBatch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4953,51 +3818,7 @@ impl ISyncFullEnumerationChangeBatch2 {
         (::windows::core::Vtable::vtable(self).AddMergeTombstoneMetadataToGroup)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbownerreplicaid), ::core::mem::transmute(pbwinneritemid), ::core::mem::transmute(pbitemid), ::core::mem::transmute(pchangeversion), ::core::mem::transmute(pcreationversion), dwworkforchange, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncChangeBuilder>(result__)
     }
 }
-impl ::core::convert::From<ISyncFullEnumerationChangeBatch2> for ::windows::core::IUnknown {
-    fn from(value: ISyncFullEnumerationChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncFullEnumerationChangeBatch2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncFullEnumerationChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncFullEnumerationChangeBatch2> for ::windows::core::IUnknown {
-    fn from(value: &ISyncFullEnumerationChangeBatch2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncFullEnumerationChangeBatch2> for ISyncChangeBatchBase {
-    fn from(value: ISyncFullEnumerationChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncFullEnumerationChangeBatch2> for &'a ISyncChangeBatchBase {
-    fn from(value: &'a ISyncFullEnumerationChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncFullEnumerationChangeBatch2> for ISyncChangeBatchBase {
-    fn from(value: &ISyncFullEnumerationChangeBatch2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncFullEnumerationChangeBatch2> for ISyncFullEnumerationChangeBatch {
-    fn from(value: ISyncFullEnumerationChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncFullEnumerationChangeBatch2> for &'a ISyncFullEnumerationChangeBatch {
-    fn from(value: &'a ISyncFullEnumerationChangeBatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncFullEnumerationChangeBatch2> for ISyncFullEnumerationChangeBatch {
-    fn from(value: &ISyncFullEnumerationChangeBatch2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncFullEnumerationChangeBatch2, ::windows::core::IUnknown, ISyncChangeBatchBase, ISyncFullEnumerationChangeBatch);
 impl ::core::clone::Clone for ISyncFullEnumerationChangeBatch2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5126,21 +3947,7 @@ impl ISyncKnowledge {
         (::windows::core::Vtable::vtable(self).GetVersion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwversion)).ok()
     }
 }
-impl ::core::convert::From<ISyncKnowledge> for ::windows::core::IUnknown {
-    fn from(value: ISyncKnowledge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncKnowledge> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncKnowledge) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncKnowledge> for ::windows::core::IUnknown {
-    fn from(value: &ISyncKnowledge) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncKnowledge, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncKnowledge {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5365,36 +4172,7 @@ impl ISyncKnowledge2 {
         (::windows::core::Vtable::vtable(self).CompareToKnowledgeCookie)(::windows::core::Vtable::as_raw(self), pknowledgecookie.into().abi(), ::core::mem::transmute(presult)).ok()
     }
 }
-impl ::core::convert::From<ISyncKnowledge2> for ::windows::core::IUnknown {
-    fn from(value: ISyncKnowledge2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncKnowledge2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncKnowledge2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncKnowledge2> for ::windows::core::IUnknown {
-    fn from(value: &ISyncKnowledge2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncKnowledge2> for ISyncKnowledge {
-    fn from(value: ISyncKnowledge2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncKnowledge2> for &'a ISyncKnowledge {
-    fn from(value: &'a ISyncKnowledge2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncKnowledge2> for ISyncKnowledge {
-    fn from(value: &ISyncKnowledge2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncKnowledge2, ::windows::core::IUnknown, ISyncKnowledge);
 impl ::core::clone::Clone for ISyncKnowledge2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5447,21 +4225,7 @@ impl ISyncMergeTombstoneChange {
         (::windows::core::Vtable::vtable(self).GetWinnerItemId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbwinneritemid), ::core::mem::transmute(pcbidsize)).ok()
     }
 }
-impl ::core::convert::From<ISyncMergeTombstoneChange> for ::windows::core::IUnknown {
-    fn from(value: ISyncMergeTombstoneChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMergeTombstoneChange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMergeTombstoneChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMergeTombstoneChange> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMergeTombstoneChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMergeTombstoneChange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMergeTombstoneChange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5500,21 +4264,7 @@ impl ISyncProvider {
         (::windows::core::Vtable::vtable(self).GetIdParameters)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidparameters)).ok()
     }
 }
-impl ::core::convert::From<ISyncProvider> for ::windows::core::IUnknown {
-    fn from(value: ISyncProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISyncProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5585,21 +4335,7 @@ impl ISyncProviderConfigUI {
         (::windows::core::Vtable::vtable(self).ModifySyncProvider)(::windows::core::Vtable::as_raw(self), hwndparent.into(), punkcontext.into().abi(), pproviderinfo.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISyncProviderConfigUI> for ::windows::core::IUnknown {
-    fn from(value: ISyncProviderConfigUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncProviderConfigUI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncProviderConfigUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncProviderConfigUI> for ::windows::core::IUnknown {
-    fn from(value: &ISyncProviderConfigUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncProviderConfigUI, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncProviderConfigUI {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5683,41 +4419,7 @@ impl ISyncProviderConfigUIInfo {
     }
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl ::core::convert::From<ISyncProviderConfigUIInfo> for ::windows::core::IUnknown {
-    fn from(value: ISyncProviderConfigUIInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl<'a> ::core::convert::From<&'a ISyncProviderConfigUIInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncProviderConfigUIInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl ::core::convert::From<&ISyncProviderConfigUIInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISyncProviderConfigUIInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl ::core::convert::From<ISyncProviderConfigUIInfo> for super::super::UI::Shell::PropertiesSystem::IPropertyStore {
-    fn from(value: ISyncProviderConfigUIInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl<'a> ::core::convert::From<&'a ISyncProviderConfigUIInfo> for &'a super::super::UI::Shell::PropertiesSystem::IPropertyStore {
-    fn from(value: &'a ISyncProviderConfigUIInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl ::core::convert::From<&ISyncProviderConfigUIInfo> for super::super::UI::Shell::PropertiesSystem::IPropertyStore {
-    fn from(value: &ISyncProviderConfigUIInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncProviderConfigUIInfo, ::windows::core::IUnknown, super::super::UI::Shell::PropertiesSystem::IPropertyStore);
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl ::core::clone::Clone for ISyncProviderConfigUIInfo {
     fn clone(&self) -> Self {
@@ -5793,41 +4495,7 @@ impl ISyncProviderInfo {
     }
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl ::core::convert::From<ISyncProviderInfo> for ::windows::core::IUnknown {
-    fn from(value: ISyncProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl<'a> ::core::convert::From<&'a ISyncProviderInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl ::core::convert::From<&ISyncProviderInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISyncProviderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl ::core::convert::From<ISyncProviderInfo> for super::super::UI::Shell::PropertiesSystem::IPropertyStore {
-    fn from(value: ISyncProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl<'a> ::core::convert::From<&'a ISyncProviderInfo> for &'a super::super::UI::Shell::PropertiesSystem::IPropertyStore {
-    fn from(value: &'a ISyncProviderInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl ::core::convert::From<&ISyncProviderInfo> for super::super::UI::Shell::PropertiesSystem::IPropertyStore {
-    fn from(value: &ISyncProviderInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncProviderInfo, ::windows::core::IUnknown, super::super::UI::Shell::PropertiesSystem::IPropertyStore);
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl ::core::clone::Clone for ISyncProviderInfo {
     fn clone(&self) -> Self {
@@ -5949,21 +4617,7 @@ impl ISyncProviderRegistration {
         (::windows::core::Vtable::vtable(self).GetChange)(::windows::core::Vtable::as_raw(self), hevent.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncRegistrationChange>(result__)
     }
 }
-impl ::core::convert::From<ISyncProviderRegistration> for ::windows::core::IUnknown {
-    fn from(value: ISyncProviderRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncProviderRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncProviderRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncProviderRegistration> for ::windows::core::IUnknown {
-    fn from(value: &ISyncProviderRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncProviderRegistration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncProviderRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6044,21 +4698,7 @@ impl ISyncRegistrationChange {
         (::windows::core::Vtable::vtable(self).GetInstanceId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<ISyncRegistrationChange> for ::windows::core::IUnknown {
-    fn from(value: ISyncRegistrationChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncRegistrationChange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncRegistrationChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncRegistrationChange> for ::windows::core::IUnknown {
-    fn from(value: &ISyncRegistrationChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncRegistrationChange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncRegistrationChange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6097,21 +4737,7 @@ impl ISyncSessionExtendedErrorInfo {
         (::windows::core::Vtable::vtable(self).GetSyncProviderWithError)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncProvider>(result__)
     }
 }
-impl ::core::convert::From<ISyncSessionExtendedErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: ISyncSessionExtendedErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncSessionExtendedErrorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncSessionExtendedErrorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncSessionExtendedErrorInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISyncSessionExtendedErrorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncSessionExtendedErrorInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncSessionExtendedErrorInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6168,21 +4794,7 @@ impl ISyncSessionState {
         (::windows::core::Vtable::vtable(self).OnProgress)(::windows::core::Vtable::as_raw(self), provider, syncstage, dwcompletedwork, dwtotalwork).ok()
     }
 }
-impl ::core::convert::From<ISyncSessionState> for ::windows::core::IUnknown {
-    fn from(value: ISyncSessionState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncSessionState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncSessionState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncSessionState> for ::windows::core::IUnknown {
-    fn from(value: &ISyncSessionState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncSessionState, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncSessionState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6259,36 +4871,7 @@ impl ISyncSessionState2 {
         (::windows::core::Vtable::vtable(self).GetSessionErrorStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phrsessionerror)).ok()
     }
 }
-impl ::core::convert::From<ISyncSessionState2> for ::windows::core::IUnknown {
-    fn from(value: ISyncSessionState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncSessionState2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncSessionState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncSessionState2> for ::windows::core::IUnknown {
-    fn from(value: &ISyncSessionState2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncSessionState2> for ISyncSessionState {
-    fn from(value: ISyncSessionState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncSessionState2> for &'a ISyncSessionState {
-    fn from(value: &'a ISyncSessionState2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncSessionState2> for ISyncSessionState {
-    fn from(value: &ISyncSessionState2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncSessionState2, ::windows::core::IUnknown, ISyncSessionState);
 impl ::core::clone::Clone for ISyncSessionState2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6338,21 +4921,7 @@ impl ISynchronousDataRetriever {
         (::windows::core::Vtable::vtable(self).LoadChangeData)(::windows::core::Vtable::as_raw(self), ploadchangecontext.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<ISynchronousDataRetriever> for ::windows::core::IUnknown {
-    fn from(value: ISynchronousDataRetriever) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISynchronousDataRetriever> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISynchronousDataRetriever) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISynchronousDataRetriever> for ::windows::core::IUnknown {
-    fn from(value: &ISynchronousDataRetriever) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISynchronousDataRetriever, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISynchronousDataRetriever {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
@@ -31,21 +31,7 @@ impl IEnumWbemClassObject {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ltimeout, ncount)
     }
 }
-impl ::core::convert::From<IEnumWbemClassObject> for ::windows::core::IUnknown {
-    fn from(value: IEnumWbemClassObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumWbemClassObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumWbemClassObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumWbemClassObject> for ::windows::core::IUnknown {
-    fn from(value: &IEnumWbemClassObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumWbemClassObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumWbemClassObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -110,21 +96,7 @@ impl IMofCompiler {
         (::windows::core::Vtable::vtable(self).CreateBMOF)(::windows::core::Vtable::as_raw(self), textfilename.into(), bmoffilename.into(), serverandnamespace.into(), loptionflags, lclassflags, linstanceflags, ::core::mem::transmute(pinfo)).ok()
     }
 }
-impl ::core::convert::From<IMofCompiler> for ::windows::core::IUnknown {
-    fn from(value: IMofCompiler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMofCompiler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMofCompiler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMofCompiler> for ::windows::core::IUnknown {
-    fn from(value: &IMofCompiler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMofCompiler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMofCompiler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -303,41 +275,7 @@ impl ISWbemDateTime {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemDateTime> for ::windows::core::IUnknown {
-    fn from(value: ISWbemDateTime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemDateTime> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemDateTime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemDateTime> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemDateTime) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemDateTime> for super::Com::IDispatch {
-    fn from(value: ISWbemDateTime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemDateTime> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemDateTime) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemDateTime> for super::Com::IDispatch {
-    fn from(value: &ISWbemDateTime) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemDateTime, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemDateTime {
     fn clone(&self) -> Self {
@@ -432,41 +370,7 @@ impl ISWbemEventSource {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemEventSource> for ::windows::core::IUnknown {
-    fn from(value: ISWbemEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemEventSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemEventSource> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemEventSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemEventSource> for super::Com::IDispatch {
-    fn from(value: ISWbemEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemEventSource> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemEventSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemEventSource> for super::Com::IDispatch {
-    fn from(value: &ISWbemEventSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemEventSource, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemEventSource {
     fn clone(&self) -> Self {
@@ -718,59 +622,7 @@ impl ISWbemLastError {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemLastError> for ::windows::core::IUnknown {
-    fn from(value: ISWbemLastError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemLastError> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemLastError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemLastError> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemLastError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemLastError> for super::Com::IDispatch {
-    fn from(value: ISWbemLastError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemLastError> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemLastError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemLastError> for super::Com::IDispatch {
-    fn from(value: &ISWbemLastError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemLastError> for ISWbemObject {
-    fn from(value: ISWbemLastError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemLastError> for &'a ISWbemObject {
-    fn from(value: &'a ISWbemLastError) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemLastError> for ISWbemObject {
-    fn from(value: &ISWbemLastError) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemLastError, ::windows::core::IUnknown, super::Com::IDispatch, ISWbemObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemLastError {
     fn clone(&self) -> Self {
@@ -828,41 +680,7 @@ impl ISWbemLocator {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemLocator> for ::windows::core::IUnknown {
-    fn from(value: ISWbemLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemLocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemLocator> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemLocator> for super::Com::IDispatch {
-    fn from(value: ISWbemLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemLocator> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemLocator> for super::Com::IDispatch {
-    fn from(value: &ISWbemLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemLocator, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemLocator {
     fn clone(&self) -> Self {
@@ -939,41 +757,7 @@ impl ISWbemMethod {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemMethod> for ::windows::core::IUnknown {
-    fn from(value: ISWbemMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemMethod> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemMethod> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemMethod) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemMethod> for super::Com::IDispatch {
-    fn from(value: ISWbemMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemMethod> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemMethod) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemMethod> for super::Com::IDispatch {
-    fn from(value: &ISWbemMethod) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemMethod, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemMethod {
     fn clone(&self) -> Self {
@@ -1044,41 +828,7 @@ impl ISWbemMethodSet {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemMethodSet> for ::windows::core::IUnknown {
-    fn from(value: ISWbemMethodSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemMethodSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemMethodSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemMethodSet> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemMethodSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemMethodSet> for super::Com::IDispatch {
-    fn from(value: ISWbemMethodSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemMethodSet> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemMethodSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemMethodSet> for super::Com::IDispatch {
-    fn from(value: &ISWbemMethodSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemMethodSet, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemMethodSet {
     fn clone(&self) -> Self {
@@ -1142,41 +892,7 @@ impl ISWbemNamedValue {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemNamedValue> for ::windows::core::IUnknown {
-    fn from(value: ISWbemNamedValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemNamedValue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemNamedValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemNamedValue> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemNamedValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemNamedValue> for super::Com::IDispatch {
-    fn from(value: ISWbemNamedValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemNamedValue> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemNamedValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemNamedValue> for super::Com::IDispatch {
-    fn from(value: &ISWbemNamedValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemNamedValue, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemNamedValue {
     fn clone(&self) -> Self {
@@ -1260,41 +976,7 @@ impl ISWbemNamedValueSet {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemNamedValueSet> for ::windows::core::IUnknown {
-    fn from(value: ISWbemNamedValueSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemNamedValueSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemNamedValueSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemNamedValueSet> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemNamedValueSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemNamedValueSet> for super::Com::IDispatch {
-    fn from(value: ISWbemNamedValueSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemNamedValueSet> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemNamedValueSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemNamedValueSet> for super::Com::IDispatch {
-    fn from(value: &ISWbemNamedValueSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemNamedValueSet, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemNamedValueSet {
     fn clone(&self) -> Self {
@@ -1554,41 +1236,7 @@ impl ISWbemObject {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemObject> for ::windows::core::IUnknown {
-    fn from(value: ISWbemObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemObject> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemObject> for super::Com::IDispatch {
-    fn from(value: ISWbemObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemObject> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemObject> for super::Com::IDispatch {
-    fn from(value: &ISWbemObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemObject, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemObject {
     fn clone(&self) -> Self {
@@ -1960,59 +1608,7 @@ impl ISWbemObjectEx {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemObjectEx> for ::windows::core::IUnknown {
-    fn from(value: ISWbemObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemObjectEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemObjectEx> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemObjectEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemObjectEx> for super::Com::IDispatch {
-    fn from(value: ISWbemObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemObjectEx> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemObjectEx> for super::Com::IDispatch {
-    fn from(value: &ISWbemObjectEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemObjectEx> for ISWbemObject {
-    fn from(value: ISWbemObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemObjectEx> for &'a ISWbemObject {
-    fn from(value: &'a ISWbemObjectEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemObjectEx> for ISWbemObject {
-    fn from(value: &ISWbemObjectEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemObjectEx, ::windows::core::IUnknown, super::Com::IDispatch, ISWbemObject);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemObjectEx {
     fn clone(&self) -> Self {
@@ -2157,41 +1753,7 @@ impl ISWbemObjectPath {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemObjectPath> for ::windows::core::IUnknown {
-    fn from(value: ISWbemObjectPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemObjectPath> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemObjectPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemObjectPath> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemObjectPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemObjectPath> for super::Com::IDispatch {
-    fn from(value: ISWbemObjectPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemObjectPath> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemObjectPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemObjectPath> for super::Com::IDispatch {
-    fn from(value: &ISWbemObjectPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemObjectPath, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemObjectPath {
     fn clone(&self) -> Self {
@@ -2289,41 +1851,7 @@ impl ISWbemObjectSet {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemObjectSet> for ::windows::core::IUnknown {
-    fn from(value: ISWbemObjectSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemObjectSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemObjectSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemObjectSet> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemObjectSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemObjectSet> for super::Com::IDispatch {
-    fn from(value: ISWbemObjectSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemObjectSet> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemObjectSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemObjectSet> for super::Com::IDispatch {
-    fn from(value: &ISWbemObjectSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemObjectSet, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemObjectSet {
     fn clone(&self) -> Self {
@@ -2399,41 +1927,7 @@ impl ISWbemPrivilege {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemPrivilege> for ::windows::core::IUnknown {
-    fn from(value: ISWbemPrivilege) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemPrivilege> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemPrivilege) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemPrivilege> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemPrivilege) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemPrivilege> for super::Com::IDispatch {
-    fn from(value: ISWbemPrivilege) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemPrivilege> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemPrivilege) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemPrivilege> for super::Com::IDispatch {
-    fn from(value: &ISWbemPrivilege) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemPrivilege, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemPrivilege {
     fn clone(&self) -> Self {
@@ -2513,41 +2007,7 @@ impl ISWbemPrivilegeSet {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemPrivilegeSet> for ::windows::core::IUnknown {
-    fn from(value: ISWbemPrivilegeSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemPrivilegeSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemPrivilegeSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemPrivilegeSet> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemPrivilegeSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemPrivilegeSet> for super::Com::IDispatch {
-    fn from(value: ISWbemPrivilegeSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemPrivilegeSet> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemPrivilegeSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemPrivilegeSet> for super::Com::IDispatch {
-    fn from(value: &ISWbemPrivilegeSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemPrivilegeSet, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemPrivilegeSet {
     fn clone(&self) -> Self {
@@ -2643,41 +2103,7 @@ impl ISWbemProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemProperty> for ::windows::core::IUnknown {
-    fn from(value: ISWbemProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemProperty> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemProperty> for super::Com::IDispatch {
-    fn from(value: ISWbemProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemProperty> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemProperty> for super::Com::IDispatch {
-    fn from(value: &ISWbemProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemProperty, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemProperty {
     fn clone(&self) -> Self {
@@ -2760,41 +2186,7 @@ impl ISWbemPropertySet {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemPropertySet> for ::windows::core::IUnknown {
-    fn from(value: ISWbemPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemPropertySet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemPropertySet> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemPropertySet> for super::Com::IDispatch {
-    fn from(value: ISWbemPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemPropertySet> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemPropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemPropertySet> for super::Com::IDispatch {
-    fn from(value: &ISWbemPropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemPropertySet, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemPropertySet {
     fn clone(&self) -> Self {
@@ -2892,41 +2284,7 @@ impl ISWbemQualifier {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemQualifier> for ::windows::core::IUnknown {
-    fn from(value: ISWbemQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemQualifier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemQualifier> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemQualifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemQualifier> for super::Com::IDispatch {
-    fn from(value: ISWbemQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemQualifier> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemQualifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemQualifier> for super::Com::IDispatch {
-    fn from(value: &ISWbemQualifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemQualifier, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemQualifier {
     fn clone(&self) -> Self {
@@ -3009,41 +2367,7 @@ impl ISWbemQualifierSet {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemQualifierSet> for ::windows::core::IUnknown {
-    fn from(value: ISWbemQualifierSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemQualifierSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemQualifierSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemQualifierSet> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemQualifierSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemQualifierSet> for super::Com::IDispatch {
-    fn from(value: ISWbemQualifierSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemQualifierSet> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemQualifierSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemQualifierSet> for super::Com::IDispatch {
-    fn from(value: &ISWbemQualifierSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemQualifierSet, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemQualifierSet {
     fn clone(&self) -> Self {
@@ -3126,41 +2450,7 @@ impl ISWbemRefreshableItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemRefreshableItem> for ::windows::core::IUnknown {
-    fn from(value: ISWbemRefreshableItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemRefreshableItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemRefreshableItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemRefreshableItem> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemRefreshableItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemRefreshableItem> for super::Com::IDispatch {
-    fn from(value: ISWbemRefreshableItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemRefreshableItem> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemRefreshableItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemRefreshableItem> for super::Com::IDispatch {
-    fn from(value: &ISWbemRefreshableItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemRefreshableItem, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemRefreshableItem {
     fn clone(&self) -> Self {
@@ -3268,41 +2558,7 @@ impl ISWbemRefresher {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemRefresher> for ::windows::core::IUnknown {
-    fn from(value: ISWbemRefresher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemRefresher> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemRefresher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemRefresher> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemRefresher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemRefresher> for super::Com::IDispatch {
-    fn from(value: ISWbemRefresher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemRefresher> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemRefresher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemRefresher> for super::Com::IDispatch {
-    fn from(value: &ISWbemRefresher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemRefresher, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemRefresher {
     fn clone(&self) -> Self {
@@ -3384,41 +2640,7 @@ impl ISWbemSecurity {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemSecurity> for ::windows::core::IUnknown {
-    fn from(value: ISWbemSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemSecurity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemSecurity> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemSecurity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemSecurity> for super::Com::IDispatch {
-    fn from(value: ISWbemSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemSecurity> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemSecurity> for super::Com::IDispatch {
-    fn from(value: &ISWbemSecurity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemSecurity, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemSecurity {
     fn clone(&self) -> Self {
@@ -3663,41 +2885,7 @@ impl ISWbemServices {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemServices> for ::windows::core::IUnknown {
-    fn from(value: ISWbemServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemServices> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemServices> for super::Com::IDispatch {
-    fn from(value: ISWbemServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemServices> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemServices> for super::Com::IDispatch {
-    fn from(value: &ISWbemServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemServices, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemServices {
     fn clone(&self) -> Self {
@@ -4031,59 +3219,7 @@ impl ISWbemServicesEx {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemServicesEx> for ::windows::core::IUnknown {
-    fn from(value: ISWbemServicesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemServicesEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemServicesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemServicesEx> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemServicesEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemServicesEx> for super::Com::IDispatch {
-    fn from(value: ISWbemServicesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemServicesEx> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemServicesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemServicesEx> for super::Com::IDispatch {
-    fn from(value: &ISWbemServicesEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemServicesEx> for ISWbemServices {
-    fn from(value: ISWbemServicesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemServicesEx> for &'a ISWbemServices {
-    fn from(value: &'a ISWbemServicesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemServicesEx> for ISWbemServices {
-    fn from(value: &ISWbemServicesEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemServicesEx, ::windows::core::IUnknown, super::Com::IDispatch, ISWbemServices);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemServicesEx {
     fn clone(&self) -> Self {
@@ -4137,41 +3273,7 @@ impl ISWbemSink {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemSink> for ::windows::core::IUnknown {
-    fn from(value: ISWbemSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemSink> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemSink> for super::Com::IDispatch {
-    fn from(value: ISWbemSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemSink> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemSink> for super::Com::IDispatch {
-    fn from(value: &ISWbemSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemSink, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemSink {
     fn clone(&self) -> Self {
@@ -4214,41 +3316,7 @@ pub struct ISWbemSinkEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl ISWbemSinkEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemSinkEvents> for ::windows::core::IUnknown {
-    fn from(value: ISWbemSinkEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemSinkEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISWbemSinkEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemSinkEvents> for ::windows::core::IUnknown {
-    fn from(value: &ISWbemSinkEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISWbemSinkEvents> for super::Com::IDispatch {
-    fn from(value: ISWbemSinkEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISWbemSinkEvents> for &'a super::Com::IDispatch {
-    fn from(value: &'a ISWbemSinkEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISWbemSinkEvents> for super::Com::IDispatch {
-    fn from(value: &ISWbemSinkEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISWbemSinkEvents, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISWbemSinkEvents {
     fn clone(&self) -> Self {
@@ -4295,21 +3363,7 @@ impl IUnsecuredApartment {
         (::windows::core::Vtable::vtable(self).CreateObjectStub)(::windows::core::Vtable::as_raw(self), pobject.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IUnsecuredApartment> for ::windows::core::IUnknown {
-    fn from(value: IUnsecuredApartment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUnsecuredApartment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUnsecuredApartment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUnsecuredApartment> for ::windows::core::IUnknown {
-    fn from(value: &IUnsecuredApartment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUnsecuredApartment, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUnsecuredApartment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4362,41 +3416,7 @@ impl IWMIExtension {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMIExtension> for ::windows::core::IUnknown {
-    fn from(value: IWMIExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMIExtension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWMIExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMIExtension> for ::windows::core::IUnknown {
-    fn from(value: &IWMIExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWMIExtension> for super::Com::IDispatch {
-    fn from(value: IWMIExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWMIExtension> for &'a super::Com::IDispatch {
-    fn from(value: &'a IWMIExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWMIExtension> for super::Com::IDispatch {
-    fn from(value: &IWMIExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWMIExtension, ::windows::core::IUnknown, super::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWMIExtension {
     fn clone(&self) -> Self {
@@ -4451,21 +3471,7 @@ impl IWbemAddressResolution {
         (::windows::core::Vtable::vtable(self).Resolve)(::windows::core::Vtable::as_raw(self), wsznamespacepath.into(), ::core::mem::transmute(wszaddresstype), ::core::mem::transmute(pdwaddresslength), ::core::mem::transmute(pabbinaryaddress)).ok()
     }
 }
-impl ::core::convert::From<IWbemAddressResolution> for ::windows::core::IUnknown {
-    fn from(value: IWbemAddressResolution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemAddressResolution> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemAddressResolution) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemAddressResolution> for ::windows::core::IUnknown {
-    fn from(value: &IWbemAddressResolution) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemAddressResolution, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemAddressResolution {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4511,21 +3517,7 @@ impl IWbemBackupRestore {
         (::windows::core::Vtable::vtable(self).Restore)(::windows::core::Vtable::as_raw(self), strrestorefromfile.into(), lflags).ok()
     }
 }
-impl ::core::convert::From<IWbemBackupRestore> for ::windows::core::IUnknown {
-    fn from(value: IWbemBackupRestore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemBackupRestore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemBackupRestore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemBackupRestore> for ::windows::core::IUnknown {
-    fn from(value: &IWbemBackupRestore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemBackupRestore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemBackupRestore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4578,36 +3570,7 @@ impl IWbemBackupRestoreEx {
         (::windows::core::Vtable::vtable(self).Resume)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWbemBackupRestoreEx> for ::windows::core::IUnknown {
-    fn from(value: IWbemBackupRestoreEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemBackupRestoreEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemBackupRestoreEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemBackupRestoreEx> for ::windows::core::IUnknown {
-    fn from(value: &IWbemBackupRestoreEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWbemBackupRestoreEx> for IWbemBackupRestore {
-    fn from(value: IWbemBackupRestoreEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemBackupRestoreEx> for &'a IWbemBackupRestore {
-    fn from(value: &'a IWbemBackupRestoreEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemBackupRestoreEx> for IWbemBackupRestore {
-    fn from(value: &IWbemBackupRestoreEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemBackupRestoreEx, ::windows::core::IUnknown, IWbemBackupRestore);
 impl ::core::clone::Clone for IWbemBackupRestoreEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4658,21 +3621,7 @@ impl IWbemCallResult {
         (::windows::core::Vtable::vtable(self).GetCallStatus)(::windows::core::Vtable::as_raw(self), ltimeout, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IWbemCallResult> for ::windows::core::IUnknown {
-    fn from(value: IWbemCallResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemCallResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemCallResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemCallResult> for ::windows::core::IUnknown {
-    fn from(value: &IWbemCallResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemCallResult, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemCallResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4840,21 +3789,7 @@ impl IWbemClassObject {
         (::windows::core::Vtable::vtable(self).GetMethodOrigin)(::windows::core::Vtable::as_raw(self), wszmethodname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IWbemClassObject> for ::windows::core::IUnknown {
-    fn from(value: IWbemClassObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemClassObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemClassObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemClassObject> for ::windows::core::IUnknown {
-    fn from(value: &IWbemClassObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemClassObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemClassObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4944,21 +3879,7 @@ impl IWbemClientConnectionTransport {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self), lflags, phandler.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWbemClientConnectionTransport> for ::windows::core::IUnknown {
-    fn from(value: IWbemClientConnectionTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemClientConnectionTransport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemClientConnectionTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemClientConnectionTransport> for ::windows::core::IUnknown {
-    fn from(value: &IWbemClientConnectionTransport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemClientConnectionTransport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemClientConnectionTransport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5001,21 +3922,7 @@ impl IWbemClientTransport {
         (::windows::core::Vtable::vtable(self).ConnectServer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(straddresstype), abbinaryaddress.len() as _, ::core::mem::transmute(abbinaryaddress.as_ptr()), ::core::mem::transmute_copy(strnetworkresource), ::core::mem::transmute_copy(struser), ::core::mem::transmute_copy(strpassword), ::core::mem::transmute_copy(strlocale), lsecurityflags, ::core::mem::transmute_copy(strauthority), pctx.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWbemServices>(result__)
     }
 }
-impl ::core::convert::From<IWbemClientTransport> for ::windows::core::IUnknown {
-    fn from(value: IWbemClientTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemClientTransport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemClientTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemClientTransport> for ::windows::core::IUnknown {
-    fn from(value: &IWbemClientTransport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemClientTransport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemClientTransport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5082,21 +3989,7 @@ impl IWbemConfigureRefresher {
         (::windows::core::Vtable::vtable(self).AddEnum)(::windows::core::Vtable::as_raw(self), pnamespace.into().abi(), wszclassname.into(), lflags, pcontext.into().abi(), ::core::mem::transmute(ppenum), ::core::mem::transmute(plid)).ok()
     }
 }
-impl ::core::convert::From<IWbemConfigureRefresher> for ::windows::core::IUnknown {
-    fn from(value: IWbemConfigureRefresher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemConfigureRefresher> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemConfigureRefresher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemConfigureRefresher> for ::windows::core::IUnknown {
-    fn from(value: &IWbemConfigureRefresher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemConfigureRefresher, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemConfigureRefresher {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5144,21 +4037,7 @@ impl IWbemConnectorLogin {
         (::windows::core::Vtable::vtable(self).ConnectorLogin)(::windows::core::Vtable::as_raw(self), wsznetworkresource.into(), wszpreferredlocale.into(), lflags, pctx.into().abi(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IWbemConnectorLogin> for ::windows::core::IUnknown {
-    fn from(value: IWbemConnectorLogin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemConnectorLogin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemConnectorLogin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemConnectorLogin> for ::windows::core::IUnknown {
-    fn from(value: &IWbemConnectorLogin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemConnectorLogin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemConnectorLogin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5214,21 +4093,7 @@ impl IWbemConstructClassObject {
         (::windows::core::Vtable::vtable(self).SetServerNamespace)(::windows::core::Vtable::as_raw(self), wszserver.into(), wsznamespace.into()).ok()
     }
 }
-impl ::core::convert::From<IWbemConstructClassObject> for ::windows::core::IUnknown {
-    fn from(value: IWbemConstructClassObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemConstructClassObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemConstructClassObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemConstructClassObject> for ::windows::core::IUnknown {
-    fn from(value: &IWbemConstructClassObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemConstructClassObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemConstructClassObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5312,21 +4177,7 @@ impl IWbemContext {
         (::windows::core::Vtable::vtable(self).DeleteAll)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWbemContext> for ::windows::core::IUnknown {
-    fn from(value: IWbemContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemContext> for ::windows::core::IUnknown {
-    fn from(value: &IWbemContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5408,36 +4259,7 @@ impl IWbemDecoupledBasicEventProvider {
         (::windows::core::Vtable::vtable(self).GetService)(::windows::core::Vtable::as_raw(self), a_flags, a_context.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWbemServices>(result__)
     }
 }
-impl ::core::convert::From<IWbemDecoupledBasicEventProvider> for ::windows::core::IUnknown {
-    fn from(value: IWbemDecoupledBasicEventProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemDecoupledBasicEventProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemDecoupledBasicEventProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemDecoupledBasicEventProvider> for ::windows::core::IUnknown {
-    fn from(value: &IWbemDecoupledBasicEventProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWbemDecoupledBasicEventProvider> for IWbemDecoupledRegistrar {
-    fn from(value: IWbemDecoupledBasicEventProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemDecoupledBasicEventProvider> for &'a IWbemDecoupledRegistrar {
-    fn from(value: &'a IWbemDecoupledBasicEventProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemDecoupledBasicEventProvider> for IWbemDecoupledRegistrar {
-    fn from(value: &IWbemDecoupledBasicEventProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemDecoupledBasicEventProvider, ::windows::core::IUnknown, IWbemDecoupledRegistrar);
 impl ::core::clone::Clone for IWbemDecoupledBasicEventProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5486,21 +4308,7 @@ impl IWbemDecoupledRegistrar {
         (::windows::core::Vtable::vtable(self).UnRegister)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWbemDecoupledRegistrar> for ::windows::core::IUnknown {
-    fn from(value: IWbemDecoupledRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemDecoupledRegistrar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemDecoupledRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemDecoupledRegistrar> for ::windows::core::IUnknown {
-    fn from(value: &IWbemDecoupledRegistrar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemDecoupledRegistrar, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemDecoupledRegistrar {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5542,21 +4350,7 @@ impl IWbemEventConsumerProvider {
         (::windows::core::Vtable::vtable(self).FindConsumer)(::windows::core::Vtable::as_raw(self), plogicalconsumer.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWbemUnboundObjectSink>(result__)
     }
 }
-impl ::core::convert::From<IWbemEventConsumerProvider> for ::windows::core::IUnknown {
-    fn from(value: IWbemEventConsumerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemEventConsumerProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemEventConsumerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemEventConsumerProvider> for ::windows::core::IUnknown {
-    fn from(value: &IWbemEventConsumerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemEventConsumerProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemEventConsumerProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5596,21 +4390,7 @@ impl IWbemEventProvider {
         (::windows::core::Vtable::vtable(self).ProvideEvents)(::windows::core::Vtable::as_raw(self), psink.into().abi(), lflags).ok()
     }
 }
-impl ::core::convert::From<IWbemEventProvider> for ::windows::core::IUnknown {
-    fn from(value: IWbemEventProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemEventProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemEventProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemEventProvider> for ::windows::core::IUnknown {
-    fn from(value: &IWbemEventProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemEventProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemEventProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5650,21 +4430,7 @@ impl IWbemEventProviderQuerySink {
         (::windows::core::Vtable::vtable(self).CancelQuery)(::windows::core::Vtable::as_raw(self), dwid).ok()
     }
 }
-impl ::core::convert::From<IWbemEventProviderQuerySink> for ::windows::core::IUnknown {
-    fn from(value: IWbemEventProviderQuerySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemEventProviderQuerySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemEventProviderQuerySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemEventProviderQuerySink> for ::windows::core::IUnknown {
-    fn from(value: &IWbemEventProviderQuerySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemEventProviderQuerySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemEventProviderQuerySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5702,21 +4468,7 @@ impl IWbemEventProviderSecurity {
         (::windows::core::Vtable::vtable(self).AccessCheck)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(wszquerylanguage), ::core::mem::transmute(wszquery), psid.len() as _, ::core::mem::transmute(psid.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IWbemEventProviderSecurity> for ::windows::core::IUnknown {
-    fn from(value: IWbemEventProviderSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemEventProviderSecurity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemEventProviderSecurity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemEventProviderSecurity> for ::windows::core::IUnknown {
-    fn from(value: &IWbemEventProviderSecurity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemEventProviderSecurity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemEventProviderSecurity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5775,36 +4527,7 @@ impl IWbemEventSink {
         (::windows::core::Vtable::vtable(self).SetBatchingParameters)(::windows::core::Vtable::as_raw(self), lflags, dwmaxbuffersize, dwmaxsendlatency).ok()
     }
 }
-impl ::core::convert::From<IWbemEventSink> for ::windows::core::IUnknown {
-    fn from(value: IWbemEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemEventSink> for ::windows::core::IUnknown {
-    fn from(value: &IWbemEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWbemEventSink> for IWbemObjectSink {
-    fn from(value: IWbemEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemEventSink> for &'a IWbemObjectSink {
-    fn from(value: &'a IWbemEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemEventSink> for IWbemObjectSink {
-    fn from(value: &IWbemEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemEventSink, ::windows::core::IUnknown, IWbemObjectSink);
 impl ::core::clone::Clone for IWbemEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5853,21 +4576,7 @@ impl IWbemHiPerfEnum {
         (::windows::core::Vtable::vtable(self).RemoveAll)(::windows::core::Vtable::as_raw(self), lflags).ok()
     }
 }
-impl ::core::convert::From<IWbemHiPerfEnum> for ::windows::core::IUnknown {
-    fn from(value: IWbemHiPerfEnum) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemHiPerfEnum> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemHiPerfEnum) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemHiPerfEnum> for ::windows::core::IUnknown {
-    fn from(value: &IWbemHiPerfEnum) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemHiPerfEnum, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemHiPerfEnum {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5953,21 +4662,7 @@ impl IWbemHiPerfProvider {
         (::windows::core::Vtable::vtable(self).GetObjects)(::windows::core::Vtable::as_raw(self), pnamespace.into().abi(), apobj.len() as _, ::core::mem::transmute(apobj.as_ptr()), lflags, pcontext.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWbemHiPerfProvider> for ::windows::core::IUnknown {
-    fn from(value: IWbemHiPerfProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemHiPerfProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemHiPerfProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemHiPerfProvider> for ::windows::core::IUnknown {
-    fn from(value: &IWbemHiPerfProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemHiPerfProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemHiPerfProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6038,21 +4733,7 @@ impl IWbemLevel1Login {
         (::windows::core::Vtable::vtable(self).NTLMLogin)(::windows::core::Vtable::as_raw(self), wsznetworkresource.into(), wszpreferredlocale.into(), lflags, pctx.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWbemServices>(result__)
     }
 }
-impl ::core::convert::From<IWbemLevel1Login> for ::windows::core::IUnknown {
-    fn from(value: IWbemLevel1Login) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemLevel1Login> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemLevel1Login) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemLevel1Login> for ::windows::core::IUnknown {
-    fn from(value: &IWbemLevel1Login) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemLevel1Login, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemLevel1Login {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6096,21 +4777,7 @@ impl IWbemLocator {
         (::windows::core::Vtable::vtable(self).ConnectServer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(strnetworkresource), ::core::mem::transmute_copy(struser), ::core::mem::transmute_copy(strpassword), ::core::mem::transmute_copy(strlocale), lsecurityflags, ::core::mem::transmute_copy(strauthority), pctx.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWbemServices>(result__)
     }
 }
-impl ::core::convert::From<IWbemLocator> for ::windows::core::IUnknown {
-    fn from(value: IWbemLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemLocator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemLocator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemLocator> for ::windows::core::IUnknown {
-    fn from(value: &IWbemLocator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemLocator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemLocator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6310,36 +4977,7 @@ impl IWbemObjectAccess {
         (::windows::core::Vtable::vtable(self).Unlock)(::windows::core::Vtable::as_raw(self), lflags).ok()
     }
 }
-impl ::core::convert::From<IWbemObjectAccess> for ::windows::core::IUnknown {
-    fn from(value: IWbemObjectAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemObjectAccess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemObjectAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemObjectAccess> for ::windows::core::IUnknown {
-    fn from(value: &IWbemObjectAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWbemObjectAccess> for IWbemClassObject {
-    fn from(value: IWbemObjectAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemObjectAccess> for &'a IWbemClassObject {
-    fn from(value: &'a IWbemObjectAccess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemObjectAccess> for IWbemClassObject {
-    fn from(value: &IWbemObjectAccess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemObjectAccess, ::windows::core::IUnknown, IWbemClassObject);
 impl ::core::clone::Clone for IWbemObjectAccess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6391,21 +5029,7 @@ impl IWbemObjectSink {
         (::windows::core::Vtable::vtable(self).SetStatus)(::windows::core::Vtable::as_raw(self), lflags, hresult, ::core::mem::transmute_copy(strparam), pobjparam.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWbemObjectSink> for ::windows::core::IUnknown {
-    fn from(value: IWbemObjectSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemObjectSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemObjectSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemObjectSink> for ::windows::core::IUnknown {
-    fn from(value: &IWbemObjectSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemObjectSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemObjectSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6471,36 +5095,7 @@ impl IWbemObjectSinkEx {
         (::windows::core::Vtable::vtable(self).WriteStreamParameter)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(strname), ::core::mem::transmute(vtvalue), ultype, ulflags).ok()
     }
 }
-impl ::core::convert::From<IWbemObjectSinkEx> for ::windows::core::IUnknown {
-    fn from(value: IWbemObjectSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemObjectSinkEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemObjectSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemObjectSinkEx> for ::windows::core::IUnknown {
-    fn from(value: &IWbemObjectSinkEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWbemObjectSinkEx> for IWbemObjectSink {
-    fn from(value: IWbemObjectSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemObjectSinkEx> for &'a IWbemObjectSink {
-    fn from(value: &'a IWbemObjectSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemObjectSinkEx> for IWbemObjectSink {
-    fn from(value: &IWbemObjectSinkEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemObjectSinkEx, ::windows::core::IUnknown, IWbemObjectSink);
 impl ::core::clone::Clone for IWbemObjectSinkEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6556,21 +5151,7 @@ impl IWbemObjectTextSrc {
         (::windows::core::Vtable::vtable(self).CreateFromText)(::windows::core::Vtable::as_raw(self), lflags, ::core::mem::transmute_copy(strtext), uobjtextformat, pctx.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWbemClassObject>(result__)
     }
 }
-impl ::core::convert::From<IWbemObjectTextSrc> for ::windows::core::IUnknown {
-    fn from(value: IWbemObjectTextSrc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemObjectTextSrc> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemObjectTextSrc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemObjectTextSrc> for ::windows::core::IUnknown {
-    fn from(value: &IWbemObjectTextSrc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemObjectTextSrc, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemObjectTextSrc {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6730,21 +5311,7 @@ impl IWbemPath {
         (::windows::core::Vtable::vtable(self).IsSameClassName)(::windows::core::Vtable::as_raw(self), wszclass.into())
     }
 }
-impl ::core::convert::From<IWbemPath> for ::windows::core::IUnknown {
-    fn from(value: IWbemPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemPath> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemPath) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemPath> for ::windows::core::IUnknown {
-    fn from(value: &IWbemPath) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemPath, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemPath {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6860,21 +5427,7 @@ impl IWbemPathKeyList {
         (::windows::core::Vtable::vtable(self).GetText)(::windows::core::Vtable::as_raw(self), lflags, ::core::mem::transmute(pubufflength), ::core::mem::transmute(psztext)).ok()
     }
 }
-impl ::core::convert::From<IWbemPathKeyList> for ::windows::core::IUnknown {
-    fn from(value: IWbemPathKeyList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemPathKeyList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemPathKeyList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemPathKeyList> for ::windows::core::IUnknown {
-    fn from(value: &IWbemPathKeyList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemPathKeyList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemPathKeyList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6934,21 +5487,7 @@ impl IWbemPropertyProvider {
         (::windows::core::Vtable::vtable(self).PutProperty)(::windows::core::Vtable::as_raw(self), lflags, ::core::mem::transmute_copy(strlocale), ::core::mem::transmute_copy(strclassmapping), ::core::mem::transmute_copy(strinstmapping), ::core::mem::transmute_copy(strpropmapping), ::core::mem::transmute(pvvalue)).ok()
     }
 }
-impl ::core::convert::From<IWbemPropertyProvider> for ::windows::core::IUnknown {
-    fn from(value: IWbemPropertyProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemPropertyProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemPropertyProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemPropertyProvider> for ::windows::core::IUnknown {
-    fn from(value: &IWbemPropertyProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemPropertyProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemPropertyProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6995,21 +5534,7 @@ impl IWbemProviderIdentity {
         (::windows::core::Vtable::vtable(self).SetRegistrationObject)(::windows::core::Vtable::as_raw(self), lflags, pprovreg.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWbemProviderIdentity> for ::windows::core::IUnknown {
-    fn from(value: IWbemProviderIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemProviderIdentity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemProviderIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemProviderIdentity> for ::windows::core::IUnknown {
-    fn from(value: &IWbemProviderIdentity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemProviderIdentity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemProviderIdentity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7054,21 +5579,7 @@ impl IWbemProviderInit {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), wszuser.into(), lflags, wsznamespace.into(), wszlocale.into(), pnamespace.into().abi(), pctx.into().abi(), pinitsink.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWbemProviderInit> for ::windows::core::IUnknown {
-    fn from(value: IWbemProviderInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemProviderInit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemProviderInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemProviderInit> for ::windows::core::IUnknown {
-    fn from(value: &IWbemProviderInit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemProviderInit, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemProviderInit {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7105,21 +5616,7 @@ impl IWbemProviderInitSink {
         (::windows::core::Vtable::vtable(self).SetStatus)(::windows::core::Vtable::as_raw(self), lstatus, lflags).ok()
     }
 }
-impl ::core::convert::From<IWbemProviderInitSink> for ::windows::core::IUnknown {
-    fn from(value: IWbemProviderInitSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemProviderInitSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemProviderInitSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemProviderInitSink> for ::windows::core::IUnknown {
-    fn from(value: &IWbemProviderInitSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemProviderInitSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemProviderInitSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7192,21 +5689,7 @@ impl IWbemQualifierSet {
         (::windows::core::Vtable::vtable(self).EndEnumeration)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWbemQualifierSet> for ::windows::core::IUnknown {
-    fn from(value: IWbemQualifierSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemQualifierSet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemQualifierSet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemQualifierSet> for ::windows::core::IUnknown {
-    fn from(value: &IWbemQualifierSet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemQualifierSet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemQualifierSet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7283,21 +5766,7 @@ impl IWbemQuery {
         (::windows::core::Vtable::vtable(self).GetQueryInfo)(::windows::core::Vtable::as_raw(self), uanalysistype, uinfoid, ubufsize, ::core::mem::transmute(pdestbuf)).ok()
     }
 }
-impl ::core::convert::From<IWbemQuery> for ::windows::core::IUnknown {
-    fn from(value: IWbemQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemQuery> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemQuery) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemQuery> for ::windows::core::IUnknown {
-    fn from(value: &IWbemQuery) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemQuery, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemQuery {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7340,21 +5809,7 @@ impl IWbemRefresher {
         (::windows::core::Vtable::vtable(self).Refresh)(::windows::core::Vtable::as_raw(self), lflags).ok()
     }
 }
-impl ::core::convert::From<IWbemRefresher> for ::windows::core::IUnknown {
-    fn from(value: IWbemRefresher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemRefresher> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemRefresher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemRefresher> for ::windows::core::IUnknown {
-    fn from(value: &IWbemRefresher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemRefresher, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemRefresher {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7544,21 +5999,7 @@ impl IWbemServices {
         (::windows::core::Vtable::vtable(self).ExecMethodAsync)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(strobjectpath), ::core::mem::transmute_copy(strmethodname), lflags, pctx.into().abi(), pinparams.into().abi(), presponsehandler.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWbemServices> for ::windows::core::IUnknown {
-    fn from(value: IWbemServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemServices> for ::windows::core::IUnknown {
-    fn from(value: &IWbemServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7620,21 +6061,7 @@ impl IWbemShutdown {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self), ureason, umaxmilliseconds, pctx.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IWbemShutdown> for ::windows::core::IUnknown {
-    fn from(value: IWbemShutdown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemShutdown> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemShutdown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemShutdown> for ::windows::core::IUnknown {
-    fn from(value: &IWbemShutdown) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemShutdown, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemShutdown {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7676,21 +6103,7 @@ impl IWbemStatusCodeText {
         (::windows::core::Vtable::vtable(self).GetFacilityCodeText)(::windows::core::Vtable::as_raw(self), hres, localeid, lflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IWbemStatusCodeText> for ::windows::core::IUnknown {
-    fn from(value: IWbemStatusCodeText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemStatusCodeText> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemStatusCodeText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemStatusCodeText> for ::windows::core::IUnknown {
-    fn from(value: &IWbemStatusCodeText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemStatusCodeText, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemStatusCodeText {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7728,21 +6141,7 @@ impl IWbemTransport {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IWbemTransport> for ::windows::core::IUnknown {
-    fn from(value: IWbemTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemTransport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemTransport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemTransport> for ::windows::core::IUnknown {
-    fn from(value: &IWbemTransport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemTransport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemTransport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7782,21 +6181,7 @@ impl IWbemUnboundObjectSink {
         (::windows::core::Vtable::vtable(self).IndicateToConsumer)(::windows::core::Vtable::as_raw(self), plogicalconsumer.into().abi(), apobjects.len() as _, ::core::mem::transmute(apobjects.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IWbemUnboundObjectSink> for ::windows::core::IUnknown {
-    fn from(value: IWbemUnboundObjectSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemUnboundObjectSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemUnboundObjectSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemUnboundObjectSink> for ::windows::core::IUnknown {
-    fn from(value: &IWbemUnboundObjectSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemUnboundObjectSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWbemUnboundObjectSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7845,36 +6230,7 @@ impl IWbemUnsecuredApartment {
         (::windows::core::Vtable::vtable(self).CreateSinkStub)(::windows::core::Vtable::as_raw(self), psink.into().abi(), dwflags, wszreserved.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IWbemObjectSink>(result__)
     }
 }
-impl ::core::convert::From<IWbemUnsecuredApartment> for ::windows::core::IUnknown {
-    fn from(value: IWbemUnsecuredApartment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemUnsecuredApartment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWbemUnsecuredApartment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemUnsecuredApartment> for ::windows::core::IUnknown {
-    fn from(value: &IWbemUnsecuredApartment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWbemUnsecuredApartment> for IUnsecuredApartment {
-    fn from(value: IWbemUnsecuredApartment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWbemUnsecuredApartment> for &'a IUnsecuredApartment {
-    fn from(value: &'a IWbemUnsecuredApartment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWbemUnsecuredApartment> for IUnsecuredApartment {
-    fn from(value: &IWbemUnsecuredApartment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWbemUnsecuredApartment, ::windows::core::IUnknown, IUnsecuredApartment);
 impl ::core::clone::Clone for IWbemUnsecuredApartment {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
@@ -1517,21 +1517,7 @@ impl IAccIdentity {
         (::windows::core::Vtable::vtable(self).GetIdentityString)(::windows::core::Vtable::as_raw(self), dwidchild, ::core::mem::transmute(ppidstring), ::core::mem::transmute(pdwidstringlen)).ok()
     }
 }
-impl ::core::convert::From<IAccIdentity> for ::windows::core::IUnknown {
-    fn from(value: IAccIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccIdentity> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccIdentity) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccIdentity> for ::windows::core::IUnknown {
-    fn from(value: &IAccIdentity) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccIdentity, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccIdentity {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1570,21 +1556,7 @@ impl IAccPropServer {
         (::windows::core::Vtable::vtable(self).GetPropValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidstring.as_ptr()), pidstring.len() as _, ::core::mem::transmute(idprop), ::core::mem::transmute(pvarvalue), ::core::mem::transmute(pfhasprop)).ok()
     }
 }
-impl ::core::convert::From<IAccPropServer> for ::windows::core::IUnknown {
-    fn from(value: IAccPropServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccPropServer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccPropServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccPropServer> for ::windows::core::IUnknown {
-    fn from(value: &IAccPropServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccPropServer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccPropServer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1734,21 +1706,7 @@ impl IAccPropServices {
         (::windows::core::Vtable::vtable(self).DecomposeHmenuIdentityString)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidstring.as_ptr()), pidstring.len() as _, ::core::mem::transmute(phmenu), ::core::mem::transmute(pidchild)).ok()
     }
 }
-impl ::core::convert::From<IAccPropServices> for ::windows::core::IUnknown {
-    fn from(value: IAccPropServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccPropServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccPropServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccPropServices> for ::windows::core::IUnknown {
-    fn from(value: &IAccPropServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccPropServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccPropServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2004,41 +1962,7 @@ impl IAccessible {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAccessible> for ::windows::core::IUnknown {
-    fn from(value: IAccessible) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAccessible> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccessible) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAccessible> for ::windows::core::IUnknown {
-    fn from(value: &IAccessible) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IAccessible> for super::super::System::Com::IDispatch {
-    fn from(value: IAccessible) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IAccessible> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IAccessible) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IAccessible> for super::super::System::Com::IDispatch {
-    fn from(value: &IAccessible) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccessible, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IAccessible {
     fn clone(&self) -> Self {
@@ -2181,21 +2105,7 @@ impl IAccessibleEx {
         (::windows::core::Vtable::vtable(self).ConvertReturnedElement)(::windows::core::Vtable::as_raw(self), pin.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAccessibleEx>(result__)
     }
 }
-impl ::core::convert::From<IAccessibleEx> for ::windows::core::IUnknown {
-    fn from(value: IAccessibleEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccessibleEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccessibleEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccessibleEx> for ::windows::core::IUnknown {
-    fn from(value: &IAccessibleEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccessibleEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccessibleEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2244,21 +2154,7 @@ impl IAccessibleHandler {
         (::windows::core::Vtable::vtable(self).AccessibleObjectFromID)(::windows::core::Vtable::as_raw(self), hwnd, lobjectid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAccessible>(result__)
     }
 }
-impl ::core::convert::From<IAccessibleHandler> for ::windows::core::IUnknown {
-    fn from(value: IAccessibleHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccessibleHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccessibleHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccessibleHandler> for ::windows::core::IUnknown {
-    fn from(value: &IAccessibleHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccessibleHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccessibleHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2308,21 +2204,7 @@ impl IAccessibleHostingElementProviders {
         (::windows::core::Vtable::vtable(self).GetObjectIdForProvider)(::windows::core::Vtable::as_raw(self), pprovider.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IAccessibleHostingElementProviders> for ::windows::core::IUnknown {
-    fn from(value: IAccessibleHostingElementProviders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccessibleHostingElementProviders> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccessibleHostingElementProviders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccessibleHostingElementProviders> for ::windows::core::IUnknown {
-    fn from(value: &IAccessibleHostingElementProviders) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccessibleHostingElementProviders, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccessibleHostingElementProviders {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2388,21 +2270,7 @@ impl IAccessibleWindowlessSite {
         (::windows::core::Vtable::vtable(self).GetParentAccessible)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAccessible>(result__)
     }
 }
-impl ::core::convert::From<IAccessibleWindowlessSite> for ::windows::core::IUnknown {
-    fn from(value: IAccessibleWindowlessSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccessibleWindowlessSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccessibleWindowlessSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccessibleWindowlessSite> for ::windows::core::IUnknown {
-    fn from(value: &IAccessibleWindowlessSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccessibleWindowlessSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccessibleWindowlessSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2465,21 +2333,7 @@ impl IAnnotationProvider {
         (::windows::core::Vtable::vtable(self).Target)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRawElementProviderSimple>(result__)
     }
 }
-impl ::core::convert::From<IAnnotationProvider> for ::windows::core::IUnknown {
-    fn from(value: IAnnotationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAnnotationProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAnnotationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAnnotationProvider> for ::windows::core::IUnknown {
-    fn from(value: &IAnnotationProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAnnotationProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAnnotationProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2521,21 +2375,7 @@ impl ICustomNavigationProvider {
         (::windows::core::Vtable::vtable(self).Navigate)(::windows::core::Vtable::as_raw(self), direction, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRawElementProviderSimple>(result__)
     }
 }
-impl ::core::convert::From<ICustomNavigationProvider> for ::windows::core::IUnknown {
-    fn from(value: ICustomNavigationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICustomNavigationProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICustomNavigationProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICustomNavigationProvider> for ::windows::core::IUnknown {
-    fn from(value: &ICustomNavigationProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICustomNavigationProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICustomNavigationProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2576,21 +2416,7 @@ impl IDockProvider {
         (::windows::core::Vtable::vtable(self).DockPosition)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DockPosition>(result__)
     }
 }
-impl ::core::convert::From<IDockProvider> for ::windows::core::IUnknown {
-    fn from(value: IDockProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDockProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDockProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDockProvider> for ::windows::core::IUnknown {
-    fn from(value: &IDockProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDockProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDockProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2647,21 +2473,7 @@ impl IDragProvider {
         (::windows::core::Vtable::vtable(self).GetGrabbedItems)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IDragProvider> for ::windows::core::IUnknown {
-    fn from(value: IDragProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDragProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDragProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDragProvider> for ::windows::core::IUnknown {
-    fn from(value: &IDragProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDragProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDragProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2717,21 +2529,7 @@ impl IDropTargetProvider {
         (::windows::core::Vtable::vtable(self).DropTargetEffects)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IDropTargetProvider> for ::windows::core::IUnknown {
-    fn from(value: IDropTargetProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDropTargetProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDropTargetProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDropTargetProvider> for ::windows::core::IUnknown {
-    fn from(value: &IDropTargetProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDropTargetProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDropTargetProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2779,21 +2577,7 @@ impl IExpandCollapseProvider {
         (::windows::core::Vtable::vtable(self).ExpandCollapseState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ExpandCollapseState>(result__)
     }
 }
-impl ::core::convert::From<IExpandCollapseProvider> for ::windows::core::IUnknown {
-    fn from(value: IExpandCollapseProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExpandCollapseProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExpandCollapseProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExpandCollapseProvider> for ::windows::core::IUnknown {
-    fn from(value: &IExpandCollapseProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExpandCollapseProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExpandCollapseProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2849,21 +2633,7 @@ impl IGridItemProvider {
         (::windows::core::Vtable::vtable(self).ContainingGrid)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRawElementProviderSimple>(result__)
     }
 }
-impl ::core::convert::From<IGridItemProvider> for ::windows::core::IUnknown {
-    fn from(value: IGridItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGridItemProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGridItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGridItemProvider> for ::windows::core::IUnknown {
-    fn from(value: &IGridItemProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGridItemProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGridItemProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2913,21 +2683,7 @@ impl IGridProvider {
         (::windows::core::Vtable::vtable(self).ColumnCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IGridProvider> for ::windows::core::IUnknown {
-    fn from(value: IGridProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGridProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGridProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGridProvider> for ::windows::core::IUnknown {
-    fn from(value: &IGridProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGridProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGridProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2966,21 +2722,7 @@ impl IInvokeProvider {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInvokeProvider> for ::windows::core::IUnknown {
-    fn from(value: IInvokeProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInvokeProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInvokeProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInvokeProvider> for ::windows::core::IUnknown {
-    fn from(value: &IInvokeProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInvokeProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInvokeProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3024,21 +2766,7 @@ impl IItemContainerProvider {
         (::windows::core::Vtable::vtable(self).FindItemByProperty)(::windows::core::Vtable::as_raw(self), pstartafter.into().abi(), propertyid, value.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRawElementProviderSimple>(result__)
     }
 }
-impl ::core::convert::From<IItemContainerProvider> for ::windows::core::IUnknown {
-    fn from(value: IItemContainerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IItemContainerProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IItemContainerProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IItemContainerProvider> for ::windows::core::IUnknown {
-    fn from(value: &IItemContainerProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IItemContainerProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IItemContainerProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3135,21 +2863,7 @@ impl ILegacyIAccessibleProvider {
         (::windows::core::Vtable::vtable(self).DefaultAction)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ILegacyIAccessibleProvider> for ::windows::core::IUnknown {
-    fn from(value: ILegacyIAccessibleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILegacyIAccessibleProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILegacyIAccessibleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILegacyIAccessibleProvider> for ::windows::core::IUnknown {
-    fn from(value: &ILegacyIAccessibleProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILegacyIAccessibleProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILegacyIAccessibleProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3219,21 +2933,7 @@ impl IMultipleViewProvider {
         (::windows::core::Vtable::vtable(self).GetSupportedViews)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IMultipleViewProvider> for ::windows::core::IUnknown {
-    fn from(value: IMultipleViewProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMultipleViewProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMultipleViewProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMultipleViewProvider> for ::windows::core::IUnknown {
-    fn from(value: &IMultipleViewProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMultipleViewProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMultipleViewProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3277,21 +2977,7 @@ impl IObjectModelProvider {
         (::windows::core::Vtable::vtable(self).GetUnderlyingObjectModel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IObjectModelProvider> for ::windows::core::IUnknown {
-    fn from(value: IObjectModelProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectModelProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectModelProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectModelProvider> for ::windows::core::IUnknown {
-    fn from(value: &IObjectModelProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectModelProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectModelProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3334,21 +3020,7 @@ impl IProxyProviderWinEventHandler {
         (::windows::core::Vtable::vtable(self).RespondToWinEvent)(::windows::core::Vtable::as_raw(self), idwinevent, hwnd.into(), idobject, idchild, psink.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IProxyProviderWinEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IProxyProviderWinEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProxyProviderWinEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProxyProviderWinEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProxyProviderWinEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IProxyProviderWinEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProxyProviderWinEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProxyProviderWinEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3408,21 +3080,7 @@ impl IProxyProviderWinEventSink {
         (::windows::core::Vtable::vtable(self).AddStructureChangedEvent)(::windows::core::Vtable::as_raw(self), pprovider.into().abi(), structurechangetype, ::core::mem::transmute(runtimeid)).ok()
     }
 }
-impl ::core::convert::From<IProxyProviderWinEventSink> for ::windows::core::IUnknown {
-    fn from(value: IProxyProviderWinEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProxyProviderWinEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProxyProviderWinEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProxyProviderWinEventSink> for ::windows::core::IUnknown {
-    fn from(value: &IProxyProviderWinEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProxyProviderWinEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProxyProviderWinEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3493,21 +3151,7 @@ impl IRangeValueProvider {
         (::windows::core::Vtable::vtable(self).SmallChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<f64>(result__)
     }
 }
-impl ::core::convert::From<IRangeValueProvider> for ::windows::core::IUnknown {
-    fn from(value: IRangeValueProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRangeValueProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRangeValueProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRangeValueProvider> for ::windows::core::IUnknown {
-    fn from(value: &IRangeValueProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRangeValueProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRangeValueProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3560,21 +3204,7 @@ impl IRawElementProviderAdviseEvents {
         (::windows::core::Vtable::vtable(self).AdviseEventRemoved)(::windows::core::Vtable::as_raw(self), eventid, ::core::mem::transmute(propertyids)).ok()
     }
 }
-impl ::core::convert::From<IRawElementProviderAdviseEvents> for ::windows::core::IUnknown {
-    fn from(value: IRawElementProviderAdviseEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderAdviseEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawElementProviderAdviseEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderAdviseEvents> for ::windows::core::IUnknown {
-    fn from(value: &IRawElementProviderAdviseEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawElementProviderAdviseEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRawElementProviderAdviseEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3642,21 +3272,7 @@ impl IRawElementProviderFragment {
         (::windows::core::Vtable::vtable(self).FragmentRoot)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRawElementProviderFragmentRoot>(result__)
     }
 }
-impl ::core::convert::From<IRawElementProviderFragment> for ::windows::core::IUnknown {
-    fn from(value: IRawElementProviderFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderFragment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawElementProviderFragment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderFragment> for ::windows::core::IUnknown {
-    fn from(value: &IRawElementProviderFragment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawElementProviderFragment, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRawElementProviderFragment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3709,21 +3325,7 @@ impl IRawElementProviderFragmentRoot {
         (::windows::core::Vtable::vtable(self).GetFocus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRawElementProviderFragment>(result__)
     }
 }
-impl ::core::convert::From<IRawElementProviderFragmentRoot> for ::windows::core::IUnknown {
-    fn from(value: IRawElementProviderFragmentRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderFragmentRoot> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawElementProviderFragmentRoot) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderFragmentRoot> for ::windows::core::IUnknown {
-    fn from(value: &IRawElementProviderFragmentRoot) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawElementProviderFragmentRoot, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRawElementProviderFragmentRoot {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3764,21 +3366,7 @@ impl IRawElementProviderHostingAccessibles {
         (::windows::core::Vtable::vtable(self).GetEmbeddedAccessibles)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IRawElementProviderHostingAccessibles> for ::windows::core::IUnknown {
-    fn from(value: IRawElementProviderHostingAccessibles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderHostingAccessibles> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawElementProviderHostingAccessibles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderHostingAccessibles> for ::windows::core::IUnknown {
-    fn from(value: &IRawElementProviderHostingAccessibles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawElementProviderHostingAccessibles, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRawElementProviderHostingAccessibles {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3824,21 +3412,7 @@ impl IRawElementProviderHwndOverride {
         (::windows::core::Vtable::vtable(self).GetOverrideProviderForHwnd)(::windows::core::Vtable::as_raw(self), hwnd.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRawElementProviderSimple>(result__)
     }
 }
-impl ::core::convert::From<IRawElementProviderHwndOverride> for ::windows::core::IUnknown {
-    fn from(value: IRawElementProviderHwndOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderHwndOverride> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawElementProviderHwndOverride) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderHwndOverride> for ::windows::core::IUnknown {
-    fn from(value: &IRawElementProviderHwndOverride) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawElementProviderHwndOverride, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRawElementProviderHwndOverride {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3893,21 +3467,7 @@ impl IRawElementProviderSimple {
         (::windows::core::Vtable::vtable(self).HostRawElementProvider)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRawElementProviderSimple>(result__)
     }
 }
-impl ::core::convert::From<IRawElementProviderSimple> for ::windows::core::IUnknown {
-    fn from(value: IRawElementProviderSimple) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderSimple> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawElementProviderSimple) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderSimple> for ::windows::core::IUnknown {
-    fn from(value: &IRawElementProviderSimple) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawElementProviderSimple, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRawElementProviderSimple {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3968,36 +3528,7 @@ impl IRawElementProviderSimple2 {
         (::windows::core::Vtable::vtable(self).ShowContextMenu)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IRawElementProviderSimple2> for ::windows::core::IUnknown {
-    fn from(value: IRawElementProviderSimple2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderSimple2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawElementProviderSimple2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderSimple2> for ::windows::core::IUnknown {
-    fn from(value: &IRawElementProviderSimple2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRawElementProviderSimple2> for IRawElementProviderSimple {
-    fn from(value: IRawElementProviderSimple2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderSimple2> for &'a IRawElementProviderSimple {
-    fn from(value: &'a IRawElementProviderSimple2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderSimple2> for IRawElementProviderSimple {
-    fn from(value: &IRawElementProviderSimple2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawElementProviderSimple2, ::windows::core::IUnknown, IRawElementProviderSimple);
 impl ::core::clone::Clone for IRawElementProviderSimple2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4058,51 +3589,7 @@ impl IRawElementProviderSimple3 {
         (::windows::core::Vtable::vtable(self).GetMetadataValue)(::windows::core::Vtable::as_raw(self), targetid, metadataid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<IRawElementProviderSimple3> for ::windows::core::IUnknown {
-    fn from(value: IRawElementProviderSimple3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderSimple3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawElementProviderSimple3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderSimple3> for ::windows::core::IUnknown {
-    fn from(value: &IRawElementProviderSimple3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRawElementProviderSimple3> for IRawElementProviderSimple {
-    fn from(value: IRawElementProviderSimple3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderSimple3> for &'a IRawElementProviderSimple {
-    fn from(value: &'a IRawElementProviderSimple3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderSimple3> for IRawElementProviderSimple {
-    fn from(value: &IRawElementProviderSimple3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRawElementProviderSimple3> for IRawElementProviderSimple2 {
-    fn from(value: IRawElementProviderSimple3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderSimple3> for &'a IRawElementProviderSimple2 {
-    fn from(value: &'a IRawElementProviderSimple3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderSimple3> for IRawElementProviderSimple2 {
-    fn from(value: &IRawElementProviderSimple3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawElementProviderSimple3, ::windows::core::IUnknown, IRawElementProviderSimple, IRawElementProviderSimple2);
 impl ::core::clone::Clone for IRawElementProviderSimple3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4149,21 +3636,7 @@ impl IRawElementProviderWindowlessSite {
         (::windows::core::Vtable::vtable(self).GetRuntimeIdPrefix)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IRawElementProviderWindowlessSite> for ::windows::core::IUnknown {
-    fn from(value: IRawElementProviderWindowlessSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRawElementProviderWindowlessSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRawElementProviderWindowlessSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRawElementProviderWindowlessSite> for ::windows::core::IUnknown {
-    fn from(value: &IRawElementProviderWindowlessSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRawElementProviderWindowlessSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRawElementProviderWindowlessSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4207,21 +3680,7 @@ impl IRichEditUiaInformation {
         (::windows::core::Vtable::vtable(self).IsVisible)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IRichEditUiaInformation> for ::windows::core::IUnknown {
-    fn from(value: IRichEditUiaInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRichEditUiaInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRichEditUiaInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRichEditUiaInformation> for ::windows::core::IUnknown {
-    fn from(value: &IRichEditUiaInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRichEditUiaInformation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRichEditUiaInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4263,21 +3722,7 @@ impl IRicheditWindowlessAccessibility {
         (::windows::core::Vtable::vtable(self).CreateProvider)(::windows::core::Vtable::as_raw(self), psite.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRawElementProviderSimple>(result__)
     }
 }
-impl ::core::convert::From<IRicheditWindowlessAccessibility> for ::windows::core::IUnknown {
-    fn from(value: IRicheditWindowlessAccessibility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRicheditWindowlessAccessibility> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRicheditWindowlessAccessibility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRicheditWindowlessAccessibility> for ::windows::core::IUnknown {
-    fn from(value: &IRicheditWindowlessAccessibility) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRicheditWindowlessAccessibility, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRicheditWindowlessAccessibility {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4314,21 +3759,7 @@ impl IScrollItemProvider {
         (::windows::core::Vtable::vtable(self).ScrollIntoView)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IScrollItemProvider> for ::windows::core::IUnknown {
-    fn from(value: IScrollItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScrollItemProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IScrollItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScrollItemProvider> for ::windows::core::IUnknown {
-    fn from(value: &IScrollItemProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IScrollItemProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IScrollItemProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4396,21 +3827,7 @@ impl IScrollProvider {
         (::windows::core::Vtable::vtable(self).VerticallyScrollable)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IScrollProvider> for ::windows::core::IUnknown {
-    fn from(value: IScrollProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IScrollProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IScrollProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IScrollProvider> for ::windows::core::IUnknown {
-    fn from(value: &IScrollProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IScrollProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IScrollProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4476,21 +3893,7 @@ impl ISelectionItemProvider {
         (::windows::core::Vtable::vtable(self).SelectionContainer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRawElementProviderSimple>(result__)
     }
 }
-impl ::core::convert::From<ISelectionItemProvider> for ::windows::core::IUnknown {
-    fn from(value: ISelectionItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISelectionItemProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISelectionItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISelectionItemProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISelectionItemProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISelectionItemProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISelectionItemProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4549,21 +3952,7 @@ impl ISelectionProvider {
         (::windows::core::Vtable::vtable(self).IsSelectionRequired)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ISelectionProvider> for ::windows::core::IUnknown {
-    fn from(value: ISelectionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISelectionProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISelectionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISelectionProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISelectionProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISelectionProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISelectionProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4642,36 +4031,7 @@ impl ISelectionProvider2 {
         (::windows::core::Vtable::vtable(self).ItemCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<ISelectionProvider2> for ::windows::core::IUnknown {
-    fn from(value: ISelectionProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISelectionProvider2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISelectionProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISelectionProvider2> for ::windows::core::IUnknown {
-    fn from(value: &ISelectionProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISelectionProvider2> for ISelectionProvider {
-    fn from(value: ISelectionProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISelectionProvider2> for &'a ISelectionProvider {
-    fn from(value: &'a ISelectionProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISelectionProvider2> for ISelectionProvider {
-    fn from(value: &ISelectionProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISelectionProvider2, ::windows::core::IUnknown, ISelectionProvider);
 impl ::core::clone::Clone for ISelectionProvider2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4724,21 +4084,7 @@ impl ISpreadsheetItemProvider {
         (::windows::core::Vtable::vtable(self).GetAnnotationTypes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<ISpreadsheetItemProvider> for ::windows::core::IUnknown {
-    fn from(value: ISpreadsheetItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpreadsheetItemProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpreadsheetItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpreadsheetItemProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISpreadsheetItemProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpreadsheetItemProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpreadsheetItemProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4787,21 +4133,7 @@ impl ISpreadsheetProvider {
         (::windows::core::Vtable::vtable(self).GetItemByName)(::windows::core::Vtable::as_raw(self), name.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IRawElementProviderSimple>(result__)
     }
 }
-impl ::core::convert::From<ISpreadsheetProvider> for ::windows::core::IUnknown {
-    fn from(value: ISpreadsheetProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpreadsheetProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpreadsheetProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpreadsheetProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISpreadsheetProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpreadsheetProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpreadsheetProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4863,21 +4195,7 @@ impl IStylesProvider {
         (::windows::core::Vtable::vtable(self).ExtendedProperties)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IStylesProvider> for ::windows::core::IUnknown {
-    fn from(value: IStylesProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStylesProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStylesProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStylesProvider> for ::windows::core::IUnknown {
-    fn from(value: &IStylesProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStylesProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStylesProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4923,21 +4241,7 @@ impl ISynchronizedInputProvider {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISynchronizedInputProvider> for ::windows::core::IUnknown {
-    fn from(value: ISynchronizedInputProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISynchronizedInputProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISynchronizedInputProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISynchronizedInputProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISynchronizedInputProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISynchronizedInputProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISynchronizedInputProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4984,21 +4288,7 @@ impl ITableItemProvider {
         (::windows::core::Vtable::vtable(self).GetColumnHeaderItems)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<ITableItemProvider> for ::windows::core::IUnknown {
-    fn from(value: ITableItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITableItemProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITableItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITableItemProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITableItemProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITableItemProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITableItemProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5055,21 +4345,7 @@ impl ITableProvider {
         (::windows::core::Vtable::vtable(self).RowOrColumnMajor)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<RowOrColumnMajor>(result__)
     }
 }
-impl ::core::convert::From<ITableProvider> for ::windows::core::IUnknown {
-    fn from(value: ITableProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITableProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITableProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITableProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITableProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITableProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITableProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5119,21 +4395,7 @@ impl ITextChildProvider {
         (::windows::core::Vtable::vtable(self).TextRange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITextRangeProvider>(result__)
     }
 }
-impl ::core::convert::From<ITextChildProvider> for ::windows::core::IUnknown {
-    fn from(value: ITextChildProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextChildProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextChildProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextChildProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITextChildProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextChildProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextChildProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5207,36 +4469,7 @@ impl ITextEditProvider {
         (::windows::core::Vtable::vtable(self).GetConversionTarget)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITextRangeProvider>(result__)
     }
 }
-impl ::core::convert::From<ITextEditProvider> for ::windows::core::IUnknown {
-    fn from(value: ITextEditProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextEditProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextEditProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextEditProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITextEditProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextEditProvider> for ITextProvider {
-    fn from(value: ITextEditProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextEditProvider> for &'a ITextProvider {
-    fn from(value: &'a ITextEditProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextEditProvider> for ITextProvider {
-    fn from(value: &ITextEditProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextEditProvider, ::windows::core::IUnknown, ITextProvider);
 impl ::core::clone::Clone for ITextEditProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5302,21 +4535,7 @@ impl ITextProvider {
         (::windows::core::Vtable::vtable(self).SupportedTextSelection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<SupportedTextSelection>(result__)
     }
 }
-impl ::core::convert::From<ITextProvider> for ::windows::core::IUnknown {
-    fn from(value: ITextProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITextProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5404,36 +4623,7 @@ impl ITextProvider2 {
         (::windows::core::Vtable::vtable(self).GetCaretRange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(isactive), ::core::mem::transmute(pretval)).ok()
     }
 }
-impl ::core::convert::From<ITextProvider2> for ::windows::core::IUnknown {
-    fn from(value: ITextProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextProvider2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextProvider2> for ::windows::core::IUnknown {
-    fn from(value: &ITextProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextProvider2> for ITextProvider {
-    fn from(value: ITextProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextProvider2> for &'a ITextProvider {
-    fn from(value: &'a ITextProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextProvider2> for ITextProvider {
-    fn from(value: &ITextProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextProvider2, ::windows::core::IUnknown, ITextProvider);
 impl ::core::clone::Clone for ITextProvider2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5571,21 +4761,7 @@ impl ITextRangeProvider {
         (::windows::core::Vtable::vtable(self).GetChildren)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<ITextRangeProvider> for ::windows::core::IUnknown {
-    fn from(value: ITextRangeProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextRangeProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextRangeProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextRangeProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITextRangeProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextRangeProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextRangeProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5760,36 +4936,7 @@ impl ITextRangeProvider2 {
         (::windows::core::Vtable::vtable(self).ShowContextMenu)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITextRangeProvider2> for ::windows::core::IUnknown {
-    fn from(value: ITextRangeProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextRangeProvider2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextRangeProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextRangeProvider2> for ::windows::core::IUnknown {
-    fn from(value: &ITextRangeProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextRangeProvider2> for ITextRangeProvider {
-    fn from(value: ITextRangeProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextRangeProvider2> for &'a ITextRangeProvider {
-    fn from(value: &'a ITextRangeProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextRangeProvider2> for ITextRangeProvider {
-    fn from(value: &ITextRangeProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextRangeProvider2, ::windows::core::IUnknown, ITextRangeProvider);
 impl ::core::clone::Clone for ITextRangeProvider2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5830,21 +4977,7 @@ impl IToggleProvider {
         (::windows::core::Vtable::vtable(self).ToggleState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ToggleState>(result__)
     }
 }
-impl ::core::convert::From<IToggleProvider> for ::windows::core::IUnknown {
-    fn from(value: IToggleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IToggleProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IToggleProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IToggleProvider> for ::windows::core::IUnknown {
-    fn from(value: &IToggleProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IToggleProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IToggleProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5906,21 +5039,7 @@ impl ITransformProvider {
         (::windows::core::Vtable::vtable(self).CanRotate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITransformProvider> for ::windows::core::IUnknown {
-    fn from(value: ITransformProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransformProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransformProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransformProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITransformProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransformProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransformProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6019,36 +5138,7 @@ impl ITransformProvider2 {
         (::windows::core::Vtable::vtable(self).ZoomByUnit)(::windows::core::Vtable::as_raw(self), zoomunit).ok()
     }
 }
-impl ::core::convert::From<ITransformProvider2> for ::windows::core::IUnknown {
-    fn from(value: ITransformProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransformProvider2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransformProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransformProvider2> for ::windows::core::IUnknown {
-    fn from(value: &ITransformProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITransformProvider2> for ITransformProvider {
-    fn from(value: ITransformProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransformProvider2> for &'a ITransformProvider {
-    fn from(value: &'a ITransformProvider2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransformProvider2> for ITransformProvider {
-    fn from(value: &ITransformProvider2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransformProvider2, ::windows::core::IUnknown, ITransformProvider);
 impl ::core::clone::Clone for ITransformProvider2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6439,21 +5529,7 @@ impl IUIAutomation {
         (::windows::core::Vtable::vtable(self).ElementFromIAccessibleBuildCache)(::windows::core::Vtable::as_raw(self), accessible.into().abi(), childid, cacherequest.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElement>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomation> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6981,36 +6057,7 @@ impl IUIAutomation2 {
         (::windows::core::Vtable::vtable(self).SetTransactionTimeout)(::windows::core::Vtable::as_raw(self), timeout).ok()
     }
 }
-impl ::core::convert::From<IUIAutomation2> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation2> for IUIAutomation {
-    fn from(value: IUIAutomation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation2> for &'a IUIAutomation {
-    fn from(value: &'a IUIAutomation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation2> for IUIAutomation {
-    fn from(value: &IUIAutomation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomation2, ::windows::core::IUnknown, IUIAutomation);
 impl ::core::clone::Clone for IUIAutomation2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7447,51 +6494,7 @@ impl IUIAutomation3 {
         (::windows::core::Vtable::vtable(self).RemoveTextEditTextChangedEventHandler)(::windows::core::Vtable::as_raw(self), element.into().abi(), handler.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAutomation3> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation3> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomation3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation3> for IUIAutomation {
-    fn from(value: IUIAutomation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation3> for &'a IUIAutomation {
-    fn from(value: &'a IUIAutomation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation3> for IUIAutomation {
-    fn from(value: &IUIAutomation3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation3> for IUIAutomation2 {
-    fn from(value: IUIAutomation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation3> for &'a IUIAutomation2 {
-    fn from(value: &'a IUIAutomation3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation3> for IUIAutomation2 {
-    fn from(value: &IUIAutomation3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomation3, ::windows::core::IUnknown, IUIAutomation, IUIAutomation2);
 impl ::core::clone::Clone for IUIAutomation3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7933,66 +6936,7 @@ impl IUIAutomation4 {
         (::windows::core::Vtable::vtable(self).RemoveChangesEventHandler)(::windows::core::Vtable::as_raw(self), element.into().abi(), handler.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAutomation4> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomation4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomation4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation4> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomation4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation4> for IUIAutomation {
-    fn from(value: IUIAutomation4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation4> for &'a IUIAutomation {
-    fn from(value: &'a IUIAutomation4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation4> for IUIAutomation {
-    fn from(value: &IUIAutomation4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation4> for IUIAutomation2 {
-    fn from(value: IUIAutomation4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation4> for &'a IUIAutomation2 {
-    fn from(value: &'a IUIAutomation4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation4> for IUIAutomation2 {
-    fn from(value: &IUIAutomation4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation4> for IUIAutomation3 {
-    fn from(value: IUIAutomation4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation4> for &'a IUIAutomation3 {
-    fn from(value: &'a IUIAutomation4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation4> for IUIAutomation3 {
-    fn from(value: &IUIAutomation4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomation4, ::windows::core::IUnknown, IUIAutomation, IUIAutomation2, IUIAutomation3);
 impl ::core::clone::Clone for IUIAutomation4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8449,81 +7393,7 @@ impl IUIAutomation5 {
         (::windows::core::Vtable::vtable(self).RemoveNotificationEventHandler)(::windows::core::Vtable::as_raw(self), element.into().abi(), handler.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAutomation5> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomation5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomation5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation5> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomation5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation5> for IUIAutomation {
-    fn from(value: IUIAutomation5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation5> for &'a IUIAutomation {
-    fn from(value: &'a IUIAutomation5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation5> for IUIAutomation {
-    fn from(value: &IUIAutomation5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation5> for IUIAutomation2 {
-    fn from(value: IUIAutomation5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation5> for &'a IUIAutomation2 {
-    fn from(value: &'a IUIAutomation5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation5> for IUIAutomation2 {
-    fn from(value: &IUIAutomation5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation5> for IUIAutomation3 {
-    fn from(value: IUIAutomation5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation5> for &'a IUIAutomation3 {
-    fn from(value: &'a IUIAutomation5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation5> for IUIAutomation3 {
-    fn from(value: &IUIAutomation5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation5> for IUIAutomation4 {
-    fn from(value: IUIAutomation5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation5> for &'a IUIAutomation4 {
-    fn from(value: &'a IUIAutomation5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation5> for IUIAutomation4 {
-    fn from(value: &IUIAutomation5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomation5, ::windows::core::IUnknown, IUIAutomation, IUIAutomation2, IUIAutomation3, IUIAutomation4);
 impl ::core::clone::Clone for IUIAutomation5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9027,96 +7897,7 @@ impl IUIAutomation6 {
         (::windows::core::Vtable::vtable(self).RemoveActiveTextPositionChangedEventHandler)(::windows::core::Vtable::as_raw(self), element.into().abi(), handler.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAutomation6> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation6> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomation6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation6> for IUIAutomation {
-    fn from(value: IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation6> for &'a IUIAutomation {
-    fn from(value: &'a IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation6> for IUIAutomation {
-    fn from(value: &IUIAutomation6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation6> for IUIAutomation2 {
-    fn from(value: IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation6> for &'a IUIAutomation2 {
-    fn from(value: &'a IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation6> for IUIAutomation2 {
-    fn from(value: &IUIAutomation6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation6> for IUIAutomation3 {
-    fn from(value: IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation6> for &'a IUIAutomation3 {
-    fn from(value: &'a IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation6> for IUIAutomation3 {
-    fn from(value: &IUIAutomation6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation6> for IUIAutomation4 {
-    fn from(value: IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation6> for &'a IUIAutomation4 {
-    fn from(value: &'a IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation6> for IUIAutomation4 {
-    fn from(value: &IUIAutomation6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomation6> for IUIAutomation5 {
-    fn from(value: IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomation6> for &'a IUIAutomation5 {
-    fn from(value: &'a IUIAutomation6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomation6> for IUIAutomation5 {
-    fn from(value: &IUIAutomation6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomation6, ::windows::core::IUnknown, IUIAutomation, IUIAutomation2, IUIAutomation3, IUIAutomation4, IUIAutomation5);
 impl ::core::clone::Clone for IUIAutomation6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9165,21 +7946,7 @@ impl IUIAutomationActiveTextPositionChangedEventHandler {
         (::windows::core::Vtable::vtable(self).HandleActiveTextPositionChangedEvent)(::windows::core::Vtable::as_raw(self), sender.into().abi(), range.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationActiveTextPositionChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationActiveTextPositionChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationActiveTextPositionChangedEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationActiveTextPositionChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationActiveTextPositionChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationActiveTextPositionChangedEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationActiveTextPositionChangedEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationActiveTextPositionChangedEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9226,36 +7993,7 @@ impl IUIAutomationAndCondition {
         (::windows::core::Vtable::vtable(self).GetChildren)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationAndCondition> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationAndCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationAndCondition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationAndCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationAndCondition> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationAndCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationAndCondition> for IUIAutomationCondition {
-    fn from(value: IUIAutomationAndCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationAndCondition> for &'a IUIAutomationCondition {
-    fn from(value: &'a IUIAutomationAndCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationAndCondition> for IUIAutomationCondition {
-    fn from(value: &IUIAutomationAndCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationAndCondition, ::windows::core::IUnknown, IUIAutomationCondition);
 impl ::core::clone::Clone for IUIAutomationAndCondition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9334,21 +8072,7 @@ impl IUIAutomationAnnotationPattern {
         (::windows::core::Vtable::vtable(self).CachedTarget)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElement>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationAnnotationPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationAnnotationPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationAnnotationPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationAnnotationPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationAnnotationPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationAnnotationPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationAnnotationPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationAnnotationPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9397,36 +8121,7 @@ impl IUIAutomationBoolCondition {
         (::windows::core::Vtable::vtable(self).BooleanValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationBoolCondition> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationBoolCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationBoolCondition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationBoolCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationBoolCondition> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationBoolCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationBoolCondition> for IUIAutomationCondition {
-    fn from(value: IUIAutomationBoolCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationBoolCondition> for &'a IUIAutomationCondition {
-    fn from(value: &'a IUIAutomationBoolCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationBoolCondition> for IUIAutomationCondition {
-    fn from(value: &IUIAutomationBoolCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationBoolCondition, ::windows::core::IUnknown, IUIAutomationCondition);
 impl ::core::clone::Clone for IUIAutomationBoolCondition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9497,21 +8192,7 @@ impl IUIAutomationCacheRequest {
         (::windows::core::Vtable::vtable(self).SetAutomationElementMode)(::windows::core::Vtable::as_raw(self), mode).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationCacheRequest> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationCacheRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationCacheRequest> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationCacheRequest) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationCacheRequest> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationCacheRequest) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationCacheRequest, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationCacheRequest {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9561,21 +8242,7 @@ impl IUIAutomationChangesEventHandler {
         (::windows::core::Vtable::vtable(self).HandleChangesEvent)(::windows::core::Vtable::as_raw(self), sender.into().abi(), ::core::mem::transmute(uiachanges.as_ptr()), uiachanges.len() as _).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationChangesEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationChangesEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationChangesEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationChangesEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationChangesEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationChangesEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationChangesEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationChangesEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9611,21 +8278,7 @@ pub struct IUIAutomationChangesEventHandler_Vtbl {
 #[repr(transparent)]
 pub struct IUIAutomationCondition(::windows::core::IUnknown);
 impl IUIAutomationCondition {}
-impl ::core::convert::From<IUIAutomationCondition> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationCondition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationCondition> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationCondition, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationCondition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9662,21 +8315,7 @@ impl IUIAutomationCustomNavigationPattern {
         (::windows::core::Vtable::vtable(self).Navigate)(::windows::core::Vtable::as_raw(self), direction, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElement>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationCustomNavigationPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationCustomNavigationPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationCustomNavigationPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationCustomNavigationPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationCustomNavigationPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationCustomNavigationPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationCustomNavigationPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationCustomNavigationPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9721,21 +8360,7 @@ impl IUIAutomationDockPattern {
         (::windows::core::Vtable::vtable(self).CachedDockPosition)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<DockPosition>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationDockPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationDockPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationDockPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationDockPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationDockPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationDockPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationDockPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationDockPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9811,21 +8436,7 @@ impl IUIAutomationDragPattern {
         (::windows::core::Vtable::vtable(self).GetCachedGrabbedItems)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElementArray>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationDragPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationDragPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationDragPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationDragPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationDragPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationDragPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationDragPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationDragPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9898,21 +8509,7 @@ impl IUIAutomationDropTargetPattern {
         (::windows::core::Vtable::vtable(self).CachedDropTargetEffects)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationDropTargetPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationDropTargetPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationDropTargetPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationDropTargetPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationDropTargetPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationDropTargetPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationDropTargetPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationDropTargetPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10366,21 +8963,7 @@ impl IUIAutomationElement {
         (::windows::core::Vtable::vtable(self).GetClickablePoint)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clickable), ::core::mem::transmute(gotclickable)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationElement> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationElement, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11018,36 +9601,7 @@ impl IUIAutomationElement2 {
         (::windows::core::Vtable::vtable(self).CachedFlowsFrom)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElementArray>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationElement2> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationElement2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement2> for IUIAutomationElement {
-    fn from(value: IUIAutomationElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement2> for &'a IUIAutomationElement {
-    fn from(value: &'a IUIAutomationElement2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement2> for IUIAutomationElement {
-    fn from(value: &IUIAutomationElement2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationElement2, ::windows::core::IUnknown, IUIAutomationElement);
 impl ::core::clone::Clone for IUIAutomationElement2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11546,51 +10100,7 @@ impl IUIAutomationElement3 {
         (::windows::core::Vtable::vtable(self).CachedIsPeripheral)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationElement3> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationElement3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationElement3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement3> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationElement3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement3> for IUIAutomationElement {
-    fn from(value: IUIAutomationElement3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement3> for &'a IUIAutomationElement {
-    fn from(value: &'a IUIAutomationElement3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement3> for IUIAutomationElement {
-    fn from(value: &IUIAutomationElement3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement3> for IUIAutomationElement2 {
-    fn from(value: IUIAutomationElement3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement3> for &'a IUIAutomationElement2 {
-    fn from(value: &'a IUIAutomationElement3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement3> for IUIAutomationElement2 {
-    fn from(value: &IUIAutomationElement3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationElement3, ::windows::core::IUnknown, IUIAutomationElement, IUIAutomationElement2);
 impl ::core::clone::Clone for IUIAutomationElement3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12130,66 +10640,7 @@ impl IUIAutomationElement4 {
         (::windows::core::Vtable::vtable(self).CachedAnnotationObjects)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElementArray>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationElement4> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationElement4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationElement4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement4> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationElement4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement4> for IUIAutomationElement {
-    fn from(value: IUIAutomationElement4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement4> for &'a IUIAutomationElement {
-    fn from(value: &'a IUIAutomationElement4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement4> for IUIAutomationElement {
-    fn from(value: &IUIAutomationElement4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement4> for IUIAutomationElement2 {
-    fn from(value: IUIAutomationElement4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement4> for &'a IUIAutomationElement2 {
-    fn from(value: &'a IUIAutomationElement4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement4> for IUIAutomationElement2 {
-    fn from(value: &IUIAutomationElement4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement4> for IUIAutomationElement3 {
-    fn from(value: IUIAutomationElement4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement4> for &'a IUIAutomationElement3 {
-    fn from(value: &'a IUIAutomationElement4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement4> for IUIAutomationElement3 {
-    fn from(value: &IUIAutomationElement4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationElement4, ::windows::core::IUnknown, IUIAutomationElement, IUIAutomationElement2, IUIAutomationElement3);
 impl ::core::clone::Clone for IUIAutomationElement4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12752,81 +11203,7 @@ impl IUIAutomationElement5 {
         (::windows::core::Vtable::vtable(self).CachedLocalizedLandmarkType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationElement5> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationElement5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationElement5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement5> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationElement5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement5> for IUIAutomationElement {
-    fn from(value: IUIAutomationElement5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement5> for &'a IUIAutomationElement {
-    fn from(value: &'a IUIAutomationElement5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement5> for IUIAutomationElement {
-    fn from(value: &IUIAutomationElement5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement5> for IUIAutomationElement2 {
-    fn from(value: IUIAutomationElement5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement5> for &'a IUIAutomationElement2 {
-    fn from(value: &'a IUIAutomationElement5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement5> for IUIAutomationElement2 {
-    fn from(value: &IUIAutomationElement5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement5> for IUIAutomationElement3 {
-    fn from(value: IUIAutomationElement5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement5> for &'a IUIAutomationElement3 {
-    fn from(value: &'a IUIAutomationElement5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement5> for IUIAutomationElement3 {
-    fn from(value: &IUIAutomationElement5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement5> for IUIAutomationElement4 {
-    fn from(value: IUIAutomationElement5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement5> for &'a IUIAutomationElement4 {
-    fn from(value: &'a IUIAutomationElement5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement5> for IUIAutomationElement4 {
-    fn from(value: &IUIAutomationElement5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationElement5, ::windows::core::IUnknown, IUIAutomationElement, IUIAutomationElement2, IUIAutomationElement3, IUIAutomationElement4);
 impl ::core::clone::Clone for IUIAutomationElement5 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13385,96 +11762,7 @@ impl IUIAutomationElement6 {
         (::windows::core::Vtable::vtable(self).CachedFullDescription)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationElement6> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement6> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationElement6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement6> for IUIAutomationElement {
-    fn from(value: IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement6> for &'a IUIAutomationElement {
-    fn from(value: &'a IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement6> for IUIAutomationElement {
-    fn from(value: &IUIAutomationElement6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement6> for IUIAutomationElement2 {
-    fn from(value: IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement6> for &'a IUIAutomationElement2 {
-    fn from(value: &'a IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement6> for IUIAutomationElement2 {
-    fn from(value: &IUIAutomationElement6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement6> for IUIAutomationElement3 {
-    fn from(value: IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement6> for &'a IUIAutomationElement3 {
-    fn from(value: &'a IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement6> for IUIAutomationElement3 {
-    fn from(value: &IUIAutomationElement6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement6> for IUIAutomationElement4 {
-    fn from(value: IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement6> for &'a IUIAutomationElement4 {
-    fn from(value: &'a IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement6> for IUIAutomationElement4 {
-    fn from(value: &IUIAutomationElement6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement6> for IUIAutomationElement5 {
-    fn from(value: IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement6> for &'a IUIAutomationElement5 {
-    fn from(value: &'a IUIAutomationElement6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement6> for IUIAutomationElement5 {
-    fn from(value: &IUIAutomationElement6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationElement6, ::windows::core::IUnknown, IUIAutomationElement, IUIAutomationElement2, IUIAutomationElement3, IUIAutomationElement4, IUIAutomationElement5);
 impl ::core::clone::Clone for IUIAutomationElement6 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14071,111 +12359,7 @@ impl IUIAutomationElement7 {
         (::windows::core::Vtable::vtable(self).GetCurrentMetadataValue)(::windows::core::Vtable::as_raw(self), targetid, metadataid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationElement7> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement7> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationElement7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement7> for IUIAutomationElement {
-    fn from(value: IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement7> for &'a IUIAutomationElement {
-    fn from(value: &'a IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement7> for IUIAutomationElement {
-    fn from(value: &IUIAutomationElement7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement7> for IUIAutomationElement2 {
-    fn from(value: IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement7> for &'a IUIAutomationElement2 {
-    fn from(value: &'a IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement7> for IUIAutomationElement2 {
-    fn from(value: &IUIAutomationElement7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement7> for IUIAutomationElement3 {
-    fn from(value: IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement7> for &'a IUIAutomationElement3 {
-    fn from(value: &'a IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement7> for IUIAutomationElement3 {
-    fn from(value: &IUIAutomationElement7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement7> for IUIAutomationElement4 {
-    fn from(value: IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement7> for &'a IUIAutomationElement4 {
-    fn from(value: &'a IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement7> for IUIAutomationElement4 {
-    fn from(value: &IUIAutomationElement7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement7> for IUIAutomationElement5 {
-    fn from(value: IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement7> for &'a IUIAutomationElement5 {
-    fn from(value: &'a IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement7> for IUIAutomationElement5 {
-    fn from(value: &IUIAutomationElement7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement7> for IUIAutomationElement6 {
-    fn from(value: IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement7> for &'a IUIAutomationElement6 {
-    fn from(value: &'a IUIAutomationElement7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement7> for IUIAutomationElement6 {
-    fn from(value: &IUIAutomationElement7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationElement7, ::windows::core::IUnknown, IUIAutomationElement, IUIAutomationElement2, IUIAutomationElement3, IUIAutomationElement4, IUIAutomationElement5, IUIAutomationElement6);
 impl ::core::clone::Clone for IUIAutomationElement7 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14786,126 +12970,7 @@ impl IUIAutomationElement8 {
         (::windows::core::Vtable::vtable(self).CachedHeadingLevel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationElement8> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement8> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement8> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationElement8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement8> for IUIAutomationElement {
-    fn from(value: IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement8> for &'a IUIAutomationElement {
-    fn from(value: &'a IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement8> for IUIAutomationElement {
-    fn from(value: &IUIAutomationElement8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement8> for IUIAutomationElement2 {
-    fn from(value: IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement8> for &'a IUIAutomationElement2 {
-    fn from(value: &'a IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement8> for IUIAutomationElement2 {
-    fn from(value: &IUIAutomationElement8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement8> for IUIAutomationElement3 {
-    fn from(value: IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement8> for &'a IUIAutomationElement3 {
-    fn from(value: &'a IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement8> for IUIAutomationElement3 {
-    fn from(value: &IUIAutomationElement8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement8> for IUIAutomationElement4 {
-    fn from(value: IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement8> for &'a IUIAutomationElement4 {
-    fn from(value: &'a IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement8> for IUIAutomationElement4 {
-    fn from(value: &IUIAutomationElement8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement8> for IUIAutomationElement5 {
-    fn from(value: IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement8> for &'a IUIAutomationElement5 {
-    fn from(value: &'a IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement8> for IUIAutomationElement5 {
-    fn from(value: &IUIAutomationElement8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement8> for IUIAutomationElement6 {
-    fn from(value: IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement8> for &'a IUIAutomationElement6 {
-    fn from(value: &'a IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement8> for IUIAutomationElement6 {
-    fn from(value: &IUIAutomationElement8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement8> for IUIAutomationElement7 {
-    fn from(value: IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement8> for &'a IUIAutomationElement7 {
-    fn from(value: &'a IUIAutomationElement8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement8> for IUIAutomationElement7 {
-    fn from(value: &IUIAutomationElement8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationElement8, ::windows::core::IUnknown, IUIAutomationElement, IUIAutomationElement2, IUIAutomationElement3, IUIAutomationElement4, IUIAutomationElement5, IUIAutomationElement6, IUIAutomationElement7);
 impl ::core::clone::Clone for IUIAutomationElement8 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15522,141 +13587,7 @@ impl IUIAutomationElement9 {
         (::windows::core::Vtable::vtable(self).CachedIsDialog)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationElement9> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement9> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationElement9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement9> for IUIAutomationElement {
-    fn from(value: IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement9> for &'a IUIAutomationElement {
-    fn from(value: &'a IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement9> for IUIAutomationElement {
-    fn from(value: &IUIAutomationElement9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement9> for IUIAutomationElement2 {
-    fn from(value: IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement9> for &'a IUIAutomationElement2 {
-    fn from(value: &'a IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement9> for IUIAutomationElement2 {
-    fn from(value: &IUIAutomationElement9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement9> for IUIAutomationElement3 {
-    fn from(value: IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement9> for &'a IUIAutomationElement3 {
-    fn from(value: &'a IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement9> for IUIAutomationElement3 {
-    fn from(value: &IUIAutomationElement9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement9> for IUIAutomationElement4 {
-    fn from(value: IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement9> for &'a IUIAutomationElement4 {
-    fn from(value: &'a IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement9> for IUIAutomationElement4 {
-    fn from(value: &IUIAutomationElement9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement9> for IUIAutomationElement5 {
-    fn from(value: IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement9> for &'a IUIAutomationElement5 {
-    fn from(value: &'a IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement9> for IUIAutomationElement5 {
-    fn from(value: &IUIAutomationElement9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement9> for IUIAutomationElement6 {
-    fn from(value: IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement9> for &'a IUIAutomationElement6 {
-    fn from(value: &'a IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement9> for IUIAutomationElement6 {
-    fn from(value: &IUIAutomationElement9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement9> for IUIAutomationElement7 {
-    fn from(value: IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement9> for &'a IUIAutomationElement7 {
-    fn from(value: &'a IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement9> for IUIAutomationElement7 {
-    fn from(value: &IUIAutomationElement9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationElement9> for IUIAutomationElement8 {
-    fn from(value: IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElement9> for &'a IUIAutomationElement8 {
-    fn from(value: &'a IUIAutomationElement9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElement9> for IUIAutomationElement8 {
-    fn from(value: &IUIAutomationElement9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationElement9, ::windows::core::IUnknown, IUIAutomationElement, IUIAutomationElement2, IUIAutomationElement3, IUIAutomationElement4, IUIAutomationElement5, IUIAutomationElement6, IUIAutomationElement7, IUIAutomationElement8);
 impl ::core::clone::Clone for IUIAutomationElement9 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15705,21 +13636,7 @@ impl IUIAutomationElementArray {
         (::windows::core::Vtable::vtable(self).GetElement)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElement>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationElementArray> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationElementArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationElementArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationElementArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationElementArray> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationElementArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationElementArray, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationElementArray {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15760,21 +13677,7 @@ impl IUIAutomationEventHandler {
         (::windows::core::Vtable::vtable(self).HandleAutomationEvent)(::windows::core::Vtable::as_raw(self), sender.into().abi(), eventid).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15857,21 +13760,7 @@ impl IUIAutomationEventHandlerGroup {
         (::windows::core::Vtable::vtable(self).AddTextEditTextChangedEventHandler)(::windows::core::Vtable::as_raw(self), scope, texteditchangetype, cacherequest.into().abi(), handler.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationEventHandlerGroup> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationEventHandlerGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationEventHandlerGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationEventHandlerGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationEventHandlerGroup> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationEventHandlerGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationEventHandlerGroup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationEventHandlerGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15925,21 +13814,7 @@ impl IUIAutomationExpandCollapsePattern {
         (::windows::core::Vtable::vtable(self).CachedExpandCollapseState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ExpandCollapseState>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationExpandCollapsePattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationExpandCollapsePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationExpandCollapsePattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationExpandCollapsePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationExpandCollapsePattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationExpandCollapsePattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationExpandCollapsePattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationExpandCollapsePattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15982,21 +13857,7 @@ impl IUIAutomationFocusChangedEventHandler {
         (::windows::core::Vtable::vtable(self).HandleFocusChangedEvent)(::windows::core::Vtable::as_raw(self), sender.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationFocusChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationFocusChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationFocusChangedEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationFocusChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationFocusChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationFocusChangedEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationFocusChangedEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationFocusChangedEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16070,21 +13931,7 @@ impl IUIAutomationGridItemPattern {
         (::windows::core::Vtable::vtable(self).CachedColumnSpan)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationGridItemPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationGridItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationGridItemPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationGridItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationGridItemPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationGridItemPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationGridItemPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationGridItemPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16147,21 +13994,7 @@ impl IUIAutomationGridPattern {
         (::windows::core::Vtable::vtable(self).CachedColumnCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationGridPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationGridPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationGridPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationGridPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationGridPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationGridPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationGridPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationGridPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16202,21 +14035,7 @@ impl IUIAutomationInvokePattern {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationInvokePattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationInvokePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationInvokePattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationInvokePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationInvokePattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationInvokePattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationInvokePattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationInvokePattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16260,21 +14079,7 @@ impl IUIAutomationItemContainerPattern {
         (::windows::core::Vtable::vtable(self).FindItemByProperty)(::windows::core::Vtable::as_raw(self), pstartafter.into().abi(), propertyid, value.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElement>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationItemContainerPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationItemContainerPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationItemContainerPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationItemContainerPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationItemContainerPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationItemContainerPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationItemContainerPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationItemContainerPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16409,21 +14214,7 @@ impl IUIAutomationLegacyIAccessiblePattern {
         (::windows::core::Vtable::vtable(self).GetIAccessible)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAccessible>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationLegacyIAccessiblePattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationLegacyIAccessiblePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationLegacyIAccessiblePattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationLegacyIAccessiblePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationLegacyIAccessiblePattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationLegacyIAccessiblePattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationLegacyIAccessiblePattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationLegacyIAccessiblePattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16510,21 +14301,7 @@ impl IUIAutomationMultipleViewPattern {
         (::windows::core::Vtable::vtable(self).GetCachedSupportedViews)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationMultipleViewPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationMultipleViewPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationMultipleViewPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationMultipleViewPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationMultipleViewPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationMultipleViewPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationMultipleViewPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationMultipleViewPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16573,36 +14350,7 @@ impl IUIAutomationNotCondition {
         (::windows::core::Vtable::vtable(self).GetChild)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationCondition>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationNotCondition> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationNotCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationNotCondition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationNotCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationNotCondition> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationNotCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationNotCondition> for IUIAutomationCondition {
-    fn from(value: IUIAutomationNotCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationNotCondition> for &'a IUIAutomationCondition {
-    fn from(value: &'a IUIAutomationNotCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationNotCondition> for IUIAutomationCondition {
-    fn from(value: &IUIAutomationNotCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationNotCondition, ::windows::core::IUnknown, IUIAutomationCondition);
 impl ::core::clone::Clone for IUIAutomationNotCondition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16642,21 +14390,7 @@ impl IUIAutomationNotificationEventHandler {
         (::windows::core::Vtable::vtable(self).HandleNotificationEvent)(::windows::core::Vtable::as_raw(self), sender.into().abi(), notificationkind, notificationprocessing, ::core::mem::transmute_copy(displaystring), ::core::mem::transmute_copy(activityid)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationNotificationEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationNotificationEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationNotificationEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationNotificationEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationNotificationEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationNotificationEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationNotificationEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationNotificationEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16694,21 +14428,7 @@ impl IUIAutomationObjectModelPattern {
         (::windows::core::Vtable::vtable(self).GetUnderlyingObjectModel)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationObjectModelPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationObjectModelPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationObjectModelPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationObjectModelPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationObjectModelPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationObjectModelPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationObjectModelPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationObjectModelPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16755,36 +14475,7 @@ impl IUIAutomationOrCondition {
         (::windows::core::Vtable::vtable(self).GetChildren)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationOrCondition> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationOrCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationOrCondition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationOrCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationOrCondition> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationOrCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationOrCondition> for IUIAutomationCondition {
-    fn from(value: IUIAutomationOrCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationOrCondition> for &'a IUIAutomationCondition {
-    fn from(value: &'a IUIAutomationOrCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationOrCondition> for IUIAutomationCondition {
-    fn from(value: &IUIAutomationOrCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationOrCondition, ::windows::core::IUnknown, IUIAutomationCondition);
 impl ::core::clone::Clone for IUIAutomationOrCondition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16836,21 +14527,7 @@ impl IUIAutomationPatternHandler {
         (::windows::core::Vtable::vtable(self).Dispatch)(::windows::core::Vtable::as_raw(self), ptarget.into().abi(), index, ::core::mem::transmute(pparams), cparams).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationPatternHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationPatternHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationPatternHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationPatternHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationPatternHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationPatternHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationPatternHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationPatternHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16896,21 +14573,7 @@ impl IUIAutomationPatternInstance {
         (::windows::core::Vtable::vtable(self).CallMethod)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(pparams), cparams).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationPatternInstance> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationPatternInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationPatternInstance> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationPatternInstance) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationPatternInstance> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationPatternInstance) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationPatternInstance, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationPatternInstance {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16957,21 +14620,7 @@ impl IUIAutomationPropertyChangedEventHandler {
         (::windows::core::Vtable::vtable(self).HandlePropertyChangedEvent)(::windows::core::Vtable::as_raw(self), sender.into().abi(), propertyid, newvalue.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationPropertyChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationPropertyChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationPropertyChangedEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationPropertyChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationPropertyChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationPropertyChangedEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationPropertyChangedEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationPropertyChangedEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17022,36 +14671,7 @@ impl IUIAutomationPropertyCondition {
         (::windows::core::Vtable::vtable(self).PropertyConditionFlags)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<PropertyConditionFlags>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationPropertyCondition> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationPropertyCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationPropertyCondition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationPropertyCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationPropertyCondition> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationPropertyCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationPropertyCondition> for IUIAutomationCondition {
-    fn from(value: IUIAutomationPropertyCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationPropertyCondition> for &'a IUIAutomationCondition {
-    fn from(value: &'a IUIAutomationPropertyCondition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationPropertyCondition> for IUIAutomationCondition {
-    fn from(value: &IUIAutomationPropertyCondition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationPropertyCondition, ::windows::core::IUnknown, IUIAutomationCondition);
 impl ::core::clone::Clone for IUIAutomationPropertyCondition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17103,21 +14723,7 @@ impl IUIAutomationProxyFactory {
         (::windows::core::Vtable::vtable(self).ProxyFactoryId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationProxyFactory> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationProxyFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationProxyFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationProxyFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationProxyFactory> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationProxyFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationProxyFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationProxyFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17232,21 +14838,7 @@ impl IUIAutomationProxyFactoryEntry {
         (::windows::core::Vtable::vtable(self).GetWinEventsForAutomationEvent)(::windows::core::Vtable::as_raw(self), eventid, propertyid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationProxyFactoryEntry> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationProxyFactoryEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationProxyFactoryEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationProxyFactoryEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationProxyFactoryEntry> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationProxyFactoryEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationProxyFactoryEntry, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationProxyFactoryEntry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17355,21 +14947,7 @@ impl IUIAutomationProxyFactoryMapping {
         (::windows::core::Vtable::vtable(self).RestoreDefaultTable)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationProxyFactoryMapping> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationProxyFactoryMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationProxyFactoryMapping> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationProxyFactoryMapping) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationProxyFactoryMapping> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationProxyFactoryMapping) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationProxyFactoryMapping, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationProxyFactoryMapping {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17475,21 +15053,7 @@ impl IUIAutomationRangeValuePattern {
         (::windows::core::Vtable::vtable(self).CachedSmallChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<f64>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationRangeValuePattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationRangeValuePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationRangeValuePattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationRangeValuePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationRangeValuePattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationRangeValuePattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationRangeValuePattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationRangeValuePattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17554,21 +15118,7 @@ impl IUIAutomationRegistrar {
         (::windows::core::Vtable::vtable(self).RegisterPattern)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pattern), ::core::mem::transmute(ppatternid), ::core::mem::transmute(ppatternavailablepropertyid), ppropertyids.len() as _, ::core::mem::transmute(ppropertyids.as_ptr()), peventids.len() as _, ::core::mem::transmute(peventids.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationRegistrar> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationRegistrar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationRegistrar> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationRegistrar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationRegistrar, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationRegistrar {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17610,21 +15160,7 @@ impl IUIAutomationScrollItemPattern {
         (::windows::core::Vtable::vtable(self).ScrollIntoView)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationScrollItemPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationScrollItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationScrollItemPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationScrollItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationScrollItemPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationScrollItemPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationScrollItemPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationScrollItemPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17720,21 +15256,7 @@ impl IUIAutomationScrollPattern {
         (::windows::core::Vtable::vtable(self).CachedVerticallyScrollable)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationScrollPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationScrollPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationScrollPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationScrollPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationScrollPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationScrollPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationScrollPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationScrollPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17822,21 +15344,7 @@ impl IUIAutomationSelectionItemPattern {
         (::windows::core::Vtable::vtable(self).CachedSelectionContainer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElement>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationSelectionItemPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationSelectionItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationSelectionItemPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationSelectionItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationSelectionItemPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationSelectionItemPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationSelectionItemPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationSelectionItemPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17914,21 +15422,7 @@ impl IUIAutomationSelectionPattern {
         (::windows::core::Vtable::vtable(self).CachedIsSelectionRequired)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationSelectionPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationSelectionPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationSelectionPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationSelectionPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationSelectionPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationSelectionPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationSelectionPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationSelectionPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18043,36 +15537,7 @@ impl IUIAutomationSelectionPattern2 {
         (::windows::core::Vtable::vtable(self).CachedItemCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationSelectionPattern2> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationSelectionPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationSelectionPattern2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationSelectionPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationSelectionPattern2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationSelectionPattern2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationSelectionPattern2> for IUIAutomationSelectionPattern {
-    fn from(value: IUIAutomationSelectionPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationSelectionPattern2> for &'a IUIAutomationSelectionPattern {
-    fn from(value: &'a IUIAutomationSelectionPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationSelectionPattern2> for IUIAutomationSelectionPattern {
-    fn from(value: &IUIAutomationSelectionPattern2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationSelectionPattern2, ::windows::core::IUnknown, IUIAutomationSelectionPattern);
 impl ::core::clone::Clone for IUIAutomationSelectionPattern2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18141,21 +15606,7 @@ impl IUIAutomationSpreadsheetItemPattern {
         (::windows::core::Vtable::vtable(self).GetCachedAnnotationTypes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationSpreadsheetItemPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationSpreadsheetItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationSpreadsheetItemPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationSpreadsheetItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationSpreadsheetItemPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationSpreadsheetItemPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationSpreadsheetItemPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationSpreadsheetItemPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18204,21 +15655,7 @@ impl IUIAutomationSpreadsheetPattern {
         (::windows::core::Vtable::vtable(self).GetItemByName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(name), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElement>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationSpreadsheetPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationSpreadsheetPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationSpreadsheetPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationSpreadsheetPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationSpreadsheetPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationSpreadsheetPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationSpreadsheetPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationSpreadsheetPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18260,21 +15697,7 @@ impl IUIAutomationStructureChangedEventHandler {
         (::windows::core::Vtable::vtable(self).HandleStructureChangedEvent)(::windows::core::Vtable::as_raw(self), sender.into().abi(), changetype, ::core::mem::transmute(runtimeid)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationStructureChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationStructureChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationStructureChangedEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationStructureChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationStructureChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationStructureChangedEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationStructureChangedEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationStructureChangedEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18373,21 +15796,7 @@ impl IUIAutomationStylesPattern {
         (::windows::core::Vtable::vtable(self).GetCachedExtendedPropertiesAsArray)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(propertyarray), ::core::mem::transmute(propertycount)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationStylesPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationStylesPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationStylesPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationStylesPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationStylesPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationStylesPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationStylesPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationStylesPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18442,21 +15851,7 @@ impl IUIAutomationSynchronizedInputPattern {
         (::windows::core::Vtable::vtable(self).Cancel)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationSynchronizedInputPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationSynchronizedInputPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationSynchronizedInputPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationSynchronizedInputPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationSynchronizedInputPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationSynchronizedInputPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationSynchronizedInputPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationSynchronizedInputPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18507,21 +15902,7 @@ impl IUIAutomationTableItemPattern {
         (::windows::core::Vtable::vtable(self).GetCachedColumnHeaderItems)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElementArray>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTableItemPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTableItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTableItemPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTableItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTableItemPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTableItemPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTableItemPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationTableItemPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18582,21 +15963,7 @@ impl IUIAutomationTablePattern {
         (::windows::core::Vtable::vtable(self).CachedRowOrColumnMajor)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<RowOrColumnMajor>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTablePattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTablePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTablePattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTablePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTablePattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTablePattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTablePattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationTablePattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18643,21 +16010,7 @@ impl IUIAutomationTextChildPattern {
         (::windows::core::Vtable::vtable(self).TextRange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationTextRange>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTextChildPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTextChildPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextChildPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTextChildPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextChildPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTextChildPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTextChildPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationTextChildPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18729,36 +16082,7 @@ impl IUIAutomationTextEditPattern {
         (::windows::core::Vtable::vtable(self).GetConversionTarget)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationTextRange>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTextEditPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTextEditPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextEditPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTextEditPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextEditPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTextEditPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationTextEditPattern> for IUIAutomationTextPattern {
-    fn from(value: IUIAutomationTextEditPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextEditPattern> for &'a IUIAutomationTextPattern {
-    fn from(value: &'a IUIAutomationTextEditPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextEditPattern> for IUIAutomationTextPattern {
-    fn from(value: &IUIAutomationTextEditPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTextEditPattern, ::windows::core::IUnknown, IUIAutomationTextPattern);
 impl ::core::clone::Clone for IUIAutomationTextEditPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18801,21 +16125,7 @@ impl IUIAutomationTextEditTextChangedEventHandler {
         (::windows::core::Vtable::vtable(self).HandleTextEditTextChangedEvent)(::windows::core::Vtable::as_raw(self), sender.into().abi(), texteditchangetype, ::core::mem::transmute(eventstrings)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationTextEditTextChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTextEditTextChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextEditTextChangedEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTextEditTextChangedEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextEditTextChangedEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTextEditTextChangedEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTextEditTextChangedEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationTextEditTextChangedEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18881,21 +16191,7 @@ impl IUIAutomationTextPattern {
         (::windows::core::Vtable::vtable(self).SupportedTextSelection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<SupportedTextSelection>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTextPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTextPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTextPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTextPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTextPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationTextPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18978,36 +16274,7 @@ impl IUIAutomationTextPattern2 {
         (::windows::core::Vtable::vtable(self).GetCaretRange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(isactive), ::core::mem::transmute(range)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationTextPattern2> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTextPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextPattern2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTextPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextPattern2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTextPattern2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationTextPattern2> for IUIAutomationTextPattern {
-    fn from(value: IUIAutomationTextPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextPattern2> for &'a IUIAutomationTextPattern {
-    fn from(value: &'a IUIAutomationTextPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextPattern2> for IUIAutomationTextPattern {
-    fn from(value: &IUIAutomationTextPattern2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTextPattern2, ::windows::core::IUnknown, IUIAutomationTextPattern);
 impl ::core::clone::Clone for IUIAutomationTextPattern2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19143,21 +16410,7 @@ impl IUIAutomationTextRange {
         (::windows::core::Vtable::vtable(self).GetChildren)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationElementArray>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTextRange> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextRange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextRange> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTextRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTextRange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationTextRange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19327,36 +16580,7 @@ impl IUIAutomationTextRange2 {
         (::windows::core::Vtable::vtable(self).ShowContextMenu)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationTextRange2> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextRange2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextRange2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTextRange2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationTextRange2> for IUIAutomationTextRange {
-    fn from(value: IUIAutomationTextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextRange2> for &'a IUIAutomationTextRange {
-    fn from(value: &'a IUIAutomationTextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextRange2> for IUIAutomationTextRange {
-    fn from(value: &IUIAutomationTextRange2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTextRange2, ::windows::core::IUnknown, IUIAutomationTextRange);
 impl ::core::clone::Clone for IUIAutomationTextRange2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19511,51 +16735,7 @@ impl IUIAutomationTextRange3 {
         (::windows::core::Vtable::vtable(self).GetAttributeValues)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(attributeids.as_ptr()), attributeids.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut super::super::System::Com::SAFEARRAY>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTextRange3> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTextRange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextRange3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTextRange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextRange3> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTextRange3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationTextRange3> for IUIAutomationTextRange {
-    fn from(value: IUIAutomationTextRange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextRange3> for &'a IUIAutomationTextRange {
-    fn from(value: &'a IUIAutomationTextRange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextRange3> for IUIAutomationTextRange {
-    fn from(value: &IUIAutomationTextRange3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationTextRange3> for IUIAutomationTextRange2 {
-    fn from(value: IUIAutomationTextRange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextRange3> for &'a IUIAutomationTextRange2 {
-    fn from(value: &'a IUIAutomationTextRange3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextRange3> for IUIAutomationTextRange2 {
-    fn from(value: &IUIAutomationTextRange3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTextRange3, ::windows::core::IUnknown, IUIAutomationTextRange, IUIAutomationTextRange2);
 impl ::core::clone::Clone for IUIAutomationTextRange3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19602,21 +16782,7 @@ impl IUIAutomationTextRangeArray {
         (::windows::core::Vtable::vtable(self).GetElement)(::windows::core::Vtable::as_raw(self), index, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationTextRange>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTextRangeArray> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTextRangeArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTextRangeArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTextRangeArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTextRangeArray> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTextRangeArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTextRangeArray, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationTextRangeArray {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19662,21 +16828,7 @@ impl IUIAutomationTogglePattern {
         (::windows::core::Vtable::vtable(self).CachedToggleState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ToggleState>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTogglePattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTogglePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTogglePattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTogglePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTogglePattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTogglePattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTogglePattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationTogglePattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19757,21 +16909,7 @@ impl IUIAutomationTransformPattern {
         (::windows::core::Vtable::vtable(self).CachedCanRotate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTransformPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTransformPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTransformPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTransformPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTransformPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTransformPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTransformPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationTransformPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19918,36 +17056,7 @@ impl IUIAutomationTransformPattern2 {
         (::windows::core::Vtable::vtable(self).CachedZoomMaximum)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<f64>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTransformPattern2> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTransformPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTransformPattern2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTransformPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTransformPattern2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTransformPattern2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUIAutomationTransformPattern2> for IUIAutomationTransformPattern {
-    fn from(value: IUIAutomationTransformPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTransformPattern2> for &'a IUIAutomationTransformPattern {
-    fn from(value: &'a IUIAutomationTransformPattern2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTransformPattern2> for IUIAutomationTransformPattern {
-    fn from(value: &IUIAutomationTransformPattern2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTransformPattern2, ::windows::core::IUnknown, IUIAutomationTransformPattern);
 impl ::core::clone::Clone for IUIAutomationTransformPattern2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20090,21 +17199,7 @@ impl IUIAutomationTreeWalker {
         (::windows::core::Vtable::vtable(self).Condition)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAutomationCondition>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationTreeWalker> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationTreeWalker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationTreeWalker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationTreeWalker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationTreeWalker> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationTreeWalker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationTreeWalker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationTreeWalker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20173,21 +17268,7 @@ impl IUIAutomationValuePattern {
         (::windows::core::Vtable::vtable(self).CachedIsReadOnly)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationValuePattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationValuePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationValuePattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationValuePattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationValuePattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationValuePattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationValuePattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationValuePattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20234,21 +17315,7 @@ impl IUIAutomationVirtualizedItemPattern {
         (::windows::core::Vtable::vtable(self).Realize)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUIAutomationVirtualizedItemPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationVirtualizedItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationVirtualizedItemPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationVirtualizedItemPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationVirtualizedItemPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationVirtualizedItemPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationVirtualizedItemPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationVirtualizedItemPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20358,21 +17425,7 @@ impl IUIAutomationWindowPattern {
         (::windows::core::Vtable::vtable(self).CachedWindowInteractionState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<WindowInteractionState>(result__)
     }
 }
-impl ::core::convert::From<IUIAutomationWindowPattern> for ::windows::core::IUnknown {
-    fn from(value: IUIAutomationWindowPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAutomationWindowPattern> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAutomationWindowPattern) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAutomationWindowPattern> for ::windows::core::IUnknown {
-    fn from(value: &IUIAutomationWindowPattern) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAutomationWindowPattern, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAutomationWindowPattern {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20463,21 +17516,7 @@ impl IValueProvider {
         (::windows::core::Vtable::vtable(self).IsReadOnly)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IValueProvider> for ::windows::core::IUnknown {
-    fn from(value: IValueProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IValueProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IValueProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IValueProvider> for ::windows::core::IUnknown {
-    fn from(value: &IValueProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IValueProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IValueProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20519,21 +17558,7 @@ impl IVirtualizedItemProvider {
         (::windows::core::Vtable::vtable(self).Realize)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IVirtualizedItemProvider> for ::windows::core::IUnknown {
-    fn from(value: IVirtualizedItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVirtualizedItemProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVirtualizedItemProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVirtualizedItemProvider> for ::windows::core::IUnknown {
-    fn from(value: &IVirtualizedItemProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVirtualizedItemProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVirtualizedItemProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20611,21 +17636,7 @@ impl IWindowProvider {
         (::windows::core::Vtable::vtable(self).IsTopmost)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IWindowProvider> for ::windows::core::IUnknown {
-    fn from(value: IWindowProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWindowProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWindowProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWindowProvider> for ::windows::core::IUnknown {
-    fn from(value: &IWindowProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWindowProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWindowProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
@@ -28,21 +28,7 @@ impl IUIAnimationInterpolator {
         (::windows::core::Vtable::vtable(self).GetDependencies)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(initialvaluedependencies), ::core::mem::transmute(initialvelocitydependencies), ::core::mem::transmute(durationdependencies)).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationInterpolator> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationInterpolator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationInterpolator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationInterpolator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationInterpolator> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationInterpolator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationInterpolator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationInterpolator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -114,21 +100,7 @@ impl IUIAnimationInterpolator2 {
         (::windows::core::Vtable::vtable(self).GetDependencies)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(initialvaluedependencies), ::core::mem::transmute(initialvelocitydependencies), ::core::mem::transmute(durationdependencies)).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationInterpolator2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationInterpolator2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationInterpolator2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationInterpolator2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationInterpolator2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationInterpolator2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationInterpolator2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationInterpolator2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -176,21 +148,7 @@ impl IUIAnimationLoopIterationChangeHandler2 {
         (::windows::core::Vtable::vtable(self).OnLoopIterationChanged)(::windows::core::Vtable::as_raw(self), storyboard.into().abi(), id, newiterationcount, olditerationcount).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationLoopIterationChangeHandler2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationLoopIterationChangeHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationLoopIterationChangeHandler2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationLoopIterationChangeHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationLoopIterationChangeHandler2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationLoopIterationChangeHandler2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationLoopIterationChangeHandler2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationLoopIterationChangeHandler2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -312,21 +270,7 @@ impl IUIAnimationManager {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationManager> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationManager> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -477,21 +421,7 @@ impl IUIAnimationManager2 {
         (::windows::core::Vtable::vtable(self).Shutdown)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationManager2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationManager2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationManager2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationManager2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationManager2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationManager2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationManager2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -551,21 +481,7 @@ impl IUIAnimationManagerEventHandler {
         (::windows::core::Vtable::vtable(self).OnManagerStatusChanged)(::windows::core::Vtable::as_raw(self), newstatus, previousstatus).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationManagerEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationManagerEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationManagerEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationManagerEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationManagerEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationManagerEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationManagerEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationManagerEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -602,21 +518,7 @@ impl IUIAnimationManagerEventHandler2 {
         (::windows::core::Vtable::vtable(self).OnManagerStatusChanged)(::windows::core::Vtable::as_raw(self), newstatus, previousstatus).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationManagerEventHandler2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationManagerEventHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationManagerEventHandler2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationManagerEventHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationManagerEventHandler2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationManagerEventHandler2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationManagerEventHandler2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationManagerEventHandler2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -656,21 +558,7 @@ impl IUIAnimationPrimitiveInterpolation {
         (::windows::core::Vtable::vtable(self).AddSinusoidal)(::windows::core::Vtable::as_raw(self), dimension, beginoffset, bias, amplitude, frequency, phase).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationPrimitiveInterpolation> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationPrimitiveInterpolation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationPrimitiveInterpolation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationPrimitiveInterpolation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationPrimitiveInterpolation> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationPrimitiveInterpolation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationPrimitiveInterpolation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationPrimitiveInterpolation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -712,21 +600,7 @@ impl IUIAnimationPriorityComparison {
         (::windows::core::Vtable::vtable(self).HasPriority)(::windows::core::Vtable::as_raw(self), scheduledstoryboard.into().abi(), newstoryboard.into().abi(), priorityeffect).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationPriorityComparison> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationPriorityComparison) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationPriorityComparison> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationPriorityComparison) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationPriorityComparison> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationPriorityComparison) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationPriorityComparison, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationPriorityComparison {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -767,21 +641,7 @@ impl IUIAnimationPriorityComparison2 {
         (::windows::core::Vtable::vtable(self).HasPriority)(::windows::core::Vtable::as_raw(self), scheduledstoryboard.into().abi(), newstoryboard.into().abi(), priorityeffect).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationPriorityComparison2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationPriorityComparison2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationPriorityComparison2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationPriorityComparison2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationPriorityComparison2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationPriorityComparison2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationPriorityComparison2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationPriorityComparison2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -905,21 +765,7 @@ impl IUIAnimationStoryboard {
         (::windows::core::Vtable::vtable(self).SetStoryboardEventHandler)(::windows::core::Vtable::as_raw(self), handler.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationStoryboard> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationStoryboard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationStoryboard> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationStoryboard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationStoryboard> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationStoryboard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationStoryboard, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationStoryboard {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1070,21 +916,7 @@ impl IUIAnimationStoryboard2 {
         (::windows::core::Vtable::vtable(self).SetStoryboardEventHandler)(::windows::core::Vtable::as_raw(self), handler.into().abi(), fregisterstatuschangefornextanimationevent.into(), fregisterupdatefornextanimationevent.into()).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationStoryboard2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationStoryboard2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationStoryboard2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationStoryboard2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationStoryboard2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationStoryboard2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationStoryboard2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationStoryboard2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1153,21 +985,7 @@ impl IUIAnimationStoryboardEventHandler {
         (::windows::core::Vtable::vtable(self).OnStoryboardUpdated)(::windows::core::Vtable::as_raw(self), storyboard.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationStoryboardEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationStoryboardEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationStoryboardEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationStoryboardEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationStoryboardEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationStoryboardEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationStoryboardEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationStoryboardEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1214,21 +1032,7 @@ impl IUIAnimationStoryboardEventHandler2 {
         (::windows::core::Vtable::vtable(self).OnStoryboardUpdated)(::windows::core::Vtable::as_raw(self), storyboard.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationStoryboardEventHandler2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationStoryboardEventHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationStoryboardEventHandler2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationStoryboardEventHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationStoryboardEventHandler2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationStoryboardEventHandler2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationStoryboardEventHandler2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationStoryboardEventHandler2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1291,21 +1095,7 @@ impl IUIAnimationTimer {
         (::windows::core::Vtable::vtable(self).SetFrameRateThreshold)(::windows::core::Vtable::as_raw(self), framespersecond).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationTimer> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationTimer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationTimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationTimer> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationTimer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationTimer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationTimer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1348,21 +1138,7 @@ impl IUIAnimationTimerClientEventHandler {
         (::windows::core::Vtable::vtable(self).OnTimerClientStatusChanged)(::windows::core::Vtable::as_raw(self), newstatus, previousstatus).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationTimerClientEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationTimerClientEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationTimerClientEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationTimerClientEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationTimerClientEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationTimerClientEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationTimerClientEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationTimerClientEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1405,21 +1181,7 @@ impl IUIAnimationTimerEventHandler {
         (::windows::core::Vtable::vtable(self).OnRenderingTooSlow)(::windows::core::Vtable::as_raw(self), framespersecond).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationTimerEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationTimerEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationTimerEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationTimerEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationTimerEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationTimerEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationTimerEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationTimerEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1468,21 +1230,7 @@ impl IUIAnimationTimerUpdateHandler {
         (::windows::core::Vtable::vtable(self).ClearTimerClientEventHandler)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationTimerUpdateHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationTimerUpdateHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationTimerUpdateHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationTimerUpdateHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationTimerUpdateHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationTimerUpdateHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationTimerUpdateHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationTimerUpdateHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1531,21 +1279,7 @@ impl IUIAnimationTransition {
         (::windows::core::Vtable::vtable(self).GetDuration)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<f64>(result__)
     }
 }
-impl ::core::convert::From<IUIAnimationTransition> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationTransition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationTransition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationTransition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationTransition> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationTransition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationTransition, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationTransition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1605,21 +1339,7 @@ impl IUIAnimationTransition2 {
         (::windows::core::Vtable::vtable(self).GetDuration)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<f64>(result__)
     }
 }
-impl ::core::convert::From<IUIAnimationTransition2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationTransition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationTransition2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationTransition2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationTransition2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationTransition2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationTransition2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationTransition2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1666,21 +1386,7 @@ impl IUIAnimationTransitionFactory {
         (::windows::core::Vtable::vtable(self).CreateTransition)(::windows::core::Vtable::as_raw(self), interpolator.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAnimationTransition>(result__)
     }
 }
-impl ::core::convert::From<IUIAnimationTransitionFactory> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationTransitionFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationTransitionFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationTransitionFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationTransitionFactory> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationTransitionFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationTransitionFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationTransitionFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1721,21 +1427,7 @@ impl IUIAnimationTransitionFactory2 {
         (::windows::core::Vtable::vtable(self).CreateTransition)(::windows::core::Vtable::as_raw(self), interpolator.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAnimationTransition2>(result__)
     }
 }
-impl ::core::convert::From<IUIAnimationTransitionFactory2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationTransitionFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationTransitionFactory2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationTransitionFactory2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationTransitionFactory2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationTransitionFactory2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationTransitionFactory2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationTransitionFactory2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1817,21 +1509,7 @@ impl IUIAnimationTransitionLibrary {
         (::windows::core::Vtable::vtable(self).CreateParabolicTransitionFromAcceleration)(::windows::core::Vtable::as_raw(self), finalvalue, finalvelocity, acceleration, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAnimationTransition>(result__)
     }
 }
-impl ::core::convert::From<IUIAnimationTransitionLibrary> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationTransitionLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationTransitionLibrary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationTransitionLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationTransitionLibrary> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationTransitionLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationTransitionLibrary, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationTransitionLibrary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1952,21 +1630,7 @@ impl IUIAnimationTransitionLibrary2 {
         (::windows::core::Vtable::vtable(self).CreateCubicBezierLinearVectorTransition)(::windows::core::Vtable::as_raw(self), duration, ::core::mem::transmute(finalvalue.as_ptr()), finalvalue.len() as _, x1, y1, x2, y2, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIAnimationTransition2>(result__)
     }
 }
-impl ::core::convert::From<IUIAnimationTransitionLibrary2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationTransitionLibrary2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationTransitionLibrary2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationTransitionLibrary2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationTransitionLibrary2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationTransitionLibrary2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationTransitionLibrary2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationTransitionLibrary2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2076,21 +1740,7 @@ impl IUIAnimationVariable {
         (::windows::core::Vtable::vtable(self).SetVariableIntegerChangeHandler)(::windows::core::Vtable::as_raw(self), handler.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationVariable> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationVariable> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationVariable) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationVariable> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationVariable) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationVariable, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationVariable {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2248,21 +1898,7 @@ impl IUIAnimationVariable2 {
         (::windows::core::Vtable::vtable(self).SetVariableCurveChangeHandler)(::windows::core::Vtable::as_raw(self), handler.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationVariable2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationVariable2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationVariable2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationVariable2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationVariable2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationVariable2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationVariable2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationVariable2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2340,21 +1976,7 @@ impl IUIAnimationVariableChangeHandler {
         (::windows::core::Vtable::vtable(self).OnValueChanged)(::windows::core::Vtable::as_raw(self), storyboard.into().abi(), variable.into().abi(), newvalue, previousvalue).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationVariableChangeHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationVariableChangeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationVariableChangeHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationVariableChangeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationVariableChangeHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationVariableChangeHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationVariableChangeHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationVariableChangeHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2395,21 +2017,7 @@ impl IUIAnimationVariableChangeHandler2 {
         (::windows::core::Vtable::vtable(self).OnValueChanged)(::windows::core::Vtable::as_raw(self), storyboard.into().abi(), variable.into().abi(), ::core::mem::transmute(newvalue), ::core::mem::transmute(previousvalue), cdimension).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationVariableChangeHandler2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationVariableChangeHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationVariableChangeHandler2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationVariableChangeHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationVariableChangeHandler2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationVariableChangeHandler2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationVariableChangeHandler2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationVariableChangeHandler2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2449,21 +2057,7 @@ impl IUIAnimationVariableCurveChangeHandler2 {
         (::windows::core::Vtable::vtable(self).OnCurveChanged)(::windows::core::Vtable::as_raw(self), variable.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationVariableCurveChangeHandler2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationVariableCurveChangeHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationVariableCurveChangeHandler2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationVariableCurveChangeHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationVariableCurveChangeHandler2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationVariableCurveChangeHandler2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationVariableCurveChangeHandler2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationVariableCurveChangeHandler2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2504,21 +2098,7 @@ impl IUIAnimationVariableIntegerChangeHandler {
         (::windows::core::Vtable::vtable(self).OnIntegerValueChanged)(::windows::core::Vtable::as_raw(self), storyboard.into().abi(), variable.into().abi(), newvalue, previousvalue).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationVariableIntegerChangeHandler> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationVariableIntegerChangeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationVariableIntegerChangeHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationVariableIntegerChangeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationVariableIntegerChangeHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationVariableIntegerChangeHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationVariableIntegerChangeHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationVariableIntegerChangeHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2559,21 +2139,7 @@ impl IUIAnimationVariableIntegerChangeHandler2 {
         (::windows::core::Vtable::vtable(self).OnIntegerValueChanged)(::windows::core::Vtable::as_raw(self), storyboard.into().abi(), variable.into().abi(), ::core::mem::transmute(newvalue), ::core::mem::transmute(previousvalue), cdimension).ok()
     }
 }
-impl ::core::convert::From<IUIAnimationVariableIntegerChangeHandler2> for ::windows::core::IUnknown {
-    fn from(value: IUIAnimationVariableIntegerChangeHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIAnimationVariableIntegerChangeHandler2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIAnimationVariableIntegerChangeHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIAnimationVariableIntegerChangeHandler2> for ::windows::core::IUnknown {
-    fn from(value: &IUIAnimationVariableIntegerChangeHandler2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIAnimationVariableIntegerChangeHandler2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIAnimationVariableIntegerChangeHandler2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
@@ -1448,21 +1448,7 @@ impl IDeviceModelPlugIn {
         (::windows::core::Vtable::vtable(self).GetNeutralAxis)(::windows::core::Vtable::as_raw(self), pxyzcolors.len() as _, ::core::mem::transmute(pxyzcolors.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<IDeviceModelPlugIn> for ::windows::core::IUnknown {
-    fn from(value: IDeviceModelPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDeviceModelPlugIn> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeviceModelPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDeviceModelPlugIn> for ::windows::core::IUnknown {
-    fn from(value: &IDeviceModelPlugIn) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeviceModelPlugIn, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDeviceModelPlugIn {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1520,21 +1506,7 @@ impl IGamutMapModelPlugIn {
         (::windows::core::Vtable::vtable(self).SourceToDestinationAppearanceColors)(::windows::core::Vtable::as_raw(self), ccolors, ::core::mem::transmute(pinputcolors), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<JChColorF>(result__)
     }
 }
-impl ::core::convert::From<IGamutMapModelPlugIn> for ::windows::core::IUnknown {
-    fn from(value: IGamutMapModelPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGamutMapModelPlugIn> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGamutMapModelPlugIn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGamutMapModelPlugIn> for ::windows::core::IUnknown {
-    fn from(value: &IGamutMapModelPlugIn) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGamutMapModelPlugIn, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGamutMapModelPlugIn {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
@@ -232,21 +232,7 @@ impl IPrintDialogCallback {
         (::windows::core::Vtable::vtable(self).HandleMessage)(::windows::core::Vtable::as_raw(self), hdlg.into(), umsg, wparam.into(), lparam.into(), ::core::mem::transmute(presult)).ok()
     }
 }
-impl ::core::convert::From<IPrintDialogCallback> for ::windows::core::IUnknown {
-    fn from(value: IPrintDialogCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintDialogCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintDialogCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintDialogCallback> for ::windows::core::IUnknown {
-    fn from(value: &IPrintDialogCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintDialogCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintDialogCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -296,21 +282,7 @@ impl IPrintDialogServices {
         (::windows::core::Vtable::vtable(self).GetCurrentPortName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pportname), ::core::mem::transmute(pcchsize)).ok()
     }
 }
-impl ::core::convert::From<IPrintDialogServices> for ::windows::core::IUnknown {
-    fn from(value: IPrintDialogServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPrintDialogServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPrintDialogServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPrintDialogServices> for ::windows::core::IUnknown {
-    fn from(value: &IPrintDialogServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPrintDialogServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPrintDialogServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
@@ -87,21 +87,7 @@ impl IRichEditOle {
         (::windows::core::Vtable::vtable(self).ImportDataObject)(::windows::core::Vtable::as_raw(self), lpdataobj.into().abi(), cf, hmetapict).ok()
     }
 }
-impl ::core::convert::From<IRichEditOle> for ::windows::core::IUnknown {
-    fn from(value: IRichEditOle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRichEditOle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRichEditOle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRichEditOle> for ::windows::core::IUnknown {
-    fn from(value: &IRichEditOle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRichEditOle, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRichEditOle {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -247,21 +233,7 @@ impl IRichEditOleCallback {
         (::windows::core::Vtable::vtable(self).GetContextMenu)(::windows::core::Vtable::as_raw(self), seltype, lpoleobj.into().abi(), ::core::mem::transmute(lpchrg), ::core::mem::transmute(lphmenu)).ok()
     }
 }
-impl ::core::convert::From<IRichEditOleCallback> for ::windows::core::IUnknown {
-    fn from(value: IRichEditOleCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRichEditOleCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRichEditOleCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRichEditOleCallback> for ::windows::core::IUnknown {
-    fn from(value: &IRichEditOleCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRichEditOleCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRichEditOleCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -339,21 +311,7 @@ impl IRicheditUiaOverrides {
         (::windows::core::Vtable::vtable(self).GetPropertyOverrideValue)(::windows::core::Vtable::as_raw(self), propertyid, ::core::mem::transmute(pretvalue)).ok()
     }
 }
-impl ::core::convert::From<IRicheditUiaOverrides> for ::windows::core::IUnknown {
-    fn from(value: IRicheditUiaOverrides) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRicheditUiaOverrides> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRicheditUiaOverrides) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRicheditUiaOverrides> for ::windows::core::IUnknown {
-    fn from(value: &IRicheditUiaOverrides) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRicheditUiaOverrides, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRicheditUiaOverrides {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -392,41 +350,7 @@ pub struct ITextDisplays(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl ITextDisplays {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextDisplays> for ::windows::core::IUnknown {
-    fn from(value: ITextDisplays) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextDisplays> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextDisplays) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextDisplays> for ::windows::core::IUnknown {
-    fn from(value: &ITextDisplays) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextDisplays> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextDisplays) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextDisplays> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextDisplays) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextDisplays> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextDisplays) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextDisplays, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextDisplays {
     fn clone(&self) -> Self {
@@ -550,41 +474,7 @@ impl ITextDocument {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextDocument> for ::windows::core::IUnknown {
-    fn from(value: ITextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextDocument> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextDocument> for ::windows::core::IUnknown {
-    fn from(value: &ITextDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextDocument> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextDocument> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextDocument) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextDocument> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextDocument) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextDocument, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextDocument {
     fn clone(&self) -> Self {
@@ -936,59 +826,7 @@ impl ITextDocument2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextDocument2> for ::windows::core::IUnknown {
-    fn from(value: ITextDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextDocument2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextDocument2> for ::windows::core::IUnknown {
-    fn from(value: &ITextDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextDocument2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextDocument2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextDocument2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextDocument2> for ITextDocument {
-    fn from(value: ITextDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextDocument2> for &'a ITextDocument {
-    fn from(value: &'a ITextDocument2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextDocument2> for ITextDocument {
-    fn from(value: &ITextDocument2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextDocument2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ITextDocument);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextDocument2 {
     fn clone(&self) -> Self {
@@ -1287,59 +1125,7 @@ impl ITextDocument2Old {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextDocument2Old> for ::windows::core::IUnknown {
-    fn from(value: ITextDocument2Old) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextDocument2Old> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextDocument2Old) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextDocument2Old> for ::windows::core::IUnknown {
-    fn from(value: &ITextDocument2Old) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextDocument2Old> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextDocument2Old) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextDocument2Old> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextDocument2Old) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextDocument2Old> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextDocument2Old) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextDocument2Old> for ITextDocument {
-    fn from(value: ITextDocument2Old) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextDocument2Old> for &'a ITextDocument {
-    fn from(value: &'a ITextDocument2Old) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextDocument2Old> for ITextDocument {
-    fn from(value: &ITextDocument2Old) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextDocument2Old, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ITextDocument);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextDocument2Old {
     fn clone(&self) -> Self {
@@ -1626,41 +1412,7 @@ impl ITextFont {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextFont> for ::windows::core::IUnknown {
-    fn from(value: ITextFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextFont> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextFont> for ::windows::core::IUnknown {
-    fn from(value: &ITextFont) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextFont> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextFont> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextFont) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextFont> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextFont) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextFont, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextFont {
     fn clone(&self) -> Self {
@@ -2144,59 +1896,7 @@ impl ITextFont2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextFont2> for ::windows::core::IUnknown {
-    fn from(value: ITextFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextFont2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextFont2> for ::windows::core::IUnknown {
-    fn from(value: &ITextFont2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextFont2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextFont2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextFont2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextFont2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextFont2> for ITextFont {
-    fn from(value: ITextFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextFont2> for &'a ITextFont {
-    fn from(value: &'a ITextFont2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextFont2> for ITextFont {
-    fn from(value: &ITextFont2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextFont2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ITextFont);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextFont2 {
     fn clone(&self) -> Self {
@@ -2496,21 +2196,7 @@ impl ITextHost {
         (::windows::core::Vtable::vtable(self).TxGetSelectionBarWidth)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(lselbarwidth)).ok()
     }
 }
-impl ::core::convert::From<ITextHost> for ::windows::core::IUnknown {
-    fn from(value: ITextHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextHost> for ::windows::core::IUnknown {
-    fn from(value: &ITextHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2916,36 +2602,7 @@ impl ITextHost2 {
         (::windows::core::Vtable::vtable(self).TxGetHorzExtent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(plhorzextent)).ok()
     }
 }
-impl ::core::convert::From<ITextHost2> for ::windows::core::IUnknown {
-    fn from(value: ITextHost2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextHost2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextHost2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextHost2> for ::windows::core::IUnknown {
-    fn from(value: &ITextHost2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextHost2> for ITextHost {
-    fn from(value: ITextHost2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextHost2> for &'a ITextHost {
-    fn from(value: &'a ITextHost2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextHost2> for ITextHost {
-    fn from(value: &ITextHost2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextHost2, ::windows::core::IUnknown, ITextHost);
 impl ::core::clone::Clone for ITextHost2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3188,41 +2845,7 @@ impl ITextPara {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextPara> for ::windows::core::IUnknown {
-    fn from(value: ITextPara) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextPara> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextPara) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextPara> for ::windows::core::IUnknown {
-    fn from(value: &ITextPara) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextPara> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextPara) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextPara> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextPara) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextPara> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextPara) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextPara, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextPara {
     fn clone(&self) -> Self {
@@ -3570,59 +3193,7 @@ impl ITextPara2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextPara2> for ::windows::core::IUnknown {
-    fn from(value: ITextPara2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextPara2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextPara2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextPara2> for ::windows::core::IUnknown {
-    fn from(value: &ITextPara2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextPara2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextPara2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextPara2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextPara2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextPara2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextPara2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextPara2> for ITextPara {
-    fn from(value: ITextPara2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextPara2> for &'a ITextPara {
-    fn from(value: &'a ITextPara2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextPara2> for ITextPara {
-    fn from(value: &ITextPara2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextPara2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ITextPara);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextPara2 {
     fn clone(&self) -> Self {
@@ -3936,41 +3507,7 @@ impl ITextRange {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextRange> for ::windows::core::IUnknown {
-    fn from(value: ITextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextRange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextRange> for ::windows::core::IUnknown {
-    fn from(value: &ITextRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextRange> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextRange> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextRange> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextRange, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextRange {
     fn clone(&self) -> Self {
@@ -4580,77 +4117,7 @@ impl ITextRange2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextRange2> for ::windows::core::IUnknown {
-    fn from(value: ITextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextRange2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextRange2> for ::windows::core::IUnknown {
-    fn from(value: &ITextRange2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextRange2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextRange2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextRange2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextRange2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextRange2> for ITextRange {
-    fn from(value: ITextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextRange2> for &'a ITextRange {
-    fn from(value: &'a ITextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextRange2> for ITextRange {
-    fn from(value: &ITextRange2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextRange2> for ITextSelection {
-    fn from(value: ITextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextRange2> for &'a ITextSelection {
-    fn from(value: &'a ITextRange2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextRange2> for ITextSelection {
-    fn from(value: &ITextRange2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextRange2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ITextRange, ITextSelection);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextRange2 {
     fn clone(&self) -> Self {
@@ -4927,41 +4394,7 @@ impl ITextRow {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextRow> for ::windows::core::IUnknown {
-    fn from(value: ITextRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextRow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextRow> for ::windows::core::IUnknown {
-    fn from(value: &ITextRow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextRow> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextRow> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextRow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextRow> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextRow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextRow, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextRow {
     fn clone(&self) -> Self {
@@ -5337,59 +4770,7 @@ impl ITextSelection {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextSelection> for ::windows::core::IUnknown {
-    fn from(value: ITextSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextSelection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextSelection> for ::windows::core::IUnknown {
-    fn from(value: &ITextSelection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextSelection> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextSelection> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextSelection> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextSelection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextSelection> for ITextRange {
-    fn from(value: ITextSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextSelection> for &'a ITextRange {
-    fn from(value: &'a ITextSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextSelection> for ITextRange {
-    fn from(value: &ITextSelection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextSelection, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ITextRange);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextSelection {
     fn clone(&self) -> Self {
@@ -5898,95 +5279,7 @@ impl ITextSelection2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextSelection2> for ::windows::core::IUnknown {
-    fn from(value: ITextSelection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextSelection2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextSelection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextSelection2> for ::windows::core::IUnknown {
-    fn from(value: &ITextSelection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextSelection2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextSelection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextSelection2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextSelection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextSelection2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextSelection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextSelection2> for ITextRange {
-    fn from(value: ITextSelection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextSelection2> for &'a ITextRange {
-    fn from(value: &'a ITextSelection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextSelection2> for ITextRange {
-    fn from(value: &ITextSelection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextSelection2> for ITextSelection {
-    fn from(value: ITextSelection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextSelection2> for &'a ITextSelection {
-    fn from(value: &'a ITextSelection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextSelection2> for ITextSelection {
-    fn from(value: &ITextSelection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextSelection2> for ITextRange2 {
-    fn from(value: ITextSelection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextSelection2> for &'a ITextRange2 {
-    fn from(value: &'a ITextSelection2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextSelection2> for ITextRange2 {
-    fn from(value: &ITextSelection2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextSelection2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ITextRange, ITextSelection, ITextRange2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextSelection2 {
     fn clone(&self) -> Self {
@@ -6122,21 +5415,7 @@ impl ITextServices {
         (::windows::core::Vtable::vtable(self).TxGetCachedSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwwidth), ::core::mem::transmute(pdwheight)).ok()
     }
 }
-impl ::core::convert::From<ITextServices> for ::windows::core::IUnknown {
-    fn from(value: ITextServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextServices> for ::windows::core::IUnknown {
-    fn from(value: &ITextServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6327,36 +5606,7 @@ impl ITextServices2 {
         (::windows::core::Vtable::vtable(self).TxDrawD2D)(::windows::core::Vtable::as_raw(self), prendertarget.into().abi(), ::core::mem::transmute(lprcbounds), ::core::mem::transmute(lprcupdate), lviewid).ok()
     }
 }
-impl ::core::convert::From<ITextServices2> for ::windows::core::IUnknown {
-    fn from(value: ITextServices2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextServices2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextServices2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextServices2> for ::windows::core::IUnknown {
-    fn from(value: &ITextServices2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextServices2> for ITextServices {
-    fn from(value: ITextServices2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextServices2> for &'a ITextServices {
-    fn from(value: &'a ITextServices2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextServices2> for ITextServices {
-    fn from(value: &ITextServices2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextServices2, ::windows::core::IUnknown, ITextServices);
 impl ::core::clone::Clone for ITextServices2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6445,21 +5695,7 @@ impl ITextStory {
         (::windows::core::Vtable::vtable(self).SetText)(::windows::core::Vtable::as_raw(self), flags, ::core::mem::transmute_copy(bstr)).ok()
     }
 }
-impl ::core::convert::From<ITextStory> for ::windows::core::IUnknown {
-    fn from(value: ITextStory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStory> for ::windows::core::IUnknown {
-    fn from(value: &ITextStory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextStory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6524,41 +5760,7 @@ impl ITextStoryRanges {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextStoryRanges> for ::windows::core::IUnknown {
-    fn from(value: ITextStoryRanges) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextStoryRanges> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoryRanges) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextStoryRanges> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoryRanges) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextStoryRanges> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextStoryRanges) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextStoryRanges> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextStoryRanges) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextStoryRanges> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextStoryRanges) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoryRanges, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextStoryRanges {
     fn clone(&self) -> Self {
@@ -6627,59 +5829,7 @@ impl ITextStoryRanges2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextStoryRanges2> for ::windows::core::IUnknown {
-    fn from(value: ITextStoryRanges2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextStoryRanges2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoryRanges2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextStoryRanges2> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoryRanges2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextStoryRanges2> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextStoryRanges2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextStoryRanges2> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextStoryRanges2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextStoryRanges2> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextStoryRanges2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextStoryRanges2> for ITextStoryRanges {
-    fn from(value: ITextStoryRanges2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextStoryRanges2> for &'a ITextStoryRanges {
-    fn from(value: &'a ITextStoryRanges2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextStoryRanges2> for ITextStoryRanges {
-    fn from(value: &ITextStoryRanges2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoryRanges2, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch, ITextStoryRanges);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextStoryRanges2 {
     fn clone(&self) -> Self {
@@ -6808,41 +5958,7 @@ impl ITextStrings {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextStrings> for ::windows::core::IUnknown {
-    fn from(value: ITextStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextStrings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextStrings> for ::windows::core::IUnknown {
-    fn from(value: &ITextStrings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ITextStrings> for super::super::super::System::Com::IDispatch {
-    fn from(value: ITextStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ITextStrings> for &'a super::super::super::System::Com::IDispatch {
-    fn from(value: &'a ITextStrings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ITextStrings> for super::super::super::System::Com::IDispatch {
-    fn from(value: &ITextStrings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStrings, ::windows::core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ITextStrings {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
@@ -2827,21 +2827,7 @@ impl IImageList {
         (::windows::core::Vtable::vtable(self).GetOverlayImage)(::windows::core::Vtable::as_raw(self), ioverlay, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IImageList> for ::windows::core::IUnknown {
-    fn from(value: IImageList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImageList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImageList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImageList> for ::windows::core::IUnknown {
-    fn from(value: &IImageList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImageList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IImageList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3159,36 +3145,7 @@ impl IImageList2 {
         (::windows::core::Vtable::vtable(self).ReplaceFromImageList)(::windows::core::Vtable::as_raw(self), i, pil.into().abi(), isrc, punk.into().abi(), dwflags).ok()
     }
 }
-impl ::core::convert::From<IImageList2> for ::windows::core::IUnknown {
-    fn from(value: IImageList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImageList2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImageList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImageList2> for ::windows::core::IUnknown {
-    fn from(value: &IImageList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IImageList2> for IImageList {
-    fn from(value: IImageList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImageList2> for &'a IImageList {
-    fn from(value: &'a IImageList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImageList2> for IImageList {
-    fn from(value: &IImageList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImageList2, ::windows::core::IUnknown, IImageList);
 impl ::core::clone::Clone for IImageList2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
@@ -1200,21 +1200,7 @@ impl IActiveIME {
         (::windows::core::Vtable::vtable(self).GetLangId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u16>(result__)
     }
 }
-impl ::core::convert::From<IActiveIME> for ::windows::core::IUnknown {
-    fn from(value: IActiveIME) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveIME> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveIME) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveIME> for ::windows::core::IUnknown {
-    fn from(value: &IActiveIME) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveIME, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveIME {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1417,36 +1403,7 @@ impl IActiveIME2 {
         (::windows::core::Vtable::vtable(self).Unsleep)(::windows::core::Vtable::as_raw(self), fdead.into()).ok()
     }
 }
-impl ::core::convert::From<IActiveIME2> for ::windows::core::IUnknown {
-    fn from(value: IActiveIME2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveIME2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveIME2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveIME2> for ::windows::core::IUnknown {
-    fn from(value: &IActiveIME2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IActiveIME2> for IActiveIME {
-    fn from(value: IActiveIME2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveIME2> for &'a IActiveIME {
-    fn from(value: &'a IActiveIME2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveIME2> for IActiveIME {
-    fn from(value: &IActiveIME2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveIME2, ::windows::core::IUnknown, IActiveIME);
 impl ::core::clone::Clone for IActiveIME2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2056,21 +2013,7 @@ impl IActiveIMMApp {
         (::windows::core::Vtable::vtable(self).EnumInputContext)(::windows::core::Vtable::as_raw(self), idthread, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumInputContext>(result__)
     }
 }
-impl ::core::convert::From<IActiveIMMApp> for ::windows::core::IUnknown {
-    fn from(value: IActiveIMMApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveIMMApp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveIMMApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveIMMApp> for ::windows::core::IUnknown {
-    fn from(value: &IActiveIMMApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveIMMApp, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveIMMApp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3095,21 +3038,7 @@ impl IActiveIMMIME {
         (::windows::core::Vtable::vtable(self).IsSleeping)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IActiveIMMIME> for ::windows::core::IUnknown {
-    fn from(value: IActiveIMMIME) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveIMMIME> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveIMMIME) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveIMMIME> for ::windows::core::IUnknown {
-    fn from(value: &IActiveIMMIME) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveIMMIME, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveIMMIME {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3494,21 +3423,7 @@ impl IActiveIMMMessagePumpOwner {
         (::windows::core::Vtable::vtable(self).Resume)(::windows::core::Vtable::as_raw(self), dwcookie).ok()
     }
 }
-impl ::core::convert::From<IActiveIMMMessagePumpOwner> for ::windows::core::IUnknown {
-    fn from(value: IActiveIMMMessagePumpOwner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveIMMMessagePumpOwner> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveIMMMessagePumpOwner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveIMMMessagePumpOwner> for ::windows::core::IUnknown {
-    fn from(value: &IActiveIMMMessagePumpOwner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveIMMMessagePumpOwner, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveIMMMessagePumpOwner {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3559,21 +3474,7 @@ impl IActiveIMMRegistrar {
         (::windows::core::Vtable::vtable(self).UnregisterIME)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid)).ok()
     }
 }
-impl ::core::convert::From<IActiveIMMRegistrar> for ::windows::core::IUnknown {
-    fn from(value: IActiveIMMRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveIMMRegistrar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveIMMRegistrar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveIMMRegistrar> for ::windows::core::IUnknown {
-    fn from(value: &IActiveIMMRegistrar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveIMMRegistrar, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveIMMRegistrar {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3623,21 +3524,7 @@ impl IEnumInputContext {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumInputContext> for ::windows::core::IUnknown {
-    fn from(value: IEnumInputContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumInputContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumInputContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumInputContext> for ::windows::core::IUnknown {
-    fn from(value: &IEnumInputContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumInputContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumInputContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3690,21 +3577,7 @@ impl IEnumRegisterWordA {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumRegisterWordA> for ::windows::core::IUnknown {
-    fn from(value: IEnumRegisterWordA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumRegisterWordA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumRegisterWordA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumRegisterWordA> for ::windows::core::IUnknown {
-    fn from(value: &IEnumRegisterWordA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumRegisterWordA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumRegisterWordA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3754,21 +3627,7 @@ impl IEnumRegisterWordW {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumRegisterWordW> for ::windows::core::IUnknown {
-    fn from(value: IEnumRegisterWordW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumRegisterWordW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumRegisterWordW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumRegisterWordW> for ::windows::core::IUnknown {
-    fn from(value: &IEnumRegisterWordW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumRegisterWordW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumRegisterWordW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3826,41 +3685,7 @@ impl IFEClassFactory {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFEClassFactory> for ::windows::core::IUnknown {
-    fn from(value: IFEClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFEClassFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFEClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFEClassFactory> for ::windows::core::IUnknown {
-    fn from(value: &IFEClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFEClassFactory> for super::super::super::System::Com::IClassFactory {
-    fn from(value: IFEClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFEClassFactory> for &'a super::super::super::System::Com::IClassFactory {
-    fn from(value: &'a IFEClassFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFEClassFactory> for super::super::super::System::Com::IClassFactory {
-    fn from(value: &IFEClassFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFEClassFactory, ::windows::core::IUnknown, super::super::super::System::Com::IClassFactory);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFEClassFactory {
     fn clone(&self) -> Self {
@@ -3916,21 +3741,7 @@ impl IFECommon {
         (::windows::core::Vtable::vtable(self).InvokeDictToolDialog)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pimedlg)).ok()
     }
 }
-impl ::core::convert::From<IFECommon> for ::windows::core::IUnknown {
-    fn from(value: IFECommon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFECommon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFECommon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFECommon> for ::windows::core::IUnknown {
-    fn from(value: &IFECommon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFECommon, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFECommon {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4056,21 +3867,7 @@ impl IFEDictionary {
         (::windows::core::Vtable::vtable(self).ConvertFromUserToSys)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IFEDictionary> for ::windows::core::IUnknown {
-    fn from(value: IFEDictionary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFEDictionary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFEDictionary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFEDictionary> for ::windows::core::IUnknown {
-    fn from(value: &IFEDictionary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFEDictionary, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFEDictionary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4159,21 +3956,7 @@ impl IFELanguage {
         (::windows::core::Vtable::vtable(self).GetConversion)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(string), start, length, ::core::mem::transmute(result)).ok()
     }
 }
-impl ::core::convert::From<IFELanguage> for ::windows::core::IUnknown {
-    fn from(value: IFELanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFELanguage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFELanguage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFELanguage> for ::windows::core::IUnknown {
-    fn from(value: &IFELanguage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFELanguage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFELanguage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4222,21 +4005,7 @@ impl IImePad {
         (::windows::core::Vtable::vtable(self).Request)(::windows::core::Vtable::as_raw(self), piimepadapplet.into().abi(), reqid, wparam.into(), lparam.into()).ok()
     }
 }
-impl ::core::convert::From<IImePad> for ::windows::core::IUnknown {
-    fn from(value: IImePad) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImePad> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImePad) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImePad> for ::windows::core::IUnknown {
-    fn from(value: &IImePad) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImePad, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IImePad {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4305,21 +4074,7 @@ impl IImePadApplet {
         (::windows::core::Vtable::vtable(self).Notify)(::windows::core::Vtable::as_raw(self), lpimepad.into().abi(), notify, wparam.into(), lparam.into()).ok()
     }
 }
-impl ::core::convert::From<IImePadApplet> for ::windows::core::IUnknown {
-    fn from(value: IImePadApplet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImePadApplet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImePadApplet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImePadApplet> for ::windows::core::IUnknown {
-    fn from(value: &IImePadApplet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImePadApplet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IImePadApplet {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4374,21 +4129,7 @@ impl IImePlugInDictDictionaryList {
         (::windows::core::Vtable::vtable(self).DeleteDictionary)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrdictionaryguid)).ok()
     }
 }
-impl ::core::convert::From<IImePlugInDictDictionaryList> for ::windows::core::IUnknown {
-    fn from(value: IImePlugInDictDictionaryList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImePlugInDictDictionaryList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImePlugInDictDictionaryList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImePlugInDictDictionaryList> for ::windows::core::IUnknown {
-    fn from(value: &IImePlugInDictDictionaryList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImePlugInDictDictionaryList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IImePlugInDictDictionaryList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4429,21 +4170,7 @@ impl IImeSpecifyApplets {
         (::windows::core::Vtable::vtable(self).GetAppletIIDList)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(refiid), ::core::mem::transmute(lpiidlist)).ok()
     }
 }
-impl ::core::convert::From<IImeSpecifyApplets> for ::windows::core::IUnknown {
-    fn from(value: IImeSpecifyApplets) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImeSpecifyApplets> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImeSpecifyApplets) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImeSpecifyApplets> for ::windows::core::IUnknown {
-    fn from(value: &IImeSpecifyApplets) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImeSpecifyApplets, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IImeSpecifyApplets {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ink/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ink/mod.rs
@@ -6,21 +6,7 @@ impl IInkCommitRequestHandler {
         (::windows::core::Vtable::vtable(self).OnCommitRequested)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInkCommitRequestHandler> for ::windows::core::IUnknown {
-    fn from(value: IInkCommitRequestHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkCommitRequestHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkCommitRequestHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkCommitRequestHandler> for ::windows::core::IUnknown {
-    fn from(value: &IInkCommitRequestHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkCommitRequestHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInkCommitRequestHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -64,21 +50,7 @@ impl IInkD2DRenderer {
         (::windows::core::Vtable::vtable(self).Draw)(::windows::core::Vtable::as_raw(self), pd2d1devicecontext.into().abi(), pinkstrokeiterable.into().abi(), fhighcontrast.into()).ok()
     }
 }
-impl ::core::convert::From<IInkD2DRenderer> for ::windows::core::IUnknown {
-    fn from(value: IInkD2DRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkD2DRenderer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkD2DRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkD2DRenderer> for ::windows::core::IUnknown {
-    fn from(value: &IInkD2DRenderer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkD2DRenderer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInkD2DRenderer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -122,21 +94,7 @@ impl IInkD2DRenderer2 {
         (::windows::core::Vtable::vtable(self).Draw)(::windows::core::Vtable::as_raw(self), pd2d1devicecontext.into().abi(), pinkstrokeiterable.into().abi(), highcontrastadjustment).ok()
     }
 }
-impl ::core::convert::From<IInkD2DRenderer2> for ::windows::core::IUnknown {
-    fn from(value: IInkD2DRenderer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkD2DRenderer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkD2DRenderer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkD2DRenderer2> for ::windows::core::IUnknown {
-    fn from(value: &IInkD2DRenderer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkD2DRenderer2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInkD2DRenderer2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -191,21 +149,7 @@ impl IInkDesktopHost {
         (::windows::core::Vtable::vtable(self).CreateAndInitializeInkPresenter)(::windows::core::Vtable::as_raw(self), rootvisual.into().abi(), width, height, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IInkDesktopHost> for ::windows::core::IUnknown {
-    fn from(value: IInkDesktopHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkDesktopHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkDesktopHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkDesktopHost> for ::windows::core::IUnknown {
-    fn from(value: &IInkDesktopHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkDesktopHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInkDesktopHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -244,21 +188,7 @@ impl IInkHostWorkItem {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInkHostWorkItem> for ::windows::core::IUnknown {
-    fn from(value: IInkHostWorkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkHostWorkItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkHostWorkItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkHostWorkItem> for ::windows::core::IUnknown {
-    fn from(value: &IInkHostWorkItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkHostWorkItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInkHostWorkItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -314,21 +244,7 @@ impl IInkPresenterDesktop {
         (::windows::core::Vtable::vtable(self).OnHighContrastChanged)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInkPresenterDesktop> for ::windows::core::IUnknown {
-    fn from(value: IInkPresenterDesktop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkPresenterDesktop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkPresenterDesktop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkPresenterDesktop> for ::windows::core::IUnknown {
-    fn from(value: &IInkPresenterDesktop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkPresenterDesktop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInkPresenterDesktop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Radial/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Radial/mod.rs
@@ -13,36 +13,7 @@ impl IRadialControllerConfigurationInterop {
         (::windows::core::Vtable::vtable(self).GetForWindow)(::windows::core::Vtable::as_raw(self), hwnd.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IRadialControllerConfigurationInterop> for ::windows::core::IUnknown {
-    fn from(value: IRadialControllerConfigurationInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRadialControllerConfigurationInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRadialControllerConfigurationInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRadialControllerConfigurationInterop> for ::windows::core::IUnknown {
-    fn from(value: &IRadialControllerConfigurationInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRadialControllerConfigurationInterop> for ::windows::core::IInspectable {
-    fn from(value: IRadialControllerConfigurationInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRadialControllerConfigurationInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IRadialControllerConfigurationInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRadialControllerConfigurationInterop> for ::windows::core::IInspectable {
-    fn from(value: &IRadialControllerConfigurationInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRadialControllerConfigurationInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IRadialControllerConfigurationInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -89,36 +60,7 @@ impl IRadialControllerIndependentInputSourceInterop {
         (::windows::core::Vtable::vtable(self).CreateForWindow)(::windows::core::Vtable::as_raw(self), hwnd.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IRadialControllerIndependentInputSourceInterop> for ::windows::core::IUnknown {
-    fn from(value: IRadialControllerIndependentInputSourceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRadialControllerIndependentInputSourceInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRadialControllerIndependentInputSourceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRadialControllerIndependentInputSourceInterop> for ::windows::core::IUnknown {
-    fn from(value: &IRadialControllerIndependentInputSourceInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRadialControllerIndependentInputSourceInterop> for ::windows::core::IInspectable {
-    fn from(value: IRadialControllerIndependentInputSourceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRadialControllerIndependentInputSourceInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IRadialControllerIndependentInputSourceInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRadialControllerIndependentInputSourceInterop> for ::windows::core::IInspectable {
-    fn from(value: &IRadialControllerIndependentInputSourceInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRadialControllerIndependentInputSourceInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IRadialControllerIndependentInputSourceInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -165,36 +107,7 @@ impl IRadialControllerInterop {
         (::windows::core::Vtable::vtable(self).CreateForWindow)(::windows::core::Vtable::as_raw(self), hwnd.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IRadialControllerInterop> for ::windows::core::IUnknown {
-    fn from(value: IRadialControllerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRadialControllerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRadialControllerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRadialControllerInterop> for ::windows::core::IUnknown {
-    fn from(value: &IRadialControllerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IRadialControllerInterop> for ::windows::core::IInspectable {
-    fn from(value: IRadialControllerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRadialControllerInterop> for &'a ::windows::core::IInspectable {
-    fn from(value: &'a IRadialControllerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRadialControllerInterop> for ::windows::core::IInspectable {
-    fn from(value: &IRadialControllerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRadialControllerInterop, ::windows::core::IUnknown, ::windows::core::IInspectable);
 impl ::core::clone::Clone for IRadialControllerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
@@ -308,21 +308,7 @@ impl IInertiaProcessor {
         (::windows::core::Vtable::vtable(self).CompleteTime)(::windows::core::Vtable::as_raw(self), timestamp).ok()
     }
 }
-impl ::core::convert::From<IInertiaProcessor> for ::windows::core::IUnknown {
-    fn from(value: IInertiaProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInertiaProcessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInertiaProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInertiaProcessor> for ::windows::core::IUnknown {
-    fn from(value: &IInertiaProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInertiaProcessor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInertiaProcessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -482,21 +468,7 @@ impl IManipulationProcessor {
         (::windows::core::Vtable::vtable(self).SetMinimumScaleRotateRadius)(::windows::core::Vtable::as_raw(self), minradius).ok()
     }
 }
-impl ::core::convert::From<IManipulationProcessor> for ::windows::core::IUnknown {
-    fn from(value: IManipulationProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IManipulationProcessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IManipulationProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IManipulationProcessor> for ::windows::core::IUnknown {
-    fn from(value: &IManipulationProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IManipulationProcessor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IManipulationProcessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -559,21 +531,7 @@ impl _IManipulationEvents {
         (::windows::core::Vtable::vtable(self).ManipulationCompleted)(::windows::core::Vtable::as_raw(self), x, y, cumulativetranslationx, cumulativetranslationy, cumulativescale, cumulativeexpansion, cumulativerotation).ok()
     }
 }
-impl ::core::convert::From<_IManipulationEvents> for ::windows::core::IUnknown {
-    fn from(value: _IManipulationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a _IManipulationEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IManipulationEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&_IManipulationEvents> for ::windows::core::IUnknown {
-    fn from(value: &_IManipulationEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IManipulationEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for _IManipulationEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/mod.rs
@@ -20,21 +20,7 @@ impl IADesktopP2 {
         (::windows::core::Vtable::vtable(self).MakeDynamicChanges)(::windows::core::Vtable::as_raw(self), poleobj.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IADesktopP2> for ::windows::core::IUnknown {
-    fn from(value: IADesktopP2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IADesktopP2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IADesktopP2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IADesktopP2> for ::windows::core::IUnknown {
-    fn from(value: &IADesktopP2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IADesktopP2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IADesktopP2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -89,21 +75,7 @@ impl IActiveDesktopP {
         (::windows::core::Vtable::vtable(self).GetScheme)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwszschemename), ::core::mem::transmute(pdwcchbuffer), dwflags).ok()
     }
 }
-impl ::core::convert::From<IActiveDesktopP> for ::windows::core::IUnknown {
-    fn from(value: IActiveDesktopP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActiveDesktopP> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActiveDesktopP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActiveDesktopP> for ::windows::core::IUnknown {
-    fn from(value: &IActiveDesktopP) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActiveDesktopP, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActiveDesktopP {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -148,21 +120,7 @@ impl IBriefcaseInitiator {
         (::windows::core::Vtable::vtable(self).IsMonikerInBriefcase)(::windows::core::Vtable::as_raw(self), pmk.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IBriefcaseInitiator> for ::windows::core::IUnknown {
-    fn from(value: IBriefcaseInitiator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBriefcaseInitiator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBriefcaseInitiator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBriefcaseInitiator> for ::windows::core::IUnknown {
-    fn from(value: &IBriefcaseInitiator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBriefcaseInitiator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBriefcaseInitiator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -232,21 +190,7 @@ impl IEmptyVolumeCache {
         (::windows::core::Vtable::vtable(self).Deactivate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<EMPTY_VOLUME_CACHE_FLAGS>(result__)
     }
 }
-impl ::core::convert::From<IEmptyVolumeCache> for ::windows::core::IUnknown {
-    fn from(value: IEmptyVolumeCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEmptyVolumeCache> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEmptyVolumeCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEmptyVolumeCache> for ::windows::core::IUnknown {
-    fn from(value: &IEmptyVolumeCache) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEmptyVolumeCache, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEmptyVolumeCache {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -333,36 +277,7 @@ impl IEmptyVolumeCache2 {
         (::windows::core::Vtable::vtable(self).InitializeEx)(::windows::core::Vtable::as_raw(self), hkregkey.into(), pcwszvolume.into(), pcwszkeyname.into(), ::core::mem::transmute(ppwszdisplayname), ::core::mem::transmute(ppwszdescription), ::core::mem::transmute(ppwszbtntext), ::core::mem::transmute(pdwflags)).ok()
     }
 }
-impl ::core::convert::From<IEmptyVolumeCache2> for ::windows::core::IUnknown {
-    fn from(value: IEmptyVolumeCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEmptyVolumeCache2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEmptyVolumeCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEmptyVolumeCache2> for ::windows::core::IUnknown {
-    fn from(value: &IEmptyVolumeCache2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IEmptyVolumeCache2> for IEmptyVolumeCache {
-    fn from(value: IEmptyVolumeCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEmptyVolumeCache2> for &'a IEmptyVolumeCache {
-    fn from(value: &'a IEmptyVolumeCache2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEmptyVolumeCache2> for IEmptyVolumeCache {
-    fn from(value: &IEmptyVolumeCache2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEmptyVolumeCache2, ::windows::core::IUnknown, IEmptyVolumeCache);
 impl ::core::clone::Clone for IEmptyVolumeCache2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -411,21 +326,7 @@ impl IEmptyVolumeCacheCallBack {
         (::windows::core::Vtable::vtable(self).PurgeProgress)(::windows::core::Vtable::as_raw(self), dwlspacefreed, dwlspacetofree, dwflags, pcwszstatus.into()).ok()
     }
 }
-impl ::core::convert::From<IEmptyVolumeCacheCallBack> for ::windows::core::IUnknown {
-    fn from(value: IEmptyVolumeCacheCallBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEmptyVolumeCacheCallBack> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEmptyVolumeCacheCallBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEmptyVolumeCacheCallBack> for ::windows::core::IUnknown {
-    fn from(value: &IEmptyVolumeCacheCallBack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEmptyVolumeCacheCallBack, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEmptyVolumeCacheCallBack {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -475,21 +376,7 @@ impl IReconcilableObject {
         (::windows::core::Vtable::vtable(self).GetProgressFeedbackMaxEstimate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IReconcilableObject> for ::windows::core::IUnknown {
-    fn from(value: IReconcilableObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IReconcilableObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IReconcilableObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IReconcilableObject> for ::windows::core::IUnknown {
-    fn from(value: &IReconcilableObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IReconcilableObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IReconcilableObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -536,21 +423,7 @@ impl IReconcileInitiator {
         (::windows::core::Vtable::vtable(self).SetProgressFeedback)(::windows::core::Vtable::as_raw(self), ulprogress, ulprogressmax).ok()
     }
 }
-impl ::core::convert::From<IReconcileInitiator> for ::windows::core::IUnknown {
-    fn from(value: IReconcileInitiator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IReconcileInitiator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IReconcileInitiator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IReconcileInitiator> for ::windows::core::IUnknown {
-    fn from(value: &IReconcileInitiator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IReconcileInitiator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IReconcileInitiator {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Notifications/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Notifications/mod.rs
@@ -10,21 +10,7 @@ impl INotificationActivationCallback {
         (::windows::core::Vtable::vtable(self).Activate)(::windows::core::Vtable::as_raw(self), appusermodelid.into(), invokedargs.into(), ::core::mem::transmute(data.as_ptr()), data.len() as _).ok()
     }
 }
-impl ::core::convert::From<INotificationActivationCallback> for ::windows::core::IUnknown {
-    fn from(value: INotificationActivationCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INotificationActivationCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INotificationActivationCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INotificationActivationCallback> for ::windows::core::IUnknown {
-    fn from(value: &INotificationActivationCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INotificationActivationCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INotificationActivationCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
@@ -19,21 +19,7 @@ impl IUIApplication {
         (::windows::core::Vtable::vtable(self).OnDestroyUICommand)(::windows::core::Vtable::as_raw(self), commandid, typeid, commandhandler.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIApplication> for ::windows::core::IUnknown {
-    fn from(value: IUIApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIApplication> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIApplication) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIApplication> for ::windows::core::IUnknown {
-    fn from(value: &IUIApplication) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIApplication, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIApplication {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -101,21 +87,7 @@ impl IUICollection {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUICollection> for ::windows::core::IUnknown {
-    fn from(value: IUICollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUICollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUICollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUICollection> for ::windows::core::IUnknown {
-    fn from(value: &IUICollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUICollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUICollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -162,21 +134,7 @@ impl IUICollectionChangedEvent {
         (::windows::core::Vtable::vtable(self).OnChanged)(::windows::core::Vtable::as_raw(self), action, oldindex, olditem.into().abi(), newindex, newitem.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUICollectionChangedEvent> for ::windows::core::IUnknown {
-    fn from(value: IUICollectionChangedEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUICollectionChangedEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUICollectionChangedEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUICollectionChangedEvent> for ::windows::core::IUnknown {
-    fn from(value: &IUICollectionChangedEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUICollectionChangedEvent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUICollectionChangedEvent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -224,21 +182,7 @@ impl IUICommandHandler {
         (::windows::core::Vtable::vtable(self).UpdateProperty)(::windows::core::Vtable::as_raw(self), commandid, ::core::mem::transmute(key), ::core::mem::transmute(currentvalue.unwrap_or(::std::ptr::null())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::StructuredStorage::PROPVARIANT>(result__)
     }
 }
-impl ::core::convert::From<IUICommandHandler> for ::windows::core::IUnknown {
-    fn from(value: IUICommandHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUICommandHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUICommandHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUICommandHandler> for ::windows::core::IUnknown {
-    fn from(value: &IUICommandHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUICommandHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUICommandHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -282,21 +226,7 @@ impl IUIContextualUI {
         (::windows::core::Vtable::vtable(self).ShowAtLocation)(::windows::core::Vtable::as_raw(self), x, y).ok()
     }
 }
-impl ::core::convert::From<IUIContextualUI> for ::windows::core::IUnknown {
-    fn from(value: IUIContextualUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIContextualUI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIContextualUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIContextualUI> for ::windows::core::IUnknown {
-    fn from(value: &IUIContextualUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIContextualUI, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIContextualUI {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -333,21 +263,7 @@ impl IUIEventLogger {
         (::windows::core::Vtable::vtable(self).OnUIEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(peventparams))
     }
 }
-impl ::core::convert::From<IUIEventLogger> for ::windows::core::IUnknown {
-    fn from(value: IUIEventLogger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIEventLogger> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIEventLogger) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIEventLogger> for ::windows::core::IUnknown {
-    fn from(value: &IUIEventLogger) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIEventLogger, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIEventLogger {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -387,21 +303,7 @@ impl IUIEventingManager {
         (::windows::core::Vtable::vtable(self).SetEventLogger)(::windows::core::Vtable::as_raw(self), eventlogger.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIEventingManager> for ::windows::core::IUnknown {
-    fn from(value: IUIEventingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIEventingManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIEventingManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIEventingManager> for ::windows::core::IUnknown {
-    fn from(value: &IUIEventingManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIEventingManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIEventingManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -481,21 +383,7 @@ impl IUIFramework {
         (::windows::core::Vtable::vtable(self).SetModes)(::windows::core::Vtable::as_raw(self), imodes).ok()
     }
 }
-impl ::core::convert::From<IUIFramework> for ::windows::core::IUnknown {
-    fn from(value: IUIFramework) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIFramework> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIFramework) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIFramework> for ::windows::core::IUnknown {
-    fn from(value: &IUIFramework) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIFramework, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIFramework {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -558,21 +446,7 @@ impl IUIImage {
         (::windows::core::Vtable::vtable(self).GetBitmap)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Graphics::Gdi::HBITMAP>(result__)
     }
 }
-impl ::core::convert::From<IUIImage> for ::windows::core::IUnknown {
-    fn from(value: IUIImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIImage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIImage> for ::windows::core::IUnknown {
-    fn from(value: &IUIImage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIImage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIImage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -618,21 +492,7 @@ impl IUIImageFromBitmap {
         (::windows::core::Vtable::vtable(self).CreateImage)(::windows::core::Vtable::as_raw(self), bitmap.into(), options, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IUIImage>(result__)
     }
 }
-impl ::core::convert::From<IUIImageFromBitmap> for ::windows::core::IUnknown {
-    fn from(value: IUIImageFromBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIImageFromBitmap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIImageFromBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIImageFromBitmap> for ::windows::core::IUnknown {
-    fn from(value: &IUIImageFromBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIImageFromBitmap, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIImageFromBitmap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -689,21 +549,7 @@ impl IUIRibbon {
         (::windows::core::Vtable::vtable(self).SaveSettingsToStream)(::windows::core::Vtable::as_raw(self), pstream.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IUIRibbon> for ::windows::core::IUnknown {
-    fn from(value: IUIRibbon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIRibbon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIRibbon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIRibbon> for ::windows::core::IUnknown {
-    fn from(value: &IUIRibbon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIRibbon, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIRibbon {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -751,21 +597,7 @@ impl IUISimplePropertySet {
         (::windows::core::Vtable::vtable(self).GetValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(key), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::StructuredStorage::PROPVARIANT>(result__)
     }
 }
-impl ::core::convert::From<IUISimplePropertySet> for ::windows::core::IUnknown {
-    fn from(value: IUISimplePropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUISimplePropertySet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUISimplePropertySet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUISimplePropertySet> for ::windows::core::IUnknown {
-    fn from(value: &IUISimplePropertySet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUISimplePropertySet, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUISimplePropertySet {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/mod.rs
@@ -14,21 +14,7 @@ impl IObjectArray {
         (::windows::core::Vtable::vtable(self).GetAt)(::windows::core::Vtable::as_raw(self), uiindex, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IObjectArray> for ::windows::core::IUnknown {
-    fn from(value: IObjectArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectArray> for ::windows::core::IUnknown {
-    fn from(value: &IObjectArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectArray, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectArray {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -92,36 +78,7 @@ impl IObjectCollection {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IObjectCollection> for ::windows::core::IUnknown {
-    fn from(value: IObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectCollection> for ::windows::core::IUnknown {
-    fn from(value: &IObjectCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IObjectCollection> for IObjectArray {
-    fn from(value: IObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectCollection> for &'a IObjectArray {
-    fn from(value: &'a IObjectCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectCollection> for IObjectArray {
-    fn from(value: &IObjectCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectCollection, ::windows::core::IUnknown, IObjectArray);
 impl ::core::clone::Clone for IObjectCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
@@ -2622,21 +2622,7 @@ impl ICreateObject {
         (::windows::core::Vtable::vtable(self).CreateObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clsid), punkouter.into().abi(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ICreateObject> for ::windows::core::IUnknown {
-    fn from(value: ICreateObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateObject> for ::windows::core::IUnknown {
-    fn from(value: &ICreateObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICreateObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2692,36 +2678,7 @@ impl IDelayedPropertyStoreFactory {
         (::windows::core::Vtable::vtable(self).GetDelayedPropertyStore)(::windows::core::Vtable::as_raw(self), flags, dwstoreid, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IDelayedPropertyStoreFactory> for ::windows::core::IUnknown {
-    fn from(value: IDelayedPropertyStoreFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDelayedPropertyStoreFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDelayedPropertyStoreFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDelayedPropertyStoreFactory> for ::windows::core::IUnknown {
-    fn from(value: &IDelayedPropertyStoreFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDelayedPropertyStoreFactory> for IPropertyStoreFactory {
-    fn from(value: IDelayedPropertyStoreFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDelayedPropertyStoreFactory> for &'a IPropertyStoreFactory {
-    fn from(value: &'a IDelayedPropertyStoreFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDelayedPropertyStoreFactory> for IPropertyStoreFactory {
-    fn from(value: &IDelayedPropertyStoreFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDelayedPropertyStoreFactory, ::windows::core::IUnknown, IPropertyStoreFactory);
 impl ::core::clone::Clone for IDelayedPropertyStoreFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2761,21 +2718,7 @@ impl IInitializeWithFile {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pszfilepath.into(), grfmode).ok()
     }
 }
-impl ::core::convert::From<IInitializeWithFile> for ::windows::core::IUnknown {
-    fn from(value: IInitializeWithFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeWithFile> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitializeWithFile) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeWithFile> for ::windows::core::IUnknown {
-    fn from(value: &IInitializeWithFile) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitializeWithFile, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInitializeWithFile {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2817,21 +2760,7 @@ impl IInitializeWithStream {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pstream.into().abi(), grfmode).ok()
     }
 }
-impl ::core::convert::From<IInitializeWithStream> for ::windows::core::IUnknown {
-    fn from(value: IInitializeWithStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeWithStream> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitializeWithStream) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeWithStream> for ::windows::core::IUnknown {
-    fn from(value: &IInitializeWithStream) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitializeWithStream, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInitializeWithStream {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2893,21 +2822,7 @@ impl INamedPropertyStore {
         (::windows::core::Vtable::vtable(self).GetNameAt)(::windows::core::Vtable::as_raw(self), iprop, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<INamedPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: INamedPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INamedPropertyStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INamedPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INamedPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: &INamedPropertyStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INamedPropertyStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INamedPropertyStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2957,21 +2872,7 @@ impl IObjectWithPropertyKey {
         (::windows::core::Vtable::vtable(self).GetPropertyKey)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<PROPERTYKEY>(result__)
     }
 }
-impl ::core::convert::From<IObjectWithPropertyKey> for ::windows::core::IUnknown {
-    fn from(value: IObjectWithPropertyKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectWithPropertyKey> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectWithPropertyKey) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectWithPropertyKey> for ::windows::core::IUnknown {
-    fn from(value: &IObjectWithPropertyKey) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectWithPropertyKey, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectWithPropertyKey {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3015,21 +2916,7 @@ impl IPersistSerializedPropStorage {
         (::windows::core::Vtable::vtable(self).GetPropertyStorage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppsps), ::core::mem::transmute(pcb)).ok()
     }
 }
-impl ::core::convert::From<IPersistSerializedPropStorage> for ::windows::core::IUnknown {
-    fn from(value: IPersistSerializedPropStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistSerializedPropStorage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistSerializedPropStorage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistSerializedPropStorage> for ::windows::core::IUnknown {
-    fn from(value: &IPersistSerializedPropStorage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistSerializedPropStorage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPersistSerializedPropStorage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3081,36 +2968,7 @@ impl IPersistSerializedPropStorage2 {
         (::windows::core::Vtable::vtable(self).GetPropertyStorageBuffer)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(psps), cb, ::core::mem::transmute(pcbwritten)).ok()
     }
 }
-impl ::core::convert::From<IPersistSerializedPropStorage2> for ::windows::core::IUnknown {
-    fn from(value: IPersistSerializedPropStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistSerializedPropStorage2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistSerializedPropStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistSerializedPropStorage2> for ::windows::core::IUnknown {
-    fn from(value: &IPersistSerializedPropStorage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPersistSerializedPropStorage2> for IPersistSerializedPropStorage {
-    fn from(value: IPersistSerializedPropStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPersistSerializedPropStorage2> for &'a IPersistSerializedPropStorage {
-    fn from(value: &'a IPersistSerializedPropStorage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPersistSerializedPropStorage2> for IPersistSerializedPropStorage {
-    fn from(value: &IPersistSerializedPropStorage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistSerializedPropStorage2, ::windows::core::IUnknown, IPersistSerializedPropStorage);
 impl ::core::clone::Clone for IPersistSerializedPropStorage2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3158,36 +3016,7 @@ impl IPropertyChange {
         (::windows::core::Vtable::vtable(self).ApplyToPropVariant)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(propvarin), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::super::System::Com::StructuredStorage::PROPVARIANT>(result__)
     }
 }
-impl ::core::convert::From<IPropertyChange> for ::windows::core::IUnknown {
-    fn from(value: IPropertyChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyChange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyChange> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertyChange> for IObjectWithPropertyKey {
-    fn from(value: IPropertyChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyChange> for &'a IObjectWithPropertyKey {
-    fn from(value: &'a IPropertyChange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyChange> for IObjectWithPropertyKey {
-    fn from(value: &IPropertyChange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyChange, ::windows::core::IUnknown, IObjectWithPropertyKey);
 impl ::core::clone::Clone for IPropertyChange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3259,21 +3088,7 @@ impl IPropertyChangeArray {
         (::windows::core::Vtable::vtable(self).IsKeyInArray)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(key)).ok()
     }
 }
-impl ::core::convert::From<IPropertyChangeArray> for ::windows::core::IUnknown {
-    fn from(value: IPropertyChangeArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyChangeArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyChangeArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyChangeArray> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyChangeArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyChangeArray, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyChangeArray {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3411,21 +3226,7 @@ impl IPropertyDescription {
         (::windows::core::Vtable::vtable(self).IsValueCanonical)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(propvar)).ok()
     }
 }
-impl ::core::convert::From<IPropertyDescription> for ::windows::core::IUnknown {
-    fn from(value: IPropertyDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyDescription> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyDescription) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyDescription> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyDescription) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyDescription, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyDescription {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3601,36 +3402,7 @@ impl IPropertyDescription2 {
         (::windows::core::Vtable::vtable(self).GetImageReferenceForValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(propvar), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IPropertyDescription2> for ::windows::core::IUnknown {
-    fn from(value: IPropertyDescription2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyDescription2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyDescription2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyDescription2> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyDescription2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertyDescription2> for IPropertyDescription {
-    fn from(value: IPropertyDescription2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyDescription2> for &'a IPropertyDescription {
-    fn from(value: &'a IPropertyDescription2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyDescription2> for IPropertyDescription {
-    fn from(value: &IPropertyDescription2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyDescription2, ::windows::core::IUnknown, IPropertyDescription);
 impl ::core::clone::Clone for IPropertyDescription2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3779,36 +3551,7 @@ impl IPropertyDescriptionAliasInfo {
         (::windows::core::Vtable::vtable(self).GetAdditionalSortByAliases)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IPropertyDescriptionAliasInfo> for ::windows::core::IUnknown {
-    fn from(value: IPropertyDescriptionAliasInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyDescriptionAliasInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyDescriptionAliasInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyDescriptionAliasInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyDescriptionAliasInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertyDescriptionAliasInfo> for IPropertyDescription {
-    fn from(value: IPropertyDescriptionAliasInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyDescriptionAliasInfo> for &'a IPropertyDescription {
-    fn from(value: &'a IPropertyDescriptionAliasInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyDescriptionAliasInfo> for IPropertyDescription {
-    fn from(value: &IPropertyDescriptionAliasInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyDescriptionAliasInfo, ::windows::core::IUnknown, IPropertyDescription);
 impl ::core::clone::Clone for IPropertyDescriptionAliasInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3854,21 +3597,7 @@ impl IPropertyDescriptionList {
         (::windows::core::Vtable::vtable(self).GetAt)(::windows::core::Vtable::as_raw(self), ielem, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IPropertyDescriptionList> for ::windows::core::IUnknown {
-    fn from(value: IPropertyDescriptionList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyDescriptionList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyDescriptionList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyDescriptionList> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyDescriptionList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyDescriptionList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyDescriptionList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4009,36 +3738,7 @@ impl IPropertyDescriptionRelatedPropertyInfo {
         (::windows::core::Vtable::vtable(self).GetRelatedProperty)(::windows::core::Vtable::as_raw(self), pszrelationshipname.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IPropertyDescriptionRelatedPropertyInfo> for ::windows::core::IUnknown {
-    fn from(value: IPropertyDescriptionRelatedPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyDescriptionRelatedPropertyInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyDescriptionRelatedPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyDescriptionRelatedPropertyInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyDescriptionRelatedPropertyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertyDescriptionRelatedPropertyInfo> for IPropertyDescription {
-    fn from(value: IPropertyDescriptionRelatedPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyDescriptionRelatedPropertyInfo> for &'a IPropertyDescription {
-    fn from(value: &'a IPropertyDescriptionRelatedPropertyInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyDescriptionRelatedPropertyInfo> for IPropertyDescription {
-    fn from(value: &IPropertyDescriptionRelatedPropertyInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyDescriptionRelatedPropertyInfo, ::windows::core::IUnknown, IPropertyDescription);
 impl ::core::clone::Clone for IPropertyDescriptionRelatedPropertyInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4186,36 +3886,7 @@ impl IPropertyDescriptionSearchInfo {
         (::windows::core::Vtable::vtable(self).GetMaxSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IPropertyDescriptionSearchInfo> for ::windows::core::IUnknown {
-    fn from(value: IPropertyDescriptionSearchInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyDescriptionSearchInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyDescriptionSearchInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyDescriptionSearchInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyDescriptionSearchInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertyDescriptionSearchInfo> for IPropertyDescription {
-    fn from(value: IPropertyDescriptionSearchInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyDescriptionSearchInfo> for &'a IPropertyDescription {
-    fn from(value: &'a IPropertyDescriptionSearchInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyDescriptionSearchInfo> for IPropertyDescription {
-    fn from(value: &IPropertyDescriptionSearchInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyDescriptionSearchInfo, ::windows::core::IUnknown, IPropertyDescription);
 impl ::core::clone::Clone for IPropertyDescriptionSearchInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4278,21 +3949,7 @@ impl IPropertyEnumType {
         (::windows::core::Vtable::vtable(self).GetDisplayText)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IPropertyEnumType> for ::windows::core::IUnknown {
-    fn from(value: IPropertyEnumType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyEnumType> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyEnumType) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyEnumType> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyEnumType) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyEnumType, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyEnumType {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4369,36 +4026,7 @@ impl IPropertyEnumType2 {
         (::windows::core::Vtable::vtable(self).GetImageReference)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IPropertyEnumType2> for ::windows::core::IUnknown {
-    fn from(value: IPropertyEnumType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyEnumType2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyEnumType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyEnumType2> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyEnumType2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertyEnumType2> for IPropertyEnumType {
-    fn from(value: IPropertyEnumType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyEnumType2> for &'a IPropertyEnumType {
-    fn from(value: &'a IPropertyEnumType2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyEnumType2> for IPropertyEnumType {
-    fn from(value: &IPropertyEnumType2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyEnumType2, ::windows::core::IUnknown, IPropertyEnumType);
 impl ::core::clone::Clone for IPropertyEnumType2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4456,21 +4084,7 @@ impl IPropertyEnumTypeList {
         (::windows::core::Vtable::vtable(self).FindMatchingIndex)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(propvarcmp), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IPropertyEnumTypeList> for ::windows::core::IUnknown {
-    fn from(value: IPropertyEnumTypeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyEnumTypeList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyEnumTypeList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyEnumTypeList> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyEnumTypeList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyEnumTypeList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyEnumTypeList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4532,21 +4146,7 @@ impl IPropertyStore {
         (::windows::core::Vtable::vtable(self).Commit)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: IPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4629,36 +4229,7 @@ impl IPropertyStoreCache {
         (::windows::core::Vtable::vtable(self).SetValueAndState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(key), ::core::mem::transmute(ppropvar), state).ok()
     }
 }
-impl ::core::convert::From<IPropertyStoreCache> for ::windows::core::IUnknown {
-    fn from(value: IPropertyStoreCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyStoreCache> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyStoreCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyStoreCache> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyStoreCache) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPropertyStoreCache> for IPropertyStore {
-    fn from(value: IPropertyStoreCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyStoreCache> for &'a IPropertyStore {
-    fn from(value: &'a IPropertyStoreCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyStoreCache> for IPropertyStore {
-    fn from(value: &IPropertyStoreCache) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyStoreCache, ::windows::core::IUnknown, IPropertyStore);
 impl ::core::clone::Clone for IPropertyStoreCache {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4704,21 +4275,7 @@ impl IPropertyStoreCapabilities {
         (::windows::core::Vtable::vtable(self).IsPropertyWritable)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(key)).ok()
     }
 }
-impl ::core::convert::From<IPropertyStoreCapabilities> for ::windows::core::IUnknown {
-    fn from(value: IPropertyStoreCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyStoreCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyStoreCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyStoreCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyStoreCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyStoreCapabilities, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyStoreCapabilities {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4767,21 +4324,7 @@ impl IPropertyStoreFactory {
         (::windows::core::Vtable::vtable(self).GetPropertyStoreForKeys)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rgkeys), ckeys, flags, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IPropertyStoreFactory> for ::windows::core::IUnknown {
-    fn from(value: IPropertyStoreFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyStoreFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyStoreFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyStoreFactory> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyStoreFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyStoreFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyStoreFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4872,21 +4415,7 @@ impl IPropertySystem {
         (::windows::core::Vtable::vtable(self).RefreshPropertySchema)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPropertySystem> for ::windows::core::IUnknown {
-    fn from(value: IPropertySystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertySystem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertySystem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertySystem> for ::windows::core::IUnknown {
-    fn from(value: &IPropertySystem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertySystem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertySystem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4937,21 +4466,7 @@ impl IPropertySystemChangeNotify {
         (::windows::core::Vtable::vtable(self).SchemaRefreshed)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPropertySystemChangeNotify> for ::windows::core::IUnknown {
-    fn from(value: IPropertySystemChangeNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertySystemChangeNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertySystemChangeNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertySystemChangeNotify> for ::windows::core::IUnknown {
-    fn from(value: &IPropertySystemChangeNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertySystemChangeNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertySystemChangeNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5016,21 +4531,7 @@ impl IPropertyUI {
         (::windows::core::Vtable::vtable(self).GetHelpInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(fmtid), pid, ::core::mem::transmute(pwszhelpfile.as_ptr()), pwszhelpfile.len() as _, ::core::mem::transmute(puhelpid)).ok()
     }
 }
-impl ::core::convert::From<IPropertyUI> for ::windows::core::IUnknown {
-    fn from(value: IPropertyUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyUI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyUI> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyUI, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyUI {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
@@ -8643,41 +8643,7 @@ impl CIE4ConnectionPoint {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<CIE4ConnectionPoint> for ::windows::core::IUnknown {
-    fn from(value: CIE4ConnectionPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a CIE4ConnectionPoint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a CIE4ConnectionPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&CIE4ConnectionPoint> for ::windows::core::IUnknown {
-    fn from(value: &CIE4ConnectionPoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<CIE4ConnectionPoint> for super::super::System::Com::IConnectionPoint {
-    fn from(value: CIE4ConnectionPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a CIE4ConnectionPoint> for &'a super::super::System::Com::IConnectionPoint {
-    fn from(value: &'a CIE4ConnectionPoint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&CIE4ConnectionPoint> for super::super::System::Com::IConnectionPoint {
-    fn from(value: &CIE4ConnectionPoint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(CIE4ConnectionPoint, ::windows::core::IUnknown, super::super::System::Com::IConnectionPoint);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for CIE4ConnectionPoint {
     fn clone(&self) -> Self {
@@ -8738,41 +8704,7 @@ impl DFConstraint {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DFConstraint> for ::windows::core::IUnknown {
-    fn from(value: DFConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DFConstraint> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DFConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DFConstraint> for ::windows::core::IUnknown {
-    fn from(value: &DFConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DFConstraint> for super::super::System::Com::IDispatch {
-    fn from(value: DFConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DFConstraint> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DFConstraint) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DFConstraint> for super::super::System::Com::IDispatch {
-    fn from(value: &DFConstraint) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DFConstraint, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DFConstraint {
     fn clone(&self) -> Self {
@@ -8819,41 +8751,7 @@ pub struct DShellFolderViewEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DShellFolderViewEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DShellFolderViewEvents> for ::windows::core::IUnknown {
-    fn from(value: DShellFolderViewEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DShellFolderViewEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DShellFolderViewEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DShellFolderViewEvents> for ::windows::core::IUnknown {
-    fn from(value: &DShellFolderViewEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DShellFolderViewEvents> for super::super::System::Com::IDispatch {
-    fn from(value: DShellFolderViewEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DShellFolderViewEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DShellFolderViewEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DShellFolderViewEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &DShellFolderViewEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DShellFolderViewEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DShellFolderViewEvents {
     fn clone(&self) -> Self {
@@ -8895,41 +8793,7 @@ pub struct DShellNameSpaceEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DShellNameSpaceEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DShellNameSpaceEvents> for ::windows::core::IUnknown {
-    fn from(value: DShellNameSpaceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DShellNameSpaceEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DShellNameSpaceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DShellNameSpaceEvents> for ::windows::core::IUnknown {
-    fn from(value: &DShellNameSpaceEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DShellNameSpaceEvents> for super::super::System::Com::IDispatch {
-    fn from(value: DShellNameSpaceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DShellNameSpaceEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DShellNameSpaceEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DShellNameSpaceEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &DShellNameSpaceEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DShellNameSpaceEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DShellNameSpaceEvents {
     fn clone(&self) -> Self {
@@ -8971,41 +8835,7 @@ pub struct DShellWindowsEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DShellWindowsEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DShellWindowsEvents> for ::windows::core::IUnknown {
-    fn from(value: DShellWindowsEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DShellWindowsEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DShellWindowsEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DShellWindowsEvents> for ::windows::core::IUnknown {
-    fn from(value: &DShellWindowsEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DShellWindowsEvents> for super::super::System::Com::IDispatch {
-    fn from(value: DShellWindowsEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DShellWindowsEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DShellWindowsEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DShellWindowsEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &DShellWindowsEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DShellWindowsEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DShellWindowsEvents {
     fn clone(&self) -> Self {
@@ -9047,41 +8877,7 @@ pub struct DWebBrowserEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DWebBrowserEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DWebBrowserEvents> for ::windows::core::IUnknown {
-    fn from(value: DWebBrowserEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DWebBrowserEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DWebBrowserEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DWebBrowserEvents> for ::windows::core::IUnknown {
-    fn from(value: &DWebBrowserEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DWebBrowserEvents> for super::super::System::Com::IDispatch {
-    fn from(value: DWebBrowserEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DWebBrowserEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DWebBrowserEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DWebBrowserEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &DWebBrowserEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DWebBrowserEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DWebBrowserEvents {
     fn clone(&self) -> Self {
@@ -9123,41 +8919,7 @@ pub struct DWebBrowserEvents2(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl DWebBrowserEvents2 {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DWebBrowserEvents2> for ::windows::core::IUnknown {
-    fn from(value: DWebBrowserEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DWebBrowserEvents2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a DWebBrowserEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DWebBrowserEvents2> for ::windows::core::IUnknown {
-    fn from(value: &DWebBrowserEvents2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<DWebBrowserEvents2> for super::super::System::Com::IDispatch {
-    fn from(value: DWebBrowserEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a DWebBrowserEvents2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a DWebBrowserEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&DWebBrowserEvents2> for super::super::System::Com::IDispatch {
-    fn from(value: &DWebBrowserEvents2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(DWebBrowserEvents2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for DWebBrowserEvents2 {
     fn clone(&self) -> Self {
@@ -9269,41 +9031,7 @@ impl Folder {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Folder> for ::windows::core::IUnknown {
-    fn from(value: Folder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Folder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Folder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Folder> for ::windows::core::IUnknown {
-    fn from(value: &Folder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Folder> for super::super::System::Com::IDispatch {
-    fn from(value: Folder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Folder> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a Folder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Folder> for super::super::System::Com::IDispatch {
-    fn from(value: &Folder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Folder, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Folder {
     fn clone(&self) -> Self {
@@ -9472,59 +9200,7 @@ impl Folder2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Folder2> for ::windows::core::IUnknown {
-    fn from(value: Folder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Folder2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Folder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Folder2> for ::windows::core::IUnknown {
-    fn from(value: &Folder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Folder2> for super::super::System::Com::IDispatch {
-    fn from(value: Folder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Folder2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a Folder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Folder2> for super::super::System::Com::IDispatch {
-    fn from(value: &Folder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Folder2> for Folder {
-    fn from(value: Folder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Folder2> for &'a Folder {
-    fn from(value: &'a Folder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Folder2> for Folder {
-    fn from(value: &Folder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Folder2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, Folder);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Folder2 {
     fn clone(&self) -> Self {
@@ -9671,77 +9347,7 @@ impl Folder3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Folder3> for ::windows::core::IUnknown {
-    fn from(value: Folder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Folder3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a Folder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Folder3> for ::windows::core::IUnknown {
-    fn from(value: &Folder3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Folder3> for super::super::System::Com::IDispatch {
-    fn from(value: Folder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Folder3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a Folder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Folder3> for super::super::System::Com::IDispatch {
-    fn from(value: &Folder3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Folder3> for Folder {
-    fn from(value: Folder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Folder3> for &'a Folder {
-    fn from(value: &'a Folder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Folder3> for Folder {
-    fn from(value: &Folder3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<Folder3> for Folder2 {
-    fn from(value: Folder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a Folder3> for &'a Folder2 {
-    fn from(value: &'a Folder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&Folder3> for Folder2 {
-    fn from(value: &Folder3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(Folder3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, Folder, Folder2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for Folder3 {
     fn clone(&self) -> Self {
@@ -9866,41 +9472,7 @@ impl FolderItem {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItem> for ::windows::core::IUnknown {
-    fn from(value: FolderItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a FolderItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItem> for ::windows::core::IUnknown {
-    fn from(value: &FolderItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItem> for super::super::System::Com::IDispatch {
-    fn from(value: FolderItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItem> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a FolderItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItem> for super::super::System::Com::IDispatch {
-    fn from(value: &FolderItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(FolderItem, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for FolderItem {
     fn clone(&self) -> Self {
@@ -10073,59 +9645,7 @@ impl FolderItem2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItem2> for ::windows::core::IUnknown {
-    fn from(value: FolderItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a FolderItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItem2> for ::windows::core::IUnknown {
-    fn from(value: &FolderItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItem2> for super::super::System::Com::IDispatch {
-    fn from(value: FolderItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItem2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a FolderItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItem2> for super::super::System::Com::IDispatch {
-    fn from(value: &FolderItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItem2> for FolderItem {
-    fn from(value: FolderItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItem2> for &'a FolderItem {
-    fn from(value: &'a FolderItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItem2> for FolderItem {
-    fn from(value: &FolderItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(FolderItem2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, FolderItem);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for FolderItem2 {
     fn clone(&self) -> Self {
@@ -10195,41 +9715,7 @@ impl FolderItemVerb {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItemVerb> for ::windows::core::IUnknown {
-    fn from(value: FolderItemVerb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItemVerb> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a FolderItemVerb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItemVerb> for ::windows::core::IUnknown {
-    fn from(value: &FolderItemVerb) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItemVerb> for super::super::System::Com::IDispatch {
-    fn from(value: FolderItemVerb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItemVerb> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a FolderItemVerb) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItemVerb> for super::super::System::Com::IDispatch {
-    fn from(value: &FolderItemVerb) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(FolderItemVerb, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for FolderItemVerb {
     fn clone(&self) -> Self {
@@ -10311,41 +9797,7 @@ impl FolderItemVerbs {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItemVerbs> for ::windows::core::IUnknown {
-    fn from(value: FolderItemVerbs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItemVerbs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a FolderItemVerbs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItemVerbs> for ::windows::core::IUnknown {
-    fn from(value: &FolderItemVerbs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItemVerbs> for super::super::System::Com::IDispatch {
-    fn from(value: FolderItemVerbs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItemVerbs> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a FolderItemVerbs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItemVerbs> for super::super::System::Com::IDispatch {
-    fn from(value: &FolderItemVerbs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(FolderItemVerbs, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for FolderItemVerbs {
     fn clone(&self) -> Self {
@@ -10431,41 +9883,7 @@ impl FolderItems {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItems> for ::windows::core::IUnknown {
-    fn from(value: FolderItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a FolderItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItems> for ::windows::core::IUnknown {
-    fn from(value: &FolderItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItems> for super::super::System::Com::IDispatch {
-    fn from(value: FolderItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItems> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a FolderItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItems> for super::super::System::Com::IDispatch {
-    fn from(value: &FolderItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(FolderItems, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for FolderItems {
     fn clone(&self) -> Self {
@@ -10560,59 +9978,7 @@ impl FolderItems2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItems2> for ::windows::core::IUnknown {
-    fn from(value: FolderItems2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItems2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a FolderItems2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItems2> for ::windows::core::IUnknown {
-    fn from(value: &FolderItems2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItems2> for super::super::System::Com::IDispatch {
-    fn from(value: FolderItems2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItems2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a FolderItems2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItems2> for super::super::System::Com::IDispatch {
-    fn from(value: &FolderItems2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItems2> for FolderItems {
-    fn from(value: FolderItems2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItems2> for &'a FolderItems {
-    fn from(value: &'a FolderItems2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItems2> for FolderItems {
-    fn from(value: &FolderItems2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(FolderItems2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, FolderItems);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for FolderItems2 {
     fn clone(&self) -> Self {
@@ -10706,77 +10072,7 @@ impl FolderItems3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItems3> for ::windows::core::IUnknown {
-    fn from(value: FolderItems3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItems3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a FolderItems3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItems3> for ::windows::core::IUnknown {
-    fn from(value: &FolderItems3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItems3> for super::super::System::Com::IDispatch {
-    fn from(value: FolderItems3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItems3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a FolderItems3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItems3> for super::super::System::Com::IDispatch {
-    fn from(value: &FolderItems3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItems3> for FolderItems {
-    fn from(value: FolderItems3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItems3> for &'a FolderItems {
-    fn from(value: &'a FolderItems3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItems3> for FolderItems {
-    fn from(value: &FolderItems3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<FolderItems3> for FolderItems2 {
-    fn from(value: FolderItems3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a FolderItems3> for &'a FolderItems2 {
-    fn from(value: &'a FolderItems3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&FolderItems3> for FolderItems2 {
-    fn from(value: &FolderItems3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(FolderItems3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, FolderItems, FolderItems2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for FolderItems3 {
     fn clone(&self) -> Self {
@@ -10827,21 +10123,7 @@ impl IACList {
         (::windows::core::Vtable::vtable(self).Expand)(::windows::core::Vtable::as_raw(self), pszexpand.into()).ok()
     }
 }
-impl ::core::convert::From<IACList> for ::windows::core::IUnknown {
-    fn from(value: IACList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IACList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IACList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IACList> for ::windows::core::IUnknown {
-    fn from(value: &IACList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IACList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IACList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10888,36 +10170,7 @@ impl IACList2 {
         (::windows::core::Vtable::vtable(self).GetOptions)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IACList2> for ::windows::core::IUnknown {
-    fn from(value: IACList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IACList2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IACList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IACList2> for ::windows::core::IUnknown {
-    fn from(value: &IACList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IACList2> for IACList {
-    fn from(value: IACList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IACList2> for &'a IACList {
-    fn from(value: &'a IACList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IACList2> for IACList {
-    fn from(value: &IACList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IACList2, ::windows::core::IUnknown, IACList);
 impl ::core::clone::Clone for IACList2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10978,21 +10231,7 @@ impl IAccessibilityDockingService {
         (::windows::core::Vtable::vtable(self).UndockWindow)(::windows::core::Vtable::as_raw(self), hwnd.into()).ok()
     }
 }
-impl ::core::convert::From<IAccessibilityDockingService> for ::windows::core::IUnknown {
-    fn from(value: IAccessibilityDockingService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccessibilityDockingService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccessibilityDockingService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccessibilityDockingService> for ::windows::core::IUnknown {
-    fn from(value: &IAccessibilityDockingService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccessibilityDockingService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccessibilityDockingService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11040,21 +10279,7 @@ impl IAccessibilityDockingServiceCallback {
         (::windows::core::Vtable::vtable(self).Undocked)(::windows::core::Vtable::as_raw(self), undockreason).ok()
     }
 }
-impl ::core::convert::From<IAccessibilityDockingServiceCallback> for ::windows::core::IUnknown {
-    fn from(value: IAccessibilityDockingServiceCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccessibilityDockingServiceCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccessibilityDockingServiceCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccessibilityDockingServiceCallback> for ::windows::core::IUnknown {
-    fn from(value: &IAccessibilityDockingServiceCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccessibilityDockingServiceCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccessibilityDockingServiceCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11094,21 +10319,7 @@ impl IAccessibleObject {
         (::windows::core::Vtable::vtable(self).SetAccessibleName)(::windows::core::Vtable::as_raw(self), pszname.into()).ok()
     }
 }
-impl ::core::convert::From<IAccessibleObject> for ::windows::core::IUnknown {
-    fn from(value: IAccessibleObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccessibleObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccessibleObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccessibleObject> for ::windows::core::IUnknown {
-    fn from(value: &IAccessibleObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccessibleObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccessibleObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11169,21 +10380,7 @@ impl IActionProgress {
         (::windows::core::Vtable::vtable(self).End)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IActionProgress> for ::windows::core::IUnknown {
-    fn from(value: IActionProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActionProgress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActionProgress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActionProgress> for ::windows::core::IUnknown {
-    fn from(value: &IActionProgress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActionProgress, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActionProgress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11238,21 +10435,7 @@ impl IActionProgressDialog {
         (::windows::core::Vtable::vtable(self).Stop)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IActionProgressDialog> for ::windows::core::IUnknown {
-    fn from(value: IActionProgressDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IActionProgressDialog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IActionProgressDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IActionProgressDialog> for ::windows::core::IUnknown {
-    fn from(value: &IActionProgressDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IActionProgressDialog, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IActionProgressDialog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11313,21 +10496,7 @@ impl IAppActivationUIInfo {
         (::windows::core::Vtable::vtable(self).GetKeyState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAppActivationUIInfo> for ::windows::core::IUnknown {
-    fn from(value: IAppActivationUIInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppActivationUIInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppActivationUIInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppActivationUIInfo> for ::windows::core::IUnknown {
-    fn from(value: &IAppActivationUIInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppActivationUIInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppActivationUIInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11390,21 +10559,7 @@ impl IAppPublisher {
         (::windows::core::Vtable::vtable(self).EnumApps)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pappcategoryid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumPublishedApps>(result__)
     }
 }
-impl ::core::convert::From<IAppPublisher> for ::windows::core::IUnknown {
-    fn from(value: IAppPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppPublisher> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppPublisher) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppPublisher> for ::windows::core::IUnknown {
-    fn from(value: &IAppPublisher) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppPublisher, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppPublisher {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11466,21 +10621,7 @@ impl IAppVisibility {
         (::windows::core::Vtable::vtable(self).Unadvise)(::windows::core::Vtable::as_raw(self), dwcookie).ok()
     }
 }
-impl ::core::convert::From<IAppVisibility> for ::windows::core::IUnknown {
-    fn from(value: IAppVisibility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppVisibility> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppVisibility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppVisibility> for ::windows::core::IUnknown {
-    fn from(value: &IAppVisibility) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppVisibility, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppVisibility {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11539,21 +10680,7 @@ impl IAppVisibilityEvents {
         (::windows::core::Vtable::vtable(self).LauncherVisibilityChange)(::windows::core::Vtable::as_raw(self), currentvisiblestate.into()).ok()
     }
 }
-impl ::core::convert::From<IAppVisibilityEvents> for ::windows::core::IUnknown {
-    fn from(value: IAppVisibilityEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAppVisibilityEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAppVisibilityEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAppVisibilityEvents> for ::windows::core::IUnknown {
-    fn from(value: &IAppVisibilityEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAppVisibilityEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAppVisibilityEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11619,21 +10746,7 @@ impl IApplicationActivationManager {
         (::windows::core::Vtable::vtable(self).ActivateForProtocol)(::windows::core::Vtable::as_raw(self), appusermodelid.into(), itemarray.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IApplicationActivationManager> for ::windows::core::IUnknown {
-    fn from(value: IApplicationActivationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationActivationManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApplicationActivationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationActivationManager> for ::windows::core::IUnknown {
-    fn from(value: &IApplicationActivationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApplicationActivationManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApplicationActivationManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11711,21 +10824,7 @@ impl IApplicationAssociationRegistration {
         (::windows::core::Vtable::vtable(self).ClearUserAssociations)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IApplicationAssociationRegistration> for ::windows::core::IUnknown {
-    fn from(value: IApplicationAssociationRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationAssociationRegistration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApplicationAssociationRegistration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationAssociationRegistration> for ::windows::core::IUnknown {
-    fn from(value: &IApplicationAssociationRegistration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApplicationAssociationRegistration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApplicationAssociationRegistration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11776,21 +10875,7 @@ impl IApplicationAssociationRegistrationUI {
         (::windows::core::Vtable::vtable(self).LaunchAdvancedAssociationUI)(::windows::core::Vtable::as_raw(self), pszappregistryname.into()).ok()
     }
 }
-impl ::core::convert::From<IApplicationAssociationRegistrationUI> for ::windows::core::IUnknown {
-    fn from(value: IApplicationAssociationRegistrationUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationAssociationRegistrationUI> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApplicationAssociationRegistrationUI) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationAssociationRegistrationUI> for ::windows::core::IUnknown {
-    fn from(value: &IApplicationAssociationRegistrationUI) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApplicationAssociationRegistrationUI, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApplicationAssociationRegistrationUI {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11852,21 +10937,7 @@ impl IApplicationDesignModeSettings {
         (::windows::core::Vtable::vtable(self).TriggerEdgeGesture)(::windows::core::Vtable::as_raw(self), edgegesturekind).ok()
     }
 }
-impl ::core::convert::From<IApplicationDesignModeSettings> for ::windows::core::IUnknown {
-    fn from(value: IApplicationDesignModeSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationDesignModeSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApplicationDesignModeSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationDesignModeSettings> for ::windows::core::IUnknown {
-    fn from(value: &IApplicationDesignModeSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApplicationDesignModeSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApplicationDesignModeSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11976,36 +11047,7 @@ impl IApplicationDesignModeSettings2 {
         (::windows::core::Vtable::vtable(self).GetApplicationViewOrientation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(applicationsizepixels), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<APPLICATION_VIEW_ORIENTATION>(result__)
     }
 }
-impl ::core::convert::From<IApplicationDesignModeSettings2> for ::windows::core::IUnknown {
-    fn from(value: IApplicationDesignModeSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationDesignModeSettings2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApplicationDesignModeSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationDesignModeSettings2> for ::windows::core::IUnknown {
-    fn from(value: &IApplicationDesignModeSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IApplicationDesignModeSettings2> for IApplicationDesignModeSettings {
-    fn from(value: IApplicationDesignModeSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationDesignModeSettings2> for &'a IApplicationDesignModeSettings {
-    fn from(value: &'a IApplicationDesignModeSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationDesignModeSettings2> for IApplicationDesignModeSettings {
-    fn from(value: &IApplicationDesignModeSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApplicationDesignModeSettings2, ::windows::core::IUnknown, IApplicationDesignModeSettings);
 impl ::core::clone::Clone for IApplicationDesignModeSettings2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12069,21 +11111,7 @@ impl IApplicationDestinations {
         (::windows::core::Vtable::vtable(self).RemoveAllDestinations)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IApplicationDestinations> for ::windows::core::IUnknown {
-    fn from(value: IApplicationDestinations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationDestinations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApplicationDestinations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationDestinations> for ::windows::core::IUnknown {
-    fn from(value: &IApplicationDestinations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApplicationDestinations, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApplicationDestinations {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12132,21 +11160,7 @@ impl IApplicationDocumentLists {
         (::windows::core::Vtable::vtable(self).GetList)(::windows::core::Vtable::as_raw(self), listtype, citemsdesired, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IApplicationDocumentLists> for ::windows::core::IUnknown {
-    fn from(value: IApplicationDocumentLists) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IApplicationDocumentLists> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IApplicationDocumentLists) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IApplicationDocumentLists> for ::windows::core::IUnknown {
-    fn from(value: &IApplicationDocumentLists) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IApplicationDocumentLists, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IApplicationDocumentLists {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12218,21 +11232,7 @@ impl IAssocHandler {
         (::windows::core::Vtable::vtable(self).CreateInvoker)(::windows::core::Vtable::as_raw(self), pdo.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAssocHandlerInvoker>(result__)
     }
 }
-impl ::core::convert::From<IAssocHandler> for ::windows::core::IUnknown {
-    fn from(value: IAssocHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAssocHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAssocHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAssocHandler> for ::windows::core::IUnknown {
-    fn from(value: &IAssocHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAssocHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAssocHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12284,21 +11284,7 @@ impl IAssocHandlerInvoker {
         (::windows::core::Vtable::vtable(self).Invoke)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAssocHandlerInvoker> for ::windows::core::IUnknown {
-    fn from(value: IAssocHandlerInvoker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAssocHandlerInvoker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAssocHandlerInvoker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAssocHandlerInvoker> for ::windows::core::IUnknown {
-    fn from(value: &IAssocHandlerInvoker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAssocHandlerInvoker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAssocHandlerInvoker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12402,21 +11388,7 @@ impl IAttachmentExecute {
         (::windows::core::Vtable::vtable(self).ClearClientState)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAttachmentExecute> for ::windows::core::IUnknown {
-    fn from(value: IAttachmentExecute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAttachmentExecute> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAttachmentExecute) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAttachmentExecute> for ::windows::core::IUnknown {
-    fn from(value: &IAttachmentExecute) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAttachmentExecute, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAttachmentExecute {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12489,21 +11461,7 @@ impl IAutoComplete {
         (::windows::core::Vtable::vtable(self).Enable)(::windows::core::Vtable::as_raw(self), fenable.into()).ok()
     }
 }
-impl ::core::convert::From<IAutoComplete> for ::windows::core::IUnknown {
-    fn from(value: IAutoComplete) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAutoComplete> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAutoComplete) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAutoComplete> for ::windows::core::IUnknown {
-    fn from(value: &IAutoComplete) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAutoComplete, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAutoComplete {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12570,36 +11528,7 @@ impl IAutoComplete2 {
         (::windows::core::Vtable::vtable(self).GetOptions)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IAutoComplete2> for ::windows::core::IUnknown {
-    fn from(value: IAutoComplete2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAutoComplete2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAutoComplete2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAutoComplete2> for ::windows::core::IUnknown {
-    fn from(value: &IAutoComplete2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IAutoComplete2> for IAutoComplete {
-    fn from(value: IAutoComplete2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAutoComplete2> for &'a IAutoComplete {
-    fn from(value: &'a IAutoComplete2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAutoComplete2> for IAutoComplete {
-    fn from(value: &IAutoComplete2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAutoComplete2, ::windows::core::IUnknown, IAutoComplete);
 impl ::core::clone::Clone for IAutoComplete2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12640,21 +11569,7 @@ impl IAutoCompleteDropDown {
         (::windows::core::Vtable::vtable(self).ResetEnumerator)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IAutoCompleteDropDown> for ::windows::core::IUnknown {
-    fn from(value: IAutoCompleteDropDown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAutoCompleteDropDown> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAutoCompleteDropDown) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAutoCompleteDropDown> for ::windows::core::IUnknown {
-    fn from(value: &IAutoCompleteDropDown) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAutoCompleteDropDown, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAutoCompleteDropDown {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12711,21 +11626,7 @@ impl IBandHost {
         (::windows::core::Vtable::vtable(self).DestroyBand)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsidband)).ok()
     }
 }
-impl ::core::convert::From<IBandHost> for ::windows::core::IUnknown {
-    fn from(value: IBandHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBandHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBandHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBandHost> for ::windows::core::IUnknown {
-    fn from(value: &IBandHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBandHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBandHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12801,21 +11702,7 @@ impl IBandSite {
         (::windows::core::Vtable::vtable(self).GetBandSiteInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbsinfo)).ok()
     }
 }
-impl ::core::convert::From<IBandSite> for ::windows::core::IUnknown {
-    fn from(value: IBandSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBandSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBandSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBandSite> for ::windows::core::IUnknown {
-    fn from(value: &IBandSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBandSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBandSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12862,21 +11749,7 @@ impl IBannerNotificationHandler {
         (::windows::core::Vtable::vtable(self).OnBannerEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(notification)).ok()
     }
 }
-impl ::core::convert::From<IBannerNotificationHandler> for ::windows::core::IUnknown {
-    fn from(value: IBannerNotificationHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBannerNotificationHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBannerNotificationHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBannerNotificationHandler> for ::windows::core::IUnknown {
-    fn from(value: &IBannerNotificationHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBannerNotificationHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBannerNotificationHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12931,21 +11804,7 @@ impl IBanneredBar {
         (::windows::core::Vtable::vtable(self).GetBitmap)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Graphics::Gdi::HBITMAP>(result__)
     }
 }
-impl ::core::convert::From<IBanneredBar> for ::windows::core::IUnknown {
-    fn from(value: IBanneredBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBanneredBar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBanneredBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBanneredBar> for ::windows::core::IUnknown {
-    fn from(value: &IBanneredBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBanneredBar, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBanneredBar {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12992,21 +11851,7 @@ impl IBrowserFrameOptions {
         (::windows::core::Vtable::vtable(self).GetFrameOptions)(::windows::core::Vtable::as_raw(self), dwmask, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IBrowserFrameOptions> for ::windows::core::IUnknown {
-    fn from(value: IBrowserFrameOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBrowserFrameOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBrowserFrameOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBrowserFrameOptions> for ::windows::core::IUnknown {
-    fn from(value: &IBrowserFrameOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBrowserFrameOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBrowserFrameOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13214,21 +12059,7 @@ impl IBrowserService {
         (::windows::core::Vtable::vtable(self).RegisterWindow)(::windows::core::Vtable::as_raw(self), fforceregister.into(), swc).ok()
     }
 }
-impl ::core::convert::From<IBrowserService> for ::windows::core::IUnknown {
-    fn from(value: IBrowserService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBrowserService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBrowserService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBrowserService> for ::windows::core::IUnknown {
-    fn from(value: &IBrowserService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBrowserService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBrowserService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -13863,36 +12694,7 @@ impl IBrowserService2 {
         (::windows::core::Vtable::vtable(self).v_CheckZoneCrossing)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidl)).ok()
     }
 }
-impl ::core::convert::From<IBrowserService2> for ::windows::core::IUnknown {
-    fn from(value: IBrowserService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBrowserService2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBrowserService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBrowserService2> for ::windows::core::IUnknown {
-    fn from(value: &IBrowserService2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBrowserService2> for IBrowserService {
-    fn from(value: IBrowserService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBrowserService2> for &'a IBrowserService {
-    fn from(value: &'a IBrowserService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBrowserService2> for IBrowserService {
-    fn from(value: &IBrowserService2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBrowserService2, ::windows::core::IUnknown, IBrowserService);
 impl ::core::clone::Clone for IBrowserService2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -14621,51 +13423,7 @@ impl IBrowserService3 {
         (::windows::core::Vtable::vtable(self).IEParseDisplayNameEx)(::windows::core::Vtable::as_raw(self), uicp, pwszpath.into(), dwflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut Common::ITEMIDLIST>(result__)
     }
 }
-impl ::core::convert::From<IBrowserService3> for ::windows::core::IUnknown {
-    fn from(value: IBrowserService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBrowserService3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBrowserService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBrowserService3> for ::windows::core::IUnknown {
-    fn from(value: &IBrowserService3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBrowserService3> for IBrowserService {
-    fn from(value: IBrowserService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBrowserService3> for &'a IBrowserService {
-    fn from(value: &'a IBrowserService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBrowserService3> for IBrowserService {
-    fn from(value: &IBrowserService3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBrowserService3> for IBrowserService2 {
-    fn from(value: IBrowserService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBrowserService3> for &'a IBrowserService2 {
-    fn from(value: &'a IBrowserService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBrowserService3> for IBrowserService2 {
-    fn from(value: &IBrowserService3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBrowserService3, ::windows::core::IUnknown, IBrowserService, IBrowserService2);
 impl ::core::clone::Clone for IBrowserService3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15252,66 +14010,7 @@ impl IBrowserService4 {
         (::windows::core::Vtable::vtable(self)._ResizeAllBorders)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IBrowserService4> for ::windows::core::IUnknown {
-    fn from(value: IBrowserService4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBrowserService4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBrowserService4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBrowserService4> for ::windows::core::IUnknown {
-    fn from(value: &IBrowserService4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBrowserService4> for IBrowserService {
-    fn from(value: IBrowserService4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBrowserService4> for &'a IBrowserService {
-    fn from(value: &'a IBrowserService4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBrowserService4> for IBrowserService {
-    fn from(value: &IBrowserService4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBrowserService4> for IBrowserService2 {
-    fn from(value: IBrowserService4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBrowserService4> for &'a IBrowserService2 {
-    fn from(value: &'a IBrowserService4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBrowserService4> for IBrowserService2 {
-    fn from(value: &IBrowserService4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IBrowserService4> for IBrowserService3 {
-    fn from(value: IBrowserService4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBrowserService4> for &'a IBrowserService3 {
-    fn from(value: &'a IBrowserService4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBrowserService4> for IBrowserService3 {
-    fn from(value: &IBrowserService4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBrowserService4, ::windows::core::IUnknown, IBrowserService, IBrowserService2, IBrowserService3);
 impl ::core::clone::Clone for IBrowserService4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15367,21 +14066,7 @@ impl ICDBurn {
         (::windows::core::Vtable::vtable(self).HasRecordableDrive)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ICDBurn> for ::windows::core::IUnknown {
-    fn from(value: ICDBurn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICDBurn> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICDBurn) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICDBurn> for ::windows::core::IUnknown {
-    fn from(value: &ICDBurn) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICDBurn, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICDBurn {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15427,21 +14112,7 @@ impl ICDBurnExt {
         (::windows::core::Vtable::vtable(self).GetSupportedActionTypes)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ICDBurnExt> for ::windows::core::IUnknown {
-    fn from(value: ICDBurnExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICDBurnExt> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICDBurnExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICDBurnExt> for ::windows::core::IUnknown {
-    fn from(value: &ICDBurnExt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICDBurnExt, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICDBurnExt {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15491,21 +14162,7 @@ impl ICategorizer {
         (::windows::core::Vtable::vtable(self).CompareCategory)(::windows::core::Vtable::as_raw(self), csfflags, dwcategoryid1, dwcategoryid2).ok()
     }
 }
-impl ::core::convert::From<ICategorizer> for ::windows::core::IUnknown {
-    fn from(value: ICategorizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICategorizer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICategorizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICategorizer> for ::windows::core::IUnknown {
-    fn from(value: &ICategorizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICategorizer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICategorizer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15577,21 +14234,7 @@ impl ICategoryProvider {
         (::windows::core::Vtable::vtable(self).CreateCategory)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguid), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ICategoryProvider> for ::windows::core::IUnknown {
-    fn from(value: ICategoryProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICategoryProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICategoryProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICategoryProvider> for ::windows::core::IUnknown {
-    fn from(value: &ICategoryProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICategoryProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICategoryProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15666,21 +14309,7 @@ impl IColumnManager {
         (::windows::core::Vtable::vtable(self).SetColumns)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rgkeyorder.as_ptr()), rgkeyorder.len() as _).ok()
     }
 }
-impl ::core::convert::From<IColumnManager> for ::windows::core::IUnknown {
-    fn from(value: IColumnManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IColumnManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IColumnManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IColumnManager> for ::windows::core::IUnknown {
-    fn from(value: &IColumnManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IColumnManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IColumnManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15745,21 +14374,7 @@ impl IColumnProvider {
         (::windows::core::Vtable::vtable(self).GetItemData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pscid), ::core::mem::transmute(pscd), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<IColumnProvider> for ::windows::core::IUnknown {
-    fn from(value: IColumnProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IColumnProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IColumnProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IColumnProvider> for ::windows::core::IUnknown {
-    fn from(value: &IColumnProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IColumnProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IColumnProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15825,21 +14440,7 @@ impl ICommDlgBrowser {
         (::windows::core::Vtable::vtable(self).IncludeObject)(::windows::core::Vtable::as_raw(self), ppshv.into().abi(), ::core::mem::transmute(pidl)).ok()
     }
 }
-impl ::core::convert::From<ICommDlgBrowser> for ::windows::core::IUnknown {
-    fn from(value: ICommDlgBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommDlgBrowser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommDlgBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommDlgBrowser> for ::windows::core::IUnknown {
-    fn from(value: &ICommDlgBrowser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommDlgBrowser, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICommDlgBrowser {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -15928,36 +14529,7 @@ impl ICommDlgBrowser2 {
         (::windows::core::Vtable::vtable(self).GetViewFlags)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ICommDlgBrowser2> for ::windows::core::IUnknown {
-    fn from(value: ICommDlgBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommDlgBrowser2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommDlgBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommDlgBrowser2> for ::windows::core::IUnknown {
-    fn from(value: &ICommDlgBrowser2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICommDlgBrowser2> for ICommDlgBrowser {
-    fn from(value: ICommDlgBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommDlgBrowser2> for &'a ICommDlgBrowser {
-    fn from(value: &'a ICommDlgBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommDlgBrowser2> for ICommDlgBrowser {
-    fn from(value: &ICommDlgBrowser2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommDlgBrowser2, ::windows::core::IUnknown, ICommDlgBrowser);
 impl ::core::clone::Clone for ICommDlgBrowser2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16062,51 +14634,7 @@ impl ICommDlgBrowser3 {
         (::windows::core::Vtable::vtable(self).OnPreViewCreated)(::windows::core::Vtable::as_raw(self), ppshv.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ICommDlgBrowser3> for ::windows::core::IUnknown {
-    fn from(value: ICommDlgBrowser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommDlgBrowser3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICommDlgBrowser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommDlgBrowser3> for ::windows::core::IUnknown {
-    fn from(value: &ICommDlgBrowser3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICommDlgBrowser3> for ICommDlgBrowser {
-    fn from(value: ICommDlgBrowser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommDlgBrowser3> for &'a ICommDlgBrowser {
-    fn from(value: &'a ICommDlgBrowser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommDlgBrowser3> for ICommDlgBrowser {
-    fn from(value: &ICommDlgBrowser3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICommDlgBrowser3> for ICommDlgBrowser2 {
-    fn from(value: ICommDlgBrowser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICommDlgBrowser3> for &'a ICommDlgBrowser2 {
-    fn from(value: &'a ICommDlgBrowser3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICommDlgBrowser3> for ICommDlgBrowser2 {
-    fn from(value: &ICommDlgBrowser3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICommDlgBrowser3, ::windows::core::IUnknown, ICommDlgBrowser, ICommDlgBrowser2);
 impl ::core::clone::Clone for ICommDlgBrowser3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16151,21 +14679,7 @@ impl IComputerInfoChangeNotify {
         (::windows::core::Vtable::vtable(self).ComputerInfoChanged)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IComputerInfoChangeNotify> for ::windows::core::IUnknown {
-    fn from(value: IComputerInfoChangeNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IComputerInfoChangeNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IComputerInfoChangeNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IComputerInfoChangeNotify> for ::windows::core::IUnknown {
-    fn from(value: &IComputerInfoChangeNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IComputerInfoChangeNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IComputerInfoChangeNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16287,36 +14801,7 @@ impl IConnectableCredentialProviderCredential {
         (::windows::core::Vtable::vtable(self).Disconnect)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IConnectableCredentialProviderCredential> for ::windows::core::IUnknown {
-    fn from(value: IConnectableCredentialProviderCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConnectableCredentialProviderCredential> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IConnectableCredentialProviderCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConnectableCredentialProviderCredential> for ::windows::core::IUnknown {
-    fn from(value: &IConnectableCredentialProviderCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IConnectableCredentialProviderCredential> for ICredentialProviderCredential {
-    fn from(value: IConnectableCredentialProviderCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IConnectableCredentialProviderCredential> for &'a ICredentialProviderCredential {
-    fn from(value: &'a IConnectableCredentialProviderCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IConnectableCredentialProviderCredential> for ICredentialProviderCredential {
-    fn from(value: &IConnectableCredentialProviderCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IConnectableCredentialProviderCredential, ::windows::core::IUnknown, ICredentialProviderCredential);
 impl ::core::clone::Clone for IConnectableCredentialProviderCredential {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16360,21 +14845,7 @@ impl IContactManagerInterop {
         (::windows::core::Vtable::vtable(self).ShowContactCardForWindow)(::windows::core::Vtable::as_raw(self), appwindow.into(), contact.into().abi(), ::core::mem::transmute(selection), preferredplacement).ok()
     }
 }
-impl ::core::convert::From<IContactManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: IContactManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContactManagerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContactManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContactManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: &IContactManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContactManagerInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContactManagerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16427,21 +14898,7 @@ impl IContextMenu {
         (::windows::core::Vtable::vtable(self).GetCommandString)(::windows::core::Vtable::as_raw(self), idcmd, utype, ::core::mem::transmute(preserved.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pszname), cchmax).ok()
     }
 }
-impl ::core::convert::From<IContextMenu> for ::windows::core::IUnknown {
-    fn from(value: IContextMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenu> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenu> for ::windows::core::IUnknown {
-    fn from(value: &IContextMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextMenu, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContextMenu {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16508,36 +14965,7 @@ impl IContextMenu2 {
         (::windows::core::Vtable::vtable(self).HandleMenuMsg)(::windows::core::Vtable::as_raw(self), umsg, wparam.into(), lparam.into()).ok()
     }
 }
-impl ::core::convert::From<IContextMenu2> for ::windows::core::IUnknown {
-    fn from(value: IContextMenu2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenu2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextMenu2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenu2> for ::windows::core::IUnknown {
-    fn from(value: &IContextMenu2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContextMenu2> for IContextMenu {
-    fn from(value: IContextMenu2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenu2> for &'a IContextMenu {
-    fn from(value: &'a IContextMenu2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenu2> for IContextMenu {
-    fn from(value: &IContextMenu2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextMenu2, ::windows::core::IUnknown, IContextMenu);
 impl ::core::clone::Clone for IContextMenu2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16609,51 +15037,7 @@ impl IContextMenu3 {
         (::windows::core::Vtable::vtable(self).HandleMenuMsg2)(::windows::core::Vtable::as_raw(self), umsg, wparam.into(), lparam.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::LRESULT>(result__)
     }
 }
-impl ::core::convert::From<IContextMenu3> for ::windows::core::IUnknown {
-    fn from(value: IContextMenu3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenu3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextMenu3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenu3> for ::windows::core::IUnknown {
-    fn from(value: &IContextMenu3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContextMenu3> for IContextMenu {
-    fn from(value: IContextMenu3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenu3> for &'a IContextMenu {
-    fn from(value: &'a IContextMenu3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenu3> for IContextMenu {
-    fn from(value: &IContextMenu3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IContextMenu3> for IContextMenu2 {
-    fn from(value: IContextMenu3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenu3> for &'a IContextMenu2 {
-    fn from(value: &'a IContextMenu3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenu3> for IContextMenu2 {
-    fn from(value: &IContextMenu3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextMenu3, ::windows::core::IUnknown, IContextMenu, IContextMenu2);
 impl ::core::clone::Clone for IContextMenu3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16702,21 +15086,7 @@ impl IContextMenuCB {
         (::windows::core::Vtable::vtable(self).CallBack)(::windows::core::Vtable::as_raw(self), psf.into().abi(), hwndowner.into(), pdtobj.into().abi(), umsg, wparam.into(), lparam.into()).ok()
     }
 }
-impl ::core::convert::From<IContextMenuCB> for ::windows::core::IUnknown {
-    fn from(value: IContextMenuCB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenuCB> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextMenuCB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenuCB> for ::windows::core::IUnknown {
-    fn from(value: &IContextMenuCB) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextMenuCB, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContextMenuCB {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16761,21 +15131,7 @@ impl IContextMenuSite {
         (::windows::core::Vtable::vtable(self).DoContextMenuPopup)(::windows::core::Vtable::as_raw(self), punkcontextmenu.into().abi(), fflags, ::core::mem::transmute(pt)).ok()
     }
 }
-impl ::core::convert::From<IContextMenuSite> for ::windows::core::IUnknown {
-    fn from(value: IContextMenuSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IContextMenuSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IContextMenuSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IContextMenuSite> for ::windows::core::IUnknown {
-    fn from(value: &IContextMenuSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IContextMenuSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IContextMenuSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16822,21 +15178,7 @@ impl ICopyHookA {
         (::windows::core::Vtable::vtable(self).CopyCallback)(::windows::core::Vtable::as_raw(self), hwnd.into(), wfunc, wflags, pszsrcfile.into(), dwsrcattribs, pszdestfile.into(), dwdestattribs)
     }
 }
-impl ::core::convert::From<ICopyHookA> for ::windows::core::IUnknown {
-    fn from(value: ICopyHookA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICopyHookA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICopyHookA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICopyHookA> for ::windows::core::IUnknown {
-    fn from(value: &ICopyHookA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICopyHookA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICopyHookA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16883,21 +15225,7 @@ impl ICopyHookW {
         (::windows::core::Vtable::vtable(self).CopyCallback)(::windows::core::Vtable::as_raw(self), hwnd.into(), wfunc, wflags, pszsrcfile.into(), dwsrcattribs, pszdestfile.into(), dwdestattribs)
     }
 }
-impl ::core::convert::From<ICopyHookW> for ::windows::core::IUnknown {
-    fn from(value: ICopyHookW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICopyHookW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICopyHookW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICopyHookW> for ::windows::core::IUnknown {
-    fn from(value: &ICopyHookW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICopyHookW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICopyHookW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -16963,21 +15291,7 @@ impl ICreateProcessInputs {
         (::windows::core::Vtable::vtable(self).SetEnvironmentVariable)(::windows::core::Vtable::as_raw(self), pszname.into(), pszvalue.into()).ok()
     }
 }
-impl ::core::convert::From<ICreateProcessInputs> for ::windows::core::IUnknown {
-    fn from(value: ICreateProcessInputs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreateProcessInputs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreateProcessInputs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreateProcessInputs> for ::windows::core::IUnknown {
-    fn from(value: &ICreateProcessInputs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreateProcessInputs, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICreateProcessInputs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17023,21 +15337,7 @@ impl ICreatingProcess {
         (::windows::core::Vtable::vtable(self).OnCreating)(::windows::core::Vtable::as_raw(self), pcpi.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ICreatingProcess> for ::windows::core::IUnknown {
-    fn from(value: ICreatingProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICreatingProcess> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICreatingProcess) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICreatingProcess> for ::windows::core::IUnknown {
-    fn from(value: &ICreatingProcess) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICreatingProcess, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICreatingProcess {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17103,21 +15403,7 @@ impl ICredentialProvider {
         (::windows::core::Vtable::vtable(self).GetCredentialAt)(::windows::core::Vtable::as_raw(self), dwindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ICredentialProviderCredential>(result__)
     }
 }
-impl ::core::convert::From<ICredentialProvider> for ::windows::core::IUnknown {
-    fn from(value: ICredentialProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICredentialProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProvider> for ::windows::core::IUnknown {
-    fn from(value: &ICredentialProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICredentialProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICredentialProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17240,21 +15526,7 @@ impl ICredentialProviderCredential {
         (::windows::core::Vtable::vtable(self).ReportResult)(::windows::core::Vtable::as_raw(self), ntsstatus.into(), ntssubstatus.into(), ::core::mem::transmute(ppszoptionalstatustext.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pcpsioptionalstatusicon)).ok()
     }
 }
-impl ::core::convert::From<ICredentialProviderCredential> for ::windows::core::IUnknown {
-    fn from(value: ICredentialProviderCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderCredential> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICredentialProviderCredential) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderCredential> for ::windows::core::IUnknown {
-    fn from(value: &ICredentialProviderCredential) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICredentialProviderCredential, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICredentialProviderCredential {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17402,36 +15674,7 @@ impl ICredentialProviderCredential2 {
         (::windows::core::Vtable::vtable(self).GetUserSid)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ICredentialProviderCredential2> for ::windows::core::IUnknown {
-    fn from(value: ICredentialProviderCredential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderCredential2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICredentialProviderCredential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderCredential2> for ::windows::core::IUnknown {
-    fn from(value: &ICredentialProviderCredential2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICredentialProviderCredential2> for ICredentialProviderCredential {
-    fn from(value: ICredentialProviderCredential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderCredential2> for &'a ICredentialProviderCredential {
-    fn from(value: &'a ICredentialProviderCredential2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderCredential2> for ICredentialProviderCredential {
-    fn from(value: &ICredentialProviderCredential2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICredentialProviderCredential2, ::windows::core::IUnknown, ICredentialProviderCredential);
 impl ::core::clone::Clone for ICredentialProviderCredential2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17534,21 +15777,7 @@ impl ICredentialProviderCredentialEvents {
         (::windows::core::Vtable::vtable(self).OnCreatingWindow)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::HWND>(result__)
     }
 }
-impl ::core::convert::From<ICredentialProviderCredentialEvents> for ::windows::core::IUnknown {
-    fn from(value: ICredentialProviderCredentialEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderCredentialEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICredentialProviderCredentialEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderCredentialEvents> for ::windows::core::IUnknown {
-    fn from(value: &ICredentialProviderCredentialEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICredentialProviderCredentialEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICredentialProviderCredentialEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17681,36 +15910,7 @@ impl ICredentialProviderCredentialEvents2 {
         (::windows::core::Vtable::vtable(self).SetFieldOptions)(::windows::core::Vtable::as_raw(self), credential.into().abi(), fieldid, options).ok()
     }
 }
-impl ::core::convert::From<ICredentialProviderCredentialEvents2> for ::windows::core::IUnknown {
-    fn from(value: ICredentialProviderCredentialEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderCredentialEvents2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICredentialProviderCredentialEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderCredentialEvents2> for ::windows::core::IUnknown {
-    fn from(value: &ICredentialProviderCredentialEvents2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICredentialProviderCredentialEvents2> for ICredentialProviderCredentialEvents {
-    fn from(value: ICredentialProviderCredentialEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderCredentialEvents2> for &'a ICredentialProviderCredentialEvents {
-    fn from(value: &'a ICredentialProviderCredentialEvents2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderCredentialEvents2> for ICredentialProviderCredentialEvents {
-    fn from(value: &ICredentialProviderCredentialEvents2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICredentialProviderCredentialEvents2, ::windows::core::IUnknown, ICredentialProviderCredentialEvents);
 impl ::core::clone::Clone for ICredentialProviderCredentialEvents2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17750,21 +15950,7 @@ impl ICredentialProviderCredentialWithFieldOptions {
         (::windows::core::Vtable::vtable(self).GetFieldOptions)(::windows::core::Vtable::as_raw(self), fieldid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS>(result__)
     }
 }
-impl ::core::convert::From<ICredentialProviderCredentialWithFieldOptions> for ::windows::core::IUnknown {
-    fn from(value: ICredentialProviderCredentialWithFieldOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderCredentialWithFieldOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICredentialProviderCredentialWithFieldOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderCredentialWithFieldOptions> for ::windows::core::IUnknown {
-    fn from(value: &ICredentialProviderCredentialWithFieldOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICredentialProviderCredentialWithFieldOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICredentialProviderCredentialWithFieldOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17801,21 +15987,7 @@ impl ICredentialProviderEvents {
         (::windows::core::Vtable::vtable(self).CredentialsChanged)(::windows::core::Vtable::as_raw(self), upadvisecontext).ok()
     }
 }
-impl ::core::convert::From<ICredentialProviderEvents> for ::windows::core::IUnknown {
-    fn from(value: ICredentialProviderEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICredentialProviderEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderEvents> for ::windows::core::IUnknown {
-    fn from(value: &ICredentialProviderEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICredentialProviderEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICredentialProviderEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17858,21 +16030,7 @@ impl ICredentialProviderFilter {
         (::windows::core::Vtable::vtable(self).UpdateRemoteCredential)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcpcsin), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION>(result__)
     }
 }
-impl ::core::convert::From<ICredentialProviderFilter> for ::windows::core::IUnknown {
-    fn from(value: ICredentialProviderFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICredentialProviderFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderFilter> for ::windows::core::IUnknown {
-    fn from(value: &ICredentialProviderFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICredentialProviderFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICredentialProviderFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17916,21 +16074,7 @@ impl ICredentialProviderSetUserArray {
         (::windows::core::Vtable::vtable(self).SetUserArray)(::windows::core::Vtable::as_raw(self), users.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ICredentialProviderSetUserArray> for ::windows::core::IUnknown {
-    fn from(value: ICredentialProviderSetUserArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderSetUserArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICredentialProviderSetUserArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderSetUserArray> for ::windows::core::IUnknown {
-    fn from(value: &ICredentialProviderSetUserArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICredentialProviderSetUserArray, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICredentialProviderSetUserArray {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -17984,21 +16128,7 @@ impl ICredentialProviderUser {
         (::windows::core::Vtable::vtable(self).GetValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(key), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::StructuredStorage::PROPVARIANT>(result__)
     }
 }
-impl ::core::convert::From<ICredentialProviderUser> for ::windows::core::IUnknown {
-    fn from(value: ICredentialProviderUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderUser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICredentialProviderUser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderUser> for ::windows::core::IUnknown {
-    fn from(value: &ICredentialProviderUser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICredentialProviderUser, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICredentialProviderUser {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18056,21 +16186,7 @@ impl ICredentialProviderUserArray {
         (::windows::core::Vtable::vtable(self).GetAt)(::windows::core::Vtable::as_raw(self), userindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ICredentialProviderUser>(result__)
     }
 }
-impl ::core::convert::From<ICredentialProviderUserArray> for ::windows::core::IUnknown {
-    fn from(value: ICredentialProviderUserArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICredentialProviderUserArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICredentialProviderUserArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICredentialProviderUserArray> for ::windows::core::IUnknown {
-    fn from(value: &ICredentialProviderUserArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICredentialProviderUserArray, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICredentialProviderUserArray {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18117,36 +16233,7 @@ impl ICurrentItem {
         (::windows::core::Vtable::vtable(self).base__.GetItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IShellItem>(result__)
     }
 }
-impl ::core::convert::From<ICurrentItem> for ::windows::core::IUnknown {
-    fn from(value: ICurrentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICurrentItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICurrentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICurrentItem> for ::windows::core::IUnknown {
-    fn from(value: &ICurrentItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ICurrentItem> for IRelatedItem {
-    fn from(value: ICurrentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICurrentItem> for &'a IRelatedItem {
-    fn from(value: &'a ICurrentItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICurrentItem> for IRelatedItem {
-    fn from(value: &ICurrentItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICurrentItem, ::windows::core::IUnknown, IRelatedItem);
 impl ::core::clone::Clone for ICurrentItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18188,21 +16275,7 @@ impl ICurrentWorkingDirectory {
         (::windows::core::Vtable::vtable(self).SetDirectory)(::windows::core::Vtable::as_raw(self), pwzpath.into()).ok()
     }
 }
-impl ::core::convert::From<ICurrentWorkingDirectory> for ::windows::core::IUnknown {
-    fn from(value: ICurrentWorkingDirectory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICurrentWorkingDirectory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICurrentWorkingDirectory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICurrentWorkingDirectory> for ::windows::core::IUnknown {
-    fn from(value: &ICurrentWorkingDirectory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICurrentWorkingDirectory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICurrentWorkingDirectory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18289,21 +16362,7 @@ impl ICustomDestinationList {
         (::windows::core::Vtable::vtable(self).AbortList)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ICustomDestinationList> for ::windows::core::IUnknown {
-    fn from(value: ICustomDestinationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICustomDestinationList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICustomDestinationList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICustomDestinationList> for ::windows::core::IUnknown {
-    fn from(value: &ICustomDestinationList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICustomDestinationList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICustomDestinationList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18387,21 +16446,7 @@ impl IDataObjectAsyncCapability {
         (::windows::core::Vtable::vtable(self).EndOperation)(::windows::core::Vtable::as_raw(self), hresult, pbcreserved.into().abi(), dweffects).ok()
     }
 }
-impl ::core::convert::From<IDataObjectAsyncCapability> for ::windows::core::IUnknown {
-    fn from(value: IDataObjectAsyncCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataObjectAsyncCapability> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataObjectAsyncCapability) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataObjectAsyncCapability> for ::windows::core::IUnknown {
-    fn from(value: &IDataObjectAsyncCapability) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataObjectAsyncCapability, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataObjectAsyncCapability {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18468,21 +16513,7 @@ impl IDataObjectProvider {
         (::windows::core::Vtable::vtable(self).SetDataObject)(::windows::core::Vtable::as_raw(self), dataobject.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDataObjectProvider> for ::windows::core::IUnknown {
-    fn from(value: IDataObjectProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataObjectProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataObjectProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataObjectProvider> for ::windows::core::IUnknown {
-    fn from(value: &IDataObjectProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataObjectProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataObjectProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18541,21 +16572,7 @@ impl IDataTransferManagerInterop {
         (::windows::core::Vtable::vtable(self).ShowShareUIForWindow)(::windows::core::Vtable::as_raw(self), appwindow.into()).ok()
     }
 }
-impl ::core::convert::From<IDataTransferManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: IDataTransferManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDataTransferManagerInterop> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDataTransferManagerInterop) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDataTransferManagerInterop> for ::windows::core::IUnknown {
-    fn from(value: &IDataTransferManagerInterop) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDataTransferManagerInterop, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDataTransferManagerInterop {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18631,21 +16648,7 @@ impl IDefaultExtractIconInit {
         (::windows::core::Vtable::vtable(self).SetDefaultIcon)(::windows::core::Vtable::as_raw(self), pszfile.into(), iicon).ok()
     }
 }
-impl ::core::convert::From<IDefaultExtractIconInit> for ::windows::core::IUnknown {
-    fn from(value: IDefaultExtractIconInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDefaultExtractIconInit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDefaultExtractIconInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDefaultExtractIconInit> for ::windows::core::IUnknown {
-    fn from(value: &IDefaultExtractIconInit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDefaultExtractIconInit, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDefaultExtractIconInit {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18708,21 +16711,7 @@ impl IDefaultFolderMenuInitialize {
         (::windows::core::Vtable::vtable(self).SetHandlerClsid)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid)).ok()
     }
 }
-impl ::core::convert::From<IDefaultFolderMenuInitialize> for ::windows::core::IUnknown {
-    fn from(value: IDefaultFolderMenuInitialize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDefaultFolderMenuInitialize> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDefaultFolderMenuInitialize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDefaultFolderMenuInitialize> for ::windows::core::IUnknown {
-    fn from(value: &IDefaultFolderMenuInitialize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDefaultFolderMenuInitialize, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDefaultFolderMenuInitialize {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18770,21 +16759,7 @@ impl IDelegateFolder {
         (::windows::core::Vtable::vtable(self).SetItemAlloc)(::windows::core::Vtable::as_raw(self), pmalloc.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDelegateFolder> for ::windows::core::IUnknown {
-    fn from(value: IDelegateFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDelegateFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDelegateFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDelegateFolder> for ::windows::core::IUnknown {
-    fn from(value: &IDelegateFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDelegateFolder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDelegateFolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18831,36 +16806,7 @@ impl IDelegateItem {
         (::windows::core::Vtable::vtable(self).base__.GetItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IShellItem>(result__)
     }
 }
-impl ::core::convert::From<IDelegateItem> for ::windows::core::IUnknown {
-    fn from(value: IDelegateItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDelegateItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDelegateItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDelegateItem> for ::windows::core::IUnknown {
-    fn from(value: &IDelegateItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDelegateItem> for IRelatedItem {
-    fn from(value: IDelegateItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDelegateItem> for &'a IRelatedItem {
-    fn from(value: &'a IDelegateItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDelegateItem> for IRelatedItem {
-    fn from(value: &IDelegateItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDelegateItem, ::windows::core::IUnknown, IRelatedItem);
 impl ::core::clone::Clone for IDelegateItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -18935,59 +16881,7 @@ impl IDeskBand {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDeskBand> for ::windows::core::IUnknown {
-    fn from(value: IDeskBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDeskBand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeskBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDeskBand> for ::windows::core::IUnknown {
-    fn from(value: &IDeskBand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDeskBand> for super::super::System::Ole::IOleWindow {
-    fn from(value: IDeskBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDeskBand> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IDeskBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDeskBand> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IDeskBand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDeskBand> for IDockingWindow {
-    fn from(value: IDeskBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDeskBand> for &'a IDockingWindow {
-    fn from(value: &'a IDeskBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDeskBand> for IDockingWindow {
-    fn from(value: &IDeskBand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeskBand, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow, IDockingWindow);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IDeskBand {
     fn clone(&self) -> Self {
@@ -19093,77 +16987,7 @@ impl IDeskBand2 {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDeskBand2> for ::windows::core::IUnknown {
-    fn from(value: IDeskBand2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDeskBand2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeskBand2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDeskBand2> for ::windows::core::IUnknown {
-    fn from(value: &IDeskBand2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDeskBand2> for super::super::System::Ole::IOleWindow {
-    fn from(value: IDeskBand2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDeskBand2> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IDeskBand2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDeskBand2> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IDeskBand2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDeskBand2> for IDockingWindow {
-    fn from(value: IDeskBand2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDeskBand2> for &'a IDockingWindow {
-    fn from(value: &'a IDeskBand2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDeskBand2> for IDockingWindow {
-    fn from(value: &IDeskBand2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDeskBand2> for IDeskBand {
-    fn from(value: IDeskBand2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDeskBand2> for &'a IDeskBand {
-    fn from(value: &'a IDeskBand2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDeskBand2> for IDeskBand {
-    fn from(value: &IDeskBand2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeskBand2, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow, IDockingWindow, IDeskBand);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IDeskBand2 {
     fn clone(&self) -> Self {
@@ -19219,21 +17043,7 @@ impl IDeskBandInfo {
         (::windows::core::Vtable::vtable(self).GetDefaultBandWidth)(::windows::core::Vtable::as_raw(self), dwbandid, dwviewmode, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IDeskBandInfo> for ::windows::core::IUnknown {
-    fn from(value: IDeskBandInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDeskBandInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeskBandInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDeskBandInfo> for ::windows::core::IUnknown {
-    fn from(value: &IDeskBandInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeskBandInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDeskBandInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19299,41 +17109,7 @@ impl IDeskBar {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDeskBar> for ::windows::core::IUnknown {
-    fn from(value: IDeskBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDeskBar> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeskBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDeskBar> for ::windows::core::IUnknown {
-    fn from(value: &IDeskBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDeskBar> for super::super::System::Ole::IOleWindow {
-    fn from(value: IDeskBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDeskBar> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IDeskBar) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDeskBar> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IDeskBar) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeskBar, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IDeskBar {
     fn clone(&self) -> Self {
@@ -19414,41 +17190,7 @@ impl IDeskBarClient {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDeskBarClient> for ::windows::core::IUnknown {
-    fn from(value: IDeskBarClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDeskBarClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDeskBarClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDeskBarClient> for ::windows::core::IUnknown {
-    fn from(value: &IDeskBarClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDeskBarClient> for super::super::System::Ole::IOleWindow {
-    fn from(value: IDeskBarClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDeskBarClient> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IDeskBarClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDeskBarClient> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IDeskBarClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDeskBarClient, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IDeskBarClient {
     fn clone(&self) -> Self {
@@ -19501,21 +17243,7 @@ impl IDesktopGadget {
         (::windows::core::Vtable::vtable(self).RunGadget)(::windows::core::Vtable::as_raw(self), gadgetpath.into()).ok()
     }
 }
-impl ::core::convert::From<IDesktopGadget> for ::windows::core::IUnknown {
-    fn from(value: IDesktopGadget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDesktopGadget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDesktopGadget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDesktopGadget> for ::windows::core::IUnknown {
-    fn from(value: &IDesktopGadget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDesktopGadget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDesktopGadget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19635,21 +17363,7 @@ impl IDesktopWallpaper {
         (::windows::core::Vtable::vtable(self).Enable)(::windows::core::Vtable::as_raw(self), enable.into()).ok()
     }
 }
-impl ::core::convert::From<IDesktopWallpaper> for ::windows::core::IUnknown {
-    fn from(value: IDesktopWallpaper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDesktopWallpaper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDesktopWallpaper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDesktopWallpaper> for ::windows::core::IUnknown {
-    fn from(value: &IDesktopWallpaper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDesktopWallpaper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDesktopWallpaper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19716,21 +17430,7 @@ impl IDestinationStreamFactory {
         (::windows::core::Vtable::vtable(self).GetDestinationStream)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IDestinationStreamFactory> for ::windows::core::IUnknown {
-    fn from(value: IDestinationStreamFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDestinationStreamFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDestinationStreamFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDestinationStreamFactory> for ::windows::core::IUnknown {
-    fn from(value: &IDestinationStreamFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDestinationStreamFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDestinationStreamFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19777,36 +17477,7 @@ impl IDisplayItem {
         (::windows::core::Vtable::vtable(self).base__.GetItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IShellItem>(result__)
     }
 }
-impl ::core::convert::From<IDisplayItem> for ::windows::core::IUnknown {
-    fn from(value: IDisplayItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDisplayItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDisplayItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDisplayItem> for ::windows::core::IUnknown {
-    fn from(value: &IDisplayItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDisplayItem> for IRelatedItem {
-    fn from(value: IDisplayItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDisplayItem> for &'a IRelatedItem {
-    fn from(value: &'a IDisplayItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDisplayItem> for IRelatedItem {
-    fn from(value: &IDisplayItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDisplayItem, ::windows::core::IUnknown, IRelatedItem);
 impl ::core::clone::Clone for IDisplayItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19844,21 +17515,7 @@ impl IDocViewSite {
         (::windows::core::Vtable::vtable(self).OnSetTitle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvtitle)).ok()
     }
 }
-impl ::core::convert::From<IDocViewSite> for ::windows::core::IUnknown {
-    fn from(value: IDocViewSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDocViewSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDocViewSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDocViewSite> for ::windows::core::IUnknown {
-    fn from(value: &IDocViewSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDocViewSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDocViewSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -19932,41 +17589,7 @@ impl IDockingWindow {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDockingWindow> for ::windows::core::IUnknown {
-    fn from(value: IDockingWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDockingWindow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDockingWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDockingWindow> for ::windows::core::IUnknown {
-    fn from(value: &IDockingWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDockingWindow> for super::super::System::Ole::IOleWindow {
-    fn from(value: IDockingWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDockingWindow> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IDockingWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDockingWindow> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IDockingWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDockingWindow, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IDockingWindow {
     fn clone(&self) -> Self {
@@ -20051,41 +17674,7 @@ impl IDockingWindowFrame {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDockingWindowFrame> for ::windows::core::IUnknown {
-    fn from(value: IDockingWindowFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDockingWindowFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDockingWindowFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDockingWindowFrame> for ::windows::core::IUnknown {
-    fn from(value: &IDockingWindowFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDockingWindowFrame> for super::super::System::Ole::IOleWindow {
-    fn from(value: IDockingWindowFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDockingWindowFrame> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IDockingWindowFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDockingWindowFrame> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IDockingWindowFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDockingWindowFrame, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IDockingWindowFrame {
     fn clone(&self) -> Self {
@@ -20170,41 +17759,7 @@ impl IDockingWindowSite {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDockingWindowSite> for ::windows::core::IUnknown {
-    fn from(value: IDockingWindowSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDockingWindowSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDockingWindowSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDockingWindowSite> for ::windows::core::IUnknown {
-    fn from(value: &IDockingWindowSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IDockingWindowSite> for super::super::System::Ole::IOleWindow {
-    fn from(value: IDockingWindowSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IDockingWindowSite> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IDockingWindowSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IDockingWindowSite> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IDockingWindowSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDockingWindowSite, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IDockingWindowSite {
     fn clone(&self) -> Self {
@@ -20273,21 +17828,7 @@ impl IDragSourceHelper {
         (::windows::core::Vtable::vtable(self).InitializeFromWindow)(::windows::core::Vtable::as_raw(self), hwnd.into(), ::core::mem::transmute(ppt.unwrap_or(::std::ptr::null())), pdataobject.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IDragSourceHelper> for ::windows::core::IUnknown {
-    fn from(value: IDragSourceHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDragSourceHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDragSourceHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDragSourceHelper> for ::windows::core::IUnknown {
-    fn from(value: &IDragSourceHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDragSourceHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDragSourceHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20348,36 +17889,7 @@ impl IDragSourceHelper2 {
         (::windows::core::Vtable::vtable(self).SetFlags)(::windows::core::Vtable::as_raw(self), dwflags).ok()
     }
 }
-impl ::core::convert::From<IDragSourceHelper2> for ::windows::core::IUnknown {
-    fn from(value: IDragSourceHelper2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDragSourceHelper2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDragSourceHelper2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDragSourceHelper2> for ::windows::core::IUnknown {
-    fn from(value: &IDragSourceHelper2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IDragSourceHelper2> for IDragSourceHelper {
-    fn from(value: IDragSourceHelper2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDragSourceHelper2> for &'a IDragSourceHelper {
-    fn from(value: &'a IDragSourceHelper2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDragSourceHelper2> for IDragSourceHelper {
-    fn from(value: &IDragSourceHelper2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDragSourceHelper2, ::windows::core::IUnknown, IDragSourceHelper);
 impl ::core::clone::Clone for IDragSourceHelper2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20444,21 +17956,7 @@ impl IDropTargetHelper {
         (::windows::core::Vtable::vtable(self).Show)(::windows::core::Vtable::as_raw(self), fshow.into()).ok()
     }
 }
-impl ::core::convert::From<IDropTargetHelper> for ::windows::core::IUnknown {
-    fn from(value: IDropTargetHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDropTargetHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDropTargetHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDropTargetHelper> for ::windows::core::IUnknown {
-    fn from(value: &IDropTargetHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDropTargetHelper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDropTargetHelper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20515,21 +18013,7 @@ impl IDynamicHWHandler {
         (::windows::core::Vtable::vtable(self).GetDynamicInfo)(::windows::core::Vtable::as_raw(self), pszdeviceid.into(), dwcontenttype, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IDynamicHWHandler> for ::windows::core::IUnknown {
-    fn from(value: IDynamicHWHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDynamicHWHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDynamicHWHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDynamicHWHandler> for ::windows::core::IUnknown {
-    fn from(value: &IDynamicHWHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDynamicHWHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDynamicHWHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20597,41 +18081,7 @@ impl IEnumACString {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumACString> for ::windows::core::IUnknown {
-    fn from(value: IEnumACString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumACString> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumACString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumACString> for ::windows::core::IUnknown {
-    fn from(value: &IEnumACString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IEnumACString> for super::super::System::Com::IEnumString {
-    fn from(value: IEnumACString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IEnumACString> for &'a super::super::System::Com::IEnumString {
-    fn from(value: &'a IEnumACString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IEnumACString> for super::super::System::Com::IEnumString {
-    fn from(value: &IEnumACString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumACString, ::windows::core::IUnknown, super::super::System::Com::IEnumString);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IEnumACString {
     fn clone(&self) -> Self {
@@ -20677,21 +18127,7 @@ impl IEnumAssocHandlers {
         (::windows::core::Vtable::vtable(self).Next)(::windows::core::Vtable::as_raw(self), rgelt.len() as _, ::core::mem::transmute(rgelt.as_ptr()), ::core::mem::transmute(pceltfetched.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IEnumAssocHandlers> for ::windows::core::IUnknown {
-    fn from(value: IEnumAssocHandlers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumAssocHandlers> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumAssocHandlers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumAssocHandlers> for ::windows::core::IUnknown {
-    fn from(value: &IEnumAssocHandlers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumAssocHandlers, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumAssocHandlers {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20738,21 +18174,7 @@ impl IEnumExplorerCommand {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumExplorerCommand>(result__)
     }
 }
-impl ::core::convert::From<IEnumExplorerCommand> for ::windows::core::IUnknown {
-    fn from(value: IEnumExplorerCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumExplorerCommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumExplorerCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumExplorerCommand> for ::windows::core::IUnknown {
-    fn from(value: &IEnumExplorerCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumExplorerCommand, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumExplorerCommand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20802,21 +18224,7 @@ impl IEnumExtraSearch {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumExtraSearch>(result__)
     }
 }
-impl ::core::convert::From<IEnumExtraSearch> for ::windows::core::IUnknown {
-    fn from(value: IEnumExtraSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumExtraSearch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumExtraSearch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumExtraSearch> for ::windows::core::IUnknown {
-    fn from(value: &IEnumExtraSearch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumExtraSearch, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumExtraSearch {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20868,21 +18276,7 @@ impl IEnumFullIDList {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumFullIDList>(result__)
     }
 }
-impl ::core::convert::From<IEnumFullIDList> for ::windows::core::IUnknown {
-    fn from(value: IEnumFullIDList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumFullIDList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumFullIDList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumFullIDList> for ::windows::core::IUnknown {
-    fn from(value: &IEnumFullIDList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumFullIDList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumFullIDList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -20935,21 +18329,7 @@ impl IEnumHLITEM {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumHLITEM>(result__)
     }
 }
-impl ::core::convert::From<IEnumHLITEM> for ::windows::core::IUnknown {
-    fn from(value: IEnumHLITEM) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumHLITEM> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumHLITEM) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumHLITEM> for ::windows::core::IUnknown {
-    fn from(value: &IEnumHLITEM) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumHLITEM, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumHLITEM {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21000,21 +18380,7 @@ impl IEnumIDList {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppenum))
     }
 }
-impl ::core::convert::From<IEnumIDList> for ::windows::core::IUnknown {
-    fn from(value: IEnumIDList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumIDList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumIDList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumIDList> for ::windows::core::IUnknown {
-    fn from(value: &IEnumIDList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumIDList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumIDList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21067,21 +18433,7 @@ impl IEnumObjects {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumObjects>(result__)
     }
 }
-impl ::core::convert::From<IEnumObjects> for ::windows::core::IUnknown {
-    fn from(value: IEnumObjects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumObjects> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumObjects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumObjects> for ::windows::core::IUnknown {
-    fn from(value: &IEnumObjects) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumObjects, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumObjects {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21125,21 +18477,7 @@ impl IEnumPublishedApps {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IEnumPublishedApps> for ::windows::core::IUnknown {
-    fn from(value: IEnumPublishedApps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumPublishedApps> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumPublishedApps) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumPublishedApps> for ::windows::core::IUnknown {
-    fn from(value: &IEnumPublishedApps) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumPublishedApps, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumPublishedApps {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21177,21 +18515,7 @@ impl IEnumReadyCallback {
         (::windows::core::Vtable::vtable(self).EnumReady)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IEnumReadyCallback> for ::windows::core::IUnknown {
-    fn from(value: IEnumReadyCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumReadyCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumReadyCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumReadyCallback> for ::windows::core::IUnknown {
-    fn from(value: &IEnumReadyCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumReadyCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumReadyCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21238,21 +18562,7 @@ impl IEnumResources {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumResources>(result__)
     }
 }
-impl ::core::convert::From<IEnumResources> for ::windows::core::IUnknown {
-    fn from(value: IEnumResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumResources> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumResources> for ::windows::core::IUnknown {
-    fn from(value: &IEnumResources) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumResources, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumResources {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21302,21 +18612,7 @@ impl IEnumShellItems {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumShellItems>(result__)
     }
 }
-impl ::core::convert::From<IEnumShellItems> for ::windows::core::IUnknown {
-    fn from(value: IEnumShellItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumShellItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumShellItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumShellItems> for ::windows::core::IUnknown {
-    fn from(value: &IEnumShellItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumShellItems, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumShellItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21366,21 +18662,7 @@ impl IEnumSyncMgrConflict {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSyncMgrConflict>(result__)
     }
 }
-impl ::core::convert::From<IEnumSyncMgrConflict> for ::windows::core::IUnknown {
-    fn from(value: IEnumSyncMgrConflict) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSyncMgrConflict> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSyncMgrConflict) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSyncMgrConflict> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSyncMgrConflict) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSyncMgrConflict, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSyncMgrConflict {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21430,21 +18712,7 @@ impl IEnumSyncMgrEvents {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSyncMgrEvents>(result__)
     }
 }
-impl ::core::convert::From<IEnumSyncMgrEvents> for ::windows::core::IUnknown {
-    fn from(value: IEnumSyncMgrEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSyncMgrEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSyncMgrEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSyncMgrEvents> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSyncMgrEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSyncMgrEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSyncMgrEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21494,21 +18762,7 @@ impl IEnumSyncMgrSyncItems {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumSyncMgrSyncItems>(result__)
     }
 }
-impl ::core::convert::From<IEnumSyncMgrSyncItems> for ::windows::core::IUnknown {
-    fn from(value: IEnumSyncMgrSyncItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSyncMgrSyncItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSyncMgrSyncItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSyncMgrSyncItems> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSyncMgrSyncItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSyncMgrSyncItems, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSyncMgrSyncItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21558,21 +18812,7 @@ impl IEnumTravelLogEntry {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumTravelLogEntry>(result__)
     }
 }
-impl ::core::convert::From<IEnumTravelLogEntry> for ::windows::core::IUnknown {
-    fn from(value: IEnumTravelLogEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTravelLogEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTravelLogEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTravelLogEntry> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTravelLogEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTravelLogEntry, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTravelLogEntry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21621,21 +18861,7 @@ impl IEnumerableView {
         (::windows::core::Vtable::vtable(self).CreateEnumIDListFromContents)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidlfolder), dwenumflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumIDList>(result__)
     }
 }
-impl ::core::convert::From<IEnumerableView> for ::windows::core::IUnknown {
-    fn from(value: IEnumerableView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumerableView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumerableView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumerableView> for ::windows::core::IUnknown {
-    fn from(value: &IEnumerableView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumerableView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumerableView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21707,21 +18933,7 @@ impl IExecuteCommand {
         (::windows::core::Vtable::vtable(self).Execute)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IExecuteCommand> for ::windows::core::IUnknown {
-    fn from(value: IExecuteCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExecuteCommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExecuteCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExecuteCommand> for ::windows::core::IUnknown {
-    fn from(value: &IExecuteCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExecuteCommand, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExecuteCommand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21771,21 +18983,7 @@ impl IExecuteCommandApplicationHostEnvironment {
         (::windows::core::Vtable::vtable(self).GetValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<AHE_TYPE>(result__)
     }
 }
-impl ::core::convert::From<IExecuteCommandApplicationHostEnvironment> for ::windows::core::IUnknown {
-    fn from(value: IExecuteCommandApplicationHostEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExecuteCommandApplicationHostEnvironment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExecuteCommandApplicationHostEnvironment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExecuteCommandApplicationHostEnvironment> for ::windows::core::IUnknown {
-    fn from(value: &IExecuteCommandApplicationHostEnvironment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExecuteCommandApplicationHostEnvironment, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExecuteCommandApplicationHostEnvironment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21823,21 +19021,7 @@ impl IExecuteCommandHost {
         (::windows::core::Vtable::vtable(self).GetUIMode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<EC_HOST_UI_MODE>(result__)
     }
 }
-impl ::core::convert::From<IExecuteCommandHost> for ::windows::core::IUnknown {
-    fn from(value: IExecuteCommandHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExecuteCommandHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExecuteCommandHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExecuteCommandHost> for ::windows::core::IUnknown {
-    fn from(value: &IExecuteCommandHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExecuteCommandHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExecuteCommandHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21887,21 +19071,7 @@ impl IExpDispSupport {
         (::windows::core::Vtable::vtable(self).OnInvoke)(::windows::core::Vtable::as_raw(self), dispidmember, ::core::mem::transmute(iid), lcid, wflags, ::core::mem::transmute(pdispparams), ::core::mem::transmute(pvarresult), ::core::mem::transmute(pexcepinfo), ::core::mem::transmute(puargerr)).ok()
     }
 }
-impl ::core::convert::From<IExpDispSupport> for ::windows::core::IUnknown {
-    fn from(value: IExpDispSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExpDispSupport> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExpDispSupport) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExpDispSupport> for ::windows::core::IUnknown {
-    fn from(value: &IExpDispSupport) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExpDispSupport, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExpDispSupport {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -21962,21 +19132,7 @@ impl IExpDispSupportXP {
         (::windows::core::Vtable::vtable(self).OnInvoke)(::windows::core::Vtable::as_raw(self), dispidmember, ::core::mem::transmute(iid), lcid, wflags, ::core::mem::transmute(pdispparams), ::core::mem::transmute(pvarresult), ::core::mem::transmute(pexcepinfo), ::core::mem::transmute(puargerr)).ok()
     }
 }
-impl ::core::convert::From<IExpDispSupportXP> for ::windows::core::IUnknown {
-    fn from(value: IExpDispSupportXP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExpDispSupportXP> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExpDispSupportXP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExpDispSupportXP> for ::windows::core::IUnknown {
-    fn from(value: &IExpDispSupportXP) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExpDispSupportXP, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExpDispSupportXP {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22096,21 +19252,7 @@ impl IExplorerBrowser {
         (::windows::core::Vtable::vtable(self).GetCurrentView)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IExplorerBrowser> for ::windows::core::IUnknown {
-    fn from(value: IExplorerBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExplorerBrowser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExplorerBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExplorerBrowser> for ::windows::core::IUnknown {
-    fn from(value: &IExplorerBrowser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExplorerBrowser, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExplorerBrowser {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22190,21 +19332,7 @@ impl IExplorerBrowserEvents {
         (::windows::core::Vtable::vtable(self).OnNavigationFailed)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidlfolder)).ok()
     }
 }
-impl ::core::convert::From<IExplorerBrowserEvents> for ::windows::core::IUnknown {
-    fn from(value: IExplorerBrowserEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExplorerBrowserEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExplorerBrowserEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExplorerBrowserEvents> for ::windows::core::IUnknown {
-    fn from(value: &IExplorerBrowserEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExplorerBrowserEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExplorerBrowserEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22305,21 +19433,7 @@ impl IExplorerCommand {
         (::windows::core::Vtable::vtable(self).EnumSubCommands)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumExplorerCommand>(result__)
     }
 }
-impl ::core::convert::From<IExplorerCommand> for ::windows::core::IUnknown {
-    fn from(value: IExplorerCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExplorerCommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExplorerCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExplorerCommand> for ::windows::core::IUnknown {
-    fn from(value: &IExplorerCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExplorerCommand, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExplorerCommand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22381,21 +19495,7 @@ impl IExplorerCommandProvider {
         (::windows::core::Vtable::vtable(self).GetCommand)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rguidcommandid), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IExplorerCommandProvider> for ::windows::core::IUnknown {
-    fn from(value: IExplorerCommandProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExplorerCommandProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExplorerCommandProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExplorerCommandProvider> for ::windows::core::IUnknown {
-    fn from(value: &IExplorerCommandProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExplorerCommandProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExplorerCommandProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22440,21 +19540,7 @@ impl IExplorerCommandState {
         (::windows::core::Vtable::vtable(self).GetState)(::windows::core::Vtable::as_raw(self), psiitemarray.into().abi(), foktobeslow.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IExplorerCommandState> for ::windows::core::IUnknown {
-    fn from(value: IExplorerCommandState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExplorerCommandState> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExplorerCommandState) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExplorerCommandState> for ::windows::core::IUnknown {
-    fn from(value: &IExplorerCommandState) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExplorerCommandState, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExplorerCommandState {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22495,21 +19581,7 @@ impl IExplorerPaneVisibility {
         (::windows::core::Vtable::vtable(self).GetPaneState)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ep), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IExplorerPaneVisibility> for ::windows::core::IUnknown {
-    fn from(value: IExplorerPaneVisibility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExplorerPaneVisibility> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExplorerPaneVisibility) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExplorerPaneVisibility> for ::windows::core::IUnknown {
-    fn from(value: &IExplorerPaneVisibility) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExplorerPaneVisibility, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExplorerPaneVisibility {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22559,21 +19631,7 @@ impl IExtensionServices {
         (::windows::core::Vtable::vtable(self).SetAuthenticateData)(::windows::core::Vtable::as_raw(self), phwnd.into(), pwzusername.into(), pwzpassword.into()).ok()
     }
 }
-impl ::core::convert::From<IExtensionServices> for ::windows::core::IUnknown {
-    fn from(value: IExtensionServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtensionServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExtensionServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtensionServices> for ::windows::core::IUnknown {
-    fn from(value: &IExtensionServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExtensionServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExtensionServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22622,21 +19680,7 @@ impl IExtractIconA {
         (::windows::core::Vtable::vtable(self).Extract)(::windows::core::Vtable::as_raw(self), pszfile.into(), niconindex, ::core::mem::transmute(phiconlarge.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(phiconsmall.unwrap_or(::std::ptr::null_mut())), niconsize).ok()
     }
 }
-impl ::core::convert::From<IExtractIconA> for ::windows::core::IUnknown {
-    fn from(value: IExtractIconA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtractIconA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExtractIconA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtractIconA> for ::windows::core::IUnknown {
-    fn from(value: &IExtractIconA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExtractIconA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExtractIconA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22685,21 +19729,7 @@ impl IExtractIconW {
         (::windows::core::Vtable::vtable(self).Extract)(::windows::core::Vtable::as_raw(self), pszfile.into(), niconindex, ::core::mem::transmute(phiconlarge.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(phiconsmall.unwrap_or(::std::ptr::null_mut())), niconsize).ok()
     }
 }
-impl ::core::convert::From<IExtractIconW> for ::windows::core::IUnknown {
-    fn from(value: IExtractIconW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtractIconW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExtractIconW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtractIconW> for ::windows::core::IUnknown {
-    fn from(value: &IExtractIconW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExtractIconW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExtractIconW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22748,21 +19778,7 @@ impl IExtractImage {
         (::windows::core::Vtable::vtable(self).Extract)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Graphics::Gdi::HBITMAP>(result__)
     }
 }
-impl ::core::convert::From<IExtractImage> for ::windows::core::IUnknown {
-    fn from(value: IExtractImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtractImage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExtractImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtractImage> for ::windows::core::IUnknown {
-    fn from(value: &IExtractImage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExtractImage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IExtractImage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -22820,36 +19836,7 @@ impl IExtractImage2 {
         (::windows::core::Vtable::vtable(self).GetDateStamp)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::FILETIME>(result__)
     }
 }
-impl ::core::convert::From<IExtractImage2> for ::windows::core::IUnknown {
-    fn from(value: IExtractImage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtractImage2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IExtractImage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtractImage2> for ::windows::core::IUnknown {
-    fn from(value: &IExtractImage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IExtractImage2> for IExtractImage {
-    fn from(value: IExtractImage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IExtractImage2> for &'a IExtractImage {
-    fn from(value: &'a IExtractImage2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IExtractImage2> for IExtractImage {
-    fn from(value: &IExtractImage2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IExtractImage2, ::windows::core::IUnknown, IExtractImage);
 impl ::core::clone::Clone for IExtractImage2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23002,36 +19989,7 @@ impl IFileDialog {
         (::windows::core::Vtable::vtable(self).SetFilter)(::windows::core::Vtable::as_raw(self), pfilter.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IFileDialog> for ::windows::core::IUnknown {
-    fn from(value: IFileDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileDialog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileDialog> for ::windows::core::IUnknown {
-    fn from(value: &IFileDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileDialog> for IModalWindow {
-    fn from(value: IFileDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileDialog> for &'a IModalWindow {
-    fn from(value: &'a IFileDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileDialog> for IModalWindow {
-    fn from(value: &IFileDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileDialog, ::windows::core::IUnknown, IModalWindow);
 impl ::core::clone::Clone for IFileDialog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23218,51 +20176,7 @@ impl IFileDialog2 {
         (::windows::core::Vtable::vtable(self).SetNavigationRoot)(::windows::core::Vtable::as_raw(self), psi.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IFileDialog2> for ::windows::core::IUnknown {
-    fn from(value: IFileDialog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileDialog2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileDialog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileDialog2> for ::windows::core::IUnknown {
-    fn from(value: &IFileDialog2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileDialog2> for IModalWindow {
-    fn from(value: IFileDialog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileDialog2> for &'a IModalWindow {
-    fn from(value: &'a IFileDialog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileDialog2> for IModalWindow {
-    fn from(value: &IFileDialog2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileDialog2> for IFileDialog {
-    fn from(value: IFileDialog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileDialog2> for &'a IFileDialog {
-    fn from(value: &'a IFileDialog2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileDialog2> for IFileDialog {
-    fn from(value: &IFileDialog2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileDialog2, ::windows::core::IUnknown, IModalWindow, IFileDialog);
 impl ::core::clone::Clone for IFileDialog2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23324,21 +20238,7 @@ impl IFileDialogControlEvents {
         (::windows::core::Vtable::vtable(self).OnControlActivating)(::windows::core::Vtable::as_raw(self), pfdc.into().abi(), dwidctl).ok()
     }
 }
-impl ::core::convert::From<IFileDialogControlEvents> for ::windows::core::IUnknown {
-    fn from(value: IFileDialogControlEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileDialogControlEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileDialogControlEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileDialogControlEvents> for ::windows::core::IUnknown {
-    fn from(value: &IFileDialogControlEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileDialogControlEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFileDialogControlEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23504,21 +20404,7 @@ impl IFileDialogCustomize {
         (::windows::core::Vtable::vtable(self).SetControlItemText)(::windows::core::Vtable::as_raw(self), dwidctl, dwiditem, pszlabel.into()).ok()
     }
 }
-impl ::core::convert::From<IFileDialogCustomize> for ::windows::core::IUnknown {
-    fn from(value: IFileDialogCustomize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileDialogCustomize> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileDialogCustomize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileDialogCustomize> for ::windows::core::IUnknown {
-    fn from(value: &IFileDialogCustomize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileDialogCustomize, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFileDialogCustomize {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23634,21 +20520,7 @@ impl IFileDialogEvents {
         (::windows::core::Vtable::vtable(self).OnOverwrite)(::windows::core::Vtable::as_raw(self), pfd.into().abi(), psi.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<FDE_OVERWRITE_RESPONSE>(result__)
     }
 }
-impl ::core::convert::From<IFileDialogEvents> for ::windows::core::IUnknown {
-    fn from(value: IFileDialogEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileDialogEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileDialogEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileDialogEvents> for ::windows::core::IUnknown {
-    fn from(value: &IFileDialogEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileDialogEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFileDialogEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23709,21 +20581,7 @@ impl IFileIsInUse {
         (::windows::core::Vtable::vtable(self).CloseFile)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IFileIsInUse> for ::windows::core::IUnknown {
-    fn from(value: IFileIsInUse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileIsInUse> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileIsInUse) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileIsInUse> for ::windows::core::IUnknown {
-    fn from(value: &IFileIsInUse) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileIsInUse, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFileIsInUse {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -23888,51 +20746,7 @@ impl IFileOpenDialog {
         (::windows::core::Vtable::vtable(self).GetSelectedItems)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IShellItemArray>(result__)
     }
 }
-impl ::core::convert::From<IFileOpenDialog> for ::windows::core::IUnknown {
-    fn from(value: IFileOpenDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileOpenDialog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileOpenDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileOpenDialog> for ::windows::core::IUnknown {
-    fn from(value: &IFileOpenDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileOpenDialog> for IModalWindow {
-    fn from(value: IFileOpenDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileOpenDialog> for &'a IModalWindow {
-    fn from(value: &'a IFileOpenDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileOpenDialog> for IModalWindow {
-    fn from(value: &IFileOpenDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileOpenDialog> for IFileDialog {
-    fn from(value: IFileOpenDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileOpenDialog> for &'a IFileDialog {
-    fn from(value: &'a IFileOpenDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileOpenDialog> for IFileDialog {
-    fn from(value: &IFileOpenDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileOpenDialog, ::windows::core::IUnknown, IModalWindow, IFileDialog);
 impl ::core::clone::Clone for IFileOpenDialog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24098,21 +20912,7 @@ impl IFileOperation {
         (::windows::core::Vtable::vtable(self).GetAnyOperationsAborted)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IFileOperation> for ::windows::core::IUnknown {
-    fn from(value: IFileOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileOperation> for ::windows::core::IUnknown {
-    fn from(value: &IFileOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileOperation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFileOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24308,36 +21108,7 @@ impl IFileOperation2 {
         (::windows::core::Vtable::vtable(self).SetOperationFlags2)(::windows::core::Vtable::as_raw(self), operationflags2).ok()
     }
 }
-impl ::core::convert::From<IFileOperation2> for ::windows::core::IUnknown {
-    fn from(value: IFileOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileOperation2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileOperation2> for ::windows::core::IUnknown {
-    fn from(value: &IFileOperation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileOperation2> for IFileOperation {
-    fn from(value: IFileOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileOperation2> for &'a IFileOperation {
-    fn from(value: &'a IFileOperation2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileOperation2> for IFileOperation {
-    fn from(value: &IFileOperation2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileOperation2, ::windows::core::IUnknown, IFileOperation);
 impl ::core::clone::Clone for IFileOperation2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24467,21 +21238,7 @@ impl IFileOperationProgressSink {
         (::windows::core::Vtable::vtable(self).ResumeTimer)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IFileOperationProgressSink> for ::windows::core::IUnknown {
-    fn from(value: IFileOperationProgressSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileOperationProgressSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileOperationProgressSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileOperationProgressSink> for ::windows::core::IUnknown {
-    fn from(value: &IFileOperationProgressSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileOperationProgressSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFileOperationProgressSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24686,51 +21443,7 @@ impl IFileSaveDialog {
         (::windows::core::Vtable::vtable(self).ApplyProperties)(::windows::core::Vtable::as_raw(self), psi.into().abi(), pstore.into().abi(), hwnd.into(), psink.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IFileSaveDialog> for ::windows::core::IUnknown {
-    fn from(value: IFileSaveDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileSaveDialog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSaveDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileSaveDialog> for ::windows::core::IUnknown {
-    fn from(value: &IFileSaveDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileSaveDialog> for IModalWindow {
-    fn from(value: IFileSaveDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileSaveDialog> for &'a IModalWindow {
-    fn from(value: &'a IFileSaveDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileSaveDialog> for IModalWindow {
-    fn from(value: &IFileSaveDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileSaveDialog> for IFileDialog {
-    fn from(value: IFileSaveDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileSaveDialog> for &'a IFileDialog {
-    fn from(value: &'a IFileSaveDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileSaveDialog> for IFileDialog {
-    fn from(value: &IFileSaveDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSaveDialog, ::windows::core::IUnknown, IModalWindow, IFileDialog);
 impl ::core::clone::Clone for IFileSaveDialog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24807,41 +21520,7 @@ impl IFileSearchBand {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSearchBand> for ::windows::core::IUnknown {
-    fn from(value: IFileSearchBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSearchBand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSearchBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSearchBand> for ::windows::core::IUnknown {
-    fn from(value: &IFileSearchBand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFileSearchBand> for super::super::System::Com::IDispatch {
-    fn from(value: IFileSearchBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFileSearchBand> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFileSearchBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFileSearchBand> for super::super::System::Com::IDispatch {
-    fn from(value: &IFileSearchBand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSearchBand, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFileSearchBand {
     fn clone(&self) -> Self {
@@ -24912,21 +21591,7 @@ impl IFileSyncMergeHandler {
         (::windows::core::Vtable::vtable(self).ShowResolveConflictUIAsync)(::windows::core::Vtable::as_raw(self), localfilepath.into(), monitortodisplayon.into()).ok()
     }
 }
-impl ::core::convert::From<IFileSyncMergeHandler> for ::windows::core::IUnknown {
-    fn from(value: IFileSyncMergeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileSyncMergeHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSyncMergeHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileSyncMergeHandler> for ::windows::core::IUnknown {
-    fn from(value: &IFileSyncMergeHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSyncMergeHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFileSyncMergeHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -24975,21 +21640,7 @@ impl IFileSystemBindData {
         (::windows::core::Vtable::vtable(self).GetFindData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Storage::FileSystem::WIN32_FIND_DATAW>(result__)
     }
 }
-impl ::core::convert::From<IFileSystemBindData> for ::windows::core::IUnknown {
-    fn from(value: IFileSystemBindData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileSystemBindData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSystemBindData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileSystemBindData> for ::windows::core::IUnknown {
-    fn from(value: &IFileSystemBindData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSystemBindData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFileSystemBindData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25055,36 +21706,7 @@ impl IFileSystemBindData2 {
         (::windows::core::Vtable::vtable(self).GetJunctionCLSID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IFileSystemBindData2> for ::windows::core::IUnknown {
-    fn from(value: IFileSystemBindData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileSystemBindData2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFileSystemBindData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileSystemBindData2> for ::windows::core::IUnknown {
-    fn from(value: &IFileSystemBindData2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFileSystemBindData2> for IFileSystemBindData {
-    fn from(value: IFileSystemBindData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFileSystemBindData2> for &'a IFileSystemBindData {
-    fn from(value: &'a IFileSystemBindData2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFileSystemBindData2> for IFileSystemBindData {
-    fn from(value: &IFileSystemBindData2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFileSystemBindData2, ::windows::core::IUnknown, IFileSystemBindData);
 impl ::core::clone::Clone for IFileSystemBindData2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25153,21 +21775,7 @@ impl IFolderBandPriv {
         (::windows::core::Vtable::vtable(self).SetNoText)(::windows::core::Vtable::as_raw(self), fnotext.into()).ok()
     }
 }
-impl ::core::convert::From<IFolderBandPriv> for ::windows::core::IUnknown {
-    fn from(value: IFolderBandPriv) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFolderBandPriv> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderBandPriv) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFolderBandPriv> for ::windows::core::IUnknown {
-    fn from(value: &IFolderBandPriv) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderBandPriv, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFolderBandPriv {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25232,21 +21840,7 @@ impl IFolderFilter {
         (::windows::core::Vtable::vtable(self).GetEnumFlags)(::windows::core::Vtable::as_raw(self), psf.into().abi(), ::core::mem::transmute(pidlfolder), ::core::mem::transmute(phwnd), ::core::mem::transmute(pgrfflags)).ok()
     }
 }
-impl ::core::convert::From<IFolderFilter> for ::windows::core::IUnknown {
-    fn from(value: IFolderFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFolderFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFolderFilter> for ::windows::core::IUnknown {
-    fn from(value: &IFolderFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFolderFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25293,21 +21887,7 @@ impl IFolderFilterSite {
         (::windows::core::Vtable::vtable(self).SetFilter)(::windows::core::Vtable::as_raw(self), punk.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IFolderFilterSite> for ::windows::core::IUnknown {
-    fn from(value: IFolderFilterSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFolderFilterSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderFilterSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFolderFilterSite> for ::windows::core::IUnknown {
-    fn from(value: &IFolderFilterSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderFilterSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFolderFilterSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25408,21 +21988,7 @@ impl IFolderView {
         (::windows::core::Vtable::vtable(self).SelectAndPositionItems)(::windows::core::Vtable::as_raw(self), cidl, ::core::mem::transmute(apidl), ::core::mem::transmute(apt.unwrap_or(::std::ptr::null())), dwflags).ok()
     }
 }
-impl ::core::convert::From<IFolderView> for ::windows::core::IUnknown {
-    fn from(value: IFolderView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFolderView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFolderView> for ::windows::core::IUnknown {
-    fn from(value: &IFolderView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFolderView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25686,36 +22252,7 @@ impl IFolderView2 {
         (::windows::core::Vtable::vtable(self).DoRename)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IFolderView2> for ::windows::core::IUnknown {
-    fn from(value: IFolderView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFolderView2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFolderView2> for ::windows::core::IUnknown {
-    fn from(value: &IFolderView2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IFolderView2> for IFolderView {
-    fn from(value: IFolderView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFolderView2> for &'a IFolderView {
-    fn from(value: &'a IFolderView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFolderView2> for IFolderView {
-    fn from(value: &IFolderView2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderView2, ::windows::core::IUnknown, IFolderView);
 impl ::core::clone::Clone for IFolderView2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25818,21 +22355,7 @@ impl IFolderViewHost {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), hwndparent.into(), pdo.into().abi(), ::core::mem::transmute(prc)).ok()
     }
 }
-impl ::core::convert::From<IFolderViewHost> for ::windows::core::IUnknown {
-    fn from(value: IFolderViewHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFolderViewHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderViewHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFolderViewHost> for ::windows::core::IUnknown {
-    fn from(value: &IFolderViewHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderViewHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFolderViewHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -25880,41 +22403,7 @@ impl IFolderViewOC {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFolderViewOC> for ::windows::core::IUnknown {
-    fn from(value: IFolderViewOC) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFolderViewOC> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderViewOC) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFolderViewOC> for ::windows::core::IUnknown {
-    fn from(value: &IFolderViewOC) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IFolderViewOC> for super::super::System::Com::IDispatch {
-    fn from(value: IFolderViewOC) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IFolderViewOC> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IFolderViewOC) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IFolderViewOC> for super::super::System::Com::IDispatch {
-    fn from(value: &IFolderViewOC) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderViewOC, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IFolderViewOC {
     fn clone(&self) -> Self {
@@ -25965,21 +22454,7 @@ impl IFolderViewOptions {
         (::windows::core::Vtable::vtable(self).GetFolderViewOptions)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<FOLDERVIEWOPTIONS>(result__)
     }
 }
-impl ::core::convert::From<IFolderViewOptions> for ::windows::core::IUnknown {
-    fn from(value: IFolderViewOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFolderViewOptions> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderViewOptions) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFolderViewOptions> for ::windows::core::IUnknown {
-    fn from(value: &IFolderViewOptions) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderViewOptions, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFolderViewOptions {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26046,21 +22521,7 @@ impl IFolderViewSettings {
         (::windows::core::Vtable::vtable(self).GetGroupSubsetCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IFolderViewSettings> for ::windows::core::IUnknown {
-    fn from(value: IFolderViewSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFolderViewSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFolderViewSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFolderViewSettings> for ::windows::core::IUnknown {
-    fn from(value: &IFolderViewSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFolderViewSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFolderViewSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26133,21 +22594,7 @@ impl IFrameworkInputPane {
         (::windows::core::Vtable::vtable(self).Location)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::RECT>(result__)
     }
 }
-impl ::core::convert::From<IFrameworkInputPane> for ::windows::core::IUnknown {
-    fn from(value: IFrameworkInputPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFrameworkInputPane> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFrameworkInputPane) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFrameworkInputPane> for ::windows::core::IUnknown {
-    fn from(value: &IFrameworkInputPane) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFrameworkInputPane, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFrameworkInputPane {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26206,21 +22653,7 @@ impl IFrameworkInputPaneHandler {
         (::windows::core::Vtable::vtable(self).Hiding)(::windows::core::Vtable::as_raw(self), fensurefocusedelementinview.into()).ok()
     }
 }
-impl ::core::convert::From<IFrameworkInputPaneHandler> for ::windows::core::IUnknown {
-    fn from(value: IFrameworkInputPaneHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IFrameworkInputPaneHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IFrameworkInputPaneHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IFrameworkInputPaneHandler> for ::windows::core::IUnknown {
-    fn from(value: &IFrameworkInputPaneHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IFrameworkInputPaneHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IFrameworkInputPaneHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26264,21 +22697,7 @@ impl IGetServiceIds {
         (::windows::core::Vtable::vtable(self).GetServiceIds)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(serviceidcount), ::core::mem::transmute(serviceids)).ok()
     }
 }
-impl ::core::convert::From<IGetServiceIds> for ::windows::core::IUnknown {
-    fn from(value: IGetServiceIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGetServiceIds> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGetServiceIds) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGetServiceIds> for ::windows::core::IUnknown {
-    fn from(value: &IGetServiceIds) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGetServiceIds, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGetServiceIds {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26338,21 +22757,7 @@ impl IHWEventHandler {
         (::windows::core::Vtable::vtable(self).HandleEventWithContent)(::windows::core::Vtable::as_raw(self), pszdeviceid.into(), pszaltdeviceid.into(), pszeventtype.into(), pszcontenttypehandler.into(), pdataobject.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IHWEventHandler> for ::windows::core::IUnknown {
-    fn from(value: IHWEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHWEventHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHWEventHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHWEventHandler> for ::windows::core::IUnknown {
-    fn from(value: &IHWEventHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHWEventHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHWEventHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26428,36 +22833,7 @@ impl IHWEventHandler2 {
         (::windows::core::Vtable::vtable(self).HandleEventWithHWND)(::windows::core::Vtable::as_raw(self), pszdeviceid.into(), pszaltdeviceid.into(), pszeventtype.into(), hwndowner.into()).ok()
     }
 }
-impl ::core::convert::From<IHWEventHandler2> for ::windows::core::IUnknown {
-    fn from(value: IHWEventHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHWEventHandler2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHWEventHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHWEventHandler2> for ::windows::core::IUnknown {
-    fn from(value: &IHWEventHandler2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHWEventHandler2> for IHWEventHandler {
-    fn from(value: IHWEventHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHWEventHandler2> for &'a IHWEventHandler {
-    fn from(value: &'a IHWEventHandler2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHWEventHandler2> for IHWEventHandler {
-    fn from(value: &IHWEventHandler2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHWEventHandler2, ::windows::core::IUnknown, IHWEventHandler);
 impl ::core::clone::Clone for IHWEventHandler2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26509,21 +22885,7 @@ impl IHandlerActivationHost {
         (::windows::core::Vtable::vtable(self).BeforeCreateProcess)(::windows::core::Vtable::as_raw(self), applicationpath.into(), commandline.into(), handlerinfo.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IHandlerActivationHost> for ::windows::core::IUnknown {
-    fn from(value: IHandlerActivationHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHandlerActivationHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHandlerActivationHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHandlerActivationHost> for ::windows::core::IUnknown {
-    fn from(value: &IHandlerActivationHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHandlerActivationHost, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHandlerActivationHost {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26570,21 +22932,7 @@ impl IHandlerInfo {
         (::windows::core::Vtable::vtable(self).GetApplicationIconReference)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IHandlerInfo> for ::windows::core::IUnknown {
-    fn from(value: IHandlerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHandlerInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHandlerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHandlerInfo> for ::windows::core::IUnknown {
-    fn from(value: &IHandlerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHandlerInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHandlerInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26636,36 +22984,7 @@ impl IHandlerInfo2 {
         (::windows::core::Vtable::vtable(self).GetApplicationId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IHandlerInfo2> for ::windows::core::IUnknown {
-    fn from(value: IHandlerInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHandlerInfo2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHandlerInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHandlerInfo2> for ::windows::core::IUnknown {
-    fn from(value: &IHandlerInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IHandlerInfo2> for IHandlerInfo {
-    fn from(value: IHandlerInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHandlerInfo2> for &'a IHandlerInfo {
-    fn from(value: &'a IHandlerInfo2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHandlerInfo2> for IHandlerInfo {
-    fn from(value: &IHandlerInfo2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHandlerInfo2, ::windows::core::IUnknown, IHandlerInfo);
 impl ::core::clone::Clone for IHandlerInfo2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26776,21 +23095,7 @@ impl IHlink {
         (::windows::core::Vtable::vtable(self).GetAdditionalParams)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IHlink> for ::windows::core::IUnknown {
-    fn from(value: IHlink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHlink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHlink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHlink> for ::windows::core::IUnknown {
-    fn from(value: &IHlink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHlink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHlink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -26935,21 +23240,7 @@ impl IHlinkBrowseContext {
         (::windows::core::Vtable::vtable(self).Close)(::windows::core::Vtable::as_raw(self), reserved).ok()
     }
 }
-impl ::core::convert::From<IHlinkBrowseContext> for ::windows::core::IUnknown {
-    fn from(value: IHlinkBrowseContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHlinkBrowseContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHlinkBrowseContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHlinkBrowseContext> for ::windows::core::IUnknown {
-    fn from(value: &IHlinkBrowseContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHlinkBrowseContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHlinkBrowseContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27057,21 +23348,7 @@ impl IHlinkFrame {
         (::windows::core::Vtable::vtable(self).UpdateHlink)(::windows::core::Vtable::as_raw(self), uhlid, pimktarget.into().abi(), pwzlocation.into(), pwzfriendlyname.into()).ok()
     }
 }
-impl ::core::convert::From<IHlinkFrame> for ::windows::core::IUnknown {
-    fn from(value: IHlinkFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHlinkFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHlinkFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHlinkFrame> for ::windows::core::IUnknown {
-    fn from(value: &IHlinkFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHlinkFrame, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHlinkFrame {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27137,21 +23414,7 @@ impl IHlinkSite {
         (::windows::core::Vtable::vtable(self).OnNavigationComplete)(::windows::core::Vtable::as_raw(self), dwsitedata, dwreserved, hrerror, pwzerror.into()).ok()
     }
 }
-impl ::core::convert::From<IHlinkSite> for ::windows::core::IUnknown {
-    fn from(value: IHlinkSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHlinkSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHlinkSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHlinkSite> for ::windows::core::IUnknown {
-    fn from(value: &IHlinkSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHlinkSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHlinkSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27223,21 +23486,7 @@ impl IHlinkTarget {
         (::windows::core::Vtable::vtable(self).GetFriendlyName)(::windows::core::Vtable::as_raw(self), pwzlocation.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IHlinkTarget> for ::windows::core::IUnknown {
-    fn from(value: IHlinkTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHlinkTarget> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHlinkTarget) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHlinkTarget> for ::windows::core::IUnknown {
-    fn from(value: &IHlinkTarget) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHlinkTarget, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHlinkTarget {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27293,21 +23542,7 @@ impl IHomeGroup {
         (::windows::core::Vtable::vtable(self).ShowSharingWizard)(::windows::core::Vtable::as_raw(self), owner.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<HOMEGROUPSHARINGCHOICES>(result__)
     }
 }
-impl ::core::convert::From<IHomeGroup> for ::windows::core::IUnknown {
-    fn from(value: IHomeGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHomeGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHomeGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHomeGroup> for ::windows::core::IUnknown {
-    fn from(value: &IHomeGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHomeGroup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHomeGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27354,21 +23589,7 @@ impl IIOCancelInformation {
         (::windows::core::Vtable::vtable(self).GetCancelInformation)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pdwthreadid.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pumsgcancel.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IIOCancelInformation> for ::windows::core::IUnknown {
-    fn from(value: IIOCancelInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIOCancelInformation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIOCancelInformation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIOCancelInformation> for ::windows::core::IUnknown {
-    fn from(value: &IIOCancelInformation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIOCancelInformation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IIOCancelInformation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27413,36 +23634,7 @@ impl IIdentityName {
         (::windows::core::Vtable::vtable(self).base__.GetItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IShellItem>(result__)
     }
 }
-impl ::core::convert::From<IIdentityName> for ::windows::core::IUnknown {
-    fn from(value: IIdentityName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIdentityName> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IIdentityName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIdentityName> for ::windows::core::IUnknown {
-    fn from(value: &IIdentityName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IIdentityName> for IRelatedItem {
-    fn from(value: IIdentityName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IIdentityName> for &'a IRelatedItem {
-    fn from(value: &'a IIdentityName) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IIdentityName> for IRelatedItem {
-    fn from(value: &IIdentityName) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IIdentityName, ::windows::core::IUnknown, IRelatedItem);
 impl ::core::clone::Clone for IIdentityName {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27485,21 +23677,7 @@ impl IImageRecompress {
         (::windows::core::Vtable::vtable(self).RecompressImage)(::windows::core::Vtable::as_raw(self), psi.into().abi(), cx, cy, iquality, pstg.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<IImageRecompress> for ::windows::core::IUnknown {
-    fn from(value: IImageRecompress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IImageRecompress> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IImageRecompress) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IImageRecompress> for ::windows::core::IUnknown {
-    fn from(value: &IImageRecompress) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IImageRecompress, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IImageRecompress {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27545,21 +23723,7 @@ impl IInitializeCommand {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pszcommandname.into(), ppb.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IInitializeCommand> for ::windows::core::IUnknown {
-    fn from(value: IInitializeCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeCommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitializeCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeCommand> for ::windows::core::IUnknown {
-    fn from(value: &IInitializeCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitializeCommand, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInitializeCommand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27605,21 +23769,7 @@ impl IInitializeNetworkFolder {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidl), ::core::mem::transmute(pidltarget), udisplaytype, pszresname.into(), pszprovider.into()).ok()
     }
 }
-impl ::core::convert::From<IInitializeNetworkFolder> for ::windows::core::IUnknown {
-    fn from(value: IInitializeNetworkFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeNetworkFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitializeNetworkFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeNetworkFolder> for ::windows::core::IUnknown {
-    fn from(value: &IInitializeNetworkFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitializeNetworkFolder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInitializeNetworkFolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27659,21 +23809,7 @@ impl IInitializeObject {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInitializeObject> for ::windows::core::IUnknown {
-    fn from(value: IInitializeObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitializeObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeObject> for ::windows::core::IUnknown {
-    fn from(value: &IInitializeObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitializeObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInitializeObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27715,21 +23851,7 @@ impl IInitializeWithBindCtx {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pbc.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IInitializeWithBindCtx> for ::windows::core::IUnknown {
-    fn from(value: IInitializeWithBindCtx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeWithBindCtx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitializeWithBindCtx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeWithBindCtx> for ::windows::core::IUnknown {
-    fn from(value: &IInitializeWithBindCtx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitializeWithBindCtx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInitializeWithBindCtx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27772,21 +23894,7 @@ impl IInitializeWithItem {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), psi.into().abi(), grfmode).ok()
     }
 }
-impl ::core::convert::From<IInitializeWithItem> for ::windows::core::IUnknown {
-    fn from(value: IInitializeWithItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeWithItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitializeWithItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeWithItem> for ::windows::core::IUnknown {
-    fn from(value: &IInitializeWithItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitializeWithItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInitializeWithItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27828,21 +23936,7 @@ impl IInitializeWithPropertyStore {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pps.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IInitializeWithPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: IInitializeWithPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeWithPropertyStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitializeWithPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeWithPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: &IInitializeWithPropertyStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitializeWithPropertyStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInitializeWithPropertyStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27887,21 +23981,7 @@ impl IInitializeWithWindow {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), hwnd.into()).ok()
     }
 }
-impl ::core::convert::From<IInitializeWithWindow> for ::windows::core::IUnknown {
-    fn from(value: IInitializeWithWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInitializeWithWindow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInitializeWithWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInitializeWithWindow> for ::windows::core::IUnknown {
-    fn from(value: &IInitializeWithWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInitializeWithWindow, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInitializeWithWindow {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -27954,21 +24034,7 @@ impl IInputObject {
         (::windows::core::Vtable::vtable(self).TranslateAcceleratorIO)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg)).ok()
     }
 }
-impl ::core::convert::From<IInputObject> for ::windows::core::IUnknown {
-    fn from(value: IInputObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInputObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputObject> for ::windows::core::IUnknown {
-    fn from(value: &IInputObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInputObject, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInputObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28031,36 +24097,7 @@ impl IInputObject2 {
         (::windows::core::Vtable::vtable(self).TranslateAcceleratorGlobal)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg)).ok()
     }
 }
-impl ::core::convert::From<IInputObject2> for ::windows::core::IUnknown {
-    fn from(value: IInputObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputObject2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInputObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputObject2> for ::windows::core::IUnknown {
-    fn from(value: &IInputObject2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IInputObject2> for IInputObject {
-    fn from(value: IInputObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputObject2> for &'a IInputObject {
-    fn from(value: &'a IInputObject2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputObject2> for IInputObject {
-    fn from(value: &IInputObject2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInputObject2, ::windows::core::IUnknown, IInputObject);
 impl ::core::clone::Clone for IInputObject2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28106,21 +24143,7 @@ impl IInputObjectSite {
         (::windows::core::Vtable::vtable(self).OnFocusChangeIS)(::windows::core::Vtable::as_raw(self), punkobj.into().abi(), fsetfocus.into()).ok()
     }
 }
-impl ::core::convert::From<IInputObjectSite> for ::windows::core::IUnknown {
-    fn from(value: IInputObjectSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputObjectSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInputObjectSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputObjectSite> for ::windows::core::IUnknown {
-    fn from(value: &IInputObjectSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInputObjectSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInputObjectSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28166,21 +24189,7 @@ impl IInputPaneAnimationCoordinator {
         (::windows::core::Vtable::vtable(self).AddAnimation)(::windows::core::Vtable::as_raw(self), device.into().abi(), animation.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IInputPaneAnimationCoordinator> for ::windows::core::IUnknown {
-    fn from(value: IInputPaneAnimationCoordinator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputPaneAnimationCoordinator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInputPaneAnimationCoordinator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputPaneAnimationCoordinator> for ::windows::core::IUnknown {
-    fn from(value: &IInputPaneAnimationCoordinator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInputPaneAnimationCoordinator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInputPaneAnimationCoordinator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28220,21 +24229,7 @@ impl IInputPanelConfiguration {
         (::windows::core::Vtable::vtable(self).EnableFocusTracking)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInputPanelConfiguration> for ::windows::core::IUnknown {
-    fn from(value: IInputPanelConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputPanelConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInputPanelConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputPanelConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &IInputPanelConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInputPanelConfiguration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInputPanelConfiguration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28271,21 +24266,7 @@ impl IInputPanelInvocationConfiguration {
         (::windows::core::Vtable::vtable(self).RequireTouchInEditControl)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInputPanelInvocationConfiguration> for ::windows::core::IUnknown {
-    fn from(value: IInputPanelInvocationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputPanelInvocationConfiguration> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInputPanelInvocationConfiguration) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputPanelInvocationConfiguration> for ::windows::core::IUnknown {
-    fn from(value: &IInputPanelInvocationConfiguration) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInputPanelInvocationConfiguration, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInputPanelInvocationConfiguration {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28324,21 +24305,7 @@ impl IInsertItem {
         (::windows::core::Vtable::vtable(self).InsertItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidl)).ok()
     }
 }
-impl ::core::convert::From<IInsertItem> for ::windows::core::IUnknown {
-    fn from(value: IInsertItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInsertItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInsertItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInsertItem> for ::windows::core::IUnknown {
-    fn from(value: &IInsertItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInsertItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInsertItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28385,21 +24352,7 @@ impl IItemNameLimits {
         (::windows::core::Vtable::vtable(self).GetMaxLength)(::windows::core::Vtable::as_raw(self), pszname.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IItemNameLimits> for ::windows::core::IUnknown {
-    fn from(value: IItemNameLimits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IItemNameLimits> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IItemNameLimits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IItemNameLimits> for ::windows::core::IUnknown {
-    fn from(value: &IItemNameLimits) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IItemNameLimits, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IItemNameLimits {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28477,21 +24430,7 @@ impl IKnownFolder {
         (::windows::core::Vtable::vtable(self).GetFolderDefinition)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<KNOWNFOLDER_DEFINITION>(result__)
     }
 }
-impl ::core::convert::From<IKnownFolder> for ::windows::core::IUnknown {
-    fn from(value: IKnownFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKnownFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKnownFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKnownFolder> for ::windows::core::IUnknown {
-    fn from(value: &IKnownFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKnownFolder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKnownFolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28587,21 +24526,7 @@ impl IKnownFolderManager {
         (::windows::core::Vtable::vtable(self).Redirect)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rfid), hwnd.into(), flags, psztargetpath.into(), pexclusion.as_deref().map_or(0, |slice| slice.len() as _), ::core::mem::transmute(pexclusion.as_deref().map_or(::core::ptr::null(), |slice| slice.as_ptr())), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IKnownFolderManager> for ::windows::core::IUnknown {
-    fn from(value: IKnownFolderManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IKnownFolderManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IKnownFolderManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IKnownFolderManager> for ::windows::core::IUnknown {
-    fn from(value: &IKnownFolderManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IKnownFolderManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IKnownFolderManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28654,21 +24579,7 @@ impl ILaunchSourceAppUserModelId {
         (::windows::core::Vtable::vtable(self).GetAppUserModelId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ILaunchSourceAppUserModelId> for ::windows::core::IUnknown {
-    fn from(value: ILaunchSourceAppUserModelId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILaunchSourceAppUserModelId> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILaunchSourceAppUserModelId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILaunchSourceAppUserModelId> for ::windows::core::IUnknown {
-    fn from(value: &ILaunchSourceAppUserModelId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILaunchSourceAppUserModelId, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILaunchSourceAppUserModelId {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28712,21 +24623,7 @@ impl ILaunchSourceViewSizePreference {
         (::windows::core::Vtable::vtable(self).GetSourceViewSizePreference)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<APPLICATION_VIEW_SIZE_PREFERENCE>(result__)
     }
 }
-impl ::core::convert::From<ILaunchSourceViewSizePreference> for ::windows::core::IUnknown {
-    fn from(value: ILaunchSourceViewSizePreference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILaunchSourceViewSizePreference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILaunchSourceViewSizePreference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILaunchSourceViewSizePreference> for ::windows::core::IUnknown {
-    fn from(value: &ILaunchSourceViewSizePreference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILaunchSourceViewSizePreference, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILaunchSourceViewSizePreference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28770,21 +24667,7 @@ impl ILaunchTargetMonitor {
         (::windows::core::Vtable::vtable(self).GetMonitor)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Graphics::Gdi::HMONITOR>(result__)
     }
 }
-impl ::core::convert::From<ILaunchTargetMonitor> for ::windows::core::IUnknown {
-    fn from(value: ILaunchTargetMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILaunchTargetMonitor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILaunchTargetMonitor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILaunchTargetMonitor> for ::windows::core::IUnknown {
-    fn from(value: &ILaunchTargetMonitor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILaunchTargetMonitor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILaunchTargetMonitor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28825,21 +24708,7 @@ impl ILaunchTargetViewSizePreference {
         (::windows::core::Vtable::vtable(self).GetTargetViewSizePreference)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<APPLICATION_VIEW_SIZE_PREFERENCE>(result__)
     }
 }
-impl ::core::convert::From<ILaunchTargetViewSizePreference> for ::windows::core::IUnknown {
-    fn from(value: ILaunchTargetViewSizePreference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILaunchTargetViewSizePreference> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILaunchTargetViewSizePreference) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILaunchTargetViewSizePreference> for ::windows::core::IUnknown {
-    fn from(value: &ILaunchTargetViewSizePreference) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILaunchTargetViewSizePreference, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILaunchTargetViewSizePreference {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28884,21 +24753,7 @@ impl ILaunchUIContext {
         (::windows::core::Vtable::vtable(self).SetTabGroupingPreference)(::windows::core::Vtable::as_raw(self), value).ok()
     }
 }
-impl ::core::convert::From<ILaunchUIContext> for ::windows::core::IUnknown {
-    fn from(value: ILaunchUIContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILaunchUIContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILaunchUIContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILaunchUIContext> for ::windows::core::IUnknown {
-    fn from(value: &ILaunchUIContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILaunchUIContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILaunchUIContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -28942,21 +24797,7 @@ impl ILaunchUIContextProvider {
         (::windows::core::Vtable::vtable(self).UpdateContext)(::windows::core::Vtable::as_raw(self), context.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ILaunchUIContextProvider> for ::windows::core::IUnknown {
-    fn from(value: ILaunchUIContextProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ILaunchUIContextProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ILaunchUIContextProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ILaunchUIContextProvider> for ::windows::core::IUnknown {
-    fn from(value: &ILaunchUIContextProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ILaunchUIContextProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ILaunchUIContextProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29000,21 +24841,7 @@ impl IMenuBand {
         (::windows::core::Vtable::vtable(self).TranslateMenuMessage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg), ::core::mem::transmute(plret)).ok()
     }
 }
-impl ::core::convert::From<IMenuBand> for ::windows::core::IUnknown {
-    fn from(value: IMenuBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMenuBand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMenuBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMenuBand> for ::windows::core::IUnknown {
-    fn from(value: &IMenuBand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMenuBand, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMenuBand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29104,59 +24931,7 @@ impl IMenuPopup {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IMenuPopup> for ::windows::core::IUnknown {
-    fn from(value: IMenuPopup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IMenuPopup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMenuPopup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IMenuPopup> for ::windows::core::IUnknown {
-    fn from(value: &IMenuPopup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IMenuPopup> for super::super::System::Ole::IOleWindow {
-    fn from(value: IMenuPopup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IMenuPopup> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IMenuPopup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IMenuPopup> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IMenuPopup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IMenuPopup> for IDeskBar {
-    fn from(value: IMenuPopup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IMenuPopup> for &'a IDeskBar {
-    fn from(value: &'a IMenuPopup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IMenuPopup> for IDeskBar {
-    fn from(value: &IMenuPopup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMenuPopup, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow, IDeskBar);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IMenuPopup {
     fn clone(&self) -> Self {
@@ -29213,21 +24988,7 @@ impl IModalWindow {
         (::windows::core::Vtable::vtable(self).Show)(::windows::core::Vtable::as_raw(self), hwndowner.into()).ok()
     }
 }
-impl ::core::convert::From<IModalWindow> for ::windows::core::IUnknown {
-    fn from(value: IModalWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IModalWindow> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IModalWindow) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IModalWindow> for ::windows::core::IUnknown {
-    fn from(value: &IModalWindow) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IModalWindow, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IModalWindow {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29286,21 +25047,7 @@ impl INameSpaceTreeAccessible {
         (::windows::core::Vtable::vtable(self).OnGetAccessibilityRole)(::windows::core::Vtable::as_raw(self), psi.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<INameSpaceTreeAccessible> for ::windows::core::IUnknown {
-    fn from(value: INameSpaceTreeAccessible) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INameSpaceTreeAccessible> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INameSpaceTreeAccessible) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INameSpaceTreeAccessible> for ::windows::core::IUnknown {
-    fn from(value: &INameSpaceTreeAccessible) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INameSpaceTreeAccessible, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INameSpaceTreeAccessible {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29451,21 +25198,7 @@ impl INameSpaceTreeControl {
         (::windows::core::Vtable::vtable(self).CollapseAll)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<INameSpaceTreeControl> for ::windows::core::IUnknown {
-    fn from(value: INameSpaceTreeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INameSpaceTreeControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INameSpaceTreeControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INameSpaceTreeControl> for ::windows::core::IUnknown {
-    fn from(value: &INameSpaceTreeControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INameSpaceTreeControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INameSpaceTreeControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29652,36 +25385,7 @@ impl INameSpaceTreeControl2 {
         (::windows::core::Vtable::vtable(self).GetControlStyle2)(::windows::core::Vtable::as_raw(self), nstcsmask, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<NSTCSTYLE2>(result__)
     }
 }
-impl ::core::convert::From<INameSpaceTreeControl2> for ::windows::core::IUnknown {
-    fn from(value: INameSpaceTreeControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INameSpaceTreeControl2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INameSpaceTreeControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INameSpaceTreeControl2> for ::windows::core::IUnknown {
-    fn from(value: &INameSpaceTreeControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INameSpaceTreeControl2> for INameSpaceTreeControl {
-    fn from(value: INameSpaceTreeControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INameSpaceTreeControl2> for &'a INameSpaceTreeControl {
-    fn from(value: &'a INameSpaceTreeControl2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INameSpaceTreeControl2> for INameSpaceTreeControl {
-    fn from(value: &INameSpaceTreeControl2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INameSpaceTreeControl2, ::windows::core::IUnknown, INameSpaceTreeControl);
 impl ::core::clone::Clone for INameSpaceTreeControl2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29751,21 +25455,7 @@ impl INameSpaceTreeControlCustomDraw {
         (::windows::core::Vtable::vtable(self).ItemPostPaint)(::windows::core::Vtable::as_raw(self), hdc.into(), ::core::mem::transmute(prc), ::core::mem::transmute(pnstccditem)).ok()
     }
 }
-impl ::core::convert::From<INameSpaceTreeControlCustomDraw> for ::windows::core::IUnknown {
-    fn from(value: INameSpaceTreeControlCustomDraw) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INameSpaceTreeControlCustomDraw> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INameSpaceTreeControlCustomDraw) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INameSpaceTreeControlCustomDraw> for ::windows::core::IUnknown {
-    fn from(value: &INameSpaceTreeControlCustomDraw) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INameSpaceTreeControlCustomDraw, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INameSpaceTreeControlCustomDraw {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -29858,21 +25548,7 @@ impl INameSpaceTreeControlDropHandler {
         (::windows::core::Vtable::vtable(self).OnDragLeave)(::windows::core::Vtable::as_raw(self), psiover.into().abi()).ok()
     }
 }
-impl ::core::convert::From<INameSpaceTreeControlDropHandler> for ::windows::core::IUnknown {
-    fn from(value: INameSpaceTreeControlDropHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INameSpaceTreeControlDropHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INameSpaceTreeControlDropHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INameSpaceTreeControlDropHandler> for ::windows::core::IUnknown {
-    fn from(value: &INameSpaceTreeControlDropHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INameSpaceTreeControlDropHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INameSpaceTreeControlDropHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30032,21 +25708,7 @@ impl INameSpaceTreeControlEvents {
         (::windows::core::Vtable::vtable(self).OnGetDefaultIconIndex)(::windows::core::Vtable::as_raw(self), psi.into().abi(), ::core::mem::transmute(pidefaulticon), ::core::mem::transmute(piopenicon)).ok()
     }
 }
-impl ::core::convert::From<INameSpaceTreeControlEvents> for ::windows::core::IUnknown {
-    fn from(value: INameSpaceTreeControlEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INameSpaceTreeControlEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INameSpaceTreeControlEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INameSpaceTreeControlEvents> for ::windows::core::IUnknown {
-    fn from(value: &INameSpaceTreeControlEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INameSpaceTreeControlEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INameSpaceTreeControlEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30110,21 +25772,7 @@ impl INameSpaceTreeControlFolderCapabilities {
         (::windows::core::Vtable::vtable(self).GetFolderCapabilities)(::windows::core::Vtable::as_raw(self), nfcmask, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<NSTCFOLDERCAPABILITIES>(result__)
     }
 }
-impl ::core::convert::From<INameSpaceTreeControlFolderCapabilities> for ::windows::core::IUnknown {
-    fn from(value: INameSpaceTreeControlFolderCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INameSpaceTreeControlFolderCapabilities> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INameSpaceTreeControlFolderCapabilities) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INameSpaceTreeControlFolderCapabilities> for ::windows::core::IUnknown {
-    fn from(value: &INameSpaceTreeControlFolderCapabilities) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INameSpaceTreeControlFolderCapabilities, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INameSpaceTreeControlFolderCapabilities {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30183,21 +25831,7 @@ impl INamedPropertyBag {
         (::windows::core::Vtable::vtable(self).RemovePropertyNPB)(::windows::core::Vtable::as_raw(self), pszbagname.into(), pszpropname.into()).ok()
     }
 }
-impl ::core::convert::From<INamedPropertyBag> for ::windows::core::IUnknown {
-    fn from(value: INamedPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INamedPropertyBag> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INamedPropertyBag) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INamedPropertyBag> for ::windows::core::IUnknown {
-    fn from(value: &INamedPropertyBag) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INamedPropertyBag, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INamedPropertyBag {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30251,21 +25885,7 @@ impl INamespaceWalk {
         (::windows::core::Vtable::vtable(self).GetIDArrayResult)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pcitems), ::core::mem::transmute(prgpidl)).ok()
     }
 }
-impl ::core::convert::From<INamespaceWalk> for ::windows::core::IUnknown {
-    fn from(value: INamespaceWalk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INamespaceWalk> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INamespaceWalk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INamespaceWalk> for ::windows::core::IUnknown {
-    fn from(value: &INamespaceWalk) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INamespaceWalk, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INamespaceWalk {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30330,21 +25950,7 @@ impl INamespaceWalkCB {
         (::windows::core::Vtable::vtable(self).InitializeProgressDialog)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppsztitle), ::core::mem::transmute(ppszcancel)).ok()
     }
 }
-impl ::core::convert::From<INamespaceWalkCB> for ::windows::core::IUnknown {
-    fn from(value: INamespaceWalkCB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INamespaceWalkCB> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INamespaceWalkCB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INamespaceWalkCB> for ::windows::core::IUnknown {
-    fn from(value: &INamespaceWalkCB) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INamespaceWalkCB, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INamespaceWalkCB {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30420,36 +26026,7 @@ impl INamespaceWalkCB2 {
         (::windows::core::Vtable::vtable(self).WalkComplete)(::windows::core::Vtable::as_raw(self), hr).ok()
     }
 }
-impl ::core::convert::From<INamespaceWalkCB2> for ::windows::core::IUnknown {
-    fn from(value: INamespaceWalkCB2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INamespaceWalkCB2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INamespaceWalkCB2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INamespaceWalkCB2> for ::windows::core::IUnknown {
-    fn from(value: &INamespaceWalkCB2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<INamespaceWalkCB2> for INamespaceWalkCB {
-    fn from(value: INamespaceWalkCB2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INamespaceWalkCB2> for &'a INamespaceWalkCB {
-    fn from(value: &'a INamespaceWalkCB2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INamespaceWalkCB2> for INamespaceWalkCB {
-    fn from(value: &INamespaceWalkCB2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INamespaceWalkCB2, ::windows::core::IUnknown, INamespaceWalkCB);
 impl ::core::clone::Clone for INamespaceWalkCB2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30498,21 +26075,7 @@ impl INetworkFolderInternal {
         (::windows::core::Vtable::vtable(self).GetProvider)(::windows::core::Vtable::as_raw(self), itemids.len() as _, ::core::mem::transmute(itemids.as_ptr()), provider.len() as _, ::core::mem::transmute(provider.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<INetworkFolderInternal> for ::windows::core::IUnknown {
-    fn from(value: INetworkFolderInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INetworkFolderInternal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INetworkFolderInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INetworkFolderInternal> for ::windows::core::IUnknown {
-    fn from(value: &INetworkFolderInternal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INetworkFolderInternal, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INetworkFolderInternal {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30563,21 +26126,7 @@ impl INewMenuClient {
         (::windows::core::Vtable::vtable(self).SelectAndEditItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidlitem), flags).ok()
     }
 }
-impl ::core::convert::From<INewMenuClient> for ::windows::core::IUnknown {
-    fn from(value: INewMenuClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INewMenuClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INewMenuClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INewMenuClient> for ::windows::core::IUnknown {
-    fn from(value: &INewMenuClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INewMenuClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INewMenuClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30642,21 +26191,7 @@ impl INewShortcutHookA {
         (::windows::core::Vtable::vtable(self).GetExtension)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pszextension.as_ptr()), pszextension.len() as _).ok()
     }
 }
-impl ::core::convert::From<INewShortcutHookA> for ::windows::core::IUnknown {
-    fn from(value: INewShortcutHookA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INewShortcutHookA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INewShortcutHookA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INewShortcutHookA> for ::windows::core::IUnknown {
-    fn from(value: &INewShortcutHookA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INewShortcutHookA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INewShortcutHookA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30725,21 +26260,7 @@ impl INewShortcutHookW {
         (::windows::core::Vtable::vtable(self).GetExtension)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pszextension.as_ptr()), pszextension.len() as _).ok()
     }
 }
-impl ::core::convert::From<INewShortcutHookW> for ::windows::core::IUnknown {
-    fn from(value: INewShortcutHookW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INewShortcutHookW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INewShortcutHookW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INewShortcutHookW> for ::windows::core::IUnknown {
-    fn from(value: &INewShortcutHookW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INewShortcutHookW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INewShortcutHookW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30821,59 +26342,7 @@ impl INewWDEvents {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INewWDEvents> for ::windows::core::IUnknown {
-    fn from(value: INewWDEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INewWDEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INewWDEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INewWDEvents> for ::windows::core::IUnknown {
-    fn from(value: &INewWDEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INewWDEvents> for super::super::System::Com::IDispatch {
-    fn from(value: INewWDEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INewWDEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a INewWDEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INewWDEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &INewWDEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<INewWDEvents> for IWebWizardHost {
-    fn from(value: INewWDEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a INewWDEvents> for &'a IWebWizardHost {
-    fn from(value: &'a INewWDEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&INewWDEvents> for IWebWizardHost {
-    fn from(value: &INewWDEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INewWDEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWebWizardHost);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for INewWDEvents {
     fn clone(&self) -> Self {
@@ -30926,21 +26395,7 @@ impl INewWindowManager {
         (::windows::core::Vtable::vtable(self).EvaluateNewWindow)(::windows::core::Vtable::as_raw(self), pszurl.into(), pszname.into(), pszurlcontext.into(), pszfeatures.into(), freplace.into(), dwflags, dwuseractiontime).ok()
     }
 }
-impl ::core::convert::From<INewWindowManager> for ::windows::core::IUnknown {
-    fn from(value: INewWindowManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INewWindowManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INewWindowManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INewWindowManager> for ::windows::core::IUnknown {
-    fn from(value: &INewWindowManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INewWindowManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INewWindowManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -30982,21 +26437,7 @@ impl INotifyReplica {
         (::windows::core::Vtable::vtable(self).YouAreAReplica)(::windows::core::Vtable::as_raw(self), rgpmkotherreplicas.len() as _, ::core::mem::transmute(rgpmkotherreplicas.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<INotifyReplica> for ::windows::core::IUnknown {
-    fn from(value: INotifyReplica) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a INotifyReplica> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a INotifyReplica) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&INotifyReplica> for ::windows::core::IUnknown {
-    fn from(value: &INotifyReplica) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(INotifyReplica, ::windows::core::IUnknown);
 impl ::core::clone::Clone for INotifyReplica {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31045,21 +26486,7 @@ impl IObjMgr {
         (::windows::core::Vtable::vtable(self).Remove)(::windows::core::Vtable::as_raw(self), punk.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IObjMgr> for ::windows::core::IUnknown {
-    fn from(value: IObjMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjMgr> for ::windows::core::IUnknown {
-    fn from(value: &IObjMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31101,21 +26528,7 @@ impl IObjectProvider {
         (::windows::core::Vtable::vtable(self).QueryObject)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidobject), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IObjectProvider> for ::windows::core::IUnknown {
-    fn from(value: IObjectProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectProvider> for ::windows::core::IUnknown {
-    fn from(value: &IObjectProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31159,21 +26572,7 @@ impl IObjectWithAppUserModelID {
         (::windows::core::Vtable::vtable(self).GetAppID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IObjectWithAppUserModelID> for ::windows::core::IUnknown {
-    fn from(value: IObjectWithAppUserModelID) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectWithAppUserModelID> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectWithAppUserModelID) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectWithAppUserModelID> for ::windows::core::IUnknown {
-    fn from(value: &IObjectWithAppUserModelID) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectWithAppUserModelID, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectWithAppUserModelID {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31211,21 +26610,7 @@ impl IObjectWithBackReferences {
         (::windows::core::Vtable::vtable(self).RemoveBackReferences)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IObjectWithBackReferences> for ::windows::core::IUnknown {
-    fn from(value: IObjectWithBackReferences) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectWithBackReferences> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectWithBackReferences) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectWithBackReferences> for ::windows::core::IUnknown {
-    fn from(value: &IObjectWithBackReferences) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectWithBackReferences, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectWithBackReferences {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31265,21 +26650,7 @@ impl IObjectWithCancelEvent {
         (::windows::core::Vtable::vtable(self).GetCancelEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::HANDLE>(result__)
     }
 }
-impl ::core::convert::From<IObjectWithCancelEvent> for ::windows::core::IUnknown {
-    fn from(value: IObjectWithCancelEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectWithCancelEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectWithCancelEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectWithCancelEvent> for ::windows::core::IUnknown {
-    fn from(value: &IObjectWithCancelEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectWithCancelEvent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectWithCancelEvent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31323,21 +26694,7 @@ impl IObjectWithFolderEnumMode {
         (::windows::core::Vtable::vtable(self).GetMode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<FOLDER_ENUM_MODE>(result__)
     }
 }
-impl ::core::convert::From<IObjectWithFolderEnumMode> for ::windows::core::IUnknown {
-    fn from(value: IObjectWithFolderEnumMode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectWithFolderEnumMode> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectWithFolderEnumMode) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectWithFolderEnumMode> for ::windows::core::IUnknown {
-    fn from(value: &IObjectWithFolderEnumMode) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectWithFolderEnumMode, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectWithFolderEnumMode {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31382,21 +26739,7 @@ impl IObjectWithProgID {
         (::windows::core::Vtable::vtable(self).GetProgID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IObjectWithProgID> for ::windows::core::IUnknown {
-    fn from(value: IObjectWithProgID) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectWithProgID> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectWithProgID) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectWithProgID> for ::windows::core::IUnknown {
-    fn from(value: &IObjectWithProgID) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectWithProgID, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectWithProgID {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31444,21 +26787,7 @@ impl IObjectWithSelection {
         (::windows::core::Vtable::vtable(self).GetSelection)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IObjectWithSelection> for ::windows::core::IUnknown {
-    fn from(value: IObjectWithSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IObjectWithSelection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IObjectWithSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IObjectWithSelection> for ::windows::core::IUnknown {
-    fn from(value: &IObjectWithSelection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IObjectWithSelection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IObjectWithSelection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31511,21 +26840,7 @@ impl IOpenControlPanel {
         (::windows::core::Vtable::vtable(self).GetCurrentView)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<CPVIEW>(result__)
     }
 }
-impl ::core::convert::From<IOpenControlPanel> for ::windows::core::IUnknown {
-    fn from(value: IOpenControlPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpenControlPanel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpenControlPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpenControlPanel> for ::windows::core::IUnknown {
-    fn from(value: &IOpenControlPanel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpenControlPanel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpenControlPanel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31572,21 +26887,7 @@ impl IOpenSearchSource {
         (::windows::core::Vtable::vtable(self).GetResults)(::windows::core::Vtable::as_raw(self), hwnd.into(), pszquery.into(), dwstartindex, dwcount, &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IOpenSearchSource> for ::windows::core::IUnknown {
-    fn from(value: IOpenSearchSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOpenSearchSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOpenSearchSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOpenSearchSource> for ::windows::core::IUnknown {
-    fn from(value: &IOpenSearchSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOpenSearchSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOpenSearchSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31669,21 +26970,7 @@ impl IOperationsProgressDialog {
         (::windows::core::Vtable::vtable(self).GetOperationStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<PropertiesSystem::PDOPSTATUS>(result__)
     }
 }
-impl ::core::convert::From<IOperationsProgressDialog> for ::windows::core::IUnknown {
-    fn from(value: IOperationsProgressDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IOperationsProgressDialog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IOperationsProgressDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IOperationsProgressDialog> for ::windows::core::IUnknown {
-    fn from(value: &IOperationsProgressDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IOperationsProgressDialog, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IOperationsProgressDialog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31819,21 +27106,7 @@ impl IPackageDebugSettings {
         (::windows::core::Vtable::vtable(self).UnregisterForPackageStateChanges)(::windows::core::Vtable::as_raw(self), dwcookie).ok()
     }
 }
-impl ::core::convert::From<IPackageDebugSettings> for ::windows::core::IUnknown {
-    fn from(value: IPackageDebugSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPackageDebugSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPackageDebugSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPackageDebugSettings> for ::windows::core::IUnknown {
-    fn from(value: &IPackageDebugSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPackageDebugSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPackageDebugSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -31973,36 +27246,7 @@ impl IPackageDebugSettings2 {
         (::windows::core::Vtable::vtable(self).EnumerateApps)(::windows::core::Vtable::as_raw(self), packagefullname.into(), ::core::mem::transmute(appcount), ::core::mem::transmute(appusermodelids), ::core::mem::transmute(appdisplaynames)).ok()
     }
 }
-impl ::core::convert::From<IPackageDebugSettings2> for ::windows::core::IUnknown {
-    fn from(value: IPackageDebugSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPackageDebugSettings2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPackageDebugSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPackageDebugSettings2> for ::windows::core::IUnknown {
-    fn from(value: &IPackageDebugSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPackageDebugSettings2> for IPackageDebugSettings {
-    fn from(value: IPackageDebugSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPackageDebugSettings2> for &'a IPackageDebugSettings {
-    fn from(value: &'a IPackageDebugSettings2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPackageDebugSettings2> for IPackageDebugSettings {
-    fn from(value: &IPackageDebugSettings2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPackageDebugSettings2, ::windows::core::IUnknown, IPackageDebugSettings);
 impl ::core::clone::Clone for IPackageDebugSettings2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32042,21 +27286,7 @@ impl IPackageExecutionStateChangeNotification {
         (::windows::core::Vtable::vtable(self).OnStateChanged)(::windows::core::Vtable::as_raw(self), pszpackagefullname.into(), pesnewstate).ok()
     }
 }
-impl ::core::convert::From<IPackageExecutionStateChangeNotification> for ::windows::core::IUnknown {
-    fn from(value: IPackageExecutionStateChangeNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPackageExecutionStateChangeNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPackageExecutionStateChangeNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPackageExecutionStateChangeNotification> for ::windows::core::IUnknown {
-    fn from(value: &IPackageExecutionStateChangeNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPackageExecutionStateChangeNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPackageExecutionStateChangeNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32103,21 +27333,7 @@ impl IParentAndItem {
         (::windows::core::Vtable::vtable(self).GetParentAndItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppidlparent.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ppsf.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(ppidlchild.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IParentAndItem> for ::windows::core::IUnknown {
-    fn from(value: IParentAndItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IParentAndItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IParentAndItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IParentAndItem> for ::windows::core::IUnknown {
-    fn from(value: &IParentAndItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IParentAndItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IParentAndItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32171,21 +27387,7 @@ impl IParseAndCreateItem {
         (::windows::core::Vtable::vtable(self).GetItem)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IParseAndCreateItem> for ::windows::core::IUnknown {
-    fn from(value: IParseAndCreateItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IParseAndCreateItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IParseAndCreateItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IParseAndCreateItem> for ::windows::core::IUnknown {
-    fn from(value: &IParseAndCreateItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IParseAndCreateItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IParseAndCreateItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32234,41 +27436,7 @@ impl IPersistFolder {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistFolder> for ::windows::core::IUnknown {
-    fn from(value: IPersistFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistFolder> for ::windows::core::IUnknown {
-    fn from(value: &IPersistFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistFolder> for super::super::System::Com::IPersist {
-    fn from(value: IPersistFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistFolder> for &'a super::super::System::Com::IPersist {
-    fn from(value: &'a IPersistFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistFolder> for super::super::System::Com::IPersist {
-    fn from(value: &IPersistFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistFolder, ::windows::core::IUnknown, super::super::System::Com::IPersist);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPersistFolder {
     fn clone(&self) -> Self {
@@ -32332,59 +27500,7 @@ impl IPersistFolder2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistFolder2> for ::windows::core::IUnknown {
-    fn from(value: IPersistFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistFolder2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistFolder2> for ::windows::core::IUnknown {
-    fn from(value: &IPersistFolder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistFolder2> for super::super::System::Com::IPersist {
-    fn from(value: IPersistFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistFolder2> for &'a super::super::System::Com::IPersist {
-    fn from(value: &'a IPersistFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistFolder2> for super::super::System::Com::IPersist {
-    fn from(value: &IPersistFolder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistFolder2> for IPersistFolder {
-    fn from(value: IPersistFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistFolder2> for &'a IPersistFolder {
-    fn from(value: &'a IPersistFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistFolder2> for IPersistFolder {
-    fn from(value: &IPersistFolder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistFolder2, ::windows::core::IUnknown, super::super::System::Com::IPersist, IPersistFolder);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPersistFolder2 {
     fn clone(&self) -> Self {
@@ -32462,77 +27578,7 @@ impl IPersistFolder3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistFolder3> for ::windows::core::IUnknown {
-    fn from(value: IPersistFolder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistFolder3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistFolder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistFolder3> for ::windows::core::IUnknown {
-    fn from(value: &IPersistFolder3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistFolder3> for super::super::System::Com::IPersist {
-    fn from(value: IPersistFolder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistFolder3> for &'a super::super::System::Com::IPersist {
-    fn from(value: &'a IPersistFolder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistFolder3> for super::super::System::Com::IPersist {
-    fn from(value: &IPersistFolder3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistFolder3> for IPersistFolder {
-    fn from(value: IPersistFolder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistFolder3> for &'a IPersistFolder {
-    fn from(value: &'a IPersistFolder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistFolder3> for IPersistFolder {
-    fn from(value: &IPersistFolder3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistFolder3> for IPersistFolder2 {
-    fn from(value: IPersistFolder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistFolder3> for &'a IPersistFolder2 {
-    fn from(value: &'a IPersistFolder3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistFolder3> for IPersistFolder2 {
-    fn from(value: &IPersistFolder3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistFolder3, ::windows::core::IUnknown, super::super::System::Com::IPersist, IPersistFolder, IPersistFolder2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPersistFolder3 {
     fn clone(&self) -> Self {
@@ -32600,41 +27646,7 @@ impl IPersistIDList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistIDList> for ::windows::core::IUnknown {
-    fn from(value: IPersistIDList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistIDList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPersistIDList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistIDList> for ::windows::core::IUnknown {
-    fn from(value: &IPersistIDList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPersistIDList> for super::super::System::Com::IPersist {
-    fn from(value: IPersistIDList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPersistIDList> for &'a super::super::System::Com::IPersist {
-    fn from(value: &'a IPersistIDList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPersistIDList> for super::super::System::Com::IPersist {
-    fn from(value: &IPersistIDList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPersistIDList, ::windows::core::IUnknown, super::super::System::Com::IPersist);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPersistIDList {
     fn clone(&self) -> Self {
@@ -32715,21 +27727,7 @@ impl IPreviewHandler {
         (::windows::core::Vtable::vtable(self).TranslateAccelerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg)).ok()
     }
 }
-impl ::core::convert::From<IPreviewHandler> for ::windows::core::IUnknown {
-    fn from(value: IPreviewHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPreviewHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPreviewHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPreviewHandler> for ::windows::core::IUnknown {
-    fn from(value: &IPreviewHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPreviewHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPreviewHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32792,21 +27790,7 @@ impl IPreviewHandlerFrame {
         (::windows::core::Vtable::vtable(self).TranslateAccelerator)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg)).ok()
     }
 }
-impl ::core::convert::From<IPreviewHandlerFrame> for ::windows::core::IUnknown {
-    fn from(value: IPreviewHandlerFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPreviewHandlerFrame> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPreviewHandlerFrame) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPreviewHandlerFrame> for ::windows::core::IUnknown {
-    fn from(value: &IPreviewHandlerFrame) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPreviewHandlerFrame, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPreviewHandlerFrame {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32868,21 +27852,7 @@ impl IPreviewHandlerVisuals {
         (::windows::core::Vtable::vtable(self).SetTextColor)(::windows::core::Vtable::as_raw(self), color.into()).ok()
     }
 }
-impl ::core::convert::From<IPreviewHandlerVisuals> for ::windows::core::IUnknown {
-    fn from(value: IPreviewHandlerVisuals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPreviewHandlerVisuals> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPreviewHandlerVisuals) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPreviewHandlerVisuals> for ::windows::core::IUnknown {
-    fn from(value: &IPreviewHandlerVisuals) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPreviewHandlerVisuals, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPreviewHandlerVisuals {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -32937,36 +27907,7 @@ impl IPreviewItem {
         (::windows::core::Vtable::vtable(self).base__.GetItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IShellItem>(result__)
     }
 }
-impl ::core::convert::From<IPreviewItem> for ::windows::core::IUnknown {
-    fn from(value: IPreviewItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPreviewItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPreviewItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPreviewItem> for ::windows::core::IUnknown {
-    fn from(value: &IPreviewItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPreviewItem> for IRelatedItem {
-    fn from(value: IPreviewItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPreviewItem> for &'a IRelatedItem {
-    fn from(value: &'a IPreviewItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPreviewItem> for IRelatedItem {
-    fn from(value: &IPreviewItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPreviewItem, ::windows::core::IUnknown, IRelatedItem);
 impl ::core::clone::Clone for IPreviewItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33009,21 +27950,7 @@ impl IPreviousVersionsInfo {
         (::windows::core::Vtable::vtable(self).AreSnapshotsAvailable)(::windows::core::Vtable::as_raw(self), pszpath.into(), foktobeslow.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IPreviousVersionsInfo> for ::windows::core::IUnknown {
-    fn from(value: IPreviousVersionsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPreviousVersionsInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPreviousVersionsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPreviousVersionsInfo> for ::windows::core::IUnknown {
-    fn from(value: &IPreviousVersionsInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPreviousVersionsInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPreviousVersionsInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33072,21 +27999,7 @@ impl IProfferService {
         (::windows::core::Vtable::vtable(self).RevokeService)(::windows::core::Vtable::as_raw(self), cookie).ok()
     }
 }
-impl ::core::convert::From<IProfferService> for ::windows::core::IUnknown {
-    fn from(value: IProfferService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProfferService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProfferService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProfferService> for ::windows::core::IUnknown {
-    fn from(value: &IProfferService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProfferService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProfferService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33179,21 +28092,7 @@ impl IProgressDialog {
         (::windows::core::Vtable::vtable(self).Timer)(::windows::core::Vtable::as_raw(self), dwtimeraction, ::core::mem::transmute(pvresevered.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IProgressDialog> for ::windows::core::IUnknown {
-    fn from(value: IProgressDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IProgressDialog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IProgressDialog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IProgressDialog> for ::windows::core::IUnknown {
-    fn from(value: &IProgressDialog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IProgressDialog, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IProgressDialog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33276,21 +28175,7 @@ impl IPropertyKeyStore {
         (::windows::core::Vtable::vtable(self).RemoveKey)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(key)).ok()
     }
 }
-impl ::core::convert::From<IPropertyKeyStore> for ::windows::core::IUnknown {
-    fn from(value: IPropertyKeyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPropertyKeyStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPropertyKeyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPropertyKeyStore> for ::windows::core::IUnknown {
-    fn from(value: &IPropertyKeyStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPropertyKeyStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IPropertyKeyStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33376,36 +28261,7 @@ impl IPublishedApp {
         (::windows::core::Vtable::vtable(self).Unschedule)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IPublishedApp> for ::windows::core::IUnknown {
-    fn from(value: IPublishedApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPublishedApp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPublishedApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPublishedApp> for ::windows::core::IUnknown {
-    fn from(value: &IPublishedApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPublishedApp> for IShellApp {
-    fn from(value: IPublishedApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPublishedApp> for &'a IShellApp {
-    fn from(value: &'a IPublishedApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPublishedApp> for IShellApp {
-    fn from(value: &IPublishedApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPublishedApp, ::windows::core::IUnknown, IShellApp);
 impl ::core::clone::Clone for IPublishedApp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33490,51 +28346,7 @@ impl IPublishedApp2 {
         (::windows::core::Vtable::vtable(self).Install2)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pstinstall), hwndparent.into()).ok()
     }
 }
-impl ::core::convert::From<IPublishedApp2> for ::windows::core::IUnknown {
-    fn from(value: IPublishedApp2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPublishedApp2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPublishedApp2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPublishedApp2> for ::windows::core::IUnknown {
-    fn from(value: &IPublishedApp2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPublishedApp2> for IShellApp {
-    fn from(value: IPublishedApp2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPublishedApp2> for &'a IShellApp {
-    fn from(value: &'a IPublishedApp2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPublishedApp2> for IShellApp {
-    fn from(value: &IPublishedApp2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPublishedApp2> for IPublishedApp {
-    fn from(value: IPublishedApp2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPublishedApp2> for &'a IPublishedApp {
-    fn from(value: &'a IPublishedApp2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPublishedApp2> for IPublishedApp {
-    fn from(value: &IPublishedApp2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPublishedApp2, ::windows::core::IUnknown, IShellApp, IPublishedApp);
 impl ::core::clone::Clone for IPublishedApp2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33602,36 +28414,7 @@ impl IPublishingWizard {
         (::windows::core::Vtable::vtable(self).GetTransferManifest)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phrfromtransfer.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pdocmanifest.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IPublishingWizard> for ::windows::core::IUnknown {
-    fn from(value: IPublishingWizard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPublishingWizard> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPublishingWizard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPublishingWizard> for ::windows::core::IUnknown {
-    fn from(value: &IPublishingWizard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IPublishingWizard> for IWizardExtension {
-    fn from(value: IPublishingWizard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IPublishingWizard> for &'a IWizardExtension {
-    fn from(value: &'a IPublishingWizard) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IPublishingWizard> for IWizardExtension {
-    fn from(value: &IPublishingWizard) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPublishingWizard, ::windows::core::IUnknown, IWizardExtension);
 impl ::core::clone::Clone for IPublishingWizard {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33709,21 +28492,7 @@ impl IQueryAssociations {
         (::windows::core::Vtable::vtable(self).GetEnum)(::windows::core::Vtable::as_raw(self), flags, assocenum, pszextra.into(), ::core::mem::transmute(riid), ::core::mem::transmute(ppvout)).ok()
     }
 }
-impl ::core::convert::From<IQueryAssociations> for ::windows::core::IUnknown {
-    fn from(value: IQueryAssociations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQueryAssociations> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryAssociations) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQueryAssociations> for ::windows::core::IUnknown {
-    fn from(value: &IQueryAssociations) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryAssociations, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IQueryAssociations {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33774,21 +28543,7 @@ impl IQueryCancelAutoPlay {
         (::windows::core::Vtable::vtable(self).AllowAutoPlay)(::windows::core::Vtable::as_raw(self), pszpath.into(), dwcontenttype, pszlabel.into(), dwserialnumber).ok()
     }
 }
-impl ::core::convert::From<IQueryCancelAutoPlay> for ::windows::core::IUnknown {
-    fn from(value: IQueryCancelAutoPlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQueryCancelAutoPlay> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryCancelAutoPlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQueryCancelAutoPlay> for ::windows::core::IUnknown {
-    fn from(value: &IQueryCancelAutoPlay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryCancelAutoPlay, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IQueryCancelAutoPlay {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33829,21 +28584,7 @@ impl IQueryCodePage {
         (::windows::core::Vtable::vtable(self).SetCodePage)(::windows::core::Vtable::as_raw(self), uicodepage).ok()
     }
 }
-impl ::core::convert::From<IQueryCodePage> for ::windows::core::IUnknown {
-    fn from(value: IQueryCodePage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQueryCodePage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryCodePage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQueryCodePage> for ::windows::core::IUnknown {
-    fn from(value: &IQueryCodePage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryCodePage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IQueryCodePage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33881,21 +28622,7 @@ impl IQueryContinue {
         (::windows::core::Vtable::vtable(self).QueryContinue)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IQueryContinue> for ::windows::core::IUnknown {
-    fn from(value: IQueryContinue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQueryContinue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryContinue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQueryContinue> for ::windows::core::IUnknown {
-    fn from(value: &IQueryContinue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryContinue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IQueryContinue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -33938,36 +28665,7 @@ impl IQueryContinueWithStatus {
         (::windows::core::Vtable::vtable(self).SetStatusMessage)(::windows::core::Vtable::as_raw(self), psz.into()).ok()
     }
 }
-impl ::core::convert::From<IQueryContinueWithStatus> for ::windows::core::IUnknown {
-    fn from(value: IQueryContinueWithStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQueryContinueWithStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryContinueWithStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQueryContinueWithStatus> for ::windows::core::IUnknown {
-    fn from(value: &IQueryContinueWithStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IQueryContinueWithStatus> for IQueryContinue {
-    fn from(value: IQueryContinueWithStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQueryContinueWithStatus> for &'a IQueryContinue {
-    fn from(value: &'a IQueryContinueWithStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQueryContinueWithStatus> for IQueryContinue {
-    fn from(value: &IQueryContinueWithStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryContinueWithStatus, ::windows::core::IUnknown, IQueryContinue);
 impl ::core::clone::Clone for IQueryContinueWithStatus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34009,21 +28707,7 @@ impl IQueryInfo {
         (::windows::core::Vtable::vtable(self).GetInfoFlags)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IQueryInfo> for ::windows::core::IUnknown {
-    fn from(value: IQueryInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IQueryInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IQueryInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IQueryInfo> for ::windows::core::IUnknown {
-    fn from(value: &IQueryInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IQueryInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IQueryInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34072,21 +28756,7 @@ impl IRegTreeItem {
         (::windows::core::Vtable::vtable(self).SetCheckState)(::windows::core::Vtable::as_raw(self), bcheck.into()).ok()
     }
 }
-impl ::core::convert::From<IRegTreeItem> for ::windows::core::IUnknown {
-    fn from(value: IRegTreeItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRegTreeItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRegTreeItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRegTreeItem> for ::windows::core::IUnknown {
-    fn from(value: &IRegTreeItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRegTreeItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRegTreeItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34137,21 +28807,7 @@ impl IRelatedItem {
         (::windows::core::Vtable::vtable(self).GetItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IShellItem>(result__)
     }
 }
-impl ::core::convert::From<IRelatedItem> for ::windows::core::IUnknown {
-    fn from(value: IRelatedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRelatedItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRelatedItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRelatedItem> for ::windows::core::IUnknown {
-    fn from(value: &IRelatedItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRelatedItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRelatedItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34198,21 +28854,7 @@ impl IRemoteComputer {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pszmachine.into(), benumerating.into()).ok()
     }
 }
-impl ::core::convert::From<IRemoteComputer> for ::windows::core::IUnknown {
-    fn from(value: IRemoteComputer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRemoteComputer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRemoteComputer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRemoteComputer> for ::windows::core::IUnknown {
-    fn from(value: &IRemoteComputer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRemoteComputer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRemoteComputer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34258,21 +28900,7 @@ impl IResolveShellLink {
         (::windows::core::Vtable::vtable(self).ResolveShellLink)(::windows::core::Vtable::as_raw(self), punklink.into().abi(), hwnd.into(), fflags).ok()
     }
 }
-impl ::core::convert::From<IResolveShellLink> for ::windows::core::IUnknown {
-    fn from(value: IResolveShellLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResolveShellLink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResolveShellLink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResolveShellLink> for ::windows::core::IUnknown {
-    fn from(value: &IResolveShellLink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResolveShellLink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IResolveShellLink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34335,21 +28963,7 @@ impl IResultsFolder {
         (::windows::core::Vtable::vtable(self).RemoveAll)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IResultsFolder> for ::windows::core::IUnknown {
-    fn from(value: IResultsFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IResultsFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IResultsFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IResultsFolder> for ::windows::core::IUnknown {
-    fn from(value: &IResultsFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IResultsFolder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IResultsFolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34413,21 +29027,7 @@ impl IRunnableTask {
         (::windows::core::Vtable::vtable(self).IsRunning)(::windows::core::Vtable::as_raw(self))
     }
 }
-impl ::core::convert::From<IRunnableTask> for ::windows::core::IUnknown {
-    fn from(value: IRunnableTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRunnableTask> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRunnableTask) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRunnableTask> for ::windows::core::IUnknown {
-    fn from(value: &IRunnableTask) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRunnableTask, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRunnableTask {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34543,41 +29143,7 @@ impl IScriptErrorList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IScriptErrorList> for ::windows::core::IUnknown {
-    fn from(value: IScriptErrorList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IScriptErrorList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IScriptErrorList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IScriptErrorList> for ::windows::core::IUnknown {
-    fn from(value: &IScriptErrorList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IScriptErrorList> for super::super::System::Com::IDispatch {
-    fn from(value: IScriptErrorList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IScriptErrorList> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IScriptErrorList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IScriptErrorList> for super::super::System::Com::IDispatch {
-    fn from(value: &IScriptErrorList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IScriptErrorList, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IScriptErrorList {
     fn clone(&self) -> Self {
@@ -34663,21 +29229,7 @@ impl ISearchBoxInfo {
         (::windows::core::Vtable::vtable(self).GetText)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ISearchBoxInfo> for ::windows::core::IUnknown {
-    fn from(value: ISearchBoxInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchBoxInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchBoxInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchBoxInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISearchBoxInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchBoxInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchBoxInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34724,21 +29276,7 @@ impl ISearchContext {
         (::windows::core::Vtable::vtable(self).GetSearchStyle)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ISearchContext> for ::windows::core::IUnknown {
-    fn from(value: ISearchContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchContext> for ::windows::core::IUnknown {
-    fn from(value: &ISearchContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34836,21 +29374,7 @@ impl ISearchFolderItemFactory {
         (::windows::core::Vtable::vtable(self).GetIDList)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut Common::ITEMIDLIST>(result__)
     }
 }
-impl ::core::convert::From<ISearchFolderItemFactory> for ::windows::core::IUnknown {
-    fn from(value: ISearchFolderItemFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISearchFolderItemFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISearchFolderItemFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISearchFolderItemFactory> for ::windows::core::IUnknown {
-    fn from(value: &ISearchFolderItemFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISearchFolderItemFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISearchFolderItemFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -34943,21 +29467,7 @@ impl ISharedBitmap {
         (::windows::core::Vtable::vtable(self).Detach)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Graphics::Gdi::HBITMAP>(result__)
     }
 }
-impl ::core::convert::From<ISharedBitmap> for ::windows::core::IUnknown {
-    fn from(value: ISharedBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISharedBitmap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISharedBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISharedBitmap> for ::windows::core::IUnknown {
-    fn from(value: &ISharedBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISharedBitmap, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISharedBitmap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35029,21 +29539,7 @@ impl ISharingConfigurationManager {
         (::windows::core::Vtable::vtable(self).ArePrintersShared)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISharingConfigurationManager> for ::windows::core::IUnknown {
-    fn from(value: ISharingConfigurationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISharingConfigurationManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISharingConfigurationManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISharingConfigurationManager> for ::windows::core::IUnknown {
-    fn from(value: &ISharingConfigurationManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISharingConfigurationManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISharingConfigurationManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35105,21 +29601,7 @@ impl IShellApp {
         (::windows::core::Vtable::vtable(self).IsInstalled)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IShellApp> for ::windows::core::IUnknown {
-    fn from(value: IShellApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellApp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellApp> for ::windows::core::IUnknown {
-    fn from(value: &IShellApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellApp, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellApp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35270,41 +29752,7 @@ impl IShellBrowser {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IShellBrowser> for ::windows::core::IUnknown {
-    fn from(value: IShellBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IShellBrowser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IShellBrowser> for ::windows::core::IUnknown {
-    fn from(value: &IShellBrowser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IShellBrowser> for super::super::System::Ole::IOleWindow {
-    fn from(value: IShellBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IShellBrowser> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IShellBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IShellBrowser> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IShellBrowser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellBrowser, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IShellBrowser {
     fn clone(&self) -> Self {
@@ -35398,21 +29846,7 @@ impl IShellChangeNotify {
         (::windows::core::Vtable::vtable(self).OnChange)(::windows::core::Vtable::as_raw(self), levent, ::core::mem::transmute(pidl1.unwrap_or(::std::ptr::null())), ::core::mem::transmute(pidl2.unwrap_or(::std::ptr::null()))).ok()
     }
 }
-impl ::core::convert::From<IShellChangeNotify> for ::windows::core::IUnknown {
-    fn from(value: IShellChangeNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellChangeNotify> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellChangeNotify) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellChangeNotify> for ::windows::core::IUnknown {
-    fn from(value: &IShellChangeNotify) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellChangeNotify, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellChangeNotify {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35458,21 +29892,7 @@ impl IShellDetails {
         (::windows::core::Vtable::vtable(self).ColumnClick)(::windows::core::Vtable::as_raw(self), icolumn).ok()
     }
 }
-impl ::core::convert::From<IShellDetails> for ::windows::core::IUnknown {
-    fn from(value: IShellDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellDetails> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellDetails) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellDetails> for ::windows::core::IUnknown {
-    fn from(value: &IShellDetails) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellDetails, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellDetails {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -35613,41 +30033,7 @@ impl IShellDispatch {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch> for ::windows::core::IUnknown {
-    fn from(value: IShellDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch> for ::windows::core::IUnknown {
-    fn from(value: &IShellDispatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch> for super::super::System::Com::IDispatch {
-    fn from(value: IShellDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellDispatch) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellDispatch) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellDispatch, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellDispatch {
     fn clone(&self) -> Self {
@@ -35897,59 +30283,7 @@ impl IShellDispatch2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch2> for ::windows::core::IUnknown {
-    fn from(value: IShellDispatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellDispatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch2> for ::windows::core::IUnknown {
-    fn from(value: &IShellDispatch2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch2> for super::super::System::Com::IDispatch {
-    fn from(value: IShellDispatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellDispatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch2> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellDispatch2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch2> for IShellDispatch {
-    fn from(value: IShellDispatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch2> for &'a IShellDispatch {
-    fn from(value: &'a IShellDispatch2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch2> for IShellDispatch {
-    fn from(value: &IShellDispatch2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellDispatch2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellDispatch2 {
     fn clone(&self) -> Self {
@@ -36193,77 +30527,7 @@ impl IShellDispatch3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch3> for ::windows::core::IUnknown {
-    fn from(value: IShellDispatch3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellDispatch3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch3> for ::windows::core::IUnknown {
-    fn from(value: &IShellDispatch3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch3> for super::super::System::Com::IDispatch {
-    fn from(value: IShellDispatch3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellDispatch3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch3> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellDispatch3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch3> for IShellDispatch {
-    fn from(value: IShellDispatch3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch3> for &'a IShellDispatch {
-    fn from(value: &'a IShellDispatch3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch3> for IShellDispatch {
-    fn from(value: &IShellDispatch3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch3> for IShellDispatch2 {
-    fn from(value: IShellDispatch3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch3> for &'a IShellDispatch2 {
-    fn from(value: &'a IShellDispatch3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch3> for IShellDispatch2 {
-    fn from(value: &IShellDispatch3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellDispatch3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellDispatch, IShellDispatch2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellDispatch3 {
     fn clone(&self) -> Self {
@@ -36497,95 +30761,7 @@ impl IShellDispatch4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch4> for ::windows::core::IUnknown {
-    fn from(value: IShellDispatch4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellDispatch4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch4> for ::windows::core::IUnknown {
-    fn from(value: &IShellDispatch4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch4> for super::super::System::Com::IDispatch {
-    fn from(value: IShellDispatch4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch4> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellDispatch4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch4> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellDispatch4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch4> for IShellDispatch {
-    fn from(value: IShellDispatch4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch4> for &'a IShellDispatch {
-    fn from(value: &'a IShellDispatch4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch4> for IShellDispatch {
-    fn from(value: &IShellDispatch4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch4> for IShellDispatch2 {
-    fn from(value: IShellDispatch4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch4> for &'a IShellDispatch2 {
-    fn from(value: &'a IShellDispatch4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch4> for IShellDispatch2 {
-    fn from(value: &IShellDispatch4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch4> for IShellDispatch3 {
-    fn from(value: IShellDispatch4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch4> for &'a IShellDispatch3 {
-    fn from(value: &'a IShellDispatch4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch4> for IShellDispatch3 {
-    fn from(value: &IShellDispatch4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellDispatch4, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellDispatch, IShellDispatch2, IShellDispatch3);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellDispatch4 {
     fn clone(&self) -> Self {
@@ -36825,113 +31001,7 @@ impl IShellDispatch5 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch5> for ::windows::core::IUnknown {
-    fn from(value: IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch5> for ::windows::core::IUnknown {
-    fn from(value: &IShellDispatch5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch5> for super::super::System::Com::IDispatch {
-    fn from(value: IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch5> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch5> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellDispatch5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch5> for IShellDispatch {
-    fn from(value: IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch5> for &'a IShellDispatch {
-    fn from(value: &'a IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch5> for IShellDispatch {
-    fn from(value: &IShellDispatch5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch5> for IShellDispatch2 {
-    fn from(value: IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch5> for &'a IShellDispatch2 {
-    fn from(value: &'a IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch5> for IShellDispatch2 {
-    fn from(value: &IShellDispatch5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch5> for IShellDispatch3 {
-    fn from(value: IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch5> for &'a IShellDispatch3 {
-    fn from(value: &'a IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch5> for IShellDispatch3 {
-    fn from(value: &IShellDispatch5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch5> for IShellDispatch4 {
-    fn from(value: IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch5> for &'a IShellDispatch4 {
-    fn from(value: &'a IShellDispatch5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch5> for IShellDispatch4 {
-    fn from(value: &IShellDispatch5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellDispatch5, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellDispatch, IShellDispatch2, IShellDispatch3, IShellDispatch4);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellDispatch5 {
     fn clone(&self) -> Self {
@@ -37168,131 +31238,7 @@ impl IShellDispatch6 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch6> for ::windows::core::IUnknown {
-    fn from(value: IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch6> for ::windows::core::IUnknown {
-    fn from(value: &IShellDispatch6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch6> for super::super::System::Com::IDispatch {
-    fn from(value: IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch6> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch6> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellDispatch6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch6> for IShellDispatch {
-    fn from(value: IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch6> for &'a IShellDispatch {
-    fn from(value: &'a IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch6> for IShellDispatch {
-    fn from(value: &IShellDispatch6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch6> for IShellDispatch2 {
-    fn from(value: IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch6> for &'a IShellDispatch2 {
-    fn from(value: &'a IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch6> for IShellDispatch2 {
-    fn from(value: &IShellDispatch6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch6> for IShellDispatch3 {
-    fn from(value: IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch6> for &'a IShellDispatch3 {
-    fn from(value: &'a IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch6> for IShellDispatch3 {
-    fn from(value: &IShellDispatch6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch6> for IShellDispatch4 {
-    fn from(value: IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch6> for &'a IShellDispatch4 {
-    fn from(value: &'a IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch6> for IShellDispatch4 {
-    fn from(value: &IShellDispatch6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellDispatch6> for IShellDispatch5 {
-    fn from(value: IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellDispatch6> for &'a IShellDispatch5 {
-    fn from(value: &'a IShellDispatch6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellDispatch6> for IShellDispatch5 {
-    fn from(value: &IShellDispatch6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellDispatch6, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellDispatch, IShellDispatch2, IShellDispatch3, IShellDispatch4, IShellDispatch5);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellDispatch6 {
     fn clone(&self) -> Self {
@@ -37342,21 +31288,7 @@ impl IShellExtInit {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidlfolder.unwrap_or(::std::ptr::null())), pdtobj.into().abi(), hkeyprogid.into()).ok()
     }
 }
-impl ::core::convert::From<IShellExtInit> for ::windows::core::IUnknown {
-    fn from(value: IShellExtInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellExtInit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellExtInit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellExtInit> for ::windows::core::IUnknown {
-    fn from(value: &IShellExtInit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellExtInit, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellExtInit {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37438,41 +31370,7 @@ impl IShellFavoritesNameSpace {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellFavoritesNameSpace> for ::windows::core::IUnknown {
-    fn from(value: IShellFavoritesNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellFavoritesNameSpace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellFavoritesNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellFavoritesNameSpace> for ::windows::core::IUnknown {
-    fn from(value: &IShellFavoritesNameSpace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellFavoritesNameSpace> for super::super::System::Com::IDispatch {
-    fn from(value: IShellFavoritesNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellFavoritesNameSpace> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellFavoritesNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellFavoritesNameSpace> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellFavoritesNameSpace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellFavoritesNameSpace, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellFavoritesNameSpace {
     fn clone(&self) -> Self {
@@ -37612,21 +31510,7 @@ impl IShellFolder {
         (::windows::core::Vtable::vtable(self).SetNameOf)(::windows::core::Vtable::as_raw(self), hwnd.into(), ::core::mem::transmute(pidl), pszname.into(), uflags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut Common::ITEMIDLIST>(result__)
     }
 }
-impl ::core::convert::From<IShellFolder> for ::windows::core::IUnknown {
-    fn from(value: IShellFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellFolder> for ::windows::core::IUnknown {
-    fn from(value: &IShellFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellFolder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellFolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37819,36 +31703,7 @@ impl IShellFolder2 {
         (::windows::core::Vtable::vtable(self).MapColumnToSCID)(::windows::core::Vtable::as_raw(self), icolumn, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<PropertiesSystem::PROPERTYKEY>(result__)
     }
 }
-impl ::core::convert::From<IShellFolder2> for ::windows::core::IUnknown {
-    fn from(value: IShellFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellFolder2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellFolder2> for ::windows::core::IUnknown {
-    fn from(value: &IShellFolder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IShellFolder2> for IShellFolder {
-    fn from(value: IShellFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellFolder2> for &'a IShellFolder {
-    fn from(value: &'a IShellFolder2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellFolder2> for IShellFolder {
-    fn from(value: &IShellFolder2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellFolder2, ::windows::core::IUnknown, IShellFolder);
 impl ::core::clone::Clone for IShellFolder2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -37915,21 +31770,7 @@ impl IShellFolderBand {
         (::windows::core::Vtable::vtable(self).GetBandInfoSFB)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pbi)).ok()
     }
 }
-impl ::core::convert::From<IShellFolderBand> for ::windows::core::IUnknown {
-    fn from(value: IShellFolderBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellFolderBand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellFolderBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellFolderBand> for ::windows::core::IUnknown {
-    fn from(value: &IShellFolderBand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellFolderBand, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellFolderBand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -38132,21 +31973,7 @@ impl IShellFolderView {
         (::windows::core::Vtable::vtable(self).SetAutomationObject)(::windows::core::Vtable::as_raw(self), pdisp.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IShellFolderView> for ::windows::core::IUnknown {
-    fn from(value: IShellFolderView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellFolderView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellFolderView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellFolderView> for ::windows::core::IUnknown {
-    fn from(value: &IShellFolderView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellFolderView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellFolderView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -38270,21 +32097,7 @@ impl IShellFolderViewCB {
         (::windows::core::Vtable::vtable(self).MessageSFVCB)(::windows::core::Vtable::as_raw(self), umsg, wparam.into(), lparam.into()).ok()
     }
 }
-impl ::core::convert::From<IShellFolderViewCB> for ::windows::core::IUnknown {
-    fn from(value: IShellFolderViewCB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellFolderViewCB> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellFolderViewCB) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellFolderViewCB> for ::windows::core::IUnknown {
-    fn from(value: &IShellFolderViewCB) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellFolderViewCB, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellFolderViewCB {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -38380,41 +32193,7 @@ impl IShellFolderViewDual {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellFolderViewDual> for ::windows::core::IUnknown {
-    fn from(value: IShellFolderViewDual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellFolderViewDual> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellFolderViewDual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellFolderViewDual> for ::windows::core::IUnknown {
-    fn from(value: &IShellFolderViewDual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellFolderViewDual> for super::super::System::Com::IDispatch {
-    fn from(value: IShellFolderViewDual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellFolderViewDual> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellFolderViewDual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellFolderViewDual> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellFolderViewDual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellFolderViewDual, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellFolderViewDual {
     fn clone(&self) -> Self {
@@ -38556,59 +32335,7 @@ impl IShellFolderViewDual2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellFolderViewDual2> for ::windows::core::IUnknown {
-    fn from(value: IShellFolderViewDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellFolderViewDual2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellFolderViewDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellFolderViewDual2> for ::windows::core::IUnknown {
-    fn from(value: &IShellFolderViewDual2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellFolderViewDual2> for super::super::System::Com::IDispatch {
-    fn from(value: IShellFolderViewDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellFolderViewDual2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellFolderViewDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellFolderViewDual2> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellFolderViewDual2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellFolderViewDual2> for IShellFolderViewDual {
-    fn from(value: IShellFolderViewDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellFolderViewDual2> for &'a IShellFolderViewDual {
-    fn from(value: &'a IShellFolderViewDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellFolderViewDual2> for IShellFolderViewDual {
-    fn from(value: &IShellFolderViewDual2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellFolderViewDual2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellFolderViewDual);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellFolderViewDual2 {
     fn clone(&self) -> Self {
@@ -38751,77 +32478,7 @@ impl IShellFolderViewDual3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellFolderViewDual3> for ::windows::core::IUnknown {
-    fn from(value: IShellFolderViewDual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellFolderViewDual3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellFolderViewDual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellFolderViewDual3> for ::windows::core::IUnknown {
-    fn from(value: &IShellFolderViewDual3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellFolderViewDual3> for super::super::System::Com::IDispatch {
-    fn from(value: IShellFolderViewDual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellFolderViewDual3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellFolderViewDual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellFolderViewDual3> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellFolderViewDual3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellFolderViewDual3> for IShellFolderViewDual {
-    fn from(value: IShellFolderViewDual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellFolderViewDual3> for &'a IShellFolderViewDual {
-    fn from(value: &'a IShellFolderViewDual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellFolderViewDual3> for IShellFolderViewDual {
-    fn from(value: &IShellFolderViewDual3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellFolderViewDual3> for IShellFolderViewDual2 {
-    fn from(value: IShellFolderViewDual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellFolderViewDual3> for &'a IShellFolderViewDual2 {
-    fn from(value: &'a IShellFolderViewDual3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellFolderViewDual3> for IShellFolderViewDual2 {
-    fn from(value: &IShellFolderViewDual3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellFolderViewDual3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellFolderViewDual, IShellFolderViewDual2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellFolderViewDual3 {
     fn clone(&self) -> Self {
@@ -38876,21 +32533,7 @@ impl IShellIcon {
         (::windows::core::Vtable::vtable(self).GetIconOf)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidl), flags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IShellIcon> for ::windows::core::IUnknown {
-    fn from(value: IShellIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellIcon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellIcon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellIcon> for ::windows::core::IUnknown {
-    fn from(value: &IShellIcon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellIcon, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellIcon {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -38937,21 +32580,7 @@ impl IShellIconOverlay {
         (::windows::core::Vtable::vtable(self).GetOverlayIconIndex)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidl), ::core::mem::transmute(piconindex)).ok()
     }
 }
-impl ::core::convert::From<IShellIconOverlay> for ::windows::core::IUnknown {
-    fn from(value: IShellIconOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellIconOverlay> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellIconOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellIconOverlay> for ::windows::core::IUnknown {
-    fn from(value: &IShellIconOverlay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellIconOverlay, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellIconOverlay {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -39005,21 +32634,7 @@ impl IShellIconOverlayIdentifier {
         (::windows::core::Vtable::vtable(self).GetPriority)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IShellIconOverlayIdentifier> for ::windows::core::IUnknown {
-    fn from(value: IShellIconOverlayIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellIconOverlayIdentifier> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellIconOverlayIdentifier) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellIconOverlayIdentifier> for ::windows::core::IUnknown {
-    fn from(value: &IShellIconOverlayIdentifier) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellIconOverlayIdentifier, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellIconOverlayIdentifier {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -39081,21 +32696,7 @@ impl IShellIconOverlayManager {
         (::windows::core::Vtable::vtable(self).OverlayIndexFromImageIndex)(::windows::core::Vtable::as_raw(self), iimage, ::core::mem::transmute(piindex), fadd.into()).ok()
     }
 }
-impl ::core::convert::From<IShellIconOverlayManager> for ::windows::core::IUnknown {
-    fn from(value: IShellIconOverlayManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellIconOverlayManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellIconOverlayManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellIconOverlayManager> for ::windows::core::IUnknown {
-    fn from(value: &IShellIconOverlayManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellIconOverlayManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellIconOverlayManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -39248,21 +32849,7 @@ impl IShellImageData {
         (::windows::core::Vtable::vtable(self).ReplaceFrame)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pimg)).ok()
     }
 }
-impl ::core::convert::From<IShellImageData> for ::windows::core::IUnknown {
-    fn from(value: IShellImageData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellImageData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellImageData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellImageData> for ::windows::core::IUnknown {
-    fn from(value: &IShellImageData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellImageData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellImageData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -39340,21 +32927,7 @@ impl IShellImageDataAbort {
         (::windows::core::Vtable::vtable(self).QueryAbort)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IShellImageDataAbort> for ::windows::core::IUnknown {
-    fn from(value: IShellImageDataAbort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellImageDataAbort> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellImageDataAbort) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellImageDataAbort> for ::windows::core::IUnknown {
-    fn from(value: &IShellImageDataAbort) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellImageDataAbort, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellImageDataAbort {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -39415,21 +32988,7 @@ impl IShellImageDataFactory {
         (::windows::core::Vtable::vtable(self).GetDataFormatFromPath)(::windows::core::Vtable::as_raw(self), pszpath.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IShellImageDataFactory> for ::windows::core::IUnknown {
-    fn from(value: IShellImageDataFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellImageDataFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellImageDataFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellImageDataFactory> for ::windows::core::IUnknown {
-    fn from(value: &IShellImageDataFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellImageDataFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellImageDataFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -39500,21 +33059,7 @@ impl IShellItem {
         (::windows::core::Vtable::vtable(self).Compare)(::windows::core::Vtable::as_raw(self), psi.into().abi(), hint, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i32>(result__)
     }
 }
-impl ::core::convert::From<IShellItem> for ::windows::core::IUnknown {
-    fn from(value: IShellItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellItem> for ::windows::core::IUnknown {
-    fn from(value: &IShellItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -39682,36 +33227,7 @@ impl IShellItem2 {
         (::windows::core::Vtable::vtable(self).GetBool)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(key), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<IShellItem2> for ::windows::core::IUnknown {
-    fn from(value: IShellItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellItem2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellItem2> for ::windows::core::IUnknown {
-    fn from(value: &IShellItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IShellItem2> for IShellItem {
-    fn from(value: IShellItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellItem2> for &'a IShellItem {
-    fn from(value: &'a IShellItem2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellItem2> for IShellItem {
-    fn from(value: &IShellItem2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellItem2, ::windows::core::IUnknown, IShellItem);
 impl ::core::clone::Clone for IShellItem2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -39842,21 +33358,7 @@ impl IShellItemArray {
         (::windows::core::Vtable::vtable(self).EnumItems)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumShellItems>(result__)
     }
 }
-impl ::core::convert::From<IShellItemArray> for ::windows::core::IUnknown {
-    fn from(value: IShellItemArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellItemArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellItemArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellItemArray> for ::windows::core::IUnknown {
-    fn from(value: &IShellItemArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellItemArray, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellItemArray {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -39921,21 +33423,7 @@ impl IShellItemFilter {
         (::windows::core::Vtable::vtable(self).GetEnumFlagsForItem)(::windows::core::Vtable::as_raw(self), psi.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IShellItemFilter> for ::windows::core::IUnknown {
-    fn from(value: IShellItemFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellItemFilter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellItemFilter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellItemFilter> for ::windows::core::IUnknown {
-    fn from(value: &IShellItemFilter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellItemFilter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellItemFilter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -39976,21 +33464,7 @@ impl IShellItemImageFactory {
         (::windows::core::Vtable::vtable(self).GetImage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(size), flags, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Graphics::Gdi::HBITMAP>(result__)
     }
 }
-impl ::core::convert::From<IShellItemImageFactory> for ::windows::core::IUnknown {
-    fn from(value: IShellItemImageFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellItemImageFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellItemImageFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellItemImageFactory> for ::windows::core::IUnknown {
-    fn from(value: &IShellItemImageFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellItemImageFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellItemImageFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -40073,21 +33547,7 @@ impl IShellItemResources {
         (::windows::core::Vtable::vtable(self).MarkForDelete)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IShellItemResources> for ::windows::core::IUnknown {
-    fn from(value: IShellItemResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellItemResources> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellItemResources) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellItemResources> for ::windows::core::IUnknown {
-    fn from(value: &IShellItemResources) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellItemResources, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellItemResources {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -40227,21 +33687,7 @@ impl IShellLibrary {
         (::windows::core::Vtable::vtable(self).SaveInKnownFolder)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(kfidtosavein), pszlibraryname.into(), lsf, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IShellItem>(result__)
     }
 }
-impl ::core::convert::From<IShellLibrary> for ::windows::core::IUnknown {
-    fn from(value: IShellLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellLibrary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellLibrary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellLibrary> for ::windows::core::IUnknown {
-    fn from(value: &IShellLibrary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellLibrary, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellLibrary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -40377,21 +33823,7 @@ impl IShellLinkA {
         (::windows::core::Vtable::vtable(self).SetPath)(::windows::core::Vtable::as_raw(self), pszfile.into()).ok()
     }
 }
-impl ::core::convert::From<IShellLinkA> for ::windows::core::IUnknown {
-    fn from(value: IShellLinkA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellLinkA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellLinkA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellLinkA> for ::windows::core::IUnknown {
-    fn from(value: &IShellLinkA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellLinkA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellLinkA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -40470,21 +33902,7 @@ impl IShellLinkDataList {
         (::windows::core::Vtable::vtable(self).SetFlags)(::windows::core::Vtable::as_raw(self), dwflags).ok()
     }
 }
-impl ::core::convert::From<IShellLinkDataList> for ::windows::core::IUnknown {
-    fn from(value: IShellLinkDataList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellLinkDataList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellLinkDataList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellLinkDataList> for ::windows::core::IUnknown {
-    fn from(value: &IShellLinkDataList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellLinkDataList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellLinkDataList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -40584,41 +34002,7 @@ impl IShellLinkDual {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellLinkDual> for ::windows::core::IUnknown {
-    fn from(value: IShellLinkDual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellLinkDual> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellLinkDual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellLinkDual> for ::windows::core::IUnknown {
-    fn from(value: &IShellLinkDual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellLinkDual> for super::super::System::Com::IDispatch {
-    fn from(value: IShellLinkDual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellLinkDual> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellLinkDual) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellLinkDual> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellLinkDual) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellLinkDual, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellLinkDual {
     fn clone(&self) -> Self {
@@ -40745,59 +34129,7 @@ impl IShellLinkDual2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellLinkDual2> for ::windows::core::IUnknown {
-    fn from(value: IShellLinkDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellLinkDual2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellLinkDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellLinkDual2> for ::windows::core::IUnknown {
-    fn from(value: &IShellLinkDual2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellLinkDual2> for super::super::System::Com::IDispatch {
-    fn from(value: IShellLinkDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellLinkDual2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellLinkDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellLinkDual2> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellLinkDual2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellLinkDual2> for IShellLinkDual {
-    fn from(value: IShellLinkDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellLinkDual2> for &'a IShellLinkDual {
-    fn from(value: &'a IShellLinkDual2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellLinkDual2> for IShellLinkDual {
-    fn from(value: &IShellLinkDual2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellLinkDual2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellLinkDual);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellLinkDual2 {
     fn clone(&self) -> Self {
@@ -40927,21 +34259,7 @@ impl IShellLinkW {
         (::windows::core::Vtable::vtable(self).SetPath)(::windows::core::Vtable::as_raw(self), pszfile.into()).ok()
     }
 }
-impl ::core::convert::From<IShellLinkW> for ::windows::core::IUnknown {
-    fn from(value: IShellLinkW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellLinkW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellLinkW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellLinkW> for ::windows::core::IUnknown {
-    fn from(value: &IShellLinkW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellLinkW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellLinkW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -41058,21 +34376,7 @@ impl IShellMenu {
         (::windows::core::Vtable::vtable(self).SetMenuToolbar)(::windows::core::Vtable::as_raw(self), punk.into().abi(), dwflags).ok()
     }
 }
-impl ::core::convert::From<IShellMenu> for ::windows::core::IUnknown {
-    fn from(value: IShellMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellMenu> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellMenu> for ::windows::core::IUnknown {
-    fn from(value: &IShellMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellMenu, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellMenu {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -41141,21 +34445,7 @@ impl IShellMenuCallback {
         (::windows::core::Vtable::vtable(self).CallbackSM)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(psmd), umsg, wparam.into(), lparam.into()).ok()
     }
 }
-impl ::core::convert::From<IShellMenuCallback> for ::windows::core::IUnknown {
-    fn from(value: IShellMenuCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellMenuCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellMenuCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellMenuCallback> for ::windows::core::IUnknown {
-    fn from(value: &IShellMenuCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellMenuCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellMenuCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -41331,59 +34621,7 @@ impl IShellNameSpace {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellNameSpace> for ::windows::core::IUnknown {
-    fn from(value: IShellNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellNameSpace> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellNameSpace> for ::windows::core::IUnknown {
-    fn from(value: &IShellNameSpace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellNameSpace> for super::super::System::Com::IDispatch {
-    fn from(value: IShellNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellNameSpace> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellNameSpace> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellNameSpace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellNameSpace> for IShellFavoritesNameSpace {
-    fn from(value: IShellNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellNameSpace> for &'a IShellFavoritesNameSpace {
-    fn from(value: &'a IShellNameSpace) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellNameSpace> for IShellFavoritesNameSpace {
-    fn from(value: &IShellNameSpace) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellNameSpace, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellFavoritesNameSpace);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellNameSpace {
     fn clone(&self) -> Self {
@@ -41478,21 +34716,7 @@ impl IShellPropSheetExt {
         (::windows::core::Vtable::vtable(self).ReplacePage)(::windows::core::Vtable::as_raw(self), upageid, ::core::mem::transmute(pfnreplacewith), lparam.into()).ok()
     }
 }
-impl ::core::convert::From<IShellPropSheetExt> for ::windows::core::IUnknown {
-    fn from(value: IShellPropSheetExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellPropSheetExt> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellPropSheetExt) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellPropSheetExt> for ::windows::core::IUnknown {
-    fn from(value: &IShellPropSheetExt) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellPropSheetExt, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellPropSheetExt {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -41539,21 +34763,7 @@ impl IShellRunDll {
         (::windows::core::Vtable::vtable(self).Run)(::windows::core::Vtable::as_raw(self), pszargs.into()).ok()
     }
 }
-impl ::core::convert::From<IShellRunDll> for ::windows::core::IUnknown {
-    fn from(value: IShellRunDll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellRunDll> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellRunDll) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellRunDll> for ::windows::core::IUnknown {
-    fn from(value: &IShellRunDll) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellRunDll, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellRunDll {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -41593,21 +34803,7 @@ impl IShellService {
         (::windows::core::Vtable::vtable(self).SetOwner)(::windows::core::Vtable::as_raw(self), punkowner.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IShellService> for ::windows::core::IUnknown {
-    fn from(value: IShellService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellService> for ::windows::core::IUnknown {
-    fn from(value: &IShellService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -41661,21 +34857,7 @@ impl IShellTaskScheduler {
         (::windows::core::Vtable::vtable(self).Status)(::windows::core::Vtable::as_raw(self), dwreleasestatus, dwthreadtimeout).ok()
     }
 }
-impl ::core::convert::From<IShellTaskScheduler> for ::windows::core::IUnknown {
-    fn from(value: IShellTaskScheduler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IShellTaskScheduler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellTaskScheduler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IShellTaskScheduler> for ::windows::core::IUnknown {
-    fn from(value: &IShellTaskScheduler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellTaskScheduler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IShellTaskScheduler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -41773,41 +34955,7 @@ impl IShellUIHelper {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper> for ::windows::core::IUnknown {
-    fn from(value: IShellUIHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellUIHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper> for ::windows::core::IUnknown {
-    fn from(value: &IShellUIHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper> for super::super::System::Com::IDispatch {
-    fn from(value: IShellUIHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellUIHelper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellUIHelper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellUIHelper, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellUIHelper {
     fn clone(&self) -> Self {
@@ -41995,59 +35143,7 @@ impl IShellUIHelper2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper2> for ::windows::core::IUnknown {
-    fn from(value: IShellUIHelper2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellUIHelper2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper2> for ::windows::core::IUnknown {
-    fn from(value: &IShellUIHelper2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper2> for super::super::System::Com::IDispatch {
-    fn from(value: IShellUIHelper2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellUIHelper2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper2> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellUIHelper2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper2> for IShellUIHelper {
-    fn from(value: IShellUIHelper2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper2> for &'a IShellUIHelper {
-    fn from(value: &'a IShellUIHelper2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper2> for IShellUIHelper {
-    fn from(value: &IShellUIHelper2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellUIHelper2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellUIHelper);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellUIHelper2 {
     fn clone(&self) -> Self {
@@ -42261,77 +35357,7 @@ impl IShellUIHelper3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper3> for ::windows::core::IUnknown {
-    fn from(value: IShellUIHelper3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellUIHelper3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper3> for ::windows::core::IUnknown {
-    fn from(value: &IShellUIHelper3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper3> for super::super::System::Com::IDispatch {
-    fn from(value: IShellUIHelper3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellUIHelper3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper3> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellUIHelper3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper3> for IShellUIHelper {
-    fn from(value: IShellUIHelper3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper3> for &'a IShellUIHelper {
-    fn from(value: &'a IShellUIHelper3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper3> for IShellUIHelper {
-    fn from(value: &IShellUIHelper3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper3> for IShellUIHelper2 {
-    fn from(value: IShellUIHelper3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper3> for &'a IShellUIHelper2 {
-    fn from(value: &'a IShellUIHelper3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper3> for IShellUIHelper2 {
-    fn from(value: &IShellUIHelper3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellUIHelper3, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellUIHelper, IShellUIHelper2);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellUIHelper3 {
     fn clone(&self) -> Self {
@@ -42629,95 +35655,7 @@ impl IShellUIHelper4 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper4> for ::windows::core::IUnknown {
-    fn from(value: IShellUIHelper4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellUIHelper4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper4> for ::windows::core::IUnknown {
-    fn from(value: &IShellUIHelper4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper4> for super::super::System::Com::IDispatch {
-    fn from(value: IShellUIHelper4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper4> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellUIHelper4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper4> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellUIHelper4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper4> for IShellUIHelper {
-    fn from(value: IShellUIHelper4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper4> for &'a IShellUIHelper {
-    fn from(value: &'a IShellUIHelper4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper4> for IShellUIHelper {
-    fn from(value: &IShellUIHelper4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper4> for IShellUIHelper2 {
-    fn from(value: IShellUIHelper4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper4> for &'a IShellUIHelper2 {
-    fn from(value: &'a IShellUIHelper4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper4> for IShellUIHelper2 {
-    fn from(value: &IShellUIHelper4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper4> for IShellUIHelper3 {
-    fn from(value: IShellUIHelper4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper4> for &'a IShellUIHelper3 {
-    fn from(value: &'a IShellUIHelper4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper4> for IShellUIHelper3 {
-    fn from(value: &IShellUIHelper4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellUIHelper4, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellUIHelper, IShellUIHelper2, IShellUIHelper3);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellUIHelper4 {
     fn clone(&self) -> Self {
@@ -43062,113 +36000,7 @@ impl IShellUIHelper5 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper5> for ::windows::core::IUnknown {
-    fn from(value: IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper5> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper5> for ::windows::core::IUnknown {
-    fn from(value: &IShellUIHelper5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper5> for super::super::System::Com::IDispatch {
-    fn from(value: IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper5> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper5> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellUIHelper5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper5> for IShellUIHelper {
-    fn from(value: IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper5> for &'a IShellUIHelper {
-    fn from(value: &'a IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper5> for IShellUIHelper {
-    fn from(value: &IShellUIHelper5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper5> for IShellUIHelper2 {
-    fn from(value: IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper5> for &'a IShellUIHelper2 {
-    fn from(value: &'a IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper5> for IShellUIHelper2 {
-    fn from(value: &IShellUIHelper5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper5> for IShellUIHelper3 {
-    fn from(value: IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper5> for &'a IShellUIHelper3 {
-    fn from(value: &'a IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper5> for IShellUIHelper3 {
-    fn from(value: &IShellUIHelper5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper5> for IShellUIHelper4 {
-    fn from(value: IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper5> for &'a IShellUIHelper4 {
-    fn from(value: &'a IShellUIHelper5) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper5> for IShellUIHelper4 {
-    fn from(value: &IShellUIHelper5) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellUIHelper5, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellUIHelper, IShellUIHelper2, IShellUIHelper3, IShellUIHelper4);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellUIHelper5 {
     fn clone(&self) -> Self {
@@ -43555,131 +36387,7 @@ impl IShellUIHelper6 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper6> for ::windows::core::IUnknown {
-    fn from(value: IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper6> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper6> for ::windows::core::IUnknown {
-    fn from(value: &IShellUIHelper6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper6> for super::super::System::Com::IDispatch {
-    fn from(value: IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper6> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper6> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellUIHelper6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper6> for IShellUIHelper {
-    fn from(value: IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper6> for &'a IShellUIHelper {
-    fn from(value: &'a IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper6> for IShellUIHelper {
-    fn from(value: &IShellUIHelper6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper6> for IShellUIHelper2 {
-    fn from(value: IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper6> for &'a IShellUIHelper2 {
-    fn from(value: &'a IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper6> for IShellUIHelper2 {
-    fn from(value: &IShellUIHelper6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper6> for IShellUIHelper3 {
-    fn from(value: IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper6> for &'a IShellUIHelper3 {
-    fn from(value: &'a IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper6> for IShellUIHelper3 {
-    fn from(value: &IShellUIHelper6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper6> for IShellUIHelper4 {
-    fn from(value: IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper6> for &'a IShellUIHelper4 {
-    fn from(value: &'a IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper6> for IShellUIHelper4 {
-    fn from(value: &IShellUIHelper6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper6> for IShellUIHelper5 {
-    fn from(value: IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper6> for &'a IShellUIHelper5 {
-    fn from(value: &'a IShellUIHelper6) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper6> for IShellUIHelper5 {
-    fn from(value: &IShellUIHelper6) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellUIHelper6, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellUIHelper, IShellUIHelper2, IShellUIHelper3, IShellUIHelper4, IShellUIHelper5);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellUIHelper6 {
     fn clone(&self) -> Self {
@@ -44116,149 +36824,7 @@ impl IShellUIHelper7 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper7> for ::windows::core::IUnknown {
-    fn from(value: IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper7> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper7> for ::windows::core::IUnknown {
-    fn from(value: &IShellUIHelper7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper7> for super::super::System::Com::IDispatch {
-    fn from(value: IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper7> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper7> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellUIHelper7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper7> for IShellUIHelper {
-    fn from(value: IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper7> for &'a IShellUIHelper {
-    fn from(value: &'a IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper7> for IShellUIHelper {
-    fn from(value: &IShellUIHelper7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper7> for IShellUIHelper2 {
-    fn from(value: IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper7> for &'a IShellUIHelper2 {
-    fn from(value: &'a IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper7> for IShellUIHelper2 {
-    fn from(value: &IShellUIHelper7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper7> for IShellUIHelper3 {
-    fn from(value: IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper7> for &'a IShellUIHelper3 {
-    fn from(value: &'a IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper7> for IShellUIHelper3 {
-    fn from(value: &IShellUIHelper7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper7> for IShellUIHelper4 {
-    fn from(value: IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper7> for &'a IShellUIHelper4 {
-    fn from(value: &'a IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper7> for IShellUIHelper4 {
-    fn from(value: &IShellUIHelper7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper7> for IShellUIHelper5 {
-    fn from(value: IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper7> for &'a IShellUIHelper5 {
-    fn from(value: &'a IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper7> for IShellUIHelper5 {
-    fn from(value: &IShellUIHelper7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper7> for IShellUIHelper6 {
-    fn from(value: IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper7> for &'a IShellUIHelper6 {
-    fn from(value: &'a IShellUIHelper7) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper7> for IShellUIHelper6 {
-    fn from(value: &IShellUIHelper7) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellUIHelper7, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellUIHelper, IShellUIHelper2, IShellUIHelper3, IShellUIHelper4, IShellUIHelper5, IShellUIHelper6);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellUIHelper7 {
     fn clone(&self) -> Self {
@@ -44700,167 +37266,7 @@ impl IShellUIHelper8 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper8> for ::windows::core::IUnknown {
-    fn from(value: IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper8> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper8> for ::windows::core::IUnknown {
-    fn from(value: &IShellUIHelper8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper8> for super::super::System::Com::IDispatch {
-    fn from(value: IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper8> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper8> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellUIHelper8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper8> for IShellUIHelper {
-    fn from(value: IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper8> for &'a IShellUIHelper {
-    fn from(value: &'a IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper8> for IShellUIHelper {
-    fn from(value: &IShellUIHelper8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper8> for IShellUIHelper2 {
-    fn from(value: IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper8> for &'a IShellUIHelper2 {
-    fn from(value: &'a IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper8> for IShellUIHelper2 {
-    fn from(value: &IShellUIHelper8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper8> for IShellUIHelper3 {
-    fn from(value: IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper8> for &'a IShellUIHelper3 {
-    fn from(value: &'a IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper8> for IShellUIHelper3 {
-    fn from(value: &IShellUIHelper8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper8> for IShellUIHelper4 {
-    fn from(value: IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper8> for &'a IShellUIHelper4 {
-    fn from(value: &'a IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper8> for IShellUIHelper4 {
-    fn from(value: &IShellUIHelper8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper8> for IShellUIHelper5 {
-    fn from(value: IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper8> for &'a IShellUIHelper5 {
-    fn from(value: &'a IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper8> for IShellUIHelper5 {
-    fn from(value: &IShellUIHelper8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper8> for IShellUIHelper6 {
-    fn from(value: IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper8> for &'a IShellUIHelper6 {
-    fn from(value: &'a IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper8> for IShellUIHelper6 {
-    fn from(value: &IShellUIHelper8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper8> for IShellUIHelper7 {
-    fn from(value: IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper8> for &'a IShellUIHelper7 {
-    fn from(value: &'a IShellUIHelper8) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper8> for IShellUIHelper7 {
-    fn from(value: &IShellUIHelper8) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellUIHelper8, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellUIHelper, IShellUIHelper2, IShellUIHelper3, IShellUIHelper4, IShellUIHelper5, IShellUIHelper6, IShellUIHelper7);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellUIHelper8 {
     fn clone(&self) -> Self {
@@ -45304,185 +37710,7 @@ impl IShellUIHelper9 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper9> for ::windows::core::IUnknown {
-    fn from(value: IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper9> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper9> for ::windows::core::IUnknown {
-    fn from(value: &IShellUIHelper9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper9> for super::super::System::Com::IDispatch {
-    fn from(value: IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper9> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper9> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellUIHelper9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper9> for IShellUIHelper {
-    fn from(value: IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper9> for &'a IShellUIHelper {
-    fn from(value: &'a IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper9> for IShellUIHelper {
-    fn from(value: &IShellUIHelper9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper9> for IShellUIHelper2 {
-    fn from(value: IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper9> for &'a IShellUIHelper2 {
-    fn from(value: &'a IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper9> for IShellUIHelper2 {
-    fn from(value: &IShellUIHelper9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper9> for IShellUIHelper3 {
-    fn from(value: IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper9> for &'a IShellUIHelper3 {
-    fn from(value: &'a IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper9> for IShellUIHelper3 {
-    fn from(value: &IShellUIHelper9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper9> for IShellUIHelper4 {
-    fn from(value: IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper9> for &'a IShellUIHelper4 {
-    fn from(value: &'a IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper9> for IShellUIHelper4 {
-    fn from(value: &IShellUIHelper9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper9> for IShellUIHelper5 {
-    fn from(value: IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper9> for &'a IShellUIHelper5 {
-    fn from(value: &'a IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper9> for IShellUIHelper5 {
-    fn from(value: &IShellUIHelper9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper9> for IShellUIHelper6 {
-    fn from(value: IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper9> for &'a IShellUIHelper6 {
-    fn from(value: &'a IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper9> for IShellUIHelper6 {
-    fn from(value: &IShellUIHelper9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper9> for IShellUIHelper7 {
-    fn from(value: IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper9> for &'a IShellUIHelper7 {
-    fn from(value: &'a IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper9> for IShellUIHelper7 {
-    fn from(value: &IShellUIHelper9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellUIHelper9> for IShellUIHelper8 {
-    fn from(value: IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellUIHelper9> for &'a IShellUIHelper8 {
-    fn from(value: &'a IShellUIHelper9) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellUIHelper9> for IShellUIHelper8 {
-    fn from(value: &IShellUIHelper9) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellUIHelper9, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IShellUIHelper, IShellUIHelper2, IShellUIHelper3, IShellUIHelper4, IShellUIHelper5, IShellUIHelper6, IShellUIHelper7, IShellUIHelper8);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellUIHelper9 {
     fn clone(&self) -> Self {
@@ -45599,41 +37827,7 @@ impl IShellView {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IShellView> for ::windows::core::IUnknown {
-    fn from(value: IShellView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IShellView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IShellView> for ::windows::core::IUnknown {
-    fn from(value: &IShellView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IShellView> for super::super::System::Ole::IOleWindow {
-    fn from(value: IShellView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IShellView> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IShellView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IShellView> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IShellView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellView, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IShellView {
     fn clone(&self) -> Self {
@@ -45793,59 +37987,7 @@ impl IShellView2 {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IShellView2> for ::windows::core::IUnknown {
-    fn from(value: IShellView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IShellView2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IShellView2> for ::windows::core::IUnknown {
-    fn from(value: &IShellView2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IShellView2> for super::super::System::Ole::IOleWindow {
-    fn from(value: IShellView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IShellView2> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IShellView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IShellView2> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IShellView2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IShellView2> for IShellView {
-    fn from(value: IShellView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IShellView2> for &'a IShellView {
-    fn from(value: &'a IShellView2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IShellView2> for IShellView {
-    fn from(value: &IShellView2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellView2, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow, IShellView);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IShellView2 {
     fn clone(&self) -> Self {
@@ -46002,77 +38144,7 @@ impl IShellView3 {
     }
 }
 #[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IShellView3> for ::windows::core::IUnknown {
-    fn from(value: IShellView3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IShellView3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellView3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IShellView3> for ::windows::core::IUnknown {
-    fn from(value: &IShellView3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IShellView3> for super::super::System::Ole::IOleWindow {
-    fn from(value: IShellView3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IShellView3> for &'a super::super::System::Ole::IOleWindow {
-    fn from(value: &'a IShellView3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IShellView3> for super::super::System::Ole::IOleWindow {
-    fn from(value: &IShellView3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IShellView3> for IShellView {
-    fn from(value: IShellView3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IShellView3> for &'a IShellView {
-    fn from(value: &'a IShellView3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IShellView3> for IShellView {
-    fn from(value: &IShellView3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<IShellView3> for IShellView2 {
-    fn from(value: IShellView3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl<'a> ::core::convert::From<&'a IShellView3> for &'a IShellView2 {
-    fn from(value: &'a IShellView3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Ole")]
-impl ::core::convert::From<&IShellView3> for IShellView2 {
-    fn from(value: &IShellView3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellView3, ::windows::core::IUnknown, super::super::System::Ole::IOleWindow, IShellView, IShellView2);
 #[cfg(feature = "Win32_System_Ole")]
 impl ::core::clone::Clone for IShellView3 {
     fn clone(&self) -> Self {
@@ -46176,41 +38248,7 @@ impl IShellWindows {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellWindows> for ::windows::core::IUnknown {
-    fn from(value: IShellWindows) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellWindows> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IShellWindows) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellWindows> for ::windows::core::IUnknown {
-    fn from(value: &IShellWindows) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IShellWindows> for super::super::System::Com::IDispatch {
-    fn from(value: IShellWindows) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IShellWindows> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IShellWindows) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IShellWindows> for super::super::System::Com::IDispatch {
-    fn from(value: &IShellWindows) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IShellWindows, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IShellWindows {
     fn clone(&self) -> Self {
@@ -46290,21 +38328,7 @@ impl ISortColumnArray {
         (::windows::core::Vtable::vtable(self).GetSortType)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<SORT_ORDER_TYPE>(result__)
     }
 }
-impl ::core::convert::From<ISortColumnArray> for ::windows::core::IUnknown {
-    fn from(value: ISortColumnArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISortColumnArray> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISortColumnArray) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISortColumnArray> for ::windows::core::IUnknown {
-    fn from(value: &ISortColumnArray) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISortColumnArray, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISortColumnArray {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -46349,21 +38373,7 @@ impl IStartMenuPinnedList {
         (::windows::core::Vtable::vtable(self).RemoveFromList)(::windows::core::Vtable::as_raw(self), pitem.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IStartMenuPinnedList> for ::windows::core::IUnknown {
-    fn from(value: IStartMenuPinnedList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStartMenuPinnedList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStartMenuPinnedList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStartMenuPinnedList> for ::windows::core::IUnknown {
-    fn from(value: &IStartMenuPinnedList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStartMenuPinnedList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStartMenuPinnedList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -46426,21 +38436,7 @@ impl IStorageProviderBanners {
         (::windows::core::Vtable::vtable(self).GetBanner)(::windows::core::Vtable::as_raw(self), provideridentity.into(), subscriptionid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<IStorageProviderBanners> for ::windows::core::IUnknown {
-    fn from(value: IStorageProviderBanners) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderBanners> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageProviderBanners) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderBanners> for ::windows::core::IUnknown {
-    fn from(value: &IStorageProviderBanners) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageProviderBanners, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStorageProviderBanners {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -46488,21 +38484,7 @@ impl IStorageProviderCopyHook {
         (::windows::core::Vtable::vtable(self).CopyCallback)(::windows::core::Vtable::as_raw(self), hwnd.into(), operation, flags, srcfile.into(), srcattribs, destfile.into(), destattribs, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IStorageProviderCopyHook> for ::windows::core::IUnknown {
-    fn from(value: IStorageProviderCopyHook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderCopyHook> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageProviderCopyHook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderCopyHook> for ::windows::core::IUnknown {
-    fn from(value: &IStorageProviderCopyHook) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageProviderCopyHook, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStorageProviderCopyHook {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -46560,21 +38542,7 @@ impl IStorageProviderHandler {
         (::windows::core::Vtable::vtable(self).GetPropertyHandlerFromFileId)(::windows::core::Vtable::as_raw(self), fileid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IStorageProviderPropertyHandler>(result__)
     }
 }
-impl ::core::convert::From<IStorageProviderHandler> for ::windows::core::IUnknown {
-    fn from(value: IStorageProviderHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageProviderHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderHandler> for ::windows::core::IUnknown {
-    fn from(value: &IStorageProviderHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageProviderHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStorageProviderHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -46624,21 +38592,7 @@ impl IStorageProviderPropertyHandler {
         (::windows::core::Vtable::vtable(self).SaveProperties)(::windows::core::Vtable::as_raw(self), propertiestosave.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IStorageProviderPropertyHandler> for ::windows::core::IUnknown {
-    fn from(value: IStorageProviderPropertyHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStorageProviderPropertyHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStorageProviderPropertyHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStorageProviderPropertyHandler> for ::windows::core::IUnknown {
-    fn from(value: &IStorageProviderPropertyHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStorageProviderPropertyHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStorageProviderPropertyHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -46763,59 +38717,7 @@ impl IStreamAsync {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamAsync> for ::windows::core::IUnknown {
-    fn from(value: IStreamAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamAsync> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStreamAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamAsync> for ::windows::core::IUnknown {
-    fn from(value: &IStreamAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamAsync> for super::super::System::Com::ISequentialStream {
-    fn from(value: IStreamAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamAsync> for &'a super::super::System::Com::ISequentialStream {
-    fn from(value: &'a IStreamAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamAsync> for super::super::System::Com::ISequentialStream {
-    fn from(value: &IStreamAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IStreamAsync> for super::super::System::Com::IStream {
-    fn from(value: IStreamAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IStreamAsync> for &'a super::super::System::Com::IStream {
-    fn from(value: &'a IStreamAsync) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IStreamAsync> for super::super::System::Com::IStream {
-    fn from(value: &IStreamAsync) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStreamAsync, ::windows::core::IUnknown, super::super::System::Com::ISequentialStream, super::super::System::Com::IStream);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IStreamAsync {
     fn clone(&self) -> Self {
@@ -46872,21 +38774,7 @@ impl IStreamUnbufferedInfo {
         (::windows::core::Vtable::vtable(self).GetSectorSize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IStreamUnbufferedInfo> for ::windows::core::IUnknown {
-    fn from(value: IStreamUnbufferedInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStreamUnbufferedInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStreamUnbufferedInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStreamUnbufferedInfo> for ::windows::core::IUnknown {
-    fn from(value: &IStreamUnbufferedInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStreamUnbufferedInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStreamUnbufferedInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -46944,21 +38832,7 @@ impl ISuspensionDependencyManager {
         (::windows::core::Vtable::vtable(self).UngroupChildFromParent)(::windows::core::Vtable::as_raw(self), childprocesshandle.into()).ok()
     }
 }
-impl ::core::convert::From<ISuspensionDependencyManager> for ::windows::core::IUnknown {
-    fn from(value: ISuspensionDependencyManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISuspensionDependencyManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISuspensionDependencyManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISuspensionDependencyManager> for ::windows::core::IUnknown {
-    fn from(value: &ISuspensionDependencyManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISuspensionDependencyManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISuspensionDependencyManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47032,21 +38906,7 @@ impl ISyncMgrConflict {
         (::windows::core::Vtable::vtable(self).GetResolutionHandler)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ISyncMgrConflict> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrConflict) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrConflict> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrConflict) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrConflict> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrConflict) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrConflict, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrConflict {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47099,21 +38959,7 @@ impl ISyncMgrConflictFolder {
         (::windows::core::Vtable::vtable(self).GetConflictIDList)(::windows::core::Vtable::as_raw(self), pconflict.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut Common::ITEMIDLIST>(result__)
     }
 }
-impl ::core::convert::From<ISyncMgrConflictFolder> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrConflictFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrConflictFolder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrConflictFolder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrConflictFolder> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrConflictFolder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrConflictFolder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrConflictFolder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47158,21 +39004,7 @@ impl ISyncMgrConflictItems {
         (::windows::core::Vtable::vtable(self).GetItem)(::windows::core::Vtable::as_raw(self), iindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<CONFIRM_CONFLICT_ITEM>(result__)
     }
 }
-impl ::core::convert::From<ISyncMgrConflictItems> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrConflictItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrConflictItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrConflictItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrConflictItems> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrConflictItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrConflictItems, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrConflictItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47214,21 +39046,7 @@ impl ISyncMgrConflictPresenter {
         (::windows::core::Vtable::vtable(self).PresentConflict)(::windows::core::Vtable::as_raw(self), pconflict.into().abi(), presolveinfo.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrConflictPresenter> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrConflictPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrConflictPresenter> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrConflictPresenter) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrConflictPresenter> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrConflictPresenter) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrConflictPresenter, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrConflictPresenter {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47270,21 +39088,7 @@ impl ISyncMgrConflictResolutionItems {
         (::windows::core::Vtable::vtable(self).GetItem)(::windows::core::Vtable::as_raw(self), iindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<CONFIRM_CONFLICT_RESULT_INFO>(result__)
     }
 }
-impl ::core::convert::From<ISyncMgrConflictResolutionItems> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrConflictResolutionItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrConflictResolutionItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrConflictResolutionItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrConflictResolutionItems> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrConflictResolutionItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrConflictResolutionItems, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrConflictResolutionItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47353,21 +39157,7 @@ impl ISyncMgrConflictResolveInfo {
         (::windows::core::Vtable::vtable(self).SetItemChoices)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prgiconflictitemindexes), cchoices).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrConflictResolveInfo> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrConflictResolveInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrConflictResolveInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrConflictResolveInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrConflictResolveInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrConflictResolveInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrConflictResolveInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrConflictResolveInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47444,21 +39234,7 @@ impl ISyncMgrConflictStore {
         (::windows::core::Vtable::vtable(self).GetCount)(::windows::core::Vtable::as_raw(self), pszhandlerid.into(), pszitemid.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ISyncMgrConflictStore> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrConflictStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrConflictStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrConflictStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrConflictStore> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrConflictStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrConflictStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrConflictStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47615,21 +39391,7 @@ impl ISyncMgrControl {
         (::windows::core::Vtable::vtable(self).EnableItem)(::windows::core::Vtable::as_raw(self), fenable.into(), pszhandlerid.into(), pszitemid.into(), hwndowner.into(), ncontrolflags).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrControl> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrControl> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47710,21 +39472,7 @@ impl ISyncMgrEnumItems {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncMgrEnumItems>(result__)
     }
 }
-impl ::core::convert::From<ISyncMgrEnumItems> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrEnumItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrEnumItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrEnumItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrEnumItems> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrEnumItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrEnumItems, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrEnumItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47810,21 +39558,7 @@ impl ISyncMgrEvent {
         (::windows::core::Vtable::vtable(self).GetContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ISyncMgrEvent> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrEvent> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrEvent) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrEvent> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrEvent) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrEvent, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrEvent {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47885,36 +39619,7 @@ impl ISyncMgrEventLinkUIOperation {
         (::windows::core::Vtable::vtable(self).Init)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rguideventid), pevent.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrEventLinkUIOperation> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrEventLinkUIOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrEventLinkUIOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrEventLinkUIOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrEventLinkUIOperation> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrEventLinkUIOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncMgrEventLinkUIOperation> for ISyncMgrUIOperation {
-    fn from(value: ISyncMgrEventLinkUIOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrEventLinkUIOperation> for &'a ISyncMgrUIOperation {
-    fn from(value: &'a ISyncMgrEventLinkUIOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrEventLinkUIOperation> for ISyncMgrUIOperation {
-    fn from(value: &ISyncMgrEventLinkUIOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrEventLinkUIOperation, ::windows::core::IUnknown, ISyncMgrUIOperation);
 impl ::core::clone::Clone for ISyncMgrEventLinkUIOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -47963,21 +39668,7 @@ impl ISyncMgrEventStore {
         (::windows::core::Vtable::vtable(self).RemoveEvent)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguideventids.as_ptr()), pguideventids.len() as _).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrEventStore> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrEventStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrEventStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrEventStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrEventStore> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrEventStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrEventStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrEventStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48063,21 +39754,7 @@ impl ISyncMgrHandler {
         (::windows::core::Vtable::vtable(self).Synchronize)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ppszitemids.as_ptr()), ppszitemids.len() as _, hwndowner.into(), psessioncreator.into().abi(), punk.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrHandler> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrHandler> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48141,21 +39818,7 @@ impl ISyncMgrHandlerCollection {
         (::windows::core::Vtable::vtable(self).BindToHandler)(::windows::core::Vtable::as_raw(self), pszhandlerid.into(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<ISyncMgrHandlerCollection> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrHandlerCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrHandlerCollection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrHandlerCollection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrHandlerCollection> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrHandlerCollection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrHandlerCollection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrHandlerCollection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48220,21 +39883,7 @@ impl ISyncMgrHandlerInfo {
         (::windows::core::Vtable::vtable(self).IsConnected)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrHandlerInfo> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrHandlerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrHandlerInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrHandlerInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrHandlerInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrHandlerInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrHandlerInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrHandlerInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48289,21 +39938,7 @@ impl ISyncMgrRegister {
         (::windows::core::Vtable::vtable(self).GetHandlerRegistrationInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clsidhandler), ::core::mem::transmute(pdwsyncmgrregisterflags)).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrRegister> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrRegister) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrRegister> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrRegister) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrRegister> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrRegister) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrRegister, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrRegister {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48365,21 +40000,7 @@ impl ISyncMgrResolutionHandler {
         (::windows::core::Vtable::vtable(self).KeepItems)(::windows::core::Vtable::as_raw(self), parray.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<SYNCMGR_RESOLUTION_FEEDBACK>(result__)
     }
 }
-impl ::core::convert::From<ISyncMgrResolutionHandler> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrResolutionHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrResolutionHandler> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrResolutionHandler) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrResolutionHandler> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrResolutionHandler) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrResolutionHandler, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrResolutionHandler {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48431,36 +40052,7 @@ impl ISyncMgrScheduleWizardUIOperation {
         (::windows::core::Vtable::vtable(self).InitWizard)(::windows::core::Vtable::as_raw(self), pszhandlerid.into()).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrScheduleWizardUIOperation> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrScheduleWizardUIOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrScheduleWizardUIOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrScheduleWizardUIOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrScheduleWizardUIOperation> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrScheduleWizardUIOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ISyncMgrScheduleWizardUIOperation> for ISyncMgrUIOperation {
-    fn from(value: ISyncMgrScheduleWizardUIOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrScheduleWizardUIOperation> for &'a ISyncMgrUIOperation {
-    fn from(value: &'a ISyncMgrScheduleWizardUIOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrScheduleWizardUIOperation> for ISyncMgrUIOperation {
-    fn from(value: &ISyncMgrScheduleWizardUIOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrScheduleWizardUIOperation, ::windows::core::IUnknown, ISyncMgrUIOperation);
 impl ::core::clone::Clone for ISyncMgrScheduleWizardUIOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48501,21 +40093,7 @@ impl ISyncMgrSessionCreator {
         (::windows::core::Vtable::vtable(self).CreateSession)(::windows::core::Vtable::as_raw(self), pszhandlerid.into(), ::core::mem::transmute(ppszitemids.as_ptr()), ppszitemids.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ISyncMgrSyncCallback>(result__)
     }
 }
-impl ::core::convert::From<ISyncMgrSessionCreator> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrSessionCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrSessionCreator> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrSessionCreator) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrSessionCreator> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrSessionCreator) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrSessionCreator, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrSessionCreator {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48612,21 +40190,7 @@ impl ISyncMgrSyncCallback {
         (::windows::core::Vtable::vtable(self).ReportManualSync)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrSyncCallback> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrSyncCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrSyncCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrSyncCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrSyncCallback> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrSyncCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrSyncCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrSyncCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48710,21 +40274,7 @@ impl ISyncMgrSyncItem {
         (::windows::core::Vtable::vtable(self).Delete)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrSyncItem> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrSyncItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrSyncItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrSyncItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrSyncItem> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrSyncItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrSyncItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrSyncItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48783,21 +40333,7 @@ impl ISyncMgrSyncItemContainer {
         (::windows::core::Vtable::vtable(self).GetSyncItemCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ISyncMgrSyncItemContainer> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrSyncItemContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrSyncItemContainer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrSyncItemContainer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrSyncItemContainer> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrSyncItemContainer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrSyncItemContainer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrSyncItemContainer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48853,21 +40389,7 @@ impl ISyncMgrSyncItemInfo {
         (::windows::core::Vtable::vtable(self).IsConnected)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrSyncItemInfo> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrSyncItemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrSyncItemInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrSyncItemInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrSyncItemInfo> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrSyncItemInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrSyncItemInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrSyncItemInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -48911,21 +40433,7 @@ impl ISyncMgrSyncResult {
         (::windows::core::Vtable::vtable(self).Result)(::windows::core::Vtable::as_raw(self), nstatus, cerror, cconflicts).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrSyncResult> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrSyncResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrSyncResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrSyncResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrSyncResult> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrSyncResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrSyncResult, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrSyncResult {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -49020,21 +40528,7 @@ impl ISyncMgrSynchronize {
         (::windows::core::Vtable::vtable(self).ShowError)(::windows::core::Vtable::as_raw(self), hwndparent.into(), ::core::mem::transmute(errorid)).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrSynchronize> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrSynchronize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrSynchronize> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrSynchronize) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrSynchronize> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrSynchronize) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrSynchronize, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrSynchronize {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -49130,21 +40624,7 @@ impl ISyncMgrSynchronizeCallback {
         (::windows::core::Vtable::vtable(self).EstablishConnection)(::windows::core::Vtable::as_raw(self), pwszconnection.into(), dwreserved).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrSynchronizeCallback> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrSynchronizeCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrSynchronizeCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrSynchronizeCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrSynchronizeCallback> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrSynchronizeCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrSynchronizeCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrSynchronizeCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -49195,21 +40675,7 @@ impl ISyncMgrSynchronizeInvoke {
         (::windows::core::Vtable::vtable(self).UpdateAll)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrSynchronizeInvoke> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrSynchronizeInvoke) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrSynchronizeInvoke> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrSynchronizeInvoke) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrSynchronizeInvoke> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrSynchronizeInvoke) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrSynchronizeInvoke, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrSynchronizeInvoke {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -49252,21 +40718,7 @@ impl ISyncMgrUIOperation {
         (::windows::core::Vtable::vtable(self).Run)(::windows::core::Vtable::as_raw(self), hwndowner.into()).ok()
     }
 }
-impl ::core::convert::From<ISyncMgrUIOperation> for ::windows::core::IUnknown {
-    fn from(value: ISyncMgrUIOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISyncMgrUIOperation> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISyncMgrUIOperation) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISyncMgrUIOperation> for ::windows::core::IUnknown {
-    fn from(value: &ISyncMgrUIOperation) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISyncMgrUIOperation, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISyncMgrUIOperation {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -49338,21 +40790,7 @@ impl ITaskbarList {
         (::windows::core::Vtable::vtable(self).SetActiveAlt)(::windows::core::Vtable::as_raw(self), hwnd.into()).ok()
     }
 }
-impl ::core::convert::From<ITaskbarList> for ::windows::core::IUnknown {
-    fn from(value: ITaskbarList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskbarList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskbarList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskbarList> for ::windows::core::IUnknown {
-    fn from(value: &ITaskbarList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskbarList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITaskbarList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -49446,36 +40884,7 @@ impl ITaskbarList2 {
         (::windows::core::Vtable::vtable(self).MarkFullscreenWindow)(::windows::core::Vtable::as_raw(self), hwnd.into(), ffullscreen.into()).ok()
     }
 }
-impl ::core::convert::From<ITaskbarList2> for ::windows::core::IUnknown {
-    fn from(value: ITaskbarList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskbarList2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskbarList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskbarList2> for ::windows::core::IUnknown {
-    fn from(value: &ITaskbarList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITaskbarList2> for ITaskbarList {
-    fn from(value: ITaskbarList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskbarList2> for &'a ITaskbarList {
-    fn from(value: &'a ITaskbarList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskbarList2> for ITaskbarList {
-    fn from(value: &ITaskbarList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskbarList2, ::windows::core::IUnknown, ITaskbarList);
 impl ::core::clone::Clone for ITaskbarList2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -49659,51 +41068,7 @@ impl ITaskbarList3 {
         (::windows::core::Vtable::vtable(self).SetThumbnailClip)(::windows::core::Vtable::as_raw(self), hwnd.into(), ::core::mem::transmute(prcclip)).ok()
     }
 }
-impl ::core::convert::From<ITaskbarList3> for ::windows::core::IUnknown {
-    fn from(value: ITaskbarList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskbarList3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskbarList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskbarList3> for ::windows::core::IUnknown {
-    fn from(value: &ITaskbarList3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITaskbarList3> for ITaskbarList {
-    fn from(value: ITaskbarList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskbarList3> for &'a ITaskbarList {
-    fn from(value: &'a ITaskbarList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskbarList3> for ITaskbarList {
-    fn from(value: &ITaskbarList3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITaskbarList3> for ITaskbarList2 {
-    fn from(value: ITaskbarList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskbarList3> for &'a ITaskbarList2 {
-    fn from(value: &'a ITaskbarList3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskbarList3> for ITaskbarList2 {
-    fn from(value: &ITaskbarList3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskbarList3, ::windows::core::IUnknown, ITaskbarList, ITaskbarList2);
 impl ::core::clone::Clone for ITaskbarList3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -49939,66 +41304,7 @@ impl ITaskbarList4 {
         (::windows::core::Vtable::vtable(self).SetTabProperties)(::windows::core::Vtable::as_raw(self), hwndtab.into(), stpflags).ok()
     }
 }
-impl ::core::convert::From<ITaskbarList4> for ::windows::core::IUnknown {
-    fn from(value: ITaskbarList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskbarList4> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITaskbarList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskbarList4> for ::windows::core::IUnknown {
-    fn from(value: &ITaskbarList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITaskbarList4> for ITaskbarList {
-    fn from(value: ITaskbarList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskbarList4> for &'a ITaskbarList {
-    fn from(value: &'a ITaskbarList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskbarList4> for ITaskbarList {
-    fn from(value: &ITaskbarList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITaskbarList4> for ITaskbarList2 {
-    fn from(value: ITaskbarList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskbarList4> for &'a ITaskbarList2 {
-    fn from(value: &'a ITaskbarList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskbarList4> for ITaskbarList2 {
-    fn from(value: &ITaskbarList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITaskbarList4> for ITaskbarList3 {
-    fn from(value: ITaskbarList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITaskbarList4> for &'a ITaskbarList3 {
-    fn from(value: &'a ITaskbarList4) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITaskbarList4> for ITaskbarList3 {
-    fn from(value: &ITaskbarList4) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITaskbarList4, ::windows::core::IUnknown, ITaskbarList, ITaskbarList2, ITaskbarList3);
 impl ::core::clone::Clone for ITaskbarList4 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50044,21 +41350,7 @@ impl IThumbnailCache {
         (::windows::core::Vtable::vtable(self).GetThumbnailByID)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(thumbnailid), cxyrequestedthumbsize, ::core::mem::transmute(ppvthumb.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(poutflags.unwrap_or(::std::ptr::null_mut()))).ok()
     }
 }
-impl ::core::convert::From<IThumbnailCache> for ::windows::core::IUnknown {
-    fn from(value: IThumbnailCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IThumbnailCache> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IThumbnailCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IThumbnailCache> for ::windows::core::IUnknown {
-    fn from(value: &IThumbnailCache) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IThumbnailCache, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IThumbnailCache {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50099,21 +41391,7 @@ impl IThumbnailCachePrimer {
         (::windows::core::Vtable::vtable(self).PageInThumbnail)(::windows::core::Vtable::as_raw(self), psi.into().abi(), wtsflags, cxyrequestedthumbsize).ok()
     }
 }
-impl ::core::convert::From<IThumbnailCachePrimer> for ::windows::core::IUnknown {
-    fn from(value: IThumbnailCachePrimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IThumbnailCachePrimer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IThumbnailCachePrimer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IThumbnailCachePrimer> for ::windows::core::IUnknown {
-    fn from(value: &IThumbnailCachePrimer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IThumbnailCachePrimer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IThumbnailCachePrimer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50156,21 +41434,7 @@ impl IThumbnailCapture {
         (::windows::core::Vtable::vtable(self).CaptureThumbnail)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmaxsize), phtmldoc2.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Graphics::Gdi::HBITMAP>(result__)
     }
 }
-impl ::core::convert::From<IThumbnailCapture> for ::windows::core::IUnknown {
-    fn from(value: IThumbnailCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IThumbnailCapture> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IThumbnailCapture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IThumbnailCapture> for ::windows::core::IUnknown {
-    fn from(value: &IThumbnailCapture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IThumbnailCapture, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IThumbnailCapture {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50217,21 +41481,7 @@ impl IThumbnailHandlerFactory {
         (::windows::core::Vtable::vtable(self).GetThumbnailHandler)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pidlchild), pbc.into().abi(), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IThumbnailHandlerFactory> for ::windows::core::IUnknown {
-    fn from(value: IThumbnailHandlerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IThumbnailHandlerFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IThumbnailHandlerFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IThumbnailHandlerFactory> for ::windows::core::IUnknown {
-    fn from(value: &IThumbnailHandlerFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IThumbnailHandlerFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IThumbnailHandlerFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50273,21 +41523,7 @@ impl IThumbnailProvider {
         (::windows::core::Vtable::vtable(self).GetThumbnail)(::windows::core::Vtable::as_raw(self), cx, ::core::mem::transmute(phbmp), ::core::mem::transmute(pdwalpha)).ok()
     }
 }
-impl ::core::convert::From<IThumbnailProvider> for ::windows::core::IUnknown {
-    fn from(value: IThumbnailProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IThumbnailProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IThumbnailProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IThumbnailProvider> for ::windows::core::IUnknown {
-    fn from(value: &IThumbnailProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IThumbnailProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IThumbnailProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50327,21 +41563,7 @@ impl IThumbnailSettings {
         (::windows::core::Vtable::vtable(self).SetContext)(::windows::core::Vtable::as_raw(self), dwcontext).ok()
     }
 }
-impl ::core::convert::From<IThumbnailSettings> for ::windows::core::IUnknown {
-    fn from(value: IThumbnailSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IThumbnailSettings> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IThumbnailSettings) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IThumbnailSettings> for ::windows::core::IUnknown {
-    fn from(value: &IThumbnailSettings) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IThumbnailSettings, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IThumbnailSettings {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50392,21 +41614,7 @@ impl IThumbnailStreamCache {
         (::windows::core::Vtable::vtable(self).SetThumbnailStream)(::windows::core::Vtable::as_raw(self), path.into(), cacheid, ::core::mem::transmute(thumbnailsize), thumbnailstream.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IThumbnailStreamCache> for ::windows::core::IUnknown {
-    fn from(value: IThumbnailStreamCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IThumbnailStreamCache> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IThumbnailStreamCache) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IThumbnailStreamCache> for ::windows::core::IUnknown {
-    fn from(value: &IThumbnailStreamCache) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IThumbnailStreamCache, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IThumbnailStreamCache {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50518,36 +41726,7 @@ impl ITrackShellMenu {
         (::windows::core::Vtable::vtable(self).Popup)(::windows::core::Vtable::as_raw(self), hwnd.into(), ::core::mem::transmute(ppt), ::core::mem::transmute(prcexclude), dwflags).ok()
     }
 }
-impl ::core::convert::From<ITrackShellMenu> for ::windows::core::IUnknown {
-    fn from(value: ITrackShellMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITrackShellMenu> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITrackShellMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITrackShellMenu> for ::windows::core::IUnknown {
-    fn from(value: &ITrackShellMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITrackShellMenu> for IShellMenu {
-    fn from(value: ITrackShellMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITrackShellMenu> for &'a IShellMenu {
-    fn from(value: &'a ITrackShellMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITrackShellMenu> for IShellMenu {
-    fn from(value: &ITrackShellMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITrackShellMenu, ::windows::core::IUnknown, IShellMenu);
 impl ::core::clone::Clone for ITrackShellMenu {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50597,21 +41776,7 @@ impl ITranscodeImage {
         (::windows::core::Vtable::vtable(self).TranscodeImage)(::windows::core::Vtable::as_raw(self), pshellitem.into().abi(), uimaxwidth, uimaxheight, flags, pvimage.into().abi(), ::core::mem::transmute(puiwidth), ::core::mem::transmute(puiheight)).ok()
     }
 }
-impl ::core::convert::From<ITranscodeImage> for ::windows::core::IUnknown {
-    fn from(value: ITranscodeImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITranscodeImage> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITranscodeImage) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITranscodeImage> for ::windows::core::IUnknown {
-    fn from(value: &ITranscodeImage) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITranscodeImage, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITranscodeImage {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50690,21 +41855,7 @@ impl ITransferAdviseSink {
         (::windows::core::Vtable::vtable(self).PropertyFailure)(::windows::core::Vtable::as_raw(self), psi.into().abi(), ::core::mem::transmute(pkey), hrerror).ok()
     }
 }
-impl ::core::convert::From<ITransferAdviseSink> for ::windows::core::IUnknown {
-    fn from(value: ITransferAdviseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransferAdviseSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransferAdviseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransferAdviseSink> for ::windows::core::IUnknown {
-    fn from(value: &ITransferAdviseSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransferAdviseSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransferAdviseSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50763,21 +41914,7 @@ impl ITransferDestination {
         (::windows::core::Vtable::vtable(self).CreateItem)(::windows::core::Vtable::as_raw(self), pszname.into(), dwattributes, ullsize, flags, ::core::mem::transmute(riiditem), ::core::mem::transmute(ppvitem), ::core::mem::transmute(riidresources), ::core::mem::transmute(ppvresources)).ok()
     }
 }
-impl ::core::convert::From<ITransferDestination> for ::windows::core::IUnknown {
-    fn from(value: ITransferDestination) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransferDestination> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransferDestination) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransferDestination> for ::windows::core::IUnknown {
-    fn from(value: &ITransferDestination) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransferDestination, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransferDestination {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50823,36 +41960,7 @@ impl ITransferMediumItem {
         (::windows::core::Vtable::vtable(self).base__.GetItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IShellItem>(result__)
     }
 }
-impl ::core::convert::From<ITransferMediumItem> for ::windows::core::IUnknown {
-    fn from(value: ITransferMediumItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransferMediumItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransferMediumItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransferMediumItem> for ::windows::core::IUnknown {
-    fn from(value: &ITransferMediumItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITransferMediumItem> for IRelatedItem {
-    fn from(value: ITransferMediumItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransferMediumItem> for &'a IRelatedItem {
-    fn from(value: &'a ITransferMediumItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransferMediumItem> for IRelatedItem {
-    fn from(value: &ITransferMediumItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransferMediumItem, ::windows::core::IUnknown, IRelatedItem);
 impl ::core::clone::Clone for ITransferMediumItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -50976,21 +42084,7 @@ impl ITransferSource {
         (::windows::core::Vtable::vtable(self).LeaveFolder)(::windows::core::Vtable::as_raw(self), psichildfolderdest.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITransferSource> for ::windows::core::IUnknown {
-    fn from(value: ITransferSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITransferSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITransferSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITransferSource> for ::windows::core::IUnknown {
-    fn from(value: &ITransferSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITransferSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITransferSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51060,21 +42154,7 @@ impl ITravelEntry {
         (::windows::core::Vtable::vtable(self).GetPidl)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut Common::ITEMIDLIST>(result__)
     }
 }
-impl ::core::convert::From<ITravelEntry> for ::windows::core::IUnknown {
-    fn from(value: ITravelEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITravelEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITravelEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITravelEntry> for ::windows::core::IUnknown {
-    fn from(value: &ITravelEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITravelEntry, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITravelEntry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51191,21 +42271,7 @@ impl ITravelLog {
         (::windows::core::Vtable::vtable(self).Revert)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITravelLog> for ::windows::core::IUnknown {
-    fn from(value: ITravelLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITravelLog> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITravelLog) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITravelLog> for ::windows::core::IUnknown {
-    fn from(value: &ITravelLog) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITravelLog, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITravelLog {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51280,21 +42346,7 @@ impl ITravelLogClient {
         (::windows::core::Vtable::vtable(self).LoadHistoryPosition)(::windows::core::Vtable::as_raw(self), pszurllocation.into(), dwposition).ok()
     }
 }
-impl ::core::convert::From<ITravelLogClient> for ::windows::core::IUnknown {
-    fn from(value: ITravelLogClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITravelLogClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITravelLogClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITravelLogClient> for ::windows::core::IUnknown {
-    fn from(value: &ITravelLogClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITravelLogClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITravelLogClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51341,21 +42393,7 @@ impl ITravelLogEntry {
         (::windows::core::Vtable::vtable(self).GetURL)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::PWSTR>(result__)
     }
 }
-impl ::core::convert::From<ITravelLogEntry> for ::windows::core::IUnknown {
-    fn from(value: ITravelLogEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITravelLogEntry> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITravelLogEntry) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITravelLogEntry> for ::windows::core::IUnknown {
-    fn from(value: &ITravelLogEntry) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITravelLogEntry, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITravelLogEntry {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51433,21 +42471,7 @@ impl ITravelLogStg {
         (::windows::core::Vtable::vtable(self).GetRelativeEntry)(::windows::core::Vtable::as_raw(self), ioffset, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITravelLogEntry>(result__)
     }
 }
-impl ::core::convert::From<ITravelLogStg> for ::windows::core::IUnknown {
-    fn from(value: ITravelLogStg) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITravelLogStg> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITravelLogStg) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITravelLogStg> for ::windows::core::IUnknown {
-    fn from(value: &ITravelLogStg) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITravelLogStg, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITravelLogStg {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51502,21 +42526,7 @@ impl ITrayDeskBand {
         (::windows::core::Vtable::vtable(self).DeskBandRegistrationChanged)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITrayDeskBand> for ::windows::core::IUnknown {
-    fn from(value: ITrayDeskBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITrayDeskBand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITrayDeskBand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITrayDeskBand> for ::windows::core::IUnknown {
-    fn from(value: &ITrayDeskBand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITrayDeskBand, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITrayDeskBand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51556,21 +42566,7 @@ impl IURLSearchHook {
         (::windows::core::Vtable::vtable(self).Translate)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwszsearchurl.as_ptr()), pwszsearchurl.len() as _).ok()
     }
 }
-impl ::core::convert::From<IURLSearchHook> for ::windows::core::IUnknown {
-    fn from(value: IURLSearchHook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IURLSearchHook> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IURLSearchHook) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IURLSearchHook> for ::windows::core::IUnknown {
-    fn from(value: &IURLSearchHook) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IURLSearchHook, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IURLSearchHook {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51613,36 +42609,7 @@ impl IURLSearchHook2 {
         (::windows::core::Vtable::vtable(self).TranslateWithSearchContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pwszsearchurl.as_ptr()), pwszsearchurl.len() as _, psearchcontext.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IURLSearchHook2> for ::windows::core::IUnknown {
-    fn from(value: IURLSearchHook2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IURLSearchHook2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IURLSearchHook2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IURLSearchHook2> for ::windows::core::IUnknown {
-    fn from(value: &IURLSearchHook2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IURLSearchHook2> for IURLSearchHook {
-    fn from(value: IURLSearchHook2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IURLSearchHook2> for &'a IURLSearchHook {
-    fn from(value: &'a IURLSearchHook2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IURLSearchHook2> for IURLSearchHook {
-    fn from(value: &IURLSearchHook2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IURLSearchHook2, ::windows::core::IUnknown, IURLSearchHook);
 impl ::core::clone::Clone for IURLSearchHook2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51691,21 +42658,7 @@ impl IUniformResourceLocatorA {
         (::windows::core::Vtable::vtable(self).InvokeCommand)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(purlici)).ok()
     }
 }
-impl ::core::convert::From<IUniformResourceLocatorA> for ::windows::core::IUnknown {
-    fn from(value: IUniformResourceLocatorA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUniformResourceLocatorA> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUniformResourceLocatorA) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUniformResourceLocatorA> for ::windows::core::IUnknown {
-    fn from(value: &IUniformResourceLocatorA) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUniformResourceLocatorA, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUniformResourceLocatorA {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51759,21 +42712,7 @@ impl IUniformResourceLocatorW {
         (::windows::core::Vtable::vtable(self).InvokeCommand)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(purlici)).ok()
     }
 }
-impl ::core::convert::From<IUniformResourceLocatorW> for ::windows::core::IUnknown {
-    fn from(value: IUniformResourceLocatorW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUniformResourceLocatorW> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUniformResourceLocatorW) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUniformResourceLocatorW> for ::windows::core::IUnknown {
-    fn from(value: &IUniformResourceLocatorW) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUniformResourceLocatorW, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUniformResourceLocatorW {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51821,21 +42760,7 @@ impl IUpdateIDList {
         (::windows::core::Vtable::vtable(self).Update)(::windows::core::Vtable::as_raw(self), pbc.into().abi(), ::core::mem::transmute(pidlin), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<*mut Common::ITEMIDLIST>(result__)
     }
 }
-impl ::core::convert::From<IUpdateIDList> for ::windows::core::IUnknown {
-    fn from(value: IUpdateIDList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUpdateIDList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUpdateIDList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUpdateIDList> for ::windows::core::IUnknown {
-    fn from(value: &IUpdateIDList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUpdateIDList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUpdateIDList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51882,36 +42807,7 @@ impl IUseToBrowseItem {
         (::windows::core::Vtable::vtable(self).base__.GetItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IShellItem>(result__)
     }
 }
-impl ::core::convert::From<IUseToBrowseItem> for ::windows::core::IUnknown {
-    fn from(value: IUseToBrowseItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUseToBrowseItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUseToBrowseItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUseToBrowseItem> for ::windows::core::IUnknown {
-    fn from(value: &IUseToBrowseItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IUseToBrowseItem> for IRelatedItem {
-    fn from(value: IUseToBrowseItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUseToBrowseItem> for &'a IRelatedItem {
-    fn from(value: &'a IUseToBrowseItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUseToBrowseItem> for IRelatedItem {
-    fn from(value: &IUseToBrowseItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUseToBrowseItem, ::windows::core::IUnknown, IRelatedItem);
 impl ::core::clone::Clone for IUseToBrowseItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -51950,21 +42846,7 @@ impl IUserAccountChangeCallback {
         (::windows::core::Vtable::vtable(self).OnPictureChange)(::windows::core::Vtable::as_raw(self), pszusername.into()).ok()
     }
 }
-impl ::core::convert::From<IUserAccountChangeCallback> for ::windows::core::IUnknown {
-    fn from(value: IUserAccountChangeCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserAccountChangeCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserAccountChangeCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserAccountChangeCallback> for ::windows::core::IUnknown {
-    fn from(value: &IUserAccountChangeCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserAccountChangeCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUserAccountChangeCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -52029,21 +42911,7 @@ impl IUserNotification {
         (::windows::core::Vtable::vtable(self).PlaySound)(::windows::core::Vtable::as_raw(self), pszsoundname.into()).ok()
     }
 }
-impl ::core::convert::From<IUserNotification> for ::windows::core::IUnknown {
-    fn from(value: IUserNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserNotification> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserNotification) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserNotification> for ::windows::core::IUnknown {
-    fn from(value: &IUserNotification) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserNotification, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUserNotification {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -52116,21 +42984,7 @@ impl IUserNotification2 {
         (::windows::core::Vtable::vtable(self).PlaySound)(::windows::core::Vtable::as_raw(self), pszsoundname.into()).ok()
     }
 }
-impl ::core::convert::From<IUserNotification2> for ::windows::core::IUnknown {
-    fn from(value: IUserNotification2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserNotification2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserNotification2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserNotification2> for ::windows::core::IUnknown {
-    fn from(value: &IUserNotification2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserNotification2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUserNotification2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -52186,21 +43040,7 @@ impl IUserNotificationCallback {
         (::windows::core::Vtable::vtable(self).OnContextMenu)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pt)).ok()
     }
 }
-impl ::core::convert::From<IUserNotificationCallback> for ::windows::core::IUnknown {
-    fn from(value: IUserNotificationCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUserNotificationCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUserNotificationCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUserNotificationCallback> for ::windows::core::IUnknown {
-    fn from(value: &IUserNotificationCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUserNotificationCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUserNotificationCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -52255,36 +43095,7 @@ impl IViewStateIdentityItem {
         (::windows::core::Vtable::vtable(self).base__.GetItem)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IShellItem>(result__)
     }
 }
-impl ::core::convert::From<IViewStateIdentityItem> for ::windows::core::IUnknown {
-    fn from(value: IViewStateIdentityItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewStateIdentityItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IViewStateIdentityItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewStateIdentityItem> for ::windows::core::IUnknown {
-    fn from(value: &IViewStateIdentityItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IViewStateIdentityItem> for IRelatedItem {
-    fn from(value: IViewStateIdentityItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IViewStateIdentityItem> for &'a IRelatedItem {
-    fn from(value: &'a IViewStateIdentityItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IViewStateIdentityItem> for IRelatedItem {
-    fn from(value: &IViewStateIdentityItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IViewStateIdentityItem, ::windows::core::IUnknown, IRelatedItem);
 impl ::core::clone::Clone for IViewStateIdentityItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -52343,21 +43154,7 @@ impl IVirtualDesktopManager {
         (::windows::core::Vtable::vtable(self).MoveWindowToDesktop)(::windows::core::Vtable::as_raw(self), toplevelwindow.into(), ::core::mem::transmute(desktopid)).ok()
     }
 }
-impl ::core::convert::From<IVirtualDesktopManager> for ::windows::core::IUnknown {
-    fn from(value: IVirtualDesktopManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVirtualDesktopManager> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVirtualDesktopManager) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVirtualDesktopManager> for ::windows::core::IUnknown {
-    fn from(value: &IVirtualDesktopManager) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVirtualDesktopManager, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVirtualDesktopManager {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -52452,21 +43249,7 @@ impl IVisualProperties {
         (::windows::core::Vtable::vtable(self).SetTheme)(::windows::core::Vtable::as_raw(self), pszsubappname.into(), pszsubidlist.into()).ok()
     }
 }
-impl ::core::convert::From<IVisualProperties> for ::windows::core::IUnknown {
-    fn from(value: IVisualProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVisualProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualProperties> for ::windows::core::IUnknown {
-    fn from(value: &IVisualProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVisualProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVisualProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -52625,41 +43408,7 @@ impl IWebBrowser {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebBrowser> for ::windows::core::IUnknown {
-    fn from(value: IWebBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebBrowser> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebBrowser> for ::windows::core::IUnknown {
-    fn from(value: &IWebBrowser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebBrowser> for super::super::System::Com::IDispatch {
-    fn from(value: IWebBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebBrowser> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWebBrowser) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebBrowser> for super::super::System::Com::IDispatch {
-    fn from(value: &IWebBrowser) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebBrowser, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWebBrowser {
     fn clone(&self) -> Self {
@@ -53001,77 +43750,7 @@ impl IWebBrowser2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebBrowser2> for ::windows::core::IUnknown {
-    fn from(value: IWebBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebBrowser2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebBrowser2> for ::windows::core::IUnknown {
-    fn from(value: &IWebBrowser2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebBrowser2> for super::super::System::Com::IDispatch {
-    fn from(value: IWebBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebBrowser2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWebBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebBrowser2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWebBrowser2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebBrowser2> for IWebBrowser {
-    fn from(value: IWebBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebBrowser2> for &'a IWebBrowser {
-    fn from(value: &'a IWebBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebBrowser2> for IWebBrowser {
-    fn from(value: &IWebBrowser2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebBrowser2> for IWebBrowserApp {
-    fn from(value: IWebBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebBrowser2> for &'a IWebBrowserApp {
-    fn from(value: &'a IWebBrowser2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebBrowser2> for IWebBrowserApp {
-    fn from(value: &IWebBrowser2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebBrowser2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWebBrowser, IWebBrowserApp);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWebBrowser2 {
     fn clone(&self) -> Self {
@@ -53328,59 +44007,7 @@ impl IWebBrowserApp {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebBrowserApp> for ::windows::core::IUnknown {
-    fn from(value: IWebBrowserApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebBrowserApp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebBrowserApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebBrowserApp> for ::windows::core::IUnknown {
-    fn from(value: &IWebBrowserApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebBrowserApp> for super::super::System::Com::IDispatch {
-    fn from(value: IWebBrowserApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebBrowserApp> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWebBrowserApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebBrowserApp> for super::super::System::Com::IDispatch {
-    fn from(value: &IWebBrowserApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebBrowserApp> for IWebBrowser {
-    fn from(value: IWebBrowserApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebBrowserApp> for &'a IWebBrowser {
-    fn from(value: &'a IWebBrowserApp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebBrowserApp> for IWebBrowser {
-    fn from(value: &IWebBrowserApp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebBrowserApp, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWebBrowser);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWebBrowserApp {
     fn clone(&self) -> Self {
@@ -53478,36 +44105,7 @@ impl IWebWizardExtension {
         (::windows::core::Vtable::vtable(self).SetErrorURL)(::windows::core::Vtable::as_raw(self), pszerrorurl.into()).ok()
     }
 }
-impl ::core::convert::From<IWebWizardExtension> for ::windows::core::IUnknown {
-    fn from(value: IWebWizardExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebWizardExtension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebWizardExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebWizardExtension> for ::windows::core::IUnknown {
-    fn from(value: &IWebWizardExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IWebWizardExtension> for IWizardExtension {
-    fn from(value: IWebWizardExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWebWizardExtension> for &'a IWizardExtension {
-    fn from(value: &'a IWebWizardExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWebWizardExtension> for IWizardExtension {
-    fn from(value: &IWebWizardExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebWizardExtension, ::windows::core::IUnknown, IWizardExtension);
 impl ::core::clone::Clone for IWebWizardExtension {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -53578,41 +44176,7 @@ impl IWebWizardHost {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebWizardHost> for ::windows::core::IUnknown {
-    fn from(value: IWebWizardHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebWizardHost> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebWizardHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebWizardHost> for ::windows::core::IUnknown {
-    fn from(value: &IWebWizardHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebWizardHost> for super::super::System::Com::IDispatch {
-    fn from(value: IWebWizardHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebWizardHost> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWebWizardHost) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebWizardHost> for super::super::System::Com::IDispatch {
-    fn from(value: &IWebWizardHost) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebWizardHost, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWebWizardHost {
     fn clone(&self) -> Self {
@@ -53707,59 +44271,7 @@ impl IWebWizardHost2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebWizardHost2> for ::windows::core::IUnknown {
-    fn from(value: IWebWizardHost2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebWizardHost2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWebWizardHost2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebWizardHost2> for ::windows::core::IUnknown {
-    fn from(value: &IWebWizardHost2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebWizardHost2> for super::super::System::Com::IDispatch {
-    fn from(value: IWebWizardHost2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebWizardHost2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IWebWizardHost2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebWizardHost2> for super::super::System::Com::IDispatch {
-    fn from(value: &IWebWizardHost2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IWebWizardHost2> for IWebWizardHost {
-    fn from(value: IWebWizardHost2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IWebWizardHost2> for &'a IWebWizardHost {
-    fn from(value: &'a IWebWizardHost2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IWebWizardHost2> for IWebWizardHost {
-    fn from(value: &IWebWizardHost2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWebWizardHost2, ::windows::core::IUnknown, super::super::System::Com::IDispatch, IWebWizardHost);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IWebWizardHost2 {
     fn clone(&self) -> Self {
@@ -53817,21 +44329,7 @@ impl IWizardExtension {
         (::windows::core::Vtable::vtable(self).GetLastPage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Controls::HPROPSHEETPAGE>(result__)
     }
 }
-impl ::core::convert::From<IWizardExtension> for ::windows::core::IUnknown {
-    fn from(value: IWizardExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWizardExtension> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWizardExtension) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWizardExtension> for ::windows::core::IUnknown {
-    fn from(value: &IWizardExtension) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWizardExtension, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWizardExtension {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -53894,21 +44392,7 @@ impl IWizardSite {
         (::windows::core::Vtable::vtable(self).GetCancelledPage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::Controls::HPROPSHEETPAGE>(result__)
     }
 }
-impl ::core::convert::From<IWizardSite> for ::windows::core::IUnknown {
-    fn from(value: IWizardSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IWizardSite> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IWizardSite) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IWizardSite> for ::windows::core::IUnknown {
-    fn from(value: &IWizardSite) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IWizardSite, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IWizardSite {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
@@ -422,21 +422,7 @@ impl IDynamicRenderer {
         (::windows::core::Vtable::vtable(self).Draw)(::windows::core::Vtable::as_raw(self), hdc.into()).ok()
     }
 }
-impl ::core::convert::From<IDynamicRenderer> for ::windows::core::IUnknown {
-    fn from(value: IDynamicRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDynamicRenderer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDynamicRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDynamicRenderer> for ::windows::core::IUnknown {
-    fn from(value: &IDynamicRenderer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDynamicRenderer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDynamicRenderer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -550,21 +536,7 @@ impl IGestureRecognizer {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IGestureRecognizer> for ::windows::core::IUnknown {
-    fn from(value: IGestureRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IGestureRecognizer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IGestureRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IGestureRecognizer> for ::windows::core::IUnknown {
-    fn from(value: &IGestureRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IGestureRecognizer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IGestureRecognizer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -626,21 +598,7 @@ impl IHandwrittenTextInsertion {
         (::windows::core::Vtable::vtable(self).InsertInkRecognitionResult)(::windows::core::Vtable::as_raw(self), piinkrecoresult.into().abi(), locale, falternatecontainsautospacinginformation.into()).ok()
     }
 }
-impl ::core::convert::From<IHandwrittenTextInsertion> for ::windows::core::IUnknown {
-    fn from(value: IHandwrittenTextInsertion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IHandwrittenTextInsertion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IHandwrittenTextInsertion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IHandwrittenTextInsertion> for ::windows::core::IUnknown {
-    fn from(value: &IHandwrittenTextInsertion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IHandwrittenTextInsertion, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IHandwrittenTextInsertion {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -683,41 +641,7 @@ pub struct IInk(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl IInk {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInk> for ::windows::core::IUnknown {
-    fn from(value: IInk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInk> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInk> for ::windows::core::IUnknown {
-    fn from(value: &IInk) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInk> for super::super::System::Com::IDispatch {
-    fn from(value: IInk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInk> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInk> for super::super::System::Com::IDispatch {
-    fn from(value: &IInk) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInk, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInk {
     fn clone(&self) -> Self {
@@ -955,41 +879,7 @@ impl IInkCollector {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCollector> for ::windows::core::IUnknown {
-    fn from(value: IInkCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCollector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCollector> for ::windows::core::IUnknown {
-    fn from(value: &IInkCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCollector> for super::super::System::Com::IDispatch {
-    fn from(value: IInkCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCollector> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkCollector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCollector> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkCollector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkCollector, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkCollector {
     fn clone(&self) -> Self {
@@ -1158,41 +1048,7 @@ impl IInkCursor {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCursor> for ::windows::core::IUnknown {
-    fn from(value: IInkCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCursor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCursor> for ::windows::core::IUnknown {
-    fn from(value: &IInkCursor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCursor> for super::super::System::Com::IDispatch {
-    fn from(value: IInkCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCursor> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkCursor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCursor> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkCursor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkCursor, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkCursor {
     fn clone(&self) -> Self {
@@ -1266,41 +1122,7 @@ impl IInkCursorButton {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCursorButton> for ::windows::core::IUnknown {
-    fn from(value: IInkCursorButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCursorButton> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkCursorButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCursorButton> for ::windows::core::IUnknown {
-    fn from(value: &IInkCursorButton) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCursorButton> for super::super::System::Com::IDispatch {
-    fn from(value: IInkCursorButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCursorButton> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkCursorButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCursorButton> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkCursorButton) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkCursorButton, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkCursorButton {
     fn clone(&self) -> Self {
@@ -1363,41 +1185,7 @@ impl IInkCursorButtons {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCursorButtons> for ::windows::core::IUnknown {
-    fn from(value: IInkCursorButtons) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCursorButtons> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkCursorButtons) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCursorButtons> for ::windows::core::IUnknown {
-    fn from(value: &IInkCursorButtons) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCursorButtons> for super::super::System::Com::IDispatch {
-    fn from(value: IInkCursorButtons) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCursorButtons> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkCursorButtons) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCursorButtons> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkCursorButtons) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkCursorButtons, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkCursorButtons {
     fn clone(&self) -> Self {
@@ -1460,41 +1248,7 @@ impl IInkCursors {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCursors> for ::windows::core::IUnknown {
-    fn from(value: IInkCursors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCursors> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkCursors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCursors> for ::windows::core::IUnknown {
-    fn from(value: &IInkCursors) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCursors> for super::super::System::Com::IDispatch {
-    fn from(value: IInkCursors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCursors> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkCursors) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCursors> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkCursors) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkCursors, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkCursors {
     fn clone(&self) -> Self {
@@ -1579,41 +1333,7 @@ impl IInkCustomStrokes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCustomStrokes> for ::windows::core::IUnknown {
-    fn from(value: IInkCustomStrokes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCustomStrokes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkCustomStrokes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCustomStrokes> for ::windows::core::IUnknown {
-    fn from(value: &IInkCustomStrokes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkCustomStrokes> for super::super::System::Com::IDispatch {
-    fn from(value: IInkCustomStrokes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkCustomStrokes> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkCustomStrokes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkCustomStrokes> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkCustomStrokes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkCustomStrokes, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkCustomStrokes {
     fn clone(&self) -> Self {
@@ -1856,41 +1576,7 @@ impl IInkDisp {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDisp> for ::windows::core::IUnknown {
-    fn from(value: IInkDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDisp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDisp> for ::windows::core::IUnknown {
-    fn from(value: &IInkDisp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDisp> for super::super::System::Com::IDispatch {
-    fn from(value: IInkDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDisp> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDisp> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkDisp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkDisp, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkDisp {
     fn clone(&self) -> Self {
@@ -2068,41 +1754,7 @@ impl IInkDivider {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDivider> for ::windows::core::IUnknown {
-    fn from(value: IInkDivider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDivider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkDivider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDivider> for ::windows::core::IUnknown {
-    fn from(value: &IInkDivider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDivider> for super::super::System::Com::IDispatch {
-    fn from(value: IInkDivider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDivider> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkDivider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDivider> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkDivider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkDivider, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkDivider {
     fn clone(&self) -> Self {
@@ -2179,41 +1831,7 @@ impl IInkDivisionResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDivisionResult> for ::windows::core::IUnknown {
-    fn from(value: IInkDivisionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDivisionResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkDivisionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDivisionResult> for ::windows::core::IUnknown {
-    fn from(value: &IInkDivisionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDivisionResult> for super::super::System::Com::IDispatch {
-    fn from(value: IInkDivisionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDivisionResult> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkDivisionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDivisionResult> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkDivisionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkDivisionResult, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkDivisionResult {
     fn clone(&self) -> Self {
@@ -2284,41 +1902,7 @@ impl IInkDivisionUnit {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDivisionUnit> for ::windows::core::IUnknown {
-    fn from(value: IInkDivisionUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDivisionUnit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkDivisionUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDivisionUnit> for ::windows::core::IUnknown {
-    fn from(value: &IInkDivisionUnit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDivisionUnit> for super::super::System::Com::IDispatch {
-    fn from(value: IInkDivisionUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDivisionUnit> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkDivisionUnit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDivisionUnit> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkDivisionUnit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkDivisionUnit, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkDivisionUnit {
     fn clone(&self) -> Self {
@@ -2385,41 +1969,7 @@ impl IInkDivisionUnits {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDivisionUnits> for ::windows::core::IUnknown {
-    fn from(value: IInkDivisionUnits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDivisionUnits> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkDivisionUnits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDivisionUnits> for ::windows::core::IUnknown {
-    fn from(value: &IInkDivisionUnits) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDivisionUnits> for super::super::System::Com::IDispatch {
-    fn from(value: IInkDivisionUnits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDivisionUnits> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkDivisionUnits) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDivisionUnits> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkDivisionUnits) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkDivisionUnits, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkDivisionUnits {
     fn clone(&self) -> Self {
@@ -2543,41 +2093,7 @@ impl IInkDrawingAttributes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDrawingAttributes> for ::windows::core::IUnknown {
-    fn from(value: IInkDrawingAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDrawingAttributes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkDrawingAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDrawingAttributes> for ::windows::core::IUnknown {
-    fn from(value: &IInkDrawingAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkDrawingAttributes> for super::super::System::Com::IDispatch {
-    fn from(value: IInkDrawingAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkDrawingAttributes> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkDrawingAttributes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkDrawingAttributes> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkDrawingAttributes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkDrawingAttributes, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkDrawingAttributes {
     fn clone(&self) -> Self {
@@ -3011,41 +2527,7 @@ impl IInkEdit {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkEdit> for ::windows::core::IUnknown {
-    fn from(value: IInkEdit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkEdit> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkEdit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkEdit> for ::windows::core::IUnknown {
-    fn from(value: &IInkEdit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkEdit> for super::super::System::Com::IDispatch {
-    fn from(value: IInkEdit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkEdit> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkEdit) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkEdit> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkEdit) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkEdit, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkEdit {
     fn clone(&self) -> Self {
@@ -3287,41 +2769,7 @@ impl IInkExtendedProperties {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkExtendedProperties> for ::windows::core::IUnknown {
-    fn from(value: IInkExtendedProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkExtendedProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkExtendedProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkExtendedProperties> for ::windows::core::IUnknown {
-    fn from(value: &IInkExtendedProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkExtendedProperties> for super::super::System::Com::IDispatch {
-    fn from(value: IInkExtendedProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkExtendedProperties> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkExtendedProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkExtendedProperties> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkExtendedProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkExtendedProperties, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkExtendedProperties {
     fn clone(&self) -> Self {
@@ -3398,41 +2846,7 @@ impl IInkExtendedProperty {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkExtendedProperty> for ::windows::core::IUnknown {
-    fn from(value: IInkExtendedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkExtendedProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkExtendedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkExtendedProperty> for ::windows::core::IUnknown {
-    fn from(value: &IInkExtendedProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkExtendedProperty> for super::super::System::Com::IDispatch {
-    fn from(value: IInkExtendedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkExtendedProperty> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkExtendedProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkExtendedProperty> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkExtendedProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkExtendedProperty, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkExtendedProperty {
     fn clone(&self) -> Self {
@@ -3495,41 +2909,7 @@ impl IInkGesture {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkGesture> for ::windows::core::IUnknown {
-    fn from(value: IInkGesture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkGesture> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkGesture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkGesture> for ::windows::core::IUnknown {
-    fn from(value: &IInkGesture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkGesture> for super::super::System::Com::IDispatch {
-    fn from(value: IInkGesture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkGesture> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkGesture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkGesture> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkGesture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkGesture, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkGesture {
     fn clone(&self) -> Self {
@@ -3602,21 +2982,7 @@ impl IInkLineInfo {
         (::windows::core::Vtable::vtable(self).Recognize)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInkLineInfo> for ::windows::core::IUnknown {
-    fn from(value: IInkLineInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInkLineInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkLineInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInkLineInfo> for ::windows::core::IUnknown {
-    fn from(value: &IInkLineInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkLineInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInkLineInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3923,41 +3289,7 @@ impl IInkOverlay {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkOverlay> for ::windows::core::IUnknown {
-    fn from(value: IInkOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkOverlay> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkOverlay> for ::windows::core::IUnknown {
-    fn from(value: &IInkOverlay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkOverlay> for super::super::System::Com::IDispatch {
-    fn from(value: IInkOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkOverlay> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkOverlay) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkOverlay> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkOverlay) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkOverlay, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkOverlay {
     fn clone(&self) -> Self {
@@ -4392,41 +3724,7 @@ impl IInkPicture {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkPicture> for ::windows::core::IUnknown {
-    fn from(value: IInkPicture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkPicture> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkPicture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkPicture> for ::windows::core::IUnknown {
-    fn from(value: &IInkPicture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkPicture> for super::super::System::Com::IDispatch {
-    fn from(value: IInkPicture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkPicture> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkPicture) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkPicture> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkPicture) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkPicture, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkPicture {
     fn clone(&self) -> Self {
@@ -4679,41 +3977,7 @@ impl IInkRecognitionAlternate {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognitionAlternate> for ::windows::core::IUnknown {
-    fn from(value: IInkRecognitionAlternate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognitionAlternate> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRecognitionAlternate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognitionAlternate> for ::windows::core::IUnknown {
-    fn from(value: &IInkRecognitionAlternate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognitionAlternate> for super::super::System::Com::IDispatch {
-    fn from(value: IInkRecognitionAlternate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognitionAlternate> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkRecognitionAlternate) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognitionAlternate> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkRecognitionAlternate) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRecognitionAlternate, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkRecognitionAlternate {
     fn clone(&self) -> Self {
@@ -4827,41 +4091,7 @@ impl IInkRecognitionAlternates {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognitionAlternates> for ::windows::core::IUnknown {
-    fn from(value: IInkRecognitionAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognitionAlternates> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRecognitionAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognitionAlternates> for ::windows::core::IUnknown {
-    fn from(value: &IInkRecognitionAlternates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognitionAlternates> for super::super::System::Com::IDispatch {
-    fn from(value: IInkRecognitionAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognitionAlternates> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkRecognitionAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognitionAlternates> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkRecognitionAlternates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRecognitionAlternates, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkRecognitionAlternates {
     fn clone(&self) -> Self {
@@ -4951,41 +4181,7 @@ impl IInkRecognitionResult {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognitionResult> for ::windows::core::IUnknown {
-    fn from(value: IInkRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognitionResult> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognitionResult> for ::windows::core::IUnknown {
-    fn from(value: &IInkRecognitionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognitionResult> for super::super::System::Com::IDispatch {
-    fn from(value: IInkRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognitionResult> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkRecognitionResult) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognitionResult> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkRecognitionResult) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRecognitionResult, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkRecognitionResult {
     fn clone(&self) -> Self {
@@ -5083,41 +4279,7 @@ impl IInkRecognizer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizer> for ::windows::core::IUnknown {
-    fn from(value: IInkRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizer> for ::windows::core::IUnknown {
-    fn from(value: &IInkRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizer> for super::super::System::Com::IDispatch {
-    fn from(value: IInkRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizer> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkRecognizer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizer> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkRecognizer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRecognizer, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkRecognizer {
     fn clone(&self) -> Self {
@@ -5189,41 +4351,7 @@ impl IInkRecognizer2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizer2> for ::windows::core::IUnknown {
-    fn from(value: IInkRecognizer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizer2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRecognizer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizer2> for ::windows::core::IUnknown {
-    fn from(value: &IInkRecognizer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizer2> for super::super::System::Com::IDispatch {
-    fn from(value: IInkRecognizer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizer2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkRecognizer2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizer2> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkRecognizer2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRecognizer2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkRecognizer2 {
     fn clone(&self) -> Self {
@@ -5391,41 +4519,7 @@ impl IInkRecognizerContext {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizerContext> for ::windows::core::IUnknown {
-    fn from(value: IInkRecognizerContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizerContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRecognizerContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizerContext> for ::windows::core::IUnknown {
-    fn from(value: &IInkRecognizerContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizerContext> for super::super::System::Com::IDispatch {
-    fn from(value: IInkRecognizerContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizerContext> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkRecognizerContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizerContext> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkRecognizerContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRecognizerContext, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkRecognizerContext {
     fn clone(&self) -> Self {
@@ -5539,41 +4633,7 @@ impl IInkRecognizerContext2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizerContext2> for ::windows::core::IUnknown {
-    fn from(value: IInkRecognizerContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizerContext2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRecognizerContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizerContext2> for ::windows::core::IUnknown {
-    fn from(value: &IInkRecognizerContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizerContext2> for super::super::System::Com::IDispatch {
-    fn from(value: IInkRecognizerContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizerContext2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkRecognizerContext2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizerContext2> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkRecognizerContext2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRecognizerContext2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkRecognizerContext2 {
     fn clone(&self) -> Self {
@@ -5684,41 +4744,7 @@ impl IInkRecognizerGuide {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizerGuide> for ::windows::core::IUnknown {
-    fn from(value: IInkRecognizerGuide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizerGuide> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRecognizerGuide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizerGuide> for ::windows::core::IUnknown {
-    fn from(value: &IInkRecognizerGuide) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizerGuide> for super::super::System::Com::IDispatch {
-    fn from(value: IInkRecognizerGuide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizerGuide> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkRecognizerGuide) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizerGuide> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkRecognizerGuide) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRecognizerGuide, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkRecognizerGuide {
     fn clone(&self) -> Self {
@@ -5811,41 +4837,7 @@ impl IInkRecognizers {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizers> for ::windows::core::IUnknown {
-    fn from(value: IInkRecognizers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizers> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRecognizers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizers> for ::windows::core::IUnknown {
-    fn from(value: &IInkRecognizers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRecognizers> for super::super::System::Com::IDispatch {
-    fn from(value: IInkRecognizers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRecognizers> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkRecognizers) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRecognizers> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkRecognizers) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRecognizers, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkRecognizers {
     fn clone(&self) -> Self {
@@ -5943,41 +4935,7 @@ impl IInkRectangle {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRectangle> for ::windows::core::IUnknown {
-    fn from(value: IInkRectangle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRectangle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRectangle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRectangle> for ::windows::core::IUnknown {
-    fn from(value: &IInkRectangle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRectangle> for super::super::System::Com::IDispatch {
-    fn from(value: IInkRectangle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRectangle> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkRectangle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRectangle> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkRectangle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRectangle, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkRectangle {
     fn clone(&self) -> Self {
@@ -6131,41 +5089,7 @@ impl IInkRenderer {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRenderer> for ::windows::core::IUnknown {
-    fn from(value: IInkRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRenderer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRenderer> for ::windows::core::IUnknown {
-    fn from(value: &IInkRenderer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkRenderer> for super::super::System::Com::IDispatch {
-    fn from(value: IInkRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkRenderer> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkRenderer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkRenderer> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkRenderer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkRenderer, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkRenderer {
     fn clone(&self) -> Self {
@@ -6443,41 +5367,7 @@ impl IInkStrokeDisp {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkStrokeDisp> for ::windows::core::IUnknown {
-    fn from(value: IInkStrokeDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkStrokeDisp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkStrokeDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkStrokeDisp> for ::windows::core::IUnknown {
-    fn from(value: &IInkStrokeDisp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkStrokeDisp> for super::super::System::Com::IDispatch {
-    fn from(value: IInkStrokeDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkStrokeDisp> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkStrokeDisp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkStrokeDisp> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkStrokeDisp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkStrokeDisp, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkStrokeDisp {
     fn clone(&self) -> Self {
@@ -6734,41 +5624,7 @@ impl IInkStrokes {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkStrokes> for ::windows::core::IUnknown {
-    fn from(value: IInkStrokes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkStrokes> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkStrokes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkStrokes> for ::windows::core::IUnknown {
-    fn from(value: &IInkStrokes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkStrokes> for super::super::System::Com::IDispatch {
-    fn from(value: IInkStrokes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkStrokes> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkStrokes) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkStrokes> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkStrokes) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkStrokes, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkStrokes {
     fn clone(&self) -> Self {
@@ -6892,41 +5748,7 @@ impl IInkTablet {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkTablet> for ::windows::core::IUnknown {
-    fn from(value: IInkTablet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkTablet> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkTablet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkTablet> for ::windows::core::IUnknown {
-    fn from(value: &IInkTablet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkTablet> for super::super::System::Com::IDispatch {
-    fn from(value: IInkTablet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkTablet> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkTablet) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkTablet> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkTablet) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkTablet, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkTablet {
     fn clone(&self) -> Self {
@@ -6982,41 +5804,7 @@ impl IInkTablet2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkTablet2> for ::windows::core::IUnknown {
-    fn from(value: IInkTablet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkTablet2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkTablet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkTablet2> for ::windows::core::IUnknown {
-    fn from(value: &IInkTablet2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkTablet2> for super::super::System::Com::IDispatch {
-    fn from(value: IInkTablet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkTablet2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkTablet2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkTablet2> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkTablet2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkTablet2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkTablet2 {
     fn clone(&self) -> Self {
@@ -7068,41 +5856,7 @@ impl IInkTablet3 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkTablet3> for ::windows::core::IUnknown {
-    fn from(value: IInkTablet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkTablet3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkTablet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkTablet3> for ::windows::core::IUnknown {
-    fn from(value: &IInkTablet3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkTablet3> for super::super::System::Com::IDispatch {
-    fn from(value: IInkTablet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkTablet3> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkTablet3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkTablet3> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkTablet3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkTablet3, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkTablet3 {
     fn clone(&self) -> Self {
@@ -7171,41 +5925,7 @@ impl IInkTablets {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkTablets> for ::windows::core::IUnknown {
-    fn from(value: IInkTablets) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkTablets> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkTablets) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkTablets> for ::windows::core::IUnknown {
-    fn from(value: &IInkTablets) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkTablets> for super::super::System::Com::IDispatch {
-    fn from(value: IInkTablets) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkTablets> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkTablets) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkTablets> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkTablets) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkTablets, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkTablets {
     fn clone(&self) -> Self {
@@ -7336,41 +6056,7 @@ impl IInkTransform {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkTransform> for ::windows::core::IUnknown {
-    fn from(value: IInkTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkTransform> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkTransform> for ::windows::core::IUnknown {
-    fn from(value: &IInkTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkTransform> for super::super::System::Com::IDispatch {
-    fn from(value: IInkTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkTransform> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkTransform) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkTransform> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkTransform) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkTransform, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkTransform {
     fn clone(&self) -> Self {
@@ -7455,41 +6141,7 @@ impl IInkWordList {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkWordList> for ::windows::core::IUnknown {
-    fn from(value: IInkWordList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkWordList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkWordList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkWordList> for ::windows::core::IUnknown {
-    fn from(value: &IInkWordList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkWordList> for super::super::System::Com::IDispatch {
-    fn from(value: IInkWordList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkWordList> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkWordList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkWordList> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkWordList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkWordList, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkWordList {
     fn clone(&self) -> Self {
@@ -7541,41 +6193,7 @@ impl IInkWordList2 {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkWordList2> for ::windows::core::IUnknown {
-    fn from(value: IInkWordList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkWordList2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInkWordList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkWordList2> for ::windows::core::IUnknown {
-    fn from(value: &IInkWordList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IInkWordList2> for super::super::System::Com::IDispatch {
-    fn from(value: IInkWordList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IInkWordList2> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IInkWordList2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IInkWordList2> for super::super::System::Com::IDispatch {
-    fn from(value: &IInkWordList2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInkWordList2, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IInkWordList2 {
     fn clone(&self) -> Self {
@@ -7630,21 +6248,7 @@ impl IInputPanelWindowHandle {
         (::windows::core::Vtable::vtable(self).SetAttachedEditWindow64)(::windows::core::Vtable::as_raw(self), attachededitwindow).ok()
     }
 }
-impl ::core::convert::From<IInputPanelWindowHandle> for ::windows::core::IUnknown {
-    fn from(value: IInputPanelWindowHandle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInputPanelWindowHandle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInputPanelWindowHandle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInputPanelWindowHandle> for ::windows::core::IUnknown {
-    fn from(value: &IInputPanelWindowHandle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInputPanelWindowHandle, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInputPanelWindowHandle {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7745,41 +6349,7 @@ impl IMathInputControl {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMathInputControl> for ::windows::core::IUnknown {
-    fn from(value: IMathInputControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMathInputControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMathInputControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMathInputControl> for ::windows::core::IUnknown {
-    fn from(value: &IMathInputControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IMathInputControl> for super::super::System::Com::IDispatch {
-    fn from(value: IMathInputControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IMathInputControl> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IMathInputControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IMathInputControl> for super::super::System::Com::IDispatch {
-    fn from(value: &IMathInputControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMathInputControl, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IMathInputControl {
     fn clone(&self) -> Self {
@@ -7933,41 +6503,7 @@ impl IPenInputPanel {
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPenInputPanel> for ::windows::core::IUnknown {
-    fn from(value: IPenInputPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPenInputPanel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IPenInputPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPenInputPanel> for ::windows::core::IUnknown {
-    fn from(value: &IPenInputPanel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<IPenInputPanel> for super::super::System::Com::IDispatch {
-    fn from(value: IPenInputPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a IPenInputPanel> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a IPenInputPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&IPenInputPanel> for super::super::System::Com::IDispatch {
-    fn from(value: &IPenInputPanel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IPenInputPanel, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for IPenInputPanel {
     fn clone(&self) -> Self {
@@ -8188,21 +6724,7 @@ impl IRealTimeStylus {
         (::windows::core::Vtable::vtable(self).GetPacketDescriptionData)(::windows::core::Vtable::as_raw(self), tcid, ::core::mem::transmute(pfinktodevicescalex.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pfinktodevicescaley.unwrap_or(::std::ptr::null_mut())), ::core::mem::transmute(pcpacketproperties), ::core::mem::transmute(pppacketproperties)).ok()
     }
 }
-impl ::core::convert::From<IRealTimeStylus> for ::windows::core::IUnknown {
-    fn from(value: IRealTimeStylus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRealTimeStylus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRealTimeStylus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRealTimeStylus> for ::windows::core::IUnknown {
-    fn from(value: &IRealTimeStylus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRealTimeStylus, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRealTimeStylus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8319,21 +6841,7 @@ impl IRealTimeStylus2 {
         (::windows::core::Vtable::vtable(self).SetFlicksEnabled)(::windows::core::Vtable::as_raw(self), fenable.into()).ok()
     }
 }
-impl ::core::convert::From<IRealTimeStylus2> for ::windows::core::IUnknown {
-    fn from(value: IRealTimeStylus2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRealTimeStylus2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRealTimeStylus2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRealTimeStylus2> for ::windows::core::IUnknown {
-    fn from(value: &IRealTimeStylus2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRealTimeStylus2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRealTimeStylus2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8388,21 +6896,7 @@ impl IRealTimeStylus3 {
         (::windows::core::Vtable::vtable(self).SetMultiTouchEnabled)(::windows::core::Vtable::as_raw(self), fenable.into()).ok()
     }
 }
-impl ::core::convert::From<IRealTimeStylus3> for ::windows::core::IUnknown {
-    fn from(value: IRealTimeStylus3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRealTimeStylus3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRealTimeStylus3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRealTimeStylus3> for ::windows::core::IUnknown {
-    fn from(value: &IRealTimeStylus3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRealTimeStylus3, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRealTimeStylus3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8449,21 +6943,7 @@ impl IRealTimeStylusSynchronization {
         (::windows::core::Vtable::vtable(self).ReleaseLock)(::windows::core::Vtable::as_raw(self), lock).ok()
     }
 }
-impl ::core::convert::From<IRealTimeStylusSynchronization> for ::windows::core::IUnknown {
-    fn from(value: IRealTimeStylusSynchronization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IRealTimeStylusSynchronization> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IRealTimeStylusSynchronization) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IRealTimeStylusSynchronization> for ::windows::core::IUnknown {
-    fn from(value: &IRealTimeStylusSynchronization) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IRealTimeStylusSynchronization, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IRealTimeStylusSynchronization {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8500,41 +6980,7 @@ pub struct ISketchInk(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl ISketchInk {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISketchInk> for ::windows::core::IUnknown {
-    fn from(value: ISketchInk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISketchInk> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISketchInk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISketchInk> for ::windows::core::IUnknown {
-    fn from(value: &ISketchInk) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<ISketchInk> for super::super::System::Com::IDispatch {
-    fn from(value: ISketchInk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a ISketchInk> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a ISketchInk) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&ISketchInk> for super::super::System::Com::IDispatch {
-    fn from(value: &ISketchInk) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISketchInk, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for ISketchInk {
     fn clone(&self) -> Self {
@@ -8606,21 +7052,7 @@ impl IStrokeBuilder {
         (::windows::core::Vtable::vtable(self).putref_Ink)(::windows::core::Vtable::as_raw(self), piinkobj.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IStrokeBuilder> for ::windows::core::IUnknown {
-    fn from(value: IStrokeBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStrokeBuilder> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStrokeBuilder) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStrokeBuilder> for ::windows::core::IUnknown {
-    fn from(value: &IStrokeBuilder) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStrokeBuilder, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStrokeBuilder {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8790,36 +7222,7 @@ impl IStylusAsyncPlugin {
         (::windows::core::Vtable::vtable(self).base__.DataInterest)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<RealTimeStylusDataInterest>(result__)
     }
 }
-impl ::core::convert::From<IStylusAsyncPlugin> for ::windows::core::IUnknown {
-    fn from(value: IStylusAsyncPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStylusAsyncPlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStylusAsyncPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStylusAsyncPlugin> for ::windows::core::IUnknown {
-    fn from(value: &IStylusAsyncPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStylusAsyncPlugin> for IStylusPlugin {
-    fn from(value: IStylusAsyncPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStylusAsyncPlugin> for &'a IStylusPlugin {
-    fn from(value: &'a IStylusAsyncPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStylusAsyncPlugin> for IStylusPlugin {
-    fn from(value: &IStylusAsyncPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStylusAsyncPlugin, ::windows::core::IUnknown, IStylusPlugin);
 impl ::core::clone::Clone for IStylusAsyncPlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8968,21 +7371,7 @@ impl IStylusPlugin {
         (::windows::core::Vtable::vtable(self).DataInterest)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<RealTimeStylusDataInterest>(result__)
     }
 }
-impl ::core::convert::From<IStylusPlugin> for ::windows::core::IUnknown {
-    fn from(value: IStylusPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStylusPlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStylusPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStylusPlugin> for ::windows::core::IUnknown {
-    fn from(value: &IStylusPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStylusPlugin, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IStylusPlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9169,36 +7558,7 @@ impl IStylusSyncPlugin {
         (::windows::core::Vtable::vtable(self).base__.DataInterest)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<RealTimeStylusDataInterest>(result__)
     }
 }
-impl ::core::convert::From<IStylusSyncPlugin> for ::windows::core::IUnknown {
-    fn from(value: IStylusSyncPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStylusSyncPlugin> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IStylusSyncPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStylusSyncPlugin> for ::windows::core::IUnknown {
-    fn from(value: &IStylusSyncPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IStylusSyncPlugin> for IStylusPlugin {
-    fn from(value: IStylusSyncPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IStylusSyncPlugin> for &'a IStylusPlugin {
-    fn from(value: &'a IStylusSyncPlugin) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IStylusSyncPlugin> for IStylusPlugin {
-    fn from(value: &IStylusSyncPlugin) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IStylusSyncPlugin, ::windows::core::IUnknown, IStylusPlugin);
 impl ::core::clone::Clone for IStylusSyncPlugin {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9353,21 +7713,7 @@ impl ITextInputPanel {
         (::windows::core::Vtable::vtable(self).Unadvise)(::windows::core::Vtable::as_raw(self), eventsink.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITextInputPanel> for ::windows::core::IUnknown {
-    fn from(value: ITextInputPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextInputPanel> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextInputPanel) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextInputPanel> for ::windows::core::IUnknown {
-    fn from(value: &ITextInputPanel) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextInputPanel, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextInputPanel {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9505,21 +7851,7 @@ impl ITextInputPanelEventSink {
         (::windows::core::Vtable::vtable(self).TextInserted)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ink)).ok()
     }
 }
-impl ::core::convert::From<ITextInputPanelEventSink> for ::windows::core::IUnknown {
-    fn from(value: ITextInputPanelEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextInputPanelEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextInputPanelEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextInputPanelEventSink> for ::windows::core::IUnknown {
-    fn from(value: &ITextInputPanelEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextInputPanelEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextInputPanelEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9588,21 +7920,7 @@ impl ITextInputPanelRunInfo {
         (::windows::core::Vtable::vtable(self).IsTipRunning)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITextInputPanelRunInfo> for ::windows::core::IUnknown {
-    fn from(value: ITextInputPanelRunInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextInputPanelRunInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextInputPanelRunInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextInputPanelRunInfo> for ::windows::core::IUnknown {
-    fn from(value: &ITextInputPanelRunInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextInputPanelRunInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextInputPanelRunInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9674,21 +7992,7 @@ impl ITipAutoCompleteClient {
         (::windows::core::Vtable::vtable(self).RequestShowUI)(::windows::core::Vtable::as_raw(self), hwndlist.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITipAutoCompleteClient> for ::windows::core::IUnknown {
-    fn from(value: ITipAutoCompleteClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITipAutoCompleteClient> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITipAutoCompleteClient) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITipAutoCompleteClient> for ::windows::core::IUnknown {
-    fn from(value: &ITipAutoCompleteClient) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITipAutoCompleteClient, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITipAutoCompleteClient {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9749,21 +8053,7 @@ impl ITipAutoCompleteProvider {
         (::windows::core::Vtable::vtable(self).Show)(::windows::core::Vtable::as_raw(self), fshow.into()).ok()
     }
 }
-impl ::core::convert::From<ITipAutoCompleteProvider> for ::windows::core::IUnknown {
-    fn from(value: ITipAutoCompleteProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITipAutoCompleteProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITipAutoCompleteProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITipAutoCompleteProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITipAutoCompleteProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITipAutoCompleteProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITipAutoCompleteProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9803,41 +8093,7 @@ pub struct _IInkCollectorEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _IInkCollectorEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkCollectorEvents> for ::windows::core::IUnknown {
-    fn from(value: _IInkCollectorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkCollectorEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IInkCollectorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkCollectorEvents> for ::windows::core::IUnknown {
-    fn from(value: &_IInkCollectorEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkCollectorEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _IInkCollectorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkCollectorEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _IInkCollectorEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkCollectorEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_IInkCollectorEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IInkCollectorEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IInkCollectorEvents {
     fn clone(&self) -> Self {
@@ -9879,41 +8135,7 @@ pub struct _IInkEditEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _IInkEditEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkEditEvents> for ::windows::core::IUnknown {
-    fn from(value: _IInkEditEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkEditEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IInkEditEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkEditEvents> for ::windows::core::IUnknown {
-    fn from(value: &_IInkEditEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkEditEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _IInkEditEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkEditEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _IInkEditEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkEditEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_IInkEditEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IInkEditEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IInkEditEvents {
     fn clone(&self) -> Self {
@@ -9955,41 +8177,7 @@ pub struct _IInkEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _IInkEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkEvents> for ::windows::core::IUnknown {
-    fn from(value: _IInkEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IInkEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkEvents> for ::windows::core::IUnknown {
-    fn from(value: &_IInkEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _IInkEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _IInkEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_IInkEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IInkEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IInkEvents {
     fn clone(&self) -> Self {
@@ -10031,41 +8219,7 @@ pub struct _IInkOverlayEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _IInkOverlayEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkOverlayEvents> for ::windows::core::IUnknown {
-    fn from(value: _IInkOverlayEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkOverlayEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IInkOverlayEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkOverlayEvents> for ::windows::core::IUnknown {
-    fn from(value: &_IInkOverlayEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkOverlayEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _IInkOverlayEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkOverlayEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _IInkOverlayEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkOverlayEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_IInkOverlayEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IInkOverlayEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IInkOverlayEvents {
     fn clone(&self) -> Self {
@@ -10107,41 +8261,7 @@ pub struct _IInkPictureEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _IInkPictureEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkPictureEvents> for ::windows::core::IUnknown {
-    fn from(value: _IInkPictureEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkPictureEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IInkPictureEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkPictureEvents> for ::windows::core::IUnknown {
-    fn from(value: &_IInkPictureEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkPictureEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _IInkPictureEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkPictureEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _IInkPictureEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkPictureEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_IInkPictureEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IInkPictureEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IInkPictureEvents {
     fn clone(&self) -> Self {
@@ -10183,41 +8303,7 @@ pub struct _IInkRecognitionEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _IInkRecognitionEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkRecognitionEvents> for ::windows::core::IUnknown {
-    fn from(value: _IInkRecognitionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkRecognitionEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IInkRecognitionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkRecognitionEvents> for ::windows::core::IUnknown {
-    fn from(value: &_IInkRecognitionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkRecognitionEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _IInkRecognitionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkRecognitionEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _IInkRecognitionEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkRecognitionEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_IInkRecognitionEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IInkRecognitionEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IInkRecognitionEvents {
     fn clone(&self) -> Self {
@@ -10259,41 +8345,7 @@ pub struct _IInkStrokesEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _IInkStrokesEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkStrokesEvents> for ::windows::core::IUnknown {
-    fn from(value: _IInkStrokesEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkStrokesEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IInkStrokesEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkStrokesEvents> for ::windows::core::IUnknown {
-    fn from(value: &_IInkStrokesEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IInkStrokesEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _IInkStrokesEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IInkStrokesEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _IInkStrokesEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IInkStrokesEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_IInkStrokesEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IInkStrokesEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IInkStrokesEvents {
     fn clone(&self) -> Self {
@@ -10335,41 +8387,7 @@ pub struct _IMathInputControlEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _IMathInputControlEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IMathInputControlEvents> for ::windows::core::IUnknown {
-    fn from(value: _IMathInputControlEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IMathInputControlEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IMathInputControlEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IMathInputControlEvents> for ::windows::core::IUnknown {
-    fn from(value: &_IMathInputControlEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IMathInputControlEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _IMathInputControlEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IMathInputControlEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _IMathInputControlEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IMathInputControlEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_IMathInputControlEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IMathInputControlEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IMathInputControlEvents {
     fn clone(&self) -> Self {
@@ -10411,41 +8429,7 @@ pub struct _IPenInputPanelEvents(::windows::core::IUnknown);
 #[cfg(feature = "Win32_System_Com")]
 impl _IPenInputPanelEvents {}
 #[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IPenInputPanelEvents> for ::windows::core::IUnknown {
-    fn from(value: _IPenInputPanelEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IPenInputPanelEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a _IPenInputPanelEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IPenInputPanelEvents> for ::windows::core::IUnknown {
-    fn from(value: &_IPenInputPanelEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<_IPenInputPanelEvents> for super::super::System::Com::IDispatch {
-    fn from(value: _IPenInputPanelEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl<'a> ::core::convert::From<&'a _IPenInputPanelEvents> for &'a super::super::System::Com::IDispatch {
-    fn from(value: &'a _IPenInputPanelEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl ::core::convert::From<&_IPenInputPanelEvents> for super::super::System::Com::IDispatch {
-    fn from(value: &_IPenInputPanelEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(_IPenInputPanelEvents, ::windows::core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ::core::clone::Clone for _IPenInputPanelEvents {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
@@ -59,21 +59,7 @@ impl IAccClientDocMgr {
         (::windows::core::Vtable::vtable(self).GetFocused)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IAccClientDocMgr> for ::windows::core::IUnknown {
-    fn from(value: IAccClientDocMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccClientDocMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccClientDocMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccClientDocMgr> for ::windows::core::IUnknown {
-    fn from(value: &IAccClientDocMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccClientDocMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccClientDocMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -142,21 +128,7 @@ impl IAccDictionary {
         (::windows::core::Vtable::vtable(self).ConvertValueToString)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(term), lcid, varvalue.into().abi(), ::core::mem::transmute(pbstrresult), ::core::mem::transmute(plcid)).ok()
     }
 }
-impl ::core::convert::From<IAccDictionary> for ::windows::core::IUnknown {
-    fn from(value: IAccDictionary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccDictionary> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccDictionary) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccDictionary> for ::windows::core::IUnknown {
-    fn from(value: &IAccDictionary) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccDictionary, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccDictionary {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -215,21 +187,7 @@ impl IAccServerDocMgr {
         (::windows::core::Vtable::vtable(self).OnDocumentFocus)(::windows::core::Vtable::as_raw(self), punk.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IAccServerDocMgr> for ::windows::core::IUnknown {
-    fn from(value: IAccServerDocMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccServerDocMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccServerDocMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccServerDocMgr> for ::windows::core::IUnknown {
-    fn from(value: &IAccServerDocMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccServerDocMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccServerDocMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -308,21 +266,7 @@ impl IAccStore {
         (::windows::core::Vtable::vtable(self).GetFocused)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IAccStore> for ::windows::core::IUnknown {
-    fn from(value: IAccStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAccStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAccStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAccStore> for ::windows::core::IUnknown {
-    fn from(value: &IAccStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAccStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAccStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -426,21 +370,7 @@ impl IAnchor {
         (::windows::core::Vtable::vtable(self).Clone)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IAnchor>(result__)
     }
 }
-impl ::core::convert::From<IAnchor> for ::windows::core::IUnknown {
-    fn from(value: IAnchor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IAnchor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IAnchor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IAnchor> for ::windows::core::IUnknown {
-    fn from(value: &IAnchor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IAnchor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IAnchor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -497,21 +427,7 @@ impl IClonableWrapper {
         (::windows::core::Vtable::vtable(self).CloneNewWrapper)(::windows::core::Vtable::as_raw(self), &<T as ::windows::core::Interface>::IID, &mut result__ as *mut _ as *mut _).and_some(result__)
     }
 }
-impl ::core::convert::From<IClonableWrapper> for ::windows::core::IUnknown {
-    fn from(value: IClonableWrapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IClonableWrapper> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IClonableWrapper) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IClonableWrapper> for ::windows::core::IUnknown {
-    fn from(value: &IClonableWrapper) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IClonableWrapper, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IClonableWrapper {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -554,21 +470,7 @@ impl ICoCreateLocally {
         (::windows::core::Vtable::vtable(self).CoCreateLocally)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid), dwclscontext, ::core::mem::transmute(riid), ::core::mem::transmute(punk), ::core::mem::transmute(riidparam), punkparam.into().abi(), varparam.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ICoCreateLocally> for ::windows::core::IUnknown {
-    fn from(value: ICoCreateLocally) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoCreateLocally> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoCreateLocally) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoCreateLocally> for ::windows::core::IUnknown {
-    fn from(value: &ICoCreateLocally) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoCreateLocally, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICoCreateLocally {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -615,21 +517,7 @@ impl ICoCreatedLocally {
         (::windows::core::Vtable::vtable(self).LocalInit)(::windows::core::Vtable::as_raw(self), punklocalobject.into().abi(), ::core::mem::transmute(riidparam), punkparam.into().abi(), varparam.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ICoCreatedLocally> for ::windows::core::IUnknown {
-    fn from(value: ICoCreatedLocally) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ICoCreatedLocally> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ICoCreatedLocally) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ICoCreatedLocally> for ::windows::core::IUnknown {
-    fn from(value: &ICoCreatedLocally) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ICoCreatedLocally, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ICoCreatedLocally {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -676,21 +564,7 @@ impl IDocWrap {
         (::windows::core::Vtable::vtable(self).GetWrappedDoc)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<IDocWrap> for ::windows::core::IUnknown {
-    fn from(value: IDocWrap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IDocWrap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IDocWrap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IDocWrap> for ::windows::core::IUnknown {
-    fn from(value: &IDocWrap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IDocWrap, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IDocWrap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -738,21 +612,7 @@ impl IEnumITfCompositionView {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumITfCompositionView> for ::windows::core::IUnknown {
-    fn from(value: IEnumITfCompositionView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumITfCompositionView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumITfCompositionView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumITfCompositionView> for ::windows::core::IUnknown {
-    fn from(value: &IEnumITfCompositionView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumITfCompositionView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumITfCompositionView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -802,21 +662,7 @@ impl IEnumSpeechCommands {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumSpeechCommands> for ::windows::core::IUnknown {
-    fn from(value: IEnumSpeechCommands) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumSpeechCommands> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumSpeechCommands) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumSpeechCommands> for ::windows::core::IUnknown {
-    fn from(value: &IEnumSpeechCommands) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumSpeechCommands, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumSpeechCommands {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -866,21 +712,7 @@ impl IEnumTfCandidates {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfCandidates> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfCandidates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfCandidates> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfCandidates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfCandidates> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfCandidates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfCandidates, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfCandidates {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -930,21 +762,7 @@ impl IEnumTfContextViews {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfContextViews> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfContextViews) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfContextViews> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfContextViews) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfContextViews> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfContextViews) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfContextViews, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfContextViews {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -994,21 +812,7 @@ impl IEnumTfContexts {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfContexts> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfContexts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfContexts> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfContexts) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfContexts> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfContexts) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfContexts, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfContexts {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1058,21 +862,7 @@ impl IEnumTfDisplayAttributeInfo {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfDisplayAttributeInfo> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfDisplayAttributeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfDisplayAttributeInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfDisplayAttributeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfDisplayAttributeInfo> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfDisplayAttributeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfDisplayAttributeInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfDisplayAttributeInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1122,21 +912,7 @@ impl IEnumTfDocumentMgrs {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfDocumentMgrs> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfDocumentMgrs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfDocumentMgrs> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfDocumentMgrs) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfDocumentMgrs> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfDocumentMgrs) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfDocumentMgrs, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfDocumentMgrs {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1186,21 +962,7 @@ impl IEnumTfFunctionProviders {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfFunctionProviders> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfFunctionProviders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfFunctionProviders> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfFunctionProviders) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfFunctionProviders> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfFunctionProviders) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfFunctionProviders, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfFunctionProviders {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1250,21 +1012,7 @@ impl IEnumTfInputProcessorProfiles {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfInputProcessorProfiles> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfInputProcessorProfiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfInputProcessorProfiles> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfInputProcessorProfiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfInputProcessorProfiles> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfInputProcessorProfiles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfInputProcessorProfiles, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfInputProcessorProfiles {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1314,21 +1062,7 @@ impl IEnumTfLangBarItems {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfLangBarItems> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfLangBarItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfLangBarItems> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfLangBarItems) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfLangBarItems> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfLangBarItems) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfLangBarItems, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfLangBarItems {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1380,21 +1114,7 @@ impl IEnumTfLanguageProfiles {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfLanguageProfiles> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfLanguageProfiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfLanguageProfiles> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfLanguageProfiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfLanguageProfiles> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfLanguageProfiles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfLanguageProfiles, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfLanguageProfiles {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1447,21 +1167,7 @@ impl IEnumTfLatticeElements {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfLatticeElements> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfLatticeElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfLatticeElements> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfLatticeElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfLatticeElements> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfLatticeElements) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfLatticeElements, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfLatticeElements {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1511,21 +1217,7 @@ impl IEnumTfProperties {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfProperties> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfProperties> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfProperties) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfProperties> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfProperties) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfProperties, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfProperties {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1577,21 +1269,7 @@ impl IEnumTfPropertyValue {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfPropertyValue> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfPropertyValue> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfPropertyValue) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfPropertyValue> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfPropertyValue) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfPropertyValue, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfPropertyValue {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1644,21 +1322,7 @@ impl IEnumTfRanges {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfRanges> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfRanges) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfRanges> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfRanges) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfRanges> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfRanges) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfRanges, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfRanges {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1708,21 +1372,7 @@ impl IEnumTfUIElements {
         (::windows::core::Vtable::vtable(self).Skip)(::windows::core::Vtable::as_raw(self), ulcount).ok()
     }
 }
-impl ::core::convert::From<IEnumTfUIElements> for ::windows::core::IUnknown {
-    fn from(value: IEnumTfUIElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IEnumTfUIElements> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IEnumTfUIElements) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IEnumTfUIElements> for ::windows::core::IUnknown {
-    fn from(value: &IEnumTfUIElements) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IEnumTfUIElements, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IEnumTfUIElements {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1762,21 +1412,7 @@ impl IInternalDocWrap {
         (::windows::core::Vtable::vtable(self).NotifyRevoke)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IInternalDocWrap> for ::windows::core::IUnknown {
-    fn from(value: IInternalDocWrap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IInternalDocWrap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IInternalDocWrap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IInternalDocWrap> for ::windows::core::IUnknown {
-    fn from(value: &IInternalDocWrap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IInternalDocWrap, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IInternalDocWrap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1817,21 +1453,7 @@ impl ISpeechCommandProvider {
         (::windows::core::Vtable::vtable(self).ProcessCommand)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pszcommand.as_ptr()), pszcommand.len() as _, langid).ok()
     }
 }
-impl ::core::convert::From<ISpeechCommandProvider> for ::windows::core::IUnknown {
-    fn from(value: ISpeechCommandProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ISpeechCommandProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ISpeechCommandProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ISpeechCommandProvider> for ::windows::core::IUnknown {
-    fn from(value: &ISpeechCommandProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ISpeechCommandProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ISpeechCommandProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1992,21 +1614,7 @@ impl ITextStoreACP {
         (::windows::core::Vtable::vtable(self).GetWnd)(::windows::core::Vtable::as_raw(self), vcview, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::HWND>(result__)
     }
 }
-impl ::core::convert::From<ITextStoreACP> for ::windows::core::IUnknown {
-    fn from(value: ITextStoreACP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreACP> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoreACP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreACP> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoreACP) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoreACP, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextStoreACP {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2221,21 +1829,7 @@ impl ITextStoreACP2 {
         (::windows::core::Vtable::vtable(self).GetScreenExt)(::windows::core::Vtable::as_raw(self), vcview, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::RECT>(result__)
     }
 }
-impl ::core::convert::From<ITextStoreACP2> for ::windows::core::IUnknown {
-    fn from(value: ITextStoreACP2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreACP2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoreACP2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreACP2> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoreACP2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoreACP2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextStoreACP2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2331,21 +1925,7 @@ impl ITextStoreACPEx {
         (::windows::core::Vtable::vtable(self).ScrollToRect)(::windows::core::Vtable::as_raw(self), acpstart, acpend, ::core::mem::transmute(rc), dwposition).ok()
     }
 }
-impl ::core::convert::From<ITextStoreACPEx> for ::windows::core::IUnknown {
-    fn from(value: ITextStoreACPEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreACPEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoreACPEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreACPEx> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoreACPEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoreACPEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextStoreACPEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2412,21 +1992,7 @@ impl ITextStoreACPServices {
         (::windows::core::Vtable::vtable(self).CreateRange)(::windows::core::Vtable::as_raw(self), acpstart, acpend, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfRangeACP>(result__)
     }
 }
-impl ::core::convert::From<ITextStoreACPServices> for ::windows::core::IUnknown {
-    fn from(value: ITextStoreACPServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreACPServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoreACPServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreACPServices> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoreACPServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoreACPServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextStoreACPServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2493,21 +2059,7 @@ impl ITextStoreACPSink {
         (::windows::core::Vtable::vtable(self).OnEndEditTransaction)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITextStoreACPSink> for ::windows::core::IUnknown {
-    fn from(value: ITextStoreACPSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreACPSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoreACPSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreACPSink> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoreACPSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoreACPSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextStoreACPSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2575,36 +2127,7 @@ impl ITextStoreACPSinkEx {
         (::windows::core::Vtable::vtable(self).OnDisconnect)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITextStoreACPSinkEx> for ::windows::core::IUnknown {
-    fn from(value: ITextStoreACPSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreACPSinkEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoreACPSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreACPSinkEx> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoreACPSinkEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextStoreACPSinkEx> for ITextStoreACPSink {
-    fn from(value: ITextStoreACPSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreACPSinkEx> for &'a ITextStoreACPSink {
-    fn from(value: &'a ITextStoreACPSinkEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreACPSinkEx> for ITextStoreACPSink {
-    fn from(value: &ITextStoreACPSinkEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoreACPSinkEx, ::windows::core::IUnknown, ITextStoreACPSink);
 impl ::core::clone::Clone for ITextStoreACPSinkEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2804,21 +2327,7 @@ impl ITextStoreAnchor {
         (::windows::core::Vtable::vtable(self).InsertEmbeddedAtSelection)(::windows::core::Vtable::as_raw(self), dwflags, pdataobject.into().abi(), ::core::mem::transmute(ppastart), ::core::mem::transmute(ppaend)).ok()
     }
 }
-impl ::core::convert::From<ITextStoreAnchor> for ::windows::core::IUnknown {
-    fn from(value: ITextStoreAnchor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreAnchor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoreAnchor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreAnchor> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoreAnchor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoreAnchor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextStoreAnchor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -2926,21 +2435,7 @@ impl ITextStoreAnchorEx {
         (::windows::core::Vtable::vtable(self).ScrollToRect)(::windows::core::Vtable::as_raw(self), pstart.into().abi(), pend.into().abi(), ::core::mem::transmute(rc), dwposition).ok()
     }
 }
-impl ::core::convert::From<ITextStoreAnchorEx> for ::windows::core::IUnknown {
-    fn from(value: ITextStoreAnchorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreAnchorEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoreAnchorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreAnchorEx> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoreAnchorEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoreAnchorEx, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextStoreAnchorEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3009,21 +2504,7 @@ impl ITextStoreAnchorSink {
         (::windows::core::Vtable::vtable(self).OnEndEditTransaction)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITextStoreAnchorSink> for ::windows::core::IUnknown {
-    fn from(value: ITextStoreAnchorSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreAnchorSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoreAnchorSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreAnchorSink> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoreAnchorSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoreAnchorSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITextStoreAnchorSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3099,36 +2580,7 @@ impl ITextStoreSinkAnchorEx {
         (::windows::core::Vtable::vtable(self).OnDisconnect)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITextStoreSinkAnchorEx> for ::windows::core::IUnknown {
-    fn from(value: ITextStoreSinkAnchorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreSinkAnchorEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITextStoreSinkAnchorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreSinkAnchorEx> for ::windows::core::IUnknown {
-    fn from(value: &ITextStoreSinkAnchorEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITextStoreSinkAnchorEx> for ITextStoreAnchorSink {
-    fn from(value: ITextStoreSinkAnchorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITextStoreSinkAnchorEx> for &'a ITextStoreAnchorSink {
-    fn from(value: &'a ITextStoreSinkAnchorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITextStoreSinkAnchorEx> for ITextStoreAnchorSink {
-    fn from(value: &ITextStoreSinkAnchorEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITextStoreSinkAnchorEx, ::windows::core::IUnknown, ITextStoreAnchorSink);
 impl ::core::clone::Clone for ITextStoreSinkAnchorEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3170,21 +2622,7 @@ impl ITfActiveLanguageProfileNotifySink {
         (::windows::core::Vtable::vtable(self).OnActivated)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(clsid), ::core::mem::transmute(guidprofile), factivated.into()).ok()
     }
 }
-impl ::core::convert::From<ITfActiveLanguageProfileNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITfActiveLanguageProfileNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfActiveLanguageProfileNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfActiveLanguageProfileNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfActiveLanguageProfileNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITfActiveLanguageProfileNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfActiveLanguageProfileNotifySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfActiveLanguageProfileNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3236,21 +2674,7 @@ impl ITfCandidateList {
         (::windows::core::Vtable::vtable(self).SetResult)(::windows::core::Vtable::as_raw(self), nindex, imcr).ok()
     }
 }
-impl ::core::convert::From<ITfCandidateList> for ::windows::core::IUnknown {
-    fn from(value: ITfCandidateList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCandidateList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCandidateList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCandidateList> for ::windows::core::IUnknown {
-    fn from(value: &ITfCandidateList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCandidateList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfCandidateList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3339,36 +2763,7 @@ impl ITfCandidateListUIElement {
         (::windows::core::Vtable::vtable(self).GetCurrentPage)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ITfCandidateListUIElement> for ::windows::core::IUnknown {
-    fn from(value: ITfCandidateListUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCandidateListUIElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCandidateListUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCandidateListUIElement> for ::windows::core::IUnknown {
-    fn from(value: &ITfCandidateListUIElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfCandidateListUIElement> for ITfUIElement {
-    fn from(value: ITfCandidateListUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCandidateListUIElement> for &'a ITfUIElement {
-    fn from(value: &'a ITfCandidateListUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCandidateListUIElement> for ITfUIElement {
-    fn from(value: &ITfCandidateListUIElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCandidateListUIElement, ::windows::core::IUnknown, ITfUIElement);
 impl ::core::clone::Clone for ITfCandidateListUIElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3470,51 +2865,7 @@ impl ITfCandidateListUIElementBehavior {
         (::windows::core::Vtable::vtable(self).Abort)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITfCandidateListUIElementBehavior> for ::windows::core::IUnknown {
-    fn from(value: ITfCandidateListUIElementBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCandidateListUIElementBehavior> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCandidateListUIElementBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCandidateListUIElementBehavior> for ::windows::core::IUnknown {
-    fn from(value: &ITfCandidateListUIElementBehavior) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfCandidateListUIElementBehavior> for ITfUIElement {
-    fn from(value: ITfCandidateListUIElementBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCandidateListUIElementBehavior> for &'a ITfUIElement {
-    fn from(value: &'a ITfCandidateListUIElementBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCandidateListUIElementBehavior> for ITfUIElement {
-    fn from(value: &ITfCandidateListUIElementBehavior) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfCandidateListUIElementBehavior> for ITfCandidateListUIElement {
-    fn from(value: ITfCandidateListUIElementBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCandidateListUIElementBehavior> for &'a ITfCandidateListUIElement {
-    fn from(value: &'a ITfCandidateListUIElementBehavior) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCandidateListUIElementBehavior> for ITfCandidateListUIElement {
-    fn from(value: &ITfCandidateListUIElementBehavior) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCandidateListUIElementBehavior, ::windows::core::IUnknown, ITfUIElement, ITfCandidateListUIElement);
 impl ::core::clone::Clone for ITfCandidateListUIElementBehavior {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3558,21 +2909,7 @@ impl ITfCandidateString {
         (::windows::core::Vtable::vtable(self).GetIndex)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ITfCandidateString> for ::windows::core::IUnknown {
-    fn from(value: ITfCandidateString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCandidateString> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCandidateString) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCandidateString> for ::windows::core::IUnknown {
-    fn from(value: &ITfCandidateString) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCandidateString, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfCandidateString {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3662,21 +2999,7 @@ impl ITfCategoryMgr {
         (::windows::core::Vtable::vtable(self).IsEqualTfGuidAtom)(::windows::core::Vtable::as_raw(self), guidatom, ::core::mem::transmute(rguid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITfCategoryMgr> for ::windows::core::IUnknown {
-    fn from(value: ITfCategoryMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCategoryMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCategoryMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCategoryMgr> for ::windows::core::IUnknown {
-    fn from(value: &ITfCategoryMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCategoryMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfCategoryMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3738,21 +3061,7 @@ impl ITfCleanupContextDurationSink {
         (::windows::core::Vtable::vtable(self).OnEndCleanupContext)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITfCleanupContextDurationSink> for ::windows::core::IUnknown {
-    fn from(value: ITfCleanupContextDurationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCleanupContextDurationSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCleanupContextDurationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCleanupContextDurationSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfCleanupContextDurationSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCleanupContextDurationSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfCleanupContextDurationSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3793,21 +3102,7 @@ impl ITfCleanupContextSink {
         (::windows::core::Vtable::vtable(self).OnCleanupContext)(::windows::core::Vtable::as_raw(self), ecwrite, pic.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfCleanupContextSink> for ::windows::core::IUnknown {
-    fn from(value: ITfCleanupContextSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCleanupContextSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCleanupContextSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCleanupContextSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfCleanupContextSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCleanupContextSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfCleanupContextSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3845,21 +3140,7 @@ impl ITfClientId {
         (::windows::core::Vtable::vtable(self).GetClientId)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ITfClientId> for ::windows::core::IUnknown {
-    fn from(value: ITfClientId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfClientId> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfClientId) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfClientId> for ::windows::core::IUnknown {
-    fn from(value: &ITfClientId) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfClientId, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfClientId {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3904,21 +3185,7 @@ impl ITfCompartment {
         (::windows::core::Vtable::vtable(self).GetValue)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<ITfCompartment> for ::windows::core::IUnknown {
-    fn from(value: ITfCompartment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCompartment> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCompartment) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCompartment> for ::windows::core::IUnknown {
-    fn from(value: &ITfCompartment) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCompartment, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfCompartment {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -3962,21 +3229,7 @@ impl ITfCompartmentEventSink {
         (::windows::core::Vtable::vtable(self).OnChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rguid)).ok()
     }
 }
-impl ::core::convert::From<ITfCompartmentEventSink> for ::windows::core::IUnknown {
-    fn from(value: ITfCompartmentEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCompartmentEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCompartmentEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCompartmentEventSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfCompartmentEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCompartmentEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfCompartmentEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4023,21 +3276,7 @@ impl ITfCompartmentMgr {
         (::windows::core::Vtable::vtable(self).EnumCompartments)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IEnumGUID>(result__)
     }
 }
-impl ::core::convert::From<ITfCompartmentMgr> for ::windows::core::IUnknown {
-    fn from(value: ITfCompartmentMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCompartmentMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCompartmentMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCompartmentMgr> for ::windows::core::IUnknown {
-    fn from(value: &ITfCompartmentMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCompartmentMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfCompartmentMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4095,21 +3334,7 @@ impl ITfComposition {
         (::windows::core::Vtable::vtable(self).EndComposition)(::windows::core::Vtable::as_raw(self), ecwrite).ok()
     }
 }
-impl ::core::convert::From<ITfComposition> for ::windows::core::IUnknown {
-    fn from(value: ITfComposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfComposition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfComposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfComposition> for ::windows::core::IUnknown {
-    fn from(value: &ITfComposition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfComposition, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfComposition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4152,21 +3377,7 @@ impl ITfCompositionSink {
         (::windows::core::Vtable::vtable(self).OnCompositionTerminated)(::windows::core::Vtable::as_raw(self), ecwrite, pcomposition.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfCompositionSink> for ::windows::core::IUnknown {
-    fn from(value: ITfCompositionSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCompositionSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCompositionSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCompositionSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfCompositionSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCompositionSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfCompositionSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4208,21 +3419,7 @@ impl ITfCompositionView {
         (::windows::core::Vtable::vtable(self).GetRange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfRange>(result__)
     }
 }
-impl ::core::convert::From<ITfCompositionView> for ::windows::core::IUnknown {
-    fn from(value: ITfCompositionView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCompositionView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCompositionView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCompositionView> for ::windows::core::IUnknown {
-    fn from(value: &ITfCompositionView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCompositionView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfCompositionView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4263,21 +3460,7 @@ impl ITfConfigureSystemKeystrokeFeed {
         (::windows::core::Vtable::vtable(self).EnableSystemKeystrokeFeed)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITfConfigureSystemKeystrokeFeed> for ::windows::core::IUnknown {
-    fn from(value: ITfConfigureSystemKeystrokeFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfConfigureSystemKeystrokeFeed> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfConfigureSystemKeystrokeFeed) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfConfigureSystemKeystrokeFeed> for ::windows::core::IUnknown {
-    fn from(value: &ITfConfigureSystemKeystrokeFeed) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfConfigureSystemKeystrokeFeed, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfConfigureSystemKeystrokeFeed {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4382,21 +3565,7 @@ impl ITfContext {
         (::windows::core::Vtable::vtable(self).CreateRangeBackup)(::windows::core::Vtable::as_raw(self), ec, prange.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfRangeBackup>(result__)
     }
 }
-impl ::core::convert::From<ITfContext> for ::windows::core::IUnknown {
-    fn from(value: ITfContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfContext> for ::windows::core::IUnknown {
-    fn from(value: &ITfContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4480,21 +3649,7 @@ impl ITfContextComposition {
         (::windows::core::Vtable::vtable(self).TakeOwnership)(::windows::core::Vtable::as_raw(self), ecwrite, pcomposition.into().abi(), psink.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfComposition>(result__)
     }
 }
-impl ::core::convert::From<ITfContextComposition> for ::windows::core::IUnknown {
-    fn from(value: ITfContextComposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfContextComposition> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfContextComposition) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfContextComposition> for ::windows::core::IUnknown {
-    fn from(value: &ITfContextComposition) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfContextComposition, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfContextComposition {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4571,21 +3726,7 @@ impl ITfContextKeyEventSink {
         (::windows::core::Vtable::vtable(self).OnTestKeyUp)(::windows::core::Vtable::as_raw(self), wparam.into(), lparam.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITfContextKeyEventSink> for ::windows::core::IUnknown {
-    fn from(value: ITfContextKeyEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfContextKeyEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfContextKeyEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfContextKeyEventSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfContextKeyEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfContextKeyEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfContextKeyEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4667,21 +3808,7 @@ impl ITfContextOwner {
         (::windows::core::Vtable::vtable(self).GetAttribute)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rguidattribute), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::VARIANT>(result__)
     }
 }
-impl ::core::convert::From<ITfContextOwner> for ::windows::core::IUnknown {
-    fn from(value: ITfContextOwner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfContextOwner> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfContextOwner) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfContextOwner> for ::windows::core::IUnknown {
-    fn from(value: &ITfContextOwner) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfContextOwner, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfContextOwner {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4768,36 +3895,7 @@ impl ITfContextOwnerCompositionServices {
         (::windows::core::Vtable::vtable(self).TerminateComposition)(::windows::core::Vtable::as_raw(self), pcomposition.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfContextOwnerCompositionServices> for ::windows::core::IUnknown {
-    fn from(value: ITfContextOwnerCompositionServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfContextOwnerCompositionServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfContextOwnerCompositionServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfContextOwnerCompositionServices> for ::windows::core::IUnknown {
-    fn from(value: &ITfContextOwnerCompositionServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfContextOwnerCompositionServices> for ITfContextComposition {
-    fn from(value: ITfContextOwnerCompositionServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfContextOwnerCompositionServices> for &'a ITfContextComposition {
-    fn from(value: &'a ITfContextOwnerCompositionServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfContextOwnerCompositionServices> for ITfContextComposition {
-    fn from(value: &ITfContextOwnerCompositionServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfContextOwnerCompositionServices, ::windows::core::IUnknown, ITfContextComposition);
 impl ::core::clone::Clone for ITfContextOwnerCompositionServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4853,21 +3951,7 @@ impl ITfContextOwnerCompositionSink {
         (::windows::core::Vtable::vtable(self).OnEndComposition)(::windows::core::Vtable::as_raw(self), pcomposition.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfContextOwnerCompositionSink> for ::windows::core::IUnknown {
-    fn from(value: ITfContextOwnerCompositionSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfContextOwnerCompositionSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfContextOwnerCompositionSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfContextOwnerCompositionSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfContextOwnerCompositionSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfContextOwnerCompositionSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfContextOwnerCompositionSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -4945,21 +4029,7 @@ impl ITfContextOwnerServices {
         (::windows::core::Vtable::vtable(self).CreateRange)(::windows::core::Vtable::as_raw(self), acpstart, acpend, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfRangeACP>(result__)
     }
 }
-impl ::core::convert::From<ITfContextOwnerServices> for ::windows::core::IUnknown {
-    fn from(value: ITfContextOwnerServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfContextOwnerServices> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfContextOwnerServices) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfContextOwnerServices> for ::windows::core::IUnknown {
-    fn from(value: &ITfContextOwnerServices) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfContextOwnerServices, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfContextOwnerServices {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5031,21 +4101,7 @@ impl ITfContextView {
         (::windows::core::Vtable::vtable(self).GetWnd)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::HWND>(result__)
     }
 }
-impl ::core::convert::From<ITfContextView> for ::windows::core::IUnknown {
-    fn from(value: ITfContextView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfContextView> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfContextView) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfContextView> for ::windows::core::IUnknown {
-    fn from(value: &ITfContextView) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfContextView, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfContextView {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5114,21 +4170,7 @@ impl ITfCreatePropertyStore {
         (::windows::core::Vtable::vtable(self).CreatePropertyStore)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guidprop), prange.into().abi(), cb, pstream.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfPropertyStore>(result__)
     }
 }
-impl ::core::convert::From<ITfCreatePropertyStore> for ::windows::core::IUnknown {
-    fn from(value: ITfCreatePropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfCreatePropertyStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfCreatePropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfCreatePropertyStore> for ::windows::core::IUnknown {
-    fn from(value: &ITfCreatePropertyStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfCreatePropertyStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfCreatePropertyStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5191,21 +4233,7 @@ impl ITfDisplayAttributeInfo {
         (::windows::core::Vtable::vtable(self).Reset)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITfDisplayAttributeInfo> for ::windows::core::IUnknown {
-    fn from(value: ITfDisplayAttributeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfDisplayAttributeInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfDisplayAttributeInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfDisplayAttributeInfo> for ::windows::core::IUnknown {
-    fn from(value: &ITfDisplayAttributeInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfDisplayAttributeInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfDisplayAttributeInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5259,21 +4287,7 @@ impl ITfDisplayAttributeMgr {
         (::windows::core::Vtable::vtable(self).GetDisplayAttributeInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), ::core::mem::transmute(ppinfo), ::core::mem::transmute(pclsidowner)).ok()
     }
 }
-impl ::core::convert::From<ITfDisplayAttributeMgr> for ::windows::core::IUnknown {
-    fn from(value: ITfDisplayAttributeMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfDisplayAttributeMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfDisplayAttributeMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfDisplayAttributeMgr> for ::windows::core::IUnknown {
-    fn from(value: &ITfDisplayAttributeMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfDisplayAttributeMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfDisplayAttributeMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5312,21 +4326,7 @@ impl ITfDisplayAttributeNotifySink {
         (::windows::core::Vtable::vtable(self).OnUpdateInfo)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITfDisplayAttributeNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITfDisplayAttributeNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfDisplayAttributeNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfDisplayAttributeNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfDisplayAttributeNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITfDisplayAttributeNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfDisplayAttributeNotifySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfDisplayAttributeNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5368,21 +4368,7 @@ impl ITfDisplayAttributeProvider {
         (::windows::core::Vtable::vtable(self).GetDisplayAttributeInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(guid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfDisplayAttributeInfo>(result__)
     }
 }
-impl ::core::convert::From<ITfDisplayAttributeProvider> for ::windows::core::IUnknown {
-    fn from(value: ITfDisplayAttributeProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfDisplayAttributeProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfDisplayAttributeProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfDisplayAttributeProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITfDisplayAttributeProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfDisplayAttributeProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfDisplayAttributeProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5444,21 +4430,7 @@ impl ITfDocumentMgr {
         (::windows::core::Vtable::vtable(self).EnumContexts)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumTfContexts>(result__)
     }
 }
-impl ::core::convert::From<ITfDocumentMgr> for ::windows::core::IUnknown {
-    fn from(value: ITfDocumentMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfDocumentMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfDocumentMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfDocumentMgr> for ::windows::core::IUnknown {
-    fn from(value: &ITfDocumentMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfDocumentMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfDocumentMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5507,21 +4479,7 @@ impl ITfEditRecord {
         (::windows::core::Vtable::vtable(self).GetTextAndPropertyUpdates)(::windows::core::Vtable::as_raw(self), dwflags, ::core::mem::transmute(prgproperties.as_ptr()), prgproperties.len() as _, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumTfRanges>(result__)
     }
 }
-impl ::core::convert::From<ITfEditRecord> for ::windows::core::IUnknown {
-    fn from(value: ITfEditRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfEditRecord> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfEditRecord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfEditRecord> for ::windows::core::IUnknown {
-    fn from(value: &ITfEditRecord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfEditRecord, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfEditRecord {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5562,21 +4520,7 @@ impl ITfEditSession {
         (::windows::core::Vtable::vtable(self).DoEditSession)(::windows::core::Vtable::as_raw(self), ec).ok()
     }
 }
-impl ::core::convert::From<ITfEditSession> for ::windows::core::IUnknown {
-    fn from(value: ITfEditSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfEditSession> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfEditSession) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfEditSession> for ::windows::core::IUnknown {
-    fn from(value: &ITfEditSession) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfEditSession, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfEditSession {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5622,21 +4566,7 @@ impl ITfEditTransactionSink {
         (::windows::core::Vtable::vtable(self).OnEndEditTransaction)(::windows::core::Vtable::as_raw(self), pic.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfEditTransactionSink> for ::windows::core::IUnknown {
-    fn from(value: ITfEditTransactionSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfEditTransactionSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfEditTransactionSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfEditTransactionSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfEditTransactionSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfEditTransactionSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfEditTransactionSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5688,36 +4618,7 @@ impl ITfFnAdviseText {
         (::windows::core::Vtable::vtable(self).OnLatticeUpdate)(::windows::core::Vtable::as_raw(self), prange.into().abi(), plattice.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfFnAdviseText> for ::windows::core::IUnknown {
-    fn from(value: ITfFnAdviseText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnAdviseText> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnAdviseText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnAdviseText> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnAdviseText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnAdviseText> for ITfFunction {
-    fn from(value: ITfFnAdviseText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnAdviseText> for &'a ITfFunction {
-    fn from(value: &'a ITfFnAdviseText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnAdviseText> for ITfFunction {
-    fn from(value: &ITfFnAdviseText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnAdviseText, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnAdviseText {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5755,21 +4656,7 @@ impl ITfFnBalloon {
         (::windows::core::Vtable::vtable(self).UpdateBalloon)(::windows::core::Vtable::as_raw(self), style, ::core::mem::transmute(pch.as_ptr()), pch.len() as _).ok()
     }
 }
-impl ::core::convert::From<ITfFnBalloon> for ::windows::core::IUnknown {
-    fn from(value: ITfFnBalloon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnBalloon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnBalloon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnBalloon> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnBalloon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnBalloon, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfFnBalloon {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5815,36 +4702,7 @@ impl ITfFnConfigure {
         (::windows::core::Vtable::vtable(self).Show)(::windows::core::Vtable::as_raw(self), hwndparent.into(), langid, ::core::mem::transmute(rguidprofile)).ok()
     }
 }
-impl ::core::convert::From<ITfFnConfigure> for ::windows::core::IUnknown {
-    fn from(value: ITfFnConfigure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnConfigure> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnConfigure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnConfigure> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnConfigure) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnConfigure> for ITfFunction {
-    fn from(value: ITfFnConfigure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnConfigure> for &'a ITfFunction {
-    fn from(value: &'a ITfFnConfigure) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnConfigure> for ITfFunction {
-    fn from(value: &ITfFnConfigure) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnConfigure, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnConfigure {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5893,36 +4751,7 @@ impl ITfFnConfigureRegisterEudc {
         (::windows::core::Vtable::vtable(self).Show)(::windows::core::Vtable::as_raw(self), hwndparent.into(), langid, ::core::mem::transmute(rguidprofile), ::core::mem::transmute_copy(bstrregistered)).ok()
     }
 }
-impl ::core::convert::From<ITfFnConfigureRegisterEudc> for ::windows::core::IUnknown {
-    fn from(value: ITfFnConfigureRegisterEudc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnConfigureRegisterEudc> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnConfigureRegisterEudc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnConfigureRegisterEudc> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnConfigureRegisterEudc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnConfigureRegisterEudc> for ITfFunction {
-    fn from(value: ITfFnConfigureRegisterEudc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnConfigureRegisterEudc> for &'a ITfFunction {
-    fn from(value: &'a ITfFnConfigureRegisterEudc) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnConfigureRegisterEudc> for ITfFunction {
-    fn from(value: &ITfFnConfigureRegisterEudc) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnConfigureRegisterEudc, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnConfigureRegisterEudc {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -5971,36 +4800,7 @@ impl ITfFnConfigureRegisterWord {
         (::windows::core::Vtable::vtable(self).Show)(::windows::core::Vtable::as_raw(self), hwndparent.into(), langid, ::core::mem::transmute(rguidprofile), ::core::mem::transmute_copy(bstrregistered)).ok()
     }
 }
-impl ::core::convert::From<ITfFnConfigureRegisterWord> for ::windows::core::IUnknown {
-    fn from(value: ITfFnConfigureRegisterWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnConfigureRegisterWord> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnConfigureRegisterWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnConfigureRegisterWord> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnConfigureRegisterWord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnConfigureRegisterWord> for ITfFunction {
-    fn from(value: ITfFnConfigureRegisterWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnConfigureRegisterWord> for &'a ITfFunction {
-    fn from(value: &'a ITfFnConfigureRegisterWord) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnConfigureRegisterWord> for ITfFunction {
-    fn from(value: &ITfFnConfigureRegisterWord) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnConfigureRegisterWord, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnConfigureRegisterWord {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6047,36 +4847,7 @@ impl ITfFnCustomSpeechCommand {
         (::windows::core::Vtable::vtable(self).SetSpeechCommandProvider)(::windows::core::Vtable::as_raw(self), pspcmdprovider.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfFnCustomSpeechCommand> for ::windows::core::IUnknown {
-    fn from(value: ITfFnCustomSpeechCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnCustomSpeechCommand> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnCustomSpeechCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnCustomSpeechCommand> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnCustomSpeechCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnCustomSpeechCommand> for ITfFunction {
-    fn from(value: ITfFnCustomSpeechCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnCustomSpeechCommand> for &'a ITfFunction {
-    fn from(value: &'a ITfFnCustomSpeechCommand) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnCustomSpeechCommand> for ITfFunction {
-    fn from(value: &ITfFnCustomSpeechCommand) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnCustomSpeechCommand, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnCustomSpeechCommand {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6121,36 +4892,7 @@ impl ITfFnGetLinguisticAlternates {
         (::windows::core::Vtable::vtable(self).GetAlternates)(::windows::core::Vtable::as_raw(self), prange.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfCandidateList>(result__)
     }
 }
-impl ::core::convert::From<ITfFnGetLinguisticAlternates> for ::windows::core::IUnknown {
-    fn from(value: ITfFnGetLinguisticAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnGetLinguisticAlternates> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnGetLinguisticAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnGetLinguisticAlternates> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnGetLinguisticAlternates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnGetLinguisticAlternates> for ITfFunction {
-    fn from(value: ITfFnGetLinguisticAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnGetLinguisticAlternates> for &'a ITfFunction {
-    fn from(value: &'a ITfFnGetLinguisticAlternates) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnGetLinguisticAlternates> for ITfFunction {
-    fn from(value: &ITfFnGetLinguisticAlternates) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnGetLinguisticAlternates, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnGetLinguisticAlternates {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6191,36 +4933,7 @@ impl ITfFnGetPreferredTouchKeyboardLayout {
         (::windows::core::Vtable::vtable(self).GetLayout)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(ptkblayouttype), ::core::mem::transmute(pwpreferredlayoutid)).ok()
     }
 }
-impl ::core::convert::From<ITfFnGetPreferredTouchKeyboardLayout> for ::windows::core::IUnknown {
-    fn from(value: ITfFnGetPreferredTouchKeyboardLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnGetPreferredTouchKeyboardLayout> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnGetPreferredTouchKeyboardLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnGetPreferredTouchKeyboardLayout> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnGetPreferredTouchKeyboardLayout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnGetPreferredTouchKeyboardLayout> for ITfFunction {
-    fn from(value: ITfFnGetPreferredTouchKeyboardLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnGetPreferredTouchKeyboardLayout> for &'a ITfFunction {
-    fn from(value: &'a ITfFnGetPreferredTouchKeyboardLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnGetPreferredTouchKeyboardLayout> for ITfFunction {
-    fn from(value: &ITfFnGetPreferredTouchKeyboardLayout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnGetPreferredTouchKeyboardLayout, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnGetPreferredTouchKeyboardLayout {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6262,36 +4975,7 @@ impl ITfFnGetSAPIObject {
         (::windows::core::Vtable::vtable(self).Get)(::windows::core::Vtable::as_raw(self), sobj, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<ITfFnGetSAPIObject> for ::windows::core::IUnknown {
-    fn from(value: ITfFnGetSAPIObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnGetSAPIObject> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnGetSAPIObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnGetSAPIObject> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnGetSAPIObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnGetSAPIObject> for ITfFunction {
-    fn from(value: ITfFnGetSAPIObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnGetSAPIObject> for &'a ITfFunction {
-    fn from(value: &'a ITfFnGetSAPIObject) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnGetSAPIObject> for ITfFunction {
-    fn from(value: &ITfFnGetSAPIObject) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnGetSAPIObject, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnGetSAPIObject {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6389,51 +5073,7 @@ impl ITfFnLMInternal {
         (::windows::core::Vtable::vtable(self).ProcessLattice)(::windows::core::Vtable::as_raw(self), prange.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfFnLMInternal> for ::windows::core::IUnknown {
-    fn from(value: ITfFnLMInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnLMInternal> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnLMInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnLMInternal> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnLMInternal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnLMInternal> for ITfFunction {
-    fn from(value: ITfFnLMInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnLMInternal> for &'a ITfFunction {
-    fn from(value: &'a ITfFnLMInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnLMInternal> for ITfFunction {
-    fn from(value: &ITfFnLMInternal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnLMInternal> for ITfFnLMProcessor {
-    fn from(value: ITfFnLMInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnLMInternal> for &'a ITfFnLMProcessor {
-    fn from(value: &'a ITfFnLMInternal) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnLMInternal> for ITfFnLMProcessor {
-    fn from(value: &ITfFnLMInternal) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnLMInternal, ::windows::core::IUnknown, ITfFunction, ITfFnLMProcessor);
 impl ::core::clone::Clone for ITfFnLMInternal {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6525,36 +5165,7 @@ impl ITfFnLMProcessor {
         (::windows::core::Vtable::vtable(self).InvokeFunc)(::windows::core::Vtable::as_raw(self), pic.into().abi(), ::core::mem::transmute(refguidfunc)).ok()
     }
 }
-impl ::core::convert::From<ITfFnLMProcessor> for ::windows::core::IUnknown {
-    fn from(value: ITfFnLMProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnLMProcessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnLMProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnLMProcessor> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnLMProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnLMProcessor> for ITfFunction {
-    fn from(value: ITfFnLMProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnLMProcessor> for &'a ITfFunction {
-    fn from(value: &'a ITfFnLMProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnLMProcessor> for ITfFunction {
-    fn from(value: &ITfFnLMProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnLMProcessor, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnLMProcessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6619,36 +5230,7 @@ impl ITfFnLangProfileUtil {
         (::windows::core::Vtable::vtable(self).IsProfileAvailableForLang)(::windows::core::Vtable::as_raw(self), langid, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITfFnLangProfileUtil> for ::windows::core::IUnknown {
-    fn from(value: ITfFnLangProfileUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnLangProfileUtil> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnLangProfileUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnLangProfileUtil> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnLangProfileUtil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnLangProfileUtil> for ITfFunction {
-    fn from(value: ITfFnLangProfileUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnLangProfileUtil> for &'a ITfFunction {
-    fn from(value: &'a ITfFnLangProfileUtil) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnLangProfileUtil> for ITfFunction {
-    fn from(value: &ITfFnLangProfileUtil) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnLangProfileUtil, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnLangProfileUtil {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6704,36 +5286,7 @@ impl ITfFnPlayBack {
         (::windows::core::Vtable::vtable(self).Play)(::windows::core::Vtable::as_raw(self), prange.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfFnPlayBack> for ::windows::core::IUnknown {
-    fn from(value: ITfFnPlayBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnPlayBack> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnPlayBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnPlayBack> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnPlayBack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnPlayBack> for ITfFunction {
-    fn from(value: ITfFnPlayBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnPlayBack> for &'a ITfFunction {
-    fn from(value: &'a ITfFnPlayBack) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnPlayBack> for ITfFunction {
-    fn from(value: &ITfFnPlayBack) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnPlayBack, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnPlayBack {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6782,36 +5335,7 @@ impl ITfFnPropertyUIStatus {
         (::windows::core::Vtable::vtable(self).SetStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(refguidprop), dw).ok()
     }
 }
-impl ::core::convert::From<ITfFnPropertyUIStatus> for ::windows::core::IUnknown {
-    fn from(value: ITfFnPropertyUIStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnPropertyUIStatus> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnPropertyUIStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnPropertyUIStatus> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnPropertyUIStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnPropertyUIStatus> for ITfFunction {
-    fn from(value: ITfFnPropertyUIStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnPropertyUIStatus> for &'a ITfFunction {
-    fn from(value: &'a ITfFnPropertyUIStatus) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnPropertyUIStatus> for ITfFunction {
-    fn from(value: &ITfFnPropertyUIStatus) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnPropertyUIStatus, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnPropertyUIStatus {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6871,36 +5395,7 @@ impl ITfFnReconversion {
         (::windows::core::Vtable::vtable(self).Reconvert)(::windows::core::Vtable::as_raw(self), prange.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfFnReconversion> for ::windows::core::IUnknown {
-    fn from(value: ITfFnReconversion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnReconversion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnReconversion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnReconversion> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnReconversion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnReconversion> for ITfFunction {
-    fn from(value: ITfFnReconversion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnReconversion> for &'a ITfFunction {
-    fn from(value: &'a ITfFnReconversion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnReconversion> for ITfFunction {
-    fn from(value: &ITfFnReconversion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnReconversion, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnReconversion {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -6950,36 +5445,7 @@ impl ITfFnSearchCandidateProvider {
         (::windows::core::Vtable::vtable(self).SetResult)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute_copy(bstrquery), ::core::mem::transmute_copy(bstrapplicationid), ::core::mem::transmute_copy(bstrresult)).ok()
     }
 }
-impl ::core::convert::From<ITfFnSearchCandidateProvider> for ::windows::core::IUnknown {
-    fn from(value: ITfFnSearchCandidateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnSearchCandidateProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnSearchCandidateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnSearchCandidateProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnSearchCandidateProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnSearchCandidateProvider> for ITfFunction {
-    fn from(value: ITfFnSearchCandidateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnSearchCandidateProvider> for &'a ITfFunction {
-    fn from(value: &'a ITfFnSearchCandidateProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnSearchCandidateProvider> for ITfFunction {
-    fn from(value: &ITfFnSearchCandidateProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnSearchCandidateProvider, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnSearchCandidateProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7026,36 +5492,7 @@ impl ITfFnShowHelp {
         (::windows::core::Vtable::vtable(self).Show)(::windows::core::Vtable::as_raw(self), hwndparent.into()).ok()
     }
 }
-impl ::core::convert::From<ITfFnShowHelp> for ::windows::core::IUnknown {
-    fn from(value: ITfFnShowHelp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnShowHelp> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFnShowHelp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnShowHelp> for ::windows::core::IUnknown {
-    fn from(value: &ITfFnShowHelp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfFnShowHelp> for ITfFunction {
-    fn from(value: ITfFnShowHelp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFnShowHelp> for &'a ITfFunction {
-    fn from(value: &'a ITfFnShowHelp) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFnShowHelp> for ITfFunction {
-    fn from(value: &ITfFnShowHelp) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFnShowHelp, ::windows::core::IUnknown, ITfFunction);
 impl ::core::clone::Clone for ITfFnShowHelp {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7096,21 +5533,7 @@ impl ITfFunction {
         (::windows::core::Vtable::vtable(self).GetDisplayName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITfFunction> for ::windows::core::IUnknown {
-    fn from(value: ITfFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFunction> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFunction) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFunction> for ::windows::core::IUnknown {
-    fn from(value: &ITfFunction) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFunction, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfFunction {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7156,21 +5579,7 @@ impl ITfFunctionProvider {
         (::windows::core::Vtable::vtable(self).GetFunction)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rguid), ::core::mem::transmute(riid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::IUnknown>(result__)
     }
 }
-impl ::core::convert::From<ITfFunctionProvider> for ::windows::core::IUnknown {
-    fn from(value: ITfFunctionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfFunctionProvider> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfFunctionProvider) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfFunctionProvider> for ::windows::core::IUnknown {
-    fn from(value: &ITfFunctionProvider) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfFunctionProvider, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfFunctionProvider {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7212,21 +5621,7 @@ impl ITfInputProcessorProfileActivationSink {
         (::windows::core::Vtable::vtable(self).OnActivated)(::windows::core::Vtable::as_raw(self), dwprofiletype, langid, ::core::mem::transmute(clsid), ::core::mem::transmute(catid), ::core::mem::transmute(guidprofile), hkl.into(), dwflags).ok()
     }
 }
-impl ::core::convert::From<ITfInputProcessorProfileActivationSink> for ::windows::core::IUnknown {
-    fn from(value: ITfInputProcessorProfileActivationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfInputProcessorProfileActivationSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfInputProcessorProfileActivationSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfInputProcessorProfileActivationSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfInputProcessorProfileActivationSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfInputProcessorProfileActivationSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfInputProcessorProfileActivationSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7302,21 +5697,7 @@ impl ITfInputProcessorProfileMgr {
         (::windows::core::Vtable::vtable(self).GetActiveProfile)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(catid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<TF_INPUTPROCESSORPROFILE>(result__)
     }
 }
-impl ::core::convert::From<ITfInputProcessorProfileMgr> for ::windows::core::IUnknown {
-    fn from(value: ITfInputProcessorProfileMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfInputProcessorProfileMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfInputProcessorProfileMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfInputProcessorProfileMgr> for ::windows::core::IUnknown {
-    fn from(value: &ITfInputProcessorProfileMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfInputProcessorProfileMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfInputProcessorProfileMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7364,21 +5745,7 @@ impl ITfInputProcessorProfileSubstituteLayout {
         (::windows::core::Vtable::vtable(self).GetSubstituteKeyboardLayout)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid), langid, ::core::mem::transmute(guidprofile), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<HKL>(result__)
     }
 }
-impl ::core::convert::From<ITfInputProcessorProfileSubstituteLayout> for ::windows::core::IUnknown {
-    fn from(value: ITfInputProcessorProfileSubstituteLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfInputProcessorProfileSubstituteLayout> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfInputProcessorProfileSubstituteLayout) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfInputProcessorProfileSubstituteLayout> for ::windows::core::IUnknown {
-    fn from(value: &ITfInputProcessorProfileSubstituteLayout) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfInputProcessorProfileSubstituteLayout, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfInputProcessorProfileSubstituteLayout {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7488,21 +5855,7 @@ impl ITfInputProcessorProfiles {
         (::windows::core::Vtable::vtable(self).SubstituteKeyboardLayout)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid), langid, ::core::mem::transmute(guidprofile), hkl.into()).ok()
     }
 }
-impl ::core::convert::From<ITfInputProcessorProfiles> for ::windows::core::IUnknown {
-    fn from(value: ITfInputProcessorProfiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfInputProcessorProfiles> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfInputProcessorProfiles) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfInputProcessorProfiles> for ::windows::core::IUnknown {
-    fn from(value: &ITfInputProcessorProfiles) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfInputProcessorProfiles, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfInputProcessorProfiles {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7644,36 +5997,7 @@ impl ITfInputProcessorProfilesEx {
         (::windows::core::Vtable::vtable(self).SetLanguageProfileDisplayName)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(rclsid), langid, ::core::mem::transmute(guidprofile), ::core::mem::transmute(pchfile.as_ptr()), pchfile.len() as _, uresid).ok()
     }
 }
-impl ::core::convert::From<ITfInputProcessorProfilesEx> for ::windows::core::IUnknown {
-    fn from(value: ITfInputProcessorProfilesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfInputProcessorProfilesEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfInputProcessorProfilesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfInputProcessorProfilesEx> for ::windows::core::IUnknown {
-    fn from(value: &ITfInputProcessorProfilesEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfInputProcessorProfilesEx> for ITfInputProcessorProfiles {
-    fn from(value: ITfInputProcessorProfilesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfInputProcessorProfilesEx> for &'a ITfInputProcessorProfiles {
-    fn from(value: &'a ITfInputProcessorProfilesEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfInputProcessorProfilesEx> for ITfInputProcessorProfiles {
-    fn from(value: &ITfInputProcessorProfilesEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfInputProcessorProfilesEx, ::windows::core::IUnknown, ITfInputProcessorProfiles);
 impl ::core::clone::Clone for ITfInputProcessorProfilesEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7725,21 +6049,7 @@ impl ITfInputScope {
         (::windows::core::Vtable::vtable(self).GetXML)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITfInputScope> for ::windows::core::IUnknown {
-    fn from(value: ITfInputScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfInputScope> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfInputScope) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfInputScope> for ::windows::core::IUnknown {
-    fn from(value: &ITfInputScope) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfInputScope, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfInputScope {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7801,36 +6111,7 @@ impl ITfInputScope2 {
         (::windows::core::Vtable::vtable(self).EnumWordList)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IEnumString>(result__)
     }
 }
-impl ::core::convert::From<ITfInputScope2> for ::windows::core::IUnknown {
-    fn from(value: ITfInputScope2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfInputScope2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfInputScope2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfInputScope2> for ::windows::core::IUnknown {
-    fn from(value: &ITfInputScope2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfInputScope2> for ITfInputScope {
-    fn from(value: ITfInputScope2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfInputScope2> for &'a ITfInputScope {
-    fn from(value: &'a ITfInputScope2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfInputScope2> for ITfInputScope {
-    fn from(value: &ITfInputScope2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfInputScope2, ::windows::core::IUnknown, ITfInputScope);
 impl ::core::clone::Clone for ITfInputScope2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7880,21 +6161,7 @@ impl ITfInsertAtSelection {
         (::windows::core::Vtable::vtable(self).InsertEmbeddedAtSelection)(::windows::core::Vtable::as_raw(self), ec, dwflags, pdataobject.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfRange>(result__)
     }
 }
-impl ::core::convert::From<ITfInsertAtSelection> for ::windows::core::IUnknown {
-    fn from(value: ITfInsertAtSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfInsertAtSelection> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfInsertAtSelection) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfInsertAtSelection> for ::windows::core::IUnknown {
-    fn from(value: &ITfInsertAtSelection) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfInsertAtSelection, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfInsertAtSelection {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -7958,21 +6225,7 @@ impl ITfIntegratableCandidateListUIElement {
         (::windows::core::Vtable::vtable(self).FinalizeExactCompositionString)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITfIntegratableCandidateListUIElement> for ::windows::core::IUnknown {
-    fn from(value: ITfIntegratableCandidateListUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfIntegratableCandidateListUIElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfIntegratableCandidateListUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfIntegratableCandidateListUIElement> for ::windows::core::IUnknown {
-    fn from(value: &ITfIntegratableCandidateListUIElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfIntegratableCandidateListUIElement, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfIntegratableCandidateListUIElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8077,21 +6330,7 @@ impl ITfKeyEventSink {
         (::windows::core::Vtable::vtable(self).OnPreservedKey)(::windows::core::Vtable::as_raw(self), pic.into().abi(), ::core::mem::transmute(rguid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITfKeyEventSink> for ::windows::core::IUnknown {
-    fn from(value: ITfKeyEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfKeyEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfKeyEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfKeyEventSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfKeyEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfKeyEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfKeyEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8166,21 +6405,7 @@ impl ITfKeyTraceEventSink {
         (::windows::core::Vtable::vtable(self).OnKeyTraceUp)(::windows::core::Vtable::as_raw(self), wparam.into(), lparam.into()).ok()
     }
 }
-impl ::core::convert::From<ITfKeyTraceEventSink> for ::windows::core::IUnknown {
-    fn from(value: ITfKeyTraceEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfKeyTraceEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfKeyTraceEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfKeyTraceEventSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfKeyTraceEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfKeyTraceEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfKeyTraceEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8312,21 +6537,7 @@ impl ITfKeystrokeMgr {
         (::windows::core::Vtable::vtable(self).SimulatePreservedKey)(::windows::core::Vtable::as_raw(self), pic.into().abi(), ::core::mem::transmute(rguid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITfKeystrokeMgr> for ::windows::core::IUnknown {
-    fn from(value: ITfKeystrokeMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfKeystrokeMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfKeystrokeMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfKeystrokeMgr> for ::windows::core::IUnknown {
-    fn from(value: &ITfKeystrokeMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfKeystrokeMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfKeystrokeMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8404,21 +6615,7 @@ impl ITfLMLattice {
         (::windows::core::Vtable::vtable(self).EnumLatticeElements)(::windows::core::Vtable::as_raw(self), dwframestart, ::core::mem::transmute(rguidtype), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumTfLatticeElements>(result__)
     }
 }
-impl ::core::convert::From<ITfLMLattice> for ::windows::core::IUnknown {
-    fn from(value: ITfLMLattice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLMLattice> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfLMLattice) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLMLattice> for ::windows::core::IUnknown {
-    fn from(value: &ITfLMLattice) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfLMLattice, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfLMLattice {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8483,21 +6680,7 @@ impl ITfLangBarEventSink {
         (::windows::core::Vtable::vtable(self).GetItemFloatingRect)(::windows::core::Vtable::as_raw(self), dwthreadid, ::core::mem::transmute(rguid), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::RECT>(result__)
     }
 }
-impl ::core::convert::From<ITfLangBarEventSink> for ::windows::core::IUnknown {
-    fn from(value: ITfLangBarEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfLangBarEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarEventSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfLangBarEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfLangBarEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfLangBarEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8562,21 +6745,7 @@ impl ITfLangBarItem {
         (::windows::core::Vtable::vtable(self).GetTooltipString)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITfLangBarItem> for ::windows::core::IUnknown {
-    fn from(value: ITfLangBarItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfLangBarItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarItem> for ::windows::core::IUnknown {
-    fn from(value: &ITfLangBarItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfLangBarItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfLangBarItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8651,36 +6820,7 @@ impl ITfLangBarItemBalloon {
         (::windows::core::Vtable::vtable(self).GetBalloonInfo)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<TF_LBBALLOONINFO>(result__)
     }
 }
-impl ::core::convert::From<ITfLangBarItemBalloon> for ::windows::core::IUnknown {
-    fn from(value: ITfLangBarItemBalloon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarItemBalloon> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfLangBarItemBalloon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarItemBalloon> for ::windows::core::IUnknown {
-    fn from(value: &ITfLangBarItemBalloon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfLangBarItemBalloon> for ITfLangBarItem {
-    fn from(value: ITfLangBarItemBalloon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarItemBalloon> for &'a ITfLangBarItem {
-    fn from(value: &'a ITfLangBarItemBalloon) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarItemBalloon> for ITfLangBarItem {
-    fn from(value: &ITfLangBarItemBalloon) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfLangBarItemBalloon, ::windows::core::IUnknown, ITfLangBarItem);
 impl ::core::clone::Clone for ITfLangBarItemBalloon {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8758,36 +6898,7 @@ impl ITfLangBarItemBitmap {
         (::windows::core::Vtable::vtable(self).DrawBitmap)(::windows::core::Vtable::as_raw(self), bmwidth, bmheight, dwflags, ::core::mem::transmute(phbmp), ::core::mem::transmute(phbmpmask)).ok()
     }
 }
-impl ::core::convert::From<ITfLangBarItemBitmap> for ::windows::core::IUnknown {
-    fn from(value: ITfLangBarItemBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarItemBitmap> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfLangBarItemBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarItemBitmap> for ::windows::core::IUnknown {
-    fn from(value: &ITfLangBarItemBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfLangBarItemBitmap> for ITfLangBarItem {
-    fn from(value: ITfLangBarItemBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarItemBitmap> for &'a ITfLangBarItem {
-    fn from(value: &'a ITfLangBarItemBitmap) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarItemBitmap> for ITfLangBarItem {
-    fn from(value: &ITfLangBarItemBitmap) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfLangBarItemBitmap, ::windows::core::IUnknown, ITfLangBarItem);
 impl ::core::clone::Clone for ITfLangBarItemBitmap {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -8881,36 +6992,7 @@ impl ITfLangBarItemBitmapButton {
         (::windows::core::Vtable::vtable(self).GetText)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITfLangBarItemBitmapButton> for ::windows::core::IUnknown {
-    fn from(value: ITfLangBarItemBitmapButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarItemBitmapButton> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfLangBarItemBitmapButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarItemBitmapButton> for ::windows::core::IUnknown {
-    fn from(value: &ITfLangBarItemBitmapButton) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfLangBarItemBitmapButton> for ITfLangBarItem {
-    fn from(value: ITfLangBarItemBitmapButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarItemBitmapButton> for &'a ITfLangBarItem {
-    fn from(value: &'a ITfLangBarItemBitmapButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarItemBitmapButton> for ITfLangBarItem {
-    fn from(value: &ITfLangBarItemBitmapButton) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfLangBarItemBitmapButton, ::windows::core::IUnknown, ITfLangBarItem);
 impl ::core::clone::Clone for ITfLangBarItemBitmapButton {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9002,36 +7084,7 @@ impl ITfLangBarItemButton {
         (::windows::core::Vtable::vtable(self).GetText)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITfLangBarItemButton> for ::windows::core::IUnknown {
-    fn from(value: ITfLangBarItemButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarItemButton> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfLangBarItemButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarItemButton> for ::windows::core::IUnknown {
-    fn from(value: &ITfLangBarItemButton) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfLangBarItemButton> for ITfLangBarItem {
-    fn from(value: ITfLangBarItemButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarItemButton> for &'a ITfLangBarItem {
-    fn from(value: &'a ITfLangBarItemButton) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarItemButton> for ITfLangBarItem {
-    fn from(value: &ITfLangBarItemButton) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfLangBarItemButton, ::windows::core::IUnknown, ITfLangBarItem);
 impl ::core::clone::Clone for ITfLangBarItemButton {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9128,21 +7181,7 @@ impl ITfLangBarItemMgr {
         (::windows::core::Vtable::vtable(self).UnadviseItemsSink)(::windows::core::Vtable::as_raw(self), pdwcookie.len() as _, ::core::mem::transmute(pdwcookie.as_ptr())).ok()
     }
 }
-impl ::core::convert::From<ITfLangBarItemMgr> for ::windows::core::IUnknown {
-    fn from(value: ITfLangBarItemMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarItemMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfLangBarItemMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarItemMgr> for ::windows::core::IUnknown {
-    fn from(value: &ITfLangBarItemMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfLangBarItemMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfLangBarItemMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9193,21 +7232,7 @@ impl ITfLangBarItemSink {
         (::windows::core::Vtable::vtable(self).OnUpdate)(::windows::core::Vtable::as_raw(self), dwflags).ok()
     }
 }
-impl ::core::convert::From<ITfLangBarItemSink> for ::windows::core::IUnknown {
-    fn from(value: ITfLangBarItemSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarItemSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfLangBarItemSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarItemSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfLangBarItemSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfLangBarItemSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfLangBarItemSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9284,21 +7309,7 @@ impl ITfLangBarMgr {
         (::windows::core::Vtable::vtable(self).GetShowFloatingStatus)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ITfLangBarMgr> for ::windows::core::IUnknown {
-    fn from(value: ITfLangBarMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLangBarMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfLangBarMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLangBarMgr> for ::windows::core::IUnknown {
-    fn from(value: &ITfLangBarMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfLangBarMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfLangBarMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9355,21 +7366,7 @@ impl ITfLanguageProfileNotifySink {
         (::windows::core::Vtable::vtable(self).OnLanguageChanged)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITfLanguageProfileNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITfLanguageProfileNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfLanguageProfileNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfLanguageProfileNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfLanguageProfileNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITfLanguageProfileNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfLanguageProfileNotifySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfLanguageProfileNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9413,21 +7410,7 @@ impl ITfMSAAControl {
         (::windows::core::Vtable::vtable(self).SystemDisableMSAA)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITfMSAAControl> for ::windows::core::IUnknown {
-    fn from(value: ITfMSAAControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfMSAAControl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfMSAAControl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfMSAAControl> for ::windows::core::IUnknown {
-    fn from(value: &ITfMSAAControl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfMSAAControl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfMSAAControl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9471,21 +7454,7 @@ impl ITfMenu {
         (::windows::core::Vtable::vtable(self).AddMenuItem)(::windows::core::Vtable::as_raw(self), uid, dwflags, hbmp.into(), hbmpmask.into(), ::core::mem::transmute(pch.as_ptr()), pch.len() as _, ::core::mem::transmute(ppmenu)).ok()
     }
 }
-impl ::core::convert::From<ITfMenu> for ::windows::core::IUnknown {
-    fn from(value: ITfMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfMenu> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfMenu) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfMenu> for ::windows::core::IUnknown {
-    fn from(value: &ITfMenu) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfMenu, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfMenu {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9554,21 +7523,7 @@ impl ITfMessagePump {
         (::windows::core::Vtable::vtable(self).GetMessageW)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pmsg), hwnd.into(), wmsgfiltermin, wmsgfiltermax, ::core::mem::transmute(pfresult)).ok()
     }
 }
-impl ::core::convert::From<ITfMessagePump> for ::windows::core::IUnknown {
-    fn from(value: ITfMessagePump) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfMessagePump> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfMessagePump) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfMessagePump> for ::windows::core::IUnknown {
-    fn from(value: &ITfMessagePump) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfMessagePump, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfMessagePump {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9623,21 +7578,7 @@ impl ITfMouseSink {
         (::windows::core::Vtable::vtable(self).OnMouseEvent)(::windows::core::Vtable::as_raw(self), uedge, uquadrant, dwbtnstatus, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITfMouseSink> for ::windows::core::IUnknown {
-    fn from(value: ITfMouseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfMouseSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfMouseSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfMouseSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfMouseSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfMouseSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfMouseSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9685,21 +7626,7 @@ impl ITfMouseTracker {
         (::windows::core::Vtable::vtable(self).UnadviseMouseSink)(::windows::core::Vtable::as_raw(self), dwcookie).ok()
     }
 }
-impl ::core::convert::From<ITfMouseTracker> for ::windows::core::IUnknown {
-    fn from(value: ITfMouseTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfMouseTracker> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfMouseTracker) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfMouseTracker> for ::windows::core::IUnknown {
-    fn from(value: &ITfMouseTracker) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfMouseTracker, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfMouseTracker {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9745,21 +7672,7 @@ impl ITfMouseTrackerACP {
         (::windows::core::Vtable::vtable(self).UnadviseMouseSink)(::windows::core::Vtable::as_raw(self), dwcookie).ok()
     }
 }
-impl ::core::convert::From<ITfMouseTrackerACP> for ::windows::core::IUnknown {
-    fn from(value: ITfMouseTrackerACP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfMouseTrackerACP> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfMouseTrackerACP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfMouseTrackerACP> for ::windows::core::IUnknown {
-    fn from(value: &ITfMouseTrackerACP) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfMouseTrackerACP, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfMouseTrackerACP {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9800,21 +7713,7 @@ impl ITfPersistentPropertyLoaderACP {
         (::windows::core::Vtable::vtable(self).LoadProperty)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(phdr), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::System::Com::IStream>(result__)
     }
 }
-impl ::core::convert::From<ITfPersistentPropertyLoaderACP> for ::windows::core::IUnknown {
-    fn from(value: ITfPersistentPropertyLoaderACP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfPersistentPropertyLoaderACP> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfPersistentPropertyLoaderACP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfPersistentPropertyLoaderACP> for ::windows::core::IUnknown {
-    fn from(value: &ITfPersistentPropertyLoaderACP) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfPersistentPropertyLoaderACP, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfPersistentPropertyLoaderACP {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9854,21 +7753,7 @@ impl ITfPreservedKeyNotifySink {
         (::windows::core::Vtable::vtable(self).OnUpdated)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pprekey)).ok()
     }
 }
-impl ::core::convert::From<ITfPreservedKeyNotifySink> for ::windows::core::IUnknown {
-    fn from(value: ITfPreservedKeyNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfPreservedKeyNotifySink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfPreservedKeyNotifySink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfPreservedKeyNotifySink> for ::windows::core::IUnknown {
-    fn from(value: &ITfPreservedKeyNotifySink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfPreservedKeyNotifySink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfPreservedKeyNotifySink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -9952,36 +7837,7 @@ impl ITfProperty {
         (::windows::core::Vtable::vtable(self).Clear)(::windows::core::Vtable::as_raw(self), ec, prange.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfProperty> for ::windows::core::IUnknown {
-    fn from(value: ITfProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfProperty> for ::windows::core::IUnknown {
-    fn from(value: &ITfProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfProperty> for ITfReadOnlyProperty {
-    fn from(value: ITfProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfProperty> for &'a ITfReadOnlyProperty {
-    fn from(value: &'a ITfProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfProperty> for ITfReadOnlyProperty {
-    fn from(value: &ITfProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfProperty, ::windows::core::IUnknown, ITfReadOnlyProperty);
 impl ::core::clone::Clone for ITfProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10078,21 +7934,7 @@ impl ITfPropertyStore {
         (::windows::core::Vtable::vtable(self).Serialize)(::windows::core::Vtable::as_raw(self), pstream.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ITfPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: ITfPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfPropertyStore> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfPropertyStore) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfPropertyStore> for ::windows::core::IUnknown {
-    fn from(value: &ITfPropertyStore) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfPropertyStore, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfPropertyStore {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10152,21 +7994,7 @@ impl ITfQueryEmbedded {
         (::windows::core::Vtable::vtable(self).QueryInsertEmbedded)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pguidservice), ::core::mem::transmute(pformatetc), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITfQueryEmbedded> for ::windows::core::IUnknown {
-    fn from(value: ITfQueryEmbedded) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfQueryEmbedded> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfQueryEmbedded) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfQueryEmbedded> for ::windows::core::IUnknown {
-    fn from(value: &ITfQueryEmbedded) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfQueryEmbedded, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfQueryEmbedded {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10318,21 +8146,7 @@ impl ITfRange {
         (::windows::core::Vtable::vtable(self).GetContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfContext>(result__)
     }
 }
-impl ::core::convert::From<ITfRange> for ::windows::core::IUnknown {
-    fn from(value: ITfRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfRange> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfRange) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfRange> for ::windows::core::IUnknown {
-    fn from(value: &ITfRange) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfRange, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfRange {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10532,36 +8346,7 @@ impl ITfRangeACP {
         (::windows::core::Vtable::vtable(self).SetExtent)(::windows::core::Vtable::as_raw(self), acpanchor, cch).ok()
     }
 }
-impl ::core::convert::From<ITfRangeACP> for ::windows::core::IUnknown {
-    fn from(value: ITfRangeACP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfRangeACP> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfRangeACP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfRangeACP> for ::windows::core::IUnknown {
-    fn from(value: &ITfRangeACP) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfRangeACP> for ITfRange {
-    fn from(value: ITfRangeACP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfRangeACP> for &'a ITfRange {
-    fn from(value: &'a ITfRangeACP) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfRangeACP> for ITfRange {
-    fn from(value: &ITfRangeACP) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfRangeACP, ::windows::core::IUnknown, ITfRange);
 impl ::core::clone::Clone for ITfRangeACP {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10602,21 +8387,7 @@ impl ITfRangeBackup {
         (::windows::core::Vtable::vtable(self).Restore)(::windows::core::Vtable::as_raw(self), ec, prange.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfRangeBackup> for ::windows::core::IUnknown {
-    fn from(value: ITfRangeBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfRangeBackup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfRangeBackup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfRangeBackup> for ::windows::core::IUnknown {
-    fn from(value: &ITfRangeBackup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfRangeBackup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfRangeBackup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10673,21 +8444,7 @@ impl ITfReadOnlyProperty {
         (::windows::core::Vtable::vtable(self).GetContext)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfContext>(result__)
     }
 }
-impl ::core::convert::From<ITfReadOnlyProperty> for ::windows::core::IUnknown {
-    fn from(value: ITfReadOnlyProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfReadOnlyProperty> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfReadOnlyProperty) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfReadOnlyProperty> for ::windows::core::IUnknown {
-    fn from(value: &ITfReadOnlyProperty) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfReadOnlyProperty, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfReadOnlyProperty {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10775,36 +8532,7 @@ impl ITfReadingInformationUIElement {
         (::windows::core::Vtable::vtable(self).IsVerticalOrderPreferred)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITfReadingInformationUIElement> for ::windows::core::IUnknown {
-    fn from(value: ITfReadingInformationUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfReadingInformationUIElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfReadingInformationUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfReadingInformationUIElement> for ::windows::core::IUnknown {
-    fn from(value: &ITfReadingInformationUIElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfReadingInformationUIElement> for ITfUIElement {
-    fn from(value: ITfReadingInformationUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfReadingInformationUIElement> for &'a ITfUIElement {
-    fn from(value: &'a ITfReadingInformationUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfReadingInformationUIElement> for ITfUIElement {
-    fn from(value: &ITfReadingInformationUIElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfReadingInformationUIElement, ::windows::core::IUnknown, ITfUIElement);
 impl ::core::clone::Clone for ITfReadingInformationUIElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10853,21 +8581,7 @@ impl ITfReverseConversion {
         (::windows::core::Vtable::vtable(self).DoReverseConversion)(::windows::core::Vtable::as_raw(self), lpstr.into(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfReverseConversionList>(result__)
     }
 }
-impl ::core::convert::From<ITfReverseConversion> for ::windows::core::IUnknown {
-    fn from(value: ITfReverseConversion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfReverseConversion> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfReverseConversion) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfReverseConversion> for ::windows::core::IUnknown {
-    fn from(value: &ITfReverseConversion) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfReverseConversion, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfReverseConversion {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10909,21 +8623,7 @@ impl ITfReverseConversionList {
         (::windows::core::Vtable::vtable(self).GetString)(::windows::core::Vtable::as_raw(self), uindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITfReverseConversionList> for ::windows::core::IUnknown {
-    fn from(value: ITfReverseConversionList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfReverseConversionList> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfReverseConversionList) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfReverseConversionList> for ::windows::core::IUnknown {
-    fn from(value: &ITfReverseConversionList) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfReverseConversionList, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfReverseConversionList {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -10962,21 +8662,7 @@ impl ITfReverseConversionMgr {
         (::windows::core::Vtable::vtable(self).GetReverseConversion)(::windows::core::Vtable::as_raw(self), langid, ::core::mem::transmute(guidprofile), dwflag, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfReverseConversion>(result__)
     }
 }
-impl ::core::convert::From<ITfReverseConversionMgr> for ::windows::core::IUnknown {
-    fn from(value: ITfReverseConversionMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfReverseConversionMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfReverseConversionMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfReverseConversionMgr> for ::windows::core::IUnknown {
-    fn from(value: &ITfReverseConversionMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfReverseConversionMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfReverseConversionMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11020,21 +8706,7 @@ impl ITfSource {
         (::windows::core::Vtable::vtable(self).UnadviseSink)(::windows::core::Vtable::as_raw(self), dwcookie).ok()
     }
 }
-impl ::core::convert::From<ITfSource> for ::windows::core::IUnknown {
-    fn from(value: ITfSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfSource> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfSource) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfSource> for ::windows::core::IUnknown {
-    fn from(value: &ITfSource) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfSource, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfSource {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11078,21 +8750,7 @@ impl ITfSourceSingle {
         (::windows::core::Vtable::vtable(self).UnadviseSingleSink)(::windows::core::Vtable::as_raw(self), tid, ::core::mem::transmute(riid)).ok()
     }
 }
-impl ::core::convert::From<ITfSourceSingle> for ::windows::core::IUnknown {
-    fn from(value: ITfSourceSingle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfSourceSingle> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfSourceSingle) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfSourceSingle> for ::windows::core::IUnknown {
-    fn from(value: &ITfSourceSingle) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfSourceSingle, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfSourceSingle {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11141,21 +8799,7 @@ impl ITfSpeechUIServer {
         (::windows::core::Vtable::vtable(self).UpdateBalloon)(::windows::core::Vtable::as_raw(self), style, ::core::mem::transmute(pch.as_ptr()), pch.len() as _).ok()
     }
 }
-impl ::core::convert::From<ITfSpeechUIServer> for ::windows::core::IUnknown {
-    fn from(value: ITfSpeechUIServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfSpeechUIServer> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfSpeechUIServer) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfSpeechUIServer> for ::windows::core::IUnknown {
-    fn from(value: &ITfSpeechUIServer) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfSpeechUIServer, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfSpeechUIServer {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11200,21 +8844,7 @@ impl ITfStatusSink {
         (::windows::core::Vtable::vtable(self).OnStatusChange)(::windows::core::Vtable::as_raw(self), pic.into().abi(), dwflags).ok()
     }
 }
-impl ::core::convert::From<ITfStatusSink> for ::windows::core::IUnknown {
-    fn from(value: ITfStatusSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfStatusSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfStatusSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfStatusSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfStatusSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfStatusSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfStatusSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11255,21 +8885,7 @@ impl ITfSystemDeviceTypeLangBarItem {
         (::windows::core::Vtable::vtable(self).GetIconMode)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ITfSystemDeviceTypeLangBarItem> for ::windows::core::IUnknown {
-    fn from(value: ITfSystemDeviceTypeLangBarItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfSystemDeviceTypeLangBarItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfSystemDeviceTypeLangBarItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfSystemDeviceTypeLangBarItem> for ::windows::core::IUnknown {
-    fn from(value: &ITfSystemDeviceTypeLangBarItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfSystemDeviceTypeLangBarItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfSystemDeviceTypeLangBarItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11315,21 +8931,7 @@ impl ITfSystemLangBarItem {
         (::windows::core::Vtable::vtable(self).SetTooltipString)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pchtooltip.as_ptr()), pchtooltip.len() as _).ok()
     }
 }
-impl ::core::convert::From<ITfSystemLangBarItem> for ::windows::core::IUnknown {
-    fn from(value: ITfSystemLangBarItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfSystemLangBarItem> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfSystemLangBarItem) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfSystemLangBarItem> for ::windows::core::IUnknown {
-    fn from(value: &ITfSystemLangBarItem) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfSystemLangBarItem, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfSystemLangBarItem {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11376,21 +8978,7 @@ impl ITfSystemLangBarItemSink {
         (::windows::core::Vtable::vtable(self).OnMenuSelect)(::windows::core::Vtable::as_raw(self), wid).ok()
     }
 }
-impl ::core::convert::From<ITfSystemLangBarItemSink> for ::windows::core::IUnknown {
-    fn from(value: ITfSystemLangBarItemSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfSystemLangBarItemSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfSystemLangBarItemSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfSystemLangBarItemSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfSystemLangBarItemSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfSystemLangBarItemSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfSystemLangBarItemSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11432,21 +9020,7 @@ impl ITfSystemLangBarItemText {
         (::windows::core::Vtable::vtable(self).GetItemText)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITfSystemLangBarItemText> for ::windows::core::IUnknown {
-    fn from(value: ITfSystemLangBarItemText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfSystemLangBarItemText> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfSystemLangBarItemText) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfSystemLangBarItemText> for ::windows::core::IUnknown {
-    fn from(value: &ITfSystemLangBarItemText) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfSystemLangBarItemText, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfSystemLangBarItemText {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11488,21 +9062,7 @@ impl ITfTextEditSink {
         (::windows::core::Vtable::vtable(self).OnEndEdit)(::windows::core::Vtable::as_raw(self), pic.into().abi(), ecreadonly, peditrecord.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfTextEditSink> for ::windows::core::IUnknown {
-    fn from(value: ITfTextEditSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfTextEditSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfTextEditSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfTextEditSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfTextEditSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfTextEditSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfTextEditSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11545,21 +9105,7 @@ impl ITfTextInputProcessor {
         (::windows::core::Vtable::vtable(self).Deactivate)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITfTextInputProcessor> for ::windows::core::IUnknown {
-    fn from(value: ITfTextInputProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfTextInputProcessor> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfTextInputProcessor) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfTextInputProcessor> for ::windows::core::IUnknown {
-    fn from(value: &ITfTextInputProcessor) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfTextInputProcessor, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfTextInputProcessor {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11609,36 +9155,7 @@ impl ITfTextInputProcessorEx {
         (::windows::core::Vtable::vtable(self).ActivateEx)(::windows::core::Vtable::as_raw(self), ptim.into().abi(), tid, dwflags).ok()
     }
 }
-impl ::core::convert::From<ITfTextInputProcessorEx> for ::windows::core::IUnknown {
-    fn from(value: ITfTextInputProcessorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfTextInputProcessorEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfTextInputProcessorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfTextInputProcessorEx> for ::windows::core::IUnknown {
-    fn from(value: &ITfTextInputProcessorEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfTextInputProcessorEx> for ITfTextInputProcessor {
-    fn from(value: ITfTextInputProcessorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfTextInputProcessorEx> for &'a ITfTextInputProcessor {
-    fn from(value: &'a ITfTextInputProcessorEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfTextInputProcessorEx> for ITfTextInputProcessor {
-    fn from(value: &ITfTextInputProcessorEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfTextInputProcessorEx, ::windows::core::IUnknown, ITfTextInputProcessor);
 impl ::core::clone::Clone for ITfTextInputProcessorEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11679,21 +9196,7 @@ impl ITfTextLayoutSink {
         (::windows::core::Vtable::vtable(self).OnLayoutChange)(::windows::core::Vtable::as_raw(self), pic.into().abi(), lcode, pview.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfTextLayoutSink> for ::windows::core::IUnknown {
-    fn from(value: ITfTextLayoutSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfTextLayoutSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfTextLayoutSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfTextLayoutSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfTextLayoutSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfTextLayoutSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfTextLayoutSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11733,21 +9236,7 @@ impl ITfThreadFocusSink {
         (::windows::core::Vtable::vtable(self).OnKillThreadFocus)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITfThreadFocusSink> for ::windows::core::IUnknown {
-    fn from(value: ITfThreadFocusSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfThreadFocusSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfThreadFocusSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfThreadFocusSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfThreadFocusSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfThreadFocusSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfThreadFocusSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11835,21 +9324,7 @@ impl ITfThreadMgr {
         (::windows::core::Vtable::vtable(self).GetGlobalCompartment)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfCompartmentMgr>(result__)
     }
 }
-impl ::core::convert::From<ITfThreadMgr> for ::windows::core::IUnknown {
-    fn from(value: ITfThreadMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfThreadMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfThreadMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfThreadMgr> for ::windows::core::IUnknown {
-    fn from(value: &ITfThreadMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfThreadMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfThreadMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -11955,21 +9430,7 @@ impl ITfThreadMgr2 {
         (::windows::core::Vtable::vtable(self).ResumeKeystrokeHandling)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<ITfThreadMgr2> for ::windows::core::IUnknown {
-    fn from(value: ITfThreadMgr2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfThreadMgr2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfThreadMgr2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfThreadMgr2> for ::windows::core::IUnknown {
-    fn from(value: &ITfThreadMgr2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfThreadMgr2, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfThreadMgr2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12050,21 +9511,7 @@ impl ITfThreadMgrEventSink {
         (::windows::core::Vtable::vtable(self).OnPopContext)(::windows::core::Vtable::as_raw(self), pic.into().abi()).ok()
     }
 }
-impl ::core::convert::From<ITfThreadMgrEventSink> for ::windows::core::IUnknown {
-    fn from(value: ITfThreadMgrEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfThreadMgrEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfThreadMgrEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfThreadMgrEventSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfThreadMgrEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfThreadMgrEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfThreadMgrEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12162,36 +9609,7 @@ impl ITfThreadMgrEx {
         (::windows::core::Vtable::vtable(self).GetActiveFlags)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<ITfThreadMgrEx> for ::windows::core::IUnknown {
-    fn from(value: ITfThreadMgrEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfThreadMgrEx> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfThreadMgrEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfThreadMgrEx> for ::windows::core::IUnknown {
-    fn from(value: &ITfThreadMgrEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfThreadMgrEx> for ITfThreadMgr {
-    fn from(value: ITfThreadMgrEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfThreadMgrEx> for &'a ITfThreadMgr {
-    fn from(value: &'a ITfThreadMgrEx) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfThreadMgrEx> for ITfThreadMgr {
-    fn from(value: &ITfThreadMgrEx) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfThreadMgrEx, ::windows::core::IUnknown, ITfThreadMgr);
 impl ::core::clone::Clone for ITfThreadMgrEx {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12252,36 +9670,7 @@ impl ITfToolTipUIElement {
         (::windows::core::Vtable::vtable(self).GetString)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<ITfToolTipUIElement> for ::windows::core::IUnknown {
-    fn from(value: ITfToolTipUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfToolTipUIElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfToolTipUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfToolTipUIElement> for ::windows::core::IUnknown {
-    fn from(value: &ITfToolTipUIElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfToolTipUIElement> for ITfUIElement {
-    fn from(value: ITfToolTipUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfToolTipUIElement> for &'a ITfUIElement {
-    fn from(value: &'a ITfToolTipUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfToolTipUIElement> for ITfUIElement {
-    fn from(value: &ITfToolTipUIElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfToolTipUIElement, ::windows::core::IUnknown, ITfUIElement);
 impl ::core::clone::Clone for ITfToolTipUIElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12326,21 +9715,7 @@ impl ITfTransitoryExtensionSink {
         (::windows::core::Vtable::vtable(self).OnTransitoryExtensionUpdated)(::windows::core::Vtable::as_raw(self), pic.into().abi(), ecreadonly, presultrange.into().abi(), pcompositionrange.into().abi(), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITfTransitoryExtensionSink> for ::windows::core::IUnknown {
-    fn from(value: ITfTransitoryExtensionSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfTransitoryExtensionSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfTransitoryExtensionSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfTransitoryExtensionSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfTransitoryExtensionSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfTransitoryExtensionSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfTransitoryExtensionSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12403,36 +9778,7 @@ impl ITfTransitoryExtensionUIElement {
         (::windows::core::Vtable::vtable(self).GetDocumentMgr)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<ITfDocumentMgr>(result__)
     }
 }
-impl ::core::convert::From<ITfTransitoryExtensionUIElement> for ::windows::core::IUnknown {
-    fn from(value: ITfTransitoryExtensionUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfTransitoryExtensionUIElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfTransitoryExtensionUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfTransitoryExtensionUIElement> for ::windows::core::IUnknown {
-    fn from(value: &ITfTransitoryExtensionUIElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<ITfTransitoryExtensionUIElement> for ITfUIElement {
-    fn from(value: ITfTransitoryExtensionUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfTransitoryExtensionUIElement> for &'a ITfUIElement {
-    fn from(value: &'a ITfTransitoryExtensionUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfTransitoryExtensionUIElement> for ITfUIElement {
-    fn from(value: &ITfTransitoryExtensionUIElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfTransitoryExtensionUIElement, ::windows::core::IUnknown, ITfUIElement);
 impl ::core::clone::Clone for ITfTransitoryExtensionUIElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12488,21 +9834,7 @@ impl ITfUIElement {
         (::windows::core::Vtable::vtable(self).IsShown)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<super::super::Foundation::BOOL>(result__)
     }
 }
-impl ::core::convert::From<ITfUIElement> for ::windows::core::IUnknown {
-    fn from(value: ITfUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfUIElement> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfUIElement) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfUIElement> for ::windows::core::IUnknown {
-    fn from(value: &ITfUIElement) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfUIElement, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfUIElement {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12567,21 +9899,7 @@ impl ITfUIElementMgr {
         (::windows::core::Vtable::vtable(self).EnumUIElements)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IEnumTfUIElements>(result__)
     }
 }
-impl ::core::convert::From<ITfUIElementMgr> for ::windows::core::IUnknown {
-    fn from(value: ITfUIElementMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfUIElementMgr> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfUIElementMgr) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfUIElementMgr> for ::windows::core::IUnknown {
-    fn from(value: &ITfUIElementMgr) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfUIElementMgr, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfUIElementMgr {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12633,21 +9951,7 @@ impl ITfUIElementSink {
         (::windows::core::Vtable::vtable(self).EndUIElement)(::windows::core::Vtable::as_raw(self), dwuielementid).ok()
     }
 }
-impl ::core::convert::From<ITfUIElementSink> for ::windows::core::IUnknown {
-    fn from(value: ITfUIElementSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a ITfUIElementSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a ITfUIElementSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&ITfUIElementSink> for ::windows::core::IUnknown {
-    fn from(value: &ITfUIElementSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(ITfUIElementSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for ITfUIElementSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12712,21 +10016,7 @@ impl IUIManagerEventSink {
         (::windows::core::Vtable::vtable(self).OnWindowClosed)(::windows::core::Vtable::as_raw(self)).ok()
     }
 }
-impl ::core::convert::From<IUIManagerEventSink> for ::windows::core::IUnknown {
-    fn from(value: IUIManagerEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IUIManagerEventSink> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IUIManagerEventSink) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IUIManagerEventSink> for ::windows::core::IUnknown {
-    fn from(value: &IUIManagerEventSink) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IUIManagerEventSink, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IUIManagerEventSink {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -12796,21 +10086,7 @@ impl IVersionInfo {
         (::windows::core::Vtable::vtable(self).GetInstanceDescription)(::windows::core::Vtable::as_raw(self), ulsub, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IVersionInfo> for ::windows::core::IUnknown {
-    fn from(value: IVersionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVersionInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVersionInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVersionInfo> for ::windows::core::IUnknown {
-    fn from(value: &IVersionInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVersionInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVersionInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
@@ -24,21 +24,7 @@ impl IMILBitmapEffect {
         (::windows::core::Vtable::vtable(self).SetInputSource)(::windows::core::Vtable::as_raw(self), uiindex, pbitmapsource.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMILBitmapEffect> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffect> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffect) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffect> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffect) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffect, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffect {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -88,21 +74,7 @@ impl IMILBitmapEffectConnections {
         (::windows::core::Vtable::vtable(self).GetOutputConnector)(::windows::core::Vtable::as_raw(self), uiindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMILBitmapEffectOutputConnector>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffectConnections> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectConnections) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectConnections> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectConnections) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectConnections> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectConnections) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectConnections, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectConnections {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -153,21 +125,7 @@ impl IMILBitmapEffectConnectionsInfo {
         (::windows::core::Vtable::vtable(self).GetOutputConnectorInfo)(::windows::core::Vtable::as_raw(self), uiindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMILBitmapEffectConnectorInfo>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffectConnectionsInfo> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectConnectionsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectConnectionsInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectConnectionsInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectConnectionsInfo> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectConnectionsInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectConnectionsInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectConnectionsInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -228,36 +186,7 @@ impl IMILBitmapEffectConnector {
         (::windows::core::Vtable::vtable(self).GetBitmapEffect)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMILBitmapEffect>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffectConnector> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectConnector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectConnector> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMILBitmapEffectConnector> for IMILBitmapEffectConnectorInfo {
-    fn from(value: IMILBitmapEffectConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectConnector> for &'a IMILBitmapEffectConnectorInfo {
-    fn from(value: &'a IMILBitmapEffectConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectConnector> for IMILBitmapEffectConnectorInfo {
-    fn from(value: &IMILBitmapEffectConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectConnector, ::windows::core::IUnknown, IMILBitmapEffectConnectorInfo);
 impl ::core::clone::Clone for IMILBitmapEffectConnector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -308,21 +237,7 @@ impl IMILBitmapEffectConnectorInfo {
         (::windows::core::Vtable::vtable(self).GetFormat)(::windows::core::Vtable::as_raw(self), ulindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::GUID>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffectConnectorInfo> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectConnectorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectConnectorInfo> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectConnectorInfo) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectConnectorInfo> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectConnectorInfo) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectConnectorInfo, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectConnectorInfo {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -371,21 +286,7 @@ impl IMILBitmapEffectEvents {
         (::windows::core::Vtable::vtable(self).DirtyRegion)(::windows::core::Vtable::as_raw(self), peffect.into().abi(), ::core::mem::transmute(prect)).ok()
     }
 }
-impl ::core::convert::From<IMILBitmapEffectEvents> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectEvents> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectEvents) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectEvents> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectEvents) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectEvents, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectEvents {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -432,21 +333,7 @@ impl IMILBitmapEffectFactory {
         (::windows::core::Vtable::vtable(self).CreateEffectOuter)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMILBitmapEffect>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffectFactory> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectFactory> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectFactory) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectFactory> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectFactory) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectFactory, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectFactory {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -496,21 +383,7 @@ impl IMILBitmapEffectGroup {
         (::windows::core::Vtable::vtable(self).Add)(::windows::core::Vtable::as_raw(self), peffect.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMILBitmapEffectGroup> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectGroup> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectGroup) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectGroup> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectGroup) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectGroup, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectGroup {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -560,21 +433,7 @@ impl IMILBitmapEffectGroupImpl {
         (::windows::core::Vtable::vtable(self).GetChildren)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMILBitmapEffects>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffectGroupImpl> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectGroupImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectGroupImpl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectGroupImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectGroupImpl> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectGroupImpl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectGroupImpl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectGroupImpl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -655,21 +514,7 @@ impl IMILBitmapEffectImpl {
         (::windows::core::Vtable::vtable(self).Initialize)(::windows::core::Vtable::as_raw(self), pinner.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMILBitmapEffectImpl> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectImpl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectImpl> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectImpl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectImpl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectImpl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -752,51 +597,7 @@ impl IMILBitmapEffectInputConnector {
         (::windows::core::Vtable::vtable(self).GetConnection)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMILBitmapEffectOutputConnector>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffectInputConnector> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectInputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectInputConnector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectInputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectInputConnector> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectInputConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMILBitmapEffectInputConnector> for IMILBitmapEffectConnectorInfo {
-    fn from(value: IMILBitmapEffectInputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectInputConnector> for &'a IMILBitmapEffectConnectorInfo {
-    fn from(value: &'a IMILBitmapEffectInputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectInputConnector> for IMILBitmapEffectConnectorInfo {
-    fn from(value: &IMILBitmapEffectInputConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMILBitmapEffectInputConnector> for IMILBitmapEffectConnector {
-    fn from(value: IMILBitmapEffectInputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectInputConnector> for &'a IMILBitmapEffectConnector {
-    fn from(value: &'a IMILBitmapEffectInputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectInputConnector> for IMILBitmapEffectConnector {
-    fn from(value: &IMILBitmapEffectInputConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectInputConnector, ::windows::core::IUnknown, IMILBitmapEffectConnectorInfo, IMILBitmapEffectConnector);
 impl ::core::clone::Clone for IMILBitmapEffectInputConnector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -835,21 +636,7 @@ impl IMILBitmapEffectInteriorInputConnector {
         (::windows::core::Vtable::vtable(self).GetInputConnector)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMILBitmapEffectInputConnector>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffectInteriorInputConnector> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectInteriorInputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectInteriorInputConnector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectInteriorInputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectInteriorInputConnector> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectInteriorInputConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectInteriorInputConnector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectInteriorInputConnector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -887,21 +674,7 @@ impl IMILBitmapEffectInteriorOutputConnector {
         (::windows::core::Vtable::vtable(self).GetOutputConnector)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMILBitmapEffectOutputConnector>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffectInteriorOutputConnector> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectInteriorOutputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectInteriorOutputConnector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectInteriorOutputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectInteriorOutputConnector> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectInteriorOutputConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectInteriorOutputConnector, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectInteriorOutputConnector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -967,51 +740,7 @@ impl IMILBitmapEffectOutputConnector {
         (::windows::core::Vtable::vtable(self).GetConnection)(::windows::core::Vtable::as_raw(self), uiindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IMILBitmapEffectInputConnector>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffectOutputConnector> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectOutputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectOutputConnector> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectOutputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectOutputConnector> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectOutputConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMILBitmapEffectOutputConnector> for IMILBitmapEffectConnectorInfo {
-    fn from(value: IMILBitmapEffectOutputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectOutputConnector> for &'a IMILBitmapEffectConnectorInfo {
-    fn from(value: &'a IMILBitmapEffectOutputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectOutputConnector> for IMILBitmapEffectConnectorInfo {
-    fn from(value: &IMILBitmapEffectOutputConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IMILBitmapEffectOutputConnector> for IMILBitmapEffectConnector {
-    fn from(value: IMILBitmapEffectOutputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectOutputConnector> for &'a IMILBitmapEffectConnector {
-    fn from(value: &'a IMILBitmapEffectOutputConnector) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectOutputConnector> for IMILBitmapEffectConnector {
-    fn from(value: &IMILBitmapEffectOutputConnector) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectOutputConnector, ::windows::core::IUnknown, IMILBitmapEffectConnectorInfo, IMILBitmapEffectConnector);
 impl ::core::clone::Clone for IMILBitmapEffectOutputConnector {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1058,21 +787,7 @@ impl IMILBitmapEffectOutputConnectorImpl {
         (::windows::core::Vtable::vtable(self).RemoveBackLink)(::windows::core::Vtable::as_raw(self), pconnection.into().abi()).ok()
     }
 }
-impl ::core::convert::From<IMILBitmapEffectOutputConnectorImpl> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectOutputConnectorImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectOutputConnectorImpl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectOutputConnectorImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectOutputConnectorImpl> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectOutputConnectorImpl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectOutputConnectorImpl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectOutputConnectorImpl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1140,21 +855,7 @@ impl IMILBitmapEffectPrimitive {
         (::windows::core::Vtable::vtable(self).GetAffineMatrix)(::windows::core::Vtable::as_raw(self), uiindex, ::core::mem::transmute(pmatrix)).ok()
     }
 }
-impl ::core::convert::From<IMILBitmapEffectPrimitive> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectPrimitive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectPrimitive> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectPrimitive) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectPrimitive> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectPrimitive) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectPrimitive, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectPrimitive {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1206,21 +907,7 @@ impl IMILBitmapEffectPrimitiveImpl {
         (::windows::core::Vtable::vtable(self).IsVolatile)(::windows::core::Vtable::as_raw(self), uioutputindex, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<i16>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffectPrimitiveImpl> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectPrimitiveImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectPrimitiveImpl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectPrimitiveImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectPrimitiveImpl> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectPrimitiveImpl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectPrimitiveImpl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectPrimitiveImpl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1281,21 +968,7 @@ impl IMILBitmapEffectRenderContext {
         (::windows::core::Vtable::vtable(self).SetRegionOfInterest)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prect)).ok()
     }
 }
-impl ::core::convert::From<IMILBitmapEffectRenderContext> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectRenderContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectRenderContext> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectRenderContext) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectRenderContext> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectRenderContext) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectRenderContext, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectRenderContext {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1352,21 +1025,7 @@ impl IMILBitmapEffectRenderContextImpl {
         (::windows::core::Vtable::vtable(self).UpdateOutputBounds)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(prect)).ok()
     }
 }
-impl ::core::convert::From<IMILBitmapEffectRenderContextImpl> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffectRenderContextImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffectRenderContextImpl> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffectRenderContextImpl) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffectRenderContextImpl> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffectRenderContextImpl) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffectRenderContextImpl, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffectRenderContextImpl {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -1420,21 +1079,7 @@ impl IMILBitmapEffects {
         (::windows::core::Vtable::vtable(self).Count)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<u32>(result__)
     }
 }
-impl ::core::convert::From<IMILBitmapEffects> for ::windows::core::IUnknown {
-    fn from(value: IMILBitmapEffects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IMILBitmapEffects> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IMILBitmapEffects) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IMILBitmapEffects> for ::windows::core::IUnknown {
-    fn from(value: &IMILBitmapEffects) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IMILBitmapEffects, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IMILBitmapEffects {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/mod.rs
@@ -51,21 +51,7 @@ impl IBitmapData {
         (::windows::core::Vtable::vtable(self).GetSourceBitmapDescription)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<BitmapDescription>(result__)
     }
 }
-impl ::core::convert::From<IBitmapData> for ::windows::core::IUnknown {
-    fn from(value: IBitmapData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IBitmapData> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IBitmapData) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IBitmapData> for ::windows::core::IUnknown {
-    fn from(value: &IBitmapData) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IBitmapData, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IBitmapData {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -156,21 +142,7 @@ impl IVisualTreeService {
         (::windows::core::Vtable::vtable(self).ClearChildren)(::windows::core::Vtable::as_raw(self), parent).ok()
     }
 }
-impl ::core::convert::From<IVisualTreeService> for ::windows::core::IUnknown {
-    fn from(value: IVisualTreeService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualTreeService> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVisualTreeService) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualTreeService> for ::windows::core::IUnknown {
-    fn from(value: &IVisualTreeService) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVisualTreeService, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVisualTreeService {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -287,36 +259,7 @@ impl IVisualTreeService2 {
         (::windows::core::Vtable::vtable(self).RenderTargetBitmap)(::windows::core::Vtable::as_raw(self), handle, options, maxpixelwidth, maxpixelheight, ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<IBitmapData>(result__)
     }
 }
-impl ::core::convert::From<IVisualTreeService2> for ::windows::core::IUnknown {
-    fn from(value: IVisualTreeService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualTreeService2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVisualTreeService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualTreeService2> for ::windows::core::IUnknown {
-    fn from(value: &IVisualTreeService2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVisualTreeService2> for IVisualTreeService {
-    fn from(value: IVisualTreeService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualTreeService2> for &'a IVisualTreeService {
-    fn from(value: &'a IVisualTreeService2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualTreeService2> for IVisualTreeService {
-    fn from(value: &IVisualTreeService2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVisualTreeService2, ::windows::core::IUnknown, IVisualTreeService);
 impl ::core::clone::Clone for IVisualTreeService2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -441,51 +384,7 @@ impl IVisualTreeService3 {
         (::windows::core::Vtable::vtable(self).RemoveDictionaryItem)(::windows::core::Vtable::as_raw(self), dictionaryhandle, resourcekey).ok()
     }
 }
-impl ::core::convert::From<IVisualTreeService3> for ::windows::core::IUnknown {
-    fn from(value: IVisualTreeService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualTreeService3> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVisualTreeService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualTreeService3> for ::windows::core::IUnknown {
-    fn from(value: &IVisualTreeService3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVisualTreeService3> for IVisualTreeService {
-    fn from(value: IVisualTreeService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualTreeService3> for &'a IVisualTreeService {
-    fn from(value: &'a IVisualTreeService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualTreeService3> for IVisualTreeService {
-    fn from(value: &IVisualTreeService3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVisualTreeService3> for IVisualTreeService2 {
-    fn from(value: IVisualTreeService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualTreeService3> for &'a IVisualTreeService2 {
-    fn from(value: &'a IVisualTreeService3) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualTreeService3> for IVisualTreeService2 {
-    fn from(value: &IVisualTreeService3) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVisualTreeService3, ::windows::core::IUnknown, IVisualTreeService, IVisualTreeService2);
 impl ::core::clone::Clone for IVisualTreeService3 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -531,21 +430,7 @@ impl IVisualTreeServiceCallback {
         (::windows::core::Vtable::vtable(self).OnVisualTreeChange)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(relation), element.into().abi(), mutationtype).ok()
     }
 }
-impl ::core::convert::From<IVisualTreeServiceCallback> for ::windows::core::IUnknown {
-    fn from(value: IVisualTreeServiceCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualTreeServiceCallback> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVisualTreeServiceCallback) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualTreeServiceCallback> for ::windows::core::IUnknown {
-    fn from(value: &IVisualTreeServiceCallback) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVisualTreeServiceCallback, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IVisualTreeServiceCallback {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -591,36 +476,7 @@ impl IVisualTreeServiceCallback2 {
         (::windows::core::Vtable::vtable(self).OnElementStateChanged)(::windows::core::Vtable::as_raw(self), element, elementstate, context.into()).ok()
     }
 }
-impl ::core::convert::From<IVisualTreeServiceCallback2> for ::windows::core::IUnknown {
-    fn from(value: IVisualTreeServiceCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualTreeServiceCallback2> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IVisualTreeServiceCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualTreeServiceCallback2> for ::windows::core::IUnknown {
-    fn from(value: &IVisualTreeServiceCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<IVisualTreeServiceCallback2> for IVisualTreeServiceCallback {
-    fn from(value: IVisualTreeServiceCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IVisualTreeServiceCallback2> for &'a IVisualTreeServiceCallback {
-    fn from(value: &'a IVisualTreeServiceCallback2) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IVisualTreeServiceCallback2> for IVisualTreeServiceCallback {
-    fn from(value: &IVisualTreeServiceCallback2) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IVisualTreeServiceCallback2, ::windows::core::IUnknown, IVisualTreeServiceCallback);
 impl ::core::clone::Clone for IVisualTreeServiceCallback2 {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -693,21 +549,7 @@ impl IXamlDiagnostics {
         (::windows::core::Vtable::vtable(self).GetInitializationData)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(result__.as_mut_ptr())).from_abi::<::windows::core::BSTR>(result__)
     }
 }
-impl ::core::convert::From<IXamlDiagnostics> for ::windows::core::IUnknown {
-    fn from(value: IXamlDiagnostics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl<'a> ::core::convert::From<&'a IXamlDiagnostics> for &'a ::windows::core::IUnknown {
-    fn from(value: &'a IXamlDiagnostics) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&IXamlDiagnostics> for ::windows::core::IUnknown {
-    fn from(value: &IXamlDiagnostics) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
+::windows::core::interface_hierarchy!(IXamlDiagnostics, ::windows::core::IUnknown);
 impl ::core::clone::Clone for IXamlDiagnostics {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -95,3 +95,32 @@ fn wide_trim_end(mut wide: &[u16]) -> &[u16] {
     }
     wide
 }
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! interface_hierarchy {
+    ($child:ty, $parent:ty) => {
+        impl ::core::convert::From<$child> for $parent {
+            fn from(value: $child) -> Self {
+                unsafe { ::core::mem::transmute(value) }
+            }
+        }
+        impl ::core::convert::From<&$child> for &$parent {
+            fn from(value: &$child) -> Self {
+                unsafe { ::core::mem::transmute(value) }
+            }
+        }
+        impl ::core::convert::From<&$child> for $parent {
+            fn from(value: &$child) -> Self {
+                unsafe { ::core::mem::transmute(::core::clone::Clone::clone(value)) }
+            }
+        }
+    };
+    ($child:ty, $first:ty, $($rest:ty),+) => {
+        crate::core::interface_hierarchy!($child, $first);
+        crate::core::interface_hierarchy!($child, $($rest),+);
+    };
+}
+
+#[doc(hidden)]
+pub use interface_hierarchy;

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -100,25 +100,25 @@ fn wide_trim_end(mut wide: &[u16]) -> &[u16] {
 #[macro_export]
 macro_rules! interface_hierarchy {
     ($child:ty, $parent:ty) => {
-        impl ::core::convert::From<$child> for $parent {
+        impl ::std::convert::From<$child> for $parent {
             fn from(value: $child) -> Self {
-                unsafe { ::core::mem::transmute(value) }
+                unsafe { ::std::mem::transmute(value) }
             }
         }
-        impl ::core::convert::From<&$child> for &$parent {
+        impl ::std::convert::From<&$child> for &$parent {
             fn from(value: &$child) -> Self {
-                unsafe { ::core::mem::transmute(value) }
+                unsafe { ::std::mem::transmute(value) }
             }
         }
-        impl ::core::convert::From<&$child> for $parent {
+        impl ::std::convert::From<&$child> for $parent {
             fn from(value: &$child) -> Self {
-                unsafe { ::core::mem::transmute(::core::clone::Clone::clone(value)) }
+                unsafe { ::std::mem::transmute(::std::clone::Clone::clone(value)) }
             }
         }
     };
     ($child:ty, $first:ty, $($rest:ty),+) => {
-        crate::core::interface_hierarchy!($child, $first);
-        crate::core::interface_hierarchy!($child, $($rest),+);
+        $crate::core::interface_hierarchy!($child, $first);
+        $crate::core::interface_hierarchy!($child, $($rest),+);
     };
 }
 

--- a/crates/tests/component/src/bindings.rs
+++ b/crates/tests/component/src/bindings.rs
@@ -84,36 +84,7 @@ unsafe impl ::windows::core::Interface for Class {
 impl ::windows::core::RuntimeName for Class {
     const NAME: &'static str = "test_component.Class";
 }
-impl ::core::convert::From<Class> for ::windows::core::IUnknown {
-    fn from(value: Class) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Class> for ::windows::core::IUnknown {
-    fn from(value: &Class) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Class> for &::windows::core::IUnknown {
-    fn from(value: &Class) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Class> for ::windows::core::IInspectable {
-    fn from(value: Class) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Class> for ::windows::core::IInspectable {
-    fn from(value: &Class) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Class> for &::windows::core::IInspectable {
-    fn from(value: &Class) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Class, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Class {}
 unsafe impl ::core::marker::Sync for Class {}
 pub trait IClass_Impl: Sized {

--- a/crates/tests/component_client/src/bindings.rs
+++ b/crates/tests/component_client/src/bindings.rs
@@ -84,36 +84,7 @@ unsafe impl ::windows::core::Interface for Class {
 impl ::windows::core::RuntimeName for Class {
     const NAME: &'static str = "test_component.Class";
 }
-impl ::core::convert::From<Class> for ::windows::core::IUnknown {
-    fn from(value: Class) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Class> for ::windows::core::IUnknown {
-    fn from(value: &Class) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Class> for &::windows::core::IUnknown {
-    fn from(value: &Class) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<Class> for ::windows::core::IInspectable {
-    fn from(value: Class) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
-impl ::core::convert::From<&Class> for ::windows::core::IInspectable {
-    fn from(value: &Class) -> Self {
-        ::core::convert::From::from(::core::clone::Clone::clone(value))
-    }
-}
-impl ::core::convert::From<&Class> for &::windows::core::IInspectable {
-    fn from(value: &Class) -> Self {
-        unsafe { ::core::mem::transmute(value) }
-    }
-}
+::windows::core::interface_hierarchy!(Class, ::windows::core::IUnknown, ::windows::core::IInspectable);
 unsafe impl ::core::marker::Send for Class {}
 unsafe impl ::core::marker::Sync for Class {}
 pub trait IClass_Impl: Sized {


### PR DESCRIPTION
The `windows` and `windows-sys` crates avoid `derive` macros as much as possible as they tend to be very slow at scale. There is however a lot of boilerplate code that could be avoided with selective use of macros, so I am going to start making conservative use of `macro_rules` to replace large chunks of boilerplate code. I tested the change in this update and could not measure any difference in build time, so I think this is a good first step in reducing code gen and overall crate size. 

The new `interface_hierarchy` macro stamps out most of the `From` implementations for COM and WinRT types that can often have large interface hierarchies. For example, `ID3D12Device9` derives from 11 other interfaces leading to 33 `From` implementations that can be generated by the `interface_hierarchy` macro far more concisely. 

https://github.com/microsoft/windows-rs/blob/6ed9da4b44d06fa451a14bfc0cf8c6e7b7524ce8/crates/libs/windows/src/core/mod.rs#L101-L123
